### PR TITLE
fix(app): allow provenance in page task output

### DIFF
--- a/mozaiksai/core/workflow/task_batches.py
+++ b/mozaiksai/core/workflow/task_batches.py
@@ -959,6 +959,7 @@ def _optional_task_output_paths(task: dict[str, Any]) -> set[str]:
             "brand/theme_config.json",
             "config/asset_manifest.json",
             "data/contract.json",
+            "provenance.yaml",
             "config/shell.json",
             "ui/index.js",
             "ui/route_manifest.json",

--- a/tests/test_task_batch_contracts.py
+++ b/tests/test_task_batch_contracts.py
@@ -618,7 +618,7 @@ async def test_page_bundle_task_normalizes_owned_pages_from_app_plan() -> None:
     code_files = context["app_task_batch_results"]["pages"]["code_files"]
     output = context["app_task_batch_results"]["pages"]
     file_map = {entry["filename"]: entry["content"] for entry in code_files}
-    assert set(file_map) >= {"ui/pages/tickets.yaml", "ui/pages/settings.yaml"}
+    assert set(file_map) >= {"provenance.yaml", "ui/pages/tickets.yaml", "ui/pages/settings.yaml"}
     assert output["_page_materialization_source"] == "app_build_plan.pages"
     assert output["_page_materialized_paths"] == [
         "ui/pages/tickets.yaml",

--- a/tests/test_task_batches_extended_helpers.py
+++ b/tests/test_task_batches_extended_helpers.py
@@ -246,6 +246,7 @@ class TestOptionalTaskOutputPaths:
         result = _optional_task_output_paths({"task_type": "page_bundle"})
         assert "config/shell.json" in result
         assert "data/contract.json" in result
+        assert "provenance.yaml" in result
 
     def test_module_contract_with_module_id_returns_paths(self):
         task = {"task_type": "module_contract", "capability_pack_id": "billing"}

--- a/tests/test_workflow_ui_tool_contracts.py
+++ b/tests/test_workflow_ui_tool_contracts.py
@@ -198,7 +198,7 @@ def test_app_generator_page_contract_stays_declarative() -> None:
     assert "`AppBuildPlan.pages[]` is the authoritative persistent page inventory" in content
     assert "Do NOT plan a second raw-frontend lane inside AppGenerator." in content
     assert "Persistent page materialization is exclusively AppBuildPlan-driven" in content
-    assert "persistent app pages still belong in `app.json` + `ui/pages/*.yaml`" in content
+    assert "persistent app pages still belong in `app.json` + `provenance.yaml` + `ui/pages/*.yaml`" in content
     assert "ui/index.js" in content
     assert "theme_config_patch" in content
     assert "shell_config" in content


### PR DESCRIPTION
## Summary
- Allow deterministic `provenance.yaml` output from page-bundle task materialization.
- Lock the optional page-bundle system output in task-batch helper tests.
- Update the AppGenerator UI contract assertion to include the provenance artifact.

## Validation
- `python -m pytest --no-cov tests/test_task_batch_contracts.py::test_page_bundle_task_normalizes_owned_pages_from_app_plan tests/test_workflow_ui_tool_contracts.py::test_app_generator_page_contract_stays_declarative tests/test_task_batches_extended_helpers.py::TestOptionalTaskOutputPaths -q`
- `python -m pytest --no-cov tests/test_task_batch_contracts.py tests/test_workflow_ui_tool_contracts.py tests/test_task_batches_extended_helpers.py -q`
- `python -m ruff check mozaiksai/core/workflow/task_batches.py tests/test_task_batches_extended_helpers.py tests/test_task_batch_contracts.py tests/test_workflow_ui_tool_contracts.py`
- `git diff --check -- mozaiksai/core/workflow/task_batches.py tests/test_task_batch_contracts.py tests/test_task_batches_extended_helpers.py tests/test_workflow_ui_tool_contracts.py`