### PR TITLE
Fix hosted shell auth metadata and API defaults

### DIFF
--- a/chat-ui/src/adapters/api.js
+++ b/chat-ui/src/adapters/api.js
@@ -4,6 +4,17 @@ import resolveWorkflow from '../utils/resolveWorkflow';
 import config from '../config';
 import platform from '../platform/index.js';
 
+function _firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string') return value;
+  }
+  return undefined;
+}
+
+function _trimTrailingSlash(value) {
+  return typeof value === 'string' && value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
 /**
  * Get the current access token from storage.
  * In production, this should be provided by the auth adapter.
@@ -132,20 +143,30 @@ export class ApiAdapter {
 
   getHttpBaseUrl() {
     const fallback = typeof config?.get === 'function' ? config.get('api.baseUrl') : undefined;
-    const raw = this.config?.baseUrl
-      || this.config?.api?.baseUrl
-      || fallback
-      || platform.resolveHttpUrl({ port: '8000' });
-    return typeof raw === 'string' && raw.endsWith('/') ? raw.slice(0, -1) : raw;
+    const raw = _firstString(
+      this.config?.baseUrl,
+      this.config?.api?.baseUrl,
+      fallback,
+      platform.resolveHttpUrl()
+    );
+    return _trimTrailingSlash(raw);
   }
 
   getWsBaseUrl() {
     const fallback = typeof config?.get === 'function' ? config.get('api.wsUrl') : undefined;
-    const raw = this.config?.wsUrl
-      || this.config?.api?.wsUrl
-      || fallback
-      || platform.resolveWsUrl({ port: '8000' });
-    return typeof raw === 'string' && raw.endsWith('/') ? raw.slice(0, -1) : raw;
+    const raw = _firstString(
+      this.config?.wsUrl,
+      this.config?.api?.wsUrl,
+      fallback
+    );
+    if (raw && raw.trim()) return _trimTrailingSlash(raw);
+
+    const httpBase = this.getHttpBaseUrl();
+    if (httpBase && httpBase.trim()) {
+      return _trimTrailingSlash(httpBase.replace(/^http/, 'ws'));
+    }
+
+    return _trimTrailingSlash(platform.resolveWsUrl());
   }
 
   async sendMessage(_message, _appId, _userId) {

--- a/chat-ui/src/admin/components/AdminPrimitives.jsx
+++ b/chat-ui/src/admin/components/AdminPrimitives.jsx
@@ -16,7 +16,7 @@ import AdminSchemaPanel from './AdminSchemaPanel.jsx'
 
 const API_BASE =
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_URL) ||
-  'http://localhost:8000'
+  ''
 
 // ---------------------------------------------------------------------------
 // Data hook — fetches from the mozaiksai runtime

--- a/chat-ui/src/admin/pages/SettingsSection.jsx
+++ b/chat-ui/src/admin/pages/SettingsSection.jsx
@@ -25,7 +25,8 @@ export function SettingsSection({ extensionPanels }) {
   const backendUrl = config?.appBackendUrl || config?.app_backend_url || null
   const apiUrl =
     (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_URL) ||
-    'http://localhost:8000'
+    ''
+  const displayedApiUrl = apiUrl || 'same-origin'
 
   return (
     <SectionFrame
@@ -36,7 +37,7 @@ export function SettingsSection({ extensionPanels }) {
       <div className="grid gap-3 sm:grid-cols-2">
         <ConfigRow label="App Name"    value={appName}     mono={false} />
         <ConfigRow label="App ID"      value={appId} />
-        <ConfigRow label="Runtime API" value={apiUrl} />
+        <ConfigRow label="Runtime API" value={displayedApiUrl} />
         <ConfigRow label="Backend URL" value={backendUrl} />
       </div>
 

--- a/chat-ui/src/config/index.js
+++ b/chat-ui/src/config/index.js
@@ -8,8 +8,8 @@ class ChatUIConfig {
 
   loadConfig() {
     const defaultAuthMode = 'token';
-    const defaultApiBaseUrl = platform.resolveHttpUrl({ port: '8000' });
-    const defaultWsBaseUrl = platform.resolveWsUrl({ port: '8000' });
+    const defaultApiBaseUrl = platform.resolveHttpUrl();
+    const defaultWsBaseUrl = platform.resolveWsUrl();
     
     const defaultConfig = {
       // API Configuration

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -1840,13 +1840,19 @@ def _normalize_shell_page_entry(entry: dict, *, order_fallback: int) -> dict | N
         return None
 
     meta = entry.get("meta") if isinstance(entry.get("meta"), dict) else {}
+    normalized_meta = _normalize_route_requires_role_meta(meta)
+    requires_auth = (
+        entry["requiresAuth"]
+        if "requiresAuth" in entry
+        else normalized_meta.get("requiresAuth", True)
+    )
     page: dict = {
         "path": path,
         "label": entry.get("label", ""),
         "order": entry.get("order", order_fallback),
         "meta": {
-            **_normalize_route_requires_role_meta(meta),
-            "requiresAuth": entry.get("requiresAuth", True),
+            **normalized_meta,
+            "requiresAuth": requires_auth,
         },
     }
     shell_mode = _shell_mode_from_entry(entry)

--- a/tests/test_route_auth_metadata.py
+++ b/tests/test_route_auth_metadata.py
@@ -249,6 +249,29 @@ def test_route_manifest_requires_auth_still_enforced(monkeypatch, tmp_path: Path
     )
 
 
+def test_route_manifest_meta_requires_auth_false_passes_through(monkeypatch, tmp_path: Path) -> None:
+    """meta.requiresAuth: false must not be overwritten by the shell route normalizer."""
+    from mozaiksai.hosts import platform as platform_app
+
+    pages = [
+        {
+            "id": "login",
+            "label": "Sign In",
+            "path": "/login",
+            "component": "LoginPage",
+            "meta": {"requiresAuth": False, "appShell": False},
+        }
+    ]
+    app_root = _make_app_root(tmp_path, pages=pages)
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+
+    shell = asyncio.run(platform_app.build_shell_config(surface="platform"))
+
+    matching = [p for p in shell["pages"] if p["path"] == "/login"]
+    assert matching
+    assert matching[0]["meta"].get("requiresAuth") is False
+
+
 # ---------------------------------------------------------------------------
 # 4. routeAuth is enforced by RouteWrapper
 # ---------------------------------------------------------------------------

--- a/tests/test_route_auth_metadata_alignment.py
+++ b/tests/test_route_auth_metadata_alignment.py
@@ -135,6 +135,32 @@ def test_build_shell_config_preserves_requiresrole_route_metadata(
     assert matching[0]["meta"]["requiresRole"] == "admin"
 
 
+def test_build_shell_config_preserves_route_manifest_meta_requiresauth_false(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = _make_app_root(
+        tmp_path,
+        route_manifest_pages=[
+            {
+                "id": "login",
+                "label": "Sign In",
+                "path": "/login",
+                "component": "LoginPage",
+                "meta": {"requiresAuth": False, "appShell": False},
+            }
+        ],
+    )
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+
+    shell = asyncio.run(platform_app.build_shell_config(surface="platform"))
+
+    matching = [page for page in shell["pages"] if page["path"] == "/login"]
+    assert matching
+    assert matching[0]["meta"]["requiresAuth"] is False
+
+
 def test_build_shell_config_normalizes_page_schema_roles_in_shell_output(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_studio_overview_surface.py
+++ b/tests/test_studio_overview_surface.py
@@ -85,6 +85,23 @@ def test_app_shell_uses_single_app_ui_registration_barrel() -> None:
     assert "register(componentRegistry.registerComponent.bind(componentRegistry));" in source
 
 
+def test_app_shell_uses_same_origin_api_base_when_vite_api_url_is_unset() -> None:
+    source = _read("web_shell/App.jsx")
+    assert "apiBaseUrl = import.meta.env.VITE_API_URL ?? ''" in source
+    assert "baseUrl: apiBaseUrl" in source
+    assert "baseUrl: import.meta.env.VITE_API_URL || 'http://localhost:8000'" not in source
+
+    adapter_source = _read("chat-ui/src/adapters/api.js")
+    assert "platform.resolveHttpUrl()" in adapter_source
+    assert "platform.resolveHttpUrl({ port: '8000' })" not in adapter_source
+
+    admin_source = _read("chat-ui/src/admin/components/AdminPrimitives.jsx")
+    settings_source = _read("chat-ui/src/admin/pages/SettingsSection.jsx")
+    assert "'http://localhost:8000'" not in admin_source
+    assert "'http://localhost:8000'" not in settings_source
+    assert "same-origin" in settings_source
+
+
 def test_app_overview_page_fetches_summary_endpoint() -> None:
     source = _read("factory_app/app/admin/pages/AppOverviewPage.jsx")
     chrome_source = _read("factory_app/app/admin/pages/AppStudioChrome.jsx")

--- a/web_shell/App.jsx
+++ b/web_shell/App.jsx
@@ -18,9 +18,16 @@ register(componentRegistry.registerComponent.bind(componentRegistry));
 // ── API adapter ────────────────────────────────────────────────────────────
 // apiUrl and wsUrl come from the platform's app.json or env vars.
 // Vite proxies /api and /ws to apiUrl during dev (see vite.config.js).
+const apiBaseUrl = import.meta.env.VITE_API_URL ?? '';
+const wsBaseUrl = import.meta.env.VITE_WS_URL || (
+  apiBaseUrl ? apiBaseUrl.replace(/^http/, 'ws') : undefined
+);
+
 const apiAdapter = new WebSocketApiAdapter({
-  baseUrl: import.meta.env.VITE_API_URL || 'http://localhost:8000',
-  wsUrl:   import.meta.env.VITE_WS_URL  || 'ws://localhost:8000',
+  // Empty string is intentional: deployed single-origin apps should call
+  // /api on the current host. Local Vite dev proxies that relative path.
+  baseUrl: apiBaseUrl,
+  ...(wsBaseUrl ? { wsUrl: wsBaseUrl } : {}),
 });
 
 // ── Auth adapter ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Preserve `meta.requiresAuth: false` from app route manifests when building shell config.
- Default deployed web shell/admin API calls to same-origin when `VITE_API_URL` is unset.
- Add route/auth and static shell regression coverage for generated hosted apps.

## Validation
- `pytest --no-cov tests\\test_route_auth_metadata.py tests\\test_route_auth_metadata_alignment.py tests\\test_studio_overview_surface.py`

## App Zero Context
This fixes generic framework behavior found while rehearsing `mozaiks-app` staging: login routes can opt out of auth via route manifest metadata, and generated hosted apps should not call `localhost:8000` in production when no explicit API URL is configured.