### PR TITLE
docs: add app config guide

### DIFF
--- a/docs/guides/configs/ai-startup.md
+++ b/docs/guides/configs/ai-startup.md
@@ -1,0 +1,57 @@
+# AI Startup
+
+`app/config/ai.json` owns runtime startup for ask mode, chat mode, and workflow
+entry. It answers what the AI runtime should open first.
+
+Use `app/config/ai.json` for:
+
+- the ask-mode prompt
+- initial ask context variables
+- the chat startup mode
+- the default workflow entry point
+
+Do not put refinement model policy, refinement routing, provider secrets, or
+workflow definitions in this file.
+
+## Starter
+
+```json
+{
+  "ask": {
+    "ask_mode_prompt": "You are the Support Desk assistant. Help users triage requests, draft replies, and update ticket records.",
+    "ask_context_variables": null
+  },
+  "chat": {
+    "chat_startup_mode": "ask"
+  },
+  "workflows": {
+    "entry_point": "SupportIntake"
+  }
+}
+```
+
+## Field Notes
+
+| Field | Purpose |
+|-------|---------|
+| `ask.ask_mode_prompt` | System prompt for ordinary ask/chat startup |
+| `ask.ask_context_variables` | Optional initial context variables for ask mode |
+| `chat.chat_startup_mode` | Startup mode such as `ask` |
+| `workflows.entry_point` | Default workflow folder under `workflows/` |
+
+`app/config/ai.json` does not resume old workflow sessions by itself. Resuming a
+previous session requires an explicit session or chat id from the runtime.
+
+## Refinement Boundary
+
+Refinement uses two separate files:
+
+- `app/config/refinement_policy.yaml` for app-local Refinement Engine policy and
+  model profile selection.
+- `refinement_harness/config/harness.yaml` for optional app-local refinement
+  sequences, tools, prompts, and promotion policy.
+
+Keep startup in `ai.json`; keep refinement policy in
+`refinement_policy.yaml`.
+
+See also [Extending AI Functionality: Startup Config](../extending-ai-functionality/02-ai-runtime-startup.md).

--- a/docs/guides/configs/app-identity.md
+++ b/docs/guides/configs/app-identity.md
@@ -1,0 +1,59 @@
+# App Identity
+
+`app/app.json` is the app's identity and high-level runtime intent. It is the
+first file the app loader expects to find in an active app root.
+
+Use `app/app.json` for:
+
+- app name and app id
+- optional description and version
+- startup route intent
+- whether auth is required
+- local admin allowlist
+- high-level target flags such as web or mobile
+
+Do not use `app/app.json` for module actions, page schemas, navigation chrome,
+provider credentials, billing rules, or refinement routing.
+
+## Starter
+
+```json
+{
+  "appName": "Support Desk",
+  "appId": "support-desk",
+  "version": "1.0.0",
+  "startup": {
+    "landing_spot": "/dashboard"
+  },
+  "targets": {
+    "web": true,
+    "mobile": false
+  },
+  "authRequired": true,
+  "admins": ["owner@example.com"]
+}
+```
+
+## Common Fields
+
+| Field | Purpose |
+|-------|---------|
+| `appName` | Human-readable app name used by Studio and shell summaries |
+| `appId` | Stable app id for workspace and generated-artifact references |
+| `version` | App bundle version metadata |
+| `startup.landing_spot` | Default route after startup or login |
+| `targets.web` | Declares that the app has a web surface |
+| `targets.mobile` | Declares mobile target intent when present |
+| `authRequired` | Enables authenticated app behavior when paired with `app/config/auth.yaml` |
+| `admins` | Local admin email allowlist for admin-gated surfaces |
+
+Generated code may also use `name` in small fixtures or lower-level runtime
+tests. For real app workspaces, prefer `appName` and `appId` so Studio and
+workspace summaries have explicit identity metadata.
+
+## Related Files
+
+- `app/config/ai.json` chooses ask/chat/workflow startup.
+- `app/config/shell.json` controls visible navigation.
+- `app/config/auth.yaml` carries provider-neutral auth routes and env handles.
+- `app/brand/theme_config.json` carries visual identity.

