### PR TITLE
fix(ci): revert create-overlay close button to correct 'Back to Apps' label

### DIFF
--- a/web_shell/playwright/apps.responsive.smoke.spec.js
+++ b/web_shell/playwright/apps.responsive.smoke.spec.js
@@ -896,7 +896,7 @@ test('create app transition overlay can return to Apps', async ({ page }) => {
   await expect(page).toHaveURL(/\/create$/);
   await expect(page.getByRole('heading', { name: 'Choose Your App Journey' })).toBeVisible();
 
-  const closeBtn = page.getByRole('button', { name: 'Close overlay' });
+  const closeBtn = page.getByRole('button', { name: 'Back to Apps' });
   await expect(closeBtn).toBeVisible();
   await closeBtn.click();
 


### PR DESCRIPTION
## Summary

- PR #119 incorrectly changed the `/create` transition overlay close button assertion from `Back to Apps` to `Close overlay`
- `Back to Apps` is correct: it's set via `close_label: "Back to Apps"` in the `/create` transition props in `extension_registry.json`, rendered as `aria-label` by `TransitionOverlayFrame.jsx`
- `Close overlay` is the label used by the **Import App** Surface overlay (a different component, `Surface.jsx` line 380) — which is why that assertion at line 918 correctly stays as `Close overlay`

## Root Cause

`TransitionOverlayFrame.jsx`:
```js
const closeLabel = asString(screenProps.close_label) ?? 'Close transition';
// ...
aria-label={closeLabel}
```

`extension_registry.json` `/create` transition props:
```json
"close_label": "Back to Apps"
```

The original Playwright test was correct. This PR restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)