### PR TITLE
feat(appgenerator): emit integrations.yaml manifest and wire integration readiness into build

### DIFF
--- a/docs/architecture/app/account-admin-and-platform-services.md
+++ b/docs/architecture/app/account-admin-and-platform-services.md
@@ -102,7 +102,7 @@ Use the canonical `handler.py`, `service.py`, `repo.py`, `policy.py`, and
 
 | Concern | Primary UX surface | Source of truth | Extension contract | Not owned by |
 |---|---|---|---|---|
-| Account/Profile | `/me` and `/u/:username` via `ProfilePage` | `GET/PUT /api/me`, `GET /api/users/{username}` | `modules/{module}/contracts/profile.yaml` for module panels and tabs | workflows, generated page bundles |
+| Account/Profile | `/me` via `ProfilePage`; public profile `/u/:username` via `ProfilePage` | `GET/PUT /api/me`, `GET /api/users/{username}` | `modules/{module}/contracts/profile.yaml` for module panels and tabs | workflows, generated page bundles |
 | Resource relationships | My Apps/Portfolio/My Resources surfaces | `GET /api/me/relationships` | `modules/{module}/contracts/relationships.yaml` | workflows, generated page bundles, admin shell |
 | Preferences | `/me` preferences section | `GET/PUT /api/me/preferences` | none for generic preferences; module-specific config uses `contracts/settings.yaml` outside Profile | workflow prompts |
 | Notifications | shell notification surfaces and backend delivery rules | app backend plus module notification policy | `modules/{module}/contracts/notifications.yaml` | workflows as source of truth |

--- a/docs/architecture/app/app-bundle-declaratives.md
+++ b/docs/architecture/app/app-bundle-declaratives.md
@@ -25,6 +25,28 @@ admin config, and theme config. When an app needs durable runtime secrets,
 `app/security/secrets.yaml` declares the secret provider/vault policy, env
 handles, and secret names only. It must never contain raw credential values.
 
+`app/config/integrations.yaml` is the canonical generated-app integration
+requirement contract. AppGenerator materializes it during assembly from
+`AppBuildPlan.external_integrations`, capability-pack `required_integrations`,
+build-task `integration_needs`, and recorded task-agent needs. It contains
+service ids, provider-neutral purpose, required lifecycle point, setup lane
+metadata, frontend-safe managed defaults, required field names, and
+`required_by` references. It must never contain raw API keys, OAuth tokens,
+passwords, webhook secrets, or provider SDK state.
+
+When any requirement includes the `managed` setup lane, the generated bundle
+scanner also rejects raw payment-provider environment handles, provider webhook
+routes, and direct provider SDK mechanics. Managed setup means the app talks to
+the selected managed capability or app-owned facade, not to the underlying
+provider.
+
+`app/config/targets.json` is the canonical generated-app target intent
+contract. AppGenerator materializes it during assembly from the deployment
+profile and deployment target plan. It records runtime shape, health path,
+deployment profile, allowed deployment lanes, expected environment variable
+names, and domain intent. It does not own provider execution, hosted deployment
+state, cloud tenant ids, or secret values.
+
 `app/config/subscriptions.yaml` is the canonical generated-app SaaS plan
 catalog. Present only in apps that sell their own plans or need end-user
 feature gates. It declares each plan_id, its label, and the capability_ids it

--- a/docs/architecture/app/integrations-workflow.md
+++ b/docs/architecture/app/integrations-workflow.md
@@ -32,6 +32,9 @@ required_fields:
     type: text
     required: true
     frontend_safe: true
+preferred_setup_lane: bring_your_own_key
+allowed_setup_lanes:
+  - bring_your_own_key
 permissions_required:
   - integrations.manage
 resume:
@@ -43,7 +46,9 @@ resume:
 
 The UI may render the request inline or link to
 `/apps/{appId}/integrations`. Secret fields are write-only. Non-secret fields
-marked `frontend_safe: true` may be persisted as connector metadata.
+marked `frontend_safe: true` may be persisted as connector metadata. Setup
+lanes are app-agnostic: `managed`, `connect_account`, `bring_your_own_key`,
+or `not_required`.
 
 ## Workflow Behavior
 
@@ -69,6 +74,16 @@ agent/tool discovers need
 
 Generated app code references connector ids/capabilities and reads integration
 state through server-side adapters. It never receives raw secrets.
+
+AppGenerator also materializes the app's declared integration requirements to
+`app/config/integrations.yaml`. That file is a generated-app declarative
+contract, not a secret store. It contains service ids, setup lanes, field names,
+frontend-safe metadata, and `required_by` references only.
+
+Deployment/runtime target intent is materialized to `app/config/targets.json`.
+It records app-neutral runtime/deployment facts such as health path, deployment
+profile, and expected environment variable names. Hosted products may consume
+that contract, but provider mechanics remain outside the generated app.
 
 The readiness checkpoint is the task-result merge boundary before validation/download. It
 does not require manual preflight setup; it waits until the build has a concrete
@@ -236,6 +251,8 @@ filtered defensively even if malformed connector metadata reaches the frontend.
 build-task `integration_needs`, and task-agent `record_integration_need` calls
 feed the same readiness checkpoint. Agents should declare provider-neutral
 service ids, setup fields, purpose, required lifecycle point, and whether the
-need is optional. Capability-pack `required_integrations` must be structured
-objects with `required_fields`; they should not be reduced to string service
-names when a pack declares public config and secret fields.
+need is optional. They should also declare `preferred_setup_lane` and
+`allowed_setup_lanes` when the active build context knows the viable setup
+paths. Capability-pack `required_integrations` must be structured objects with
+`required_fields`; they should not be reduced to string service names when a
+pack declares public config, secret fields, or managed setup defaults.

--- a/docs/architecture/app/managed-integration-setup-ux.md
+++ b/docs/architecture/app/managed-integration-setup-ux.md
@@ -1,0 +1,317 @@
+# Managed Integration Setup UX
+
+Status: architecture and OSS generation contract
+
+Scope: Studio, Factory workflows, generated app integration contracts, and hosted product extensions.
+
+## Purpose
+
+Mozaiks should not make users hunt for provider API keys before they can build
+or run an app. Users should choose the capability they want, and the platform
+should resolve the safest available setup path.
+
+This document defines the canonical API-light setup model:
+
+```text
+user selects capability
+  -> Studio explains what the app needs
+  -> resolver offers managed, connected-account, or bring-your-own setup
+  -> generated app receives provider-neutral config and safe secret handles
+  -> runtime checks readiness without exposing raw credentials
+```
+
+The goal is not to pretend APIs do not exist. The goal is to keep API-key work
+behind clear product choices and to avoid forcing non-technical users to visit
+developer dashboards unless there is no managed or OAuth path.
+
+## User-Facing Rule
+
+Users configure outcomes, not providers.
+
+Good:
+
+```text
+Payments are ready through MozaiksPay.
+Email needs a sender connection.
+Research is ready through managed web research.
+```
+
+Avoid:
+
+```text
+Paste STRIPE_SECRET_KEY.
+Paste SENDGRID_API_KEY.
+Paste DDG_API_KEY.
+```
+
+Provider details may appear in advanced setup, operator notes, runbooks, and
+self-hosting docs. They should not be the first task presented to a builder.
+
+## Setup Lanes
+
+Every integration requirement resolves through one of these lanes.
+
+| Lane | User action | Secret owner | Best for |
+| --- | --- | --- | --- |
+| Managed by Mozaiks | Click "Use managed service" | Mozaiks App or operator service | Payments, hosted auth, web research, email, deployment, domains |
+| Connect account | OAuth or provider login | Connected user/workspace account | Google, GitHub, Microsoft, Slack, Stripe-owned accounts |
+| Bring your own key | Paste/write secret once | Workspace or app operator | Self-hosting, enterprise-owned providers, unsupported services |
+| Not required | No setup | None | Optional features or no-op local defaults |
+
+The UI should default to the first viable lane in that order. Bring-your-own
+keys are advanced setup, not the main path.
+
+## App-Agnostic OSS Contract
+
+OSS records integration requirements as provider-neutral capabilities.
+AppGenerator materializes those requirements into
+`app/config/integrations.yaml` during assembly. The file is safe to package with
+the generated app because it contains setup field names and frontend-safe
+metadata only, never raw credential values.
+
+```yaml
+integration_id: payments_checkout
+capability_id: payments.checkout
+purpose: Create checkout sessions for paid plans and token top-ups.
+required_lifecycle: runtime
+preferred_setup_lane: managed
+allowed_setup_lanes:
+  - managed
+  - connect_account
+  - bring_your_own_key
+managed_default:
+  service: mozaikspay
+  display_name: MozaiksPay
+required_fields:
+  - name: api_base
+    type: url
+    frontend_safe: true
+  - name: api_key
+    type: secret
+    frontend_safe: false
+```
+
+The generated app should bind pages and actions to app-owned facade modules and
+thin clients. It should not bind UI directly to provider internals.
+
+```text
+page
+  -> app module facade action
+  -> app/services/integrations/{service}_client.py
+  -> managed or connected service API
+```
+
+This keeps the contract replaceable. If a workspace changes from MozaiksPay to
+another provider, the generated app should preserve the same capability
+surface, entitlement gates, and token behavior.
+
+## Hosted Product Extension Contract
+
+Mozaiks App may provide managed implementations for OSS capabilities, but the
+OSS framework must not depend on proprietary hosted logic.
+
+| Concern | OSS owns | Mozaiks App owns |
+| --- | --- | --- |
+| Capability requirement shape | `app/config/integrations.yaml`, app integration declarations, build-context pack metadata | Managed-service availability and commercial policy |
+| Generated app surface | Facade module, client, env names, readiness status | Hosted API implementation |
+| Secret contract | Names-only handles and write-only setup fields | Secret issuance, rotation, storage, and provider credentials |
+| Runtime effects | Entitlement gates, token guards, provider-neutral fulfillment commands | Payment/provider verification and hosted fulfillment source facts |
+| UI extension | Studio setup slots and safe status rendering | Managed-service onboarding flows and hosted-account UI |
+
+MozaiksPay can be the default managed payment option. It must remain a selected
+managed adapter, not a hardcoded OSS payment runtime.
+
+## UI Model
+
+Studio should show a single integration setup surface with plain task states.
+
+```text
+Your app needs 4 services
+
+Ready
+- Payments: MozaiksPay managed
+- Research: Mozaiks managed web research
+
+Needs setup
+- Email: connect sender account
+- Google Calendar: connect Google
+
+Advanced
+- Custom CRM: add API key
+```
+
+Each integration detail view should include:
+
+- display name and what the service enables
+- current lane and readiness status
+- recommended setup action
+- safe fields only
+- health status when a registered health plugin exists
+- operator note
+- advanced setup collapsed by default
+
+Secret values are write-only. The frontend can show "configured" or "missing",
+never the stored value.
+
+`app/config/targets.json` is materialized at the same assembly boundary. It
+records provider-neutral deployment intent such as runtime shape, health path,
+deployment profile, and expected environment variable names. It does not record
+live provider state, cloud tenant ids, hosted-product policy, or secrets.
+
+## Workflow Behavior
+
+Build workflows should ask for setup only at real blocking points.
+
+```text
+AppGenerator records integration needs
+  -> IntegrationReadinessAgent resolves current workspace state
+  -> ready: continue build
+  -> managed available: offer managed setup
+  -> OAuth available: offer account connection
+  -> key required: show advanced BYO form
+  -> missing required setup: pause workflow with integration.required
+  -> setup saved: recheck readiness and resume
+```
+
+Agents should output structured integration needs. Tools should only persist,
+emit UI events, or call safe status APIs. Tools should not infer provider
+choices from keyword matching.
+
+## API-Key Reduction Policy
+
+Use this policy whenever a generated app needs an external capability:
+
+1. Prefer managed capability packs for high-friction provider setup.
+2. Prefer OAuth/connect-account flows over manual key entry.
+3. Ask for raw API keys only when the app explicitly owns that provider
+   integration or the workspace chooses self-host/enterprise mode.
+4. Store raw secrets only through the configured secret backend.
+5. Generate names-only env handles and secret contracts.
+6. Keep provider SDKs out of generated apps when a managed service is selected.
+7. Keep readiness configuration-based by default; provider health checks are
+   explicit operator actions.
+
+## Production Tasks
+
+### Phase 1: Contract Cleanup
+
+- [x] Define `preferred_setup_lane` and `allowed_setup_lanes` on catalog-backed
+  integration requirements.
+- [x] Add `preferred_setup_lane`, `allowed_setup_lanes`, and optional
+  `managed_default` to the integration requirement schema.
+- [x] Materialize `app/config/integrations.yaml` and `app/config/targets.json`
+  from AppGenerator assembly.
+- [x] Validate those fields in the workspace integrations module.
+- [x] Update AppGenerator structured outputs and prompts to emit capability-first
+  integration needs.
+- [x] Keep MozaiksPay as the default managed payment capability for monetizable
+  apps.
+- [x] Add scanner rules that reject direct provider leakage when a managed lane is
+  selected.
+
+Acceptance:
+
+- A build can declare `payments.checkout` without naming Stripe.
+- Generated artifacts contain safe env names and facade/client code only.
+- Tests fail if a managed integration emits raw provider SDK imports, webhook
+  handlers, or raw secrets.
+
+### Phase 2: Studio UX
+
+- Add a resolver that groups app needs into Ready, Needs setup, Optional, and
+  Advanced.
+- Render one recommended action per missing requirement.
+- Add "Use managed service" actions for managed defaults.
+- Add "Connect account" actions where OAuth support exists.
+- Keep "Add my own key" in advanced setup.
+- Render connector health only when a health plugin is registered.
+- Make readiness and health messages safe for frontend display.
+
+Acceptance:
+
+- A novice builder can see what is missing without reading env var names.
+- The setup page never displays raw secret values.
+- Manual key entry is still available for self-host and enterprise use.
+
+### Phase 3: Hosted Managed Services
+
+- In Mozaiks App, expose hosted onboarding APIs for managed service activation.
+- Let managed services issue app-scoped client credentials or OAuth grants.
+- Store hosted credentials in the hosted product secret store.
+- Return only safe status and display prefixes to OSS/Studio.
+- Add managed setup evidence to connector health/status records.
+
+Acceptance:
+
+- A user can activate MozaiksPay without opening a payment-provider dashboard.
+- A generated app receives only `MOZAIKSPAY_API_BASE` and a secret handle or
+  managed credential reference.
+- Stripe or other provider mechanics remain outside OSS and generated bundles.
+
+### Phase 4: Workflow Resume
+
+- Make `integration.required` events carry the setup lane options and the
+  recommended default.
+- Resume the paused workflow after setup succeeds.
+- Recheck readiness before continuing.
+- Persist setup decisions so switching between Ask and Workflow mode does not
+  create duplicate setup prompts.
+
+Acceptance:
+
+- A build pauses once for a missing integration, resumes after setup, and does
+  not ask again for the same configured service.
+- Chat history and app build state both show the same integration decision.
+
+### Phase 5: Observability And Runbooks
+
+- Log lane resolution decisions without secrets.
+- Track readiness state changes and manual health-check attempts.
+- Add operator runbooks for managed setup, connected-account setup, and BYO
+  setup.
+- Add smoke tests for MozaiksPay managed setup, OAuth mock setup, and BYO secret
+  setup.
+
+Acceptance:
+
+- Operators can answer why a build is blocked.
+- Test evidence covers the no-key managed path and the advanced key path.
+- Failure messages tell the user what action to take next.
+
+## Implementation Ownership
+
+| Work item | Repo | Layer |
+| --- | --- | --- |
+| Integration requirement schema | `mozaiks` | Platform / Studio module |
+| AppGenerator prompts and structured outputs | `mozaiks` | Factory |
+| Setup lane resolver | `mozaiks` | Studio |
+| Workspace/app integration pages | `mozaiks` | Studio UI |
+| Secret handles and names-only artifacts | `mozaiks` | App workspace contract |
+| Managed service activation APIs | `mozaiks-app` | Hosted product |
+| MozaiksPay provider mechanics | `mozaiks-app` | Hosted product adapters |
+| Connector health plugins | `mozaiks` contract, product implementations external | Studio / hosted extension |
+
+## Settled Decisions
+
+- Setup lanes live directly on catalog-backed integration requirements and app
+  declarations. A separate setup-policy file is unnecessary until multiple
+  products need divergent lane ordering.
+- The OSS side describes the managed lane and generates safe config. Hosted
+  products implement managed-service activation.
+
+## Open Decisions
+
+- Whether managed activation creates a workspace connector record immediately
+  or a pending setup record that becomes a connector only after hosted
+  provisioning succeeds.
+- Whether app-specific connector overrides should be visible in the workspace
+  `/integrations` page or only in `/apps/{appId}/integrations`.
+- Which OAuth providers are first-class in OSS docs versus product-specific
+  connector plugins.
+
+## Cross References
+
+- [Integrations Workflow](integrations-workflow.md)
+- [Managed Capability Packs](../modules-systems/managed-capability-packs.md)
+- [Integrations Guide](../../guides/integrations/01-overview.md)
+- [Distribution and Workspace Model](../foundations/distribution-and-workspace-model.md)

--- a/docs/architecture/builder/appgenerator-output-assembly-contract.md
+++ b/docs/architecture/builder/appgenerator-output-assembly-contract.md
@@ -187,6 +187,13 @@ binding to provider internals, facade handlers accepting synthetic payload
 wrappers, missing app-level service packages, invalid companion manifests, or
 template files that cannot be imported by the runtime loader.
 
+When `config/integrations.yaml` declares a managed setup lane, the same scanner
+also rejects raw payment-provider env handles, provider webhook/checkout routes,
+and direct provider SDK mechanics anywhere in the generated bundle. Managed
+setup is a contract boundary: provider callbacks and processor mechanics stay
+with the managed/hosted product, while the generated app uses the managed
+capability client and app-owned facade.
+
 ### Route/component registration drift
 
 For custom full-page React routes, the route contract is complete only when all