--- a/docs/guides/configs/index.md
+++ b/docs/guides/configs/index.md
@@ -1,0 +1,92 @@
+# Configs
+
+This guide is the practical file map for a Mozaiks app. Use it when you need to
+know where app data lives, which file owns a setting, and which files should be
+left alone.
+
+In an active workspace, app-owned files live under `app/`. During generation,
+the same bundle paths are often shown without the leading `app/`, such as
+`config/ai.json` or `data/contract.json`. They refer to the same app-bundle
+contracts after promotion into `app/`.
+
+## File Map
+
+| File | Owns | Use When |
+|------|------|----------|
+| `app/app.json` | App identity, startup route intent, auth-required flag, admin allowlist, high-level targets | Every app |
+| `app/config/ai.json` | Ask/chat startup and workflow entry point | The app starts AI workflows or chat |
+| `app/config/shell.json` | Header, navigation, shell chrome, footer, mobile shortcuts | The app needs navigation or shell changes |
+| `app/brand/theme_config.json` | Brand tokens, typography, colors, density, radius, logos | The app needs visual identity |
+| `app/config/auth.yaml` | Provider-neutral auth routes and OIDC env handles | Authenticated apps |
+| `app/config/integrations.yaml` | Provider-neutral external service requirements | The app needs external or managed services |
+| `app/config/targets.json` | Runtime, deployment, domain, DNS, and environment target intent | The app is packaged or deployed |
+| `app/config/subscriptions.yaml` | App-owned plans, capability gates, usage limits, token wallets, token allowances | SaaS apps and apps with paid feature gates |
+| `app/security/secrets.yaml` | Names-only secret requirements, env handles, provider/vault policy | The app needs secrets or environment handles |
+| `app/data/contract.json` | Durable data ownership, aliases, collection mappings, indexes, additive migrations | The default module persistence shape is not enough |
+| `app/config/refinement_policy.yaml` | App-local Refinement Engine policy and model profiles | The app supports artifact-aware refinement |
+| `refinement_harness/config/harness.yaml` | Optional app-local refinement routing bundle | The app overrides refinement sequences, prompts, tools, or promotion policy |
+| `app/modules/{module_id}/contracts/service.yaml` | Optional module service boundary metadata | A module exposes a stable service boundary |
+| `app/modules/{module_id}/contracts/commercial.yaml` | Optional module commercial metadata outside subscription gates | A module owns fees, terms, or custom money-flow metadata |
+
+## Required Versus Optional
+
+Start with the smallest valid app:
+
+- `app/app.json`
+- `app/config/ai.json`
+- at least one app surface: `workflows/`, `app/modules/`, `app/ui/pages/`, or
+  custom UI registered through `app/ui/index.js`
+
+Add more files only when the app needs them:
+
+- Add `app/config/shell.json` and `app/brand/theme_config.json` when the shell
+  or brand should differ from defaults.
+- Add `app/security/secrets.yaml` when the app needs named environment values
+  or vault-backed secrets.
+- Add `app/config/integrations.yaml` when the app depends on external services.
+- Add `app/config/targets.json` when build or deployment intent must be carried
+  with the bundle.
+- Add `app/config/subscriptions.yaml` only when the app sells access tiers,
+  quotas, credits, token packs, or paid feature gates.
+- Add `app/data/contract.json` only when module default persistence does not
+  express enough durable data intent.
+- Add `app/config/refinement_policy.yaml` only when the app needs app-local
+  refinement policy.
+- Add `refinement_harness/` only when the app needs an app-local refinement
+  harness bundle.
+
+## Source Of Truth Rules
+
+Each durable concern has one canonical home:
+
+- App identity stays in `app/app.json`.
+- Runtime AI startup stays in `app/config/ai.json`.
+- Shell and navigation stay in `app/config/shell.json`.
+- Visual tokens stay in `app/brand/theme_config.json`.
+- Secret names and vault policy stay in `app/security/secrets.yaml`.
+- Durable collection intent stays in `app/data/contract.json`.
+- SaaS plans and entitlement gates stay in `app/config/subscriptions.yaml`.
+- App-local refinement model policy stays in `app/config/refinement_policy.yaml`.
+- Business actions, lifecycle state, permissions, emitted events, and
+  persistence authority stay in modules.
+
+Do not create module-local `contracts/subscriptions.yaml`. The app-level
+subscription contract is `app/config/subscriptions.yaml`.
+
+You also do not need root `hosted_services.yaml` or `monetization.yaml` files
+to build a normal OSS Mozaiks app. Hosted products may keep operator summaries,
+but those summaries are not the generated-app source of truth.
+
+## Next Pages
+
+- [App Identity](app-identity.md)
+- [AI Startup](ai-startup.md)
+- [Shell and Navigation](shell-navigation.md)
+- [Integrations and Targets](integrations-targets.md)
+- [Subscriptions](subscriptions.md)
+- [Secrets and Data](secrets-data.md)
+- [Refinement](refinement.md)
+
+For the full architecture reference, see
+[Canonical App Structure](../../architecture/app/canonical-app-structure.md)
+and [App Bundle Declaratives](../../architecture/app/app-bundle-declaratives.md).

