### PR TITLE
feat(subscriptions): add canonical add-on products

### DIFF
--- a/docs/architecture/app/app-bundle-declaratives.md
+++ b/docs/architecture/app/app-bundle-declaratives.md
@@ -74,6 +74,16 @@ usage when a wallet opts into `auto_debit_usage`. This is token accounting, not
 payment processing: payment providers, checkout, invoices, and settlement remain
 app-owned or hosted-product behavior.
 
+Apps may also declare provider-neutral `add_on_products` at the same config
+root for non-token purchasable services such as placements, seats, feature
+unlocks, support, or credits. `pricing_catalog.groups[].add_on_ids` may
+reference those add-on product ids so pricing and billing surfaces can display a
+canonical product definition. Add-on products do not grant entitlements or
+replace module actions; modules still own request/order state, permissions,
+events, and fulfillment workflow. Payment-provider product ids, price ids,
+checkout sessions, invoices, taxes, and settlement details stay in app-owned or
+host-provided integration code outside `subscriptions.yaml`.
+
 During factory builds, `SubscriptionContractDesigner` is the generic workflow
 that decides whether this file is needed and emits the provider-neutral
 subscription contract artifact. `AppGenerator` may then materialize exactly

--- a/docs/architecture/app/canonical-app-structure.md
+++ b/docs/architecture/app/canonical-app-structure.md
@@ -142,7 +142,11 @@ execution code.
 commercial display metadata, fee policy, service terms, or custom money-flow
 metadata outside the core `app/config/subscriptions.yaml` contract. It does not
 grant entitlements, write subscription assignments, process payments, or
-replace `subscriptions.yaml`.
+replace `subscriptions.yaml`. Provider-neutral purchasable add-on products that
+pricing or billing pages need to list belong in root
+`app/config/subscriptions.yaml` as `add_on_products`; module commercial
+contracts may reference or complement that catalog but must not become a second
+subscription source of truth.
 
 ## Service Contract
 

--- a/docs/architecture/modules-systems/module-system.md
+++ b/docs/architecture/modules-systems/module-system.md
@@ -426,10 +426,12 @@ public_disclosure: Fees are shown before payment.
 ```
 
 Use `app/config/subscriptions.yaml` for recurring plans, paid feature gates,
-quotas, token wallets, and entitlement grants. Use module-owned
+quotas, token wallets, entitlement grants, and provider-neutral add-on product
+definitions shown on pricing or billing surfaces. Use module-owned
 `commercial.yaml` for commercial metadata that belongs to a specific module or
-service. Central app-level registries, if present in an operator app, should be
-derived or compatibility summaries rather than the source of truth.
+service, including order/fulfillment policy that complements an add-on product.
+Central app-level registries, if present in an operator app, should be derived
+or compatibility summaries rather than the source of truth.
 
 ### `contracts/admin.yaml`
 

--- a/docs/architecture/mozaiksai/monetization-contract.md
+++ b/docs/architecture/mozaiksai/monetization-contract.md
@@ -160,6 +160,8 @@ to:
 - prepaid credits
 - token wallets
 - token allowances
+- provider-neutral non-token add-on product definitions for pricing and billing
+  display
 - usage meters that feed those plans or wallets
 
 Everything else is a custom money-flow boundary, not a new OSS monetization
@@ -202,6 +204,12 @@ for those flows, such as display pricing, a fee percentage, service terms, or a
 custom money-flow label. It must not replace `subscriptions.yaml` for plan
 grants and must not expose provider identifiers, credentials, payout internals,
 or private settlement policy.
+
+If a custom flow also needs a purchasable add-on listed on pricing or billing
+surfaces, declare only the provider-neutral catalog entry in
+`app/config/subscriptions.yaml` as `add_on_products[]`. The owning module still
+keeps order state, inventory policy, fulfillment, events, and payment
+confirmation handling.
 
 ## Self-Hosted Posture
 

--- a/docs/architecture/mozaiksai/subscription-pricing-catalog.md
+++ b/docs/architecture/mozaiksai/subscription-pricing-catalog.md
@@ -7,6 +7,7 @@ and entitlement contract. The contract answers:
 - which plan is the default
 - which capabilities each plan grants
 - which usage limits and token allowances apply
+- which provider-neutral non-token add-on products can be displayed or requested
 - which provider-neutral usage charge policies apply
 - where active subscription assignments are read from
 
@@ -23,6 +24,20 @@ entitlement files unless they are genuinely separate apps.
 schema_version: mozaiks.subscriptions.v1
 label: Example SaaS
 default_plan_id: free
+
+add_on_products:
+  - add_on_id: hero_weekly
+    label: Hero Placement - Weekly
+    description: Promoted placement for seven days.
+    kind: marketplace_placement
+    billing_mode: one_time
+    required_capability: marketplace.placements.order
+    capability_groups: [marketplace.placements]
+    duration_days: 7
+    price:
+      amount_cents: 9900
+      currency: usd
+      display: "$99/week"
 
 pricing_catalog:
   default_group_id: platform
@@ -43,11 +58,15 @@ pricing_catalog:
       label: Marketing
       description: Optional marketplace promotion add-ons.
       kind: add_on
-      add_on_ids: [hero_weekly, hero_monthly]
+      add_on_ids: [hero_weekly]
 ```
 
 `pricing_catalog` is display metadata only. It does not grant access, create
 prices, create payment-provider products, or replace `plans[].capabilities`.
+When root `add_on_products` are declared, `pricing_catalog.groups[].add_on_ids`
+must reference those add-on ids. `add_on_products` may carry provider-neutral
+cash price display metadata, but they still do not grant entitlements, reserve
+inventory, create orders, start checkout, or own fulfillment state.
 
 Usage-based customer charge policy belongs beside the plan contract, not in the
 provider pricing catalog:
@@ -83,8 +102,11 @@ plans, usage allowances, and markup policy.
   the generated provider reference plus local overrides.
 - Use `pricing_catalog.groups[]` for pricing tabs or service selectors.
 - Every `group.plan_ids[]` entry must reference a declared `plans[].plan_id`.
