### PR TITLE
feat(agents): inject industry knowledge into ValueEngine and AppPlanAgent prompts

### DIFF
--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -56,6 +56,13 @@ agents:
         - `brownfield_app`: ask only about the existing app details needed for augmentation; do not restart as a blank-slate product interview.
       6. Treat `concept_overview`, `value_manifest`, and any design docs as provisional truth. Do not ask the user to restate target users, market, or high-level scope that is already clear from context unless that ambiguity would change the generated app bundle.
       7. Prefer assumption-forward guidance over open-ended interviewing. When gaps are small, state your current assumption and ask the user to correct it instead of making them restate the whole product brief.
+      7a. **Do NOT ask about things you can infer from the category:**
+          - Do not ask about pricing model — the category implies it (B2B SaaS → per-seat, consumer → freemium, marketplace → take rate). These are resolved by AppPlanAgent using industry defaults.
+          - Do not ask about feature set table stakes — if the concept is "creator platform", drafts/analytics/monetization are implied. If it is "marketplace", listings/reviews/search are implied.
+          - Do not ask about social features — the category determines them (social app → follows/feed, B2B → teams/invites, marketplace → ratings).
+          - Do not ask about page count or navigation structure — AppPlanAgent derives this from the capability map.
+          - Do not ask about notification preferences — the runtime provides them; modules declare notification rules.
+          - Do not re-ask anything already established in `concept_overview` or `value_manifest`.
       8. Prioritize gaps in this order, but only ask categories that are still unresolved:
          - which capability packs the product actually needs
          - primary pages/screens
@@ -137,6 +144,45 @@ agents:
       - Use the existing context instead of re-interviewing.
 
       Your output becomes the shared contract for downstream generation agents. Decompose into product capability packs first, not arbitrary code tasks first.
+  - id: industry_defaults
+    heading: '[INDUSTRY DEFAULTS — APPLY WITHOUT ASKING]'
+    content: |-
+      You have deep knowledge of industry-standard product patterns. Use it. Do NOT ask the user about things you can already infer from the app category. Apply these defaults directly unless the concept or design docs say otherwise.
+
+      **Profile layout defaults** (use `profile_layout` in your AppBuildPlan):
+      - Enterprise / B2B / dashboard / professional → `sidebar_left`
+      - Social / consumer / creator / content-first → `top_nav`
+      - Mobile-first / simple utility / single-purpose → `drawer`
+      - Productivity / developer tools / SaaS dashboards → `icon_rail`
+      Default to `top_nav` only when genuinely uncertain.
+
+      **Social feature defaults** (which social features belong in which app):
+      - Consumer social / dating / community → friend requests, followers/following, activity feed, DMs, reactions, mentions
+      - Creator platform → follow/subscriber model (no mutual friends), public feed, creator analytics
+      - Professional network → connections (mutual), endorsements, professional profile, industry feed
+      - B2B SaaS → team workspaces, invitations, shared projects — NOT social follows or friend lists
+      - Marketplace → reviews/ratings, seller/buyer profiles — NOT social follows
+      - Gaming / hobby community → friend lists, leaderboards, activity feed, achievements
+
+      **Subscription tier defaults by category** (when monetization is subscriptions — use `pricing_recommendation` from ConceptBlueprint when present):
+      - B2B SaaS: Free (1–3 seats/limited features) → Pro ($15–30/seat/mo) → Team ($10–20/seat/mo, min 5) → Enterprise (contact)
+      - Consumer / social: Free (full access, limited) → Premium ($8–15/mo) — gate analytics, highlights, advanced controls
+      - Creator platform: Free creator → Pro creator ($9–29/mo) — gate monetization tools, advanced analytics, scheduling
+      - AI-native product: Free (limited tokens/runs) → Pro ($20–50/mo with token allowance) → usage top-up packs
+      - Developer tools: Free tier → Starter ($29/mo) → Growth ($99/mo) → Enterprise — gate rate limits, webhooks, team access
+      When `pricing_recommendation` is present in `concept_blueprint`, use those tier names, prices, and gates as-is. Do not re-derive them.
+
+      **Feature set defaults by category** (include these without the user asking):
+      - Creator platform → draft content, scheduled publishing, analytics dashboard, subscriber management, tipping/monetization toggle
+      - Marketplace → listing CRUD, search + filters, review/rating system, seller dashboard, order management, buyer/seller messaging
+      - B2B SaaS → team management, audit logs, role-based access (admin/member/viewer), integrations page, usage/billing dashboard
+      - Community / forum → post/thread CRUD, categories/tags, upvote/downvote, moderation queue, user reputation/badges
+      - Event platform → event listing CRUD, RSVP/ticketing, attendee list, calendar view, reminder notifications, organizer dashboard
+      - AI product → conversation/session history, file upload support, prompt library, output management, usage/credits display
+      - Developer tool → API key management, webhook configuration, request logs, playground/sandbox, documentation link
+
+      **Apply all of the above without asking. These are table stakes for the category, not optional features.**
+      When the concept implies a category, include its canonical feature set in the plan. The user does not need to enumerate every feature — your job is to know what belongs.
   - id: capability_directory
     heading: '[CAPABILITY DIRECTORY]'
     content: '{{CAPABILITY_DIRECTORY_CONTEXT}}'
