### PR TITLE
fix(web-shell): constrain Tailwind v4 source detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ tmpdist/
 # Playwright test outputs
 web_shell/test-results/
 web_shell/playwright-report/
+web_shell/.mozaiks-tailwind-sources/

--- a/tests/test_web_shell_vite_config.py
+++ b/tests/test_web_shell_vite_config.py
@@ -19,6 +19,10 @@ def _vite_config() -> str:
     return (_workspace() / "web_shell" / "vite.config.js").read_text(encoding="utf-8")
 
 
+def _styles_css() -> str:
+    return (_workspace() / "web_shell" / "styles.css").read_text(encoding="utf-8")
+
+
 # ── resolve.dedupe ──────────────────────────────────────────────────────────
 
 class TestResolveDedupe:
@@ -133,6 +137,52 @@ class TestDependencyScannerJsx:
         assert re.search(r"['\"]\.js['\"]\s*:\s*['\"]jsx['\"]", optimize_deps_region), (
             "optimizeDeps.rolldownOptions.moduleTypes must map '.js' to 'jsx' "
             "or Vite dev startup fails while scanning chat-ui/factory_app UI files."
+        )
+
+
+# ── Tailwind v4 source detection ─────────────────────────────────────────────
+
+class TestTailwindV4PackagedSourceDetection:
+    """
+    The web shell is built from both repo-local source and pip-installed package
+    source. Tailwind v4 automatic detection can traverse the wrong tree when
+    web_shell is copied into a Docker build workspace, so styles.css must use
+    explicit v4 CSS-first source detection and vite.config.js must expose the
+    same chat/factory/app source roots that Vite aliases.
+    """
+
+    def test_stylesheet_uses_css_first_tailwind_v4_contract(self) -> None:
+        styles = _styles_css()
+        assert '@import "tailwindcss" source(none);' in styles
+        assert "@config" not in styles, (
+            "web_shell/styles.css must not load tailwind.config.js through "
+            "@config. The legacy JS content contract can hang packaged "
+            "production builds under Tailwind v4."
+        )
+        assert '@source "./.mozaiks-tailwind-sources";' in styles
+        assert '@source not "./node_modules";' in styles
+        assert "@theme" in styles
+        assert "--color-primary: hsl(var(--mz-primary));" in styles
+        assert "--color-muted-foreground: hsl(var(--mz-muted-foreground));" in styles
+        assert "--radius-lg: var(--mz-radius);" in styles
+        assert "--font-chat-body:" in styles
+        assert "--border-width-3: 3px;" in styles
+
+    def test_vite_config_populates_tailwind_source_links(self) -> None:
+        source = _vite_config()
+        assert "ensureTailwindSourceLinks" in source
+        assert "tailwindSourceLinkRoot" in source
+        assert "fs.symlinkSync" in source
+        assert "'.mozaiks-tailwind-sources'" in source
+        assert "['chat-ui-src', chatUiSrcRoot]" in source
+        assert "['factory-app-ui', path.resolve(factoryAppRoot, 'app/ui')]" in source
+        assert "['factory-workflows', factoryWorkflowsRoot]" in source
+        assert "['platform-ui', path.resolve(platformAppDir, 'ui')]" in source
+        assert "['platform-workflows', platformWorkflowRoot]" in source
+        assert re.search(
+            r"viteFsAllow\s*=\s*Array\.from\(new Set\(\[.*tailwindSourceLinkRoot",
+            source,
+            re.DOTALL,
         )
 
 

--- a/web_shell/README.md
+++ b/web_shell/README.md
@@ -58,6 +58,17 @@ npm --prefix web_shell run dev -- --host 0.0.0.0 --port 3000 --strictPort
 - `PLATFORM_PATH` may target either an app bundle directory containing
   `app.json` or a workspace root containing `app/app.json`.
 
+## Tailwind Source Detection
+
+`styles.css` uses Tailwind v4 CSS-first source detection. It intentionally does
+not load `tailwind.config.js` through `@config`, because packaged Docker builds
+copy `web_shell/` beside dependency trees where automatic or legacy JS-config
+source detection can scan the wrong context.
+
+`vite.config.js` creates `web_shell/.mozaiks-tailwind-sources/` at startup with
+links to chat UI, Factory UI/workflows, and the active app/workflow roots.
+That directory is generated local state and is ignored by git.
+
 ## What You Usually Edit
 
 | Path | Role |

