### PR TITLE
feat(ui): token usage display components — TokenStatusTab, AdminMyUsagePanel, AdminAppUsagePanel

### DIFF
--- a/chat-ui/src/admin/components/AdminAppUsagePanel.jsx
+++ b/chat-ui/src/admin/components/AdminAppUsagePanel.jsx
@@ -1,0 +1,140 @@
+/**
+ * AdminAppUsagePanel — admin portal panel showing aggregate AI token
+ * consumption across all end users of this app.
+ *
+ * Registered as a custom_component panel on the Usage admin page.
+ * Fetches from /api/admin/usage (admin-gated OSS endpoint) and renders
+ * per-wallet balance totals sourced from the runtime token wallet ledger.
+ *
+ * Panel props: { panel, apiBaseUrl, auth }
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchWithAuth(url, auth) {
+  const token = await auth?.getToken?.()
+  const headers = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+function fmt(n) {
+  return typeof n === 'number' ? n.toLocaleString() : '—'
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function WalletTotalRow({ wallet }) {
+  const { label, wallet_id, total_balance_remaining, total_credited, total_debited, active_scopes } = wallet
+  return (
+    <div className="rounded-xl border border-border bg-card px-5 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-foreground">{label || wallet_id}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{fmt(active_scopes)} active user scope{active_scopes !== 1 ? 's' : ''}</p>
+        </div>
+        <div className="text-right">
+          <p className="tabular-nums text-sm font-medium text-foreground">{fmt(total_balance_remaining)} remaining</p>
+          <p className="mt-0.5 tabular-nums text-xs text-muted-foreground">
+            {fmt(total_credited)} credited · {fmt(total_debited)} used
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UsageSummary({ usage }) {
+  if (!usage) return null
+  const totalTokens = usage.totals?.total_tokens
+  const totalCalls = usage.totals?.total_calls ?? usage.totals?.event_count
+  if (!totalTokens && !totalCalls) return null
+  return (
+    <div className="grid grid-cols-2 gap-3 mb-4">
+      {totalTokens != null && (
+        <div className="rounded-xl border border-border bg-card px-4 py-3 text-center">
+          <p className="tabular-nums text-lg font-bold text-foreground">{fmt(totalTokens)}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Total tokens consumed</p>
+        </div>
+      )}
+      {totalCalls != null && (
+        <div className="rounded-xl border border-border bg-card px-4 py-3 text-center">
+          <p className="tabular-nums text-lg font-bold text-foreground">{fmt(totalCalls)}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">LLM calls</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-10">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
+function ErrorBox({ message }) {
+  return (
+    <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      {message}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export default function AdminAppUsagePanel({ panel, apiBaseUrl = '', auth }) {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const body = await fetchWithAuth(`${apiBaseUrl}/api/admin/usage`, auth)
+      setData(body)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [apiBaseUrl, auth])
+
+  useEffect(() => { load() }, [load])
+
+  if (loading) return <Spinner />
+  if (error) return <ErrorBox message={`Could not load app usage: ${error}`} />
+
+  const walletTotals = data?.wallet_totals ?? []
+
+  return (
+    <div>
+      <UsageSummary usage={data} />
+
+      {walletTotals.length > 0 ? (
+        <div className="space-y-3">
+          {walletTotals.map((wallet) => (
+            <WalletTotalRow key={wallet.wallet_id} wallet={wallet} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">
+          No wallet data yet. Token usage will appear here once users start consuming credits.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/chat-ui/src/admin/components/AdminMyUsagePanel.jsx
+++ b/chat-ui/src/admin/components/AdminMyUsagePanel.jsx
@@ -1,0 +1,126 @@
+/**
+ * AdminMyUsagePanel — admin portal panel showing the signed-in admin's
+ * personal AI token balance and usage.
+ *
+ * Registered as a custom_component panel on the Usage admin page.
+ * Fetches from /api/me/tokens (the same OSS endpoint the profile tab uses).
+ *
+ * Panel props: { panel, apiBaseUrl, auth }
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { SectionHeading } from './AdminPrimitives.jsx'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchWithAuth(url, auth) {
+  const token = await auth?.getToken?.()
+  const headers = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function UsageBar({ used, allowance, unit }) {
+  if (allowance == null || allowance <= 0) return null
+  const pct = Math.min(100, Math.max(0, (used / allowance) * 100))
+  const isLow = pct >= 80
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full transition-all ${isLow ? 'bg-warning' : 'bg-primary'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {used.toLocaleString()} of {allowance.toLocaleString()} {unit} used this period
+        {isLow && <span className="ml-2 font-medium text-warning">— running low</span>}
+      </p>
+    </div>
+  )
+}
+
+function WalletRow({ wallet }) {
+  const balance = wallet.balance ?? 0
+  const allowance = wallet.plan_allowances?.[0]?.token_amount ?? null
+  const used = allowance !== null ? Math.max(0, allowance - balance) : null
+  const unit = wallet.unit || 'tokens'
+
+  return (
+    <div className="rounded-xl border border-border bg-card px-5 py-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-sm font-semibold text-foreground">{wallet.label || wallet.wallet_id}</span>
+        <span className="tabular-nums text-sm font-medium text-foreground">
+          {balance.toLocaleString()}{' '}
+          <span className="font-normal text-muted-foreground">{unit} remaining</span>
+        </span>
+      </div>
+      {used !== null && allowance !== null && (
+        <UsageBar used={used} allowance={allowance} unit={unit} />
+      )}
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-10">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
+function ErrorBox({ message }) {
+  return (
+    <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      {message}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export default function AdminMyUsagePanel({ panel, apiBaseUrl = '', auth }) {
+  const [wallets, setWallets] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const body = await fetchWithAuth(`${apiBaseUrl}/api/me/tokens`, auth)
+      setWallets(body.wallets ?? [])
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [apiBaseUrl, auth])
+
+  useEffect(() => { load() }, [load])
+
+  if (loading) return <Spinner />
+  if (error) return <ErrorBox message={`Could not load token balance: ${error}`} />
+  if (!wallets || wallets.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">No token wallets configured.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      {wallets.map((wallet) => (
+        <WalletRow key={wallet.wallet_id} wallet={wallet} />
+      ))}
+    </div>
+  )
+}

--- a/chat-ui/src/components/profile/TokenStatusTab.jsx
+++ b/chat-ui/src/components/profile/TokenStatusTab.jsx
@@ -1,0 +1,179 @@
+/**
+ * TokenStatusTab — profile tab showing a user's AI token balance.
+ *
+ * Rendered on /me when the app declares token_wallets in subscriptions.yaml.
+ * Receives { tab, data } props from ProfilePage. The platform pre-hydrates
+ * `data` via the billing_portal module's get_token_status action (mozaikspay
+ * apps) or from the OSS built-in platform_builtin token tab injection.
+ *
+ * Data shape (from wallet_summaries_for_config or get_token_status):
+ *   { wallets: [{ wallet_id, label, unit, balance, plan_allowances: [{token_amount}] }],
+ *     plan_id, source }
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { useChatUI } from '../../context/ChatUIContext'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getApiBase(config, api) {
+  if (api && typeof api.getHttpBaseUrl === 'function') {
+    const base = api.getHttpBaseUrl()
+    if (typeof base === 'string') return base.replace(/\/+$/, '')
+  }
+  return (
+    config?.apiUrl ||
+    config?.api_url ||
+    (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_URL) ||
+    ''
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function UsageBar({ used, allowance, unit }) {
+  if (allowance == null || allowance <= 0) return null
+  const pct = Math.min(100, Math.max(0, (used / allowance) * 100))
+  const isLow = pct >= 80
+  const barClass = isLow ? 'bg-warning' : 'bg-primary'
+
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full transition-all ${barClass}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {used.toLocaleString()} of {allowance.toLocaleString()} {unit} used this period
+        {isLow && (
+          <span className="ml-2 font-medium text-warning">— running low</span>
+        )}
+      </p>
+    </div>
+  )
+}
+
+function WalletRow({ wallet }) {
+  const balance = wallet.balance ?? 0
+  const allowance = wallet.plan_allowances?.[0]?.token_amount ?? null
+  const used = allowance !== null ? Math.max(0, allowance - balance) : null
+  const unit = wallet.unit || 'tokens'
+
+  return (
+    <div className="rounded-2xl border border-border bg-card px-5 py-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-sm font-semibold text-foreground">
+          {wallet.label || wallet.wallet_id}
+        </span>
+        <span className="tabular-nums text-sm font-medium text-foreground">
+          {balance.toLocaleString()}{' '}
+          <span className="font-normal text-muted-foreground">{unit} remaining</span>
+        </span>
+      </div>
+
+      {used !== null && allowance !== null && (
+        <UsageBar used={used} allowance={allowance} unit={unit} />
+      )}
+
+      {allowance == null && (
+        <p className="mt-1 text-xs text-muted-foreground">No allowance configured for current plan.</p>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Empty / error states
+// ---------------------------------------------------------------------------
+
+function Empty() {
+  return (
+    <div className="py-12 text-center">
+      <p className="text-sm text-muted-foreground">No token wallets configured for this app.</p>
+    </div>
+  )
+}
+
+function ErrorBox({ message }) {
+  return (
+    <div className="rounded-2xl border border-destructive/30 bg-destructive/10 px-5 py-4 text-sm text-destructive">
+      {message}
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+/**
+ * TokenStatusTab
+ *
+ * Props:
+ *   tab   — the tab descriptor from /api/me/profile-tabs
+ *   data  — pre-hydrated wallet summary (may be null if hydration failed)
+ */
+export default function TokenStatusTab({ tab, data: preloaded }) {
+  const { config, auth, api } = useChatUI()
+  const apiBase = getApiBase(config, api)
+
+  const [wallets, setWallets] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    // Use pre-hydrated data when present and valid
+    if (preloaded?.wallets != null) {
+      setWallets(preloaded.wallets)
+      return
+    }
+    // Fall back to fetching /api/me/tokens
+    if (!apiBase) {
+      setWallets([])
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await auth?.getToken?.()
+      const headers = {}
+      if (token) headers['Authorization'] = `Bearer ${token}`
+      const res = await fetch(`${apiBase}/api/me/tokens`, { headers })
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+      const body = await res.json()
+      setWallets(body.wallets ?? [])
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [preloaded, apiBase, auth])
+
+  useEffect(() => { load() }, [load])
+
+  if (loading) return <Spinner />
+  if (error) return <ErrorBox message={`Could not load token balance: ${error}`} />
+  if (!wallets || wallets.length === 0) return <Empty />
+
+  return (
+    <div className="space-y-3">
+      {wallets.map((wallet) => (
+        <WalletRow key={wallet.wallet_id} wallet={wallet} />
+      ))}
+    </div>
+  )
+}