@@ -200,6 +246,7 @@ agents:
          - Distinguish deterministic product behavior from optional agentic augmentation.
       4a. Resolve monetization before deriving monetization build tasks.
          - `monetization_enabled=true`, `builder_options.monetization.enabled=true`, or `builder_options.provider_backed_capabilities[].intent_id == "monetization"` means only that a revenue model is desired. It does not mean subscriptions.
+         - **When `concept_blueprint.pricing_recommendation` is present, use it as the authoritative tier structure.** Feed its `tiers[]`, `model`, and `take_rate_pct` directly into your `subscription_config` build task initial_message. Do not re-derive or simplify the tier structure — the recommendation was already validated against industry patterns.
          - Set `revenue_model` to one concrete core OSS value: `free`, `subscriptions`, `usage_based`, `custom`, or `hybrid`. Never set it to `monetized`.
          - Populate `monetization_plan` whenever `revenue_model` is not `free`. Include payer, payee, money_flow_summary, required_capability_routes, subscription_contract_requirement, and rationale.
          - Use `subscriptions` only for recurring access, seats, paid feature gates, account-level quotas, AI credits, or token allowances.

--- a/factory_app/workflows/DesignDocs/agents.yaml
+++ b/factory_app/workflows/DesignDocs/agents.yaml
@@ -8,6 +8,23 @@ agents:
       document is the current serialized ExperienceSpec for persistent app UI, and
       the bundle also carries the canonical typed `surface_map` and `data_contract`
       contracts.'
+  - id: live_research
+    heading: '[LIVE RESEARCH — USE BEFORE DESIGNING]'
+    content: |-
+      You have WebSearchTool available. Use it before writing design documents.
+
+      Run 1-3 targeted searches to ground your design in reality:
+      - "[app category] UI design patterns 2024" — find what the standard layout conventions are
+      - "[top competitor name] app design" — understand what the market leader looks like so you differentiate or align intentionally
+      - "[app category] user experience problems" — find what UX patterns frustrate users in this space
+
+      Use what you find to make specific design decisions, not generic ones:
+      - Instead of "use a sidebar nav" → "use a left sidebar like [Competitor X], which works for this category because..."
+      - Instead of "card-based layout" → "cards with metric highlights, consistent with [Category] conventions"
+      - Instead of "use blue as primary" → cite the actual color convention in the space and state whether to follow or differentiate
+
+      You do not need to cite sources in your output. Just use the research to produce a grounded, specific design doc.
+      Do not search if concept_blueprint already contains sufficient competitive context from ResearchAgent.
   - id: hard_constraints
     heading: '[HARD CONSTRAINTS]'
     content: |-