-- Add-ons can be referenced by `add_on_ids[]`, but add-on pricing and checkout
-  behavior remain app-owned or provider-pack-owned.
+- Put provider-neutral non-token add-on product metadata in root
+  `add_on_products[]`, then reference those ids from
+  `pricing_catalog.groups[].add_on_ids`.
+- Add-on checkout, order state, fulfillment, inventory, and settlement behavior
+  remain app-owned or provider-pack-owned.
 - Provider-specific price IDs, checkout URLs, invoices, settlement, and hosted
   product policy must not live in the OSS subscription enforcement schema.
 - Generated pages should render groups when present and fall back to a single
@@ -108,6 +130,8 @@ context from `concept_overview`, `concept_blueprint`, `backend_design_document`,
 - `subscription_config_file`: the canonical `app/config/subscriptions.yaml`
   payload
 - `pricing_catalog`: optional display groups inside that same payload
+- `add_on_products`: optional provider-neutral non-token add-ons referenced by
+  pricing groups inside that same payload
 - `usage_charge_policies`: optional app-level usage markup or fixed token
   pricing policy inside that same payload
 - `plan_design_rationale`: traceable reasons that map upstream signals to plan,
@@ -116,10 +140,11 @@ context from `concept_overview`, `concept_blueprint`, `backend_design_document`,
 When a chat UI is available, the workflow presents the normalized output as a
 `SubscriptionContractReview` artifact before downstream generators consume it.
 The review surface shows the subscription plans, token wallets, token
-allowances, gated module actions, workflow metering declarations, generated file
-preview, and guardrails. The user must confirm that the subscription plan
-contract matches what they want; requesting changes leaves downstream
-`subscription_contract` context empty until the agent revises the contract.
+allowances, add-on products, gated module actions, workflow metering
+declarations, generated file preview, and guardrails. The user must confirm
+that the subscription plan contract matches what they want; requesting changes
+leaves downstream `subscription_contract` context empty until the agent revises
+the contract.
 
 `AppGenerator` and `AgentGenerator` consume the saved contract. They may choose
 different UI primitive variants for the pricing surface, but the data source
@@ -133,6 +158,7 @@ OSS owns:
 - loading and validating `subscriptions.yaml`
 - provider-neutral entitlements, usage limits, and token allowances
 - provider-neutral customer usage charge estimate policy
+- provider-neutral non-token add-on product metadata
 - provider-neutral pricing catalog display grouping
 - generic UI primitives that can render grouped plan/add-on cards
 

--- a/docs/guides/configs/index.md
+++ b/docs/guides/configs/index.md
@@ -44,7 +44,7 @@ folder.
 | `app/config/auth.yaml` | Provider-neutral auth behavior and env handles | [Integrations](../integrations/01-overview.md) |
 | `app/config/integrations.yaml` | App service requirements and managed capability needs | [Integrations](../integrations/01-overview.md) |
 | `app/config/targets.json` | Runtime, deployment, health, domain, and environment intent | [Self-Hosting](../self-hosting.md) |
-| `app/config/subscriptions.yaml` | Products, plans, capabilities, usage limits, token wallets, top-ups | [Subscriptions](subscriptions.md) |
+| `app/config/subscriptions.yaml` | Products, plans, capabilities, usage limits, token wallets, top-ups, add-ons | [Subscriptions](subscriptions.md) |
 | `app/config/refinement_policy.yaml` | Refinement Engine enablement and model profiles | [Refinement](refinement.md) |
 | `app/security/secrets.yaml` | Secret names, env handles, provider policy | [Integrations](../integrations/01-overview.md) |
 | `app/data/contract.json` | Stable data aliases, indexes, aggregate ownership | [Add a Module](../adding-modules/01-overview.md) |
@@ -55,8 +55,9 @@ folder.
 
 - Secret files carry names and env handles only. Real values stay in the
   configured secret backend.
-- App-level paid access belongs in `app/config/subscriptions.yaml`. Module
-  actions reference entitlement gates by capability id.
+- App-level paid access and provider-neutral add-on product definitions belong
+  in `app/config/subscriptions.yaml`. Module actions reference entitlement gates
+  by capability id.
 - Modules own business actions, permissions, lifecycle state, emitted events,
   and persistence authority.
 - `app/services/` supports modules, workflows, and app-level routes. It is not

--- a/docs/guides/configs/subscriptions.md
+++ b/docs/guides/configs/subscriptions.md
@@ -1,8 +1,8 @@
 # Subscriptions
 
 `app/config/subscriptions.yaml` is the app-level catalog for paid access,
-capability gates, token wallets, token allowances, top-ups, and pricing-page
-groups.
+capability gates, token wallets, token allowances, top-ups, add-ons, and
+pricing-page groups.
 
 Add this file when the app is a SaaS app or when module actions need
 entitlement gates. Apps without paid access can omit it.
@@ -78,6 +78,19 @@ products:
             amount: 1000000
             cadence: monthly
 
+add_on_products:
+  - add_on_id: hero_weekly
+    label: Hero Placement - Weekly
+    kind: marketplace_placement
+    billing_mode: one_time
+    required_capability: marketplace.placements.order
+    capability_groups: [marketplace.placements]
+    duration_days: 7
+    price:
+      amount_cents: 9900
+      currency: usd
+      display: "$99/week"
+
 pricing_catalog:
   default_group_id: platform
   groups:
@@ -89,6 +102,10 @@ pricing_catalog:
       label: AI
       kind: subscription
       plan_ids: [included, ai_plus]