--- a/web_shell/styles.css
+++ b/web_shell/styles.css
@@ -1,5 +1,58 @@
-@import "tailwindcss";
-@config "./tailwind.config.js";
+@import "tailwindcss" source(none);
+
+/*
+   Tailwind v4 scans source files automatically by default. The web shell is
+   often copied out of the Python package and built beside large dependency
+   trees, so automatic detection can traverse the wrong build context. Keep
+   source detection explicit and let vite.config.js populate
+   .mozaiks-tailwind-sources with links to packaged chat UI, Factory UI, active
+   app UI, and workflow UI roots.
+*/
+@source "./";
+@source "./.mozaiks-tailwind-sources";
+@source not "./node_modules";
+@source not "./dist";
+@source not "./test-results";
+@source not "./playwright-report";
+
+@theme {
+  --color-background: hsl(var(--mz-background));
+  --color-foreground: hsl(var(--mz-foreground));
+  --color-primary: hsl(var(--mz-primary));
+  --color-primary-foreground: hsl(var(--mz-primary-foreground));
+  --color-secondary: hsl(var(--mz-secondary));
+  --color-secondary-foreground: hsl(var(--mz-secondary-foreground));
+  --color-muted: hsl(var(--mz-muted));
+  --color-muted-foreground: hsl(var(--mz-muted-foreground));
+  --color-accent: hsl(var(--mz-accent));
+  --color-accent-foreground: hsl(var(--mz-accent-foreground));
+  --color-destructive: hsl(var(--mz-destructive));
+  --color-destructive-foreground: hsl(var(--mz-destructive-foreground));
+  --color-success: hsl(var(--mz-success));
+  --color-success-foreground: hsl(var(--mz-success-foreground));
+  --color-warning: hsl(var(--mz-warning));
+  --color-warning-foreground: hsl(var(--mz-warning-foreground));
+  --color-card: hsl(var(--mz-card));
+  --color-card-foreground: hsl(var(--mz-card-foreground));
+  --color-popover: hsl(var(--mz-popover));
+  --color-popover-foreground: hsl(var(--mz-popover-foreground));
+  --color-border: hsl(var(--mz-border));
+  --color-input: hsl(var(--mz-input));
+  --color-ring: hsl(var(--mz-ring));
+
+  --radius-lg: var(--mz-radius);
+  --radius-md: calc(var(--mz-radius) - 2px);
+  --radius-sm: calc(var(--mz-radius) - 4px);
+
+  --font-sans: var(--mz-font-sans), system-ui, sans-serif;
+  --font-heading: var(--mz-font-heading), var(--mz-font-sans), system-ui, sans-serif;
+  --font-mono: var(--mz-font-mono), monospace;
+  --font-chat-body: var(--font-body, Rajdhani), ui-sans-serif, system-ui, sans-serif;
+  --font-chat-heading: var(--font-heading, Orbitron), ui-sans-serif, system-ui, sans-serif;
+  --font-logo: var(--font-logo, Fagrak Inline), ui-sans-serif, system-ui, sans-serif;
+
+  --border-width-3: 3px;
+}
 
 /* Base document styling driven entirely by brand.json CSS variables.
    These values are set at runtime by applyTheme() — nothing is hardcoded here.

--- a/web_shell/vite.config.js
+++ b/web_shell/vite.config.js
@@ -117,6 +117,37 @@ function normalizeFaviconPath(value) {
   return out || 'favicon.ico';
 }
 
+function tailwindSourceLinkType(target) {
+  const stats = fs.statSync(target);
+  if (!stats.isDirectory()) return 'file';
+  return process.platform === 'win32' ? 'junction' : 'dir';
+}
+
+function ensureTailwindSourceLinks(entries) {
+  const linkRoot = path.resolve(__dirname, '.mozaiks-tailwind-sources');
+
+  try {
+    fs.rmSync(linkRoot, { recursive: true, force: true });
+    fs.mkdirSync(linkRoot, { recursive: true });
+  } catch (error) {
+    console.warn(`[mozaiks-web-shell] Failed to prepare Tailwind source links: ${error.message}`);
+    return linkRoot;
+  }
+
+  for (const [name, target] of entries) {
+    if (!target || !fs.existsSync(target)) continue;
+
+    try {
+      const linkPath = path.join(linkRoot, name);
+      fs.symlinkSync(fs.realpathSync(target), linkPath, tailwindSourceLinkType(target));
+    } catch (error) {
+      console.warn(`[mozaiks-web-shell] Failed to link Tailwind source '${name}': ${error.message}`);
+    }
+  }
+
+  return linkRoot;
+}
+
 // Favicon — read from brand/theme_config.json if available (best-effort; runtime
 // theme loading via /api/theme-config is the authoritative source).
 export default defineConfig(({ mode }) => {
@@ -176,6 +207,13 @@ export default defineConfig(({ mode }) => {
 
   // Public (static) assets come from the active app bundle: <app>/brand
   const platformBrandDir = resolveBrandDir(platformAppDir, factoryBrandDir);
+  const tailwindSourceLinkRoot = ensureTailwindSourceLinks([
+    ['chat-ui-src', chatUiSrcRoot],
+    ['factory-app-ui', path.resolve(factoryAppRoot, 'app/ui')],
+    ['factory-workflows', factoryWorkflowsRoot],
+    ['platform-ui', path.resolve(platformAppDir, 'ui')],
+    ['platform-workflows', platformWorkflowRoot],
+  ]);
   const viteFsAllow = Array.from(new Set([
     __dirname,
     projectRoot,
@@ -189,6 +227,7 @@ export default defineConfig(({ mode }) => {
     chatUiRoot,
     chatUiSrcRoot,
     chatUiNodeModules,
+    tailwindSourceLinkRoot,
     path.resolve(__dirname, 'node_modules'),
   ]));
 


### PR DESCRIPTION
## Summary
- move web_shell Tailwind v4 tokens into CSS-first `@theme` declarations
- disable automatic Tailwind source detection and populate deterministic source links from Vite
- document and test the packaged web_shell source-detection contract

## Validation
- `python -m pytest --no-cov tests/test_web_shell_vite_config.py tests/test_contributor_guidance_framing.py::test_setup_and_chat_ui_guidance_use_web_shell_and_factory_app -q`
- `python -m ruff check tests/test_web_shell_vite_config.py`
- `npm --prefix web_shell run build`
- `git diff --check -- .gitignore web_shell/styles.css web_shell/vite.config.js web_shell/README.md tests/test_web_shell_vite_config.py`

## App Zero Impact
Fixes the packaged web shell Vite build hang hit by mozaiks-app after pinning the latest OSS ref.