### PR TITLE
fix(brownfield): discovery-first UX with intro screen and clearer path descriptions

### DIFF
--- a/factory_app/workflows/extended_orchestration/extension_registry.json
+++ b/factory_app/workflows/extended_orchestration/extension_registry.json
@@ -74,13 +74,13 @@
     },
     {
       "id": "brownfield_app_adoption",
-      "description": "Brownfield app adoption pipeline: app path context → build path intent → discovery chat → generation path selection.",
+      "description": "Brownfield app adoption pipeline: app path context → discovery intro → discovery chat → generation path selection.",
       "affected_declarative_families": ["concept", "app_bundle"],
       "steps": [
         { "transition": "app_type_selector" },
-        { "transition": "brownfield_path_selector" },
+        { "transition": "brownfield_discovery_intro" },
         { "workflows": ["ExistingAppDiscovery"] },
-        { "transition": "brownfield_generation_selector" }
+        { "transition": "brownfield_path_selector" }
       ]
     },
     {
@@ -246,7 +246,7 @@
         },
         {
           "id": "brownfield_app",
-          "route_to": "brownfield_path_selector",
+          "route_to": "brownfield_discovery_intro",
           "sequence": "brownfield_app_adoption",
           "context_variables": {
             "app_type": "brownfield_app"
@@ -287,34 +287,24 @@
       "route_to": "AppReview"
     },
     {
-      "id": "brownfield_path_selector",
+      "id": "brownfield_discovery_intro",
       "transition_type": "user_choice_context",
       "ui": {
-        "component": "BrownfieldPathSelector",
+        "component": "BrownfieldDiscoveryIntro",
         "mode": "screen",
         "shell_mode": "focused"
       },
       "options": [
         {
-          "id": "light_integration",
+          "id": "start_discovery",
           "route_to": "ExistingAppDiscovery",
           "sequence": "brownfield_app_adoption",
-          "context_variables": {
-            "brownfield_build_path": "light_integration"
-          }
-        },
-        {
-          "id": "full_migration",
-          "route_to": "ExistingAppDiscovery",
-          "sequence": "brownfield_app_adoption",
-          "context_variables": {
-            "brownfield_build_path": "full_migration"
-          }
+          "context_variables": {}
         }
       ]
     },
     {
-      "id": "brownfield_generation_selector",
+      "id": "brownfield_path_selector",
       "transition_type": "user_choice_context",
       "ui": {
         "component": "BrownfieldPathSelector",

--- a/factory_app/workflows/extended_orchestration/ui/index.js
+++ b/factory_app/workflows/extended_orchestration/ui/index.js
@@ -1,4 +1,5 @@
 export { default as AppTypeSelector } from './transitions/AppTypeSelector.js';
+export { default as BrownfieldDiscoveryIntro } from './transitions/BrownfieldDiscoveryIntro.js';
 export { default as BrownfieldPathSelector } from './transitions/BrownfieldPathSelector.js';
 export { default as BuildSatisfactionRating } from './transitions/BuildSatisfactionRating.js';
 export { default as CodingJourneySelector } from './transitions/CodingJourneySelector.js';

--- a/factory_app/workflows/extended_orchestration/ui/transitions/BrownfieldDiscoveryIntro.js
+++ b/factory_app/workflows/extended_orchestration/ui/transitions/BrownfieldDiscoveryIntro.js
@@ -1,0 +1,62 @@
+import {
+  TransitionChoicePanel,
+  useTransitionMotion,
+} from '@mozaiks/chat-ui/platform';
+
+const DISCOVERY_STEPS = [
+  {
+    label: 'App identity',
+    description: "Confirm what your app is called, what it does, and how it's built.",
+  },
+  {
+    label: 'Capability map',
+    description: 'Map the features, APIs, and services your app already owns.',
+  },
+  {
+    label: 'Integration plan',
+    description: 'Recommend how deeply Mozaiks should augment your app based on what we find.',
+  },
+];
+
+export default function BrownfieldDiscoveryIntro({ transition, onResolve, overlayTitleId, overlayDescriptionId }) {
+  const option = Array.isArray(transition?.options) ? transition.options[0] : null;
+  const motion = useTransitionMotion();
+
+  return (
+    <TransitionChoicePanel
+      eyebrow="Existing App"
+      title="Let's explore your app"
+      subtitle="We'll have a short conversation to understand what your app already does. At the end, you'll choose how deeply to integrate with Mozaiks."
+      overlayTitleId={overlayTitleId}
+      overlayDescriptionId={overlayDescriptionId}
+      entered={motion.entered}
+      prefersReducedMotion={motion.prefersReducedMotion}
+    >
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2">
+        {DISCOVERY_STEPS.map(({ label, description }) => (
+          <div
+            key={label}
+            className="flex items-start gap-3 rounded-xl border border-border/60 bg-card/60 px-4 py-3"
+          >
+            <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary/70" />
+            <div>
+              <p className="text-sm font-semibold text-foreground">{label}</p>
+              <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      {option && (
+        <div className="mx-auto w-full max-w-3xl">
+          <button
+            type="button"
+            onClick={() => onResolve(option.id)}
+            className="w-full rounded-xl bg-primary px-6 py-3.5 text-sm font-semibold text-primary-foreground shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 focus:ring-offset-background"
+          >
+            Start Discovery
+          </button>
+        </div>
+      )}
+    </TransitionChoicePanel>
+  );
+}

--- a/factory_app/workflows/extended_orchestration/ui/transitions/BrownfieldPathSelector.js
+++ b/factory_app/workflows/extended_orchestration/ui/transitions/BrownfieldPathSelector.js
@@ -8,16 +8,16 @@ const OPTION_VIEW = {
   light_integration: {
     label: 'Light Integration',
     description:
-      'Add AI workflows and generated surfaces alongside your existing app without changing its architecture. Best for embed and bridge adoption.',
+      'Keep your existing app running as-is. Mozaiks adds AI workflows, chat surfaces, and generated capabilities on top — without changing your backend architecture or codebase. Your app owns the data and business logic; Mozaiks augments from the outside.',
     cta: 'Choose Light Integration',
     badge: 'Fastest path',
   },
   full_migration: {
     label: 'Full Migration',
     description:
-      'Rebuild as canonical Mozaiks modules with full design, workflow, and app generation. Best for native migration and ecosystem adoption.',
+      'Rebuild as a native Mozaiks app. Your backend becomes Mozaiks modules, your frontend uses the Mozaiks app shell, and you go through the full generation pipeline — design docs, workflows, and app bundle. Best when you want Mozaiks to fully own the stack.',
     cta: 'Choose Full Migration',
-    badge: 'Recommended for Mozaiks apps',
+    badge: 'Full Mozaiks app',
   },
 };
 
@@ -34,7 +34,7 @@ export default function BrownfieldPathSelector({ transition, onResolve, overlayT
     <TransitionChoicePanel
       eyebrow="Build Path"
       title="Choose Your Integration Path"
-      subtitle="Select how deeply to integrate your existing app based on the adoption level your discovery session recommended."
+      subtitle="Based on what your discovery session found, choose how deeply to integrate with Mozaiks."
       overlayTitleId={overlayTitleId}
       overlayDescriptionId={overlayDescriptionId}
       entered={motion.entered}


### PR DESCRIPTION
## Summary
- Restores discovery-first sequence: `app_type_selector` → `brownfield_discovery_intro` → `ExistingAppDiscovery` → `brownfield_path_selector`
- Adds `BrownfieldDiscoveryIntro` transition: a context screen that explains the 3-stage discovery process before the chat starts, with a single "Start Discovery" CTA — no routing decision before the user has any context
- Removes redundant `brownfield_generation_selector` (was asking twice); `brownfield_path_selector` now correctly appears post-discovery where its copy is accurate
- Rewrites Light Integration / Full Migration descriptions to be concrete and jargon-free
- Updates `BrownfieldPathSelector` subtitle to reference the completed discovery session

## Flow
```
App Type Selector
  → [Existing App]
  → BrownfieldDiscoveryIntro  ← new: explains what's about to happen
  → ExistingAppDiscovery chat
  → BrownfieldPathSelector    ← post-discovery: Light Integration or Full Migration
  → generation workflows
```

## Test plan
- [ ] Click Create App → Existing App → `BrownfieldDiscoveryIntro` screen appears with 3 steps and Start Discovery button
- [ ] Click Start Discovery → ExistingAppDiscovery chat starts
- [ ] Complete discovery chat → BrownfieldPathSelector appears with updated copy
- [ ] Light Integration → AgentGenerator (overlay generation sequence)
- [ ] Full Migration → DesignDocs (module generation sequence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)