### PR TITLE
feat(generator): auto-select mozaikspay for apps with token_wallets / top_up_products

### DIFF
--- a/factory_app/build_context/mozaikspay/contract.yaml
+++ b/factory_app/build_context/mozaikspay/contract.yaml
@@ -9,6 +9,12 @@ provides_capabilities:
   - subscription_write_path
 
 selection_rules:
+  - id: select_for_token_wallets
+    when:
+      app_declares:
+        - token_wallets
+        - top_up_products
+    action: select_pack
   - id: select_for_saas_billing
     when:
       intent_any:

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -562,6 +562,44 @@ def _validate_subscriptions_contract(
     return errors
 
 
+def _scan_token_wallets_require_mozaikspay(
+    files_map: dict[str, str],
+    *,
+    capability_packs: list[dict[str, Any]] | None,
+) -> list[str]:
+    """Generated apps that declare top_up_products must select the mozaikspay pack.
+
+    top_up_products requires a hosted payment processor to create checkout sessions.
+    The OSS runtime ledger can track balances without MozaiksPay, but token top-ups
+    need a billing provider. This gate enforces the selection so the billing_portal
+    module is generated and the checkout/top-up surfaces are wired correctly.
+
+    Note: token_wallets alone without top_up_products is valid for self-hosted OSS
+    apps that use entitlement_dispatch for plan enforcement and do not sell top-ups.
+    """
+    normalized_files = _normalized_files_map(files_map)
+    subs_path = "config/subscriptions.yaml"
+    raw, _ = _load_yaml_mapping_from_file(normalized_files, subs_path)
+    if not isinstance(raw, dict):
+        return []
+
+    top_up_products = raw.get("top_up_products")
+    if not top_up_products or not isinstance(top_up_products, list) or len(top_up_products) == 0:
+        return []
+
+    # top_up_products declared — mozaikspay must be selected as a managed_capability
+    pack = _selected_pack_descriptor(capability_packs, "mozaikspay")
+    if pack and str(pack.get("capability_source") or "").strip() == "managed_capability":
+        return []
+
+    return [
+        f"{subs_path}: declares top_up_products but the mozaikspay managed capability pack "
+        "is not selected. Token top-up products require a hosted billing provider to create "
+        "checkout sessions. Add mozaikspay to AppBuildPlan.capability_packs with "
+        "capability_source: managed_capability."
+    ]
+
+
 def _scan_mozaikspay_saas_contract(
     files_map: dict[str, str],
     *,
@@ -1158,6 +1196,12 @@ def scan_generated_bundle(
     errors.extend(_scan_data_contract_module_alignment(files_map))
     errors.extend(
         _scan_selected_managed_capability_boundaries(
+            files_map,
+            capability_packs=capability_packs,
+        )
+    )
+    errors.extend(
+        _scan_token_wallets_require_mozaikspay(
             files_map,
             capability_packs=capability_packs,
         )

--- a/factory_app/workflows/AppGenerator/tools/hook_managed_capabilities_context.py
+++ b/factory_app/workflows/AppGenerator/tools/hook_managed_capabilities_context.py
@@ -264,10 +264,16 @@ def _format_selection_rules(items: Any) -> list[str]:
         rule_id = item.get("id") or "rule"
         action = item.get("action") or ""
         when = item.get("when") if isinstance(item.get("when"), dict) else {}
-        intents = when.get("intent_any") if isinstance(when, dict) else []
-        intent_text = ", ".join(str(intent) for intent in intents) if isinstance(intents, list) else ""
         suffix = f" -> {action}" if action else ""
-        lines.append(f"  - {rule_id}{suffix}" + (f" when intent_any: {intent_text}" if intent_text else ""))
+        conditions: list[str] = []
+        intents = when.get("intent_any") if isinstance(when, dict) else []
+        if isinstance(intents, list) and intents:
+            conditions.append("intent_any: " + ", ".join(str(i) for i in intents))
+        declares = when.get("app_declares") if isinstance(when, dict) else []
+        if isinstance(declares, list) and declares:
+            conditions.append("app_declares: " + ", ".join(str(d) for d in declares))
+        condition_text = "; ".join(conditions)
+        lines.append(f"  - {rule_id}{suffix}" + (f" when {condition_text}" if condition_text else ""))
     return lines
 
 


### PR DESCRIPTION
## Summary

- **`contract.yaml` selection_rules**: New `select_for_token_wallets` rule — when the app's `subscriptions.yaml` declares `token_wallets` or `top_up_products`, the AppPlanAgent auto-includes mozaikspay in `capability_packs`. MozaiksPay becomes the default for AI-usage-selling apps rather than requiring an explicit user prompt.
- **`generated_bundle_scanner`**: New `_scan_token_wallets_require_mozaikspay` gate — blocks export of any bundle that declares `top_up_products` without the mozaikspay managed capability selected. `token_wallets` alone (without `top_up_products`) remains valid for self-hosted OSS apps using `entitlement_dispatch` without MozaiksPay.
- **`hook_managed_capabilities_context`**: `_format_selection_rules` now renders `app_declares` conditions alongside `intent_any` so agents see the full rule text in their managed capabilities context.

## Boundary clarification

`token_wallets` alone = valid OSS self-hosted pattern (runtime ledger tracks balance, `entitlement_dispatch` handles plan enforcement)
`top_up_products` = requires MozaiksPay (checkout sessions need a billing provider)

## Test plan

- [x] `test_deterministic_subscription_smoke_validates_acceptance_loader_and_wiring` — passes (uses `token_wallets` + `entitlement_dispatch`, no `top_up_products`)
- [x] `test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance` — passes (has mozaikspay selected)
- [x] `test_generated_bundle_scanner` — all 46 pass
- [x] Full suite: 11045 passed, 1 pre-existing failure (unrelated docs string test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)