### PR TITLE
fix(agents): provider-aware response_schema for structured outputs

### DIFF
--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -417,13 +417,25 @@ async def create_agents(
         # Determine response schema for structured outputs
         beta_response_schema = None
         if structured_model_cls is not None:
-            # Beta response_schema is provider-enforced. Only pass models that
-            # are compatible with OpenAI strict structured outputs; models with
-            # open-ended dict fields are parsed and validated after the response.
+            # OpenAI strict structured outputs reject Dict[str, Any] fields.
+            # Anthropic (tool_use), Gemini, and Ollama have no such restriction —
+            # AG2 converts the Pydantic schema to a tool input schema internally,
+            # which handles freeform object fields. Only apply the strict-field
+            # gate for OpenAI providers; pass response_schema unconditionally for
+            # all other providers.
             try:
-                supports_strict, _ = supports_provider_response_format(structured_model_cls)
-                if supports_strict:
-                    beta_response_schema = get_provider_response_model(structured_model_cls)
+                _api_type = (
+                    ((llm_config_dict or {}).get("config_list") or [{}])[0].get("api_type") or "openai"
+                ).lower()
+                _openai_strict = _api_type in ("openai", "azure")
+                if _openai_strict:
+                    supports_strict, _ = supports_provider_response_format(structured_model_cls)
+                    if supports_strict:
+                        beta_response_schema = get_provider_response_model(structured_model_cls)
+                else:
+                    # Anthropic / Gemini / Ollama — pass the schema directly;
+                    # AG2 routes it through the provider's native mechanism.
+                    beta_response_schema = structured_model_cls
             except Exception:
                 beta_response_schema = None
 


### PR DESCRIPTION
## Summary

- The `supports_provider_response_format` strict-field gate (which rejects `Dict[str, Any]` fields) was applied to **all providers**, but it only applies to **OpenAI's strict JSON mode**
- Anthropic routes `response_schema` through AG2's tool_use path internally — the Pydantic schema becomes a tool input schema, which supports freeform object fields
- Gemini and Ollama behave similarly to Anthropic in this regard

**Before:** GapAnalysisAgent, ConceptBlueprint, and any other structured output model with `dict` fields would fall back to prompt-based JSON when using Anthropic — no provider-enforced schema validation

**After:** Anthropic/Gemini/Ollama agents with complex models (including dict fields) get AG2's native `response_schema` path → schema validated at the provider level

## How it works

```
api_type == "openai" or "azure"
  → supports_provider_response_format gate (rejects dict fields)
  → if clean: get_provider_response_model() → strict schema

api_type == "anthropic" / "gemini" / "ollama"
  → skip dict-field check
  → pass structured_model_cls directly as response_schema
  → AG2 converts to tool_use / native mechanism internally
```

## Test plan

- [ ] `pytest tests/test_sandbox_shell_contract.py` — no regression in agent creation
- [ ] Smoke test with Anthropic model: GapAnalysisAgent should produce schema-validated structured output instead of relying on prompt parsing
- [ ] Confirm OpenAI agents still use the strict gate (models with dict fields fall back to prompt-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)