### PR TITLE
feat(platform): inject token usage surfaces for generated apps with token_wallets

### DIFF
--- a/factory_app/build_context/mozaikspay/contract.yaml
+++ b/factory_app/build_context/mozaikspay/contract.yaml
@@ -77,6 +77,10 @@ required_outputs:
     owner: templates
   - path: modules/billing_portal/contracts/reactions.yaml
     owner: templates
+  - path: modules/billing_portal/contracts/profile.yaml
+    owner: templates
+  - path: modules/billing_portal/contracts/admin.yaml
+    owner: templates
   - path: ui/pages/billing.yaml
     owner: templates
   - path: ui/pages/usage.yaml

--- a/factory_app/build_context/mozaikspay/templates/modules/billing_portal/contracts/admin.yaml
+++ b/factory_app/build_context/mozaikspay/templates/modules/billing_portal/contracts/admin.yaml
@@ -1,0 +1,28 @@
+schema_version: mozaiks.admin.v2
+
+# Admin panels contributed by the billing_portal facade module.
+# Two distinct panels — keep them separate:
+#   my-usage   : the signed-in admin's own token balance (personal)
+#   app-usage  : aggregate usage across all end users of this app (operational)
+
+panels:
+  - id: my-usage
+    label: My Token Usage
+    page: usage
+    order: 10
+    renderer: custom_component
+    component: AdminMyUsagePanel
+    description: >
+      Your personal AI token balance and usage this period. Balance includes
+      any top-up credits purchased. Does not include other users' consumption.
+
+  - id: app-usage
+    label: App Usage
+    page: usage
+    order: 20
+    renderer: custom_component
+    component: AdminAppUsagePanel
+    description: >
+      Aggregate AI token consumption across all end users of this app.
+      Total tokens consumed, active user count, and per-wallet balance
+      totals. Sourced from the OSS runtime ledger — provider-neutral.

--- a/factory_app/build_context/mozaikspay/templates/modules/billing_portal/contracts/profile.yaml
+++ b/factory_app/build_context/mozaikspay/templates/modules/billing_portal/contracts/profile.yaml
@@ -1,0 +1,17 @@
+schema_version: mozaiks.profile.v1
+
+# Declares a Tokens tab on the user profile page (/me).
+# The platform hydrates the tab by calling get_token_status and passes the
+# result as `data` to the registered TokenStatusTab component.
+#
+# The platform also injects a built-in Tokens tab for any app whose
+# subscriptions.yaml declares token_wallets. This profile.yaml overrides
+# that built-in by claiming the same id, allowing the billing_portal module
+# to own the tab and customise the component when the mozaikspay pack is used.
+
+tabs:
+  - id: tokens
+    label: Tokens
+    order: 80
+    action: get_token_status
+    component: TokenStatusTab

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -1477,6 +1477,7 @@ async def get_current_user_token_ledger(
     }
 
 
+
 @app.put("/api/me/preferences")
 async def update_current_user_preferences(
     body: ProfilePreferencesUpdateRequest,
@@ -1790,6 +1791,33 @@ async def get_profile_tabs(
                 tab_out["error"] = f"Action {action!r} failed"
 
         hydrated.append(tab_out)
+
+    # Inject a built-in Tokens tab when the app declares token_wallets in
+    # subscriptions.yaml. This is provider-neutral — no MozaiksPay dependency.
+    subscriptions = getattr(app.state, "subscriptions_config", None)
+    if subscriptions is not None and getattr(subscriptions, "token_wallets", None):
+        # Only inject when no module-declared tab already claims the id "tokens".
+        if not any(t.get("id") == "tokens" for t in hydrated):
+            tokens_data = await _current_user_token_wallet_summary(
+                subscriptions,
+                app_id=resolved_app_id,
+                user_id=subject_user_id or viewer_user_id,
+                tenant_id=str(principal.tenant_id) if principal.tenant_id else None,
+                workspace_id=str(principal.workspace_id) if principal.workspace_id else None,
+                ensure_allowances=False,
+            )
+            hydrated.append(
+                {
+                    "id": "tokens",
+                    "label": "Tokens",
+                    "order": 80,
+                    "component": "TokenStatusTab",
+                    "data": tokens_data,
+                    "error": None,
+                    "source": "platform_builtin",
+                }
+            )
+            hydrated.sort(key=lambda t: t.get("order") or 100)
 
     logger.info(
         "[profile-tabs] load complete runtime_app_id=%s requested_app_id=%s hydrated_count=%s tab_ids=%s",


### PR DESCRIPTION
## Summary

- **`/api/me/profile-tabs`**: Auto-injects a built-in `Tokens` tab (`TokenStatusTab` component) when the app's `subscriptions.yaml` declares `token_wallets` and no module-declared tab already claims the `tokens` id. The mozaikspay `billing_portal` module overrides this built-in via its own `profile.yaml` contract.
- **`billing_portal/contracts/profile.yaml`**: New template file declaring the `TokenStatusTab` component for generated apps using the mozaikspay capability pack.
- **`billing_portal/contracts/admin.yaml`**: New template file declaring `AdminMyUsagePanel` (personal token balance) and `AdminAppUsagePanel` (app-wide aggregate) on the `usage` admin page. Uses `mozaiks.admin.v2` schema — fixes the failing acceptance test.

## Test plan

- [x] `test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance` — was failing due to invalid `admin.yaml` schema (v1 fields); now passes with v2 schema
- [x] `test_admin_router_persisted_usage` — unchanged, still passes
- [x] Full test suite: 7634 passed, 1 pre-existing hygiene failure (unrelated git worktree file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)