--- a/chat-ui/src/registry/coreComponents.js
+++ b/chat-ui/src/registry/coreComponents.js
@@ -26,6 +26,11 @@ import { LauncherScreen } from '../ui/screens/LauncherScreen.jsx';
 import { ConfirmScreen } from '../ui/screens/ConfirmScreen.jsx';
 import WorkflowCompletion from '../components/chat/WorkflowCompletion.jsx';
 
+// Token usage surfaces — profile tab + admin panels
+import TokenStatusTab from '../components/profile/TokenStatusTab.jsx';
+import AdminMyUsagePanel from '../admin/components/AdminMyUsagePanel.jsx';
+import AdminAppUsagePanel from '../admin/components/AdminAppUsagePanel.jsx';
+
 registerComponent('ChatPage', ChatPage, {
   core: true,
   description: 'Main chat interface page',
@@ -56,5 +61,20 @@ registerComponent('WorkflowCompletion', WorkflowCompletion, {
   description: 'Terminal transition screen shown when a workflow run completes with no server transition pending. Receives { transition, onResolve } from TransitionScreen.',
 });
 
-export const CORE_COMPONENTS = ['ChatPage', 'SchemaPage', 'LauncherScreen', 'ConfirmScreen', 'ProfilePage', 'WorkflowCompletion'];
+registerComponent('TokenStatusTab', TokenStatusTab, {
+  core: true,
+  description: 'Profile tab showing the signed-in user\'s AI token balance and usage bar. Receives { tab, data } from ProfilePage. Data shape: { wallets: [{ wallet_id, label, unit, balance, plan_allowances }] }.',
+});
+
+registerComponent('AdminMyUsagePanel', AdminMyUsagePanel, {
+  core: true,
+  description: 'Admin portal panel showing the signed-in admin\'s personal AI token balance. Fetches /api/me/tokens. Receives { panel, apiBaseUrl, auth }.',
+});
+
+registerComponent('AdminAppUsagePanel', AdminAppUsagePanel, {
+  core: true,
+  description: 'Admin portal panel showing aggregate AI token consumption across all app users. Fetches /api/admin/usage. Receives { panel, apiBaseUrl, auth }.',
+});
+
+export const CORE_COMPONENTS = ['ChatPage', 'SchemaPage', 'LauncherScreen', 'ConfirmScreen', 'ProfilePage', 'WorkflowCompletion', 'TokenStatusTab', 'AdminMyUsagePanel', 'AdminAppUsagePanel'];
 

--- a/mozaiksai/core/admin/router.py
+++ b/mozaiksai/core/admin/router.py
@@ -334,7 +334,13 @@ async def get_admin_usage(
     limit: int = Query(500, ge=1, le=1000, description="Max usage events to aggregate"),
     user: UserPrincipal = Depends(_require_admin),
 ):
-    """Return neutral token usage measurements from the runtime usage ledger."""
+    """Return token usage and wallet aggregate totals from the runtime ledgers.
+
+    Usage events come from the runtime usage ledger (LLM call metering).
+    wallet_totals are summed across all user/tenant scopes for the app
+    from the token wallet ledger — provider-neutral. Returns an empty list
+    when the wallet ledger is unavailable or no wallets are configured.
+    """
     try:
         from mozaiksai.core.usage import (
             get_runtime_token_budget_alert_ledger,
@@ -345,6 +351,44 @@ async def get_admin_usage(
         alert_ledger = get_runtime_token_budget_alert_ledger()
         usage = await ledger.query_usage(app_id=app_id, user_id=user_id, limit=limit)
         usage = await _enrich_usage_with_app_registry(usage)
+
+        wallet_totals: list[dict[str, Any]] = []
+        try:
+            from mozaiksai.core.tokens.wallet import get_token_wallet_ledger
+
+            token_ledger = get_token_wallet_ledger()
+            balances_coll, _ = await token_ledger._collections()
+            pipeline: list[dict[str, Any]] = [
+                *(
+                    [{"$match": {"app_id": app_id}}]
+                    if app_id
+                    else []
+                ),
+                {
+                    "$group": {
+                        "_id": "$wallet_id",
+                        "total_balance": {"$sum": "$balance"},
+                        "total_credited": {"$sum": "$total_credited"},
+                        "total_debited": {"$sum": "$total_debited"},
+                        "scope_count": {"$sum": 1},
+                    }
+                },
+            ]
+            wallet_docs = await balances_coll.aggregate(pipeline).to_list(length=100)
+            wallet_totals = [
+                {
+                    "wallet_id": doc["_id"],
+                    "label": doc["_id"],
+                    "total_balance_remaining": doc.get("total_balance", 0),
+                    "total_credited": doc.get("total_credited", 0),
+                    "total_debited": doc.get("total_debited", 0),
+                    "active_scopes": doc.get("scope_count", 0),
+                }
+                for doc in wallet_docs
+            ]
+        except Exception as wallet_exc:
+            logger.debug("[admin] wallet totals unavailable: %s", wallet_exc)
+
         return {
             **usage,
             "token_budget_alerts": await alert_ledger.query_alerts(
@@ -352,6 +396,7 @@ async def get_admin_usage(
                 user_id=user_id,
                 limit=min(limit, 100),
             ),
+            "wallet_totals": wallet_totals,
         }
     except Exception as e:
         logger.warning("[admin] usage query failed: %s", e)

--- a/tests/test_admin_router_persisted_usage.py
+++ b/tests/test_admin_router_persisted_usage.py
@@ -251,6 +251,7 @@ async def test_admin_usage_endpoint_delegates_to_runtime_usage_ledger(monkeypatc
         "limit": 50,
         "totals": {"total_tokens": 123},
         "token_budget_alerts": [{"app_id": "app-1", "user_id": "user-1", "limit": 50}],
+        "wallet_totals": [],
     }
 
 


### PR DESCRIPTION
## Summary

Completes the token usage display feature end-to-end by implementing the three React components declared by the billing_portal contracts.

- **`TokenStatusTab`** (`chat-ui/src/components/profile/`) — profile tab on `/me` showing per-wallet token balance with a usage progress bar. Uses pre-hydrated data from `/api/me/profile-tabs` or falls back to `/api/me/tokens`. Low-balance indicator at 80%.
- **`AdminMyUsagePanel`** (`chat-ui/src/admin/components/`) — admin portal panel showing the signed-in admin's personal token balance (fetches `/api/me/tokens`).
- **`AdminAppUsagePanel`** (`chat-ui/src/admin/components/`) — admin portal panel showing aggregate token consumption across all app users (fetches `/api/admin/usage`).
- **`/api/admin/usage`** extended with `wallet_totals` — per-wallet balance aggregated across all user/tenant scopes. Falls back to `[]` when wallet ledger is unavailable.
- All three components registered in `coreComponents.js` and resolved by registry key.

## Test plan

- [x] `test_admin_router_persisted_usage` — updated to include `wallet_totals: []` in expected shape, passes
- [x] `test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance` — still passes
- [x] Full suite: 7634 passed, 1 pre-existing hygiene failure (unrelated git worktree file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)