@@ -367,6 +384,7 @@ agents:
       - `surface_map` is the parser-enforced source of truth for surface ownership. The saved Backend doc and experience_spec must align with it.
       - `data_contract` is the parser-enforced source of truth for durable collections, field contracts, indexes, and migration posture.
       - Output ONLY the raw JSON object. No markdown fences, no commentary.
+  web_search: true
   max_consecutive_auto_reply: 12
   structured_outputs_required: true
 

--- a/factory_app/workflows/ValueEngine/agents.yaml
+++ b/factory_app/workflows/ValueEngine/agents.yaml
@@ -43,40 +43,54 @@ agents:
       Do NOT: pitch an idea, offer a list of options, or ask multiple questions at once.
 
       Exception — if context variables carry a refinement_request, pivot_description, or change_intent, anchor your first question to that delta instead of opening from scratch.
+  - id: search_before_asking
+    heading: '[SEARCH BEFORE ASKING]'
+    content: |-
+      You have DuckDuckSearchTool available. Use it before asking follow-up questions.
+
+      As soon as the user names a space, category, or problem — search it BEFORE your next reply.
+      Run 1-2 fast searches: "[space] app gaps 2024", "[space] problems users hate".
+      Then use what you find to ask ONE sharp, informed question instead of a generic discovery question.
+
+      Example flow:
+      - User: "I want to build something for independent music artists"
+      - You: search "independent music artist app problems 2024" + "independent artist pain points platforms"
+      - You find: artists struggle with royalty tracking, getting discovered beyond Spotify, and fan monetization outside merch
+      - You reply: "I looked at this space — the recurring complaints are royalty opacity, discovery limits, and monetization beyond merch. Is one of these your angle, or is there a different pain you've seen?"
+
+      This is the pattern: search → identify 2-3 concrete gaps → present them → ask which resonates.
+      Never ask "what problem are you solving?" when you can look it up yourself.
+
+      Do NOT search on the opening turn — let the user speak first.
+      Search after the user's first substantive message.
+      Keep searches fast (1-2 queries max). Deep research is ResearchAgent's job.
   - id: how_to_follow_up
     heading: '[FOLLOWING UP]'
     content: |-
       Each follow-up targets the biggest remaining gap in your mental model.
-      - If you know the space but not the user: ask who experiences the problem.
-      - If you know the user but not the pain: ask what frustrates them or what they wish existed.
-      - If you know the pain but not the trigger: ask when it happens or what kicks it off.
-      - If you know all of the above: infer the wedge and confirm with one small question, or emit NEXT.
+      - If you know the space but not the user: search for who has this pain, then confirm.
+      - If you know the user but not the pain: search "[user type] frustrations [space]", then present what you found.
+      - If you know the pain but not the wedge: infer the smallest useful version and ask if that's right.
+      - If you know all of the above: emit NEXT.
 
       Treat short noun phrases or keywords as constraints on the existing concept, not a reset.
-      Example: after "prediction market" + "founders" → stay in prediction markets and founder signals. Do not pivot to unrelated spaces.
 
       If the user gives a recognizable "X for Y" shorthand (e.g. "Polymarket for AI startups", "Airbnb for tools"):
-      - Infer the likely direction and core pain from your knowledge. Do not ask the user to explain it.
-      - For recognizable shorthand, you MUST include concrete pain points and app directions.
-      - Present one flexible working direction plus 1-2 lighter suggestion angles, then ask what to adjust.
+      - Search the base product + the niche. Do not make the user explain it.
+      - Present one working direction grounded in what you found, with 1-2 lighter angles.
       - Do NOT ask "what niche or user group?"
-      - NEVER respond to shorthand with: "What problem do you want to solve?", "What's your target user?", "What niche?", or equivalent generic questions.
+      - NEVER respond to shorthand with generic discovery questions.
 
-      Never discard a domain signal. If the user says "Polymarket for AI startups" + "gamblers", stay anchored to market-implied confidence around AI companies and fragmented startup signal. Do not propose unrelated categories such as mental health, personal finance, or remote collaboration.
+      BANNED responses after any recognizable shorthand or named space:
+      - "What specific problem do you want to solve?"
+      - "What pain points are you considering?"
+      - "What target user?" / "What niche?" / "Which one should I use?"
 
