### PR TITLE
fix: handler class names, run-infra exit code, Vite 8 Rolldown JSX

### DIFF
--- a/factory_app/build_context/messaging/templates/modules/messages/module.yaml
+++ b/factory_app/build_context/messaging/templates/modules/messages/module.yaml
@@ -6,7 +6,7 @@ module:
   description: Internal app messaging for user conversations, support threads, read state, and notification fan-out.
   owner: app
   visibility: private
-  handler: backend.handler:MessagesModule
+  handler: backend.handler:MessagesHandler
 
 permissions:
   - id: messages.read

--- a/factory_app/build_context/support/templates/modules/support/module.yaml
+++ b/factory_app/build_context/support/templates/modules/support/module.yaml
@@ -6,7 +6,7 @@ module:
   description: App support request metadata. Conversation bodies are stored in the messages module.
   owner: app
   visibility: private
-  handler: backend.handler:SupportModule
+  handler: backend.handler:SupportHandler
 
 permissions:
   - id: support.read

--- a/scripts/run-infra.ps1
+++ b/scripts/run-infra.ps1
@@ -27,6 +27,13 @@ Write-Host ("[infra] Starting profile '{0}' via docker compose..." -f $Profile) 
 Write-Host ("[infra] Services: {0}" -f ($services -join ", ")) -ForegroundColor DarkGray
 
 docker compose -f $ComposeFile up -d @services
+$composeExitCode = $LASTEXITCODE
+if ($composeExitCode -ne 0) {
+  Write-Host ("[infra] Docker Compose failed with exit code {0}." -f $composeExitCode) -ForegroundColor Red
+  Write-Host "[infra] Start Docker Desktop and rerun this command." -ForegroundColor Yellow
+  Write-Host "[infra] Use -SkipInfra only when MongoDB is already running on localhost:27017." -ForegroundColor Yellow
+  exit $composeExitCode
+}
 
 if ($Profile -eq "example") {
   Write-Host "[infra] Example infra started. Mongo: localhost:27017, Keycloak: http://localhost:8080" -ForegroundColor Green

--- a/tests/test_runtime_artifact_cleanup.py
+++ b/tests/test_runtime_artifact_cleanup.py
@@ -93,3 +93,13 @@ def test_runtime_cleanup_scripts_are_available() -> None:
     assert "CLEAR_RUNTIME_ARTIFACTS_ON_START=0" in env_example
     assert "MOZAIKS_AGENT_OUTPUTS_DIR=logs/agent_outputs" in env_example
 
+
+def test_run_infra_fails_when_docker_compose_fails() -> None:
+    run_infra = _read("scripts/run-infra.ps1")
+
+    assert "$composeExitCode = $LASTEXITCODE" in run_infra
+    assert "Docker Compose failed with exit code" in run_infra
+    assert "Start Docker Desktop and rerun this command." in run_infra
+    assert "Use -SkipInfra only when MongoDB is already running on localhost:27017." in run_infra
+    assert "Example infra started" in run_infra
+

--- a/tests/test_web_shell_vite_config.py
+++ b/tests/test_web_shell_vite_config.py
@@ -107,6 +107,37 @@ class TestResolveDedupe:
 
 # ── resolve.alias for React ─────────────────────────────────────────────────
 
+
+class TestDependencyScannerJsx:
+    """
+    The Vite dev dependency scanner runs before the jsx-in-js transform plugin.
+
+    web_shell imports first-party source files from chat-ui, factory_app, and
+    active app workspaces. Some of those canonical UI files still use JSX inside
+    .js modules. Vite 8 scans dependencies with Rolldown, so optimizeDeps must
+    teach Rolldown to parse .js as JSX or local Studio startup fails before the
+    app is served.
+    """
+
+    def test_rolldown_dependency_scan_parses_js_files_as_jsx(self) -> None:
+        source = _vite_config()
+        optimize_deps_region = _extract_object_region(source, "optimizeDeps:")
+        assert "rolldownOptions" in optimize_deps_region, (
+            "web_shell/vite.config.js must configure optimizeDeps.rolldownOptions "
+            "for Vite 8 dependency scanning."
+        )
+        assert "moduleTypes" in optimize_deps_region, (
+            "optimizeDeps.rolldownOptions.moduleTypes must be present so the "
+            "dependency scanner can parse first-party JSX-in-.js files."
+        )
+        assert re.search(r"['\"]\.js['\"]\s*:\s*['\"]jsx['\"]", optimize_deps_region), (
+            "optimizeDeps.rolldownOptions.moduleTypes must map '.js' to 'jsx' "
+            "or Vite dev startup fails while scanning chat-ui/factory_app UI files."
+        )
+
+
+# ── resolve.alias for React ─────────────────────────────────────────────────
+
 class TestReactAlias:
     """
     The resolve.alias block must pin React and react-dom to web_shell's copy.
@@ -192,4 +223,29 @@ def _extract_dedupe_region(source: str) -> str:
     end_match = re.search(r"dedupe\s*:\s*\[([^\]]*)\]", source[idx:], re.DOTALL)
     end = idx + (end_match.end() if end_match else 100)
     return source[start:end]
+
+
+def _extract_object_region(source: str, marker: str) -> str:
+    """
+    Return the brace-delimited object region that follows a property marker.
+    This is intentionally small and source-oriented; it only supports the
+    static Vite config patterns these contract tests guard.
+    """
+    marker_idx = source.find(marker)
+    if marker_idx == -1:
+        return ""
+    brace_idx = source.find("{", marker_idx)
+    if brace_idx == -1:
+        return ""
+
+    depth = 0
+    for idx in range(brace_idx, len(source)):
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_idx : idx + 1]
+    return source[brace_idx:]
 

--- a/web_shell/vite.config.js
+++ b/web_shell/vite.config.js
@@ -364,6 +364,12 @@ export default defineConfig(({ mode }) => {
 
   optimizeDeps: {
     rolldownOptions: {
+      // Vite 8 uses Rolldown for dependency scanning before normal plugins run.
+      // Several first-party UI files intentionally use JSX in .js modules, so
+      // the scanner must parse .js the same way the jsx-in-js transform does.
+      moduleTypes: {
+        '.js': 'jsx',
+      },
       plugins: [],
     },
   },


### PR DESCRIPTION
## Summary

Three independent fixes discovered while running the full test suite:

**1. Handler class name mismatch (messaging, support packs)**
After the base_handler/handler split renamed `MessagesModule` → `MessagesHandler` and `SupportModule` → `SupportHandler` in their `handler.py` files, `module.yaml` still declared the old class names. `ModuleLoader` raises `ModuleLoadError` when the declared class isn't found — broke `test_messaging_template_module_loads_with_domain_events`.

**2. `run-infra.ps1` docker compose exit code**
When Docker Desktop is not running, `docker compose up` fails but the script continued and reported success. Now captures `$LASTEXITCODE`, prints an actionable message, and exits with the same code.

**3. Vite 8 Rolldown `moduleTypes` for JSX-in-.js**
Vite 8 uses Rolldown for the `optimizeDeps` pre-scan before transform plugins run. First-party chat-ui and factory_app UI files use JSX inside `.js` modules. Without `moduleTypes: { '.js': 'jsx' }`, the Rolldown scanner crashes on those files and the dev server never starts.

## Tests

- `tests/test_appgenerator_capability_pack_selection.py` — fixes the failing messaging/support load tests
- `tests/test_runtime_artifact_cleanup.py::test_run_infra_fails_when_docker_compose_fails` — new
- `tests/test_web_shell_vite_config.py::TestDependencyScannerJsx` — new

All 41 tests in the three touched files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)