### PR TITLE
fix: tighten OSS context and dashboard contracts

### DIFF
--- a/docs/architecture/app/app-dashboard-contract.md
+++ b/docs/architecture/app/app-dashboard-contract.md
@@ -167,7 +167,7 @@ generated images, promoted assets, campaign media, and landing page visuals. The
 user-facing operation is still deterministic: review an asset, promote it to a
 target, or launch a workflow sequence.
 
-## Legacy Cleanup Direction
+## Cleanup Direction
 
 The long-term target is:
 

--- a/docs/architecture/foundations/app-context-and-brownfield-adoption.md
+++ b/docs/architecture/foundations/app-context-and-brownfield-adoption.md
@@ -178,21 +178,23 @@ Every workflow should consume the smallest useful context:
 The durable rule: summaries guide agents, graph relationships scope the work,
 and exact source retrieval provides proof.
 
-## Brownfield Sequence Registry
+## Build Journey Placement
 
-The `extension_registry.json` workflow sequences for brownfield adoption were
-renamed when the refinement layer was unified. Current canonical names:
+App Intelligence is not an `AppPage`. It is workflow and control-plane context:
 
-| Legacy sequence | Current name |
-| --- | --- |
-| `brownfield_build_light` | renamed → `brownfield_overlay_generation` |
-| `brownfield_build_full` | renamed → `brownfield_module_generation` |
+- transition UI keeps the user on an intake screen while repository extraction
+  and indexing start
+- `ExistingAppDiscovery` owns the chat-visible App Intelligence overview as a
+  workflow UI surface
+- the Refinement Engine consumes App Intelligence through checkpoint tools
+  before classifying, scoping, or coding a requested change
+- AppPages remain persistent generated app surfaces under `app/ui/`; they do
+  not own builder indexing or refinement context
 
-The discovery refresh sequence (`brownfield_discovery_refresh`) runs only
-`ExistingAppDiscovery`. It does not run `AppGenerator`, `AgentGenerator`, or
-`DesignDocs`. It does not promote or mutate source repositories. The
-`brownfield_overlay_generation` and `brownfield_module_generation` sequences
-own the subsequent generation work.
+The create journey enters `app_type_selector`, then the brownfield branch enters
+`brownfield_repo_input`, launches `ExistingAppDiscovery`, runs pre-chat indexing,
+emits `AppIntelligenceOverviewCard`, and then lets agents use retrieval tools
+for exact files.
 
 ## Implementation Map
 

--- a/docs/architecture/workflows/workflow-routing-transitions.md
+++ b/docs/architecture/workflows/workflow-routing-transitions.md
@@ -233,6 +233,8 @@ This sequence is non-mutating by shape:
 - when source files are available, it persists `source_context_bundle` before
   `app_context_graph` so refinement tools can search and read exact code
 
+It does not run `AppGenerator`, `AgentGenerator`, or `DesignDocs`.
+
 After workflow completion, the Refinement Engine can call `complete_context_refresh`
 to compare the previous context version with the new current
 `AppContextVersion` and produce a `ContextRefreshResult`. That result records

--- a/docs/architecture/workflows/workflow-routing-transitions.md
+++ b/docs/architecture/workflows/workflow-routing-transitions.md
@@ -239,8 +239,32 @@ to compare the previous context version with the new current
 whether stale context was actually resolved. It does not relaunch workflows,
 mutate source repositories, or retry the blocked refinement automatically.
 
-Brownfield generation/build sequences remain separate and should be cleaned up
-in a later architecture slice.
+Brownfield generation/build sequences remain separate:
+
+| Sequence | Purpose |
+| --- | --- |
+| `brownfield_app_adoption` | Capture source refs, index App Intelligence, run discovery chat, and pause for build-path selection. |
+| `brownfield_overlay_generation` | Generate an overlay or bridge around selected existing-app surfaces. |
+| `brownfield_module_generation` | Generate Mozaiks-owned modules from approved existing-app surfaces. |
+
+### Brownfield App Intelligence UX
+
+The existing-app intake path has two user-facing context surfaces:
+
+1. `BrownfieldRepoInput` stays mounted after the user selects a repository and
+   shows an extraction state while the workflow start request performs
+   source-backed indexing.
+2. `ExistingAppDiscovery` emits `AppIntelligenceOverviewCard` in chat after the
+   `before_chat` preload completes and before the first agent message. The card
+   renders the prompt-safe App Intelligence catalog: coverage, architecture
+   surfaces, capability boundaries, integrations, data surfaces, risk hints, and
+   agent context policy. It does not render raw source contents.
+
+These surfaces are not AppPages. `BrownfieldRepoInput` is transition UI owned by
+the build journey, and `AppIntelligenceOverviewCard` is workflow chat UI owned
+by `ExistingAppDiscovery`. The Refinement Engine consumes the same App
+Intelligence through checkpoint tools when the user later asks to revise or
+extend the app.
 
 ## Navigation Entry
 