--- a/docs/guides/integrations/01-overview.md
+++ b/docs/guides/integrations/01-overview.md
@@ -32,12 +32,14 @@ raw secrets.
 2. During planning, AppGenerator can call `check_workspace_integrations` to see
    which services are already configured.
 3. IntegrationReadinessAgent resolves the app's required and optional services.
-4. `save_integration_manifest` persists those requirements as app integration
+4. AppGenerator assembly writes `app/config/integrations.yaml` and
+   `app/config/targets.json` into the generated app bundle.
+5. `save_integration_manifest` persists those requirements as app integration
    declarations.
-5. Studio overlays live workspace setup status when the app page loads.
-6. Users can configure shared services through workspace-level environment
-   variables or saved workspace connectors.
-7. Apps read the resulting declarations/status and show whether each required
+6. Studio overlays live workspace setup status when the app page loads.
+7. Users can configure shared services through managed setup, connected-account
+   setup, or advanced bring-your-own-key setup.
+8. Apps read the resulting declarations/status and show whether each required
    service is ready, needs setup, or is app-specific.
 
 Mozaiks Pay is the default removable payment integration for monetizable apps.
@@ -72,8 +74,9 @@ The page is app-oriented:
 - **App-specific**: services outside the workspace catalog.
 
 If a required catalog service is not ready, the app points the user back to the
-workspace Integrations page. If a service is app-specific, setup belongs in the
-app environment or a dedicated app module.
+workspace Integrations page or shows the same setup task inline during a build
+checkpoint. If a service is app-specific, setup belongs in the app environment
+or a dedicated app module.
 
 ## How Apps Know What Is Ready
 
@@ -100,6 +103,11 @@ validation aligned:
 - `factory_app/app/modules/workspace_integrations/backend/schemas.py`
 - `tests/test_workspace_integrations_module.py`
 
+Generated apps receive integration requirements in
+`app/config/integrations.yaml`. Deployment/runtime target intent is recorded in
+`app/config/targets.json`. Both files are generated declaratives and must stay
+free of raw secrets.
+
 The current implementation keeps catalog data in both YAML and Python. Keep
 them synchronized until the catalog is moved behind a single typed loader.
 
@@ -114,7 +122,7 @@ internal `messages` module and use integrations only for external delivery.
 ## Connector And Secret Rules
 
 - Secret values are never returned to the frontend.
-- API responses may include secret names and boolean presence only.
+- API responses may include secret names, setup lane, and boolean presence only.
 - Workspace connectors are scoped by workspace and can be reused by apps.
 - App-scoped connectors override workspace connectors when a generated app
   explicitly needs its own credential.

--- a/docs/guides/workspace-integrations.md
+++ b/docs/guides/workspace-integrations.md
@@ -1,7 +1,7 @@
 # Workspace Integrations Implementation
 
 **Status:** Current implementation reference
-**Last updated:** 2026-07-13
+**Last updated:** 2026-07-24
 **Scope:** Factory workflow, workspace module, Studio workspace page, app integrations page
 
 For the user-facing guide, see
@@ -29,7 +29,7 @@ Workspace connector
   stores workspace-scoped credential metadata and vault references
 
 App integration declaration
-  records services a generated app needs
+  records services a generated app needs plus allowed setup lanes
 
 App facade/module/client
   consumes those services without exposing provider internals to app UI
@@ -67,17 +67,36 @@ AppGenerator owns the build-time flow:
 1. `check_workspace_integrations` lets planning inspect catalog status.
 2. IntegrationReadinessAgent resolves required, optional, and custom services.
 3. `save_integration_manifest` persists the app's integration declarations.
-4. Monetizable apps receive a removable Mozaiks Pay declaration unless the build
+4. AppGenerator assembly materializes `app/config/integrations.yaml` and
+   `app/config/targets.json` into generated app bundles.
+5. Monetizable apps receive a removable Mozaiks Pay declaration unless the build
    explicitly declared a different payment path.
 
 Important files:
 
 ```text
 factory_app/workflows/AppGenerator/tools/check_workspace_integrations.py
+factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
 factory_app/workflows/AppGenerator/tools/save_integration_manifest.py
 factory_app/workflows/AppGenerator/agents.yaml
 factory_app/workflows/AppGenerator/tools.yaml
 ```
+
+## Setup Lanes
+
+Integration requirements are not API-key-first. Each declaration may expose one
+or more setup lanes:
+
+| Lane | Meaning |
+|------|---------|
+| `managed` | A hosted or managed provider can provision the setup for the app. |
+| `connect_account` | The user connects an account through an OAuth/OIDC-style flow. |
+| `bring_your_own_key` | The user supplies their own credential values through the connector UI. |
+| `not_required` | The integration is declared for metadata or optional readiness only. |
+
+Mozaiks Pay defaults to `managed` with `bring_your_own_key` as a supported
+self-host fallback. The OSS catalog only declares those lanes. Hosted
+provisioning, billing, marketplace, and provider mechanics remain outside OSS.
 
 ## Studio UI
 
@@ -131,6 +150,10 @@ factory_app/app/modules/workspace_integrations/backend/schemas.py
 The YAML file is factory build context. The Python list is the runtime module's
 catalog. Keep both synchronized until the runtime loads the YAML through a
 strict typed catalog loader.
+
+Both catalog copies must include setup-lane metadata so Factory workflows,
+generated app config, and Studio integration screens agree on the same setup
+contract.
 
 ## Testing
 

--- a/factory_app/app/modules/workspace_integrations/backend/schemas.py
+++ b/factory_app/app/modules/workspace_integrations/backend/schemas.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from mozaiksai.core.workflow.generator_support.connector_setup import (
+    normalize_required_fields,
+    normalize_setup_lanes,
+    safe_managed_default,
+)
+
 # ---------------------------------------------------------------------------
 # Integration catalog
 # Canonical source of truth for the runtime. Keep in sync with
@@ -22,6 +28,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create a new secret key and copy it immediately (shown once)",
         ],
         "setup_url": "https://platform.openai.com/api-keys",
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "anthropic",
@@ -36,6 +44,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create a new key and copy it immediately (shown once)",
         ],
         "setup_url": "https://console.anthropic.com/settings/keys",
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "gemini",
@@ -50,6 +60,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create or select a project and copy the API key",
         ],
         "setup_url": "https://aistudio.google.com/apikey",
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "mozaikspay",
@@ -61,6 +73,9 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
         "default_for": ["subscription_or_usage_app"],
         "removable_default": True,
         "capabilities": ["subscriptions", "usage_billing", "billing_portal"],
+        "preferred_setup_lane": "managed",
+        "allowed_setup_lanes": ["managed", "bring_your_own_key"],
+        "managed_default": {"provider": "mozaikspay", "mode": "hosted"},
         "setup_steps": [
             "Open the workspace Integrations page and select Mozaiks Pay",
             "Enter the Mozaiks Pay API base URL and app-scoped API key",
@@ -79,6 +94,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create an API key with Send access",
             "Verify your sending domain under Domains",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "sendgrid",
@@ -92,6 +109,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create an API key with Mail Send access",
             "Verify your sender identity or sending domain before production delivery",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "twilio",
@@ -105,6 +124,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Copy the Account SID and Auth Token",
             "Purchase or verify a phone number to use as the sender",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "slack",
@@ -118,6 +139,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Add OAuth scopes: chat:write, channels:read",
             "Install the app to your workspace and copy the Bot User OAuth Token",
         ],
+        "preferred_setup_lane": "connect_account",
+        "allowed_setup_lanes": ["connect_account", "bring_your_own_key"],
     },
     {
         "id": "github",
@@ -131,6 +154,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Generate a token with repo and workflow scopes",
             "For org-level access, use a fine-grained token scoped to the org",
         ],
+        "preferred_setup_lane": "connect_account",
+        "allowed_setup_lanes": ["connect_account", "bring_your_own_key"],
     },
     {
         "id": "s3",
@@ -144,6 +169,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Generate Access Key ID and Secret Access Key under Security Credentials",
             "Create or identify the S3 bucket this app will use",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "cloudinary",
@@ -157,6 +184,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Copy the CLOUDINARY_URL credential for the target cloud",
             "Use a scoped product environment for production apps",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "mongodb",
@@ -170,6 +199,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create an app-scoped database user with the minimum required database permissions",
             "Copy the connection string as MONGO_URI and verify it with the readiness check before deploy",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "postgres",
@@ -182,6 +213,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Provision a PostgreSQL instance (Supabase, Neon, RDS, or self-hosted)",
             "Copy the connection string: postgresql://user:pass@host:port/dbname",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "redis",
@@ -194,6 +227,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Provision a Redis instance (Upstash, Redis Cloud, or self-hosted)",
             "Copy the connection URL: redis://user:pass@host:port",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
     {
         "id": "google_oauth",
@@ -207,6 +242,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Create an OAuth 2.0 Client ID (Web application type)",
             "Add your app's redirect URI to the Authorized redirect URIs list",
         ],
+        "preferred_setup_lane": "connect_account",
+        "allowed_setup_lanes": ["connect_account", "bring_your_own_key"],
     },
     {
         "id": "microsoft_oauth",
@@ -220,6 +257,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Add the app redirect URI under Authentication",
             "Create a client secret and store only the secret handle in the workspace connector",
         ],
+        "preferred_setup_lane": "connect_account",
+        "allowed_setup_lanes": ["connect_account", "bring_your_own_key"],
     },
     {
         "id": "segment",
@@ -232,6 +271,8 @@ INTEGRATIONS_CATALOG: list[dict[str, Any]] = [
             "Sign in to Segment → Sources → Add Source → Node.js",
             "Copy the Write Key from the source settings",
         ],
+        "preferred_setup_lane": "bring_your_own_key",
+        "allowed_setup_lanes": ["bring_your_own_key"],
     },
 ]
 
@@ -263,7 +304,14 @@ def build_integration_response(
         "setup_steps": spec.get("setup_steps", []),
         "note": note,
     }
-    for metadata_key in ("default_for", "removable_default", "capabilities"):
+    for metadata_key in (
+        "default_for",
+        "removable_default",
+        "capabilities",
+        "preferred_setup_lane",
+        "allowed_setup_lanes",
+        "managed_default",
+    ):
         if metadata_key in spec:
             response[metadata_key] = spec[metadata_key]
     if status == "missing":
@@ -308,6 +356,9 @@ def build_declaration_document(
     removable: bool = False,
     source: str = "build",
     required_fields: list[dict[str, Any]] | None = None,
+    preferred_setup_lane: str | None = None,
+    allowed_setup_lanes: list[str] | None = None,
+    managed_default: dict[str, Any] | str | None = None,
     removed: bool = False,
     declared_at: str,
 ) -> dict[str, Any]:
@@ -317,6 +368,18 @@ def build_declaration_document(
     Connector status reflects the per-app vault inventory at build time.
     Neither field stores secret values.
     """
+
+    normalized_fields = normalize_required_fields({"kind": kind, "required_fields": required_fields or []})
+    lane_source = {
+        "kind": kind,
+        "optional": optional,
+        "required_fields": normalized_fields,
+        "preferred_setup_lane": preferred_setup_lane,
+        "allowed_setup_lanes": allowed_setup_lanes,
+        "managed_default": managed_default,
+    }
+    lanes = normalize_setup_lanes(lane_source)
+    safe_default = safe_managed_default(managed_default)
     return {
         "app_id": app_id,
         "service": service,
@@ -331,7 +394,10 @@ def build_declaration_document(
         "defaulted": defaulted,
         "removable": removable,
         "source": source,
-        "required_fields": list(required_fields or []),
+        "required_fields": normalized_fields,
+        "preferred_setup_lane": lanes["preferred_setup_lane"],
+        "allowed_setup_lanes": lanes["allowed_setup_lanes"],
+        "managed_default": safe_default,
         "removed": removed,
         "declared_at": declared_at,
     }
@@ -354,6 +420,9 @@ def build_declaration_response(doc: dict[str, Any]) -> dict[str, Any]:
         "removable": bool(doc.get("removable")),
         "source": doc.get("source"),
         "required_fields": doc.get("required_fields") if isinstance(doc.get("required_fields"), list) else [],
+        "preferred_setup_lane": doc.get("preferred_setup_lane"),
+        "allowed_setup_lanes": doc.get("allowed_setup_lanes") if isinstance(doc.get("allowed_setup_lanes"), list) else [],
+        "managed_default": doc.get("managed_default") if isinstance(doc.get("managed_default"), dict) else {},
         "declared_at": doc.get("declared_at"),
         "setup_url": f"/integrations/{doc['catalog_id']}" if doc.get("catalog_id") and doc.get("workspace_status") == "missing" else None,
     }

--- a/factory_app/app/modules/workspace_integrations/backend/service.py
+++ b/factory_app/app/modules/workspace_integrations/backend/service.py
@@ -48,6 +48,9 @@ class WorkspaceIntegrationsService:
         if workspace_status is None and catalog_spec:
             workspace_status, _ = derive_status(catalog_spec["required_secrets"])
         required_fields = need.get("required_fields") if isinstance(need.get("required_fields"), list) else []
+        allowed_setup_lanes = need.get("allowed_setup_lanes")
+        if not isinstance(allowed_setup_lanes, list) and catalog_spec:
+            allowed_setup_lanes = catalog_spec.get("allowed_setup_lanes")
         return build_declaration_document(
             app_id=app_id,
             service=service,
@@ -63,6 +66,9 @@ class WorkspaceIntegrationsService:
             removable=bool(need.get("removable", False)),
             source=str(need.get("source") or "build"),
             required_fields=required_fields,
+            preferred_setup_lane=need.get("preferred_setup_lane") or (catalog_spec or {}).get("preferred_setup_lane"),
+            allowed_setup_lanes=allowed_setup_lanes,
+            managed_default=need.get("managed_default") or (catalog_spec or {}).get("managed_default"),
             declared_at=declared_at,
         )
 

--- a/factory_app/build_context/integrations/catalog.yaml
+++ b/factory_app/build_context/integrations/catalog.yaml
@@ -11,6 +11,9 @@ integrations:
     setup_steps:
       - Sign in to platform.openai.com → API Keys
       - Create a new secret key and copy it immediately (shown once)
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: anthropic
     name: Anthropic
@@ -22,6 +25,9 @@ integrations:
     setup_steps:
       - Sign in to console.anthropic.com → API Keys
       - Create a new key and copy it immediately (shown once)
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: gemini
     name: Gemini
@@ -34,6 +40,9 @@ integrations:
     setup_steps:
       - Sign in to aistudio.google.com → Get API key
       - Create or select a project and copy the API key
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: mozaikspay
     name: Mozaiks Pay
@@ -53,6 +62,13 @@ integrations:
       - subscriptions
       - usage_billing
       - billing_portal
+    preferred_setup_lane: managed
+    allowed_setup_lanes:
+      - managed
+      - bring_your_own_key
+    managed_default:
+      provider: mozaikspay
+      mode: hosted
     setup_steps:
       - Open the workspace Integrations page and select Mozaiks Pay
       - Enter the Mozaiks Pay API base URL and app-scoped API key
@@ -70,6 +86,9 @@ integrations:
       - Sign in to resend.com → API Keys
       - Create an API key with Send access
       - Verify your sending domain under Domains
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: sendgrid
     name: SendGrid
@@ -83,6 +102,9 @@ integrations:
       - Sign in to SendGrid → Settings → API Keys
       - Create an API key with Mail Send access
       - Verify your sender identity or sending domain before production delivery
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: twilio
     name: Twilio
@@ -97,6 +119,9 @@ integrations:
       - Sign in to Twilio Console → Account → API keys & tokens
       - Copy the Account SID and Auth Token
       - Purchase or verify a phone number to use as the sender
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: slack
     name: Slack
@@ -111,6 +136,10 @@ integrations:
       - Go to api.slack.com/apps → Create New App
       - Add OAuth scopes: chat:write, channels:read
       - Install the app to your workspace and copy the Bot User OAuth Token
+    preferred_setup_lane: connect_account
+    allowed_setup_lanes:
+      - connect_account
+      - bring_your_own_key
 
   - id: github
     name: GitHub
@@ -125,6 +154,10 @@ integrations:
       - Go to GitHub → Settings → Developer settings → Personal access tokens
       - Generate a token with repo and workflow scopes
       - For org-level access, use a GitHub App or fine-grained token scoped to the org
+    preferred_setup_lane: connect_account
+    allowed_setup_lanes:
+      - connect_account
+      - bring_your_own_key
 
   - id: s3
     name: AWS S3
@@ -141,6 +174,9 @@ integrations:
       - In AWS IAM, create a user with a scoped S3 policy
       - Generate Access Key ID and Secret Access Key under Security Credentials
       - Create or identify the S3 bucket this app will use
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: cloudinary
     name: Cloudinary
@@ -153,6 +189,9 @@ integrations:
       - Sign in to Cloudinary → Dashboard
       - Copy the CLOUDINARY_URL credential for the target cloud
       - Use a scoped product environment for production apps
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: mongodb
     name: MongoDB
@@ -166,6 +205,9 @@ integrations:
       - Provision MongoDB locally, in Atlas, or through a managed provider
       - Create an app-scoped database user with the minimum required database permissions
       - Copy the connection string as MONGO_URI and verify it with the readiness check before deploy
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: postgres
     name: PostgreSQL
@@ -178,6 +220,9 @@ integrations:
     setup_steps:
       - Provision a PostgreSQL instance (Supabase, Neon, RDS, or self-hosted)
       - Copy the connection string in the format postgresql://user:pass@host:port/dbname
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: redis
     name: Redis
@@ -189,6 +234,9 @@ integrations:
     setup_steps:
       - Provision a Redis instance (Upstash, Redis Cloud, or self-hosted)
       - Copy the connection URL in the format redis://user:pass@host:port
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key
 
   - id: google_oauth
     name: Google OAuth
@@ -203,6 +251,10 @@ integrations:
       - Go to Google Cloud Console → APIs & Services → Credentials
       - Create an OAuth 2.0 Client ID (Web application type)
       - Add your app's redirect URI to the Authorized redirect URIs list
+    preferred_setup_lane: connect_account
+    allowed_setup_lanes:
+      - connect_account
+      - bring_your_own_key
 
   - id: microsoft_oauth
     name: Microsoft OAuth
@@ -218,6 +270,10 @@ integrations:
       - Create an app registration in Microsoft Entra admin center
       - Add the app redirect URI under Authentication
       - Create a client secret and store only the secret handle in the workspace connector
+    preferred_setup_lane: connect_account
+    allowed_setup_lanes:
+      - connect_account
+      - bring_your_own_key
 
   - id: segment
     name: Segment
@@ -229,3 +285,6 @@ integrations:
     setup_steps:
       - Sign in to Segment → Sources → Add Source → Node.js
       - Copy the Write Key from the source settings
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes:
+      - bring_your_own_key

--- a/factory_app/workflows/AgentGenerator/ui/AgentAPIKeysBundleInput.js
+++ b/factory_app/workflows/AgentGenerator/ui/AgentAPIKeysBundleInput.js
@@ -1,11 +1,56 @@
-// ==============================================================================
-// FILE: ChatUI/src/workflows/AgentGenerator/components/AgentAPIKeysBundleInput.js
-// DESCRIPTION: Consolidated API key intake component for multi-service collection
-// ==============================================================================
-
-import { useState, useMemo, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  CheckCircle2,
+  ExternalLink,
+  KeyRound,
+  Link,
+  Plug,
+  ShieldCheck
+} from 'lucide-react';
 import { createToolsLogger } from '@mozaiks/chat-ui/platform/workflowSurfaceRuntime.js';
 import { workflowSurfaceStyles } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
+
+const SECRET_TYPES = new Set(['secret', 'password', 'api_key', 'token']);
+
+const LANE_META = {
+  managed: {
+    label: 'Use managed service',
+    description: 'Let the platform provide the connection when a managed setup is available.',
+    icon: ShieldCheck
+  },
+  connect_account: {
+    label: 'Connect account',
+    description: 'Use a provider login or consent flow when the host exposes one.',
+    icon: Link
+  },
+  bring_your_own_key: {
+    label: 'Add setup values',
+    description: 'Provide the account values needed by this generated app.',
+    icon: KeyRound
+  },
+  not_required: {
+    label: 'No setup required',
+    description: 'Continue without configuring this optional integration.',
+    icon: CheckCircle2
+  }
+};
+
+const normalizeLaneId = (value) => {
+  const raw = String(value || '').trim().toLowerCase().replace(/[-\s]+/g, '_');
+  const aliases = {
+    api_key: 'bring_your_own_key',
+    byok: 'bring_your_own_key',
+    credentials: 'bring_your_own_key',
+    credential: 'bring_your_own_key',
+    oauth: 'connect_account',
+    oauth_connect: 'connect_account',
+    hosted: 'managed',
+    none: 'not_required',
+    skip: 'not_required'
+  };
+  const lane = aliases[raw] || raw;
+  return LANE_META[lane] ? lane : '';
+};
 
 const toTitle = (value = '') => {
   return value
@@ -13,6 +58,151 @@ const toTitle = (value = '') => {
     .filter(Boolean)
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(' ');
+};
+
+const normalizeField = (field, index) => {
+  if (!field || typeof field !== 'object') {
+    return null;
+  }
+  const name = String(field.name || '').trim();
+  if (!name) {
+    return null;
+  }
+  const type = String(field.type || 'text').trim().toLowerCase();
+  const secret = Boolean(field.secret) || SECRET_TYPES.has(type);
+  return {
+    name,
+    label: field.label || toTitle(name),
+    type: secret ? 'secret' : type,
+    required: field.required === undefined ? true : Boolean(field.required),
+    frontendSafe: secret ? false : field.frontend_safe !== false,
+    options: Array.isArray(field.options) ? field.options : [],
+    order: index
+  };
+};
+
+const normalizeFields = (rawService, displayName) => {
+  const declared = Array.isArray(rawService?.required_fields)
+    ? rawService.required_fields.map(normalizeField).filter(Boolean)
+    : [];
+  if (declared.length > 0) {
+    return declared;
+  }
+  return [
+    {
+      name: 'api_key',
+      label: rawService?.label || `${displayName} API Key`,
+      type: 'secret',
+      required: rawService?.required === undefined ? true : Boolean(rawService.required),
+      frontendSafe: false,
+      options: [],
+      order: 0
+    }
+  ];
+};
+
+const normalizeLaneIds = (raw) => {
+  if (!Array.isArray(raw)) {
+    const lane = normalizeLaneId(raw);
+    return lane ? [lane] : [];
+  }
+  const lanes = [];
+  raw.forEach((entry) => {
+    const lane = normalizeLaneId(typeof entry === 'object' && entry ? entry.id : entry);
+    if (lane && !lanes.includes(lane)) {
+      lanes.push(lane);
+    }
+  });
+  return lanes;
+};
+
+const normalizeServices = (payload = {}, componentId) => {
+  if (!Array.isArray(payload.services)) {
+    return [];
+  }
+  return payload.services
+    .map((rawService, index) => {
+      const identifier = typeof rawService?.service === 'string' ? rawService.service.trim().toLowerCase() : '';
+      if (!identifier) {
+        return null;
+      }
+      const displayName =
+        rawService.service_display_name ||
+        rawService.display_name ||
+        rawService.displayName ||
+        toTitle(identifier);
+      const fields = normalizeFields(rawService, displayName);
+      const allowedLanes = normalizeLaneIds(rawService.allowed_setup_lanes);
+      const legacyLanes = normalizeLaneIds(rawService.setup_lanes);
+      const explicitLanes = allowedLanes.length > 0 ? allowedLanes : legacyLanes;
+      const lanes = explicitLanes.length > 0 ? explicitLanes : ['bring_your_own_key'];
+      const preferredLane = normalizeLaneId(rawService.preferred_setup_lane);
+      const activeLane = preferredLane && lanes.includes(preferredLane) ? preferredLane : lanes[0];
+
+      return {
+        id: `${identifier}-${index}`,
+        service: identifier,
+        integrationId: rawService.integration_id || identifier,
+        provider: rawService.provider || identifier,
+        displayName,
+        description:
+          rawService.description ||
+          rawService.purpose ||
+          `Configure ${displayName} so the generated app can use it.`,
+        required: rawService.required === undefined ? true : Boolean(rawService.required),
+        fields,
+        lanes,
+        preferredLane: activeLane,
+        managedDefault: rawService.managed_default || null,
+        integrationsUrl: payload.integrations_url || null,
+        agentMessageId:
+          rawService.agent_message_id || `${payload.agent_message_id || componentId}:${identifier}:${index}`
+      };
+    })
+    .filter(Boolean);
+};
+
+const buildInitialValues = (services) => {
+  const values = {};
+  services.forEach((svc) => {
+    values[svc.service] = {};
+    svc.fields.forEach((field) => {
+      values[svc.service][field.name] = '';
+    });
+  });
+  return values;
+};
+
+const buildInitialVisibility = (services) => {
+  const visibility = {};
+  services.forEach((svc) => {
+    visibility[svc.service] = {};
+    svc.fields.forEach((field) => {
+      visibility[svc.service][field.name] = field.type !== 'secret';
+    });
+  });
+  return visibility;
+};
+
+const buildInitialLanes = (services) => {
+  const lanes = {};
+  services.forEach((svc) => {
+    lanes[svc.service] = svc.preferredLane;
+  });
+  return lanes;
+};
+
+const fieldInputType = (field, visible) => {
+  if (field.type === 'secret') {
+    return visible ? 'text' : 'password';
+  }
+  if (field.type === 'url') {
+    return 'url';
+  }
+  if (field.type === 'number') {
+    return 'number';
+  }
+  return 'text';
 };
 
 const AgentAPIKeysBundleInput = ({
@@ -31,132 +221,59 @@ const AgentAPIKeysBundleInput = ({
     payload.workflow_name ||
     null;
 
-  const services = useMemo(() => {
-    if (!Array.isArray(payload.services)) {
-      return [];
-    }
-
-    return payload.services
-      .map((rawService, index) => {
-        const identifier = typeof rawService?.service === 'string' ? rawService.service.trim().toLowerCase() : '';
-        if (!identifier) {
-          return null;
-        }
-        const displayName =
-          rawService.service_display_name ||
-          rawService.display_name ||
-          rawService.displayName ||
-          toTitle(identifier);
-        const required = rawService.required === undefined ? true : Boolean(rawService.required);
-        const maskInput = rawService.maskInput === undefined
-          ? (rawService.mask_input === undefined ? true : Boolean(rawService.mask_input))
-          : Boolean(rawService.maskInput);
-
-        return {
-          id: `${identifier}-${index}`,
-          service: identifier,
-          displayName,
-          label: rawService.label || `${displayName} API Key`,
-          description: rawService.description || `Enter your ${displayName} API key to continue.`,
-          placeholder: rawService.placeholder || `Enter your ${displayName} API key...`,
-          required,
-          maskInput,
-          agentMessageId:
-            rawService.agent_message_id || `${payload.agent_message_id || componentId}:${identifier}:${index}`
-        };
-      })
-      .filter(Boolean);
-  }, [payload.services, payload.agent_message_id, componentId]);
-
-  const [formValues, setFormValues] = useState(() => {
-    const initial = {};
-    services.forEach((svc) => {
-      initial[svc.service] = '';
-    });
-    return initial;
-  });
-
-  const [visibility, setVisibility] = useState(() => {
-    const initial = {};
-    services.forEach((svc) => {
-      initial[svc.service] = !svc.maskInput;
-    });
-    return initial;
-  });
-
+  const services = useMemo(
+    () => normalizeServices(payload, componentId),
+    [payload, componentId]
+  );
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [formValues, setFormValues] = useState(() => buildInitialValues(services));
+  const [visibility, setVisibility] = useState(() => buildInitialVisibility(services));
+  const [selectedLanes, setSelectedLanes] = useState(() => buildInitialLanes(services));
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
     setFormValues((current) => {
-      const next = {};
+      const next = buildInitialValues(services);
       services.forEach((svc) => {
-        next[svc.service] = current[svc.service] || '';
+        svc.fields.forEach((field) => {
+          next[svc.service][field.name] = current?.[svc.service]?.[field.name] || '';
+        });
       });
       return next;
     });
     setVisibility((current) => {
-      const next = {};
+      const next = buildInitialVisibility(services);
       services.forEach((svc) => {
-        next[svc.service] = current.hasOwnProperty(svc.service) ? current[svc.service] : !svc.maskInput;
+        svc.fields.forEach((field) => {
+          if (current?.[svc.service]?.[field.name] !== undefined) {
+            next[svc.service][field.name] = current[svc.service][field.name];
+          }
+        });
       });
       return next;
     });
-    setErrors((current) => {
-      const filtered = {};
-      services.forEach((svc) => {
-        if (current[svc.service]) {
-          filtered[svc.service] = current[svc.service];
-        }
-      });
-      return filtered;
-    });
+    setSelectedLanes((current) => ({ ...buildInitialLanes(services), ...current }));
+    setErrors({});
     setCurrentIndex(0);
   }, [services]);
 
   const currentService = services[currentIndex] || null;
-
   const agentMessageId = payload.agent_message_id || null;
 
   const tlog = createToolsLogger({
     tool: toolName || componentId,
     eventId: toolCallId,
     workflowName: resolvedWorkflowName,
-    agentMessageId: agentMessageId
+    agentMessageId
   });
-
-  const containerClasses = 'w-full';
-  const cardClasses =
-    'w-full max-w-xl rounded-2xl border border-[rgba(var(--color-primary-rgb),0.18)] bg-[rgba(10,16,38,0.92)] px-6 py-5 shadow-[0_18px_38px_rgba(8,15,40,0.45)] space-y-5';
-  const headingClasses = 'text-lg font-heading font-semibold text-foreground';
-  const descriptionClasses = 'text-xs font-sans text-muted-foreground';
-  const inputClasses = (hasError, isDisabled, mask, visible) =>
-    [
-      'w-full rounded-lg border px-4 py-3 transition-colors border-border bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
-      mask ? 'pr-12' : '',
-      hasError ? 'border-destructive focus:ring-destructive focus:border-destructive' : '',
-      isDisabled ? 'opacity-50 cursor-not-allowed' : '',
-      visible ? 'tracking-wide' : ''
-    ]
-      .filter(Boolean)
-      .join(' ');
-  const assistiveTextClasses = workflowSurfaceStyles.assistiveText;
-  const errorTextClasses = workflowSurfaceStyles.errorText;
-  const buttonGroup = workflowSurfaceStyles.buttonGroup;
-  const secondaryButtonClasses = workflowSurfaceStyles.secondaryButton;
-  const primaryButtonClasses = workflowSurfaceStyles.primaryButton;
-  const skipButtonClasses = workflowSurfaceStyles.skipButton;
 
   const heading = (() => {
     const explicit = typeof payload.heading === 'string' ? payload.heading.trim() : '';
     if (explicit) {
       return explicit;
     }
-    if (currentService) {
-      return `Provide ${currentService.displayName} API Key`;
-    }
-    return 'Provide Required API Keys';
+    return currentService ? `Configure ${currentService.displayName}` : 'Configure Integrations';
   })();
 
   const introMessage = (() => {
@@ -166,30 +283,61 @@ const AgentAPIKeysBundleInput = ({
     if (explicit) {
       return explicit;
     }
-    if (currentService && currentService.description) {
+    if (currentService) {
       return currentService.description;
     }
-    return 'The workflow needs the following API keys. Only metadata is recorded; secrets are never stored.';
+    return 'Choose a setup path and provide only the fields needed to continue.';
   })();
 
-  const handleChange = (service, value) => {
+  const inputClasses = (hasError, isDisabled) =>
+    [
+      'w-full rounded-lg border px-4 py-3 transition-colors border-border bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
+      hasError ? 'border-destructive focus:ring-destructive focus:border-destructive' : '',
+      isDisabled ? 'opacity-50 cursor-not-allowed' : ''
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+  const cardClasses =
+    'w-full max-w-2xl rounded-lg border border-[rgba(var(--color-primary-rgb),0.18)] bg-[rgba(10,16,38,0.92)] px-6 py-5 shadow-[0_18px_38px_rgba(8,15,40,0.45)] space-y-5';
+  const headingClasses = 'text-lg font-heading font-semibold text-foreground';
+  const descriptionClasses = 'text-xs font-sans text-muted-foreground';
+  const assistiveTextClasses = workflowSurfaceStyles.assistiveText;
+  const errorTextClasses = workflowSurfaceStyles.errorText;
+  const buttonGroup = workflowSurfaceStyles.buttonGroup;
+  const secondaryButtonClasses = workflowSurfaceStyles.secondaryButton;
+  const primaryButtonClasses = workflowSurfaceStyles.primaryButton;
+  const skipButtonClasses = workflowSurfaceStyles.skipButton;
+
+  const updateField = (service, fieldName, value) => {
     setFormValues((current) => ({
       ...current,
-      [service]: value
+      [service]: {
+        ...(current[service] || {}),
+        [fieldName]: value
+      }
     }));
-    if (errors[service]) {
-      setErrors((current) => {
-        const next = { ...current };
-        delete next[service];
-        return next;
-      });
-    }
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[`${service}.${fieldName}`];
+      return next;
+    });
   };
 
-  const toggleVisibility = (service) => {
+  const toggleVisibility = (service, fieldName) => {
     setVisibility((current) => ({
       ...current,
-      [service]: !current[service]
+      [service]: {
+        ...(current[service] || {}),
+        [fieldName]: !current?.[service]?.[fieldName]
+      }
+    }));
+  };
+
+  const setLane = (service, lane) => {
+    setSelectedLanes((current) => ({
+      ...current,
+      [service]: lane
     }));
   };
 
@@ -197,27 +345,40 @@ const AgentAPIKeysBundleInput = ({
     if (!currentService) {
       return {};
     }
-    const value = (formValues[currentService.service] || '').trim();
-    if (currentService.required && !value) {
-      return { [currentService.service]: 'API key is required.' };
+    if (selectedLanes[currentService.service] === 'not_required') {
+      return {};
     }
-    return {};
+    const validationErrors = {};
+    currentService.fields.forEach((field) => {
+      const value = String(formValues?.[currentService.service]?.[field.name] || '').trim();
+      if (field.required && !value) {
+        validationErrors[`${currentService.service}.${field.name}`] = 'Required setup field is missing.';
+      }
+    });
+    return validationErrors;
   };
 
   const buildSubmissionPayload = (overrides = {}) => {
     return services.map((svc) => {
-      const sourceValue = Object.prototype.hasOwnProperty.call(overrides, svc.service)
-        ? overrides[svc.service]
-        : formValues[svc.service];
-      const raw = (sourceValue || '').trim();
+      const values = { ...(formValues[svc.service] || {}), ...(overrides[svc.service] || {}) };
+      const trimmedValues = {};
+      svc.fields.forEach((field) => {
+        trimmedValues[field.name] = String(values[field.name] || '').trim();
+      });
+      const firstSecret = svc.fields.find((field) => field.type === 'secret');
+      const rawSecret = firstSecret ? trimmedValues[firstSecret.name] || '' : '';
       return {
         service: svc.service,
         serviceDisplayName: svc.displayName,
-        apiKey: raw,
-        hasApiKey: Boolean(raw),
-        keyLength: raw.length,
+        integration_id: svc.integrationId,
+        provider: svc.provider,
+        apiKey: rawSecret,
+        hasApiKey: Boolean(rawSecret),
+        keyLength: rawSecret.length,
         required: svc.required,
-        maskInput: svc.maskInput,
+        maskInput: svc.fields.some((field) => field.type === 'secret'),
+        selected_setup_lane: selectedLanes[svc.service] || svc.preferredLane,
+        fields: trimmedValues,
         agent_message_id: svc.agentMessageId
       };
     });
@@ -227,43 +388,35 @@ const AgentAPIKeysBundleInput = ({
     const submission = buildSubmissionPayload(overrides);
     try {
       tlog.event('submit', 'start', {
-        services: submission.map((item) => ({ service: item.service, provided: item.hasApiKey }))
+        services: submission.map((item) => ({
+          service: item.service,
+          lane: item.selected_setup_lane,
+          provided: item.hasApiKey
+        }))
       });
-      const responsePayload = {
-        status: 'success',
-        action: 'submit',
-        data: {
-          services: submission,
-          submissionTime: new Date().toISOString(),
-          tool_name: toolName,
-          tool_call_id: toolCallId,
-          workflowName: resolvedWorkflowName,
-          sourceWorkflowName,
-          generatedWorkflowName,
-          agent_message_id: agentMessageId
-        }
-      };
       if (onResponse) {
-        await onResponse(responsePayload);
+        await onResponse({
+          status: 'success',
+          action: 'submit',
+          data: {
+            services: submission,
+            submissionTime: new Date().toISOString(),
+            tool_name: toolName,
+            tool_call_id: toolCallId,
+            workflowName: resolvedWorkflowName,
+            sourceWorkflowName,
+            generatedWorkflowName,
+            agent_message_id: agentMessageId
+          }
+        });
       }
-      setFormValues(() => {
-        const cleared = {};
-        services.forEach((svc) => {
-          cleared[svc.service] = '';
-        });
-        return cleared;
-      });
-      setVisibility(() => {
-        const next = {};
-        services.forEach((svc) => {
-          next[svc.service] = !svc.maskInput;
-        });
-        return next;
-      });
+      setFormValues(buildInitialValues(services));
+      setVisibility(buildInitialVisibility(services));
+      setSelectedLanes(buildInitialLanes(services));
       setCurrentIndex(0);
       setErrors({});
       tlog.event('submit', 'done', {
-        provided: submission.filter((item) => item.hasApiKey).length,
+        configured: submission.filter((item) => item.hasApiKey || item.selected_setup_lane === 'not_required').length,
         requested: services.length
       });
     } catch (submitError) {
@@ -272,10 +425,10 @@ const AgentAPIKeysBundleInput = ({
         services: services.length
       });
       if (onResponse) {
-        onResponse({
+        await onResponse({
           status: 'error',
           action: 'submit',
-          error: submitError?.message || 'Unable to submit API keys.',
+          error: submitError?.message || 'Unable to save integration setup.',
           data: {
             tool_name: toolName,
             tool_call_id: toolCallId
@@ -295,96 +448,73 @@ const AgentAPIKeysBundleInput = ({
 
     const validationErrors = validateCurrentService();
     if (Object.keys(validationErrors).length > 0) {
-      setErrors((prev) => ({ ...prev, ...validationErrors }));
+      setErrors((current) => ({ ...current, ...validationErrors }));
       return;
     }
 
-    const trimmedValue = (formValues[currentService.service] || '').trim();
     setIsSubmitting(true);
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[currentService.service];
-      return next;
+    const trimmed = {};
+    currentService.fields.forEach((field) => {
+      trimmed[field.name] = String(formValues?.[currentService.service]?.[field.name] || '').trim();
     });
-    setFormValues((prev) => ({
-      ...prev,
-      [currentService.service]: trimmedValue
+    setFormValues((current) => ({
+      ...current,
+      [currentService.service]: trimmed
     }));
 
-    try {
-      tlog.event('submit_step', 'done', {
-        service: currentService.service,
-        provided: Boolean(trimmedValue),
-        step: currentIndex + 1,
-        total: services.length
-      });
+    tlog.event('submit_step', 'done', {
+      service: currentService.service,
+      lane: selectedLanes[currentService.service],
+      step: currentIndex + 1,
+      total: services.length
+    });
 
-      if (currentIndex < services.length - 1) {
-        setCurrentIndex((prev) => prev + 1);
-        setIsSubmitting(false);
-      } else {
-        await finalizeSubmission({ [currentService.service]: trimmedValue });
-      }
-    } catch (submitError) {
-      tlog.error('submit step failed', {
-        service: currentService.service,
-        error: submitError?.message
-      });
+    if (currentIndex < services.length - 1) {
+      setCurrentIndex((index) => index + 1);
       setIsSubmitting(false);
+      return;
     }
+    await finalizeSubmission({ [currentService.service]: trimmed });
   };
 
   const handleSkip = async () => {
     if (!currentService) {
       return;
     }
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[currentService.service];
-      return next;
-    });
-    setFormValues((prev) => ({
-      ...prev,
-      [currentService.service]: ''
-    }));
-    tlog.event('skip', 'done', {
-      service: currentService.service,
-      step: currentIndex + 1,
-      total: services.length
-    });
-
+    setLane(currentService.service, 'not_required');
+    setErrors({});
     if (currentIndex < services.length - 1) {
-      setCurrentIndex((prev) => prev + 1);
-    } else {
-      setIsSubmitting(true);
-      await finalizeSubmission({ [currentService.service]: '' });
+      setCurrentIndex((index) => index + 1);
+      return;
     }
+    setIsSubmitting(true);
+    await finalizeSubmission({ [currentService.service]: {} });
   };
 
   const handleCancel = async () => {
     setIsSubmitting(true);
     try {
       tlog.event('cancel', 'start', { services: services.length });
-      const responsePayload = {
-        status: 'cancelled',
-        action: 'cancel',
-        data: {
-          services: buildSubmissionPayload().map((svc) => ({
-            service: svc.service,
-            required: svc.required,
-            hasApiKey: svc.hasApiKey
-          })),
-          cancelTime: new Date().toISOString(),
-          tool_name: toolName,
-          tool_call_id: toolCallId,
-          workflowName: resolvedWorkflowName,
-          sourceWorkflowName,
-          generatedWorkflowName,
-          agent_message_id: agentMessageId
-        }
-      };
       if (onResponse) {
-        await onResponse(responsePayload);
+        await onResponse({
+          status: 'cancelled',
+          action: 'cancel',
+          data: {
+            services: buildSubmissionPayload().map((svc) => ({
+              service: svc.service,
+              required: svc.required,
+              hasApiKey: svc.hasApiKey,
+              selected_setup_lane: svc.selected_setup_lane
+            })),
+            cancelTime: new Date().toISOString(),
+            tool_name: toolName,
+            tool_call_id: toolCallId,
+            workflowName: resolvedWorkflowName,
+            sourceWorkflowName,
+            generatedWorkflowName,
+            agent_message_id: agentMessageId
+          }
+        });
       }
       tlog.event('cancel', 'done', { services: services.length });
     } catch (cancelError) {
@@ -394,40 +524,32 @@ const AgentAPIKeysBundleInput = ({
     }
   };
 
-  if (services.length === 0) {
+  if (services.length === 0 || !currentService) {
     return (
-      <div className={cardClasses}>
-        <h2 className={headingClasses}>No API keys required</h2>
-        <p className={descriptionClasses}>The workflow did not declare any integrations that need configuration.</p>
-      </div>
-    );
-  }
-
-  if (!currentService) {
-    return (
-      <div className={cardClasses}>
-        <h2 className={headingClasses}>No API keys required</h2>
-        <p className={descriptionClasses}>The workflow did not declare any integrations that need configuration.</p>
-      </div>
-    );
-  }
-
-  const currentValue = formValues[currentService.service] || '';
-  const currentError = errors[currentService.service];
-  const isVisible = visibility[currentService.service];
-  const disableSubmit = isSubmitting || (currentService.required && !currentValue.trim());
-  const isLastStep = currentIndex === services.length - 1;
-
-  return (
-    <div className={containerClasses} data-agent-message-id={agentMessageId || undefined}>
       <div className={cardClasses}>
         <div className="flex items-start gap-3">
-          <span
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[rgba(255,200,0,0.12)] text-sm font-semibold"
-            aria-hidden="true"
-          >
-            {'🔑'}
-          </span>
+          <Plug className="mt-0.5 h-5 w-5 text-primary" aria-hidden="true" />
+          <div className="space-y-1">
+            <h2 className={headingClasses}>No integration setup required</h2>
+            <p className={descriptionClasses}>
+              The workflow did not declare integrations that need configuration.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const currentValues = formValues[currentService.service] || {};
+  const currentLane = selectedLanes[currentService.service] || currentService.preferredLane;
+  const isLastStep = currentIndex === services.length - 1;
+  const disableSubmit = isSubmitting || Object.keys(validateCurrentService()).length > 0;
+
+  return (
+    <div className="w-full" data-agent-message-id={agentMessageId || undefined}>
+      <div className={cardClasses}>
+        <div className="flex items-start gap-3">
+          <Plug className="mt-1 h-5 w-5 text-primary" aria-hidden="true" />
           <div className="flex-1 space-y-1.5">
             <h2 className={headingClasses}>{heading}</h2>
             <p className={descriptionClasses}>{introMessage}</p>
@@ -437,41 +559,113 @@ const AgentAPIKeysBundleInput = ({
           </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-2 pt-1">
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <label className="text-xs font-sans font-bold uppercase tracking-wide text-muted-foreground">
-                {currentService.label}
-                {currentService.required ? (
-                  <span className="ml-2 text-xs uppercase tracking-wide text-[rgba(255,255,255,0.65)]">Required</span>
-                ) : null}
-              </label>
-              <span className="text-xs font-sans text-muted-foreground">{currentService.service}</span>
-            </div>
-            <div className="relative">
-              <input
-                type={isVisible ? 'text' : 'password'}
-                value={currentValue}
-                onChange={(event) => handleChange(currentService.service, event.target.value)}
-                placeholder={currentService.placeholder}
-                required={currentService.required}
-                disabled={isSubmitting}
-                className={inputClasses(Boolean(currentError), isSubmitting, currentService.maskInput, isVisible)}
-              />
-              {currentService.maskInput && (
+        <div className="space-y-2">
+          <p className="text-xs font-sans font-bold uppercase text-muted-foreground">Setup path</p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {currentService.lanes.map((lane) => {
+              const meta = LANE_META[lane] || LANE_META.bring_your_own_key;
+              const Icon = meta.icon;
+              const active = currentLane === lane;
+              return (
                 <button
+                  key={lane}
                   type="button"
-                  onClick={() => toggleVisibility(currentService.service)}
+                  onClick={() => setLane(currentService.service, lane)}
                   disabled={isSubmitting}
-                  className="absolute inset-y-0 right-3 flex items-center text-xs font-semibold uppercase tracking-wide text-[rgba(255,255,255,0.65)] hover:text-white transition-colors"
+                  className={[
+                    'rounded-lg border px-3 py-3 text-left transition-colors',
+                    active
+                      ? 'border-primary bg-[rgba(var(--color-primary-rgb),0.16)] text-foreground'
+                      : 'border-border bg-card/70 text-muted-foreground hover:text-foreground hover:border-primary/60',
+                    isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
+                  ].filter(Boolean).join(' ')}
                 >
-                  {isVisible ? 'Hide' : 'Show'}
+                  <span className="flex items-center gap-2 text-sm font-semibold">
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                    {meta.label}
+                  </span>
+                  <span className="mt-1 block text-xs leading-5">{meta.description}</span>
                 </button>
-              )}
-            </div>
-            {currentError ? <p className={`${errorTextClasses} mt-1`}>{currentError}</p> : null}
-            <p className={assistiveTextClasses}>{currentService.description}</p>
+              );
+            })}
           </div>
+          {currentService.integrationsUrl ? (
+            <a
+              href={currentService.integrationsUrl}
+              className="inline-flex items-center gap-1 text-xs font-semibold text-primary hover:underline"
+            >
+              Open integrations
+              <ExternalLink className="h-3 w-3" aria-hidden="true" />
+            </a>
+          ) : null}
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 pt-1">
+          {currentLane !== 'not_required' ? (
+            <div className="space-y-3">
+              {currentService.fields.map((field) => {
+                const key = `${currentService.service}.${field.name}`;
+                const currentError = errors[key];
+                const visible = visibility?.[currentService.service]?.[field.name];
+                const value = currentValues[field.name] || '';
+                return (
+                  <div key={field.name} className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <label className="text-xs font-sans font-bold uppercase text-muted-foreground">
+                        {field.label}
+                        {field.required ? (
+                          <span className="ml-2 text-xs uppercase text-[rgba(255,255,255,0.65)]">Required</span>
+                        ) : null}
+                      </label>
+                      <span className="text-xs font-sans text-muted-foreground">{currentService.service}</span>
+                    </div>
+                    {field.type === 'select' ? (
+                      <select
+                        value={value}
+                        onChange={(event) => updateField(currentService.service, field.name, event.target.value)}
+                        disabled={isSubmitting}
+                        className={inputClasses(Boolean(currentError), isSubmitting)}
+                      >
+                        <option value="">Select {field.label}</option>
+                        {field.options.map((option) => (
+                          <option key={option} value={option}>{option}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <div className="relative">
+                        <input
+                          type={fieldInputType(field, visible)}
+                          value={value}
+                          onChange={(event) => updateField(currentService.service, field.name, event.target.value)}
+                          placeholder={`Enter ${field.label}`}
+                          disabled={isSubmitting}
+                          className={`${inputClasses(Boolean(currentError), isSubmitting)} ${field.type === 'secret' ? 'pr-14' : ''}`}
+                        />
+                        {field.type === 'secret' ? (
+                          <button
+                            type="button"
+                            onClick={() => toggleVisibility(currentService.service, field.name)}
+                            disabled={isSubmitting}
+                            className="absolute inset-y-0 right-3 flex items-center text-xs font-semibold uppercase text-[rgba(255,255,255,0.65)] hover:text-white transition-colors"
+                          >
+                            {visible ? 'Hide' : 'Show'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                    {currentError ? <p className={`${errorTextClasses} mt-1`}>{currentError}</p> : null}
+                  </div>
+                );
+              })}
+              <p className={assistiveTextClasses}>
+                Secret fields are write-only. Public setup values may be saved as connector metadata.
+              </p>
+            </div>
+          ) : (
+            <p className={assistiveTextClasses}>
+              This integration is marked optional for this build. No setup values will be saved.
+            </p>
+          )}
 
           <div className={buttonGroup}>
             <button
@@ -497,15 +691,10 @@ const AgentAPIKeysBundleInput = ({
               disabled={disableSubmit}
               className={primaryButtonClasses}
             >
-              {isSubmitting ? 'Processing…' : isLastStep ? 'Submit Keys' : 'Next'}
+              {isSubmitting ? 'Saving...' : isLastStep ? 'Save Setup' : 'Next'}
             </button>
           </div>
         </form>
-
-        <div className={`${assistiveTextClasses} space-y-1`}>
-          <p>Keys are used immediately to configure your workflow. Only metadata (service + length) is logged.</p>
-          <p>Optional integrations can be skipped; required ones must be completed before proceeding.</p>
-        </div>
       </div>
     </div>
   );

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -289,7 +289,7 @@ agents:
          - Pass all matched IDs in a single `check_workspace_integrations` call. Pass only IDs that exist in the catalog; omit custom or unknown services.
          - Use the result to populate `workspace_integration_status[]` in the plan:
            - `configured` (auto_wire: true) — integration is ready by configuration-only checks, or by a passing provider health check when the host registered one; the generated app can reference it without prompting the user. Do NOT pass these to `record_integration_need`.
-           - `partial` or `missing` (auto_wire: false) — call `record_integration_need` for each so `IntegrationReadinessAgent` can collect the credential inline. Include the catalog `setup_url` in the message.
+           - `partial` or `missing` (auto_wire: false) — call `record_integration_need` for each so `IntegrationReadinessAgent` can collect the setup values inline. Include the catalog `setup_url` in the message.
            - `unknown` — catalog-only mode (hosted deployment). Record status as `unknown`; do not call `record_integration_need`; surface the setup link in the build summary instead.
          - If no planned integrations match catalog IDs, skip the tool call and leave `workspace_integration_status` empty.
          - This check is read-only and non-blocking. If the tool fails, continue planning with all integrations treated as unchecked.
@@ -453,7 +453,7 @@ agents:
         - Only capability packs with `surface_kind = module` may emit `task_type: module_contract`.
         Capability source rules:
         - `host_universal` capabilities: do NOT scaffold or plan any code — they are already in the platform runtime.
-        - `managed_capability` capabilities: Do NOT plan a `module_contract` build task for it — meaning for the managed capability id itself. The provider capability already exists outside the generated app. Include it as a capability_pack entry with `implementation_mode: external_integration` and `capability_source: managed_capability`; `capability_source` must be present in the AppBuildPlan output and must not be replaced by `pack_type`. Preserve any pack-declared `required_integrations` as structured connector objects with `service`, `provider`, `display_name`, `kind`, `purpose`, `required_at`, and `required_fields`; do not downgrade them to string names. Secret fields must remain `type: "secret"` and `frontend_safe: false`. Plan an `api_surface` adapter task (owned by ControllerAgent) to generate the thin adapter client at app-bundle-relative `services/integrations/{pack_id}_client.py` (physical workspace path `app/services/integrations/{pack_id}_client.py`). Set `capability_pack_id: "{pack_id}"` on the adapter task — this is required for managed capability template expansion during assembly. The adapter client is app-level service code; never place it under `modules/{facade_id}/services/` or `modules/{pack_id}/services/`. When pages or app-owned actions need to call the managed capability, also plan a generated facade module with its own module id, `surface_kind: module`, and `capability_source: generated_module`; pages bind to that facade module, not the managed capability id. If the selected pack declares facades, pages, required_outputs, or forbidden_outputs, use those exact typed contract values instead of inventing new facade ids or routes. Every managed-capability facade module must have the normal generated module task set: `module_contract`, `data_models`, and `business_services`, unless a pack template explicitly supplies a narrower declared output family. If you are about to emit `modules/{pack_id}/...` for a managed capability, stop: choose an app-owned facade id such as `{domain}_portal`, `{domain}_dashboard`, or `{domain}_connection` instead.
+        - `managed_capability` capabilities: Do NOT plan a `module_contract` build task for it — meaning for the managed capability id itself. The provider capability already exists outside the generated app. Include it as a capability_pack entry with `implementation_mode: external_integration` and `capability_source: managed_capability`; `capability_source` must be present in the AppBuildPlan output and must not be replaced by `pack_type`. Preserve any pack-declared `required_integrations` as structured connector objects with `service`, `provider`, `display_name`, `kind`, `purpose`, `required_at`, `required_fields`, `preferred_setup_lane`, `allowed_setup_lanes`, and `managed_default`; do not downgrade them to string names. Secret fields must remain `type: "secret"` and `frontend_safe: false`. Plan an `api_surface` adapter task (owned by ControllerAgent) to generate the thin adapter client at app-bundle-relative `services/integrations/{pack_id}_client.py` (physical workspace path `app/services/integrations/{pack_id}_client.py`). Set `capability_pack_id: "{pack_id}"` on the adapter task — this is required for managed capability template expansion during assembly. The adapter client is app-level service code; never place it under `modules/{facade_id}/services/` or `modules/{pack_id}/services/`. When pages or app-owned actions need to call the managed capability, also plan a generated facade module with its own module id, `surface_kind: module`, and `capability_source: generated_module`; pages bind to that facade module, not the managed capability id. If the selected pack declares facades, pages, required_outputs, or forbidden_outputs, use those exact typed contract values instead of inventing new facade ids or routes. Every managed-capability facade module must have the normal generated module task set: `module_contract`, `data_models`, and `business_services`, unless a pack template explicitly supplies a narrower declared output family. If you are about to emit `modules/{pack_id}/...` for a managed capability, stop: choose an app-owned facade id such as `{domain}_portal`, `{domain}_dashboard`, or `{domain}_connection` instead.
         - `generated_module` capabilities: must generate full module contracts and backend files — plan `module_contract`, `data_models`, and `business_services` build tasks for these packs.
         - `external_adapter` capabilities: generate adapter/client wiring only — no provider business logic. Use app-bundle-relative `services/integrations/{service}_client.py` for external or managed API clients. Use `services/adapters/{area}/{provider}.py` for provider-specific implementation boundaries only when the generated app itself directly owns that provider integration and modules/workflows call it. Use `services/routes/` for app-level routes only when needed. These assemble into physical `app/services/**` workspace paths. Valid adapter areas include auth, source_control, deployment, dns, registrar, cloud, storage, secrets, and payments when the code is app-owned provider mechanics rather than managed platform operations.
         - Deployment, DNS/domain, billing, wallet, and platform operations may be supplied by managed platform capabilities. Do not generate provider adapters for those operations into a customer app bundle. The generated app consumes the managed platform through managed capability API clients/facade modules and host-owned records.
@@ -473,7 +473,7 @@ agents:
         - `surface_kind = external_integration` packs should use `api_surface` for thin API clients, `service_foundation` for app-owned provider adapters under `services/adapters/**`, or `agent_backend_integration` for workflow touchpoints, not `module_contract`. Use `service_foundation` only for direct app-owned provider mechanics; do not use it for managed platform deployment/domain/billing operations or deployment packaging artifacts.
         - Connector credentials, API-key metadata, and app-scoped integration records are platform-owned integration state. Do not turn them into app-owned module entities or collections.
         - Use the app connector inventory as the source of truth for which third-party integrations are already ready. If the plan references services such as email_provider, analytics_provider, crm_provider, or storage_provider that are not ready in the connector inventory, keep the integration in the product plan but explicitly mark it as a missing configuration dependency.
-        - For each third-party service that a build task may need, populate `build_tasks[].integration_needs` with service, kind, purpose, required_at, optional, and required_by. This is task metadata for the IntegrationReadinessAgent checkpoint, not a manual preflight requirement.
+        - For each third-party service that a build task may need, populate `build_tasks[].integration_needs` with service, kind, purpose, required_at, optional, required_by, setup lanes, and required_fields. This is task metadata for the IntegrationReadinessAgent checkpoint, not a manual preflight requirement.
         - Do not force the user to configure integrations before planning. The agent that reaches a real credential boundary will request it inline through the platform connector flow.
         - `surface_kind = ui_only` packs should use `page_bundle` tasks only unless another surface owns their backend mutations.
       12c. **module_contract rule**: For every capability pack with `surface_kind = module`, include a `task_type: module_contract` build task:
@@ -1393,20 +1393,23 @@ agents:
   - id: objective
     heading: '[OBJECTIVE]'
     content: |-
-      - Keep integration collection agentic: only ask inline when the generated app
-        actually needs a missing credential to continue validation, runtime wiring,
+      - Keep integration setup agentic: only ask inline when the generated app
+        actually needs missing setup values to continue validation, runtime wiring,
         or download readiness.
       - Reuse app-scoped connectors when they are already ready. If a host has
         registered a provider health check for that connector type, ready means
         the check has passed; pending or unhealthy connectors remain unresolved.
-      - Persist any newly supplied credentials through the platform connector store
+      - Persist any newly supplied setup values through the platform connector store
         so the app-scoped `/apps/:appId/integrations` surface reflects the result.
       - Treat integration requests as structured `integration.required` events:
         include integration_id, provider/service id, purpose, required_fields,
-        secret_fields, non_secret_fields, permissions_required, and resume
+        secret_fields, non_secret_fields, preferred_setup_lane,
+        allowed_setup_lanes, permissions_required, and resume
         context. Secret fields are write-only.
-      - Do not create app-owned API-key collections, module tables, or custom
-        credential forms.
+      - Use setup lanes only as an app-agnostic abstraction:
+        managed, connect_account, bring_your_own_key, or not_required.
+      - Do not create app-owned API-key collections, module tables, hosted-product
+        logic, or custom credential forms.
   - id: context
     heading: '[CONTEXT]'
     content: |-
@@ -1420,14 +1423,14 @@ agents:
       **Downstream**:
       - Schema-only bundles continue to DownloadAgent after this checkpoint.
       - Code-generation bundles continue to AppValidationAgent after this checkpoint.
-      - If the user declines required credentials, set readiness status to blocked
+      - If the user declines required setup, set readiness status to blocked
         and return to the user with the missing services.
   - id: instructions
     heading: '[INSTRUCTIONS]'
     content: |-
       1. Call `check_integration_readiness`.
          - Use `required_at`: ["build_time", "validation_time", "runtime"].
-         - Keep `prompt` true so unresolved required credentials are requested inline.
+         - Keep `prompt` true so unresolved required setup values are requested inline.
          - Required fields must distinguish `type: secret` from frontend-safe
            non-secret fields such as URLs or account ids.
       2. If the tool returns `status = "ready"`, set `ready = true`.

--- a/factory_app/workflows/AppGenerator/context_variables.yaml
+++ b/factory_app/workflows/AppGenerator/context_variables.yaml
@@ -951,7 +951,7 @@ definitions:
       App-scoped third-party connector needs discovered by AppPlanAgent build
       tasks, task batch outputs, or task agents via record_integration_need.
       IntegrationReadinessAgent aggregates this list and prompts inline only for
-      unresolved required credentials.
+      unresolved required integration setup.
     source:
       type: computed
       default: []

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -218,6 +218,18 @@ models:
         description: >
           Secret names that are missing, present when workspace_status is
           "partial" or "missing". Empty for "configured" and "unknown".
+  AppIntegrationSetupLane:
+    type: literal
+    values:
+    - managed
+    - connect_account
+    - bring_your_own_key
+    - not_required
+    description: >
+      App-agnostic integration setup lane. managed = host/operator-provided
+      setup; connect_account = OAuth/provider account connection;
+      bring_your_own_key = user supplies setup fields; not_required = optional
+      integration may be skipped.
   AppBuildIntegration:
     type: model
     fields:
@@ -251,6 +263,24 @@ models:
         type: bool
         default: false
         description: Whether the app can proceed without this integration.
+      preferred_setup_lane:
+        type: union
+        variants:
+        - AppIntegrationSetupLane
+        - 'null'
+        default: null
+        description: Preferred setup lane. Use managed only when a managed setup is available through the active host or operator context.
+      allowed_setup_lanes:
+        type: optional_list
+        items: AppIntegrationSetupLane
+        description: Allowed setup lanes for this integration. Always include bring_your_own_key when direct setup fields are required.
+      managed_default:
+        type: union
+        variants:
+        - str
+        - 'null'
+        default: null
+        description: Optional JSON-encoded frontend-safe managed setup metadata. Must not contain secrets, tenant ids, or provider execution state.
       required_fields:
         type: optional_list
         items: AppIntegrationRequiredField
@@ -346,6 +376,24 @@ models:
         type: bool
         default: false
         description: Whether the build can proceed without this service.
+      preferred_setup_lane:
+        type: union
+        variants:
+        - AppIntegrationSetupLane
+        - 'null'
+        default: null
+        description: Preferred setup lane for this task-level integration need.
+      allowed_setup_lanes:
+        type: optional_list
+        items: AppIntegrationSetupLane
+        description: Allowed setup lanes for this task-level integration need.
+      managed_default:
+        type: union
+        variants:
+        - str
+        - 'null'
+        default: null
+        description: Optional JSON-encoded frontend-safe managed setup metadata. Must not contain secrets.
       required_by:
         type: union
         variants:
@@ -397,6 +445,24 @@ models:
         type: bool
         default: false
         description: Whether the capability can run without this connector.
+      preferred_setup_lane:
+        type: union
+        variants:
+        - AppIntegrationSetupLane
+        - 'null'
+        default: null
+        description: Preferred app-agnostic setup lane for this connector.
+      allowed_setup_lanes:
+        type: optional_list
+        items: AppIntegrationSetupLane
+        description: Allowed setup lanes for this connector. Managed capability packs should include managed only when the host/operator exposes a managed setup.
+      managed_default:
+        type: union
+        variants:
+        - str
+        - 'null'
+        default: null
+        description: Optional JSON-encoded frontend-safe managed setup metadata. Must not contain secrets.
       required_fields:
         type: optional_list
         items: AppIntegrationRequiredField

--- a/factory_app/workflows/AppGenerator/tools.yaml
+++ b/factory_app/workflows/AppGenerator/tools.yaml
@@ -119,7 +119,7 @@ tools:
   description: >
     Aggregate integration needs from AppGenerator planning, task batch outputs,
     and discovered task context. Reuse app connectors when ready and
-    prompt inline for unresolved required credentials before validation/download.
+    prompt inline for unresolved required integration setup before validation/download.
   tool_type: UI_Tool
   auto_tool_call: true
   bind_to_agent: false
@@ -142,7 +142,7 @@ tools:
       additionalProperties: true
     actions_schema:
     - id: submit
-      label: Submit Keys
+      label: Save Setup
       variant: primary
       payload_schema:
         type: object

--- a/factory_app/workflows/AppGenerator/tools/assemble_app_tasks.py
+++ b/factory_app/workflows/AppGenerator/tools/assemble_app_tasks.py
@@ -18,6 +18,7 @@ from .code_file_utils import (
     extract_deleted_file_paths_from_payload,
 )
 from .generate_module_interface_files import generate_module_interface_files
+from .materialize_app_config_contracts import materialize_app_config_contracts
 from .resolve_managed_capability_templates import resolve_managed_capability_templates
 
 
@@ -160,6 +161,23 @@ def _apply_managed_capability_templates(
     return [{"filename": path, "content": content} for path, content in sorted(file_map.items())]
 
 
+def _apply_app_config_contracts(
+    code_files: list[dict[str, str]],
+    *,
+    app_id: str,
+    app_build_plan: Any,
+    context_variables: Any,
+) -> list[dict[str, str]]:
+    file_map = {str(f["filename"]): str(f["content"]) for f in code_files if f.get("filename")}
+    for file in materialize_app_config_contracts(
+        app_id=app_id,
+        app_build_plan=app_build_plan,
+        context_variables=context_variables,
+    ):
+        file_map[str(file["filename"])] = str(file["content"])
+    return [{"filename": path, "content": content} for path, content in sorted(file_map.items())]
+
+
 def _context_code_file_output(context_variables: Any | None) -> dict[str, list[dict[str, str]]] | None:
     if context_variables is None or not hasattr(context_variables, "get"):
         return None
@@ -293,6 +311,12 @@ async def assemble_app_tasks(
         context_variables=context_variables,
     )
     code_files = _apply_deleted_files(code_files, _context_deleted_files(context_variables))
+    code_files = _apply_app_config_contracts(
+        code_files,
+        app_id=str(app_id),
+        app_build_plan=app_build_plan,
+        context_variables=context_variables,
+    )
 
     # Write the assembled flat file map to context so the carry-forward
     # preservation resolver (which runs after AssemblyAgent's turn) can read

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -49,6 +49,23 @@ _RAW_PAYMENT_PROVIDER_IMPORT_RE = re.compile(
     r"from\s+(stripe|paddle|paypal|braintree|square)\s+import\b)",
     re.IGNORECASE,
 )
+_MANAGED_SETUP_RAW_PROVIDER_ENV_RE = re.compile(
+    r"\b(?:STRIPE|PADDLE|PAYPAL|BRAINTREE|SQUARE)_[A-Z0-9_]*"
+    r"(?:SECRET|KEY|TOKEN|PRIVATE|WEBHOOK|CLIENT_ID|PUBLISHABLE)[A-Z0-9_]*\b"
+)
+_MANAGED_SETUP_PROVIDER_ROUTE_RE = re.compile(
+    r"(?:^|[\"'\s:=])/?(?:api/)?(?:webhooks/(stripe|paddle|paypal|braintree|square)\b|"
+    r"(stripe|paddle|paypal|braintree|square)/webhooks?\b|"
+    r"(stripe|paddle|paypal|braintree|square)/(?:checkout|payment|billing)\b)",
+    re.IGNORECASE,
+)
+_MANAGED_SETUP_PROVIDER_MECHANIC_RE = re.compile(
+    r"\b(?:stripe|paddle|paypal|braintree|square)\s*\.\s*"
+    r"(?:checkout|webhooks|PaymentIntent|Customer|Subscription|Refund|refunds)\b|"
+    r"\bStripe-Signature\b|"
+    r"\brequire\s*\(\s*[\"'](?:stripe|paddle|paypal|braintree|square)[\"']\s*\)",
+    re.IGNORECASE,
+)
 _PAYMENT_PROVIDER_API_KEY_RE = re.compile(r"\bpayment_provider\s*\.\s*api_key\s*=")
 _PAYMENT_PROVIDER_REFUND_CALL_RE = re.compile(
     r"\bpayment_provider\s*\.\s*(?:Refund\s*\.\s*create|refunds\s*\.\s*create)\s*\(",
@@ -424,6 +441,108 @@ def _path_matches_prefix(path: str, prefix: str) -> bool:
 
 def _iter_api_endpoint_literals(content: str) -> list[str]:
     return re.findall(r'(?:["\']|:\s*)(/api/modules/[^"\'\s]+)', content)
+
+
+def _load_integration_requirements(
+    files_map: dict[str, str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    normalized_files = _normalized_files_map(files_map)
+    requirements: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for path in (
+        "config/integrations.yaml",
+        "config/integrations.yml",
+        "config/integrations.json",
+        "app/config/integrations.yaml",
+        "app/config/integrations.yml",
+        "app/config/integrations.json",
+    ):
+        raw = normalized_files.get(path)
+        if raw is None:
+            continue
+        try:
+            parsed = yaml.safe_load(raw) or {}
+        except Exception as exc:
+            errors.append(f"{path}: integration contract must be valid YAML/JSON: {exc}")
+            continue
+        if not isinstance(parsed, dict):
+            errors.append(f"{path}: integration contract must be an object.")
+            continue
+        raw_requirements = parsed.get("requirements")
+        if raw_requirements is None:
+            raw_requirements = parsed.get("integrations")
+        if raw_requirements is None:
+            continue
+        if not isinstance(raw_requirements, list):
+            errors.append(f"{path}: integration requirements must be a list.")
+            continue
+        requirements.extend(item for item in raw_requirements if isinstance(item, dict))
+    return requirements, errors
+
+
+def _requirement_uses_managed_lane(requirement: dict[str, Any]) -> bool:
+    allowed = requirement.get("allowed_setup_lanes")
+    lanes: set[str] = set()
+    if isinstance(allowed, list):
+        lanes.update(str(item or "").strip() for item in allowed)
+    preferred = str(requirement.get("preferred_setup_lane") or "").strip()
+    if preferred:
+        lanes.add(preferred)
+    return "managed" in lanes
+
+
+def _managed_requirement_labels(requirements: list[dict[str, Any]]) -> list[str]:
+    labels: list[str] = []
+    for requirement in requirements:
+        if not _requirement_uses_managed_lane(requirement):
+            continue
+        label = str(
+            requirement.get("integration_id")
+            or requirement.get("service")
+            or requirement.get("provider")
+            or "<unknown>"
+        ).strip()
+        if label and label not in labels:
+            labels.append(label)
+    return sorted(labels)
+
+
+def _scan_managed_setup_provider_leaks(
+    files_map: dict[str, str],
+    *,
+    capability_packs: list[dict[str, Any]] | None,
+) -> list[str]:
+    requirements, errors = _load_integration_requirements(files_map)
+    managed_labels = _managed_requirement_labels(requirements)
+    selected_managed = sorted(_selected_managed_capability_ids(capability_packs))
+    if not managed_labels and not selected_managed:
+        return errors
+
+    context = sorted(set(managed_labels + selected_managed))
+    context_label = ", ".join(context) if context else "managed setup"
+    normalized_files = _normalized_files_map(files_map)
+    for path, content in sorted(normalized_files.items()):
+        if not isinstance(content, str):
+            continue
+        if _MANAGED_SETUP_RAW_PROVIDER_ENV_RE.search(content):
+            errors.append(
+                f"{path}: managed setup lane ({context_label}) must not expose raw "
+                "payment-provider environment handles. Use the managed capability "
+                "client contract and names-only Mozaiks-managed handles instead."
+            )
+        if _MANAGED_SETUP_PROVIDER_ROUTE_RE.search(content):
+            errors.append(
+                f"{path}: managed setup lane ({context_label}) must not generate raw "
+                "payment-provider webhook or checkout routes. Provider callbacks "
+                "belong in the managed/hosted product boundary."
+            )
+        if _MANAGED_SETUP_PROVIDER_MECHANIC_RE.search(content):
+            errors.append(
+                f"{path}: managed setup lane ({context_label}) must not contain raw "
+                "payment-provider SDK mechanics. Generated apps should call an "
+                "app-owned facade or managed capability client."
+            )
+    return errors
 
 
 def _scan_selected_managed_capability_boundaries(
@@ -1196,6 +1315,12 @@ def scan_generated_bundle(
     errors.extend(_scan_data_contract_module_alignment(files_map))
     errors.extend(
         _scan_selected_managed_capability_boundaries(
+            files_map,
+            capability_packs=capability_packs,
+        )
+    )
+    errors.extend(
+        _scan_managed_setup_provider_leaks(
             files_map,
             capability_packs=capability_packs,
         )

--- a/factory_app/workflows/AppGenerator/tools/integration_readiness.py
+++ b/factory_app/workflows/AppGenerator/tools/integration_readiness.py
@@ -22,6 +22,9 @@ async def record_integration_need(
     required_fields: list[dict[str, Any]] | None = None,
     required_by: dict[str, Any] | None = None,
     optional: bool = False,
+    preferred_setup_lane: str | None = None,
+    allowed_setup_lanes: list[str] | None = None,
+    managed_default: dict[str, Any] | str | None = None,
     context_variables: Any = None,
 ) -> dict[str, Any]:
     """Record an integration need discovered by an AppGenerator task agent."""
@@ -36,6 +39,9 @@ async def record_integration_need(
         required_fields=required_fields,
         required_by=required_by,
         optional=optional,
+        preferred_setup_lane=preferred_setup_lane,
+        allowed_setup_lanes=allowed_setup_lanes,
+        managed_default=managed_default,
         context_variables=context_variables,
     )
 
@@ -45,7 +51,7 @@ async def check_integration_readiness(
     prompt: bool = True,
     context_variables: Any = None,
 ) -> dict[str, Any]:
-    """Aggregate AppGenerator integration needs and collect missing credentials inline."""
+    """Aggregate AppGenerator integration needs and collect missing setup inline."""
 
     return await collect_missing_connector_needs(
         context_variables=context_variables,

--- a/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
+++ b/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
@@ -1,0 +1,188 @@
+"""Materialize canonical app config contracts from AppGenerator context."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import yaml
+
+from mozaiksai.core.workflow.generator_support.connector_request import (
+    collect_integration_needs,
+)
+from mozaiksai.core.workflow.generator_support.connector_setup import (
+    normalize_setup_lanes,
+    safe_managed_default,
+)
+
+
+def _context_get(context_variables: Any, key: str, default: Any = None) -> Any:
+    if context_variables is None:
+        return default
+    getter = getattr(context_variables, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except TypeError:
+            value = getter(key)
+            return default if value is None else value
+    if isinstance(context_variables, dict):
+        return context_variables.get(key, default)
+    data = getattr(context_variables, "data", None)
+    if isinstance(data, dict):
+        return data.get(key, default)
+    return default
+
+
+def _safe_scalar(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, dict):
+            result[str(key)] = _safe_dict(item)
+        elif isinstance(item, list):
+            result[str(key)] = [_safe_scalar(entry) for entry in item]
+        else:
+            result[str(key)] = _safe_scalar(item)
+    return result
+
+
+def _materialize_integrations_yaml(*, app_id: str, context_variables: Any) -> str:
+    requirements: list[dict[str, Any]] = []
+    for need in collect_integration_needs(context_variables):
+        lanes = normalize_setup_lanes(need)
+        requirement: dict[str, Any] = {
+            "integration_id": str(need.get("integration_id") or need.get("service")),
+            "service": str(need.get("service") or ""),
+            "provider": str(need.get("provider") or need.get("service") or ""),
+            "display_name": str(need.get("display_name") or need.get("service") or ""),
+            "kind": str(need.get("kind") or "api_key"),
+            "purpose": str(need.get("purpose") or "Required by generated app integration."),
+            "required_at": str(need.get("required_at") or "runtime"),
+            "optional": bool(need.get("optional", False)),
+            "preferred_setup_lane": lanes["preferred_setup_lane"],
+            "allowed_setup_lanes": lanes["allowed_setup_lanes"],
+            "required_fields": need.get("required_fields") or [],
+            "required_by": need.get("required_by") or [],
+        }
+        managed_default = need.get("managed_default")
+        safe_default = safe_managed_default(managed_default)
+        if safe_default:
+            requirement["managed_default"] = _safe_dict(safe_default)
+        requirements.append(requirement)
+
+    payload = {
+        "schema_version": "mozaiks.integrations.v1",
+        "app_id": app_id,
+        "requirements": requirements,
+    }
+    return yaml.safe_dump(payload, sort_keys=False, default_flow_style=False)
+
+
+def _first_dict(items: Any) -> dict[str, Any]:
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict):
+                return item
+    if isinstance(items, dict):
+        return items
+    return {}
+
+
+def _materialize_targets_json(*, app_id: str, app_build_plan: Any, context_variables: Any) -> str:
+    plan = app_build_plan if isinstance(app_build_plan, dict) else {}
+    target = _first_dict(plan.get("deployment_targets"))
+    deployment_profile = (
+        target.get("deployment_profile")
+        or plan.get("deployment_profile")
+        or _context_get(context_variables, "deployment_profile")
+        or "self_hosted_container"
+    )
+
+    runtime = _safe_dict(target.get("runtime"))
+    if not runtime:
+        runtime = {
+            "kind": "web",
+            "health_path": "/health",
+            "container_port": 8000,
+        }
+
+    deployment: dict[str, Any] = {
+        "profile": str(deployment_profile),
+        "preferred_lane": str(target.get("preferred_lane") or "self_hosted"),
+        "allowed_lanes": (
+            [_safe_scalar(item) for item in target.get("allowed_lanes")]
+            if isinstance(target.get("allowed_lanes"), list)
+            else ["self_hosted"]
+        ),
+    }
+    if target.get("target_id"):
+        deployment["target_id"] = str(target["target_id"])
+    if target.get("artifact_outputs"):
+        deployment["artifact_outputs"] = [_safe_scalar(item) for item in target.get("artifact_outputs") or []]
+
+    environment = _safe_dict(target.get("environment"))
+    if environment:
+        deployment["environment"] = environment
+
+    checks = target.get("checks")
+    if isinstance(checks, list):
+        deployment["checks"] = [_safe_dict(item) if isinstance(item, dict) else _safe_scalar(item) for item in checks]
+
+    domains = _safe_dict(target.get("domains"))
+    if not domains:
+        domains = {
+            "custom_domain_supported": False,
+            "managed_dns_preferred": False,
+        }
+
+    payload = {
+        "schema_version": "mozaiks.targets.v1",
+        "app_id": app_id,
+        "runtime": runtime,
+        "deployment": deployment,
+        "domains": domains,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def materialize_app_config_contracts(
+    *,
+    app_id: str,
+    app_build_plan: Any,
+    context_variables: Any,
+) -> list[dict[str, str]]:
+    """Return generated app config files owned by AppGenerator assembly.
+
+    These files are declarative app-bundle facts. They intentionally contain no
+    raw credentials, cloud account ids, provider execution state, or hosted-only
+    policy defaults.
+    """
+
+    return [
+        {
+            "filename": "config/integrations.yaml",
+            "content": _materialize_integrations_yaml(
+                app_id=app_id,
+                context_variables=context_variables,
+            ),
+        },
+        {
+            "filename": "config/targets.json",
+            "content": _materialize_targets_json(
+                app_id=app_id,
+                app_build_plan=app_build_plan,
+                context_variables=context_variables,
+            ),
+        },
+    ]
+
+
+__all__ = ["materialize_app_config_contracts"]

--- a/factory_app/workflows/RuntimeToolCallSmoke/tools.yaml
+++ b/factory_app/workflows/RuntimeToolCallSmoke/tools.yaml
@@ -39,7 +39,7 @@ tools:
 - agent: RuntimeConnectorSmokeAgent
   file: runtime_connector_readiness.py
   function: collect_runtime_connector_readiness
-  description: Exercise shared connector readiness with inline credential collection and connector persistence.
+  description: Exercise shared connector readiness with inline integration setup and connector persistence.
   tool_type: UI_Tool
   auto_tool_call: false
   ui:
@@ -61,7 +61,7 @@ tools:
       additionalProperties: true
     actions_schema:
     - id: submit
-      label: Submit Keys
+      label: Save Setup
       variant: primary
       payload_schema:
         type: object

--- a/mozaiksai/core/workflow/generator_support/connector_request.py
+++ b/mozaiksai/core/workflow/generator_support/connector_request.py
@@ -2,9 +2,9 @@
 
 Generator agents can discover integration needs while planning or executing
 decomposed work. These helpers keep the UX agentic: check app-scoped
-connectors first, ask inline only for unresolved required credentials, then
-persist through the platform connector store so the app-scoped integrations
-surface reflects the result.
+connectors first, ask inline only for unresolved required setup, then persist
+through the platform connector store so the app-scoped integrations surface
+reflects the result.
 """
 
 from __future__ import annotations
@@ -21,9 +21,20 @@ from mozaiksai.core.workflow.generator_support.connector_service import (
     save_connector,
     save_connector_draft,
 )
+from mozaiksai.core.workflow.generator_support.connector_setup import (
+    SECRET_FIELD_TYPES,
+    normalize_required_fields,
+    normalize_setup_lane,
+    normalize_setup_lanes,
+    safe_managed_default,
+    setup_lane_ids,
+)
 from mozaiksai.core.workflow.ui_tools import UIToolError, use_ui_tool
 
-SECRET_FIELD_TYPES = {"secret", "password", "api_key", "token"}
+_normalize_required_fields = normalize_required_fields
+_normalize_setup_lane = normalize_setup_lane
+_safe_managed_default = safe_managed_default
+_setup_lane_ids = setup_lane_ids
 
 
 def _context_get(context_variables: Any, key: str, default: Any = None) -> Any:
@@ -82,6 +93,10 @@ def _append_need(
     required_fields: list[dict[str, Any]] | None = None,
     required_by: dict[str, Any] | None = None,
     optional: bool = False,
+    preferred_setup_lane: Any = None,
+    allowed_setup_lanes: Any = None,
+    setup_lanes: Any = None,
+    managed_default: Any = None,
 ) -> None:
     normalized = normalize_service(service)
     if not normalized:
@@ -92,57 +107,30 @@ def _append_need(
             "required_fields": required_fields,
         }
     )
-    needs.append(
-        {
-            "service": normalized,
-            "integration_id": normalized,
-            "provider": normalize_service(provider) or normalized,
-            "display_name": str(display_name or display_service(normalized)),
-            "kind": str(kind or "api_key"),
-            "purpose": str(purpose or "Required by generated app integration."),
-            "required_fields": required_fields,
-            "required_at": str(required_at or "runtime"),
-            "required_by": dict(required_by or {}),
-            "optional": bool(optional),
-        }
-    )
-
-
-def _normalize_required_fields(raw: dict[str, Any]) -> list[dict[str, Any]]:
-    fields = raw.get("required_fields")
-    normalized: list[dict[str, Any]] = []
-    if isinstance(fields, list):
-        for _index, field in enumerate(fields):
-            if not isinstance(field, dict):
-                continue
-            name = str(field.get("name") or "").strip()
-            if not name:
-                continue
-            field_type = str(field.get("type") or "text").strip().lower()
-            is_secret = bool(field.get("secret")) or field_type in SECRET_FIELD_TYPES
-            normalized.append(
-                {
-                    "name": name,
-                    "label": str(field.get("label") or name.replace("_", " ").title()),
-                    "type": "secret" if is_secret else field_type,
-                    "required": bool(field.get("required", True)),
-                    "frontend_safe": False if is_secret else bool(field.get("frontend_safe", True)),
-                    **({"options": field.get("options")} if isinstance(field.get("options"), list) else {}),
-                }
-            )
-    if normalized:
-        return normalized
-    kind = str(raw.get("kind") or "api_key").strip().lower()
-    secret_name = "api_key" if kind in {"api_key", "key", "secret"} else f"{kind}_secret"
-    return [
-        {
-            "name": secret_name,
-            "label": "API Key" if secret_name == "api_key" else secret_name.replace("_", " ").title(),
-            "type": "secret",
-            "required": True,
-            "frontend_safe": False,
-        }
-    ]
+    need = {
+        "service": normalized,
+        "integration_id": normalized,
+        "provider": normalize_service(provider) or normalized,
+        "display_name": str(display_name or display_service(normalized)),
+        "kind": str(kind or "api_key"),
+        "purpose": str(purpose or "Required by generated app integration."),
+        "required_fields": required_fields,
+        "required_at": str(required_at or "runtime"),
+        "required_by": dict(required_by or {}),
+        "optional": bool(optional),
+    }
+    if preferred_setup_lane is not None:
+        need["preferred_setup_lane"] = preferred_setup_lane
+    raw_lanes = allowed_setup_lanes if allowed_setup_lanes is not None else setup_lanes
+    if raw_lanes is not None:
+        need["allowed_setup_lanes"] = raw_lanes
+    safe_managed_default = _safe_managed_default(managed_default)
+    if safe_managed_default:
+        need["managed_default"] = safe_managed_default
+    lanes = normalize_setup_lanes(need)
+    need["preferred_setup_lane"] = lanes["preferred_setup_lane"]
+    need["allowed_setup_lanes"] = lanes["allowed_setup_lanes"]
+    needs.append(need)
 
 
 def _split_required_fields(fields: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -190,6 +178,10 @@ def _extract_needs_from_plan(app_build_plan: Any) -> list[dict[str, Any]]:
             required_fields=integration.get("required_fields") if isinstance(integration.get("required_fields"), list) else None,
             optional=bool(integration.get("optional", False)),
             required_by={"source": "app_build_plan.external_integrations"},
+            preferred_setup_lane=integration.get("preferred_setup_lane"),
+            allowed_setup_lanes=integration.get("allowed_setup_lanes"),
+            setup_lanes=integration.get("setup_lanes"),
+            managed_default=integration.get("managed_default"),
         )
 
     for pack in _iter_dicts(app_build_plan.get("capability_packs")):
@@ -216,6 +208,10 @@ def _extract_needs_from_plan(app_build_plan: Any) -> list[dict[str, Any]]:
                     ),
                     optional=bool(requirement.get("optional", False)),
                     required_by=required_by,
+                    preferred_setup_lane=requirement.get("preferred_setup_lane"),
+                    allowed_setup_lanes=requirement.get("allowed_setup_lanes"),
+                    setup_lanes=requirement.get("setup_lanes"),
+                    managed_default=requirement.get("managed_default"),
                 )
                 continue
             _append_need(
@@ -245,6 +241,10 @@ def _extract_needs_from_plan(app_build_plan: Any) -> list[dict[str, Any]]:
                 required_fields=need.get("required_fields") if isinstance(need.get("required_fields"), list) else None,
                 optional=bool(need.get("optional", False)),
                 required_by=required_by,
+                preferred_setup_lane=need.get("preferred_setup_lane"),
+                allowed_setup_lanes=need.get("allowed_setup_lanes"),
+                setup_lanes=need.get("setup_lanes"),
+                managed_default=need.get("managed_default"),
             )
     return needs
 
@@ -272,6 +272,10 @@ def _extract_needs_from_nested(value: Any, *, source: str) -> list[dict[str, Any
                     required_fields=need.get("required_fields") if isinstance(need.get("required_fields"), list) else None,
                     optional=bool(need.get("optional", False)),
                     required_by=required_by,
+                    preferred_setup_lane=need.get("preferred_setup_lane"),
+                    allowed_setup_lanes=need.get("allowed_setup_lanes"),
+                    setup_lanes=need.get("setup_lanes"),
+                    managed_default=need.get("managed_default"),
                 )
             for key, child in node.items():
                 if key in {"integration_needs", "connector_needs"}:
@@ -295,16 +299,25 @@ def dedupe_integration_needs(needs: Iterable[dict[str, Any]]) -> list[dict[str, 
             continue
         existing = by_service.get(service)
         if existing is None:
-            by_service[service] = {
+            lanes = normalize_setup_lanes(need)
+            safe_managed_default = _safe_managed_default(need.get("managed_default"))
+            normalized_need = {
                 **need,
                 "service": service,
                 "integration_id": need.get("integration_id") or service,
                 "provider": need.get("provider") or service,
                 "display_name": need.get("display_name") or display_service(service),
                 "required_fields": _normalize_required_fields(need),
+                "preferred_setup_lane": lanes["preferred_setup_lane"],
+                "allowed_setup_lanes": lanes["allowed_setup_lanes"],
                 "required_by": [need.get("required_by")] if isinstance(need.get("required_by"), dict) else [],
                 "optional": bool(need.get("optional", False)),
             }
+            if safe_managed_default:
+                normalized_need["managed_default"] = safe_managed_default
+            else:
+                normalized_need.pop("managed_default", None)
+            by_service[service] = normalized_need
             continue
         existing["optional"] = bool(existing.get("optional")) and bool(need.get("optional", False))
         if not existing.get("purpose") and need.get("purpose"):
@@ -320,6 +333,25 @@ def dedupe_integration_needs(needs: Iterable[dict[str, Any]]) -> list[dict[str, 
             existing["provider"] = need.get("provider")
         if need.get("display_name") and existing.get("display_name") in {None, "", display_service(service)}:
             existing["display_name"] = need.get("display_name")
+        existing_lanes = _setup_lane_ids(existing.get("allowed_setup_lanes"))
+        next_lanes = _setup_lane_ids(need.get("allowed_setup_lanes")) or _setup_lane_ids(need.get("setup_lanes"))
+        safe_managed_default = _safe_managed_default(need.get("managed_default"))
+        if safe_managed_default:
+            existing["managed_default"] = safe_managed_default
+            if "managed" not in next_lanes:
+                next_lanes.insert(0, "managed")
+        for lane in next_lanes:
+            if lane not in existing_lanes:
+                existing_lanes.append(lane)
+        if existing_lanes:
+            existing["allowed_setup_lanes"] = existing_lanes
+        preferred = _normalize_setup_lane(need.get("preferred_setup_lane"))
+        if preferred and preferred in existing_lanes:
+            existing["preferred_setup_lane"] = preferred
+        else:
+            lanes = normalize_setup_lanes(existing)
+            existing["preferred_setup_lane"] = lanes["preferred_setup_lane"]
+            existing["allowed_setup_lanes"] = lanes["allowed_setup_lanes"]
         if isinstance(need.get("required_by"), dict):
             existing.setdefault("required_by", []).append(need["required_by"])
         current_required_at = str(existing.get("required_at") or "runtime")
@@ -352,6 +384,10 @@ async def record_integration_need(
     required_fields: list[dict[str, Any]] | None = None,
     required_by: dict[str, Any] | None = None,
     optional: bool = False,
+    preferred_setup_lane: Any = None,
+    allowed_setup_lanes: Any = None,
+    setup_lanes: Any = None,
+    managed_default: Any = None,
     context_variables: Any = None,
 ) -> dict[str, Any]:
     """Record a discovered integration need in context for later readiness checks."""
@@ -369,6 +405,10 @@ async def record_integration_need(
         required_fields=required_fields,
         required_by=required_by,
         optional=optional,
+        preferred_setup_lane=preferred_setup_lane,
+        allowed_setup_lanes=allowed_setup_lanes,
+        setup_lanes=setup_lanes,
+        managed_default=managed_default,
     )
     deduped = dedupe_integration_needs(needs)
     _context_set(context_variables, "integration_needs", deduped)
@@ -398,6 +438,8 @@ def build_integration_request_payload(
             continue
         fields = _normalize_required_fields(raw)
         secret_fields, non_secret_fields = _split_required_fields(fields)
+        setup_lanes = normalize_setup_lanes(raw)
+        managed_default = _safe_managed_default(raw.get("managed_default"))
         requests.append(
             {
                 "event_type": "integration.required",
@@ -408,6 +450,9 @@ def build_integration_request_payload(
                 "required_fields": fields,
                 "secret_fields": secret_fields,
                 "non_secret_fields": non_secret_fields,
+                "preferred_setup_lane": setup_lanes["preferred_setup_lane"],
+                "allowed_setup_lanes": setup_lanes["allowed_setup_lanes"],
+                **({"managed_default": managed_default} if managed_default else {}),
                 "permissions_required": list(raw.get("permissions_required") or ["integrations.manage"]),
                 "resume": {
                     "workflow_name": workflow_name,
@@ -484,6 +529,8 @@ async def request_connector_bundle(
         required_fields = _normalize_required_fields(raw)
         secret_fields, non_secret_fields = _split_required_fields(required_fields)
         secret_label = secret_fields[0].get("label") if secret_fields else "Secret"
+        setup_lanes = normalize_setup_lanes(raw)
+        managed_default = _safe_managed_default(raw.get("managed_default"))
         normalized_services.append(
             {
                 "service": service,
@@ -495,8 +542,11 @@ async def request_connector_bundle(
                 "required_fields": required_fields,
                 "secret_fields": secret_fields,
                 "non_secret_fields": non_secret_fields,
-                "placeholder": raw.get("placeholder") or f"Enter your {display_name} {secret_label}...",
-                "description": raw.get("purpose") or raw.get("description") or f"API key for {display_name}",
+                "preferred_setup_lane": setup_lanes["preferred_setup_lane"],
+                "allowed_setup_lanes": setup_lanes["allowed_setup_lanes"],
+                **({"managed_default": managed_default} if managed_default else {}),
+                "placeholder": raw.get("placeholder") or f"Enter {display_name} {secret_label}...",
+                "description": raw.get("purpose") or raw.get("description") or f"Setup values for {display_name}",
                 "label": raw.get("label") or f"{display_name} {secret_label}",
                 "agent_message_id": f"{agent_message_id}:{service}:{idx}",
             }
@@ -511,8 +561,8 @@ async def request_connector_bundle(
     payload = {
         "event_type": "integration.required",
         "agent_message_id": agent_message_id,
-        "agent_message": agent_message or "Provide the missing integration credentials so the build can continue.",
-        "description": description or "Credentials are saved to the app connector store when vault storage is available.",
+        "agent_message": agent_message or "Configure the missing integrations so the build can continue.",
+        "description": description or "Setup values are saved to the app connector store when vault storage is available.",
         "integration_requests": integration_requests,
         "permissions_required": ["integrations.manage"],
         "integrations_url": integrations_url,
@@ -530,6 +580,9 @@ async def request_connector_bundle(
                 "required_fields": svc["required_fields"],
                 "secret_fields": svc["secret_fields"],
                 "non_secret_fields": svc["non_secret_fields"],
+                "preferred_setup_lane": svc["preferred_setup_lane"],
+                "allowed_setup_lanes": svc["allowed_setup_lanes"],
+                **({"managed_default": svc["managed_default"]} if isinstance(svc.get("managed_default"), dict) else {}),
                 "agent_message_id": svc["agent_message_id"],
             }
             for svc in normalized_services
@@ -575,6 +628,9 @@ async def request_connector_bundle(
         entry = submitted_lookup.get(svc["service"], {})
         trimmed_key = _extract_secret_value(entry, svc["required_fields"])
         public_config = _extract_frontend_safe_config(entry, svc["required_fields"])
+        selected_setup_lane = _normalize_setup_lane(entry.get("selected_setup_lane"))
+        if selected_setup_lane:
+            public_config["selected_setup_lane"] = selected_setup_lane
         has_key = bool(trimmed_key)
         needs_secret = any(str(field.get("type") or "").lower() in SECRET_FIELD_TYPES for field in svc["required_fields"])
         configured = has_key or (not needs_secret and bool(public_config))
@@ -642,6 +698,7 @@ async def request_connector_bundle(
                 "status": "success" if configured else ("missing" if svc["required"] else "skipped"),
                 "has_key": has_key,
                 "configured": configured,
+                "selected_setup_lane": selected_setup_lane or svc.get("preferred_setup_lane"),
                 "key_length": key_length,
                 "public_config": public_config,
                 "metadata_saved": metadata_saved,
@@ -811,6 +868,7 @@ __all__ = [
     "dedupe_integration_needs",
     "display_service",
     "normalize_service",
+    "normalize_setup_lanes",
     "record_integration_need",
     "request_connector_bundle",
 ]

--- a/mozaiksai/core/workflow/generator_support/connector_setup.py
+++ b/mozaiksai/core/workflow/generator_support/connector_setup.py
@@ -1,0 +1,152 @@
+"""Shared setup contract helpers for generated app integration needs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+SECRET_FIELD_TYPES = {"secret", "password", "api_key", "token"}
+SETUP_LANES = {"managed", "connect_account", "bring_your_own_key", "not_required"}
+DEFAULT_SETUP_LANE = "bring_your_own_key"
+SENSITIVE_METADATA_KEY_PARTS = {
+    "api_key",
+    "apikey",
+    "auth_token",
+    "client_secret",
+    "connection_string",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+}
+
+
+def normalize_setup_lane(value: Any) -> str:
+    lane = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "byok": "bring_your_own_key",
+        "api_key": "bring_your_own_key",
+        "credential": "bring_your_own_key",
+        "credentials": "bring_your_own_key",
+        "oauth": "connect_account",
+        "oauth_connect": "connect_account",
+        "hosted": "managed",
+        "mozaiks_managed": "managed",
+        "none": "not_required",
+        "skip": "not_required",
+    }
+    lane = aliases.get(lane, lane)
+    return lane if lane in SETUP_LANES else ""
+
+
+def setup_lane_ids(value: Any) -> list[str]:
+    lanes: list[str] = []
+    if isinstance(value, list):
+        for item in value:
+            lane = normalize_setup_lane(item.get("id") if isinstance(item, dict) else item)
+            if lane and lane not in lanes:
+                lanes.append(lane)
+    else:
+        lane = normalize_setup_lane(value)
+        if lane:
+            lanes.append(lane)
+    return lanes
+
+
+def normalize_required_fields(raw: dict[str, Any]) -> list[dict[str, Any]]:
+    fields = raw.get("required_fields")
+    normalized: list[dict[str, Any]] = []
+    if isinstance(fields, list):
+        for field in fields:
+            if not isinstance(field, dict):
+                continue
+            name = str(field.get("name") or "").strip()
+            if not name:
+                continue
+            field_type = str(field.get("type") or "text").strip().lower()
+            is_secret = bool(field.get("secret")) or field_type in SECRET_FIELD_TYPES
+            normalized.append(
+                {
+                    "name": name,
+                    "label": str(field.get("label") or name.replace("_", " ").title()),
+                    "type": "secret" if is_secret else field_type,
+                    "required": bool(field.get("required", True)),
+                    "frontend_safe": False if is_secret else bool(field.get("frontend_safe", True)),
+                    **({"options": field.get("options")} if isinstance(field.get("options"), list) else {}),
+                }
+            )
+    if normalized:
+        return normalized
+    kind = str(raw.get("kind") or "api_key").strip().lower()
+    secret_name = "api_key" if kind in {"api_key", "key", "secret"} else f"{kind}_secret"
+    return [
+        {
+            "name": secret_name,
+            "label": "API Key" if secret_name == "api_key" else secret_name.replace("_", " ").title(),
+            "type": "secret",
+            "required": True,
+            "frontend_safe": False,
+        }
+    ]
+
+
+def safe_managed_default(value: Any) -> dict[str, Any]:
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    if not isinstance(value, dict):
+        return {}
+    safe: dict[str, Any] = {}
+    for key, item in value.items():
+        normalized_key = str(key).strip().lower()
+        if any(part in normalized_key for part in SENSITIVE_METADATA_KEY_PARTS):
+            continue
+        if isinstance(item, (str, int, float, bool)) or item is None:
+            safe[str(key)] = item
+    return safe
+
+
+def normalize_setup_lanes(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return the app-agnostic setup-lane contract for an integration need."""
+
+    explicit_lanes = (
+        setup_lane_ids(raw.get("allowed_setup_lanes"))
+        or setup_lane_ids(raw.get("setup_lanes"))
+        or setup_lane_ids(raw.get("setup_lane"))
+    )
+    lanes = list(explicit_lanes)
+    kind = str(raw.get("kind") or "api_key").strip().lower()
+    has_fields = bool(normalize_required_fields(raw))
+
+    if safe_managed_default(raw.get("managed_default")) and "managed" not in lanes:
+        lanes.insert(0, "managed")
+    if kind in {"oauth", "oidc"} and "connect_account" not in lanes:
+        lanes.append("connect_account")
+    if has_fields and DEFAULT_SETUP_LANE not in lanes:
+        lanes.append(DEFAULT_SETUP_LANE)
+    if not lanes:
+        lanes = ["not_required"] if bool(raw.get("optional", False)) else [DEFAULT_SETUP_LANE]
+
+    preferred = normalize_setup_lane(raw.get("preferred_setup_lane"))
+    if preferred not in lanes:
+        preferred = lanes[0]
+
+    return {
+        "preferred_setup_lane": preferred,
+        "allowed_setup_lanes": lanes,
+    }
+
+
+__all__ = [
+    "DEFAULT_SETUP_LANE",
+    "SECRET_FIELD_TYPES",
+    "SENSITIVE_METADATA_KEY_PARTS",
+    "SETUP_LANES",
+    "normalize_required_fields",
+    "normalize_setup_lane",
+    "normalize_setup_lanes",
+    "safe_managed_default",
+    "setup_lane_ids",
+]

--- a/tests/test_app_bundle_paths.py
+++ b/tests/test_app_bundle_paths.py
@@ -163,6 +163,12 @@ class TestIsCanonicalAppConfigPath:
     def test_known_canonical_config_subscriptions(self):
         assert is_canonical_app_config_path("config/subscriptions.yaml") is True
 
+    def test_known_canonical_config_integrations_yaml(self):
+        assert is_canonical_app_config_path("config/integrations.yaml") is True
+
+    def test_known_canonical_config_targets_json(self):
+        assert is_canonical_app_config_path("config/targets.json") is True
+
     def test_sensitive_config_not_canonical(self):
         assert is_canonical_app_config_path("config/secrets.yaml") is False
 

--- a/tests/test_appgenerator_config_materializer.py
+++ b/tests/test_appgenerator_config_materializer.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from factory_app.workflows.AppGenerator.tools.materialize_app_config_contracts import (
+    materialize_app_config_contracts,
+)
+
+
+class _Context:
+    def __init__(self, data: dict):
+        self.data = dict(data)
+
+    def get(self, key: str, default=None):
+        return self.data.get(key, default)
+
+
+def test_materializes_integrations_and_targets_without_secret_values() -> None:
+    context = _Context(
+        {
+            "app_build_plan": {
+                "deployment_profile": "generic_container",
+                "deployment_targets": [
+                    {
+                        "target_id": "local-container",
+                        "deployment_profile": "generic_container",
+                        "runtime": {"kind": "web", "health_path": "/health", "container_port": 8000},
+                        "environment": {
+                            "public": ["MOZAIKSPAY_PUBLIC_API_BASE"],
+                            "secret": ["MOZAIKSPAY_API_KEY"],
+                        },
+                    }
+                ],
+                "capability_packs": [
+                    {
+                        "capability_pack_id": "mozaikspay",
+                        "required_integrations": [
+                            {
+                                "service": "mozaikspay",
+                                "provider": "mozaikspay",
+                                "display_name": "MozaiksPay",
+                                "kind": "managed_capability",
+                                "purpose": "Use hosted billing.",
+                                "preferred_setup_lane": "managed",
+                                "allowed_setup_lanes": ["managed", "bring_your_own_key"],
+                                "managed_default": '{"display_name":"MozaiksPay","client_secret":"do-not-store"}',
+                                "required_fields": [
+                                    {"name": "api_base", "type": "url", "frontend_safe": True},
+                                    {"name": "client_secret", "type": "secret", "frontend_safe": False},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+
+    files = {
+        item["filename"]: item["content"]
+        for item in materialize_app_config_contracts(
+            app_id="demo-app",
+            app_build_plan=context.get("app_build_plan"),
+            context_variables=context,
+        )
+    }
+
+    assert set(files) == {"config/integrations.yaml", "config/targets.json"}
+    integrations = yaml.safe_load(files["config/integrations.yaml"])
+    assert integrations["schema_version"] == "mozaiks.integrations.v1"
+    requirement = integrations["requirements"][0]
+    assert requirement["service"] == "mozaikspay"
+    assert requirement["preferred_setup_lane"] == "managed"
+    assert requirement["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+    assert requirement["managed_default"] == {"display_name": "MozaiksPay"}
+    assert {field["name"] for field in requirement["required_fields"]} == {"api_base", "client_secret"}
+    assert "secret-value" not in files["config/integrations.yaml"]
+    assert "do-not-store" not in files["config/integrations.yaml"]
+
+    targets = json.loads(files["config/targets.json"])
+    assert targets["schema_version"] == "mozaiks.targets.v1"
+    assert targets["app_id"] == "demo-app"
+    assert targets["deployment"]["profile"] == "generic_container"
+    assert targets["deployment"]["target_id"] == "local-container"
+    assert targets["runtime"]["health_path"] == "/health"
+    assert targets["deployment"]["environment"]["secret"] == ["MOZAIKSPAY_API_KEY"]

--- a/tests/test_appgenerator_task_batch_contracts.py
+++ b/tests/test_appgenerator_task_batch_contracts.py
@@ -455,6 +455,8 @@ async def test_appgenerator_task_batch_dogfood_path_executes_and_assembles() -> 
     generated_files = context.get("generated_files")
     assert isinstance(generated_files, dict)
     assert set(generated_files) == {
+        "config/integrations.yaml",
+        "config/targets.json",
         "services/config.py",
         "ui/pages/notifications.yaml",
     }

--- a/tests/test_appgenerator_ui_quality_gate.py
+++ b/tests/test_appgenerator_ui_quality_gate.py
@@ -410,6 +410,8 @@ async def test_assemble_app_tasks_merges_schema_artifacts_and_task_batch_outputs
     filenames = {item["filename"] for item in result["code_files"]}
     assert filenames == {
         "app.json",
+        "config/integrations.yaml",
+        "config/targets.json",
         "ui/pages/Tickets.yaml",
         "modules/tickets/module.yaml",
     }
@@ -446,9 +448,12 @@ async def test_assemble_app_tasks_accepts_task_batch_outputs_without_schema_qual
 
     result = await assemble_module.assemble_app_tasks(context_variables=context)
 
-    assert result["code_files"] == [
-        {"filename": "modules/tickets/module.yaml", "content": "id: tickets\n"}
-    ]
+    filenames = {item["filename"] for item in result["code_files"]}
+    assert filenames == {
+        "config/integrations.yaml",
+        "config/targets.json",
+        "modules/tickets/module.yaml",
+    }
     assert context.data["app_task_batch_results"]["assembled"] is True
     assert context.data["app_task_batch_results_summary"]["completed_tasks"] == ["tickets_module"]
 

--- a/tests/test_connector_request_helpers.py
+++ b/tests/test_connector_request_helpers.py
@@ -69,7 +69,9 @@ from mozaiksai.core.workflow.generator_support.connector_request import (
     dedupe_integration_needs,
     display_service,
     normalize_service,
+    normalize_setup_lanes,
 )
+from mozaiksai.core.workflow.generator_support.connector_setup import safe_managed_default
 
 # ---------------------------------------------------------------------------
 # 1. normalize_service
@@ -212,6 +214,44 @@ class TestNormalizeRequiredFields:
         assert result[0]["required"] is False
 
 
+class TestNormalizeSetupLanes:
+    def test_defaults_to_bring_your_own_key_for_secret_fields(self):
+        result = normalize_setup_lanes({"required_fields": [{"name": "api_key", "type": "secret"}]})
+
+        assert result == {
+            "preferred_setup_lane": "bring_your_own_key",
+            "allowed_setup_lanes": ["bring_your_own_key"],
+        }
+
+    def test_managed_default_adds_managed_lane(self):
+        result = normalize_setup_lanes(
+            {
+                "preferred_setup_lane": "managed",
+                "managed_default": '{"display_name":"MozaiksPay"}',
+                "required_fields": [{"name": "client_secret", "type": "secret"}],
+            }
+        )
+
+        assert result["preferred_setup_lane"] == "managed"
+        assert result["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+
+    def test_safe_managed_default_drops_secret_like_keys(self):
+        result = safe_managed_default(
+            {
+                "display_name": "MozaiksPay",
+                "client_secret": "do-not-store",
+                "api_key": "do-not-store",
+            }
+        )
+
+        assert result == {"display_name": "MozaiksPay"}
+
+    def test_oauth_kind_adds_connect_account_lane(self):
+        result = normalize_setup_lanes({"kind": "oauth"})
+
+        assert "connect_account" in result["allowed_setup_lanes"]
+
+
 # ---------------------------------------------------------------------------
 # 4. _split_required_fields
 # ---------------------------------------------------------------------------
@@ -304,6 +344,9 @@ class TestExtractNeedsFromPlan:
                             "kind": "api_key",
                             "purpose": "Connect generated app facades to hosted MozaiksPay.",
                             "required_at": "runtime",
+                            "preferred_setup_lane": "managed",
+                            "allowed_setup_lanes": ["managed", "bring_your_own_key"],
+                            "managed_default": '{"display_name":"MozaiksPay"}',
                             "required_fields": [
                                 {"name": "api_base", "type": "url", "frontend_safe": True},
                                 {"name": "client_id", "type": "text", "frontend_safe": True},
@@ -323,6 +366,9 @@ class TestExtractNeedsFromPlan:
         assert need["provider"] == "mozaikspay"
         assert need["display_name"] == "MozaiksPay"
         assert need["required_at"] == "runtime"
+        assert need["preferred_setup_lane"] == "managed"
+        assert need["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+        assert need["managed_default"] == {"display_name": "MozaiksPay"}
         assert {field["name"] for field in need["required_fields"]} == {
             "api_base",
             "client_id",

--- a/tests/test_connector_request_readiness.py
+++ b/tests/test_connector_request_readiness.py
@@ -63,6 +63,7 @@ async def test_collect_missing_connector_needs_prompts_and_persists(monkeypatch)
                     "services": [
                         {
                             "service": "email_provider",
+                            "selected_setup_lane": "bring_your_own_key",
                             "fields": {
                                 "api_key": "secret-inline-value",
                                 "sender_domain": "example.test",
@@ -136,17 +137,25 @@ async def test_collect_missing_connector_needs_prompts_and_persists(monkeypatch)
     assert payload["event_type"] == "integration.required"
     assert payload["integrations_url"] == "/apps/app-test/integrations"
     assert payload["integration_requests"][0]["event_type"] == "integration.required"
+    assert payload["integration_requests"][0]["preferred_setup_lane"] == "bring_your_own_key"
+    assert payload["integration_requests"][0]["allowed_setup_lanes"] == ["bring_your_own_key"]
     assert payload["integration_requests"][0]["secret_fields"][0]["name"] == "api_key"
     assert payload["integration_requests"][0]["non_secret_fields"][0]["name"] == "sender_domain"
     assert "secret-inline-value" not in repr(payload)
     assert metadata_calls[0]["service"] == "email_provider"
     assert metadata_calls[0]["provider"] == "email_provider"
     assert metadata_calls[0]["integration_id"] == "email_provider"
-    assert metadata_calls[0]["public_config"] == {"sender_domain": "example.test"}
+    assert metadata_calls[0]["public_config"] == {
+        "sender_domain": "example.test",
+        "selected_setup_lane": "bring_your_own_key",
+    }
     assert store_calls[0]["secret_value"] == "secret-inline-value"
     assert store_calls[0]["provider"] == "email_provider"
     assert store_calls[0]["integration_id"] == "email_provider"
-    assert store_calls[0]["public_config"] == {"sender_domain": "example.test"}
+    assert store_calls[0]["public_config"] == {
+        "sender_domain": "example.test",
+        "selected_setup_lane": "bring_your_own_key",
+    }
     assert "secret-inline-value" not in repr(result)
 
 
@@ -259,6 +268,9 @@ def test_collect_integration_needs_supports_structured_managed_capability_requir
                                 "kind": "api_key",
                                 "purpose": "Connect to hosted subscriptions.",
                                 "required_at": "runtime",
+                                "preferred_setup_lane": "managed",
+                                "allowed_setup_lanes": ["managed", "bring_your_own_key"],
+                                "managed_default": '{"display_name":"MozaiksPay"}',
                                 "required_fields": [
                                     {"name": "api_base", "type": "url", "frontend_safe": True},
                                     {"name": "client_id", "type": "text", "frontend_safe": True},
@@ -278,6 +290,9 @@ def test_collect_integration_needs_supports_structured_managed_capability_requir
     need = needs[0]
     assert need["display_name"] == "MozaiksPay"
     assert need["provider"] == "mozaikspay"
+    assert need["preferred_setup_lane"] == "managed"
+    assert need["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+    assert need["managed_default"] == {"display_name": "MozaiksPay"}
     assert {field["name"] for field in need["required_fields"]} == {
         "api_base",
         "client_id",
@@ -291,6 +306,8 @@ def test_collect_integration_needs_supports_structured_managed_capability_requir
     )[0]
     assert [field["name"] for field in payload["secret_fields"]] == ["client_secret"]
     assert {field["name"] for field in payload["non_secret_fields"]} == {"api_base", "client_id"}
+    assert payload["preferred_setup_lane"] == "managed"
+    assert payload["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
 
 
 def test_build_integration_request_payload_is_frontend_safe() -> None:

--- a/tests/test_generated_bundle_scanner.py
+++ b/tests/test_generated_bundle_scanner.py
@@ -508,6 +508,78 @@ def test_scan_generated_bundle_rejects_page_binding_to_selected_managed_capabili
     assert any("calls managed capability endpoint" in error for error in errors)
 
 
+def test_scan_generated_bundle_rejects_managed_setup_raw_provider_env_handles() -> None:
+    errors = scan_generated_bundle(
+        {
+            "config/integrations.yaml": """
+schema_version: mozaiks.integrations.v1
+requirements:
+  - integration_id: payments
+    service: mozaikspay
+    preferred_setup_lane: managed
+    allowed_setup_lanes: [managed, bring_your_own_key]
+""",
+            ".env.example": "STRIPE_SECRET_KEY=\nSTRIPE_WEBHOOK_SECRET=\n",
+        }
+    )
+
+    assert any("raw payment-provider environment handles" in error for error in errors)
+
+
+def test_scan_generated_bundle_rejects_managed_setup_provider_webhook_routes() -> None:
+    errors = scan_generated_bundle(
+        {
+            "config/integrations.yaml": """
+schema_version: mozaiks.integrations.v1
+requirements:
+  - integration_id: payments
+    service: mozaikspay
+    preferred_setup_lane: managed
+    allowed_setup_lanes: [managed, bring_your_own_key]
+""",
+            "services/routes/webhooks.py": '@router.post("/webhooks/stripe")\nasync def webhook(): pass\n',
+        }
+    )
+
+    assert any("raw payment-provider webhook or checkout routes" in error for error in errors)
+
+
+def test_scan_generated_bundle_rejects_managed_setup_provider_sdk_mechanics() -> None:
+    errors = scan_generated_bundle(
+        {
+            "config/integrations.yaml": """
+schema_version: mozaiks.integrations.v1
+requirements:
+  - integration_id: payments
+    service: mozaikspay
+    preferred_setup_lane: managed
+    allowed_setup_lanes: [managed, bring_your_own_key]
+""",
+            "modules/billing/backend/service.py": "session = stripe.checkout.Session.create()\n",
+        }
+    )
+
+    assert any("raw payment-provider SDK mechanics" in error for error in errors)
+
+
+def test_scan_generated_bundle_allows_provider_env_handles_when_no_managed_setup_lane() -> None:
+    errors = scan_generated_bundle(
+        {
+            "config/integrations.yaml": """
+schema_version: mozaiks.integrations.v1
+requirements:
+  - integration_id: direct_payments
+    service: direct_payments
+    preferred_setup_lane: bring_your_own_key
+    allowed_setup_lanes: [bring_your_own_key]
+""",
+            ".env.example": "STRIPE_SECRET_KEY=\n",
+        }
+    )
+
+    assert not any("managed setup lane" in error for error in errors)
+
+
 def test_scan_generated_bundle_accepts_mozaikspay_saas_contract_with_deployment_artifacts() -> None:
     errors = scan_generated_bundle(
         _valid_mozaikspay_saas_bundle(include_deployment=True),

--- a/tests/test_workflow_ui_tool_contracts.py
+++ b/tests/test_workflow_ui_tool_contracts.py
@@ -659,14 +659,18 @@ def test_extended_orchestration_transition_components_are_file_backed() -> None:
         "DatabaseSetupSelector",
     }.issubset(transition_components)
 
-    # Transition routing stays semantic; visual copy/images live in the React stubs.
+    # Transition routing stays semantic. ui.props is allowed only for bounded
+    # transition-frame routing behavior; visual copy/images live in the React stubs.
+    allowed_transition_props = {"dismissible", "dismiss_to", "dismissTo", "close_label", "closeLabel"}
     for entry in registry.get("transitions", []):
         if not isinstance(entry, dict):
             continue
         ui = entry.get("ui")
         if not isinstance(ui, dict):
             continue
-        assert "props" not in ui
+        props = ui.get("props") or {}
+        assert isinstance(props, dict)
+        assert set(props).issubset(allowed_transition_props)
 
 
 def test_app_type_selector_emits_generic_monetization_selection_context() -> None:

--- a/tests/test_workspace_integrations_module.py
+++ b/tests/test_workspace_integrations_module.py
@@ -42,6 +42,13 @@ def test_integrations_catalog_has_required_fields() -> None:
         assert "required_secrets" in entry
         assert isinstance(entry["required_secrets"], list)
         assert "optional_secrets" in entry
+        assert entry.get("preferred_setup_lane") in {
+            "managed",
+            "connect_account",
+            "bring_your_own_key",
+            "not_required",
+        }
+        assert isinstance(entry.get("allowed_setup_lanes"), list)
 
 
 def test_catalog_by_id_matches_catalog_list() -> None:
@@ -79,16 +86,20 @@ def test_build_context_catalog_matches_runtime_catalog() -> None:
     runtime_mozaikspay = CATALOG_BY_ID["mozaikspay"]
     assert yaml_mozaikspay["required_secrets"] == runtime_mozaikspay["required_secrets"]
     assert yaml_mozaikspay["optional_secrets"] == runtime_mozaikspay["optional_secrets"]
+    assert yaml_mozaikspay["preferred_setup_lane"] == runtime_mozaikspay["preferred_setup_lane"]
+    assert yaml_mozaikspay["allowed_setup_lanes"] == runtime_mozaikspay["allowed_setup_lanes"]
+    assert yaml_mozaikspay["managed_default"] == runtime_mozaikspay["managed_default"]
     assert [entry["id"] for entry in yaml_entries] == [entry["id"] for entry in INTEGRATIONS_CATALOG]
 
 
-def test_integrations_catalog_orders_payments_after_ai() -> None:
-    assert [entry["id"] for entry in INTEGRATIONS_CATALOG[:3]] == [
+def test_integrations_catalog_orders_payments_after_llms() -> None:
+    assert [entry["id"] for entry in INTEGRATIONS_CATALOG[:4]] == [
         "openai",
         "anthropic",
+        "gemini",
         "mozaikspay",
     ]
-    assert [entry["category"] for entry in INTEGRATIONS_CATALOG[:3]] == ["ai", "ai", "payments"]
+    assert [entry["category"] for entry in INTEGRATIONS_CATALOG[:4]] == ["llms", "llms", "llms", "payments"]
 
 
 def test_mozaikspay_catalog_is_default_removable_monetization_integration() -> None:
@@ -100,6 +111,9 @@ def test_mozaikspay_catalog_is_default_removable_monetization_integration() -> N
         "MOZAIKSPAY_API_BASE",
         "MOZAIKSPAY_API_KEY",
     }
+    assert spec["preferred_setup_lane"] == "managed"
+    assert spec["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+    assert spec["managed_default"] == {"provider": "mozaikspay", "mode": "hosted"}
 
 
 # ── module.yaml contract ──────────────────────────────────────────────────────
@@ -215,6 +229,13 @@ def test_build_integration_response_note_included() -> None:
     spec = CATALOG_BY_ID["openai"]
     response = build_integration_response(spec, status="configured", missing_secrets=[], note="rotated 2026-06")
     assert response["note"] == "rotated 2026-06"
+
+
+def test_build_integration_response_includes_setup_lanes() -> None:
+    response = build_integration_response(CATALOG_BY_ID["mozaikspay"], status="missing", missing_secrets=[])
+    assert response["preferred_setup_lane"] == "managed"
+    assert response["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+    assert response["managed_default"] == {"provider": "mozaikspay", "mode": "hosted"}
 
 
 def test_build_integration_response_missing_has_setup_url() -> None:
@@ -443,6 +464,8 @@ def test_build_declaration_document_shape() -> None:
     assert doc["workspace_status"] == "missing"
     assert doc["connector_status"] == "not_configured"
     assert doc["optional"] is False
+    assert doc["preferred_setup_lane"] == "bring_your_own_key"
+    assert doc["allowed_setup_lanes"] == ["bring_your_own_key"]
 
 
 def test_build_declaration_response_setup_url_only_when_missing() -> None:
@@ -504,6 +527,24 @@ def test_build_declaration_response_includes_removable_default_metadata() -> Non
     assert response["removable"] is True
     assert response["source"] == "monetization_default"
     assert response["required_fields"][0]["name"] == "client_secret"
+
+
+def test_build_declaration_response_includes_setup_lane_metadata() -> None:
+    doc = build_declaration_document(
+        app_id="app_1",
+        service="mozaikspay",
+        catalog_id="mozaikspay",
+        display_name="Mozaiks Pay",
+        kind="managed_capability",
+        preferred_setup_lane="managed",
+        allowed_setup_lanes=["managed", "bring_your_own_key"],
+        managed_default={"provider": "mozaikspay", "client_secret": "do-not-store"},
+        declared_at="2026-07-11T00:00:00Z",
+    )
+    response = build_declaration_response(doc)
+    assert response["preferred_setup_lane"] == "managed"
+    assert response["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
+    assert response["managed_default"] == {"provider": "mozaikspay"}
 
 
 def test_declarations_entity_constant_is_set() -> None:
@@ -572,6 +613,9 @@ async def test_declare_app_integration_needs_persists_docs() -> None:
     assert decl_repo.upserted is not None
     services = {d["service"] for d in decl_repo.upserted}
     assert services == {"resend", "twilio"}
+    resend = next(d for d in decl_repo.upserted if d["service"] == "resend")
+    assert resend["preferred_setup_lane"] == "bring_your_own_key"
+    assert resend["allowed_setup_lanes"] == ["bring_your_own_key"]
 
 
 @pytest.mark.asyncio
@@ -592,8 +636,10 @@ async def test_upsert_app_integration_need_persists_single_record() -> None:
     assert result["saved"] == 1
     assert result["declaration"]["service"] == "mozaikspay"
     assert result["declaration"]["defaulted"] is True
+    assert result["declaration"]["preferred_setup_lane"] == "managed"
     assert decl_repo.upserted is not None
     assert decl_repo.upserted[0]["removable"] is True
+    assert decl_repo.upserted[0]["allowed_setup_lanes"] == ["managed", "bring_your_own_key"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **`connector_setup.py`** — normalizes setup lanes (managed / bring_your_own_key / connect_account / not_required), safe managed defaults, field type splitting
- **`materialize_app_config_contracts.py`** — new AppGenerator tool that emits `integrations.yaml` into the generated app bundle, describing every service the app needs with setup lanes and managed defaults
- **`connector_request.py`** — structured integration need collection from task batches, deduplication, frontend-safe payload builder
- **AppGenerator workflow** — integration readiness check fires before assembly; AppPlanAgent emits `capability_pack` requirements per service; context variables and structured outputs updated
- **`integration_readiness.py`** — collects missing connectors, prompts user before proceeding if any are unconnected
- **`assemble_app_tasks.py`** — declares integration needs into the workspace_integrations module after assembly
- **`generated_bundle_scanner.py`** — validates emitted bundle paths and shapes
- **AgentAPIKeysBundleInput.js** — reworked key collection UI for AgentGenerator
- **Catalog expansion** — `connector_key`, `setup_url`, setup lanes per service; Gemini, source_control, cache, analytics entries added
- **Docs** — integrations workflow, workspace-integrations guide, managed-setup UX, app-bundle declaratives, assembly contract
- **Tests** — 109 passing, coverage across connector helpers, readiness, workspace integrations, config materializer, bundle scanner, UI tool contracts, task batch contracts

## Test plan
- [ ] `pytest` — 109 tests pass
- [ ] Generate an app that needs OpenAI — verify `integrations.yaml` appears in generated bundle with `OPENAI_API_KEY` requirement
- [ ] With OpenAI disconnected — verify readiness check surfaces the gap before download
- [ ] Connect OpenAI from the integrations page — verify readiness check clears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)