### PR TITLE
fix(runtime): v2 entitlement expired propagation + passive connector readiness

### DIFF
--- a/mozaiksai/core/runtime/app/entitlements.py
+++ b/mozaiksai/core/runtime/app/entitlements.py
@@ -112,6 +112,8 @@ class ConfiguredEntitlementAdapter:
 
         # v2: multi-product — union capabilities across all products
         if self._config.products:
+            best_reason = "no_grant"
+            best_expires_at = None
             for product in self._config.products:
                 result = await self._check_product(
                     product, capability_id,
@@ -120,7 +122,11 @@ class ConfiguredEntitlementAdapter:
                 )
                 if result.granted:
                     return result
-            return EntitlementResult(granted=False, reason="no_grant")
+                # Prefer "expired" over generic "no_grant" so callers can surface expiry UI.
+                if result.reason == "expired" and best_reason != "expired":
+                    best_reason = "expired"
+                    best_expires_at = result.expires_at
+            return EntitlementResult(granted=False, reason=best_reason, expires_at=best_expires_at)
 
         # v1: single assignment store (existing logic preserved exactly)
         store = self._config.assignment_store

--- a/mozaiksai/core/workflow/generator_support/connector_service.py
+++ b/mozaiksai/core/workflow/generator_support/connector_service.py
@@ -202,10 +202,10 @@ def _with_connector_health(
     )
     configuration_complete = enriched["health"]["status"] != "not_configured" and not enriched["health"].get("missing_fields")
     lifecycle_status = _classify_connector_status(enriched).get("status")
-    requires_provider_validation = bool(enriched["health"].get("health_check_supported"))
-    provider_ready = not requires_provider_validation or enriched["health"].get("status") == "healthy"
+    # Passive readiness (inventory) never runs live provider health checks.
+    # Active checks happen explicitly via run_connector_health_check.
     enriched["configured"] = configuration_complete
-    enriched["ready"] = lifecycle_status in {"active", "expiring"} and configuration_complete and provider_ready
+    enriched["ready"] = lifecycle_status in {"active", "expiring"} and configuration_complete
     return enriched
 
 


### PR DESCRIPTION
## Summary

Two runtime fixes discovered while dogfooding v2 subscriptions in mozaiks-app:

- **fix(entitlements): propagate expired reason in v2 multi-product check loop** — When iterating products in `ConfiguredEntitlementAdapter.check()`, the `expired` reason was discarded; only `no_grant` surfaced even when a subscription had expired. Now tracks the best denial reason across products.

- **fix(connectors): passive readiness inventory must not gate on provider health** — `_with_connector_health` used `health_check_supported` to set `requires_provider_validation`, gating passive inventory readiness on stored health status. Passive checks (inventory) must not run or gate on provider health; active checks are opt-in via `run_connector_health_check`.

## Test plan

- [ ] `test_expired_subscription_denied` in `test_subscription_entitlement_runtime.py` (mozaiks-app) verifies expired reason propagates
- [ ] `test_readiness_ignores_provider_health_by_default` in `test_provider_connections_health_plugins.py` (mozaiks-app) verifies passive readiness ignores health

🤖 Generated with [Claude Code](https://claude.com/claude-code)