@@ -314,5 +338,3 @@ to workflow-local `ui/` plus Python tools. If AgentGenerator emits a transition,
 it must keep routing/context deterministic and bind `ui.component` to a
 registered transition component key. Product-specific copy/images/layout belong
 in the React stub.
-
-

--- a/factory_app/app/modules/user_onboarding/backend/policy.py
+++ b/factory_app/app/modules/user_onboarding/backend/policy.py
@@ -6,4 +6,4 @@ def actor_id(ctx) -> str:
     uid = getattr(ctx, "user_id", None)
     if not uid:
         raise PermissionError("Unauthenticated")
-    return uid
+    return str(uid)

--- a/factory_app/build_context/onboarding/contract.yaml
+++ b/factory_app/build_context/onboarding/contract.yaml
@@ -1,13 +1,11 @@
 contract_id: onboarding
 contract_type: build_pack_instructions
 
-description: >
-  Onboarding tour pack. Produces a declarative step config (app/config/onboarding.yaml)
-  and a thin user_onboarding state module. The OSS runtime's installTour() primitive
-  reads the config and renders the tour overlay automatically. Apps that do not select
-  this pack incur zero cost — the runtime skips the tour entirely when the config is absent.
-
-  The config file is the feature flag. Its presence enables the tour; its absence disables it.
+# Onboarding tour pack. Produces a declarative step config (app/config/onboarding.yaml)
+# and a thin user_onboarding state module. The OSS runtime's installTour() primitive
+# reads the config and renders the tour overlay automatically. Apps that do not select
+# this pack incur zero cost — the runtime skips the tour entirely when the config is absent.
+# The config file is the feature flag. Its presence enables the tour; its absence disables it.
 
 # ── Step config format ──────────────────────────────────────────────────────
 #
@@ -165,6 +163,8 @@ runtime_boundaries:
       The user_onboarding module always sets user_data_scope: true and generates
       backend/account_data_handler.py implementing delete_user_data and
       export_user_data per the standard archetype constraint.
+
+facades: []
 
 cross_pack_integrations:
   - pack_id: mozaikspay

