### PR TITLE
fix(brownfield): show path selector before discovery chat, add generation selector after

### DIFF
--- a/factory_app/workflows/extended_orchestration/extension_registry.json
+++ b/factory_app/workflows/extended_orchestration/extension_registry.json
@@ -74,12 +74,13 @@
     },
     {
       "id": "brownfield_app_adoption",
-      "description": "Brownfield app adoption pipeline: app path context → host product discovery and augmentation planning → build path selection.",
+      "description": "Brownfield app adoption pipeline: app path context → build path intent → discovery chat → generation path selection.",
       "affected_declarative_families": ["concept", "app_bundle"],
       "steps": [
         { "transition": "app_type_selector" },
+        { "transition": "brownfield_path_selector" },
         { "workflows": ["ExistingAppDiscovery"] },
-        { "transition": "brownfield_path_selector" }
+        { "transition": "brownfield_generation_selector" }
       ]
     },
     {
@@ -245,7 +246,7 @@
         },
         {
           "id": "brownfield_app",
-          "route_to": "ExistingAppDiscovery",
+          "route_to": "brownfield_path_selector",
           "sequence": "brownfield_app_adoption",
           "context_variables": {
             "app_type": "brownfield_app"
@@ -287,6 +288,33 @@
     },
     {
       "id": "brownfield_path_selector",
+      "transition_type": "user_choice_context",
+      "ui": {
+        "component": "BrownfieldPathSelector",
+        "mode": "screen",
+        "shell_mode": "focused"
+      },
+      "options": [
+        {
+          "id": "light_integration",
+          "route_to": "ExistingAppDiscovery",
+          "sequence": "brownfield_app_adoption",
+          "context_variables": {
+            "brownfield_build_path": "light_integration"
+          }
+        },
+        {
+          "id": "full_migration",
+          "route_to": "ExistingAppDiscovery",
+          "sequence": "brownfield_app_adoption",
+          "context_variables": {
+            "brownfield_build_path": "full_migration"
+          }
+        }
+      ]
+    },
+    {
+      "id": "brownfield_generation_selector",
       "transition_type": "user_choice_context",
       "ui": {
         "component": "BrownfieldPathSelector",


### PR DESCRIPTION
## Summary
- Reorders `brownfield_app_adoption` sequence: `app_type_selector` → `brownfield_path_selector` → `ExistingAppDiscovery` → `brownfield_generation_selector`
- `app_type_selector` brownfield option now routes to `brownfield_path_selector` transition (not directly to `ExistingAppDiscovery` workflow)
- `brownfield_path_selector` options now both route to `ExistingAppDiscovery` with `sequence: brownfield_app_adoption`, seeding `brownfield_build_path` intent
- Adds new `brownfield_generation_selector` transition — shown after discovery chat, routes to `AgentGenerator` (overlay) or `DesignDocs` (module migration)

## Fixes
- "Choose Your Integration Path" screen now appears immediately on clicking Existing App, before the chat begins
- "Build Complete" screen no longer appears after the first discovery chat message — generation selector is shown instead

## Test plan
- [ ] Click Create App → select Existing App → BrownfieldPathSelector screen appears before chat
- [ ] Select light_integration → ExistingAppDiscovery chat starts
- [ ] Complete discovery chat → BrownfieldPathSelector (generation selector) appears
- [ ] Select path → routes to AgentGenerator or DesignDocs as appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)