--- a/docs/guides/configs/integrations-targets.md
+++ b/docs/guides/configs/integrations-targets.md
@@ -1,0 +1,92 @@
+# Integrations And Targets
+
+`app/config/integrations.yaml` and `app/config/targets.json` describe what the
+app needs from the outside world. They are provider-neutral declarative files.
+
+Use them to carry intent, not provider mechanics.
+
+## `app/config/integrations.yaml`
+
+This file declares required and optional external services for the app. It is
+safe to package with generated app bundles because it carries service ids,
+setup lanes, required field names, lifecycle points, and `required_by`
+references without raw secret values.
+
+Use it for:
+
+- required service ids such as OpenAI, email, storage, payment facade, or search
+- whether setup is managed, connected-account, bring-your-own-key, or
+  app-specific
+- frontend-safe setup metadata
+- references to the modules, workflows, pages, or build tasks that need the
+  service
+
+Do not put API keys, OAuth tokens, webhook secrets, provider tenant ids,
+checkout URLs, SDK client state, or hosted-product policy in this file.
+
+## `app/config/targets.json`
+
+This file declares deployment and runtime target intent.
+
+Use it for:
+
+- runtime shape
+- health path
+- deployment profile
+- allowed deployment lanes
+- expected environment variable names
+- domain and DNS intent
+
+Do not use it to run deployments, write cloud resources, own DNS state, store
+secrets, or embed provider-specific adapters. Direct provider mechanics belong
+behind app-owned `app/services/adapters/` only when the app itself owns that
+provider integration. Hosted platform mechanics belong in the hosted product
+that operates the app.
+
+## Example Shape
+
+```yaml
+# app/config/integrations.yaml
+schema_version: mozaiks.integrations.v1
+requirements:
+  - service_id: openai
+    purpose: AI workflow execution
+    required: true
+    setup_lane: bring_your_own_key
+    required_fields:
+      - OPENAI_API_KEY
+    required_by:
+      - kind: workflow
+        id: SupportIntake
+```
+
+```json
+{
+  "schema_version": "mozaiks.targets.v1",
+  "runtime": {
+    "kind": "web",
+    "health_path": "/health"
+  },
+  "deployment": {
+    "profile": "docker",
+    "allowed_lanes": ["local", "self_hosted"]
+  },
+  "environment": {
+    "required": ["OPENAI_API_KEY"]
+  },
+  "domain": {
+    "intent": "custom_domain_optional"
+  }
+}
+```
+
+## Related Files
+
+- Put secret names and env handles in `app/security/secrets.yaml`.
+- Put provider-specific clients in `app/services/integrations/` or
+  `app/services/adapters/` only when the app owns the integration.
+- Put deployment packaging in root files such as `Dockerfile`,
+  `docker-compose.yml`, `.env.example`, and `deployment.manifest.json` when
+  those artifacts are requested.
+
+See also [Integrations](../integrations/01-overview.md).

