### PR TITLE
feat(generator): add profile_layout to AppBuildPlan — agent-driven profile nav variation

### DIFF
--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -231,6 +231,12 @@ agents:
       8. Capture any visual/style preference the user stated during the interview (e.g. "dark", "minimal", "techy") as `theme_preferences` — raw text, no translation needed. Set to null if no preference was stated.
       9. Preserve upstream `concept_blueprint.brand_intent` as `brand_intent` whenever it exists. Only change it if the user explicitly refined the brand or experience direction.
       9a. Select `shell_preset_hint` from `[SHELL PRESET CONTEXT]` only when a preset clearly matches the app's navigation/chrome model. Set it to null when platform defaults are sufficient. This is prompt-time guidance only; do not plan a generated runtime file for the preset.
+      9b-pre. Set `profile_layout` based on app domain and brand intent — this IS written to the generated app as `app/config/profile.yaml`:
+             - `sidebar_left` — enterprise, B2B, admin-heavy, dashboard, professional tools
+             - `top_nav` — social apps, consumer apps, creator platforms, content-first products
+             - `drawer` — mobile-first apps, simple utilities, single-purpose tools
+             - `icon_rail` — productivity tools, SaaS dashboards, developer tools
+             Choose the layout that best fits the app's primary user context and domain. Default to `top_nav` only when truly uncertain. Do NOT leave this null for apps with user profiles.
       9b. **Workspace integration check** — before finalizing `external_integrations`, call `check_workspace_integrations` with the catalog IDs of every third-party service the plan requires:
          - Match each planned integration to a catalog ID where one exists: `mozaikspay`, `resend`, `sendgrid`, `twilio`, `slack`, `github`, `s3`, `cloudinary`, `postgres`, `redis`, `openai`, `anthropic`, `google_oauth`, `segment`.
          - Pass all matched IDs in a single `check_workspace_integrations` call. Pass only IDs that exist in the catalog; omit custom or unknown services.

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -1005,6 +1005,20 @@ models:
           not a runtime artifact. AppSchemaAgent uses it to choose normal
           AppPageSchema.navigation, AppPageSchema.shell_mode, and optional
           shell_config defaults. Null when platform defaults are sufficient.
+      profile_layout:
+        type: union
+        variants:
+        - str
+        - 'null'
+        description: >
+          Profile page navigation layout for this app. Controls how /me renders
+          its section nav. Pick based on app domain and brand intent:
+            sidebar_left  — desktop-first left sidebar; enterprise, B2B, dashboards
+            top_nav       — horizontal nav below hero; social, consumer, creator apps
+            drawer        — hamburger/drawer menu; mobile-first or simple apps
+            icon_rail     — icon-only rail with hover labels; productivity/SaaS tools
+          Null defaults to top_nav at runtime. Written into app/config/profile.yaml.
+          Agents must set this — do not leave null unless genuinely uncertain.
       surface_map:
         type: union
         variants:

--- a/factory_app/workflows/AppGenerator/tools/app_build_plan.py
+++ b/factory_app/workflows/AppGenerator/tools/app_build_plan.py
@@ -1665,6 +1665,10 @@ def app_build_plan(
     frontend_scope = _normalize_string_list(AppBuildPlan.get("frontend_scope"))
     theme_preferences = AppBuildPlan.get("theme_preferences")
     brand_intent = AppBuildPlan.get("brand_intent")
+    _valid_profile_layouts = frozenset({"sidebar_left", "top_nav", "drawer", "icon_rail"})
+    profile_layout = str(AppBuildPlan.get("profile_layout") or "").strip() or None
+    if profile_layout and profile_layout not in _valid_profile_layouts:
+        profile_layout = None
     capability_packs = _ensure_context_selected_capability_packs(
         _normalize_object_list(AppBuildPlan.get("capability_packs")),
         context_variables=context_variables,
@@ -1800,6 +1804,7 @@ def app_build_plan(
         "frontend_scope": frontend_scope,
         "theme_preferences": theme_preferences,
         "brand_intent": brand_intent if isinstance(brand_intent, dict) else None,
+        "profile_layout": profile_layout,
         "capability_packs": capability_packs,
         "external_integrations": external_integrations,
         "agent_backend_required": agent_backend_required,


### PR DESCRIPTION
## Summary

- Adds `profile_layout` field to `AppBuildPlan` structured output (sidebar_left | top_nav | drawer | icon_rail)
- AppPlanAgent now picks the profile navigation layout based on app domain and brand intent — every generated app gets a distinct profile shell, not a generic default
- `app_build_plan.py` validates and persists `profile_layout` in the normalized plan so downstream agents can write it to `app/config/profile.yaml`
- `agents.yaml` 9b-pre instruction guides the agent to choose based on domain: enterprise→sidebar_left, social→top_nav, mobile→drawer, SaaS tools→icon_rail

## Why

Part of the profile v2 architecture (profile shell as an admin-like section nav). Without this, every generated app would have the same profile layout. The agent picks the layout at plan time so it's deterministic per app.

## Test plan
- [x] 174 tests pass across app_build_plan and appgenerator_canonical_generation suites
- [x] No regressions in managed capabilities tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)