### PR TITLE
fix: clean up onboarding and logging fixtures

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -8,6 +8,8 @@ a385d81b03a6419a09fd82740da806dd357d9721:tests/test_review_redact_and_scan_polic
 13a383ade56fc1601b92eccb3b879b771e35ff89:docs/ai-runtime/observability.md:generic-api-key:415
 13a383ade56fc1601b92eccb3b879b771e35ff89:docs/reference/api.md:generic-api-key:22
 5daa33442a14556afc7ffff798b65a277936ba57:docs/core/authentication.md:generic-api-key:104
+2a87b6bb89f9f1d452a0ba4990ccdd0a0fffca8a:tests/test_logging_config.py:generic-api-key:83
+eaadceb724d84cec06a725cc6e1b27e3bef7de07:tests/test_logging_config.py:generic-api-key:83
 05950535816d1830e0325d67a196b9f8ca0516b6:backend/src/Identity.API/AuthServer.Api.Tests/bin/Debug/net10.0/firebase-credentials.example.json:private-key:5
 05950535816d1830e0325d67a196b9f8ca0516b6:backend/src/Identity.API/AuthServer.Api.Tests/bin/Debug/net8.0/firebase-credentials.example.json:private-key:5
 05950535816d1830e0325d67a196b9f8ca0516b6:backend/src/Identity.API/AuthServer.Api/bin/Debug/net8.0/firebase-credentials.example.json:private-key:5

--- a/factory_app/app/ui/components/OnboardingTour.jsx
+++ b/factory_app/app/ui/components/OnboardingTour.jsx
@@ -1,14 +1,13 @@
 /**
- * OnboardingTour — in-place spotlight tour overlay for the factory app.
+ * OnboardingTour - in-place spotlight tour overlay for the factory app.
  *
  * Mounts as a separate React root via installOnboardingTour.jsx.
  * Step selectors match the factory_app shell.json nav surface.
- * Prototype of the OSS installTour() primitive.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-// Module API — mirrors mozaiks-app pattern but inlined to avoid cross-package dep
+// Module API mirrors mozaiks-app pattern but is inlined to avoid cross-package deps.
 async function moduleAction(moduleName, actionName, input = {}) {
   const token =
     window.mozaiksAuth?.getAccessToken?.() ||
@@ -25,7 +24,7 @@ async function moduleAction(moduleName, actionName, input = {}) {
     headers,
     body: JSON.stringify(input),
   })
-  if (!res.ok) throw new Error(`${moduleName}.${actionName} → ${res.status}`)
+  if (!res.ok) throw new Error(`${moduleName}.${actionName} ${res.status}`)
   return res.json()
 }
 
@@ -122,7 +121,7 @@ function Tooltip({ rect, step, stepIndex, totalSteps, onNext, onSkip, acting }) 
         disabled={acting}
         className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
       >
-        {acting ? 'Saving…' : stepIndex < totalSteps - 1 ? 'Next' : 'Done'}
+        {acting ? 'Saving...' : stepIndex < totalSteps - 1 ? 'Next' : 'Done'}
       </button>
     </div>
   )
@@ -139,7 +138,6 @@ export default function OnboardingTour() {
   useEffect(() => {
     moduleAction('user_onboarding', 'get_onboarding_status', {})
       .then((status) => {
-        console.log('[OnboardingTour] status:', status)
         if (!status || status.dismissed || status.progress === 100) return
         const steps = status.steps || {}
         const firstIncomplete = TOUR_STEPS.findIndex((s) => !steps[s.id]?.completed)
@@ -147,9 +145,7 @@ export default function OnboardingTour() {
         setStepIndex(firstIncomplete)
         setReady(true)
       })
-      .catch((err) => {
-        console.warn('[OnboardingTour] get_onboarding_status failed:', err)
-      })
+      .catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -158,7 +154,6 @@ export default function OnboardingTour() {
       const step = TOUR_STEPS[stepIndex]
       if (!step) return
       const r = getRect(step.selector)
-      if (!r) console.warn('[OnboardingTour] selector not found:', step.selector)
       setRect(r)
       setVisible(Boolean(r))
     }

--- a/factory_app/app/ui/installOnboardingTour.jsx
+++ b/factory_app/app/ui/installOnboardingTour.jsx
@@ -4,7 +4,6 @@ import OnboardingTour from './components/OnboardingTour.jsx'
 let installed = false
 
 export function installOnboardingTour() {
-  console.log('[installOnboardingTour] called, installed:', installed)
   if (installed || typeof window === 'undefined' || typeof document === 'undefined') return
   installed = true
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -80,7 +80,7 @@ def test_agent_conversation_filter_keeps_summary_and_gates_full_prompt_records()
 
 
 def test_pretty_formatter_redacts_quoted_modern_api_keys() -> None:
-    key = "sk-proj-abcdefghijklmno123456789"
+    key = "sk-proj-test-redaction-key"
     record = logging.LogRecord(
         name="tests.logging",
         level=logging.DEBUG,


### PR DESCRIPTION
## Summary
- ignore historical gitleaks fingerprints for the old logging fixture while keeping the live test value synthetic
- remove debug logging and prototype phrasing from the OSS onboarding tour UI

## Validation
- gitleaks detect --source . --log-level warn --redact
- python -m pytest tests/test_logging_config.py tests/test_mobile_surface_contracts.py tests/test_workflow_ui_tool_contracts.py -q --no-cov
- ruff check .
- npm --prefix web_shell run build