--- a/factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py
@@ -183,7 +183,7 @@ def _fallback_catalog(
 
 
 def _fallback_risks(warnings: list[str]) -> list[dict[str, Any]]:
-    risks = []
+    risks: list[dict[str, Any]] = []
     if any("file_limit" in warning for warning in warnings):
         risks.append(
             {

--- a/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
@@ -951,7 +951,7 @@ async def _collect_github_context_graph_file_map(
     token = github_token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
     candidates: list[tuple[int, int, str, str, str, str, str, str]] = []
     warnings: list[str] = []
-    skipped = Counter()
+    skipped: Counter[str] = Counter()
     roots_summary: list[dict[str, Any]] = []
 
     for label, raw_repo in repos:
@@ -1017,8 +1017,8 @@ async def _collect_github_context_graph_file_map(
 
     candidates.sort(key=lambda item: (item[0], item[1], item[2]))
     file_map: dict[str, str] = {}
-    selected_by_priority = Counter()
-    selected_by_extension = Counter()
+    selected_by_priority: Counter[str] = Counter()
+    selected_by_extension: Counter[str] = Counter()
     total_chars = 0
     limit_reached = len(candidates) > policy.max_files
     fetch_candidates = candidates[: policy.max_files]
@@ -1188,7 +1188,7 @@ async def _preload_context_graph_pack(
         )
     else:
         scan_result = await _collect_github_context_graph_file_map(
-            github_sources or [],
+            list(github_sources or []),
             github_ref=github_ref,
             github_token=github_token,
             scan_policy_inputs=scan_policy_inputs,

--- a/mozaiksai/core/adapters/llm_fallback.py
+++ b/mozaiksai/core/adapters/llm_fallback.py
@@ -257,7 +257,7 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
     if api_type == "openai" and bool(llm_config.get("use_responses_api") or llm_config.get("responses_api")):
         from ag2.config import OpenAIResponsesConfig
 
-        kwargs: dict[str, Any] = {
+        response_kwargs: dict[str, Any] = {
             "model": model,
             "api_key": api_key,
             "base_url": base_url,
@@ -265,11 +265,11 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
             "streaming": streaming,
         }
         if timeout is not None:
-            kwargs["timeout"] = timeout
+            response_kwargs["timeout"] = timeout
         for key in ("max_output_tokens", "max_tool_calls", "parallel_tool_calls", "store"):
             if key in llm_config:
-                kwargs[key] = llm_config[key]
-        return OpenAIResponsesConfig(**kwargs)
+                response_kwargs[key] = llm_config[key]
+        return OpenAIResponsesConfig(**response_kwargs)
 
     from ag2.config import OpenAIConfig
     kwargs = {

--- a/mozaiksai/core/app_context/health.py
+++ b/mozaiksai/core/app_context/health.py
@@ -92,8 +92,10 @@ def _parser_fallback_warning(
     python_count = selected_by_extension.get(".py", 0)
     if js_like_count <= python_count:
         return None
-    languages = parser_status.get("languages") if isinstance(parser_status.get("languages"), dict) else {}
-    javascript = languages.get("javascript") if isinstance(languages.get("javascript"), dict) else {}
+    raw_languages = parser_status.get("languages")
+    languages = raw_languages if isinstance(raw_languages, dict) else {}
+    raw_javascript = languages.get("javascript")
+    javascript = raw_javascript if isinstance(raw_javascript, dict) else {}
     if str(javascript.get("active_parser") or "") == "regex":
         return "context_graph_javascript_parser_fallback"
     return None

--- a/mozaiksai/core/app_context/intelligence.py
+++ b/mozaiksai/core/app_context/intelligence.py
@@ -301,7 +301,7 @@ def _capability_summaries(*, bundle: SourceCorpusBundle, graph: AppContextGraph)
 
 
 def _ownership_summary(*, bundle: SourceCorpusBundle, graph: AppContextGraph) -> dict[str, Any]:
-    ownership_counts = Counter()
+    ownership_counts: Counter[str] = Counter()
     review_paths: list[str] = []
     for node in graph.nodes:
         metadata = node.metadata or {}

--- a/mozaiksai/core/app_context/source_corpus.py
+++ b/mozaiksai/core/app_context/source_corpus.py
@@ -603,7 +603,7 @@ def _matched_excerpt(text: str, matched_terms: list[str], *, max_length: int = 9
     lower = text.lower()
     first = min((lower.find(term) for term in matched_terms if term in lower), default=0)
     start = max(0, first - 180)
-    return _excerpt(text[start:], max_length=max_length)
+    return _excerpt(text[start:], max_length=max_length) or ""
 
 
 def _excerpt(text: str | None, *, max_length: int | None) -> str | None:

--- a/mozaiksai/core/app_context/source_corpus.py
+++ b/mozaiksai/core/app_context/source_corpus.py
@@ -611,7 +611,7 @@ def _excerpt(text: str | None, *, max_length: int | None) -> str | None:
         return None
     if max_length is None or max_length <= 0 or len(text) <= max_length:
         return text
-    return text[: max(0, max_length - 20)].rstrip() + "\n... [truncated]"
+    return f"{text[: max(0, max_length - 20)].rstrip()}\n... [truncated]"
 
 
 def _contains_any(value: str, needles: tuple[str, ...]) -> bool:

--- a/mozaiksai/core/dashboard/manifest.py
+++ b/mozaiksai/core/dashboard/manifest.py
@@ -83,6 +83,8 @@ def _unique_ids(items: Iterable[Any], *, owner: str) -> None:
     seen: set[str] = set()
     for item in items:
         item_id = getattr(item, "id", None)
+        if not isinstance(item_id, str):
+            raise ValueError(f"{owner} contains an item without a string id")
         if item_id in seen:
             raise ValueError(f"{owner} contains duplicate id '{item_id}'")
         seen.add(item_id)

--- a/mozaiksai/core/media/ag2.py
+++ b/mozaiksai/core/media/ag2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .types import (
     MediaInputRef,
@@ -137,7 +137,7 @@ def media_input_ref_to_ag2_input(ref: MediaInputRef) -> Any:
         MediaKind.VIDEO: VideoInput,
         MediaKind.DOCUMENT: DocumentInput,
     }
-    factory = factory_by_kind[ref.kind]
+    factory = cast(Any, factory_by_kind[ref.kind])
     if ref.data is not None:
         ag2_input = factory(data=ref.data, media_type=ref.media_type)
     elif ref.path:

--- a/mozaiksai/core/workflow/generator_support/connector_health_providers.py
+++ b/mozaiksai/core/workflow/generator_support/connector_health_providers.py
@@ -745,7 +745,7 @@ class _MongoDBProvider:
         try:
             from motor.motor_asyncio import AsyncIOMotorClient  # type: ignore[import]
 
-            client = AsyncIOMotorClient(
+            client: Any = AsyncIOMotorClient(
                 uri,
                 serverSelectionTimeoutMS=int(_TIMEOUT * 1000),
                 connectTimeoutMS=int(_TIMEOUT * 1000),

--- a/mozaiksai/hosts/routers/oauth_github.py
+++ b/mozaiksai/hosts/routers/oauth_github.py
@@ -18,7 +18,7 @@ import time
 
 import httpx
 from fastapi import APIRouter
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 router = APIRouter(tags=["oauth"])
 logger = logging.getLogger(__name__)
@@ -144,7 +144,7 @@ async def github_oauth_status() -> JSONResponse:
 
 
 @router.get("/api/oauth/github/connect")
-async def github_oauth_connect(session_key: str = "") -> HTMLResponse:
+async def github_oauth_connect(session_key: str = "") -> Response:
     """Redirect to GitHub OAuth authorization page."""
     client_id = os.getenv("GITHUB_OAUTH_CLIENT_ID", "").strip()
     if not client_id:

--- a/tests/test_brownfield_discovery_refresh_sequence.py
+++ b/tests/test_brownfield_discovery_refresh_sequence.py
@@ -121,11 +121,16 @@ def test_legacy_brownfield_build_sequences_are_not_rewired_by_refresh() -> None:
     assert _step_workflows(refresh) == ["ExistingAppDiscovery"]
 
     app_context_doc = APP_CONTEXT_DOC_PATH.read_text(encoding="utf-8")
-    assert f"`{legacy_light_sequence}`" in app_context_doc
-    assert "`brownfield_overlay_generation`" in app_context_doc
-    assert f"`{legacy_full_sequence}`" in app_context_doc
-    assert "`brownfield_module_generation`" in app_context_doc
-    assert "renamed" in app_context_doc.lower()
+    workflow_sequence_doc = WORKFLOW_SEQUENCE_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "`brownfield_overlay_generation`" in workflow_sequence_doc
+    assert "`brownfield_module_generation`" in workflow_sequence_doc
+    assert f"`{legacy_light_sequence}`" not in workflow_sequence_doc
+    assert f"`{legacy_full_sequence}`" not in workflow_sequence_doc
+    assert "renamed" not in workflow_sequence_doc.lower()
+    assert f"`{legacy_light_sequence}`" not in app_context_doc
+    assert f"`{legacy_full_sequence}`" not in app_context_doc
+    assert "renamed" not in app_context_doc.lower()
 
 
 def test_docs_describe_refresh_sequence_as_non_mutating() -> None:

--- a/tests/test_context_refresh_result_handling.py
+++ b/tests/test_context_refresh_result_handling.py
@@ -153,6 +153,7 @@ def _artifact_refs(suffix: str) -> dict[str, str]:
         for artifact_kind in BROWNFIELD_APP_CONTEXT_REQUIRED_ARTIFACT_KINDS
     }
     refs["source_context_bundle"] = f"av_source_context_bundle_{suffix}"
+    refs["app_intelligence_snapshot"] = f"av_app_intelligence_snapshot_{suffix}"
     return refs
 
 

--- a/tests/test_existing_app_discovery_contracts.py
+++ b/tests/test_existing_app_discovery_contracts.py
@@ -197,6 +197,88 @@ def test_app_intelligence_overview_emitter_surfaces_agent_visible_catalog() -> N
     assert emitted["kwargs"]["workflow_name"] == "ExistingAppDiscovery"
 
 
+def test_app_intelligence_overview_uses_real_workflow_ui_surface(monkeypatch) -> None:
+    module = _load_module(
+        "factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py",
+        "tests.emit_app_intelligence_overview_transport",
+    )
+
+    from mozaiksai.core.transport import simple_transport as transport_mod
+
+    class _FakeTransport:
+        def __init__(self) -> None:
+            self.events = []
+
+        async def send_tool_call_event(
+            self,
+            *,
+            event_id,
+            chat_id,
+            tool_name,
+            component_name,
+            display_type,
+            payload,
+            awaiting_response=True,
+            agent_name=None,
+        ):
+            self.events.append(
+                {
+                    "event_id": event_id,
+                    "chat_id": chat_id,
+                    "tool_name": tool_name,
+                    "component_name": component_name,
+                    "display_type": display_type,
+                    "payload": payload,
+                    "awaiting_response": awaiting_response,
+                    "agent_name": agent_name,
+                }
+            )
+
+    fake_transport = _FakeTransport()
+
+    async def _get_instance():
+        return fake_transport
+
+    monkeypatch.setattr(transport_mod.SimpleTransport, "get_instance", staticmethod(_get_instance))
+
+    context = _Context(
+        chat_id="chat_real_ui_surface",
+        app_id="app_1",
+        preload_status="ready",
+        github_repo="acme/app",
+        repo_summary={"repo_name": "acme/app", "source": "github_repo_scan"},
+        app_intelligence_catalog={
+            "present": True,
+            "snapshot_id": "app_intelligence_1",
+            "coverage": {"file_count": 8, "symbol_count": 21, "node_count": 13, "edge_count": 34},
+            "architecture": {"module_roots": [], "service_roots": [], "ui_surfaces": [], "workflow_roots": []},
+            "capabilities": [],
+            "integration_surfaces": [],
+            "data_surfaces": [],
+            "risk_hints": [],
+            "agent_context_policy": {"policy": "retrieve_not_dump", "authority": {}, "surfaces": []},
+            "warnings": [],
+        },
+    )
+
+    result = asyncio.run(module.emit_app_intelligence_overview_card(context_variables=context))
+
+    assert result["success"] is True
+    assert len(fake_transport.events) == 1
+    event = fake_transport.events[0]
+    assert event["chat_id"] == "chat_real_ui_surface"
+    assert event["tool_name"] == "AppIntelligenceOverviewCard"
+    assert event["component_name"] == "AppIntelligenceOverviewCard"
+    assert event["display_type"] == "artifact"
+    assert event["awaiting_response"] is False
+    assert event["agent_name"] == "ExistingAppDiscovery"
+    assert event["payload"]["workflow_name"] == "ExistingAppDiscovery"
+    assert event["payload"]["interaction_type"] == "ui_surface"
+    assert event["payload"]["component_type"] == "AppIntelligenceOverviewCard"
+    assert event["payload"]["workflow_primitive"] == "document_preview"
+    assert event["payload"]["ui_realization"] == "generated_component"
+
+
 def test_existing_app_preload_mutates_an_empty_context_container() -> None:
     module = _load_module(
         "factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py",

--- a/tests/test_mobile_surface_contracts.py
+++ b/tests/test_mobile_surface_contracts.py
@@ -258,6 +258,8 @@ def test_factory_app_react_files_are_classified() -> None:
         "factory_app/app/admin/pages/PricingHealthPanel.jsx",
         "factory_app/app/ui/components/StudioShared.jsx",
         "factory_app/app/ui/components/HarnessDecisionCard.jsx",
+        "factory_app/app/ui/components/OnboardingTour.jsx",
+        "factory_app/app/ui/installOnboardingTour.jsx",
         "factory_app/workflows/ExistingAppDiscovery/ui/DiscoveryBriefCard.jsx",
         # ExistingAppDiscovery App Intelligence overview — emitted before agent speaks
         "factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceOverviewCard.jsx",


### PR DESCRIPTION
## Summary
- fixes CI-facing type and source-hygiene issues after the app intelligence/dashboard/media merge
- tightens brownfield refresh docs and App Intelligence UI surface contract tests
- restores context refresh and mobile surface expectations for app intelligence/onboarding artifacts

## Validation
- `ruff check .`
- source hygiene scan via `scripts/production_readiness_gate.py`
- `python -m mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped`
- `python -m pytest tests/test_dashboard_manifest.py tests/test_media_multimodal.py tests/test_source_corpus_context.py tests/test_app_intelligence.py tests/test_context_refresh_result_handling.py tests/test_brownfield_discovery_refresh_sequence.py tests/test_mobile_surface_contracts.py tests/test_existing_app_discovery_contracts.py -q --no-cov`
- `python -m mkdocs build --strict`