### PR TITLE
fix(validation): resolve handler methods through base-class inheritance in acceptance gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Fixed `validate_module_implementation_contract` to resolve handler methods through single-level base class inheritance within the same module's `backend/` directory. The `base_handler.py`/`handler.py` split pattern previously caused the acceptance gate to report every action as missing a handler method on the thin workspace subclass.
 - Fixed messaging and support pack `module.yaml` handler entrypoints: after the `base_handler.py`/`handler.py` split renamed workspace subclasses from `MessagesModule`/`SupportModule` to `MessagesHandler`/`SupportHandler`, `module.yaml` still declared the old class names, causing `ModuleLoadError` at runtime and in tests.
 - Fixed `scripts/run-infra.ps1` to propagate the `docker compose up` exit code and print an actionable error message when Docker Desktop is not running. Previously the script silently continued on failure.
 - Fixed Vite 8 dev-server startup: added `optimizeDeps.rolldownOptions.moduleTypes: { '.js': 'jsx' }` so the Rolldown pre-scan can parse first-party JSX-in-.js UI files before the transform plugin runs.

--- a/factory_app/workflows/AppGenerator/tools/app_validation.py
+++ b/factory_app/workflows/AppGenerator/tools/app_validation.py
@@ -511,6 +511,52 @@ def _class_method_nodes(
     return None
 
 
+def _resolve_handler_methods(
+    handler_tree: ast.Module,
+    class_name: str,
+    module_id: str,
+    parsed_backend: dict[str, ast.Module],
+) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef] | None:
+    """Return method nodes for class_name, merging inherited methods from base
+    classes declared in the same module's backend directory.
+
+    Supports the base_handler.py + handler.py split pattern where the workspace
+    subclass is a thin override layer and all canonical methods live in the OSS
+    base handler.  Returns None only when the class itself is not found.
+    """
+    own = _class_method_nodes(handler_tree, class_name)
+    if own is None:
+        return None
+
+    # Collect simple base-class names from the class AST definition.
+    base_names: list[str] = []
+    for node in handler_tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for base in node.bases:
+                if isinstance(base, ast.Name):
+                    base_names.append(base.id)
+            break
+
+    if not base_names:
+        return own
+
+    # Look for base class methods in any backend file within the same module.
+    backend_prefix = f"modules/{module_id}/backend/"
+    inherited: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for base_name in base_names:
+        for path, tree in parsed_backend.items():
+            if not path.startswith(backend_prefix):
+                continue
+            base_methods = _class_method_nodes(tree, base_name)
+            if base_methods is not None:
+                for method_name, method_node in base_methods.items():
+                    inherited.setdefault(method_name, method_node)
+
+    # Own methods take precedence over inherited ones.
+    inherited.update(own)
+    return inherited
+
+
 def _all_method_nodes(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
     methods: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
     for node in tree.body:
@@ -760,7 +806,7 @@ def validate_module_implementation_contract(files: dict[str, str]) -> dict[str, 
             module_reports.append(module_report)
             continue
 
-        methods = _class_method_nodes(handler_tree, class_name)
+        methods = _resolve_handler_methods(handler_tree, class_name, module_id, parsed_backend)
         if methods is None:
             failed_tests.append(
                 {


### PR DESCRIPTION
## Summary

- `validate_module_implementation_contract` now walks single-level base class inheritance within the same module's `backend/` directory via new `_resolve_handler_methods` helper
- Fixes false-positive failures from the `base_handler.py`/`handler.py` split pattern: the workspace subclass is intentionally thin, so methods live on the base class, not the subclass
- Updates CHANGELOG

## Root cause

The `billing_portal` module declares `handler: backend.handler:BillingPortalHandler`. `BillingPortalHandler` subclasses `BillingPortalBaseHandler` (in `base_handler.py`) and overrides nothing. The acceptance gate's `_class_method_nodes` only returned methods *defined on* the named class, so it found zero methods and failed every action check.

## Test plan

- [x] `pytest tests/test_managed_capability_artifact_replay.py::test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance` — passes
- [x] Full test suite — pre-existing failures only (`test_source_hygiene_scan` and `test_frontend_prompts_distinguish_settings_from_account_profile`), no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)