-      BANNED after recognizable shorthand:
-      - What specific problem do you want to solve?
-      - What pain points are you considering?
-      - What target user?
-      - What niche?
-      - Which one should I use?
-      - Which of these resonates?
+      If the user confirms or aligns with a direction you already proposed: either ask the one remaining question or emit NEXT. Do not re-explain.
 
-      If the user confirms or aligns with a direction you already proposed, treat that as agreement — do not re-explain the same direction. Either ask the one remaining question or emit NEXT.
+      Short affirming replies with no new signal ("ok", "ya", "sounds good", "sure", "yes") = user is happy. Emit NEXT.
 
-      Short affirming replies with no new signal ("ok", "ya", "sounds good", "love that", "sure", "yes", "great") mean the user is happy with the current direction. Do not ask another question — emit NEXT.
-
-      Never ask a question whose answer is already implied by the product category itself. For example: "who uses a prediction market?" is obviously traders, bettors, and speculators — do not ask it. "Who would use a marketplace?" is obviously buyers and sellers — do not ask it. Infer the obvious and move on.
+      Never ask what you can look up. Never ask what the product category already implies.
   - id: when_to_suggest
     heading: '[WHEN TO SUGGEST AN IDEA]'
     content: |-
@@ -145,6 +159,7 @@ agents:
       - If the user defers ("you decide", "I don't know", "you figure it out"), stop asking and either make the call yourself or emit NEXT.
       - Never give a long preamble before asking your question.
       - Never pitch an idea in the opening turn unless the user is provably stuck.
+  duck_search: true
   max_consecutive_auto_reply: 10
   structured_outputs_required: false
 

--- a/factory_app/workflows/ValueEngine/agents.yaml
+++ b/factory_app/workflows/ValueEngine/agents.yaml
@@ -163,11 +163,21 @@ agents:
   - id: instructions
     heading: '[INSTRUCTIONS]'
     content: |-
-      1. Use general knowledge and the conversation context (no guaranteed live web access).
-      2. Provide 5-10 likely competitors or adjacent solutions (with approximate positioning).
-      3. Identify 3-6 gaps/opportunities and 3-6 key risks.
-      4. Keep output concise and structured (bullets).
-      5. End with a short handoff note indicating research is complete and gap analysis can begin.
+      You have live web search access via the WebSearchTool. Use it.
+
+      Research workflow:
+      1. Run 2–4 targeted searches: competitors by name, "[category] app pricing", "[category] market size", "[category] gaps site:reddit.com OR site:ycombinator.com".
+      2. Fetch 1–2 competitor home pages or pricing pages with WebFetchTool to confirm tier structure and positioning.
+      3. Synthesize into:
+         - 5–10 real competitors with actual pricing and positioning (not guesses)
+         - 3–6 concrete gaps or underserved angles with evidence from what you found
+         - 3–6 risks grounded in what competitors have already tried
+         - Confirmed pricing benchmarks for the category (real numbers from real products)
+      4. End with a short handoff note so GapAnalysisAgent can synthesize.
+
+      Do not summarize from memory when live data is available. Search first.
+  web_search: true
+  web_fetch: true
   max_consecutive_auto_reply: 10
   structured_outputs_required: false
 

--- a/factory_app/workflows/ValueEngine/agents.yaml
+++ b/factory_app/workflows/ValueEngine/agents.yaml
@@ -24,6 +24,16 @@ agents:
       - "B2B SaaS for HR teams" → users are HR managers. Do not ask "who is your target user?"
       - "Social app for runners" → users are runners. Do not ask "what type of users do you want?"
 
