### PR TITLE
feat(app): add app provenance contract

### DIFF
--- a/docs/architecture/app/app-dashboard-contract.md
+++ b/docs/architecture/app/app-dashboard-contract.md
@@ -2,7 +2,7 @@
 title: App Dashboard Contract
 status: Authoritative - Pre-Production
 created: 2026-07-28
-updated: 2026-07-28
+updated: 2026-07-29
 depends_on: surface-model.md, platform-navigation-contract.md, ../workflows/workflow-routing-transitions.md
 ---
 
@@ -50,6 +50,9 @@ schema_version: mozaiks.dashboard.v1
 
 When the file is missing, Studio uses the OSS default manifest. App-owned files
 can overlay the default with `extends: default` and override portals by id.
+The `dashboard/` directory is a canonical app-root plane, and
+`app/provenance.yaml` can reference `dashboard/dashboard.yaml` as the app's
+dashboard overlay.
 
 ## Ownership Boundaries
 

--- a/docs/architecture/app/canonical-app-structure.md
+++ b/docs/architecture/app/canonical-app-structure.md
@@ -11,6 +11,7 @@ orchestration lives in workflows.
 workspace/
 ├── app/
 │   ├── app.json
+│   ├── provenance.yaml        ← optional origin/refinement/contract lineage
 │   ├── config/
 │   │   ├── ai.json
 │   │   ├── auth.yaml           ← authenticated apps only
@@ -47,6 +48,8 @@ workspace/
 │   │   ├── admin_registry.yaml
 │   │   ├── index.js          ← admin/index.js registers custom page components
 │   │   └── pages/            ← admin/pages/ holds custom admin page files
+│   ├── dashboard/
+│   │   └── dashboard.yaml     ← optional App Dashboard portal overlay
 │   ├── brand/
 │   └── services/
 │       ├── platform_hooks.py  ← optional host/platform hook bundle
@@ -78,6 +81,12 @@ workspace/
 
 - `app/modules/` owns deterministic app behavior: actions, state, permissions,
   emitted events, lifecycle transitions, and persistence authority.
+- `app/provenance.yaml` owns optional origin, refinement, validation, and
+  contract-reference metadata for the app bundle. It does not own runtime
+  behavior, package installation, live hosted state, secrets, absolute local
+  paths, or provider execution state.
+- `app/dashboard/dashboard.yaml` owns optional Workspace/App Dashboard portal
+  overlays.
 - `app/services/` owns app service implementations: thin external clients,
   provider adapters, callback routes, and long-running workers. Services do
   not create business actions, own durable app facts, or hold first-class data
@@ -198,6 +207,12 @@ other operator capabilities.
 
 ## Config Contract
 
+- `app/provenance.yaml` sits beside `app.json` because it describes app-bundle
+  lineage, not runtime configuration. `requirements.txt` remains the package
+  version source, app registry/artifact records remain the live hosted state,
+  and app contracts remain the source of actual behavior. Provenance can
+  reference those contracts so Studio, CI, and refinement workflows can explain
+  which defaults and overlays shaped the bundle.
 - `app/config/integrations.yaml` declares external services and hosted
   capability requirements.
 - `app/config/auth.yaml` (authenticated apps only) is the canonical

--- a/docs/guides/configs/index.md
+++ b/docs/guides/configs/index.md
@@ -13,6 +13,7 @@ folder.
 | I want to change... | Edit this |
 |---------------------|-----------|
 | App name, default route, auth-required flag, admins | `app/app.json` |
+| App origin, contract refs, generated/refined lineage | `app/provenance.yaml` |
 | Ask/chat startup or the default workflow | `app/config/ai.json` |
 | Navigation, header actions, footer, mobile shell | `app/config/shell.json` |
 | Workspace/App Dashboard portals | `app/dashboard/dashboard.yaml` |
@@ -23,7 +24,8 @@ folder.
 
 ## Build a Mozaiks App Checklist
 
-1. Set identity and startup: `app/app.json` and `app/config/ai.json`.
+1. Set identity, lineage, and startup: `app/app.json`, `app/provenance.yaml`,
+   and `app/config/ai.json`.
 2. Shape the experience: `app/config/shell.json`,
    `app/dashboard/dashboard.yaml`, `app/brand/theme_config.json`, and `app/ui/`.
 3. Add durable behavior: `app/modules/{module_id}/module.yaml` plus module
@@ -40,6 +42,7 @@ folder.
 | File | Owns | Read |
 |------|------|------|
 | `app/app.json` | App identity, auth-required flag, default route, admin bootstrap | [Canonical App Structure](../../architecture/app/canonical-app-structure.md) |
+| `app/provenance.yaml` | App-bundle origin, refinement lineage, validation refs, and contract refs | [App Provenance](provenance.md) |
 | `app/config/ai.json` | Ask mode prompt, chat startup mode, default workflow entry point | [AI Startup](ai-startup.md) |
 | `app/config/shell.json` | Header, footer, profile menu, notifications, mobile shell | [App Shell and Branding](../custom-brand-integration/01-overview.md) |
 | `app/dashboard/dashboard.yaml` | Workspace/App Dashboard portals, panels, and dashboard actions | [App Dashboard Contract](../../architecture/app/app-dashboard-contract.md) |
@@ -70,6 +73,7 @@ folder.
 | Task | Read |
 |------|------|
 | Configure ask/chat/workflow startup | [AI Startup](ai-startup.md) |
+| Explain where an app bundle came from | [App Provenance](provenance.md) |
 | Add paid plans or token usage | [Subscriptions](subscriptions.md) |
 | Add refinement routing | [Refinement](refinement.md) |
 | Add module service or commercial metadata | [Module Contracts](module-contracts.md) |

--- a/docs/guides/configs/provenance.md
+++ b/docs/guides/configs/provenance.md
@@ -1,0 +1,73 @@
+# App Provenance
+
+`app/provenance.yaml` records where an app bundle came from and which Mozaiks
+contracts it declares. It is optional for existing apps, emitted by new
+scaffolds and generated app bundles, and loaded by Studio/refinement tooling
+when present.
+
+```yaml
+schema_version: mozaiks.provenance.v1
+app_kind: generated
+created_with:
+  mode: factory
+  mozaiks_ref: package:0.1.10
+  workflow: AppGenerator
+  workflow_sequence: full_build
+  build_id: build_123
+contracts:
+  app: mozaiks.app.v1
+  dashboard: mozaiks.dashboard.v1
+  refinement_harness: mozaiks.refinement_harness.v1
+overlays:
+  dashboard: dashboard/dashboard.yaml
+artifact_refs:
+  generated_artifact_ids: [artifact_123]
+  accepted_artifact_version_ids: []
+  app_context_version_ids: []
+```
+
+## What It Owns
+
+Provenance owns app-bundle lineage:
+
+- creation source: CLI, factory workflow, import, manual authoring, or App Zero
+- Mozaiks package/ref used when the bundle was created or refined
+- workflow, workflow sequence, build, artifact, and AppContextVersion refs
+- contract schema refs for app-owned declarative files
+- thin overlay pointers such as `dashboard: dashboard/dashboard.yaml`
+
+It does not own runtime behavior. `requirements.txt` remains the installed
+package source, app registry/artifact records remain live hosted state, and
+`app/` contracts remain the source of actual behavior.
+
+## Overlay Semantics
+
+`overlays` is a names-to-relative-path map. Paths must stay inside the app
+bundle, cannot be URLs, and cannot be absolute local paths.
+
+Overlay files express app-specific differences from OSS defaults. For example,
+an app can declare:
+
+```yaml
+overlays:
+  dashboard: dashboard/dashboard.yaml
+  refinement_policy: config/refinement_policy.yaml
+```
+
+That means the app consumes the OSS dashboard and refinement defaults, then
+applies the listed app-local files where supported by the corresponding loader.
+
+## Runtime And CI
+
+The runtime exposes these stable entrypoints:
+
+- `mozaiksai.core.runtime.app.AppProvenance`
+- `mozaiksai.core.runtime.app.build_default_app_provenance`
+- `mozaiksai.core.runtime.app.load_app_provenance`
+- `mozaiksai.core.runtime.app.write_app_provenance`
+- `mozaiksai.core.runtime.app.AppLoader.load`
+
+`AppLoader.load()` accepts missing provenance for backwards compatibility, but
+rejects malformed `app/provenance.yaml` when it is present. CI should load the
+app through the pinned `mozaiks` package, validate provenance, and verify that
+declared overlay paths remain inside the app bundle.

