### PR TITLE
feat(generator): inject mozaikspay as default billing provider for SaaS plans

### DIFF
--- a/factory_app/workflows/AppGenerator/tools/app_build_plan.py
+++ b/factory_app/workflows/AppGenerator/tools/app_build_plan.py
@@ -565,6 +565,101 @@ def _ensure_context_selected_capability_packs(
     return result
 
 
+def _inject_default_mozaikspay_if_applicable(
+    capability_packs: list[dict[str, Any]],
+    build_tasks: list[dict[str, Any]],
+    *,
+    context_variables: Any | None,
+) -> list[dict[str, Any]]:
+    """Inject mozaikspay as the default billing managed capability for SaaS plans.
+
+    Fires when ALL of the following are true:
+      1. The build plan declares a ``subscription_config`` task (SaaS billing signal).
+      2. ``mozaikspay`` is not already present in ``capability_packs``.
+      3. No other managed capability pack declares ``provides_capabilities:
+         [subscription_write_path]`` inline in its descriptor.
+
+    The descriptor is taken from the context ``available_managed_capabilities``
+    when present (operator-configured deployment), falling back to the OSS
+    factory build context at ``factory_app/build_context/mozaikspay/contract.yaml``.
+    This makes MozaiksPay the OSS default billing provider for generated SaaS apps
+    without requiring an explicit operator selection.
+
+    Override paths:
+      - Include a different managed capability that declares
+        ``provides_capabilities: [subscription_write_path]`` to prevent injection.
+      - Remove ``subscription_config`` from the plan (non-SaaS apps are unaffected).
+      - Explicitly include ``mozaikspay`` in ``capability_packs`` before this runs
+        (already-selected packs are never re-added).
+    """
+    # Only inject for SaaS billing plans
+    has_subscription_config = any(
+        isinstance(task, dict) and str(task.get("task_type") or "").strip() == "subscription_config"
+        for task in build_tasks
+    )
+    if not has_subscription_config:
+        return capability_packs
+
+    # Skip if mozaikspay is already selected
+    existing_ids = {
+        str(pack.get("capability_pack_id") or pack.get("id") or pack.get("pack_id") or "").strip()
+        for pack in capability_packs
+        if isinstance(pack, dict)
+    } - {""}
+    if "mozaikspay" in existing_ids:
+        return capability_packs
+
+    # Skip if another managed capability already provides the subscription write path
+    for pack in capability_packs:
+        if not isinstance(pack, dict):
+            continue
+        if str(pack.get("capability_source") or "").strip() != "managed_capability":
+            continue
+        inline = pack.get("provides_capabilities")
+        if isinstance(inline, list) and "subscription_write_path" in inline:
+            return capability_packs
+
+    # Try context-configured descriptor first (operator deployment)
+    available_packs = _context_available_pack_map(context_variables)
+    descriptor: dict[str, Any] | None = available_packs.get("mozaikspay")
+
+    # Fall back to OSS factory pack contract for vanilla OSS deployments
+    if descriptor is None:
+        try:
+            import yaml  # type: ignore[import]
+
+            from factory_app.workflows._shared.hook_utils import workflow_context_path
+
+            contract_path = workflow_context_path("mozaikspay", "contract.yaml")
+            with open(contract_path, encoding="utf-8") as _fh:
+                contract = yaml.safe_load(_fh) or {}
+            descriptor = {
+                "id": "mozaikspay",
+                "capability_source": "managed_capability",
+                "display_name": "MozaiksPay",
+                "description": "Managed subscription billing provider for generated SaaS apps.",
+            }
+            facades = contract.get("facades")
+            if facades:
+                descriptor["facades"] = facades
+        except Exception:
+            _logger.debug("[app_build_plan] mozaikspay contract.yaml not loadable; skipping default injection")
+            return capability_packs
+
+    injected: dict[str, Any] = dict(descriptor)
+    injected.setdefault("capability_pack_id", "mozaikspay")
+    injected.setdefault("capability_source", "managed_capability")
+    injected.setdefault("surface_id", "mozaikspay_managed")
+    injected.setdefault("surface_kind", "external_integration")
+    injected.setdefault("implementation_mode", "external_integration")
+    injected.setdefault("pack_type", "managed_capability")
+    injected.setdefault("label", injected.get("display_name") or "MozaiksPay")
+    injected.setdefault("summary", injected.get("description") or "Managed subscription billing capability.")
+
+    _logger.debug("[app_build_plan] injecting default mozaikspay managed capability for SaaS plan")
+    return [*capability_packs, injected]
+
+
 def _pack_facades(descriptor: dict[str, Any]) -> list[dict[str, Any]]:
     facades = _normalize_object_list(descriptor.get("facades"))
     if facades:
@@ -1604,6 +1699,15 @@ def app_build_plan(
             build_tasks,
             managed_capability_ids=inferred_managed_capability_ids,
         )
+    capability_packs = _inject_default_mozaikspay_if_applicable(
+        capability_packs,
+        build_tasks,
+        context_variables=context_variables,
+    )
+    capability_packs = _normalize_capability_pack_sources(
+        capability_packs,
+        context_variables=context_variables,
+    )
     data_contract = AppBuildPlan.get("data_contract")
     pending_schema_migration = AppBuildPlan.get("pending_schema_migration")
     generation_order = _normalize_string_list(AppBuildPlan.get("generation_order"))

--- a/tests/test_app_build_plan_pack_facade_helpers.py
+++ b/tests/test_app_build_plan_pack_facade_helpers.py
@@ -96,6 +96,7 @@ from factory_app.workflows.AppGenerator.tools.app_build_plan import (
     _context_get,
     _context_managed_capability_ids,
     _facade_pack_descriptor,
+    _inject_default_mozaikspay_if_applicable,
     _iter_page_api_endpoints,
     _managed_capability_backing_module_ids,
     _managed_facade_route_rules,
@@ -770,3 +771,90 @@ def test_empty_provider_actions_produces_no_rules():
     packs = [{"capability_pack_id": "billing", "capability_source": "managed_capability"}]
     rules = _managed_facade_route_rules(packs, context_variables=ctx)
     assert rules == {}
+
+
+# ---------------------------------------------------------------------------
+# 14. _inject_default_mozaikspay_if_applicable
+# ---------------------------------------------------------------------------
+
+_SUBSCRIPTION_CONFIG_TASK = {"task_type": "subscription_config", "task_id": "sub_cfg"}
+_MOZAIKSPAY_DESCRIPTOR = {
+    "id": "mozaikspay",
+    "capability_source": "managed_capability",
+    "display_name": "MozaiksPay",
+}
+
+
+class TestInjectDefaultMozaikspay:
+    def test_no_subscription_config_task_returns_unchanged(self):
+        packs = []
+        tasks = [{"task_type": "module_contract"}]
+        result = _inject_default_mozaikspay_if_applicable(packs, tasks, context_variables=None)
+        assert result == []
+
+    def test_mozaikspay_already_in_packs_returns_unchanged(self):
+        packs = [{"capability_pack_id": "mozaikspay", "capability_source": "managed_capability"}]
+        result = _inject_default_mozaikspay_if_applicable(
+            packs, [_SUBSCRIPTION_CONFIG_TASK], context_variables=None
+        )
+        assert len(result) == 1
+        assert result[0]["capability_pack_id"] == "mozaikspay"
+
+    def test_another_managed_pack_provides_subscription_write_path_skips_injection(self):
+        packs = [{
+            "capability_pack_id": "custom_billing",
+            "capability_source": "managed_capability",
+            "provides_capabilities": ["subscription_write_path"],
+        }]
+        result = _inject_default_mozaikspay_if_applicable(
+            packs, [_SUBSCRIPTION_CONFIG_TASK], context_variables=None
+        )
+        assert len(result) == 1
+        assert result[0]["capability_pack_id"] == "custom_billing"
+
+    def test_injects_from_context_when_available(self):
+        ctx = _ctx({"available_managed_capabilities": [_MOZAIKSPAY_DESCRIPTOR]})
+        result = _inject_default_mozaikspay_if_applicable(
+            [], [_SUBSCRIPTION_CONFIG_TASK], context_variables=ctx
+        )
+        assert len(result) == 1
+        assert result[0]["capability_pack_id"] == "mozaikspay"
+        assert result[0]["capability_source"] == "managed_capability"
+        assert result[0]["surface_kind"] == "external_integration"
+
+    def test_injects_from_contract_yaml_when_not_in_context(self):
+        """Falls back to factory pack contract.yaml for vanilla OSS installs."""
+        result = _inject_default_mozaikspay_if_applicable(
+            [], [_SUBSCRIPTION_CONFIG_TASK], context_variables=None
+        )
+        assert len(result) == 1
+        assert result[0]["capability_pack_id"] == "mozaikspay"
+        assert result[0]["capability_source"] == "managed_capability"
+
+    def test_context_descriptor_takes_priority_over_contract_yaml(self):
+        ctx = _ctx({"available_managed_capabilities": [{
+            **_MOZAIKSPAY_DESCRIPTOR,
+            "api_base": "https://pay.example.com",
+        }]})
+        result = _inject_default_mozaikspay_if_applicable(
+            [], [_SUBSCRIPTION_CONFIG_TASK], context_variables=ctx
+        )
+        assert result[0].get("api_base") == "https://pay.example.com"
+
+    def test_non_managed_capability_providing_sub_write_path_does_not_block_injection(self):
+        """provides_capabilities on a generated_module pack should NOT block injection."""
+        packs = [{
+            "capability_pack_id": "my_module",
+            "capability_source": "generated_module",
+            "provides_capabilities": ["subscription_write_path"],
+        }]
+        ctx = _ctx({"available_managed_capabilities": [_MOZAIKSPAY_DESCRIPTOR]})
+        result = _inject_default_mozaikspay_if_applicable(
+            packs, [_SUBSCRIPTION_CONFIG_TASK], context_variables=ctx
+        )
+        pack_ids = [p["capability_pack_id"] for p in result]
+        assert "mozaikspay" in pack_ids
+
+    def test_empty_build_tasks_list_returns_unchanged(self):
+        result = _inject_default_mozaikspay_if_applicable([], [], context_variables=None)
+        assert result == []


### PR DESCRIPTION
## Summary

- Adds `_inject_default_mozaikspay_if_applicable` to `app_build_plan.py` — deterministically injects mozaikspay as a managed capability when a build plan includes a `subscription_config` task (SaaS billing signal)
- Descriptor sourced from `available_managed_capabilities` in context (operator deployment) first, falling back to the OSS factory pack contract at `factory_app/build_context/mozaikspay/contract.yaml` for vanilla OSS installs
- Injection skipped if mozaikspay is already in `capability_packs`, or another managed pack declares `provides_capabilities: [subscription_write_path]`, or the plan has no `subscription_config` task (non-SaaS apps unaffected)
- 8 unit tests covering all override/skip paths

## Override paths (user can change it)
- Include a different managed capability with `provides_capabilities: [subscription_write_path]` → injection skipped
- Remove `subscription_config` task from plan (non-SaaS apps) → never fires
- Explicitly include mozaikspay in plan before this runs → no-op (already there)

## Test plan
- [x] `tests/test_app_build_plan_pack_facade_helpers.py` — all 88 pass (8 new for `_inject_default_mozaikspay_if_applicable`)
- [x] `tests/test_appgenerator_managed_capability_smoke.py` + `test_app_planner_managed_capability_safety.py` — 125 passed, 8 skipped
- [x] All `test_app_build_plan_*.py` — 197 passed
- [x] Full test suite — 7642 passed, 1 pre-existing failure (`test_source_hygiene_scan_passes_current_repo`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)