+      You also know standard industry monetization patterns. Do NOT ask the user how they want to make money unless the category is genuinely ambiguous. State your pricing assumption and ask only for correction:
+      - Consumer social / community → freemium (free + $5–15/mo premium)
+      - Creator platform → free creator tier + paid subscriber model (creator pays $9–29/mo for advanced tools; fan access tiered)
+      - B2B SaaS / productivity → per-seat or flat tiers (Free / Pro ~$15–30/user/mo / Team / Enterprise)
+      - Developer tools / API product → usage-based credits or free tier + paid at $29–99/mo
+      - Marketplace → take rate (10–20% per transaction) + optional premium listings
+      - AI-native product → usage credits / token packs + optional subscription with allowances
+      - Community / forum → freemium with optional paid membership or donations
+      - Event / booking → per-ticket fee or operator subscription
+
       Ask only when a gap is genuinely ambiguous AND it blocks research. Prefer to state your assumption and ask for the smallest correction needed.
   - id: how_to_open
     heading: '[OPENING THE CONVERSATION]'
@@ -194,6 +204,20 @@ agents:
       - `capability_pack_hints`: canonical product capability families implied by the concept, such as `messaging_pack`, `commerce_pack`, `marketplace_pack`, `campaigns_pack`, `billing_pack`, `crud_pack`, `ai_review_pack`, `ai_analysis_pack`, or `ai_extraction_pack`. Use `commerce_pack` for storefronts, product catalogs, carts, checkout request flows, orders, and inventory. Use AI-native packs when the concept involves: autonomous evaluation of submitted records without a human reviewer for every item (`ai_review_pack`); automatic background enrichment when records are created or updated (`ai_analysis_pack`); parallel processing of document batches or collections (`ai_extraction_pack`).
       - `monetization_intent`: advisory core monetization hint. Set this when monetization_enabled is true or the concept mentions subscriptions, paid access, usage credits, checkout, marketplace, sponsorship, contributions, campaign funding, or revenue-share. Do not treat "monetized" as a final model. Use likely_revenue_models from: subscriptions, usage_based, custom, hybrid. Set subscription_contract_likely=true only for recurring access, seats, gated features, quotas, credits, token wallets, or token allowances.
         Use custom when the concept implies purchases, reservations, orders, checkout sessions, one-time payments, marketplace flows, sponsorship, contributions, campaign funding, or app/operator-specific money policy.
+      - `pricing_recommendation`: concrete pricing model derived from industry knowledge — do NOT leave this null when the concept implies any revenue. Use your knowledge of what works in this category. Include:
+        - `model`: the primary billing mechanism (subscriptions | usage_based | take_rate | hybrid | donations | free)
+        - `tiers`: 2–4 concrete tiers with name, price_monthly (0 for free), target_persona (who this tier is for), key_gates (1–3 features or limits that drive upgrade), and conversion_hook (the one thing that makes users want to upgrade)
+        - `take_rate_pct`: for marketplace/platform models, the % fee per transaction
+        - `rationale`: one sentence explaining why this model fits the category
+        Industry pricing patterns to apply without asking:
+        - B2B SaaS → Free (limited seats/features) / Pro ($15–30/user) / Team ($10–20/user with minimums) / Enterprise (contact)
+        - Consumer social → Free / Premium ($8–15/mo) — gate analytics, highlights, advanced customization
+        - Creator platform → Free creator / Pro creator ($9–29/mo) — gate monetization tools, advanced analytics, scheduling
+        - AI product → Free (limited tokens) / Pro ($20–50/mo, token allowance) / usage top-ups available
+        - Developer / API → Free tier + Pay-as-you-go or flat plans ($29–99/mo) gating rate limits and advanced features
+        - Marketplace → 10–20% take rate; optional Premium listing fee; no subscription needed for MVP
+        - Community / forum → Free / Supporter ($5–10/mo) — gate badges, private channels, exclusive content
+        - Event / booking → Per-ticket fee (3–5%) or organizer subscription ($15–49/mo)
       - `surface_candidate_hints`: coarse realization hints for each likely surface. Each hint includes `surface_id`, `label`, `likely_surface_kind` (module/workflow/control_plane/external_integration/ui_only), `source_capability_packs`, `owner_hint` (app/hosted/platform/null), `confidence`, and `rationale`. These are planning signals for DesignDocs, not final contracts.
         - Set `owner_hint: "app"` for surfaces the generated app owns entirely (custom modules, app-specific workflows).
         - Set `owner_hint: "hosted"` for surfaces backed by framework packs provided outside the app (messaging_pack, files_pack, notifications_pack, entitlements_pack). DesignDocs will use a facade pattern for these.