+    - group_id: marketing
+      label: Marketing
+      kind: add_on
+      add_on_ids: [hero_weekly]
 ```
 
 ## What Goes Here
@@ -103,6 +120,7 @@ pricing_catalog:
 | Included token grants | `products[].plans[].token_allowances[]` |
 | Token wallet metadata | `products[].token_wallets[]` |
 | Top-up products | `products[].top_up_products[]` |
+| Non-token add-ons | `add_on_products[]` |
 | Pricing-page grouping | `pricing_catalog.groups[]` or `products[].pricing_catalog_group` |
 
 ## Module Gate Example
@@ -118,13 +136,19 @@ Any active plan that grants `reports.export` allows the action to run.
 
 ## Custom Money Rules
 
-Subscription access belongs in `app/config/subscriptions.yaml`.
+Subscription access and provider-neutral add-on product definitions belong in
+`app/config/subscriptions.yaml`.
 
 Module-owned commercial behavior belongs with the owning module. Examples:
 marketplace placement rules, usage fees, campaign terms, payout policy, or
 revenue-share display metadata can live in
 `app/modules/{module_id}/contracts/commercial.yaml` when that module owns the
 behavior.
+
+Use `add_on_products[]` for the app-level purchasable add-on catalog shown by
+pricing and billing surfaces. Do not put provider product ids, provider price
+ids, checkout sessions, order state, fulfillment state, inventory policy,
+invoices, taxes, or settlement records in `subscriptions.yaml`.
 
 ## Read Next
 

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -128,12 +128,13 @@ agents:
         `actions[].entitlement_gate`, usage/billing page requirements, and
         metering declarations. Copy module/action entitlement gates from
         `module_contract_updates` exactly; do not invent paid feature ids. Do
-        not implement a custom token ledger or usage ledger.
+        not implement a custom token ledger, usage ledger, or module-local
+        subscription extension file.
         If the contract declares `token_wallets[].auto_debit_usage`,
-        `top_up_products`, billing page requirements, or depleted-balance
-        recovery routes, plan an app-owned `billing_portal` facade module plus
-        usage/billing/pricing pages. The facade may call a selected managed
-        billing adapter, but generated pages must bind only to
+        `top_up_products`, `add_on_products`, billing page requirements, or
+        depleted-balance recovery routes, plan an app-owned `billing_portal`
+        facade module plus usage/billing/pricing pages. The facade may call a
+        selected managed billing adapter, but generated pages must bind only to
         `/api/modules/billing_portal/*`.
       - `platform_user_email`: Email of the authenticated platform user. Use this as the initial `admins` entry in `app/app.json` when the generated app needs admin bootstrap access. Non-null when running on the hosted mozaiks.ai platform; null in OSS/self-managed contexts.
       - `app_backend_url`: Base URL of the active Mozaiks app host for this app. When non-null, generated agents call this URL + the platform module action API to persist data and trigger domain events. Include this in the `module_contract` build task's initial_message so downstream module implementation agents have it.
@@ -1720,8 +1721,10 @@ agents:
         `config/subscriptions.yaml` file.
       - The file declares app plans, capabilities, assignment_store,
         token_wallets, token_wallets[].depleted_balance recovery metadata,
-        top_up_products with provider-neutral price.amount_cents/currency, usage_limits, token_allowances, usage_charge_policies,
-        and pricing_catalog display metadata only.
+        top_up_products with provider-neutral price.amount_cents/currency,
+        add_on_products with provider-neutral price.amount_cents/currency,
+        usage_limits, token_allowances, usage_charge_policies, and
+        pricing_catalog display metadata only.
 
       **Mode R (workflow_integration_repair)**:
       - Read `workflow_integration_repair_request` and `workflow_integration_repair_failed_tests`.

--- a/factory_app/workflows/AppGenerator/context_variables.yaml
+++ b/factory_app/workflows/AppGenerator/context_variables.yaml
@@ -447,8 +447,8 @@ definitions:
       Provider-neutral SubscriptionContractOutput produced by
       SubscriptionContractDesigner in the current workflow sequence, when present.
       This is the canonical contract for config/subscriptions.yaml, entitlement
-      gates, token wallets, token allowances, generated usage/billing pages, and
-      workflow/module metering declarations.
+      gates, token wallets, token allowances, add-on products, generated
+      usage/billing pages, and workflow/module metering declarations.
     source:
       type: state
       default: null

--- a/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
+++ b/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
@@ -48,7 +48,10 @@ def _safe_dict(value: Any) -> dict[str, Any]:
         if isinstance(item, dict):
             result[str(key)] = _safe_dict(item)
         elif isinstance(item, list):
-            result[str(key)] = [_safe_scalar(entry) for entry in item]
+            result[str(key)] = [
+                _safe_dict(entry) if isinstance(entry, dict) else _safe_scalar(entry)
+                for entry in item
+            ]
         else:
             result[str(key)] = _safe_scalar(item)
     return result
@@ -117,7 +120,7 @@ def _materialize_subscriptions_yaml(*, context_variables: Any) -> str | None:
             plan_docs.append(plan_doc)
         doc["plans"] = plan_docs
 
-    for list_key in ("token_wallets", "top_up_products", "usage_charge_policies"):
+    for list_key in ("token_wallets", "top_up_products", "add_on_products", "usage_charge_policies"):
         val = cfg.get(list_key)
         doc[list_key] = [_safe_dict(item) if isinstance(item, dict) else _safe_scalar(item) for item in val] if isinstance(val, list) else []
 

--- a/factory_app/workflows/SubscriptionContractDesigner/agents.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/agents.yaml
@@ -29,6 +29,9 @@ agents:
             token budgets or AI usage quotas
           - provider-neutral top_up_products when users can buy token packs
             outside a recurring plan
+          - provider-neutral add_on_products when users can buy non-token
+            services, placements, seats, features, support, or credits outside
+            a recurring plan
           - depleted-balance recovery metadata on token wallets so generated UI
             can route INSUFFICIENT_TOKENS to billing, top-up, upgrade, or admin contact
           - provider-neutral usage_charge_policies when the app charges users
@@ -148,9 +151,11 @@ agents:
                storage, seats, ecommerce, marketplace tools, integrations, support,
                marketing, domains, or hosting.
              - pricing_catalog.groups are display metadata for pricing pages.
-               They group declared plan_ids and optional app/provider-owned
-               add_on_ids; they never grant capabilities, create prices, or encode
-               payment-provider ids.
+               They group declared plan_ids and optional app-owned add_on_ids;
+               they never grant capabilities or encode payment-provider ids.
+               When purchasable non-token add-ons are needed, declare them once
+               at subscription_config_file.add_on_products and reference those
+               ids from pricing_catalog.groups[].add_on_ids.
              - If the app has one simple subscription ladder, set pricing_catalog
                to null and let AppSchemaAgent render the default plan cards.
 
@@ -196,7 +201,16 @@ agents:
               price.amount_cents plus lowercase price.currency, and must not
               contain provider product ids, provider price ids, checkout
               session ids, invoices, taxes, or settlement details.
-          9b. token_wallets[].depleted_balance declares safe app-local recovery
+          9b. add_on_products are provider-neutral app-owned non-token
+              products. Declare service, placement, seat, feature, support, or
+              credit add-ons at subscription_config_file.add_on_products when
+              pricing_catalog.groups[].add_on_ids need real purchasable product
+              metadata. They may include price.amount_cents, price.currency,
+              price.display, billing_mode, duration_days, required_capability,
+              and capability_groups, but they must not contain provider product
+              ids, provider price ids, checkout session ids, invoices, taxes,
+              settlement details, or entitlement grants.
+          9c. token_wallets[].depleted_balance declares safe app-local recovery
               routes for INSUFFICIENT_TOKENS. Routes must be generated app
               paths such as /billing, /pricing, or /support; never external
               provider URLs.
@@ -211,9 +225,11 @@ agents:
               metering service is available. Do not implement the meter in the workflow.
           12. pricing_catalog is optional display metadata inside
               subscription_config_file. pricing_catalog.groups[].plan_ids must
-              reference declared plans. pricing_catalog must not replace
-              plans[].capabilities, usage_limits, token_allowances, or
-              assignment_store.
+              reference declared plans. When subscription_config_file declares
+              add_on_products, pricing_catalog.groups[].add_on_ids must
+              reference declared add_on_products[].add_on_id. pricing_catalog
+              must not replace plans[].capabilities, usage_limits,
+              token_allowances, add_on_products, or assignment_store.
           13. The contract must not reference concrete hosted products, operator
               billing admin actions, payment-provider product ids, price ids,
               API keys, secrets, invoices, or settlement.

--- a/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
@@ -168,6 +168,64 @@ models:
         type: bool
         description: Whether the token pack is available for new top-up starts.
 
+  AddOnProductPrice:
+    type: model
+    fields:
+      amount_cents:
+        type: int
+        description: Positive cash amount in the smallest currency unit; never a provider price id.
+      currency:
+        type: str
+        description: Lowercase ISO 4217 currency code, such as usd.
+      display:
+        type: union
+        variants: [str, 'null']
+        description: Optional display price derived from amount_cents/currency, not provider state.
+      interval:
+        type: literal
+        values: [one_time, day, week, month, year, custom]
+        description: Display billing interval for this provider-neutral price.
+
+  AddOnProduct:
+    type: model
+    fields:
+      add_on_id:
+        type: str
+        description: Stable app-owned add-on id referenced by pricing_catalog.groups[].add_on_ids; never a provider price id.
+      label:
+        type: str
+        description: Human-readable add-on label.
+      description:
+        type: union
+        variants: [str, 'null']
+        description: Optional display description.
+      kind:
+        type: str
+        description: App-owned display kind such as service, placement, seat, feature, or credit.
+      billing_mode:
+        type: literal
+        values: [one_time, recurring, manual]
+        description: Provider-neutral purchase cadence; provider-specific checkout remains outside this file.
+      price:
+        type: union
+        variants: [AddOnProductPrice, 'null']
+        description: Optional provider-neutral cash price used by app facades to start checkout.
+      required_capability:
+        type: union
+        variants: [str, 'null']
+        description: Optional capability required to request or manage this add-on; does not grant that capability.
+      capability_groups:
+        type: list
+        items: str
+        description: Semantic capability families represented by this add-on.
+      duration_days:
+        type: union
+        variants: [int, 'null']
+        description: Optional display or fulfillment duration in days.
+      active:
+        type: bool
+        description: Whether the add-on is available for new purchase starts.
+
   UsageChargePolicy:
     type: model
     fields:
@@ -278,7 +336,7 @@ models:
       add_on_ids:
         type: list
         items: str
-        description: App/provider-owned add-on ids displayed in this group.
+        description: App-owned add-on ids displayed in this group; when add_on_products is present, every id must reference it.
 
   PricingCatalog:
     type: model
@@ -317,6 +375,10 @@ models:
         type: list
         items: TokenTopUpProduct
         description: Provider-neutral app-owned token packs for top-up facades.
+      add_on_products:
+        type: list
+        items: AddOnProduct
+        description: Provider-neutral app-owned non-token add-ons referenced by pricing_catalog.groups[].add_on_ids.
       usage_charge_policies:
         type: list
         items: UsageChargePolicy

--- a/factory_app/workflows/SubscriptionContractDesigner/tools/save_subscription_contract.py
+++ b/factory_app/workflows/SubscriptionContractDesigner/tools/save_subscription_contract.py
@@ -87,10 +87,11 @@ def _normalize_subscription_config(raw: Any) -> dict[str, Any]:
     config.setdefault("schema_version", "mozaiks.subscriptions.v1")
     config.setdefault("assignment_store", None)
     config.setdefault("token_wallets", [])
+    config.setdefault("add_on_products", [])
     config.setdefault("plans", [])
     validated = SubscriptionsConfig.model_validate(config)
     normalized = validated.model_dump(mode="python", exclude_none=True)
-    for key in ("token_wallets", "top_up_products", "usage_charge_policies"):
+    for key in ("token_wallets", "top_up_products", "add_on_products", "usage_charge_policies"):
         if normalized.get(key) == []:
             normalized.pop(key, None)
     for plan in normalized.get("plans") or []:
@@ -175,6 +176,7 @@ def _build_review_payload(
         "assignment_store": config.get("assignment_store"),
         "token_wallets": list(config.get("token_wallets") or []),
         "top_up_products": list(config.get("top_up_products") or []),
+        "add_on_products": list(config.get("add_on_products") or []),
         "usage_charge_policies": list(config.get("usage_charge_policies") or []),
         "pricing_groups": list((config.get("pricing_catalog") or {}).get("groups") or []),
         "plan_design_rationale": list(output.get("plan_design_rationale") or []),

--- a/factory_app/workflows/SubscriptionContractDesigner/ui/SubscriptionContractDesigner/SubscriptionContractReview.jsx
+++ b/factory_app/workflows/SubscriptionContractDesigner/ui/SubscriptionContractDesigner/SubscriptionContractReview.jsx
@@ -151,11 +151,11 @@ export default function SubscriptionContractReview({ payload = {}, onResponse })
   const plans = asList(payload.plans);
   const tokenWallets = asList(payload.token_wallets);
   const topUps = asList(payload.top_up_products);
+  const addOns = asList(payload.add_on_products);
   const usagePolicies = asList(payload.usage_charge_policies);
   const moduleUpdates = asList(payload.module_contract_updates);
   const workflowUpdates = asList(payload.workflow_contract_updates);
   const pages = asList(payload.page_surface_requirements);
-  const generatedFiles = asList(payload.generated_files);
   const forbiddenOutputs = asList(payload.forbidden_outputs);
   const contractRequired = Boolean(payload.contract_required);
   const canRequestChanges = changeText.trim().length > 0 && submitted !== 'changes_requested';
@@ -217,8 +217,8 @@ export default function SubscriptionContractReview({ payload = {}, onResponse })
       <div className="mb-4 grid gap-3 md:grid-cols-4">
         <Metric label="Plans" value={plans.length} />
         <Metric label="Token Wallets" value={tokenWallets.length} />
+        <Metric label="Add-Ons" value={addOns.length} />
         <Metric label="Gated Actions" value={moduleUpdates.length} />
-        <Metric label="Generated Files" value={generatedFiles.length} />
       </div>
 
       {contractRequired ? (
@@ -254,7 +254,7 @@ export default function SubscriptionContractReview({ payload = {}, onResponse })
               )}
             </Section>
 
-            <Section title="Top-Ups And Usage Charges">
+            <Section title="Top-Ups, Add-Ons, And Usage Charges">
               <p className="mb-2 text-xs font-semibold text-muted-foreground">Top-up products</p>
               {topUps.length ? (
                 <ul className="mb-3 flex flex-col gap-1">
@@ -262,6 +262,19 @@ export default function SubscriptionContractReview({ payload = {}, onResponse })
                     <li key={product?.product_id || index} className="text-xs text-foreground">
                       <span className="font-mono">{product?.product_id}</span>
                       {product?.token_amount != null && `: ${product.token_amount} tokens`}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mb-3 text-xs text-muted-foreground">None declared.</p>
+              )}
+              <p className="mb-2 text-xs font-semibold text-muted-foreground">Add-on products</p>
+              {addOns.length ? (
+                <ul className="mb-3 flex flex-col gap-1">
+                  {addOns.map((product, index) => (
+                    <li key={product?.add_on_id || index} className="text-xs text-foreground">
+                      <span className="font-mono">{product?.add_on_id}</span>
+                      {product?.price?.display && `: ${product.price.display}`}
                     </li>
                   ))}
                 </ul>

--- a/factory_app/workflows/_shared/subscription_contract_context.py
+++ b/factory_app/workflows/_shared/subscription_contract_context.py
@@ -103,7 +103,7 @@ def _render_contract(contract: Mapping[str, Any]) -> str:
     return "\n".join(
         [
             "[SUBSCRIPTION CONTRACT CONTEXT]",
-            "Use this provider-neutral contract as the source of truth for generated SaaS plans, entitlement gates, token wallets, depleted-balance recovery metadata, top-up products with price.amount_cents/currency, token allowances, usage pages, and workflow metering declarations.",
+            "Use this provider-neutral contract as the source of truth for generated SaaS plans, entitlement gates, token wallets, depleted-balance recovery metadata, top-up products with price.amount_cents/currency, add-on products with price.amount_cents/currency, token allowances, usage pages, and workflow metering declarations.",
             "Do not implement a custom usage ledger or token wallet. Use the OSS runtime subscription/token primitives.",
             "Do not add hosted-product provider behavior here; payment checkout, invoices, and settlement are app-owned or host-provided integration concerns.",
             "Since contract_required is true, AppPlanAgent MUST include a build task with task_type='subscription_config', capability_pack_id=null, surface_id='subscription_contract', surface_kind='app_policy', initial_agent='ConfigMiddlewareAgent', owned_paths=['config/subscriptions.yaml']. That task serializes this contract's subscription_config_file.",

--- a/mozaiksai/core/runtime/app/subscriptions_loader.py
+++ b/mozaiksai/core/runtime/app/subscriptions_loader.py
@@ -59,6 +59,15 @@ Example::
           amount_cents: 500
           currency: usd
           display: "$5"
+    add_on_products:
+      - add_on_id: priority_review
+        label: Priority Review
+        kind: service
+        billing_mode: one_time
+        price:
+          amount_cents: 2500
+          currency: usd
+          display: "$25"
     usage_charge_policies:
       - meter_id: ai_tokens
         label: AI usage
@@ -350,6 +359,103 @@ class TokenTopUpProductDef(BaseModel):
             return None
         value = value.strip()
         return value or None
+
+
+class AddOnProductPriceDef(TokenTopUpPriceDef):
+    """Provider-neutral cash price for a non-token add-on product."""
+
+    interval: Literal["one_time", "day", "week", "month", "year", "custom"] = "one_time"
+
+
+class AddOnProductDef(BaseModel):
+    """Provider-neutral purchasable add-on surfaced by pricing catalogs.
+
+    Add-on products describe app-level purchase intent only. They do not grant
+    entitlements by themselves and intentionally omit payment-provider product
+    ids, price ids, checkout sessions, invoices, taxes, and fulfillment state.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    add_on_id: str
+    label: str
+    description: str | None = None
+    kind: str = "service"
+    billing_mode: Literal["one_time", "recurring", "manual"] = "one_time"
+    price: AddOnProductPriceDef | None = None
+    required_capability: str | None = None
+    capability_groups: list[str] = Field(default_factory=list)
+    duration_days: int | None = Field(default=None, gt=0)
+    active: bool = True
+
+    @field_validator("add_on_id")
+    @classmethod
+    def _validate_add_on_id(cls, value: str) -> str:
+        value = value.strip()
+        if not value or not _CATALOG_ID_RE.match(value):
+            raise ValueError(
+                f"add_on_id must match [a-z0-9_-]+, got {value!r}"
+            )
+        return value
+
+    @field_validator("label")
+    @classmethod
+    def _validate_label(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("label must be non-empty")
+        return value
+
+    @field_validator("description")
+    @classmethod
+    def _validate_description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value or None
+
+    @field_validator("kind")
+    @classmethod
+    def _validate_kind(cls, value: str) -> str:
+        value = value.strip()
+        if not value or not _CATALOG_ID_RE.match(value):
+            raise ValueError(
+                f"kind must match [a-z0-9_-]+, got {value!r}"
+            )
+        return value
+
+    @field_validator("required_capability")
+    @classmethod
+    def _validate_required_capability(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            return None
+        if not _CAPABILITY_ID_RE.match(value):
+            raise ValueError(
+                f"capability_id must match [a-z0-9_.]+, got {value!r}"
+            )
+        return value
+
+    @field_validator("capability_groups", mode="before")
+    @classmethod
+    def _validate_capability_groups(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("capability_groups must be a list")
+        result: list[str] = []
+        for raw in value:
+            group = str(raw or "").strip()
+            if not group:
+                continue
+            if not _CAPABILITY_GROUP_RE.match(group):
+                raise ValueError(
+                    f"capability_group must match [a-z0-9_.-]+, got {group!r}"
+                )
+            result.append(group)
+        return result
 
 
 class UsageChargePolicyDef(BaseModel):
@@ -794,6 +900,7 @@ class SubscriptionsConfig(BaseModel):
     default_product_id: str | None = None
     token_wallets: list[TokenWalletDef] = Field(default_factory=list)
     top_up_products: list[TokenTopUpProductDef] = Field(default_factory=list)
+    add_on_products: list[AddOnProductDef] = Field(default_factory=list)
     usage_charge_policies: list[UsageChargePolicyDef] = Field(default_factory=list)
     pricing_catalog: PricingCatalogDef | None = None
     plans: list[PlanDef] = Field(default_factory=list)
@@ -821,6 +928,31 @@ class SubscriptionsConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_plan_catalog(self) -> SubscriptionsConfig:
         is_v2 = self.schema_version == "mozaiks.subscriptions.v2"
+        add_on_product_ids = [product.add_on_id for product in self.add_on_products]
+        if len(add_on_product_ids) != len(set(add_on_product_ids)):
+            raise ValueError("add_on_products add_on_ids must be unique")
+
+        declared_add_on_ids = set(add_on_product_ids)
+        catalog_groups: list[PricingCatalogGroupDef] = []
+        if self.pricing_catalog:
+            catalog_groups.extend(self.pricing_catalog.groups)
+        catalog_groups.extend(
+            product.pricing_catalog_group
+            for product in self.products
+            if product.pricing_catalog_group is not None
+        )
+        if declared_add_on_ids:
+            for group in catalog_groups:
+                unknown_add_on_ids = [
+                    add_on_id
+                    for add_on_id in group.add_on_ids
+                    if add_on_id not in declared_add_on_ids
+                ]
+                if unknown_add_on_ids:
+                    raise ValueError(
+                        f"pricing_catalog group {group.group_id!r} references "
+                        f"unknown add_on_ids: {unknown_add_on_ids}"
+                    )
 
         if is_v2:
             if not self.products:
@@ -985,6 +1117,31 @@ class SubscriptionsConfig(BaseModel):
             if product.wallet_id == wallet_key and product.active
         ]
 
+    def add_on_product_by_id(self, add_on_id: str | None) -> AddOnProductDef | None:
+        """Return a declared add-on product by id, or None when unknown."""
+        add_on_key = str(add_on_id or "").strip()
+        for product in self.add_on_products:
+            if product.add_on_id == add_on_key:
+                return product
+        return None
+
+    def add_on_products_for_group(self, group_id: str | None) -> list[AddOnProductDef]:
+        """Return active add-on products referenced by a pricing catalog group."""
+        group_key = str(group_id or "").strip()
+        catalog = self.assembled_pricing_catalog
+        if catalog is None:
+            return []
+        for group in catalog.groups:
+            if group.group_id != group_key:
+                continue
+            products: list[AddOnProductDef] = []
+            for add_on_id in group.add_on_ids:
+                product = self.add_on_product_by_id(add_on_id)
+                if product is not None and product.active:
+                    products.append(product)
+            return products
+        return []
+
 
 # ---------------------------------------------------------------------------
 # Loader
@@ -1027,6 +1184,8 @@ def load_subscriptions_config(app_root: Path) -> SubscriptionsConfig | None:
 
 
 __all__ = [
+    "AddOnProductDef",
+    "AddOnProductPriceDef",
     "PlanDef",
     "PricingCatalogDef",
     "PricingCatalogGroupDef",

--- a/tests/test_appgenerator_config_materializer.py
+++ b/tests/test_appgenerator_config_materializer.py
@@ -120,7 +120,35 @@ def _saas_subscription_config_file() -> dict:
         ],
         "token_wallets": [],
         "top_up_products": [],
+        "add_on_products": [
+            {
+                "add_on_id": "priority_review",
+                "label": "Priority Review",
+                "kind": "service",
+                "billing_mode": "one_time",
+                "price": {
+                    "amount_cents": 2500,
+                    "currency": "usd",
+                    "display": "$25",
+                    "interval": "one_time",
+                },
+                "active": True,
+            }
+        ],
         "usage_charge_policies": [],
+        "pricing_catalog": {
+            "default_group_id": "services",
+            "groups": [
+                {
+                    "group_id": "services",
+                    "label": "Services",
+                    "kind": "add_on",
+                    "plan_ids": [],
+                    "capability_groups": [],
+                    "add_on_ids": ["priority_review"],
+                }
+            ],
+        },
     }
 
 
@@ -163,6 +191,8 @@ def test_materialize_subscriptions_yaml_emits_valid_yaml_for_saas_app() -> None:
     assert len(doc["plans"]) == 2
     assert doc["plans"][1]["plan_id"] == "pro"
     assert doc["plans"][1]["capabilities"] == ["analytics.view", "exports.download"]
+    assert doc["add_on_products"][0]["add_on_id"] == "priority_review"
+    assert doc["pricing_catalog"]["groups"][0]["add_on_ids"] == ["priority_review"]
 
 
 def test_materialize_subscriptions_yaml_reads_artifact_fallback() -> None:

--- a/tests/test_subscription_contract_designer.py
+++ b/tests/test_subscription_contract_designer.py
@@ -103,6 +103,25 @@ def _sample_contract() -> dict:
                     "active": True,
                 }
             ],
+            "add_on_products": [
+                {
+                    "add_on_id": "priority_review",
+                    "label": "Priority Review",
+                    "description": "One-time expert review for a generated report.",
+                    "kind": "service",
+                    "billing_mode": "one_time",
+                    "price": {
+                        "amount_cents": 2500,
+                        "currency": "usd",
+                        "display": "$25",
+                        "interval": "one_time",
+                    },
+                    "required_capability": "reports.generate",
+                    "capability_groups": ["reports"],
+                    "duration_days": None,
+                    "active": True,
+                }
+            ],
             "usage_charge_policies": [
                 {
                     "meter_id": "ai_tokens",
@@ -135,6 +154,15 @@ def _sample_contract() -> dict:
                         "plan_ids": ["free", "pro"],
                         "capability_groups": ["ai_tokens"],
                         "add_on_ids": [],
+                    },
+                    {
+                        "group_id": "services",
+                        "label": "Services",
+                        "description": "Optional report services.",
+                        "kind": "add_on",
+                        "plan_ids": [],
+                        "capability_groups": ["reports"],
+                        "add_on_ids": ["priority_review"],
                     },
                 ],
             },
@@ -259,13 +287,17 @@ def test_subscription_contract_designer_schema_supports_semantic_pricing_catalog
     assert "TokenWalletRecovery" in models
     assert "TokenTopUpProduct" in models
     assert "TokenTopUpPrice" in models
+    assert "AddOnProduct" in models
+    assert "AddOnProductPrice" in models
 
     subscription_fields = models["SubscriptionConfigFile"]["fields"]
     assert subscription_fields["pricing_catalog"]["variants"] == ["PricingCatalog", "null"]
     assert subscription_fields["usage_charge_policies"]["items"] == "UsageChargePolicy"
     assert subscription_fields["top_up_products"]["items"] == "TokenTopUpProduct"
+    assert subscription_fields["add_on_products"]["items"] == "AddOnProduct"
     assert models["TokenWallet"]["fields"]["depleted_balance"]["variants"] == ["TokenWalletRecovery", "null"]
     assert models["TokenTopUpProduct"]["fields"]["price"]["type"] == "TokenTopUpPrice"
+    assert models["AddOnProduct"]["fields"]["price"]["variants"] == ["AddOnProductPrice", "null"]
 
     output_fields = models["SubscriptionContractOutput"]["fields"]
     assert output_fields["plan_design_rationale"]["items"] == "PlanDesignRationale"
@@ -287,6 +319,8 @@ def test_subscription_contract_designer_prompt_maps_plans_to_upstream_context() 
     assert "plan_design_rationale" in agents_text
     assert "Do not emit token_wallets" in agents_text
     assert "access only" in agents_text
+    assert "add_on_products" in agents_text
+    assert "pricing_catalog.groups[].add_on_ids" in agents_text
 
 
 def test_subscription_contract_designer_exposes_review_ui() -> None:
@@ -313,6 +347,7 @@ def test_subscription_contract_designer_exposes_review_ui() -> None:
     assert "Confirm Subscription Plan Contract" in ui_source
     assert "matches what the user wants" in ui_source
     assert "does not charge anyone" in ui_source
+    assert "Add-on products" in ui_source
     assert "Request Changes" in ui_source
     assert "canRequestChanges" in ui_source
 
@@ -351,6 +386,8 @@ def test_subscription_context_injection_preserves_plan_design_reasoning() -> Non
     assert trimmed["subscription_config_file"]["usage_charge_policies"][0]["markup_percent"] == 35
     assert trimmed["subscription_config_file"]["top_up_products"][0]["product_id"] == "ai_tokens_10k"
     assert trimmed["subscription_config_file"]["top_up_products"][0]["price"]["amount_cents"] == 500
+    assert trimmed["subscription_config_file"]["add_on_products"][0]["add_on_id"] == "priority_review"
+    assert trimmed["subscription_config_file"]["pricing_catalog"]["groups"][2]["add_on_ids"] == ["priority_review"]
     assert trimmed["subscription_config_file"]["token_wallets"][0]["depleted_balance"]["recovery_action"] == "top_up"
 
 
@@ -373,6 +410,7 @@ def test_appgenerator_declares_subscription_config_task_contract() -> None:
     assert "current_build_task_type == \"subscription_config\"" in agents_text
     assert "usage_charge_policies" in agents_text
     assert "top_up_products" in agents_text
+    assert "add_on_products" in agents_text
     assert "depleted_balance" in agents_text
     assert "module_contract_updates" in agents_text
     assert "set that action's `entitlement_gate` to the exact" in agents_text
@@ -508,6 +546,10 @@ async def test_save_subscription_contract_validates_and_persists_provider_neutra
     assert config.top_up_products[0].product_id == "ai_tokens_10k"
     assert config.top_up_products[0].price.amount_cents == 500
     assert config.top_up_products[0].price.currency == "usd"
+    assert config.add_on_products[0].add_on_id == "priority_review"
+    assert config.add_on_products[0].price is not None
+    assert config.add_on_products[0].price.amount_cents == 2500
+    assert config.add_on_products_for_group("services")[0].add_on_id == "priority_review"
     assert config.pricing_catalog is not None
     assert config.pricing_catalog.default_group_id == "platform"
     assert config.pricing_catalog.groups[1].group_id == "ai_usage"
@@ -585,6 +627,7 @@ def test_subscription_contract_allows_access_only_saas_without_token_wallets() -
     config = contract["subscription_config_file"]
     config.pop("token_wallets", None)
     config.pop("top_up_products", None)
+    config.pop("add_on_products", None)
     config.pop("usage_charge_policies", None)
     for plan in config["plans"]:
         plan["usage_limits"] = []
@@ -595,6 +638,7 @@ def test_subscription_contract_allows_access_only_saas_without_token_wallets() -
     parsed = normalized["subscription_config_file"]
     assert "token_wallets" not in parsed
     assert "top_up_products" not in parsed
+    assert "add_on_products" not in parsed
     assert "usage_charge_policies" not in parsed
     assert all("token_allowances" not in plan for plan in parsed["plans"])
     assert all("usage_limits" not in plan for plan in parsed["plans"])

--- a/tests/test_subscriptions_loader.py
+++ b/tests/test_subscriptions_loader.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from mozaiksai.core.runtime.app.subscriptions_loader import (
+    AddOnProductDef,
     PlanDef,
     PricingCatalogDef,
     SubscriptionAssignmentStoreDef,
@@ -322,6 +323,93 @@ def test_load_pricing_catalog_groups(tmp_path: Path) -> None:
     assert config.pricing_catalog.default_group_id == "platform"
     assert config.pricing_catalog.groups[0].plan_ids == ["free", "pro"]
     assert config.pricing_catalog.groups[1].add_on_ids == ["hero_weekly"]
+
+
+def test_load_add_on_products_for_pricing_catalog_groups(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        """
+        schema_version: mozaiks.subscriptions.v1
+        label: Multi Service SaaS
+        default_plan_id: free
+        add_on_products:
+          - add_on_id: hero_weekly
+            label: Hero Placement - Weekly
+            description: Promoted placement for seven days.
+            kind: marketplace_placement
+            billing_mode: one_time
+            required_capability: marketplace.placements.order
+            capability_groups: [marketplace.placements]
+            duration_days: 7
+            price:
+              amount_cents: 9900
+              currency: USD
+              display: "$99/week"
+              interval: one_time
+        pricing_catalog:
+          default_group_id: marketing
+          groups:
+            - group_id: marketing
+              label: Marketing
+              kind: add_on
+              add_on_ids: [hero_weekly]
+        plans:
+          - plan_id: free
+            label: Free
+            capabilities: []
+        """,
+    )
+
+    config = load_subscriptions_config(tmp_path)
+
+    assert config is not None
+    assert config.add_on_products[0].add_on_id == "hero_weekly"
+    assert config.add_on_products[0].price is not None
+    assert config.add_on_products[0].price.currency == "usd"
+    assert config.add_on_product_by_id("hero_weekly") is config.add_on_products[0]
+    assert config.add_on_products_for_group("marketing") == [config.add_on_products[0]]
+
+
+def test_add_on_products_reject_unknown_pricing_catalog_add_on_id() -> None:
+    with pytest.raises(ValidationError, match="unknown add_on_ids"):
+        SubscriptionsConfig.model_validate(
+            {
+                "schema_version": "mozaiks.subscriptions.v1",
+                "label": "Multi Service SaaS",
+                "default_plan_id": "free",
+                "add_on_products": [
+                    {
+                        "add_on_id": "hero_weekly",
+                        "label": "Hero Placement - Weekly",
+                    }
+                ],
+                "pricing_catalog": {
+                    "default_group_id": "marketing",
+                    "groups": [
+                        {
+                            "group_id": "marketing",
+                            "label": "Marketing",
+                            "kind": "add_on",
+                            "add_on_ids": ["missing"],
+                        }
+                    ],
+                },
+                "plans": [
+                    {"plan_id": "free", "label": "Free", "capabilities": []},
+                ],
+            }
+        )
+
+
+def test_add_on_product_rejects_provider_specific_extra_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AddOnProductDef.model_validate(
+            {
+                "add_on_id": "hero_weekly",
+                "label": "Hero Placement - Weekly",
+                "stripe_price_id": "price_123",
+            }
+        )
 
 
 def test_pricing_catalog_rejects_unknown_plan_id() -> None:


### PR DESCRIPTION
## Summary
- add root add_on_products to the OSS subscriptions loader with validation and lookup helpers
- teach SubscriptionContractDesigner and AppGenerator to preserve provider-neutral non-token add-ons
- update docs/tests so add-ons stay in config/subscriptions.yaml, not module-local subscription files

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_subscriptions_loader.py tests/test_subscription_contract_designer.py tests/test_appgenerator_config_materializer.py -q --no-cov
- .\\.venv\\Scripts\\python.exe -m ruff check mozaiksai/core/runtime/app/subscriptions_loader.py factory_app/workflows/SubscriptionContractDesigner/tools/save_subscription_contract.py factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py tests/test_subscriptions_loader.py tests/test_subscription_contract_designer.py tests/test_appgenerator_config_materializer.py