--- a/factory_app/build_context/AppGenerator/file_contracts.yaml
+++ b/factory_app/build_context/AppGenerator/file_contracts.yaml
@@ -22,6 +22,7 @@ task_contracts:
       - app.json
       - ui/pages/*.yaml
     optional_outputs:
+      - provenance.yaml
       - ui/route_manifest.json
       - ui/pages/custom/*.jsx
       - ui/index.js
@@ -32,6 +33,7 @@ task_contracts:
       - config/asset_manifest.json
     hard_constraints:
       - Persistent app pages stay declarative by default.
+      - provenance.yaml is app-root metadata emitted by the scaffold/generator path. It records creation/refinement/validation lineage and declared contract refs; it must not contain secrets, absolute local paths, or provider execution state.
       - "Workflow launches from pages use action_type: workflow."
       - Prefer compact config/shell.json shortcuts for common shell chrome instead of repeating full header/profile/mobile/footer arrays.
       - Shell shortcuts may target header, profile, mobile, and footer slots using primitive ids such as home, apps, workspace, wallet, create, profile, messages, notifications, signout, signin, legal, terms, cookies, and privacy. Use dashboard only when the app declares a route/page with id dashboard; it is not a built-in shortcut. Do NOT include admin_portal in any shortcuts list — it is framework-injected automatically for admin users and must not be declared by app config or generated output.

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -905,7 +905,8 @@ agents:
       persistent UI contract for the generated application — the manifest,
       declarative page schemas, optional bounded custom route bundle, optional
       theme_config patch, optional shell config, and optional asset manifest that
-      the platform shell renders or mounts.
+      the platform shell renders or mounts. The save path emits app provenance
+      metadata separately as `provenance.yaml`.
 
       If `bundle_repair_target == "AppSchemaAgent"`, you are in bounded
       generated-bundle scanner repair mode. Repair only generated UI schema or
@@ -914,7 +915,7 @@ agents:
     heading: '[OBJECTIVE]'
     content: |-
       - Read the canonical app build plan and any available design documents.
-      - Produce one AppSchemaOutput covering: app startup/product intent (app.json), declarative AppPageSchema files for the exact `app_build_plan.pages[]` set (ui/pages/*.yaml), an optional bounded custom_route_bundle (`ui/route_manifest.json` + `ui/pages/custom/*.jsx`), optional theme_config patch, optional shell_config, and optional asset_manifest.
+      - Produce one AppSchemaOutput covering: app startup/product intent (app.json), declarative AppPageSchema files for the exact `app_build_plan.pages[]` set (ui/pages/*.yaml), an optional bounded custom_route_bundle (`ui/route_manifest.json` + `ui/pages/custom/*.jsx`), optional theme_config patch, optional shell_config, and optional asset_manifest. Do not manually duplicate `provenance.yaml`; `save_app_schema` emits it from the active factory/build context.
       - Every page section must use a named primitive from the platform primitive system.
       - Keep persistent app pages declarative by default. Only emit custom full-page React when a true primitive gap remains after exhausting primitive composition.
       - When emitting custom_route_bundle, stay within the bounded app-level contract. Do not invent parallel routing systems, CSS frameworks, or shell-owned UI.
@@ -1053,6 +1054,7 @@ agents:
 
       **Artifact boundary**:
       - `app/brand/theme_config.json` is the canonical visual identity source for generated apps.
+      - `provenance.yaml` is the app-root lineage and contract-reference file. It is emitted by the generator/scaffold path, not by app.json, shell_config, asset_manifest, or custom route output.
       - `app/config/shell.json` is the canonical shell behavior, navigation, and chrome source for generated apps; it is not a visual token file.
       - `theme_config_patch` owns visual tokens only: compact `theme` selectors (`primary`, `radius`, `font`, `font_heading`, `appearance`, `density`), `primitives`, and semantic `ui.chat` / `ui.shell` / `ui.page` spacing, sizing, density, and visual styling.
       - The expanded `fonts`, `colors`, `shadows`, `ui`, and `primitives` layer is the runtime bridge for shell/chat tokens until those tokens fully migrate to `--mz-*`.
@@ -1349,7 +1351,7 @@ agents:
       `app_task_batch_results`.
       After assembly, downstream agents read `generated_files` and
       `app_task_batch_results_summary`; they do not need the full task result map.
-      This path does NOT change the page authoring rule: persistent app pages still belong in `app.json` + `ui/pages/*.yaml`, not ad hoc page React files.
+      This path does NOT change the page authoring rule: persistent app pages still belong in `app.json` + `provenance.yaml` + `ui/pages/*.yaml`, not ad hoc page React files.
   - id: instructions
     heading: '[INSTRUCTIONS]'
     content: |-

--- a/factory_app/workflows/AppGenerator/tools/app_build_plan.py
+++ b/factory_app/workflows/AppGenerator/tools/app_build_plan.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 from pydantic import Field
 
 from mozaiksai.core.runtime.app.paths import (
+    APP_PROVENANCE_PATH,
     APP_SECURITY_SECRETS_PATH,
     disallowed_legacy_app_paths,
     noncanonical_app_config_paths,
@@ -1419,8 +1420,9 @@ def _validate_build_tasks(build_tasks: list[dict[str, Any]], managed_capability_
             raise ValueError(
                 "Build task "
                 f"'{task_id}' owns path(s) outside canonical app planes: {invalid_roots}. "
-                "Allowed app-root planes are admin, backend, brand, config, data, "
-                "modules, refinement_harness, security, services, and ui."
+                "Allowed app-root planes are admin, backend, brand, config, dashboard, "
+                "data, modules, refinement_harness, security, services, and ui, plus "
+                f"canonical root files such as app.json and {APP_PROVENANCE_PATH}."
             )
 
         invalid_config_paths = noncanonical_app_config_paths(owned_paths)

--- a/factory_app/workflows/AppGenerator/tools/code_file_utils.py
+++ b/factory_app/workflows/AppGenerator/tools/code_file_utils.py
@@ -100,7 +100,7 @@ def extract_deleted_file_paths_from_payload(payload: Any) -> list[str]:
 def collect_generated_app_file_map(
     generated_app_dir: Any,
     *,
-    allowed_roots: tuple[str, ...] = ("app.json", "ui", "brand", "config"),
+    allowed_roots: tuple[str, ...] = ("app.json", "provenance.yaml", "ui", "brand", "config"),
 ) -> dict[str, str]:
     """Read persisted schema artifacts from generated/apps/{app_id}/{build_id}/app.
 

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -292,8 +292,8 @@ def _scan_canonical_app_paths(files_map: dict[str, str]) -> list[str]:
         errors.append(
             "Generated app bundle contains files outside the canonical app planes: "
             f"{invalid_root_paths}. Allowed app-root planes are admin, backend, brand, "
-            "config, control_plane, data, modules, security, services, and ui, plus "
-            "explicit deployment files."
+            "config, dashboard, data, modules, refinement_harness, security, services, "
+            "and ui, plus provenance.yaml and explicit deployment files."
         )
     return errors
 

--- a/factory_app/workflows/AppGenerator/tools/save_app_schema.py
+++ b/factory_app/workflows/AppGenerator/tools/save_app_schema.py
@@ -21,6 +21,10 @@ from factory_app.workflows._shared.generated_ui_contract import (
 from factory_app.workflows.AppGenerator.tools.default_runtime_configs import (
     load_default_ai_config,
 )
+from mozaiksai.core.runtime.app.provenance import (
+    build_default_app_provenance,
+    dump_app_provenance_yaml,
+)
 from mozaiksai.core.workflow.ui_primitives import (
     get_page_ui_primitive_names,
     validate_page_ui_primitives,
@@ -28,7 +32,16 @@ from mozaiksai.core.workflow.ui_primitives import (
 
 _logger = logging.getLogger("tools.save_app_schema")
 
-PROMOTABLE_APP_ENTRIES = ("app.json", "ui", "brand", "config", "data", "security", "services")
+PROMOTABLE_APP_ENTRIES = (
+    "app.json",
+    "provenance.yaml",
+    "ui",
+    "brand",
+    "config",
+    "data",
+    "security",
+    "services",
+)
 
 
 def _repo_root() -> Path:
@@ -63,6 +76,14 @@ def _context_get(context_variables: Any | None, key: str) -> Any | None:
     if isinstance(context_variables, dict):
         return context_variables.get(key)
     return None
+
+
+def _context_text(context_variables: Any | None, key: str) -> str | None:
+    value = _context_get(context_variables, key)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
 
 
 def _safe_path_segment(value: Any, *, fallback: str) -> str:
@@ -1415,6 +1436,7 @@ def _persist_to_filesystem(
     asset_manifest: dict[str, Any] | None,
     data_contract: dict[str, Any] | None,
     custom_route_bundle: dict[str, Any] | None,
+    context_variables: Any | None = None,
     profile_layout: str | None = None,
 ) -> list[str]:
     """Write app.json, ui/pages/*.yaml, optional custom route artifacts, and optional config artifacts.
@@ -1446,6 +1468,40 @@ def _persist_to_filesystem(
     app_json_path.parent.mkdir(parents=True, exist_ok=True)
     app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
     written.append("app.json")
+
+    workflow_sequence = _context_text(context_variables, "workflow_sequence")
+    build_id = _context_text(context_variables, "build_id")
+    generated_artifact_id = _context_text(context_variables, "generated_artifact_id")
+    artifact_version_id = _context_text(context_variables, "artifact_version_id")
+    app_context_version_id = _context_text(context_variables, "app_context_version_id")
+
+    provenance_path = output_dir / "provenance.yaml"
+    provenance_path.write_text(
+        dump_app_provenance_yaml(
+            build_default_app_provenance(
+                app_kind="generated",
+                created_mode="factory",
+                workflow="AppGenerator",
+                workflow_sequence=workflow_sequence,
+                build_id=build_id,
+                artifact_version_id=artifact_version_id,
+                app_context_version_id=app_context_version_id,
+                artifact_refs={
+                    "generated_artifact_ids": [generated_artifact_id]
+                    if generated_artifact_id
+                    else [],
+                    "accepted_artifact_version_ids": [artifact_version_id]
+                    if artifact_version_id
+                    else [],
+                    "app_context_version_ids": [app_context_version_id]
+                    if app_context_version_id
+                    else [],
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+    written.append("provenance.yaml")
 
     # config/ai.json — runtime startup contract seeded from the current factory default.
     ai_config_path = output_dir / "config" / "ai.json"
@@ -1782,6 +1838,7 @@ def save_app_schema(
             asset_manifest,
             resolved_data_contract,
             custom_route_bundle,
+            context_variables=context_variables,
             profile_layout=_profile_layout,
         )
         _logger.info(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Use Studio: guides/studio/01-overview.md
       - Config Files:
           - Overview: guides/configs/index.md
+          - App Provenance: guides/configs/provenance.md
           - AI Startup: guides/configs/ai-startup.md
           - Subscriptions: guides/configs/subscriptions.md
           - Refinement: guides/configs/refinement.md

--- a/mozaiks_cli/agent_guidance/rules/app-bundle.md
+++ b/mozaiks_cli/agent_guidance/rules/app-bundle.md
@@ -1,7 +1,9 @@
 ---
 paths:
   - "app/app.json"
+  - "app/provenance.yaml"
   - "app/config/**"
+  - "app/dashboard/**"
   - "app/security/**"
   - "app/brand/**"
   - "scripts/**"
@@ -23,6 +25,10 @@ This workspace is a standalone Mozaiks app that consumes the installed
 - shell, navigation, footer, mobile chrome, shortcuts, and route-level chrome
   behavior belong in `app/config/shell.json`
 - AI startup behavior belongs in `app/config/ai.json`
+- app provenance, lineage, contract refs, and overlay refs belong in
+  `app/provenance.yaml`; do not store secrets, local absolute paths, provider
+  execution state, or runtime package pins there
+- Workspace/App Dashboard portals belong in `app/dashboard/dashboard.yaml`
 - secret requirements and vault/provider policy belong in `app/security/secrets.yaml`
   when needed; store names and handles only, never raw secret values
 - app identity and auth flags belong in `app/app.json`

--- a/mozaiks_cli/agent_guidance/templates/AGENTS.md
+++ b/mozaiks_cli/agent_guidance/templates/AGENTS.md
@@ -38,9 +38,11 @@ Two-terminal mode:
 This repo owns app-specific behavior only:
 
 - `app/app.json` - app identity and runtime flags
+- `app/provenance.yaml` - optional origin/refinement/contract lineage metadata
 - `app/config/` - AI, shell, and app config
 - `app/security/secrets.yaml` - names-only secret management contract; never stores raw values
 - `app/brand/` - app branding assets and theme config
+- `app/dashboard/dashboard.yaml` - optional Workspace/App Dashboard portal overlay
 - `app/services/` - optional app-owned support code such as thin integrations, provider adapters, and app-level routes
 - `app/modules/` - deterministic app capabilities
 - `app/data/contract.json` and `app/data/migrations/` - canonical app data contract and additive migration artifacts
@@ -70,6 +72,7 @@ See `.claude/rules/multi-agent-coordination.md` for the full protocol.
 - Do not copy hosted platform provider adapters into this app. Hosted deployment, DNS/domain, billing, wallet, and platform operations should be consumed through hosted API clients/facade modules and host-owned records.
 - Do not put business actions, lifecycle state, emitted events, or persistence authority in app-level service support code; modules own those behaviors.
 - Use `app/security/secrets.yaml` only as a names-only contract for secret provider/vault policy, env handles, and secret names. Never store raw API keys, tokens, passwords, connection strings, private keys, or webhook secrets in source.
+- Keep `app/provenance.yaml` to lineage, contract refs, and overlay refs only. Do not put secrets, local absolute paths, or provider execution state in provenance.
 - Prefer declarative page schemas before custom React.
 - Mount custom React only through `app/ui/route_manifest.json` and `app/ui/index.js`.
 - Keep shell/navigation changes in `app/config/shell.json`.

--- a/mozaiks_cli/agent_guidance/templates/CLAUDE.md
+++ b/mozaiks_cli/agent_guidance/templates/CLAUDE.md
@@ -12,9 +12,11 @@ Keep app logic inside the canonical app workspace:
 ```text
 app/
   app.json
+  provenance.yaml
   config/
   security/
   brand/
+  dashboard/
   services/  # optional integrations/adapters/routes support code
   modules/
   ui/
@@ -29,7 +31,9 @@ and web shell behavior.
 | Work | Location |
 |------|----------|
 | App identity/config | `app/app.json`, `app/config/` |
+| App provenance and contract refs | `app/provenance.yaml` |
 | Shell, navigation, footer, mobile chrome | `app/config/shell.json` |
+| Workspace/App Dashboard portals | `app/dashboard/dashboard.yaml` |
 | Secret management contract, names only | `app/security/secrets.yaml` |
 | Branding/theme assets | `app/brand/` |
 | App-owned external clients | `app/services/integrations/<service>_client.py` |
@@ -56,6 +60,7 @@ and web shell behavior.
 - Do not copy hosted platform provider adapters into this app; consume hosted deployment, DNS/domain, billing, wallet, and platform operations through hosted API clients/facade modules and host-owned records.
 - Do not copy framework runtime auth into the app; generic auth belongs in the installed `mozaiks` package.
 - Do not put raw secret values in `app/security/secrets.yaml`; it is a names-only contract.
+- Do not put secrets, local absolute paths, or provider execution state in `app/provenance.yaml`.
 - Do not use custom React when a declarative page schema is sufficient.
 - Do not mutate generated artifacts without review/promotion.
 

--- a/mozaiks_cli/commands/init.py
+++ b/mozaiks_cli/commands/init.py
@@ -7,11 +7,16 @@ import shutil
 import sys
 from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 from mozaiks_cli.agent_guidance import build_agent_guidance_files
 from mozaiks_cli.workspace import is_framework_repo_root
+from mozaiksai.core.runtime.app.provenance import (
+    build_default_app_provenance,
+    dump_app_provenance_yaml,
+)
 from mozaiksai.resources import resolve_factory_app_root, resolve_factory_brand_root
 
 # Tier definitions
@@ -289,6 +294,18 @@ def _create_bundle_scaffold(
   }
   _write_json(app_root / "app.json", app_json)
   print(f"Created app/app.json (preset={preset})")
+
+  _write_text(
+    app_root / "provenance.yaml",
+    dump_app_provenance_yaml(
+      build_default_app_provenance(
+        app_kind="hand_authored",
+        created_mode="cli",
+        overlays={"refinement_policy": "config/refinement_policy.yaml"},
+      )
+    ),
+  )
+  print("Created app/provenance.yaml")
 
   _write_json(config_dir / "ai.json", _build_ai_config(app_name, starter=starter))
   print("Created app/config/ai.json")
@@ -962,7 +979,7 @@ def _build_shell_config(app_name: str) -> dict:
 def _resolve_default_brand_template_dir() -> Path:
     resolved = resolve_factory_brand_root()
     if resolved is not None:
-        return resolved
+        return Path(resolved)
     return (Path(__file__).resolve().parents[2] / "factory_app" / "app" / "brand").resolve()
 
 
@@ -971,7 +988,9 @@ def _load_default_brand_theme_config(app_name: str) -> dict:
     if not template_path.exists():
         raise FileNotFoundError(f"Default brand template not found: {template_path}")
 
-    payload = json.loads(template_path.read_text(encoding="utf-8"))
+    payload: Any = json.loads(template_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Default brand theme config must be a JSON object: {template_path}")
 
     identity = payload.get("identity")
     if isinstance(identity, dict):

--- a/mozaiksai/core/runtime/app/__init__.py
+++ b/mozaiksai/core/runtime/app/__init__.py
@@ -11,6 +11,22 @@ from .definition import (
 from .entitlements import ConfiguredEntitlementAdapter
 from .loader import AppLoader, AppLoadError, AppLoadResult
 from .module_loader import ActionDef, LoadedModule, ModuleDefinition, ModuleLoader, ModuleLoadError
+from .provenance import (
+    DEFAULT_APP_CONTRACTS,
+    PROVENANCE_SCHEMA_VERSION,
+    AppProvenance,
+    AppProvenanceArtifactRefs,
+    AppProvenanceKind,
+    AppProvenanceLoadError,
+    AppProvenanceMode,
+    AppProvenanceRunRef,
+    build_default_app_provenance,
+    current_mozaiks_package_ref,
+    dump_app_provenance_yaml,
+    load_app_provenance,
+    resolve_app_provenance_path,
+    write_app_provenance,
+)
 
 _STUDIO_SUMMARY_EXPORTS = {
     "build_app_overview_summary",
@@ -37,6 +53,20 @@ __all__ = [
     "ModuleDefinition",
     "ActionDef",
     "ConfiguredEntitlementAdapter",
+    "DEFAULT_APP_CONTRACTS",
+    "PROVENANCE_SCHEMA_VERSION",
+    "AppProvenance",
+    "AppProvenanceArtifactRefs",
+    "AppProvenanceKind",
+    "AppProvenanceLoadError",
+    "AppProvenanceMode",
+    "AppProvenanceRunRef",
+    "build_default_app_provenance",
+    "current_mozaiks_package_ref",
+    "dump_app_provenance_yaml",
+    "load_app_provenance",
+    "resolve_app_provenance_path",
+    "write_app_provenance",
     *_STUDIO_SUMMARY_EXPORTS,
 ]
 

--- a/mozaiksai/core/runtime/app/loader.py
+++ b/mozaiksai/core/runtime/app/loader.py
@@ -29,6 +29,11 @@ from pydantic import ValidationError
 from logs.logging_config import get_workflow_logger
 from mozaiksai.core.runtime.app.definition import AppDefinition
 from mozaiksai.core.runtime.app.module_loader import LoadedModule, ModuleLoader
+from mozaiksai.core.runtime.app.provenance import (
+    AppProvenance,
+    AppProvenanceLoadError,
+    load_app_provenance,
+)
 from mozaiksai.core.runtime.app.subscriptions_loader import (
     SubscriptionsConfig,
     SubscriptionsLoadError,
@@ -58,6 +63,7 @@ class AppLoadResult:
         data_contract:        Parsed data contract, or None
         data_entities_by_key: Data entities indexed by (module_id, entity_name)
         subscriptions_config: Parsed subscriptions config, or None for non-SaaS apps
+        provenance:           Parsed app provenance, or None when not declared
         failed_module_names:  Names of modules that failed to load — empty on full success
     """
     definition: AppDefinition
@@ -65,6 +71,7 @@ class AppLoadResult:
     data_contract: dict[str, Any] | None = None
     data_entities_by_key: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
     subscriptions_config: SubscriptionsConfig | None = None
+    provenance: AppProvenance | None = None
     failed_module_names: list[str] = field(default_factory=list)
 
 
@@ -131,6 +138,11 @@ class AppLoader:
         except DataContractLoadError as exc:
             raise AppLoadError(f"Invalid data/contract.json: {exc}") from exc
 
+        try:
+            provenance = load_app_provenance(base_path)
+        except AppProvenanceLoadError as exc:
+            raise AppLoadError(f"Invalid provenance.yaml: {exc}") from exc
+
         subscriptions_config: SubscriptionsConfig | None = None
         try:
             subscriptions_config = load_subscriptions_config(base_path)
@@ -172,6 +184,7 @@ class AppLoader:
             data_contract=data_contract,
             data_entities_by_key=data_entities_by_key,
             subscriptions_config=subscriptions_config,
+            provenance=provenance,
             failed_module_names=failed_module_names,
         )
 

--- a/mozaiksai/core/runtime/app/paths.py
+++ b/mozaiksai/core/runtime/app/paths.py
@@ -12,6 +12,7 @@ APP_DATA_MIGRATIONS_GLOB = "data/migrations/*.json"
 APP_SECURITY_SECRETS_PATH = "security/secrets.yaml"
 APP_AUTH_CONFIG_PATH = "config/auth.yaml"
 APP_REFINEMENT_POLICY_CONFIG_PATH = "config/refinement_policy.yaml"
+APP_PROVENANCE_PATH = "provenance.yaml"
 
 CANONICAL_APP_CONFIG_FILES = frozenset(
     {
@@ -35,6 +36,7 @@ CANONICAL_APP_ROOT_FILES = frozenset(
         ".env.staging.example",
         "__init__.py",
         "app.json",
+        APP_PROVENANCE_PATH,
         "deployment.manifest.json",
         "docker-compose.yml",
         "index.html",
@@ -57,6 +59,7 @@ CANONICAL_APP_ROOT_DIRS = frozenset(
         ".github",
         "config",
         "data",
+        "dashboard",
         "modules",
         "refinement_harness",
         "security",
@@ -169,6 +172,7 @@ __all__ = [
     "APP_DATA_MIGRATIONS_DIR",
     "APP_DATA_MIGRATIONS_GLOB",
     "APP_AUTH_CONFIG_PATH",
+    "APP_PROVENANCE_PATH",
     "APP_REFINEMENT_POLICY_CONFIG_PATH",
     "APP_SECURITY_SECRETS_PATH",
     "CANONICAL_APP_CONFIG_FILES",

--- a/mozaiksai/core/runtime/app/provenance.py
+++ b/mozaiksai/core/runtime/app/provenance.py
@@ -1,0 +1,333 @@
+"""Optional app provenance contract for Mozaiks app bundles."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from mozaiksai.core.runtime.app.paths import APP_PROVENANCE_PATH
+from mozaiksai.version import __version__
+
+PROVENANCE_SCHEMA_VERSION = "mozaiks.provenance.v1"
+
+AppProvenanceKind = Literal["generated", "imported", "hand_authored", "app_zero"]
+AppProvenanceMode = Literal["factory", "cli", "import", "manual", "refinement"]
+
+DEFAULT_APP_CONTRACTS: dict[str, str] = {
+    "app": "mozaiks.app.v1",
+    "asset_manifest": "mozaiks.asset_manifest.v1",
+    "auth": "mozaiks.auth.v1",
+    "dashboard": "mozaiks.dashboard.v1",
+    "data": "mozaiks.data_contract.v1",
+    "module": "mozaiks.module.v1",
+    "provenance": PROVENANCE_SCHEMA_VERSION,
+    "refinement_harness": "mozaiks.refinement_harness.v1",
+    "security": "mozaiks.secrets.v1",
+    "subscriptions": "mozaiks.subscriptions.v1",
+    "workflow": "mozaiks.workflow.v1",
+}
+
+_KEY_RE = re.compile(r"^[a-z][a-z0-9_.-]*$")
+_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/@+-]*$")
+
+
+class AppProvenanceLoadError(ValueError):
+    """Raised when app/provenance.yaml is present but invalid."""
+
+
+def _clean_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("value must be a string")
+    text = value.strip()
+    return text or None
+
+
+def _clean_ref(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    if not _REF_RE.match(text):
+        raise ValueError(f"{field_name} contains unsupported characters")
+    return text
+
+
+def _clean_key(value: Any, *, field_name: str) -> str:
+    text = _clean_ref(value, field_name=field_name).lower()
+    if not _KEY_RE.match(text):
+        raise ValueError(
+            f"{field_name} must start with a lowercase letter and contain only lowercase "
+            "letters, numbers, underscores, dots, or hyphens"
+        )
+    return text
+
+
+def _clean_relative_path(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string path")
+    raw = value.replace("\\", "/").strip()
+    if not raw:
+        raise ValueError(f"{field_name} must be a non-empty relative path")
+    if raw.startswith("/"):
+        raise ValueError(f"{field_name} must be relative, not absolute")
+    if "://" in raw:
+        raise ValueError(f"{field_name} must be an app-bundle path, not a URL")
+    if raw.startswith("./"):
+        raw = raw[2:]
+    path = PurePosixPath(raw)
+    if path.is_absolute() or any(part == ".." for part in path.parts):
+        raise ValueError(f"{field_name} must not escape the app bundle")
+    if path.parts and ":" in path.parts[0]:
+        raise ValueError(f"{field_name} must not include a drive or scheme")
+    return str(path)
+
+
+def _clean_unique_refs(value: Any, *, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        ref = _clean_ref(item, field_name=f"{field_name}[{index}]")
+        if ref not in result:
+            result.append(ref)
+    return result
+
+
+class AppProvenanceRunRef(BaseModel):
+    """One factory, CLI, import, manual, or refinement touchpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: AppProvenanceMode
+    mozaiks_ref: str | None = None
+    workflow: str | None = None
+    workflow_sequence: str | None = None
+    build_id: str | None = None
+    artifact_version_id: str | None = None
+    app_context_version_id: str | None = None
+    timestamp: str | None = None
+    notes: str | None = None
+
+    @field_validator(
+        "mozaiks_ref",
+        "workflow",
+        "workflow_sequence",
+        "build_id",
+        "artifact_version_id",
+        "app_context_version_id",
+        "timestamp",
+        "notes",
+        mode="before",
+    )
+    @classmethod
+    def _optional_text(cls, value: Any) -> str | None:
+        return _clean_optional_text(value)
+
+
+class AppProvenanceArtifactRefs(BaseModel):
+    """Optional durable artifact/version references for factory-built apps."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    generated_artifact_ids: list[str] = Field(default_factory=list)
+    accepted_artifact_version_ids: list[str] = Field(default_factory=list)
+    app_context_version_ids: list[str] = Field(default_factory=list)
+
+    @field_validator(
+        "generated_artifact_ids",
+        "accepted_artifact_version_ids",
+        "app_context_version_ids",
+        mode="before",
+    )
+    @classmethod
+    def _refs(cls, value: Any, info: Any) -> list[str]:
+        return _clean_unique_refs(value, field_name=f"artifact_refs.{info.field_name}")
+
+
+class AppProvenance(BaseModel):
+    """Validated contents of ``app/provenance.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["mozaiks.provenance.v1"] = "mozaiks.provenance.v1"
+    app_kind: AppProvenanceKind = "hand_authored"
+    created_with: AppProvenanceRunRef
+    last_refined_with: AppProvenanceRunRef | None = None
+    last_validated_with: AppProvenanceRunRef | None = None
+    contracts: dict[str, str] = Field(default_factory=lambda: dict(DEFAULT_APP_CONTRACTS))
+    overlays: dict[str, str] = Field(default_factory=dict)
+    artifact_refs: AppProvenanceArtifactRefs = Field(default_factory=AppProvenanceArtifactRefs)
+    notes: list[str] = Field(default_factory=list)
+
+    @field_validator("contracts", mode="before")
+    @classmethod
+    def _contracts(cls, value: Any) -> dict[str, str]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise ValueError("contracts must be a mapping")
+        result: dict[str, str] = {}
+        for raw_key, raw_ref in value.items():
+            key = _clean_key(raw_key, field_name="contract key")
+            result[key] = _clean_ref(raw_ref, field_name=f"contracts.{key}")
+        return result
+
+    @field_validator("overlays", mode="before")
+    @classmethod
+    def _overlays(cls, value: Any) -> dict[str, str]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise ValueError("overlays must be a mapping")
+        result: dict[str, str] = {}
+        for raw_key, raw_path in value.items():
+            key = _clean_key(raw_key, field_name="overlay key")
+            result[key] = _clean_relative_path(raw_path, field_name=f"overlays.{key}")
+        return result
+
+    @field_validator("notes", mode="before")
+    @classmethod
+    def _notes(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("notes must be a list")
+        result: list[str] = []
+        for index, item in enumerate(value):
+            text = _clean_optional_text(item)
+            if text is None:
+                raise ValueError(f"notes[{index}] must be a non-empty string")
+            result.append(text)
+        return result
+
+
+def current_mozaiks_package_ref() -> str:
+    """Return a stable package-version provenance reference."""
+
+    return f"package:{__version__}"
+
+
+def build_default_app_provenance(
+    *,
+    app_kind: AppProvenanceKind = "hand_authored",
+    created_mode: AppProvenanceMode = "cli",
+    mozaiks_ref: str | None = None,
+    workflow: str | None = None,
+    workflow_sequence: str | None = None,
+    build_id: str | None = None,
+    artifact_version_id: str | None = None,
+    app_context_version_id: str | None = None,
+    contracts: Mapping[str, str] | None = None,
+    overlays: Mapping[str, str] | None = None,
+    artifact_refs: Mapping[str, Any] | None = None,
+    notes: list[str] | None = None,
+) -> AppProvenance:
+    """Build the default provenance document for a scaffolded or generated app."""
+
+    merged_contracts = dict(DEFAULT_APP_CONTRACTS)
+    if contracts:
+        merged_contracts.update(dict(contracts))
+
+    return cast(
+        AppProvenance,
+        AppProvenance.model_validate(
+            {
+                "schema_version": PROVENANCE_SCHEMA_VERSION,
+                "app_kind": app_kind,
+                "created_with": {
+                    "mode": created_mode,
+                    "mozaiks_ref": mozaiks_ref or current_mozaiks_package_ref(),
+                    "workflow": workflow,
+                    "workflow_sequence": workflow_sequence,
+                    "build_id": build_id,
+                    "artifact_version_id": artifact_version_id,
+                    "app_context_version_id": app_context_version_id,
+                },
+                "contracts": merged_contracts,
+                "overlays": dict(overlays or {}),
+                "artifact_refs": dict(artifact_refs or {}),
+                "notes": notes or [],
+            }
+        ),
+    )
+
+
+def resolve_app_provenance_path(app_root: str | Path) -> Path:
+    """Resolve the app-root-relative provenance path."""
+
+    return Path(app_root) / APP_PROVENANCE_PATH
+
+
+def dump_app_provenance_yaml(provenance: AppProvenance | Mapping[str, Any]) -> str:
+    """Serialize app provenance to deterministic YAML."""
+
+    model = (
+        provenance
+        if isinstance(provenance, AppProvenance)
+        else AppProvenance.model_validate(dict(provenance))
+    )
+    payload = model.model_dump(mode="json", exclude_none=True)
+    return cast(str, yaml.safe_dump(payload, allow_unicode=False, sort_keys=False))
+
+
+def write_app_provenance(
+    app_root: str | Path,
+    provenance: AppProvenance | Mapping[str, Any],
+) -> Path:
+    """Write ``provenance.yaml`` under an app root."""
+
+    path = resolve_app_provenance_path(app_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_app_provenance_yaml(provenance), encoding="utf-8")
+    return path
+
+
+def load_app_provenance(app_root: str | Path, *, required: bool = False) -> AppProvenance | None:
+    """Load optional ``provenance.yaml`` from an app root."""
+
+    path = resolve_app_provenance_path(app_root)
+    if not path.exists():
+        if required:
+            raise AppProvenanceLoadError(f"{APP_PROVENANCE_PATH} not found")
+        return None
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise AppProvenanceLoadError(f"Failed to read {APP_PROVENANCE_PATH}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise AppProvenanceLoadError(f"{APP_PROVENANCE_PATH} must be a YAML object")
+
+    try:
+        return cast(AppProvenance, AppProvenance.model_validate(raw))
+    except ValidationError as exc:
+        raise AppProvenanceLoadError(f"Invalid {APP_PROVENANCE_PATH}: {exc}") from exc
+
+
+__all__ = [
+    "DEFAULT_APP_CONTRACTS",
+    "PROVENANCE_SCHEMA_VERSION",
+    "AppProvenance",
+    "AppProvenanceArtifactRefs",
+    "AppProvenanceKind",
+    "AppProvenanceLoadError",
+    "AppProvenanceMode",
+    "AppProvenanceRunRef",
+    "build_default_app_provenance",
+    "current_mozaiks_package_ref",
+    "dump_app_provenance_yaml",
+    "load_app_provenance",
+    "resolve_app_provenance_path",
+    "write_app_provenance",
+]

--- a/mozaiksai/core/workflow/generator_support/code_files.py
+++ b/mozaiksai/core/workflow/generator_support/code_files.py
@@ -7,6 +7,11 @@ from typing import Any
 
 import yaml
 
+from mozaiksai.core.runtime.app.provenance import (
+    build_default_app_provenance,
+    dump_app_provenance_yaml,
+)
+
 _MODULE_CONTRACT_FILENAMES = {
     "admin.yaml",
     "events.yaml",
@@ -81,6 +86,13 @@ def _materialize_app_schema_file_map(payload: dict[str, Any]) -> dict[str, str]:
         "admins": [],
     }
     file_map["app.json"] = json.dumps(app_json, indent=2, ensure_ascii=False)
+    file_map["provenance.yaml"] = dump_app_provenance_yaml(
+        build_default_app_provenance(
+            app_kind="generated",
+            created_mode="factory",
+            workflow="AppGenerator",
+        )
+    )
 
     for page in pages:
         if not isinstance(page, dict):

--- a/tests/test_app_bundle_paths.py
+++ b/tests/test_app_bundle_paths.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 from mozaiksai.core.runtime.app.paths import (
+    APP_PROVENANCE_PATH,
     disallowed_legacy_app_paths,
     is_canonical_app_config_path,
     is_data_migration_path,
@@ -247,13 +248,18 @@ class TestNoncanonicalAppConfigPaths:
 
 class TestNoncanonicalAppRootPaths:
     def test_canonical_root_dir_excluded(self):
-        paths = ["modules/wallet/module.yaml", "config/ai.json"]
+        paths = [
+            "modules/wallet/module.yaml",
+            "config/ai.json",
+            "dashboard/dashboard.yaml",
+        ]
         result = noncanonical_app_root_paths(paths)
         assert not result  # both are under canonical root dirs
 
     def test_canonical_root_file_excluded(self):
         paths = [
             "app.json",
+            APP_PROVENANCE_PATH,
             "Dockerfile",
             "package.json",
             "requirements.txt",

--- a/tests/test_app_provenance_contract.py
+++ b/tests/test_app_provenance_contract.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from mozaiksai.core.runtime.app import AppLoader, AppLoadError
+from mozaiksai.core.runtime.app.provenance import (
+    AppProvenanceLoadError,
+    build_default_app_provenance,
+    dump_app_provenance_yaml,
+    load_app_provenance,
+    write_app_provenance,
+)
+
+
+def test_default_app_provenance_round_trips(tmp_path) -> None:
+    provenance = build_default_app_provenance(
+        app_kind="generated",
+        created_mode="factory",
+        workflow="AppGenerator",
+        workflow_sequence="full_build",
+        overlays={"dashboard": "dashboard/dashboard.yaml"},
+    )
+
+    path = write_app_provenance(tmp_path, provenance)
+    loaded = load_app_provenance(tmp_path)
+
+    assert path.name == "provenance.yaml"
+    assert loaded is not None
+    assert loaded.app_kind == "generated"
+    assert loaded.created_with.mode == "factory"
+    assert loaded.created_with.workflow == "AppGenerator"
+    assert loaded.contracts["dashboard"] == "mozaiks.dashboard.v1"
+    assert loaded.overlays["dashboard"] == "dashboard/dashboard.yaml"
+
+
+def test_missing_app_provenance_is_optional(tmp_path) -> None:
+    assert load_app_provenance(tmp_path) is None
+
+    with pytest.raises(AppProvenanceLoadError, match="provenance.yaml not found"):
+        load_app_provenance(tmp_path, required=True)
+
+
+@pytest.mark.parametrize("path", ["../secret.yaml", "/tmp/app.yaml", "C:/Repos/app.yaml", "https://example.test/app.yaml"])
+def test_app_provenance_rejects_unsafe_overlay_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="overlays"):
+        build_default_app_provenance(
+            app_kind="generated",
+            created_mode="factory",
+            overlays={"dashboard": path},
+        )
+
+
+def test_app_provenance_yaml_omits_null_fields() -> None:
+    payload = yaml.safe_load(
+        dump_app_provenance_yaml(
+            build_default_app_provenance(
+                app_kind="hand_authored",
+                created_mode="cli",
+            )
+        )
+    )
+
+    assert "workflow" not in payload["created_with"]
+    assert "last_refined_with" not in payload
+
+
+@pytest.mark.asyncio
+async def test_app_loader_loads_optional_provenance(tmp_path) -> None:
+    (tmp_path / "app.json").write_text(json.dumps({"appName": "Demo"}), encoding="utf-8")
+    write_app_provenance(
+        tmp_path,
+        build_default_app_provenance(
+            app_kind="hand_authored",
+            created_mode="cli",
+            overlays={"refinement_policy": "config/refinement_policy.yaml"},
+        ),
+    )
+
+    result = await AppLoader.load(str(tmp_path))
+
+    assert result.provenance is not None
+    assert result.provenance.app_kind == "hand_authored"
+    assert result.provenance.overlays["refinement_policy"] == "config/refinement_policy.yaml"
+
+
+@pytest.mark.asyncio
+async def test_app_loader_rejects_invalid_provenance(tmp_path) -> None:
+    (tmp_path / "app.json").write_text(json.dumps({"appName": "Demo"}), encoding="utf-8")
+    (tmp_path / "provenance.yaml").write_text(
+        """
+        schema_version: mozaiks.provenance.v1
+        app_kind: generated
+        created_with:
+          mode: factory
+        overlays:
+          dashboard: ../dashboard.yaml
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AppLoadError, match="Invalid provenance.yaml"):
+        await AppLoader.load(str(tmp_path))

--- a/tests/test_appgenerator_data_contract_services.py
+++ b/tests/test_appgenerator_data_contract_services.py
@@ -150,6 +150,7 @@ def test_structured_outputs_expose_data_contract() -> None:
 
 
 def test_config_is_the_promotable_data_contract_entry() -> None:
+    assert "provenance.yaml" in save_app_schema_module.PROMOTABLE_APP_ENTRIES
     assert "config" in save_app_schema_module.PROMOTABLE_APP_ENTRIES
     assert "data" in save_app_schema_module.PROMOTABLE_APP_ENTRIES
     assert "security" in save_app_schema_module.PROMOTABLE_APP_ENTRIES

--- a/tests/test_appgenerator_save_app_schema.py
+++ b/tests/test_appgenerator_save_app_schema.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 def _load_save_app_schema_module():
@@ -1137,6 +1138,10 @@ def test_save_app_schema_writes_to_generated_artifact_root(monkeypatch, tmp_path
 
     output_dir = generated_root / "apps" / "app-one" / "build-one" / "app"
     assert (output_dir / "app.json").exists()
+    provenance = yaml.safe_load((output_dir / "provenance.yaml").read_text(encoding="utf-8"))
+    assert provenance["schema_version"] == "mozaiks.provenance.v1"
+    assert provenance["created_with"]["workflow"] == "AppGenerator"
+    assert provenance["created_with"]["build_id"] == "build one"
     assert (output_dir / "ui" / "pages" / "Dashboard.yaml").exists()
     assert context.data["generated_app_dir"] == str(output_dir)
 
@@ -1156,6 +1161,7 @@ def test_promote_generated_app_copies_allowlisted_artifacts(tmp_path: Path) -> N
     (source / "config").mkdir()
     (source / "services" / "integrations").mkdir(parents=True)
     (source / "app.json").write_text('{"appName": "Demo"}', encoding="utf-8")
+    (source / "provenance.yaml").write_text("schema_version: mozaiks.provenance.v1\n", encoding="utf-8")
     (source / "ui" / "pages" / "Dashboard.yaml").write_text("name: Dashboard\n", encoding="utf-8")
     (source / "brand" / "theme_config.json").write_text("{}", encoding="utf-8")
     (source / "config" / "shell.json").write_text("{}", encoding="utf-8")
@@ -1167,8 +1173,9 @@ def test_promote_generated_app_copies_allowlisted_artifacts(tmp_path: Path) -> N
     result = save_app_schema_module.promote_generated_app(source, target)
 
     assert result["status"] == "success"
-    assert sorted(result["copied"]) == ["app.json", "brand", "config", "services", "ui"]
+    assert sorted(result["copied"]) == ["app.json", "brand", "config", "provenance.yaml", "services", "ui"]
     assert (target / "app.json").exists()
+    assert (target / "provenance.yaml").exists()
     assert (target / "ui" / "pages" / "Dashboard.yaml").exists()
     assert (target / "services" / "integrations" / "email_client.py").exists()
 

--- a/tests/test_cli_init_prompt.py
+++ b/tests/test_cli_init_prompt.py
@@ -1,6 +1,8 @@
 import json
 from argparse import Namespace
 
+import yaml
+
 from mozaiks_cli.commands import add as add_command
 from mozaiks_cli.commands import init_command
 from mozaiks_cli.main import create_parser
@@ -32,10 +34,16 @@ def test_init_command_prompts_for_name_when_missing(monkeypatch, tmp_path) -> No
 
     target_dir = tmp_path / "prompted-app"
     app_json = _load_json(target_dir / "app" / "app.json")
+    provenance = yaml.safe_load((target_dir / "app" / "provenance.yaml").read_text(encoding="utf-8"))
     ai_json = _load_json(target_dir / "app" / "config" / "ai.json")
     control_plane_runtime = (target_dir / "app" / "config" / "refinement_policy.yaml").read_text(encoding="utf-8")
     shell_json = _load_json(target_dir / "app" / "config" / "shell.json")
     assert app_json["appName"] == "prompted-app"
+    assert provenance["schema_version"] == "mozaiks.provenance.v1"
+    assert provenance["app_kind"] == "hand_authored"
+    assert provenance["created_with"]["mode"] == "cli"
+    assert provenance["contracts"]["dashboard"] == "mozaiks.dashboard.v1"
+    assert provenance["overlays"]["refinement_policy"] == "config/refinement_policy.yaml"
     assert ai_json["workflows"]["entry_point"] == "ValueEngine"
     assert "control_plane" not in ai_json
     assert "enabled: true" in control_plane_runtime
@@ -144,6 +152,8 @@ def test_init_command_creates_package_consumer_scaffold(tmp_path) -> None:
     assert "Standalone Workspace Setup" in agents_md
     assert "Do not assume a sibling checkout" in agents_md
     assert "app/modules/" in agents_md
+    assert "app/provenance.yaml" in agents_md
+    assert "app/dashboard/dashboard.yaml" in agents_md
     assert "app/services/" in agents_md
     assert "app/services/adapters/" in agents_md
     assert "app/services/security/" not in agents_md
@@ -161,6 +171,8 @@ def test_init_command_creates_package_consumer_scaffold(tmp_path) -> None:
     assert "app/services/integrations/<service>_client.py" in claude_md
     assert "app/services/adapters/<area>/<provider>.py" in claude_md
     assert "app/services/adapters/auth/<provider>.py" in claude_md
+    assert "app/provenance.yaml" in claude_md
+    assert "app/dashboard/dashboard.yaml" in claude_md
     assert "Secret management contract, names only" in claude_md
     assert "app/services/security/" not in claude_md
     assert "app/security/secrets.yaml" in claude_md

--- a/tests/test_dashboard_manifest.py
+++ b/tests/test_dashboard_manifest.py
@@ -15,6 +15,7 @@ from mozaiksai.core.dashboard import (
     load_dashboard_manifest,
     merge_dashboard_manifest_overlay,
 )
+from mozaiksai.core.runtime.app.paths import noncanonical_app_root_paths
 
 
 def _portal_ids(manifest: DashboardManifest, scope: str) -> list[str]:
@@ -145,6 +146,7 @@ def test_generator_file_contract_keeps_dashboard_separate_from_workflow_routing(
     )
 
     assert "dashboard/dashboard.yaml" in contract
+    assert noncanonical_app_root_paths(["dashboard/dashboard.yaml"]) == []
     assert "Workspace/App Dashboard portal structure belongs in dashboard/dashboard.yaml" in contract
     assert "workflows/extended_orchestration/extension_registry.json" in contract
     assert "The dashboard manifest may reference workflow sequences, but it does not define" in architecture_doc

--- a/tests/test_generated_bundle_scanner.py
+++ b/tests/test_generated_bundle_scanner.py
@@ -311,6 +311,8 @@ def test_scan_generated_bundle_accepts_runtime_project_manifests() -> None:
     errors = scan_generated_bundle(
         {
             "app.json": '{"name":"Demo"}',
+            "provenance.yaml": "schema_version: mozaiks.provenance.v1\ncreated_with:\n  mode: factory\n",
+            "dashboard/dashboard.yaml": "schema_version: mozaiks.dashboard.v1\n",
             "package.json": '{"scripts":{"build":"vite"}}',
             "requirements.txt": "fastapi\n",
             "vite.config.js": "export default {};\n",

--- a/tests/test_generator_code_file_materialization.py
+++ b/tests/test_generator_code_file_materialization.py
@@ -279,10 +279,15 @@ def test_extract_code_file_map_materializes_app_schema_output() -> None:
 
     assert set(file_map) == {
         "app.json",
+        "provenance.yaml",
         "brand/theme_config.json",
         "ui/pages/tickets.yaml",
     }
     assert '"appName": "Support Operations"' in file_map["app.json"]
+    provenance = yaml.safe_load(file_map["provenance.yaml"])
+    assert provenance["schema_version"] == "mozaiks.provenance.v1"
+    assert provenance["app_kind"] == "generated"
+    assert provenance["created_with"]["workflow"] == "AppGenerator"
     assert "name: Tickets" in file_map["ui/pages/tickets.yaml"]
 
 


### PR DESCRIPTION
## Summary
- add optional `app/provenance.yaml` runtime contract, loader support, and package entrypoints
- emit provenance from `mozaiks init` and AppGenerator materialization/promotion paths
- document provenance/dashboard as canonical app-bundle planes and update generated agent guidance
- add targeted tests for provenance validation, CLI scaffolds, generator output, promotion, scanner, and dashboard allowlisting

## App Zero Refinement Impact
- Root-cause category: `runtime/platform`, `AppGenerator`, `docs/tests`
- App Zero should consume this through the pinned OSS package and thin overlays instead of copying factory/default packs.
- If App Zero needs more generic lineage fields, merge semantics, or validation behavior, those should move into OSS first.

## Validation
- `python -m pytest --no-cov tests/test_app_provenance_contract.py tests/test_app_bundle_paths.py tests/test_cli_init_prompt.py tests/test_generator_code_file_materialization.py tests/test_appgenerator_save_app_schema.py tests/test_appgenerator_data_contract_services.py tests/test_dashboard_manifest.py tests/test_generated_bundle_scanner.py::test_scan_generated_bundle_accepts_runtime_project_manifests -q`
- `python -m ruff check mozaiksai/core/runtime/app/provenance.py mozaiksai/core/runtime/app/paths.py mozaiksai/core/runtime/app/__init__.py mozaiksai/core/runtime/app/loader.py mozaiks_cli/commands/init.py factory_app/workflows/AppGenerator/tools/save_app_schema.py mozaiksai/core/workflow/generator_support/code_files.py factory_app/workflows/AppGenerator/tools/code_file_utils.py factory_app/workflows/AppGenerator/tools/app_build_plan.py tests/test_app_provenance_contract.py tests/test_app_bundle_paths.py tests/test_cli_init_prompt.py tests/test_generator_code_file_materialization.py tests/test_appgenerator_save_app_schema.py tests/test_appgenerator_data_contract_services.py tests/test_dashboard_manifest.py tests/test_generated_bundle_scanner.py`
- `python -m mypy --follow-imports=skip mozaiksai/core/runtime/app/provenance.py mozaiksai/core/runtime/app/loader.py mozaiksai/core/runtime/app/paths.py mozaiksai/core/workflow/generator_support/code_files.py mozaiks_cli/commands/init.py factory_app/workflows/AppGenerator/tools/save_app_schema.py factory_app/workflows/AppGenerator/tools/code_file_utils.py factory_app/workflows/AppGenerator/tools/app_build_plan.py`
- `python -m mkdocs build --strict`
- `git diff --check`

Note: the same pytest selection passes with `--no-cov`; running the narrow subset without `--no-cov` exits non-zero on the repo-wide coverage floor even though all 144 tests pass.