### PR TITLE
fix(shell): authenticate notification count requests

### DIFF
--- a/chat-ui/src/components/layout/Header.js
+++ b/chat-ui/src/components/layout/Header.js
@@ -13,6 +13,7 @@ import {
 } from "../../navigation/shellActions";
 import { useChatUI } from "../../context/ChatUIContext";
 import { useAppEventBus } from "../../ui/hooks/useAppEventBus.js";
+import { clearNotifications, fetchNotificationCount } from "./notificationApi.js";
 import "./header-styles.css";
 
 const ICON_FILE_RE = /\.(svg|png|jpe?g|gif|webp|ico)$/i;
@@ -253,12 +254,8 @@ const Header = ({
 
     const loadNotificationCount = async () => {
       try {
-        const response = await fetch("/api/notifications/count", {
-          signal: controller.signal,
-          headers: { Accept: "application/json" },
-        });
-        if (!response.ok) return;
-        const payload = await response.json();
+        const payload = await fetchNotificationCount({ signal: controller.signal });
+        if (!payload) return;
         const count = Number(payload?.unread_count ?? payload?.count ?? 0);
         if (mounted && Number.isFinite(count)) {
           setNotificationCount(Math.max(0, count));
@@ -281,8 +278,7 @@ const Header = ({
 
   useAppEventBus('notification.count_changed', () => {
     if (notificationsConfig.show === false) return;
-    fetch('/api/notifications/count', { headers: { Accept: 'application/json' } })
-      .then((r) => r.ok ? r.json() : null)
+    fetchNotificationCount()
       .then((payload) => {
         if (!payload) return;
         const count = Number(payload?.unread_count ?? payload?.count ?? 0);
@@ -293,7 +289,7 @@ const Header = ({
 
   const handleClearAllNotifications = async () => {
     try {
-      await fetch('/api/notifications', { method: 'DELETE', headers: { Accept: 'application/json' } });
+      await clearNotifications();
       setNotificationCount(0);
       setIsNotificationsOpen(false);
     } catch (_) {}

--- a/chat-ui/src/components/layout/MobileBottomBar.jsx
+++ b/chat-ui/src/components/layout/MobileBottomBar.jsx
@@ -5,6 +5,7 @@ import { useNavigationActions } from "../../navigation/useNavigationActions";
 import { deriveShellActionContext, isShellItemVisible, resolveShellActions } from "../../navigation/shellActions";
 import { useChatUI } from "../../context/ChatUIContext";
 import { useAppEventBus } from "../../ui/hooks/useAppEventBus.js";
+import { fetchNotificationCount } from "./notificationApi.js";
 import "./header-styles.css";
 
 const buildAutoItems = ({ headerPages, header, notifications, profile, actionContext }) => {
@@ -92,11 +93,7 @@ const MobileBottomBar = ({ route = null, shellMode = null }) => {
     let mounted = true;
 
     const loadNotificationCount = () => {
-      fetch("/api/notifications/count", {
-        signal: controller.signal,
-        headers: { Accept: "application/json" },
-      })
-        .then((response) => (response.ok ? response.json() : null))
+      fetchNotificationCount({ signal: controller.signal })
         .then((payload) => {
           if (!mounted || !payload) return;
           const count = Number(payload.unread_count ?? payload.count ?? 0);
@@ -118,8 +115,7 @@ const MobileBottomBar = ({ route = null, shellMode = null }) => {
 
   useAppEventBus('notification.count_changed', () => {
     if (notifications?.show === false) return;
-    fetch('/api/notifications/count', { headers: { Accept: 'application/json' } })
-      .then((r) => r.ok ? r.json() : null)
+    fetchNotificationCount()
       .then((payload) => {
         if (!payload) return;
         const count = Number(payload?.unread_count ?? payload?.count ?? 0);

--- a/chat-ui/src/components/layout/notificationApi.js
+++ b/chat-ui/src/components/layout/notificationApi.js
@@ -1,0 +1,37 @@
+import platform from "../../platform/index.js";
+
+const jsonHeaders = () => {
+  const headers = { Accept: "application/json" };
+  let token = null;
+  try {
+    token = platform.getAccessToken();
+  } catch {
+    token = null;
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+};
+
+export const fetchNotificationCount = async ({ signal } = {}) => {
+  const headers = jsonHeaders();
+  if (!headers.Authorization) return null;
+
+  const response = await fetch("/api/notifications/count", {
+    signal,
+    headers,
+  });
+  if (!response.ok) return null;
+  return response.json();
+};
+
+export const clearNotifications = async () => {
+  const headers = jsonHeaders();
+  if (!headers.Authorization) return null;
+
+  return fetch("/api/notifications", {
+    method: "DELETE",
+    headers,
+  });
+};

--- a/tests/test_notifications_page_schema.py
+++ b/tests/test_notifications_page_schema.py
@@ -42,6 +42,23 @@ def test_shell_notification_dropdown_links_to_yaml_notification_center() -> None
     assert "View all notifications" in source
 
 
+def test_shell_notification_fetches_use_authenticated_helper() -> None:
+    layout_dir = _workspace() / "chat-ui" / "src" / "components" / "layout"
+    helper = (layout_dir / "notificationApi.js").read_text(encoding="utf-8")
+    header = (layout_dir / "Header.js").read_text(encoding="utf-8")
+    mobile = (layout_dir / "MobileBottomBar.jsx").read_text(encoding="utf-8")
+
+    assert "platform.getAccessToken()" in helper
+    assert "headers.Authorization = `Bearer ${token}`;" in helper
+    assert 'fetch("/api/notifications/count"' in helper
+    assert 'fetch("/api/notifications"' in helper
+    assert "fetchNotificationCount" in header
+    assert "clearNotifications" in header
+    assert "fetchNotificationCount" in mobile
+    assert "fetch('/api/notifications/count'" not in header
+    assert "fetch('/api/notifications/count'" not in mobile
+
+
 def test_app_registry_yaml_page_does_not_duplicate_apps_console() -> None:
     page_path = _workspace() / "factory_app" / "app" / "ui" / "pages" / "app-registry.yaml"
 


### PR DESCRIPTION
## Summary
- adds a shared notification API helper that attaches the current platform bearer token
- routes desktop header and mobile bottom bar notification count/clear calls through that helper
- avoids unauthenticated notification polling when no token is available, preventing public/staging 401 console noise

## Tests
- `python -m pytest tests\test_notifications_page_schema.py tests\test_mobile_surface_contracts.py tests\test_route_auth_metadata_alignment.py -q --no-cov`
- `npm --prefix web_shell run build`

## Notes
- `python -m pytest tests\test_notifications_page_schema.py tests\test_mobile_surface_contracts.py tests\test_route_auth_metadata_alignment.py -q` passed its 26 tests but failed the global coverage threshold because this is a narrow slice.
- `npm --prefix web_shell ci` was run in the isolated worktree to install missing local frontend dependencies before the build; dependency versions were not changed.

## OSS Change Impact
- Affected primitive: Platform shell authenticated HTTP calls.
- Owning layer: Platform/chat-ui shell, because `/api/notifications/count` is a principal-scoped platform endpoint and the shell owns the notification badge UX.
- Declarative contracts changed: none.
- AppGenerator/generated-app impact: none; this is shared shell behavior.