--- a/docs/guides/configs/refinement.md
+++ b/docs/guides/configs/refinement.md
@@ -1,0 +1,82 @@
+# Refinement
+
+Mozaiks refinement has two app-facing files with different jobs:
+
+- `app/config/refinement_policy.yaml` is runtime policy.
+- `refinement_harness/config/harness.yaml` is an optional app-local harness
+  bundle.
+
+The Refinement Engine is the always-present runtime capability that routes and
+validates app changes. The optional Refinement Harness gives an app additional
+declarative routing, prompt, tool, validation, and promotion-policy metadata.
+
+## `app/config/refinement_policy.yaml`
+
+Use this file for:
+
+- enabling or disabling app-local refinement policy
+- model profiles
+- classifier policy
+- coding worker policy
+- contract-surface refinement policy
+
+Starter:
+
+```yaml
+schema_version: mozaiks.refinement.policy.v1
+enabled: true
+llm_profiles:
+  classifier:
+    purpose: Change classification for refinement routing.
+    expected_behavior: Distinguish patch, design, feature, and core requests.
+    llm_config:
+      model: gpt-5-nano
+      temperature: 0
+  codegen:
+    purpose: Scoped code and contract-surface refinement.
+    expected_behavior: Produce bounded app artifact changes.
+    llm_config:
+      model: gpt-5.2-codex
+      temperature: 0.1
+classifier:
+  enabled: true
+  llm_profile: classifier
+coding:
+  enabled: true
+  llm_profile: codegen
+contract_surface:
+  enabled: true
+  llm_profile: codegen
+```
+
+Do not put ask/chat startup, workflow entry points, prompt bodies, checkpoint
+handlers, or workflow sequence definitions in this file.
+
+## `refinement_harness/config/harness.yaml`
+
+Use the optional harness bundle when the app needs to declare:
+
+- app-specific refinement goals
+- workflow sequences
+- checkpoint behavior
+- prompt and tool references
+- validation gates
+- promotion policy
+
+Keep the harness declarative. Do not put model secrets, raw provider config, or
+ordinary app startup here.
+
+## What Goes Where
+
+| Concern | File |
+|---------|------|
+| Ask/chat/workflow startup | `app/config/ai.json` |
+| Refinement model profiles | `app/config/refinement_policy.yaml` |
+| Refinement routing bundle | `refinement_harness/config/harness.yaml` |
+| Workflow definitions | `workflows/{workflow_id}/` |
+| App data affected by refinement | `app/data/contract.json` and `app/data/migrations/` |
+| Module behavior affected by refinement | `app/modules/{module_id}/` |
+
+See also [Refinement Policy](../extending-ai-functionality/03-refinement-policy.md),
+[Refinement Harness](../extending-ai-functionality/04-refinement-harness.md), and
+[Refinement Engine](../../architecture/workflows/refinement-engine.md).

