### PR TITLE
fix(imports): update factory_app.control_plane refs to refinement_harness

### DIFF
--- a/factory_app/refinement_harness/tools/get_contract_surface_context.py
+++ b/factory_app/refinement_harness/tools/get_contract_surface_context.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from factory_app.control_plane.tools._artifact_workspace import load_artifact_workspace
+from factory_app.refinement_harness.tools._artifact_workspace import load_artifact_workspace
 from mozaiksai.control_plane.context_graph.query import build_context_graph_catalog
 from mozaiksai.control_plane.contracts import ControlPlaneToolContext
 from mozaiksai.core.app_context.models import AppContextGraph

--- a/factory_app/refinement_harness/tools/resolve_carry_forward_preservation.py
+++ b/factory_app/refinement_harness/tools/resolve_carry_forward_preservation.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from factory_app.control_plane.tools._artifact_workspace import load_artifact_workspace
+from factory_app.refinement_harness.tools._artifact_workspace import load_artifact_workspace
 from mozaiksai.core.artifacts.content_store import ArtifactContentStore, get_artifact_content_store
 from mozaiksai.core.artifacts.store import ArtifactStore, get_artifact_store
 

--- a/factory_app/workflows/AppGenerator/tools/read_carry_forward_module_contract.py
+++ b/factory_app/workflows/AppGenerator/tools/read_carry_forward_module_contract.py
@@ -18,7 +18,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
-from factory_app.control_plane.tools.read_carry_forward_module_contract import (
+from factory_app.refinement_harness.tools.read_carry_forward_module_contract import (
     read_carry_forward_module_contract as _core,
 )
 

--- a/factory_app/workflows/AppGenerator/tools/resolve_carry_forward_preservation.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_carry_forward_preservation.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
-from factory_app.control_plane.tools.resolve_carry_forward_preservation import (
+from factory_app.refinement_harness.tools.resolve_carry_forward_preservation import (
     resolve_carry_forward_preservation as _core,
 )
 

--- a/factory_app/workflows/_shared/context_graph/load_context_graph_context.py
+++ b/factory_app/workflows/_shared/context_graph/load_context_graph_context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from factory_app.control_plane.tools._context_graph import load_context_graph_for_tool
+from factory_app.refinement_harness.tools._context_graph import load_context_graph_for_tool
 from factory_app.workflows._shared.context_graph.prompt_pack import (
     build_context_graph_prompt_pack,
     build_context_graph_unavailable_pack,

--- a/mozaiksai/control_plane/implementations/scope_proposer.py
+++ b/mozaiksai/control_plane/implementations/scope_proposer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from factory_app.control_plane.tools._artifact_workspace import (
+from factory_app.refinement_harness.tools._artifact_workspace import (
     load_artifact_workspace,
     safe_relpath,
 )


### PR DESCRIPTION
## Summary

- `factory_app/control_plane` was renamed to `factory_app/refinement_harness` but 6 import statements were missed
- This caused `ModuleNotFoundError: No module named 'factory_app.control_plane'` on `mozaiks --version` import chain
- Blocked the `Framework consumer` CI check in `mozaiks-app` (#58, #60)

## Files fixed

- `mozaiksai/control_plane/implementations/scope_proposer.py`
- `factory_app/refinement_harness/tools/get_contract_surface_context.py`
- `factory_app/refinement_harness/tools/resolve_carry_forward_preservation.py`
- `factory_app/workflows/AppGenerator/tools/read_carry_forward_module_contract.py`
- `factory_app/workflows/AppGenerator/tools/resolve_carry_forward_preservation.py`
- `factory_app/workflows/_shared/context_graph/load_context_graph_context.py`

## Test plan
- [ ] CI passes: `mozaiks --version` resolves without ModuleNotFoundError
- [ ] `mozaiks-app` framework consumer check passes after bumping to new OSS SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)