### PR TITLE
feat(generator): write config/profile.yaml from profile_layout in save_app_schema

### DIFF
--- a/factory_app/workflows/AppGenerator/tools/save_app_schema.py
+++ b/factory_app/workflows/AppGenerator/tools/save_app_schema.py
@@ -1415,6 +1415,7 @@ def _persist_to_filesystem(
     asset_manifest: dict[str, Any] | None,
     data_contract: dict[str, Any] | None,
     custom_route_bundle: dict[str, Any] | None,
+    profile_layout: str | None = None,
 ) -> list[str]:
     """Write app.json, ui/pages/*.yaml, optional custom route artifacts, and optional config artifacts.
 
@@ -1533,6 +1534,21 @@ def _persist_to_filesystem(
             encoding="utf-8",
         )
         written.append("data/contract.json")
+
+    # config/profile.yaml — profile page layout variant chosen by AppPlanAgent.
+    # Written only when profile_layout is set; runtime defaults to top_nav when absent.
+    if profile_layout:
+        profile_config_path = output_dir / "config" / "profile.yaml"
+        profile_config_path.parent.mkdir(parents=True, exist_ok=True)
+        with profile_config_path.open("w", encoding="utf-8") as _fh:
+            yaml.dump(
+                {"schema_version": "mozaiks.profile.v1", "layout": profile_layout},
+                _fh,
+                allow_unicode=True,
+                sort_keys=False,
+                default_flow_style=False,
+            )
+        written.append("config/profile.yaml")
 
     return written
 
@@ -1746,6 +1762,10 @@ def save_app_schema(
     else:
         _logger.warning("context_variables not available or missing 'set' method")
 
+    # Read profile_layout from the app_build_plan stored by AppPlanAgent.
+    _build_plan = _context_get(context_variables, "app_build_plan") or {}
+    _profile_layout = str(_build_plan.get("profile_layout") or "").strip() or None
+
     # Persist to generated artifacts; promotion is explicit and separate.
     written: list[str] = []
     try:
@@ -1762,6 +1782,7 @@ def save_app_schema(
             asset_manifest,
             resolved_data_contract,
             custom_route_bundle,
+            profile_layout=_profile_layout,
         )
         _logger.info(
             "Wrote app schema to %s: %s",
@@ -1784,7 +1805,8 @@ def save_app_schema(
         f"Theme config patch: {'yes' if theme_config_patch else 'no'}\n"
         f"Shell config: {'yes' if shell_config else 'no'}\n"
         f"Asset manifest: {'yes' if asset_manifest else 'no'}\n"
-        f"Data contract: {'yes' if resolved_data_contract else 'no'}"
+        f"Data contract: {'yes' if resolved_data_contract else 'no'}\n"
+        f"Profile layout: {_profile_layout or 'none (runtime default: top_nav)'}"
         f"{files_written}"
     )
 

--- a/tests/test_save_app_schema_extended_helpers.py
+++ b/tests/test_save_app_schema_extended_helpers.py
@@ -87,9 +87,14 @@ Covers helpers not covered by the existing test_save_app_schema_helpers.py:
 """
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 import pytest
+import yaml
 
 from factory_app.workflows.AppGenerator.tools.save_app_schema import (
+    _persist_to_filesystem,
     _deep_merge_dicts,
     _is_non_empty_string,
     _normalize_action_data,
@@ -539,3 +544,76 @@ class TestValidateShellStringOrList:
         # Let me check: isinstance([], list) = True, all(_is_non_empty_string(item) for item in []) = True
         # So empty list should NOT raise
         _validate_shell_string_or_list([], field="field")
+
+
+# ---------------------------------------------------------------------------
+# 14. _persist_to_filesystem — config/profile.yaml write step
+# ---------------------------------------------------------------------------
+
+def _minimal_manifest() -> dict:
+    return {
+        "app_name": "Test App",
+        "default_route": "/home",
+        "auth_strategy": "public",
+    }
+
+
+def _minimal_page() -> dict:
+    return {
+        "name": "home",
+        "route": "/home",
+        "title": "Home",
+        "schema_version": "mozaiks.page.v1",
+        "sections": [
+            {
+                "id": "main",
+                "label": "Main",
+                "components": [{"id": "c1", "primitive": "Heading", "config": {"text": "Hello"}}],
+            }
+        ],
+    }
+
+
+class TestPersistProfileLayout:
+    def test_profile_yaml_written_when_layout_set(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            written = _persist_to_filesystem(
+                out,
+                _minimal_manifest(),
+                [_minimal_page()],
+                None, None, None, None, None,
+                profile_layout="sidebar_left",
+            )
+            assert "config/profile.yaml" in written
+            doc = yaml.safe_load((out / "config" / "profile.yaml").read_text())
+            assert doc["layout"] == "sidebar_left"
+            assert doc["schema_version"] == "mozaiks.profile.v1"
+
+    def test_profile_yaml_not_written_when_layout_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            written = _persist_to_filesystem(
+                out,
+                _minimal_manifest(),
+                [_minimal_page()],
+                None, None, None, None, None,
+                profile_layout=None,
+            )
+            assert "config/profile.yaml" not in written
+            assert not (out / "config" / "profile.yaml").exists()
+
+    def test_all_valid_layouts_written_correctly(self):
+        for layout in ("sidebar_left", "top_nav", "drawer", "icon_rail"):
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp)
+                written = _persist_to_filesystem(
+                    out,
+                    _minimal_manifest(),
+                    [_minimal_page()],
+                    None, None, None, None, None,
+                    profile_layout=layout,
+                )
+                assert "config/profile.yaml" in written
+                doc = yaml.safe_load((out / "config" / "profile.yaml").read_text())
+                assert doc["layout"] == layout


### PR DESCRIPTION
## Summary

- Wires the missing generation step: `save_app_schema` now reads `profile_layout` from the `app_build_plan` context variable and writes `config/profile.yaml` to the generated bundle
- `_persist_to_filesystem` gains a `profile_layout: str | None` parameter; file is only written when the value is set (runtime defaults to `top_nav` when absent)
- Closes the loop on the profile layout system: AppPlanAgent → AppBuildPlan → save_app_schema → `config/profile.yaml` → `/api/me/profile-config` → ProfilePage

## Full flow (all wired end-to-end)

1. **AppPlanAgent** sets `profile_layout` in `AppBuildPlan` structured output (PR #71)
2. **`app_build_plan.py`** validates and stores it in `context_variables["app_build_plan"]` (PR #71)
3. **`save_app_schema`** (this PR) reads it from context and calls `_persist_to_filesystem(profile_layout=...)`
4. **`config/profile.yaml`** written to generated bundle: `{ schema_version: mozaiks.profile.v1, layout: sidebar_left }`
5. **`GET /api/me/profile-config`** reads the file and returns `{ layout: ... }` (PR #70)
6. **`ProfilePage.jsx`** fetches the endpoint and renders the matching layout variant (PR #72)

## Tests

3 new tests in `TestPersistProfileLayout`:
- `config/profile.yaml` written when layout is set, correct YAML content
- `config/profile.yaml` not written when layout is `None`
- All 4 valid layouts (`sidebar_left`, `top_nav`, `drawer`, `icon_rail`) written correctly