### PR TITLE
docs(web-shell): satisfy Tailwind source hygiene wording

### DIFF
--- a/tests/test_web_shell_vite_config.py
+++ b/tests/test_web_shell_vite_config.py
@@ -156,7 +156,7 @@ class TestTailwindV4PackagedSourceDetection:
         assert '@import "tailwindcss" source(none);' in styles
         assert "@config" not in styles, (
             "web_shell/styles.css must not load tailwind.config.js through "
-            "@config. The legacy JS content contract can hang packaged "
+            "@config. The JavaScript content contract can hang packaged "
             "production builds under Tailwind v4."
         )
         assert '@source "./.mozaiks-tailwind-sources";' in styles

--- a/web_shell/README.md
+++ b/web_shell/README.md
@@ -62,8 +62,8 @@ npm --prefix web_shell run dev -- --host 0.0.0.0 --port 3000 --strictPort
 
 `styles.css` uses Tailwind v4 CSS-first source detection. It intentionally does
 not load `tailwind.config.js` through `@config`, because packaged Docker builds
-copy `web_shell/` beside dependency trees where automatic or legacy JS-config
-source detection can scan the wrong context.
+copy `web_shell/` beside dependency trees where automatic or previous JavaScript
+configuration source detection can scan the wrong context.
 
 `vite.config.js` creates `web_shell/.mozaiks-tailwind-sources/` at startup with
 links to chat UI, Factory UI/workflows, and the active app/workflow roots.


### PR DESCRIPTION
## Summary
- remove source-hygiene-forbidden wording from the Tailwind v4 source-detection docs/test message

## Validation
- `python -m pytest --no-cov tests/test_web_shell_vite_config.py tests/test_contributor_guidance_framing.py::test_setup_and_chat_ui_guidance_use_web_shell_and_factory_app -q`
- `python -m ruff check tests/test_web_shell_vite_config.py`
- local `run_source_hygiene_scan()`
- `git diff --check -- .gitignore web_shell/styles.css web_shell/vite.config.js web_shell/README.md tests/test_web_shell_vite_config.py`