--- a/docs/guides/configs/secrets-data.md
+++ b/docs/guides/configs/secrets-data.md
@@ -1,0 +1,137 @@
+# Secrets And Data
+
+`app/security/secrets.yaml` and `app/data/contract.json` are separate app
+planes. Keep them separate even when the same feature needs both.
+
+Secrets describe how the app names sensitive values. Data contracts describe
+durable app records.
+
+## `app/security/secrets.yaml`
+
+This file is names-only. It declares secret names, env handles, providers, and
+vault policy. It must never contain raw values.
+
+Use it for:
+
+- required secret names
+- environment variable handles
+- secret provider or vault policy
+- setup notes that are safe to store in source
+
+Do not put raw API keys, OAuth tokens, passwords, connection strings, private
+keys, webhook secrets, provider tenant ids, or generated credentials in this
+file.
+
+Starter:
+
+```yaml
+schema_version: mozaiks.secrets.v1
+provider: env
+secrets:
+  - name: OPENAI_API_KEY
+    backend: env
+    required: true
+    used_by:
+      - kind: workflow
+        id: SupportIntake
+  - name: RESEND_API_KEY
+    backend: env
+    required: false
+    used_by:
+      - kind: integration
+        id: email
+```
+
+Environment templates such as `.env.example`, `.env.staging.example`, and
+`.env.production.example` may repeat these names with placeholder values only.
+
+## `app/data/contract.json`
+
+This file declares durable data intent when default module persistence is not
+enough.
+
+Use it for:
+
+- stable collection aliases
+- explicit module collection ownership
+- cross-module aggregate ownership
+- mappings to existing external database collections
+- indexes that should be validated or applied at startup
+- additive data migrations
+
+Do not put credentials, connection strings, runtime record values, fixture
+data, Python helpers, or destructive migrations in this file.
+
+Starter:
+
+```json
+{
+  "version": "1",
+  "metadata_kind": "data_contract",
+  "app_id": "support-desk",
+  "aliases": [
+    {
+      "alias": "tickets.lifecycle",
+      "collection": "tickets",
+      "owner_module": "tickets"
+    }
+  ],
+  "surfaces": [
+    {
+      "surface_id": "tickets",
+      "surface_kind": "module",
+      "collections": [
+        {
+          "name": "ticket",
+          "entity_name": "ticket",
+          "mongo_collection": "tickets",
+          "data_alias": "tickets.lifecycle",
+          "scope": "app",
+          "ownership": {
+            "surface_id": "tickets",
+            "surface_kind": "module"
+          },
+          "fields": [
+            {"name": "ticket_id", "type": "string", "required": true},
+            {"name": "owner_id", "type": "string", "required": true},
+            {"name": "status", "type": "string", "required": true}
+          ],
+          "indexes": [
+            {
+              "name": "ticket_owner_status",
+              "keys": [
+                {"field": "owner_id", "order": 1},
+                {"field": "status", "order": 1}
+              ]
+            }
+          ],
+          "lifecycle": {
+            "write_mode": "module_action",
+            "migration_policy": "additive_only"
+          }
+        }
+      ]
+    }
+  ],
+  "shared_collections": [],
+  "documented_alias_exclusions": [],
+  "policies": {
+    "default_scope_field": "owner_id",
+    "allow_destructive_migrations": false
+  }
+}
+```
+
+## Default Persistence
+
+Most generated modules do not need `app/data/contract.json`. They can use the
+default module persistence contract:
+
+```python
+ctx.persistence.collection(module_id, entity_name)
+```
+
+Add `app/data/contract.json` when the app needs stable aliases, explicit
+indexes, cross-module aggregate records, or existing database mappings.
+
+See also [Data Contracts](../../architecture/app/data-contracts.md).

