### PR TITLE
Allow factory profile route override

### DIFF
--- a/chat-ui/src/platform/index.js
+++ b/chat-ui/src/platform/index.js
@@ -197,6 +197,7 @@ export const platform = {
 };
 
 export { createToolsLogger } from './workflowSurfaceRuntime.js';
+export { workflowSurfaceStyles, workflowToolbarButtonClass } from './workflowSurfaceStyles.js';
 export {
   useTransitionMotion,
   useTransitionChoiceMotion,

--- a/chat-ui/src/platform/workflowSurfaceStyles.js
+++ b/chat-ui/src/platform/workflowSurfaceStyles.js
@@ -1,0 +1,27 @@
+export const workflowSurfaceStyles = {
+  panel: 'rounded-2xl border border-border bg-card p-0 overflow-hidden',
+  primaryPanel: 'rounded-2xl border border-primary bg-card p-0 overflow-hidden',
+  darkPanel: 'rounded-2xl border border-border bg-card p-0 overflow-hidden',
+  assistiveText: 'text-xs font-sans text-muted-foreground',
+  errorText: 'text-xs font-sans text-destructive',
+  buttonGroup: 'flex items-center gap-3',
+  secondaryButton:
+    'rounded-lg border border-border bg-card px-4 py-2 text-sm font-sans text-muted-foreground transition hover:border-border hover:bg-muted disabled:opacity-60 flex-1',
+  primaryButton:
+    'rounded-lg bg-primary px-6 py-3 text-xs font-sans font-bold uppercase tracking-wide text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-60 flex-1',
+  skipButton:
+    'rounded-lg border border-border bg-card px-6 py-3 text-xs font-sans font-bold uppercase tracking-wide text-muted-foreground transition-all hover:bg-muted disabled:opacity-60 flex-1',
+  toolbarButtonBase:
+    'px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors inline-flex items-center gap-2',
+  toolbarButtonActive:
+    'bg-[rgba(var(--color-primary-rgb),0.25)] border border-[rgba(var(--color-primary-rgb),0.35)] text-white',
+  toolbarButtonInactive:
+    'bg-white/5 hover:bg-white/10 border border-white/10 text-[var(--color-text-secondary)]',
+}
+
+export function workflowToolbarButtonClass(active) {
+  return [
+    workflowSurfaceStyles.toolbarButtonBase,
+    active ? workflowSurfaceStyles.toolbarButtonActive : workflowSurfaceStyles.toolbarButtonInactive,
+  ].join(' ')
+}

--- a/factory_app/app/admin/index.js
+++ b/factory_app/app/admin/index.js
@@ -97,5 +97,6 @@ export function registerAdminComponents(registerComponent) {
 
   registerComponent('ProfilePage', ProfilePage, {
     description: 'User profile surface — account identity, avatar, bio, and profile preferences.',
+    override: true,
   })
 }

--- a/factory_app/workflows/AgentGenerator/ui/AgentAPIKeysBundleInput.js
+++ b/factory_app/workflows/AgentGenerator/ui/AgentAPIKeysBundleInput.js
@@ -5,6 +5,7 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { createToolsLogger } from '@mozaiks/chat-ui/platform/workflowSurfaceRuntime.js';
+import { workflowSurfaceStyles } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
 
 const toTitle = (value = '') => {
   return value
@@ -140,12 +141,12 @@ const AgentAPIKeysBundleInput = ({
     ]
       .filter(Boolean)
       .join(' ');
-  const assistiveTextClasses = 'text-xs font-sans text-muted-foreground';
-  const errorTextClasses = 'text-xs font-sans text-destructive';
-  const buttonGroup = 'flex items-center gap-3';
-  const secondaryButtonClasses = 'rounded-lg border border-border bg-card px-4 py-2 text-sm font-sans text-muted-foreground transition hover:border-border hover:bg-muted disabled:opacity-60 flex-1';
-  const primaryButtonClasses = 'rounded-lg bg-primary px-6 py-3 text-xs font-sans font-bold uppercase tracking-wide text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-60 flex-1';
-  const skipButtonClasses = 'rounded-lg border border-border bg-card px-6 py-3 text-xs font-sans font-bold uppercase tracking-wide text-muted-foreground transition-all hover:bg-muted disabled:opacity-60 flex-1';
+  const assistiveTextClasses = workflowSurfaceStyles.assistiveText;
+  const errorTextClasses = workflowSurfaceStyles.errorText;
+  const buttonGroup = workflowSurfaceStyles.buttonGroup;
+  const secondaryButtonClasses = workflowSurfaceStyles.secondaryButton;
+  const primaryButtonClasses = workflowSurfaceStyles.primaryButton;
+  const skipButtonClasses = workflowSurfaceStyles.skipButton;
 
   const heading = (() => {
     const explicit = typeof payload.heading === 'string' ? payload.heading.trim() : '';

--- a/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
+++ b/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
@@ -7,6 +7,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { Code, LayoutGrid, Monitor } from 'lucide-react';
 import { useWorkflowStart } from '@mozaiks/chat-ui/hooks/useWorkflowStart.js';
 import { useChatUI } from '@mozaiks/chat-ui/context/ChatUIContext.jsx';
+import { workflowSurfaceStyles, workflowToolbarButtonClass } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
 import { useAppValidationWorkbench } from './useAppValidationWorkbench';
 import { useSandbox } from './useSandbox';
 import BuildStatusArtifact from './BuildStatusArtifact';
@@ -123,15 +124,9 @@ const AppWorkbench = ({
     return 'Validation is pending. Review the bundle and wait for validation or skip explicitly.';
   }, [payload, validationStatus]);
 
-  const panelClass = 'rounded-2xl border border-border bg-card p-0 overflow-hidden';
+  const panelClass = workflowSurfaceStyles.darkPanel;
 
-  const toolbarBtn = (active) =>
-    [
-      'px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors inline-flex items-center gap-2',
-      active
-        ? 'bg-[rgba(var(--color-primary-rgb),0.25)] border border-[rgba(var(--color-primary-rgb),0.35)] text-white'
-        : 'bg-white/5 hover:bg-white/10 border border-white/10 text-[var(--color-text-secondary)]',
-    ].join(' ');
+  const toolbarBtn = workflowToolbarButtonClass;
 
   const showSplit = view === 'split';
   const showCode = view === 'code-only';

--- a/factory_app/workflows/ValueEngine/ui/ValueEngine/components/ConceptBlueprint.js
+++ b/factory_app/workflows/ValueEngine/ui/ValueEngine/components/ConceptBlueprint.js
@@ -14,6 +14,7 @@ import {
   Sparkles,
   Target,
 } from 'lucide-react';
+import { workflowSurfaceStyles } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
 
 const asText = (value) => (typeof value === 'string' ? value.trim() : '');
 
@@ -81,7 +82,7 @@ const ConceptBlueprint = ({ payload = {}, toolCallId, sourceWorkflowName, genera
   const capabilityPackHints = blueprint?.capability_pack_hints || blueprint?.capabilityPackHints;
   const agenticCapabilities = blueprint?.agentic_capabilities || blueprint?.agenticCapabilities;
 
-  const panelClass = 'rounded-2xl border border-primary bg-card p-0 overflow-hidden';
+  const panelClass = workflowSurfaceStyles.primaryPanel;
 
   return (
     <div className={panelClass}>

--- a/tests/test_build_surface.py
+++ b/tests/test_build_surface.py
@@ -81,6 +81,9 @@ def test_factory_app_ui_barrel_registers_admin_pages_and_omits_removed_pages() -
     assert "registerComponent('WorkspaceHostingPage'" not in admin_source
     assert "registerComponent('AppHealthPage'" in admin_source
     assert "registerComponent('AppAccessPage'" in admin_source
+    assert "registerComponent('ProfilePage', ProfilePage, {" in admin_source
+    assert "User profile surface" in admin_source
+    assert "override: true" in admin_source
     assert "registerComponent('AppHostingPage'" not in admin_source
     assert "./pages/AppHealthPage.jsx" in admin_source
     assert "./pages/AppAccessPage.jsx" in admin_source


### PR DESCRIPTION
## Summary
- Register the factory `ProfilePage` with `override: true` so it can replace the core registry entry without console warnings.
- Add a static regression guard for the factory admin registration contract.

## Validation
- `pytest --no-cov tests\\test_build_surface.py tests\\test_profile_contract.py tests\\test_unified_admin_surface.py tests\\test_studio_overview_surface.py`

## App Zero Context
Found during `mozaiks-app` staging user-flow rehearsal. Generated and hosted app shells should load factory account/profile routes without duplicate component warnings.