@@ -282,6 +306,27 @@ agents:
           "subscription_contract_likely": false,
           "money_flow_summary": "No revenue flow is required for the single-user MVP.",
           "rationale": "The approved scope focuses on personal productivity and does not mention paid access, checkout, usage credits, or marketplace payments."
+        },
+        "pricing_recommendation": {
+          "model": "subscriptions",
+          "tiers": [
+            {
+              "name": "Free",
+              "price_monthly": 0,
+              "target_persona": "Solo users trying out the product",
+              "key_gates": ["Up to 50 tasks", "1 project", "Basic prioritization"],
+              "conversion_hook": "AI prioritization is limited — unlock full AI on Pro"
+            },
+            {
+              "name": "Pro",
+              "price_monthly": 12,
+              "target_persona": "Busy professionals managing multiple projects",
+              "key_gates": ["Unlimited tasks and projects", "Full AI prioritization", "Calendar sync"],
+              "conversion_hook": "Full context-aware AI that learns your work patterns"
+            }
+          ],
+          "take_rate_pct": null,
+          "rationale": "Productivity tools convert best with a generous free tier that hits limits naturally, then a single low-friction Pro upgrade."
         },
         "surface_candidate_hints": [
           {

--- a/factory_app/workflows/ValueEngine/context_variables.yaml
+++ b/factory_app/workflows/ValueEngine/context_variables.yaml
@@ -5,6 +5,17 @@ definitions:
 # ============================================================================
 # CONFIG - Deployment settings (env vars)
 # ============================================================================
+  platform_user_email:
+    type: string
+    description: >
+      Email of the authenticated platform user running this session.
+      Injected from the platform at session start. Null in OSS/unauthenticated contexts.
+      When non-null, agents know who they are talking to and can personalize the experience.
+    source:
+      type: config
+      env_var: PLATFORM_USER_EMAIL
+      default: null
+
   app_type:
     type: string
     description: App path for ValueEngine. Greenfield app generation defaults to "greenfield_app".
@@ -45,6 +56,15 @@ definitions:
     source:
       type: state
       default: initial
+  workflow_sequence:
+    type: string
+    description: >
+      Active workflow sequence that launched this run, such as conceptual_replan
+      or full_rebuild. Injected by the control plane so agents can distinguish
+      reroute intent from a plain workflow id.
+    source:
+      type: state
+      default: null
   revision_scope:
     type: string
     description: >
@@ -282,10 +302,12 @@ definitions:
 agents:
   ValueInterviewAgent:
     variables:
+    - platform_user_email
     - app_type
     - context_aware
     - monetization_enabled
     - build_mode
+    - workflow_sequence
     - revision_scope
     - change_request_id
     - revision_id
@@ -307,6 +329,7 @@ agents:
   ResearchAgent:
     variables:
     - build_mode
+    - workflow_sequence
     - revision_scope
     - change_request_id
     - revision_id
@@ -329,6 +352,7 @@ agents:
   GapAnalysisAgent:
     variables:
     - build_mode
+    - workflow_sequence
     - revision_scope
     - change_request_id
     - revision_id

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -372,6 +372,21 @@ async def create_agents(
                     wf_err,
                 )
 
+        # Inject DuckDuckSearchTool when agent declares duck_search: true.
+        # No API key required — works with any model. Good fit for interview and
+        # design agents that need quick market lookups, not deep research crawls.
+        if not auto_tool_call_enabled and agent_config.get("duck_search"):
+            try:
+                from ag2.tools import DuckDuckSearchTool
+                web_tools.append(DuckDuckSearchTool())
+                logger.debug("[AGENTS] DuckDuckSearchTool attached to '%s'", agent_name)
+            except Exception as dd_err:
+                logger.warning(
+                    "[AGENTS] duck_search requested for '%s' but DuckDuckSearchTool unavailable: %s",
+                    agent_name,
+                    dd_err,
+                )
+
         # Wrap tools to inject context_variables
         wrapped_tools: list[Any] = [
             _wrap_tool_with_context(fn, context_bridge) for fn in raw_tool_fns

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -343,10 +343,39 @@ async def create_agents(
                     shell_err,
                 )
 
+        # Inject AG2 built-in WebSearchTool when agent declares web_search: true.
+        # Allows market research agents to do real-time search without custom tool code.
+        web_tools: list[Any] = []
+        if not auto_tool_call_enabled and agent_config.get("web_search"):
+            try:
+                from ag2.tools import WebSearchTool
+                web_tools.append(WebSearchTool())
+                logger.debug("[AGENTS] WebSearchTool attached to '%s'", agent_name)
+            except Exception as ws_err:
+                logger.warning(
+                    "[AGENTS] web_search requested for '%s' but WebSearchTool unavailable: %s",
+                    agent_name,
+                    ws_err,
+                )
+
+        # Inject AG2 built-in WebFetchTool when agent declares web_fetch: true.
+        # Allows agents to retrieve full page content from URLs discovered via search.
+        if not auto_tool_call_enabled and agent_config.get("web_fetch"):
+            try:
+                from ag2.tools import WebFetchTool
+                web_tools.append(WebFetchTool())
+                logger.debug("[AGENTS] WebFetchTool attached to '%s'", agent_name)
+            except Exception as wf_err:
+                logger.warning(
+                    "[AGENTS] web_fetch requested for '%s' but WebFetchTool unavailable: %s",
+                    agent_name,
+                    wf_err,
+                )
+
         # Wrap tools to inject context_variables
         wrapped_tools: list[Any] = [
             _wrap_tool_with_context(fn, context_bridge) for fn in raw_tool_fns
-        ] + shell_tools
+        ] + shell_tools + web_tools
 
         # Load workflow-local AG2 1.0 beta prompt middleware declarations.
         prompt_middleware_functions: list[Callable] = []


### PR DESCRIPTION
## Summary

Agents now infer category-standard decisions without asking the user. Three agents updated:

**ValueInterviewAgent** — pricing inference rules
- States pricing assumption based on app category (B2B SaaS → per-seat, consumer → freemium, marketplace → take rate, creator → Pro tools tier, AI product → token credits)
- Asks only for correction, not derivation

**GapAnalysisAgent** — concrete `pricing_recommendation` output
- New output field with tier name, `price_monthly`, `target_persona`, `key_gates` (what drives upgrade), and `conversion_hook`
- Industry pricing patterns built into the prompt so the agent applies them directly
- Example blueprint updated to show the full shape

**AppPlanAgent** — `[INDUSTRY DEFAULTS — APPLY WITHOUT ASKING]` section
- Profile layout defaults by domain (B2B → sidebar_left, social → top_nav, mobile → drawer, dev tools → icon_rail)
- Social feature defaults by category (friend lists vs follows vs connections vs team invites)
- Subscription tier defaults with price ranges when no `pricing_recommendation` is present
- Feature set table stakes by category (creator platform → drafts + analytics + monetization, without the user listing them)
- Monetization step 4a: consumes `concept_blueprint.pricing_recommendation` directly as authoritative tier structure
- InterviewAgent: explicit list of things not to ask (pricing model, feature table stakes, social features, page structure)

## What this changes for users

A user who says "build me a creator platform" gets:
- Freemium model with Free creator / Pro creator ($19/mo) / fan tier — without being asked
- Profile page with `top_nav` layout — without being asked
- Drafts, scheduling, analytics, monetization toggle, subscriber management — without being asked
- Follow/subscriber social model (not mutual friends) — without being asked