--- a/docs/guides/configs/shell-navigation.md
+++ b/docs/guides/configs/shell-navigation.md
@@ -1,0 +1,71 @@
+# Shell And Navigation
+
+`app/config/shell.json` owns app-wide shell behavior: header, navigation,
+shortcuts, footer, notifications, and chrome modes.
+
+Use it for:
+
+- header logo and actions
+- top-level and local navigation policy
+- mobile shortcut policy
+- footer visibility
+- notification route and empty state
+- shell chrome modes such as standard, workspace, focused, immersive, or public
+
+Do not use `shell.json` for page-local layout, business actions, permissions,
+branding tokens, or auth provider mechanics.
+
+## Starter
+
+```json
+{
+  "header": {
+    "logo": {
+      "src": "logo.svg",
+      "alt": "Support Desk",
+      "href": "/dashboard"
+    },
+    "actions": []
+  },
+  "navigation": {
+    "policy": {
+      "desktop": {
+        "global": "header",
+        "local": "sidebar",
+        "footer": "visible"
+      },
+      "mobile": {
+        "global": "bottomBar",
+        "local": "sheet",
+        "footer": "hidden"
+      },
+      "maxMobileItems": 5,
+      "autoFromPages": true
+    }
+  },
+  "chrome": {
+    "defaultMode": "standard"
+  }
+}
+```
+
+## How Routes Connect
+
+Shell navigation points at routes. Routes are owned elsewhere:
+
+- schema pages live in `app/ui/pages/*.yaml`
+- custom React routes are registered through `app/ui/route_manifest.json` and
+  `app/ui/index.js`
+- module action routes come from `app/modules/{module_id}/module.yaml`
+- workflow routes come from `workflows/{workflow_id}/`
+
+`shell.json` should assemble those surfaces into an app shell. It should not
+become a second page registry or a permissions layer.
+
+## Branding Boundary
+
+Visual tokens belong in `app/brand/theme_config.json`, not `shell.json`.
+Reference logos and wordmarks from the shell when needed, but keep colors,
+fonts, density, radius, shadows, and primitive variants in the brand config.
+
+See also [App Shell and Branding](../custom-brand-integration/01-overview.md).

--- a/docs/guides/configs/subscriptions.md
+++ b/docs/guides/configs/subscriptions.md
@@ -1,0 +1,131 @@
+# Subscriptions
+
+`app/config/subscriptions.yaml` is the canonical generated-app subscription
+contract. Add it only when the app sells access tiers, quotas, credits, token
+packs, token allowances, or paid feature gates.
+
+Non-SaaS apps omit this file. When it is absent, the runtime uses the no-op
+entitlement adapter and module entitlement gates pass.
+
+## What It Owns
+
+Use `app/config/subscriptions.yaml` for:
+
+- plan ids and labels
+- the default plan
+- capability ids granted by each plan
+- usage limits such as monthly AI token limits
+- provider-neutral token wallets
+- plan token allowances
+- top-up products and usage charge policy when the app sells token packs or
+  usage credits
+- `assignment_store` metadata when active subscription assignments are stored
+  in app data
+
+Do not put provider credentials, checkout session code, payment processor SDK
+state, invoices, settlement records, marketplace fees, or hosted operator
+policy in this file.
+
+## Minimal Access Plan
+
+```yaml
+schema_version: mozaiks.subscriptions.v1
+label: Support Desk Plans
+default_plan_id: free
+plans:
+  - plan_id: free
+    label: Free
+    capabilities: []
+  - plan_id: pro
+    label: Pro
+    capabilities:
+      - tickets.export
+      - analytics.dashboard
+```
+
+Module actions can reference these capability ids with `entitlement_gate` in
+`app/modules/{module_id}/module.yaml`.
+
+## Assignment Store
+
+Use `assignment_store` when the app stores active subscription assignments in
+app data and the runtime should enforce those assignments.
+
+```yaml
+schema_version: mozaiks.subscriptions.v1
+label: Support Desk Plans
+default_plan_id: free
+assignment_store:
+  data_alias: billing.subscriptions
+  user_id_field: user_id
+  active_statuses: [active, trialing]
+plans:
+  - plan_id: free
+    label: Free
+    capabilities: []
+  - plan_id: pro
+    label: Pro
+    capabilities: [tickets.export]
+```
+
+If a generated app declares `assignment_store`, it also needs a deterministic
+write path for assignment records. That write path can be a selected managed
+capability pack that declares `subscription_write_path`, or the OSS
+`entitlement_dispatch` module archetype.
+
+## Token Wallets
+
+Use token wallets only when the app sells AI usage, credits, quotas, token
+packs, or token allowances.
+
+```yaml
+schema_version: mozaiks.subscriptions.v1
+label: AI Support Plans
+default_plan_id: pro
+token_wallets:
+  - wallet_id: ai_tokens
+    label: AI token balance
+    unit: tokens
+    usage_meter_id: ai_tokens
+    scope: user
+    auto_debit_usage: true
+plans:
+  - plan_id: pro
+    label: Pro
+    capabilities: [ai.chat]
+    usage_limits:
+      - meter_id: ai_tokens
+        label: AI tokens
+        unit: tokens
+        monthly_limit: 100000
+        capability_id: ai.chat
+    token_allowances:
+      - wallet_id: ai_tokens
+        amount: 100000
+        cadence: monthly
+```
+
+Token usage is measured by the runtime. Generated modules should not create a
+second usage ledger.
+
+## Commercial Metadata Boundary
+
+`app/modules/{module_id}/contracts/commercial.yaml` is optional module-owned
+metadata for custom money-flow terms outside app subscription gates. Use it for
+things like fee display, service terms, marketplace placement metadata, or
+module-owned commercial policy.
+
+That file does not grant entitlements, write subscription assignments, process
+payments, or replace `app/config/subscriptions.yaml`.
+
+## Not Canonical
+
+Do not author `app/modules/{module_id}/contracts/subscriptions.yaml`.
+
+Do not use root `hosted_services.yaml` or `monetization.yaml` files as the
+source of truth for generated app plans. Hosted products may derive operator
+summaries, but generated app subscription logic belongs in
+`app/config/subscriptions.yaml`.
+
+See also [Entitlement Dispatch Archetype](../entitlement/entitlement-dispatch-archetype.md)
+and [Core Monetization Scope](../../architecture/mozaiksai/core-monetization-scope.md).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -20,6 +20,15 @@ Step-by-step guides for building and customizing Mozaiks apps.
 
     [:octicons-arrow-right-24: Studio](../studio/index.md)
 
+-   :material-cog-outline: **Configs**
+
+    ---
+
+    Know which files define app identity, AI startup, shell, subscriptions,
+    secrets, data, integrations, targets, and refinement.
+
+    [:octicons-arrow-right-24: Configs](configs/index.md)
+
 -   :material-connection: **Integrations**
 
     ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,15 @@ nav:
   - Guides:
       - guides/index.md
       - Use Studio: guides/studio/01-overview.md
+      - Configs:
+          - guides/configs/index.md
+          - App Identity: guides/configs/app-identity.md
+          - AI Startup: guides/configs/ai-startup.md
+          - Shell and Navigation: guides/configs/shell-navigation.md
+          - Integrations and Targets: guides/configs/integrations-targets.md
+          - Subscriptions: guides/configs/subscriptions.md
+          - Secrets and Data: guides/configs/secrets-data.md
+          - Refinement: guides/configs/refinement.md
       - Integrations: guides/integrations/01-overview.md
       - Add Workflows: guides/adding-workflows/01-overview.md
       - Add a Module: guides/adding-modules/01-overview.md


### PR DESCRIPTION
## Summary
- Add a first-class Guides > Configs section to the MkDocs nav.
- Document the canonical app config/data/security/refinement files users need to build a Mozaiks app.
- Clarify that subscriptions own generated-app plan and entitlement logic, while module commercial contracts are separate metadata.

## Validation
- python -m mkdocs build --strict
- python -m pytest --no-cov tests\\test_guide_overview_docs_language.py tests\\test_getting_started_docs.py tests\\test_user_facing_docs_language.py tests\\test_llm_config_canonical_surfaces.py

Note: a broader contributor-guidance pytest selection still contains stale assertions for removed llm/control-plane wording on main; this PR does not touch that unrelated contributor skill/test cleanup.