### PR TITLE
feat(refinement): support default harness overlays

### DIFF
--- a/docs/architecture/app/refinement-harness.md
+++ b/docs/architecture/app/refinement-harness.md
@@ -2,91 +2,55 @@
 title: App-Local Refinement Harness
 status: Authoritative - Pre-Production, Canonical Contract
 created: 2026-06-02
+updated: 2026-07-29
 depends_on: ../workflows/refinement-harness-architecture.md, ../workflows/refinement-engine.md
 ---
 
 # App-Local Refinement Harness
 
-This document defines what an app-local refinement harness looks like for a
-generated app workspace. It is the canonical reference for AppGenerator when
-emitting a `refinement_harness` build task.
+Most Mozaiks apps do not need an app-local refinement harness. The packaged OSS
+default `mozaiks.default_refinement_harness` owns the standard artifact routes,
+checkpoints, prompts, tools, and deterministic policies used by generated apps.
 
-Read [refinement-harness-architecture.md](../workflows/refinement-harness-architecture.md)
-first — it covers the ownership model, harness model, and AG2 implementation
-details that this document builds on.
-
----
-
-## When An App Needs A Refinement Harness
-
-Most generated apps do **not** need an app-local refinement harness. Default to
-ordinary workflow launches, module actions, and `extension_registry.json`
-workflow sequences.
-
-Add an app-local harness only when the generated app explicitly needs:
-
-- checkpointed refinement routing (classify → route → decide → patch/plan)
-- scoped coding worker support (bounded patch refinement against owned files)
-- contract surface planning (map a request to specific contract surfaces before
-  re-entering a workflow sequence)
-- multi-artifact routing (concept, design_docs, workflow_bundle, app_bundle each
-  needing separate change-class routes)
-
-If the app only needs to launch a single workflow in response to user input,
-use `extension_registry.json` sequences and transitions instead.
-
----
+Generated apps that enable refinement should carry an explicit
+`refinement_harness/config/harness.yaml` overlay. When there is no app-specific
+delta, the overlay is just `extends: mozaiks.default_refinement_harness` plus
+`overrides: {}`. The app-local file is an overlay, not a copied pack.
 
 ## File Layout
-
-A generated app refinement harness lives at the workspace root:
 
 ```text
 app/
   config/
-    refinement_policy.yaml required — LLM profiles and capability feature flags
+    ai.json
+    refinement_policy.yaml
 refinement_harness/
   config/
-    harness.yaml    required — harness manifest, routing, checkpoints
-    tools.yaml            required — context tool declarations
-    policies.yaml         optional — deterministic scope bounds
+    harness.yaml
+    tools.yaml
+    policies.yaml
   prompts/
-    change_classifier_system.yaml     required when request_submitted is declared
-    coding_scope_selection_system.yaml  required when scope_requested is declared
-    coding_refinement_system.yaml       required when coding_requested is declared
-    contract_surface_selection_system.yaml  required when contract_surface_requested is declared
+    *.yaml
+workflows/
+  extended_orchestration/
+    extension_registry.json
 ```
 
-The `app/config/ai.json` file owns ask/chat/workflow startup. The LLM profile
-policy lives beside it in `app/config/refinement_policy.yaml`; both files are
-separate from the `refinement_harness/` directory.
+Required for refinement:
 
----
+- `app/config/refinement_policy.yaml`
+- `refinement_harness/config/harness.yaml`
 
-## `app/config/ai.json` — Startup Boundary
+Optional overlay files:
 
-Startup config does not declare refinement routing, checkpoints, prompt content,
-or policy. Keep ask/chat/workflow startup in `app/config/ai.json`; put
-refinement model policy in `app/config/refinement_policy.yaml`; put refinement
-routes, checkpoints, prompts, and tools under `refinement_harness/`.
+- `refinement_harness/config/tools.yaml`
+- `refinement_harness/config/policies.yaml`
+- `refinement_harness/prompts/*.yaml`
 
-```json
-{
-  "chat": {
-    "chat_startup_mode": "ask"
-  },
-  "workflows": {
-    "entry_point": "ValueEngine"
-  }
-}
-```
+`app/config/ai.json` owns ask/chat/workflow startup. It does not declare
+refinement routing, checkpoint prompts, or scoped coding policy.
 
----
-
-## `app/config/refinement_policy.yaml` — Minimal Starter
-
-Declares LLM profiles for each capability. The classifier and codegen profiles
-are the two required for refinement-capable apps.
+## Minimal Policy
 
 ```yaml
 schema_version: mozaiks.refinement.policy.v1
@@ -95,7 +59,7 @@ profile: default
 
 llm_profiles:
   classifier:
-    purpose: Classify refinement requests into the stable change classes.
+    purpose: Classify refinement requests into stable change classes.
     expected_behavior: deterministic structured classification
     llm_config:
       model: gpt-5-nano
@@ -117,291 +81,143 @@ coding:
   llm_profile: codegen
 ```
 
-Add `contract_surface` when `contract_surface_requested` is included:
+Add `contract_surface` only when the app uses contract-surface planning:
 
 ```yaml
-  contract_surface:
-    enabled: true
-    llm_profile: codegen
+contract_surface:
+  enabled: true
+  llm_profile: codegen
 ```
 
----
+## Minimal Overlay
 
-## `refinement_harness/config/harness.yaml` — Minimal Starter (app_bundle only)
-
-The minimal harness for a generated app that supports `app_bundle` refinement with
-patch coding support:
+Use this when the packaged default is acceptable:
 
 ```yaml
 schema_version: mozaiks.refinement_harness.v1
-profile:
-  id: <app_id>
-  display_name: <AppName> Harness
-  description: App-local refinement harness for <AppName>.
-
-harness:
-  implementation: mozaiksai.control_plane.implementations.orchestration_control:OrchestrationControlHarness
-
-routing:
-  default_artifact_kind: app_bundle
-  artifacts:
-    - artifact_kind: app_bundle
-      label: app bundle
-      routes:
-        patch:
-          workflow_sequence: app_revision
-        design:
-          workflow_sequence: app_surface_revision
-        feature:
-          workflow_sequence: app_revision
-        core:
-          workflow_sequence: full_rebuild
-
-checkpoints:
-  - id: request_intake
-    event: request_submitted
-    entrypoint: mozaiksai.control_plane.implementations.change_classifier:LLMChangeClassifier
-    prompt_id: change_classifier_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-
-  - id: refinement_route
-    event: route_requested
-    entrypoint: mozaiksai.control_plane.implementations.refinement_router:RefinementTriggerRouteResolver
-
-  - id: decision
-    event: decision_requested
-    entrypoint: mozaiksai.control_plane.implementations.harness_decision:FirstPartyHarnessDecisionPolicy
-
-  - id: scope_selection
-    event: scope_requested
-    entrypoint: mozaiksai.control_plane.implementations.scope_proposer:ArtifactScopeProposer
-    prompt_id: coding_scope_selection_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-      - get_artifact_workspace_catalog
-
-  - id: coding_refinement
-    event: coding_requested
-    entrypoint: mozaiksai.control_plane.implementations.coding_worker:ScopedRefinementCodingWorker
-    prompt_id: coding_refinement_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-      - get_artifact_workspace_scope
+extends: mozaiks.default_refinement_harness
+overrides: {}
 ```
 
-Replace `<app_id>` and `<AppName>` with the generated app's id and display
-name. The `workflow_sequence` ids must exist in the app's
-`workflows/extended_orchestration/extension_registry.json`.
-
-### Adding Contract Surface Planning
-
-To add contract surface planning (for feature/design refinements that need
-surface-level targeting before workflow re-entry), add the checkpoint:
+Add only real app-specific deltas, such as an app-local context tool:
 
 ```yaml
-  - id: contract_surface_planning
-    event: contract_surface_requested
-    entrypoint: mozaiksai.control_plane.implementations.contract_surface_planner:ContractSurfacePlanner
-    prompt_id: contract_surface_selection_system
-    tool_ids:
-      - get_contract_surface_context
+schema_version: mozaiks.refinement_harness.v1
+extends: mozaiks.default_refinement_harness
+overrides:
+  checkpoints:
+    - event: coding_requested
+      append_tool_ids:
+        - app_local_context
 ```
 
-And add `contract_surface` to `refinement_policy.yaml` as shown above.
+The default harness continues to supply the standard routes, prompts, tools, and
+checkpoint declarations. The overlay only states what changes.
 
-### Multi-Artifact Routing
+## Routing Deltas
 
-For apps with multiple artifact kinds, add each as a separate entry under
-`routing.artifacts`. Each artifact kind routes independently:
+Add or adjust artifact routes under `overrides.routing.artifacts`.
+`artifact_kind` is the merge key.
 
 ```yaml
-routing:
-  default_artifact_kind: app_bundle
-  artifacts:
-    - artifact_kind: concept
-      label: concept
-      routes:
-        patch:
-          workflow_sequence: concept_patch
-        design:
-          workflow_sequence: full_rebuild
-        feature:
-          workflow_sequence: full_rebuild
-        core:
-          workflow_sequence: conceptual_replan
-    - artifact_kind: app_bundle
-      label: app bundle
-      routes:
-        patch:
-          workflow_sequence: app_revision
-        design:
-          workflow_sequence: app_surface_revision
-        feature:
-          workflow_sequence: app_revision
-        core:
-          workflow_sequence: full_rebuild
+schema_version: mozaiks.refinement_harness.v1
+extends: mozaiks.default_refinement_harness
+overrides:
+  routing:
+    artifacts:
+      - artifact_kind: report_bundle
+        label: report bundle
+        routes:
+          patch:
+            workflow_sequence: report_patch
+          design:
+            workflow_sequence: report_revision
+          feature:
+            workflow_sequence: report_revision
+          core:
+            workflow_sequence: full_rebuild
 ```
 
----
+Every `workflow_sequence` referenced by the effective harness must exist in
+`workflows/extended_orchestration/extension_registry.json` and must declare
+`affected_declarative_families`.
 
-## `refinement_harness/config/tools.yaml` — Minimal Starter
+## Tool Deltas
 
-Context tools used by checkpoints. The minimal set for the starter pack above:
+App-local tools live in `refinement_harness/config/tools.yaml`. They merge with
+the packaged tool manifest by `id`.
 
 ```yaml
 schema_version: mozaiks.refinement_harness.tools.v1
 tools:
-  - id: get_revision_context
+  - id: app_local_context
     kind: context_tool
-    description: Load session state, artifact lineage, and canonical inputs.
-    entrypoint: mozaiksai.control_plane.tools.get_revision_context:get_revision_context
-    available_to:
-      - request_submitted
-      - scope_requested
-      - coding_requested
-
-  - id: get_artifact_summary
-    kind: context_tool
-    description: Load artifact lineage, validation status, and recent change history.
-    entrypoint: factory_app.refinement_harness.tools.get_artifact_summary:get_artifact_summary
-    available_to:
-      - request_submitted
-      - scope_requested
-      - coding_requested
-
-  - id: get_artifact_workspace_catalog
-    kind: context_tool
-    description: Load workspace catalog and candidate files for scope selection.
-    entrypoint: factory_app.refinement_harness.tools.get_artifact_workspace_catalog:get_artifact_workspace_catalog
-    available_to:
-      - scope_requested
-
-  - id: get_artifact_workspace_scope
-    kind: context_tool
-    description: Load workspace tree and related-file previews for scoped coding.
-    entrypoint: factory_app.refinement_harness.tools.get_artifact_workspace_scope:get_artifact_workspace_scope
+    description: Load app-local refinement context.
+    entrypoint: app.refinement_tools:app_local_context
     available_to:
       - coding_requested
 ```
 
-`get_revision_context` is a framework-provided tool at
-`mozaiksai.control_plane.tools.*`. The workspace and artifact tools are
-first-party builder tools at `factory_app.refinement_harness.tools.*`.
+Do not add custom harness runtime Python. If a tool is generally useful to
+future generated apps, add it to the OSS default harness instead.
 
----
+## Prompt Deltas
 
-## `refinement_harness/config/policies.yaml` — Optional
-
-Scope size limits and overflow behavior. Omit when defaults are acceptable.
+Prompt overrides must be referenced explicitly from `overrides.prompts`.
 
 ```yaml
-schema_version: mozaiks.refinement_harness.policies.v1
-scope:
-  max_selected_paths: 3
-  auto_apply_max_paths: 1
-  overflow_behavior: clarify
+schema_version: mozaiks.refinement_harness.v1
+extends: mozaiks.default_refinement_harness
+overrides:
+  prompts:
+    coding_refinement_system: refinement_harness/prompts/coding_refinement_system.yaml
 ```
 
-- `max_selected_paths` — maximum file paths allowed in a scoped refinement
-- `auto_apply_max_paths` — auto-apply without confirmation at or below this count
-- `overflow_behavior` — `clarify` (ask user) or `workflow` (escalate to full workflow)
-
----
-
-## Prompts
-
-Each LLM-backed checkpoint requires a prompt file. Generated apps should adapt
-the factory_app prompts to their domain.
-
-### `prompts/change_classifier_system.yaml`
-
-Minimal starter:
-
-```yaml
-id: change_classifier_system
-content: |
-  You are the authoritative refinement change classifier for <AppName>.
-
-  Classify the request into exactly one of:
-  - patch: targeted fix or localized correction within the current artifact boundary
-  - design: visual, UX, or schema revision without changing the product concept
-  - feature: additive capability within the current product direction
-  - core: change in value proposition, target user, product identity, or architecture
-
-  Rules:
-  - Use the request text as the primary signal.
-  - Use any provided refinement_context_json as canonical persisted builder state.
-  - Treat any user-declared hint as advisory only.
-  - Be conservative about core, but choose it when the request changes what the product fundamentally is.
-  - Return JSON only. Do not include markdown fences.
-  - Keep signals short and semantic.
-```
-
-The factory_app `change_classifier_system.yaml` includes staleness-aware routing
-rules and artifact family dependency guidance — include those when the app
-supports multi-artifact routing.
-
-### `prompts/coding_scope_selection_system.yaml`
-
-```yaml
-id: coding_scope_selection_system
-content: |
-  You are the scope selection agent for <AppName> patch refinements.
-
-  Your job is to pick the narrowest safe file scope for a patch request.
-
-  Rules:
-  - Prefer one file when possible.
-  - Only choose file paths that appear in the provided workspace catalog.
-  - Use the Context Graph catalog when available to identify related files.
-  - Resolution options: scoped_files, clarify, workflow.
-  - Return JSON only. Do not include markdown fences.
-```
-
-### `prompts/coding_refinement_system.yaml`
+The prompt file must declare the same id:
 
 ```yaml
 id: coding_refinement_system
 content: |
-  You are the scoped coding refinement worker for <AppName>.
-
-  Your job is to produce a bounded patch-style refinement against explicit file inputs.
-
-  Rules:
-  - Stay scoped to the provided file paths.
-  - Return complete updated file content for every changed file in updated_files.
-  - Only edit files that appear in the provided explicit file inputs.
-  - Use refinement_context, especially Context Graph scope, to understand nearby files and symbols.
-  - Prefer the smallest safe validation strategy.
-  - Return JSON only. Do not include markdown fences.
+  You are the scoped coding refinement worker for this app.
 ```
 
----
+## Policy Deltas
 
-## Route Rules
+Use `refinement_harness/config/policies.yaml` only for deterministic scope
+policy differences:
 
-- `workflow_sequence` values in `harness.yaml` must exist in
-  `workflows/extended_orchestration/extension_registry.json`.
-- `affected_declarative_families` and `affected_workflows` belong on the
-  sequence in `extension_registry.json`, not in `harness.yaml`.
-- Do not declare `requires_replanning` or `requires_rebuild` in route manifests;
-  these are derived from the typed change class at runtime.
-- `patch` → does not require replanning; eligible for scoped coding worker.
-- `design`, `feature`, `core` → require replanning; route to workflow re-entry.
+```yaml
+schema_version: mozaiks.refinement_harness.policies.v1
+scope:
+  max_selected_paths: 5
+```
 
----
+Unspecified policy fields keep the packaged default values.
+
+## Merge Rules
+
+- `schema_version` must match the packaged schema.
+- `extends` must be `mozaiks.default_refinement_harness`.
+- manifest deltas live under `overrides`.
+- scalar values override the packaged value.
+- object values merge recursively by key.
+- `routing.artifacts` merge by `artifact_kind`.
+- `checkpoints` merge by `event`.
+- checkpoint `tool_ids` replace the packaged list.
+- checkpoint `append_tool_ids` adds tool ids while preserving packaged order.
+- `config/tools.yaml` merges tools by `id`.
+- `config/policies.yaml` merges policy objects by key.
+- `overrides.prompts` maps prompt id to app-local prompt path.
 
 ## What Not To Generate
 
-Generated refinement harnesses are declarative only:
+Generated refinement harness overlays are declarative only:
 
-- no `module.yaml` — the harness is not a module
-- no `app/modules/*/backend/control_plane*.py` — no custom harness Python
-- no business-domain logic in prompts
-- no hardcoded model names as prompt content — model config belongs in `refinement_policy.yaml`
-- no `affected_workflows` or `affected_families` in `harness.yaml` routes
-- no `context_variables.yaml` — the harness is not a workflow
+- no `module.yaml`; the harness is not a module
+- no `app/modules/*`
+- no `backend/control_plane/*.py`
+- no custom harness Python
+- no business-domain logic in generic prompts
+- no model names in prompt content; model config belongs in `refinement_policy.yaml`
+- no `affected_workflows` or `affected_declarative_families` in harness routes
+- no `context_variables.yaml`; the harness is not a workflow

--- a/docs/architecture/workflows/refinement-harness-architecture.md
+++ b/docs/architecture/workflows/refinement-harness-architecture.md
@@ -311,8 +311,9 @@ refinement_harness/config/harness.yaml  artifact routes and LLM-backed checkpoin
 `app/config/refinement_policy.yaml` provides model config. `harness.yaml` does
 not point to Python implementation files.
 
-The declarative pack lives under `factory_app/refinement_harness/` or an app-local
-override at `<workspace>/refinement_harness/`.
+The packaged default pack lives under `factory_app/refinement_harness/`. An
+app-local `<workspace>/refinement_harness/` directory is an overlay when
+`config/harness.yaml` declares `extends: mozaiks.default_refinement_harness`.
 
 ## Generated App Authoring
 
@@ -320,13 +321,14 @@ Most generated apps do not need an app-local Refinement Engine. They should use
 ordinary workflow launches, module actions, and `extension_registry.json`
 workflow sequences first.
 
-AppGenerator may emit an app-local harness only when the product explicitly
-needs checkpointed lifecycle, refinement, session, or coding-control behavior
-that cannot be expressed as normal workflow transitions.
+AppGenerator may emit an app-local harness overlay only when the product
+explicitly needs checkpointed lifecycle, refinement, session, or coding-control
+behavior that cannot be expressed by the packaged default harness plus normal
+workflow transitions.
 
 See [app/refinement-harness.md](../../architecture/app/refinement-harness.md)
-for the full starter pack reference, annotated templates, and guidance on which
-checkpoints and tools a generated app should include.
+for the overlay contract and guidance on which deltas a generated app should
+include.
 
 ### Ownership Split
 
@@ -334,7 +336,7 @@ Keep startup separate from the harness pack:
 
 - `app/config/ai.json` owns `ask`, `chat`, and `workflows` startup
 - `app/config/refinement_policy.yaml` owns runtime policy (LLM profiles, feature flags)
-- `refinement_harness/config/harness.yaml` owns declarative checkpoints and routing
+- `refinement_harness/config/harness.yaml` owns app-local checkpoint and routing deltas
 
 ### AppGenerator Build Task
 
@@ -348,12 +350,12 @@ initial_agent: RefinementHarnessAgent
 owned_paths:
   - app/config/refinement_policy.yaml
   - refinement_harness/config/harness.yaml
-  - refinement_harness/config/tools.yaml
 ```
 
 Optional owned paths:
 
 ```yaml
+- refinement_harness/config/tools.yaml
 - refinement_harness/config/policies.yaml
 - refinement_harness/prompts/*.yaml
 ```
@@ -368,8 +370,8 @@ Generated refinement harnesss are declarative only:
 - no custom harness Python
 - no business-domain logic
 
-The generated pack uses shipped `mozaiksai.control_plane` implementations and
-declared tool entrypoints from `mozaiksai.control_plane.tools.*` and
+The generated overlay uses shipped `mozaiksai.control_plane` implementations
+and declared tool entrypoints from `mozaiksai.control_plane.tools.*` and
 `factory_app.refinement_harness.tools.*`. Custom harness Python is not a v1
 generator contract.
 
@@ -389,10 +391,8 @@ generator contract.
 
 Declares:
 
-- harness entrypoint
 - artifact routing
 - checkpoint events
-- handler entrypoints
 - prompt ids
 - tool ids
 
@@ -400,12 +400,22 @@ Example:
 
 ```yaml
 schema_version: mozaiks.refinement_harness.v1
-profile:
-  id: factory_app
-  display_name: Factory App Harness
-  description: First-party declarative refinement harness for the Mozaiks build experience.
-harness:
-  implementation: mozaiksai.control_plane.implementations.orchestration_control:OrchestrationControlHarness
+extends: mozaiks.default_refinement_harness
+overrides:
+  routing:
+    artifacts:
+      - artifact_kind: app_bundle
+        label: app bundle
+  checkpoints:
+    - event: coding_requested
+      append_tool_ids:
+        - app_local_context
+```
+
+The packaged default expands to an effective manifest with this shape:
+
+```yaml
+schema_version: mozaiks.refinement_harness.v1
 routing:
   default_artifact_kind: app_bundle
   artifacts:
@@ -420,47 +430,53 @@ routing:
           workflow_sequence: app_revision
         core:
           workflow_sequence: full_rebuild
+    - artifact_kind: theme_config
+      label: theme config
+      routes:
+        patch:
+          workflow_sequence: theme_patch
+        design:
+          workflow_sequence: theme_revision
+        feature:
+          workflow_sequence: theme_revision
+        core:
+          workflow_sequence: full_rebuild
 checkpoints:
-  - id: request_intake
-    event: request_submitted
-    entrypoint: mozaiksai.control_plane.implementations.change_classifier:LLMChangeClassifier
+  - event: request_submitted
     prompt_id: change_classifier_system
     tool_ids:
       - get_revision_context
       - get_artifact_summary
-
-  - id: refinement_route
-    event: route_requested
-    entrypoint: mozaiksai.control_plane.implementations.refinement_router:RefinementTriggerRouteResolver
-
-  - id: decision
-    event: decision_requested
-    entrypoint: mozaiksai.control_plane.implementations.harness_decision:FirstPartyHarnessDecisionPolicy
-
-  - id: scope_selection
-    event: scope_requested
-    entrypoint: mozaiksai.control_plane.implementations.scope_proposer:ArtifactScopeProposer
+      - get_app_intelligence_context
+      - get_stale_artifact_families
+  - event: route_requested
+  - event: decision_requested
+  - event: scope_requested
     prompt_id: coding_scope_selection_system
     tool_ids:
       - get_revision_context
       - get_artifact_summary
+      - get_app_intelligence_context
       - get_artifact_workspace_catalog
-
-  - id: contract_surface_planning
-    event: contract_surface_requested
-    entrypoint: mozaiksai.control_plane.implementations.contract_surface_planner:ContractSurfacePlanner
+      - get_context_graph_catalog
+      - search_app_source_context
+  - event: contract_surface_requested
     prompt_id: contract_surface_selection_system
     tool_ids:
       - get_contract_surface_context
-
-  - id: coding_refinement
-    event: coding_requested
-    entrypoint: mozaiksai.control_plane.implementations.coding_worker:ScopedRefinementCodingWorker
+      - get_app_intelligence_context
+      - search_app_source_context
+  - event: coding_requested
     prompt_id: coding_refinement_system
     tool_ids:
       - get_revision_context
       - get_artifact_summary
+      - get_app_intelligence_context
       - get_artifact_workspace_scope
+      - get_context_graph_scope
+      - search_app_source_context
+      - read_app_source_file
+      - get_related_app_source_files
 ```
 
 Route rules:
@@ -478,21 +494,37 @@ Route rules:
 - Do not declare `requires_rebuild`; Refinement Engine rebuild decisions are
   runtime decision outputs, not route manifest inputs.
 
+Overlay merge rules:
+
+- overlays must declare `schema_version: mozaiks.refinement_harness.v1`
+- overlays must declare `extends: mozaiks.default_refinement_harness`
+- overlay manifest deltas live under `overrides`
+- scalar values override the packaged default
+- object values merge recursively by key
+- `routing.artifacts` merge by `artifact_kind`
+- `checkpoints` merge by `event`
+- checkpoint `tool_ids` replace the packaged list
+- checkpoint `append_tool_ids` adds tools while preserving packaged order
+- `config/tools.yaml` merges tools by `id`
+- `config/policies.yaml` merges policy objects by key
+- `overrides.prompts` maps prompt id to an app-local prompt file
+
 ### `config/tools.yaml`
 
-Declares harness-owned tools.
+Declares app-local tool additions. The packaged default declares the standard
+first-party tools.
 
 Example:
 
 ```yaml
+schema_version: mozaiks.refinement_harness.tools.v1
 tools:
-  - id: get_artifact_summary
+  - id: app_local_context
     kind: context_tool
-    description: Load artifact lineage and version metadata.
-    entrypoint: factory_app.refinement_harness.tools.get_artifact_summary:get_artifact_summary
+    description: Load app-local refinement context.
+    entrypoint: app.refinement_tools:app_local_context
     available_to:
-      - request_submitted
-      - route_requested
+      - coding_requested
 ```
 
 ### `prompts/*.yaml`
@@ -691,9 +723,9 @@ At runtime:
 
 1. `mozaiksai/core/runtime/app/ai_config.py` resolves startup from `app/config/ai.json`
 2. `mozaiksai/control_plane/config.py` resolves runtime policy from `app/config/refinement_policy.yaml`
-3. `mozaiksai/control_plane/loader.py` resolves the active pack from `refinement_harness/config/harness.yaml`
+3. `mozaiksai/control_plane/loader.py` resolves the packaged default harness and any app-local overlay
 4. `mozaiksai/control_plane/runtime.py` builds a checkpoint runtime
-5. the harness entrypoint is instantiated from `harness.implementation`
+5. checkpoint handlers are resolved from first-party runtime bindings by event
 6. the harness binds and runs the checkpoints it needs
 
 Current Studio refinement flow:

--- a/docs/guides/configs/index.md
+++ b/docs/guides/configs/index.md
@@ -35,7 +35,8 @@ folder.
    `app/security/secrets.yaml`, and optional `app/services/` support code.
 6. Add paid access only when needed: `app/config/subscriptions.yaml`.
 7. Add artifact-aware refinement only when the app needs routed revisions:
-   `app/config/refinement_policy.yaml` and `refinement_harness/config/`.
+   `app/config/refinement_policy.yaml` and, when default routes need app-local
+   deltas, `refinement_harness/config/`.
 
 ## Config Ownership
 
@@ -54,7 +55,7 @@ folder.
 | `app/security/secrets.yaml` | Secret names, env handles, provider policy | [Integrations](../integrations/01-overview.md) |
 | `app/data/contract.json` | Stable data aliases, indexes, aggregate ownership | [Add a Module](../adding-modules/01-overview.md) |
 | `app/modules/{module_id}/contracts/` | Module companion manifests | [Module Contracts](module-contracts.md) |
-| `refinement_harness/config/` | Refinement routes, checkpoints, prompt ids, tool ids | [Refinement](refinement.md) |
+| `refinement_harness/config/` | Optional overlays for packaged refinement routes, checkpoints, prompt ids, and tool ids | [Refinement](refinement.md) |
 
 ## Current Rules
 

--- a/docs/guides/configs/refinement.md
+++ b/docs/guides/configs/refinement.md
@@ -12,9 +12,10 @@ checkpoint decisions, or workflow re-entry based on request meaning.
 | File | Owns |
 |------|------|
 | `app/config/refinement_policy.yaml` | Enables refinement capabilities and selects model profiles. |
-| `refinement_harness/config/harness.yaml` | Maps artifact kinds and change classes to workflow sequences. |
-| `refinement_harness/config/tools.yaml` | Names the deterministic tools available to checkpoint handlers. |
-| `refinement_harness/prompts/*.yaml` | Prompt text referenced by checkpoint `prompt_id` values. |
+| `refinement_harness/config/harness.yaml` | Optional overlay that extends the packaged default harness. |
+| `refinement_harness/config/tools.yaml` | Optional app-local tool additions referenced by overlay checkpoints. |
+| `refinement_harness/config/policies.yaml` | Optional deterministic scope policy overrides. |
+| `refinement_harness/prompts/*.yaml` | Optional prompt overrides referenced from `overrides.prompts`. |
 | `workflows/extended_orchestration/extension_registry.json` | Workflow sequences that the harness can route into. |
 
 ## Minimal Policy
@@ -46,63 +47,43 @@ coding:
   llm_profile: codegen
 ```
 
-## Minimal Harness
+## Minimal Harness Overlay
+
+Most apps should use the packaged default harness. Add an app-local
+`refinement_harness/config/harness.yaml` only when the app needs to extend the
+default routing, checkpoint, or prompt behavior:
 
 ```yaml
 schema_version: mozaiks.refinement_harness.v1
-routing:
-  default_artifact_kind: app_bundle
-  artifacts:
-    - artifact_kind: app_bundle
-      label: app bundle
-      routes:
-        patch:
-          workflow_sequence: app_revision
-        design:
-          workflow_sequence: app_surface_revision
-        feature:
-          workflow_sequence: app_revision
-        core:
-          workflow_sequence: full_rebuild
-
-checkpoints:
-  - event: request_submitted
-    prompt_id: change_classifier_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-      - get_app_intelligence_context
-      - get_stale_artifact_families
-  - event: scope_requested
-    prompt_id: coding_scope_selection_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-      - get_app_intelligence_context
-      - get_artifact_workspace_catalog
-      - get_context_graph_catalog
-      - search_app_source_context
-  - event: contract_surface_requested
-    prompt_id: contract_surface_selection_system
-    tool_ids:
-      - get_contract_surface_context
-      - get_app_intelligence_context
-      - search_app_source_context
-  - event: coding_requested
-    prompt_id: coding_refinement_system
-    tool_ids:
-      - get_revision_context
-      - get_artifact_summary
-      - get_app_intelligence_context
-      - get_artifact_workspace_scope
-      - get_context_graph_scope
-      - search_app_source_context
-      - read_app_source_file
-      - get_related_app_source_files
+extends: mozaiks.default_refinement_harness
+overrides:
+  routing:
+    artifacts:
+      - artifact_kind: app_bundle
+        label: app bundle
+  checkpoints:
+    - event: coding_requested
+      append_tool_ids:
+        - app_local_context
 ```
 
-Every `workflow_sequence` referenced by the harness must exist in
+`extends: mozaiks.default_refinement_harness` loads the packaged
+`factory_app/refinement_harness` pack from the installed `mozaiks` package and
+then applies deterministic app-local deltas. Every new `workflow_sequence`
+referenced by an overlay must exist in
 `workflows/extended_orchestration/extension_registry.json`.
+
+Overlay merge rules:
+
+- scalar values override the default
+- object values merge recursively by key
+- `routing.artifacts` merge by `artifact_kind`
+- `checkpoints` merge by `event`
+- checkpoint `tool_ids` replace the default list
+- checkpoint `append_tool_ids` adds tools without replacing the default list
+- `config/tools.yaml` merges tools by `id`
+- `config/policies.yaml` merges policy objects by key
+- `overrides.prompts` maps prompt id to an app-local prompt file
 
 ## Code Context By Checkpoint
 
@@ -126,7 +107,8 @@ through tools only when their checkpoint needs it.
 |---------|------|
 | Ask/chat/workflow startup | `app/config/ai.json` |
 | Model profile selection | `app/config/refinement_policy.yaml` |
-| Artifact routing and checkpoints | `refinement_harness/config/harness.yaml` |
+| Default artifact routing and checkpoints | packaged `mozaiks.default_refinement_harness` |
+| App-specific routing and checkpoint deltas | `refinement_harness/config/harness.yaml` |
 | Sequence impact metadata | `workflows/extended_orchestration/extension_registry.json` |
 
 ## Read Next

--- a/docs/guides/extending-ai-functionality/01-overview.md
+++ b/docs/guides/extending-ai-functionality/01-overview.md
@@ -11,8 +11,10 @@ The key files are:
 - `workflows/{workflow_id}/` declares agents, tools, state, routing, and UI for
   a workflow.
 - `app/config/ai.json` starts ask, chat, and workflow behavior.
-- `app/config/refinement_policy.yaml` and `refinement_harness/config/` enable
-  routed artifact refinement.
+- `app/config/refinement_policy.yaml` enables routed artifact refinement.
+- `refinement_harness/config/harness.yaml` is the app-local overlay that extends
+  the packaged default harness; it may be only `overrides: {}` when the default
+  routes and checkpoints are sufficient.
 
 When a user asks for a change, the refinement engine can classify whether the
 request is a patch, design adjustment, feature addition, or concept-level
@@ -24,7 +26,7 @@ sequence ids, checkpoint events, prompt ids, and tool ids. Mozaiks runtime
 defines the harness implementation, deterministic handlers, checkpoint modes,
 handler entrypoints, and structured output contracts.
 
-In the canonical app workspace contract, app-local refinement harness files live
+In the canonical app workspace contract, app-local refinement overlay files live
 beside the app bundle:
 
 ```text
@@ -33,7 +35,7 @@ refinement_harness/
 workflows/
 ```
 
-In this repo's first-party builder workspace, the same contract is dogfooded
+In this repo's first-party builder workspace, the packaged default harness lives
 under:
 
 - `factory_app/app/config/ai.json`
@@ -43,8 +45,8 @@ under:
 
 ## When To Add This
 
-Omit an app-local refinement harness when the app is mostly deterministic modules,
-CRUD, one known workflow launch, or fixed workflow sequences.
+Omit refinement entirely when the app is mostly deterministic modules, CRUD, one
+known workflow launch, or fixed workflow sequences.
 
 Add one when the app needs at least two of these signals, or one
 governance-critical signal is dominant:
@@ -59,7 +61,9 @@ Ownership is split deliberately:
 
 - `ValueEngine` may hint that a refinement surface is needed.
 - `DesignDocs` decides whether `surface_kind = refinement` is warranted.
-- `AppGenerator` materializes the app-local refinement artifacts.
+- `AppGenerator` materializes an app-local refinement overlay for refinement
+  surfaces and emits optional tools, policies, or prompts only when the packaged
+  default harness cannot express the app-specific delta by itself.
 - `AgentGenerator` stays responsible for workflow bundles the refinement engine may route into.
 
 ## Artifacts

--- a/docs/guides/extending-ai-functionality/05-workflow-sequences.md
+++ b/docs/guides/extending-ai-functionality/05-workflow-sequences.md
@@ -6,6 +6,50 @@ sequences the Refinement Engine can re-enter.
 The Refinement Engine chooses a route. The workflow registry owns what that route
 means.
 
+Apps can use the packaged factory workflow registry directly or extend it with
+an app-local overlay:
+
+```json
+{
+  "pack_name": "MyAppOverlay",
+  "version": 3,
+  "extends": "mozaiks.default_workflow_registry",
+  "workflows": [
+    { "id": "ProductWorkflow", "description": "App-owned product workflow" }
+  ],
+  "entrypoints": [
+    { "id": "create_app", "remove": true },
+    {
+      "id": "product_workflow",
+      "workflow": "ProductWorkflow",
+      "path": "/product-workflow",
+      "label": "Product Workflow"
+    }
+  ],
+  "workflow_sequences": [
+    {
+      "id": "product_revision",
+      "affected_declarative_families": ["product_artifact"],
+      "steps": [{ "workflows": ["ProductWorkflow"] }]
+    }
+  ],
+  "artifact_dependency_graph": {
+    "product_artifact": []
+  }
+}
+```
+
+Use the overlay form when an app wants default Factory/Studio sequences and
+app-owned product workflows in the same effective registry. Lists merge by
+`id`; `{ "id": "...", "remove": true }` hides a packaged entry such as the
+default create route.
+
+When a registry extends `mozaiks.default_workflow_registry`, workflow folder
+resolution also searches the packaged factory workflow root. App-local workflow
+folders remain in the app `workflows/` directory and override packaged folders
+with the same id. Without `extends`, the app registry is explicit and only the
+selected app workflow root is searched.
+
 Example:
 
 ```json

--- a/docs/guides/platform-intelligence/03-refinement.md
+++ b/docs/guides/platform-intelligence/03-refinement.md
@@ -55,8 +55,9 @@ in scope and escalates to a full workflow if the request is broader than a patch
 
 ## For Builders: Opting In
 
-An app opts into app-local refinement by adding a refinement policy and, when
-needed, a refinement harness:
+An app opts into refinement by adding a refinement policy. The packaged default
+harness handles the standard artifact families and checkpoints. Add an app-local
+harness file only when the app has real overlay deltas:
 
 ```text
 app/config/refinement_policy.yaml
@@ -64,9 +65,10 @@ refinement_harness/config/harness.yaml
 ```
 
 `app/config/ai.json` still owns ask/chat/workflow startup only. LLM profiles live
-in `app/config/refinement_policy.yaml`; checkpoint declarations live in
-`refinement_harness/config/`. See
+in `app/config/refinement_policy.yaml`; app-specific checkpoint and route deltas
+live in `refinement_harness/config/harness.yaml` with
+`extends: mozaiks.default_refinement_harness`. See
 [App-Local Refinement Harness](../../architecture/app/refinement-harness.md)
-for the full generated app starter pack template.
+for the overlay contract.
 
 For the full runtime behavior, see [Refinement Engine](../../architecture/workflows/refinement-engine.md).

--- a/factory_app/build_context/AppGenerator/file_contracts.yaml
+++ b/factory_app/build_context/AppGenerator/file_contracts.yaml
@@ -284,8 +284,8 @@ task_contracts:
     required_outputs:
       - app/config/refinement_policy.yaml
       - refinement_harness/config/harness.yaml
-      - refinement_harness/config/tools.yaml
     optional_outputs:
+      - refinement_harness/config/tools.yaml
       - refinement_harness/config/policies.yaml
       - refinement_harness/prompts/*.yaml
     hard_constraints:
@@ -294,8 +294,10 @@ task_contracts:
       - Do NOT register this surface as a runtime module under app/modules/.
       - Stay within current_build_task.owned_paths.
       - app/config/refinement_policy.yaml is the app-local refinement policy seed. It must carry the shipped runtime contract and must not move ask/chat/workflows startup into harness.yaml.
-      - harness.yaml routes declare workflow_sequence only; do not declare route_to, affected_workflows, affected_declarative_families, requires_replanning, requires_rebuild, or scope_summary.
-      - Every workflow_sequence referenced by harness.yaml must exist in workflows/extended_orchestration/extension_registry.json and declare affected_declarative_families there.
+      - harness.yaml must be an overlay with schema_version mozaiks.refinement_harness.v1, extends mozaiks.default_refinement_harness, and overrides only for routing, checkpoints, or prompts.
+      - Do not copy packaged default routing, checkpoint, prompt, tool, or policy manifests into generated apps.
+      - harness.yaml route overrides declare workflow_sequence only; do not declare route_to, affected_workflows, affected_declarative_families, requires_replanning, requires_rebuild, or scope_summary.
+      - Every workflow_sequence referenced by harness.yaml overrides must exist in the effective workflows/extended_orchestration/extension_registry.json and declare affected_declarative_families there.
       - Use shipped mozaiksai.control_plane implementations and tool entrypoints unless a future custom-harness Python contract is explicitly introduced.
       - Refinement harness artifacts coordinate app-level lifecycle, refinement, or session state only — no business domain logic.
       - Do not duplicate host-universal refinement engine behavior already provided by the platform.

--- a/factory_app/refinement_harness/config/harness.yaml
+++ b/factory_app/refinement_harness/config/harness.yaml
@@ -46,6 +46,17 @@ routing:
           workflow_sequence: app_revision
         core:
           workflow_sequence: full_rebuild
+    - artifact_kind: theme_config
+      label: theme config
+      routes:
+        patch:
+          workflow_sequence: theme_patch
+        design:
+          workflow_sequence: theme_revision
+        feature:
+          workflow_sequence: theme_revision
+        core:
+          workflow_sequence: full_rebuild
 checkpoints:
   - event: request_submitted
     prompt_id: change_classifier_system
@@ -54,6 +65,8 @@ checkpoints:
       - get_artifact_summary
       - get_app_intelligence_context
       - get_stale_artifact_families
+  - event: route_requested
+  - event: decision_requested
   - event: scope_requested
     prompt_id: coding_scope_selection_system
     tool_ids:

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -501,9 +501,10 @@ agents:
         - `surface_kind` must be `refinement`.
         - `initial_agent` must be `RefinementHarnessAgent`.
         - Treat this task as app-local harness materialization, not workflow generation. AgentGenerator owns workflow bundles; AppGenerator emits only the harness files that route into declared workflow_sequences.
-        - `owned_paths` must include `app/config/refinement_policy.yaml`, `refinement_harness/config/harness.yaml`, and `refinement_harness/config/tools.yaml`; add `refinement_harness/config/policies.yaml` and `refinement_harness/prompts/*.yaml` only when needed.
+        - `owned_paths` must include `app/config/refinement_policy.yaml` and `refinement_harness/config/harness.yaml`; add `refinement_harness/config/tools.yaml`, `refinement_harness/config/policies.yaml`, and `refinement_harness/prompts/*.yaml` only when the app has real harness deltas.
         - `app/config/refinement_policy.yaml` is the app-local LLM profile config (co-located with `app/config/ai.json`). Keep `ask`, `chat`, and `workflows` startup in `app/config/ai.json`; do not move startup into `harness.yaml`.
-        - `initial_message` must identify the exact workflow_sequences this harness can route to. Those sequences must exist in `workflows/extended_orchestration/extension_registry.json`; route impact metadata belongs on the sequence there, not in `harness.yaml`.
+        - `harness.yaml` must extend `mozaiks.default_refinement_harness` and declare only App-specific `overrides`. Do not copy packaged default routes, checkpoints, tools, policies, or prompts.
+        - `initial_message` must identify the exact workflow_sequences this harness can route to when route overrides are needed. Those sequences must exist in the effective `workflows/extended_orchestration/extension_registry.json`; route impact metadata belongs on the sequence there, not in `harness.yaml`.
         - Do NOT generate custom harness Python, module files, backend/refinement_harness files, or app business logic in this task. Use shipped `mozaiksai.control_plane` implementations and declared context tools.
       12d. **event architecture rule**:
         - Populate `event_flows` for every durable state change that other modules, notifications, integrations, or workflows may react to.
@@ -726,7 +727,7 @@ agents:
               "initial_agent": "RefinementHarnessAgent",
               "description": "Generate the optional app-local refinement harness pack.",
               "initial_message": "Generate a declarative refinement harness that routes scoped refinements to existing workflow_sequences only.",
-              "owned_paths": ["refinement_harness/config/harness.yaml", "refinement_harness/config/tools.yaml"],
+              "owned_paths": ["app/config/refinement_policy.yaml", "refinement_harness/config/harness.yaml"],
               "depends_on": [],
               "acceptance_criteria": ["Routes use workflow_sequence only", "No custom harness Python"]
             }
@@ -2163,33 +2164,34 @@ agents:
       1. If `current_build_task_type` is not `refinement_harness`, fail instead of generating a fallback surface.
       2. Generate exactly the files listed in `current_build_task.owned_paths`.
       3. Required owned paths:
-        - `app/config/refinement_policy.yaml`
+         - `app/config/refinement_policy.yaml`
          - `refinement_harness/config/harness.yaml`
-         - `refinement_harness/config/tools.yaml`
       4. Optional owned paths:
+         - `refinement_harness/config/tools.yaml`
          - `refinement_harness/config/policies.yaml`
          - `refinement_harness/prompts/*.yaml`
       5. Do not emit any files outside `app/config/refinement_policy.yaml`, `refinement_harness/config/`, or `refinement_harness/prompts/*.yaml`.
       5a. `app/config/refinement_policy.yaml` is the LLM profile config for the harness. It is seeded from the current factory default (`factory_app/app/config/refinement_policy.yaml`). Do not put `ask`, `chat`, or `workflows` startup in `harness.yaml`.
       6. Set `harness_yaml.schema_version` to `mozaiks.refinement_harness.v1`.
-      7. Set `tools_yaml.schema_version` to `mozaiks.refinement_harness.tools.v1`.
-      8. Do not emit `profile`, `harness`, Python handler entrypoints, checkpoint ids, checkpoint modes, or output contracts. Mozaiks runtime infers those from canonical checkpoint events.
-      9. Declare only LLM-backed checkpoints that need app-specific prompts/tools:
+      7. Set `harness_yaml.extends` to `mozaiks.default_refinement_harness` and put all app-specific changes under `harness_yaml.overrides`.
+      8. Omit `tools_yaml`, `policies_yaml`, and `prompt_files` unless the current task owns those files and needs real app-specific deltas.
+      9. Do not emit `profile`, `harness`, Python handler entrypoints, checkpoint ids, checkpoint modes, output contracts, or copied default routes/checkpoints/tools/prompts. Mozaiks runtime supplies defaults from the packaged harness.
+      10. Declare only checkpoint overrides that need app-specific prompts/tools:
          - `request_submitted` for change classification.
          - `scope_requested` for file/scope selection.
          - `contract_surface_requested` for contract-surface planning.
          - `coding_requested` for scoped coding plans.
          Do not declare deterministic router or decision checkpoints; runtime supplies them.
-      10. Use tool entrypoints only from shipped context tools:
+      11. Use tool entrypoints only from shipped context tools or explicitly approved app-owned extensions:
          - `mozaiksai.control_plane.tools.get_revision_context:get_revision_context`
          - `factory_app.refinement_harness.tools.get_artifact_summary:get_artifact_summary`
          - `factory_app.refinement_harness.tools.get_artifact_workspace_catalog:get_artifact_workspace_catalog`
          - `factory_app.refinement_harness.tools.get_artifact_workspace_scope:get_artifact_workspace_scope`
-      11. In `routing.artifacts[].routes`, every route object must contain only `workflow_sequence`.
-      12. Do not emit `route_to`, `affected_workflows`, `affected_declarative_families`, `requires_replanning`, `requires_rebuild`, or `scope_summary`.
-      13. Every `workflow_sequence` referenced by routes must already exist in `workflows/extended_orchestration/extension_registry.json` and declare `affected_declarative_families` there.
-      14. Do not generate module files, backend/refinement_harness Python files, custom harness implementation files, or business-domain logic.
-      15. Mirror the typed `refinement_harness` into `code_files`.
+      12. In `overrides.routing.artifacts[].routes`, every route object must contain only `workflow_sequence`.
+      13. Do not emit `route_to`, `affected_workflows`, `affected_declarative_families`, `requires_replanning`, `requires_rebuild`, or `scope_summary`.
+      14. Every `workflow_sequence` referenced by route overrides must already exist in the effective `workflows/extended_orchestration/extension_registry.json` and declare `affected_declarative_families` there.
+      15. Do not generate module files, backend/refinement_harness Python files, custom harness implementation files, or business-domain logic.
+      16. Mirror the typed `refinement_harness` into `code_files`.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |-
@@ -2200,40 +2202,16 @@ agents:
         "refinement_harness": {
           "harness_yaml": {
             "schema_version": "mozaiks.refinement_harness.v1",
-            "routing": {
-              "default_artifact_kind": "app_bundle",
-              "artifacts": [
-                {
-                  "artifact_kind": "app_bundle",
-                  "label": "app bundle",
-                  "routes": {
-                    "patch": { "workflow_sequence": "app_revision" },
-                    "design": { "workflow_sequence": "app_surface_revision" },
-                    "feature": { "workflow_sequence": "app_revision" },
-                    "core": { "workflow_sequence": "full_rebuild" }
-                  }
-                }
-              ]
-            },
-            "checkpoints": [
-              {
-                "event": "request_submitted",
-                "prompt_id": "change_classifier_system",
-                "tool_ids": ["get_revision_context", "get_artifact_summary"]
-              }
-            ]
+            "extends": "mozaiks.default_refinement_harness",
+            "overrides": {}
           },
-          "tools_yaml": {
-            "schema_version": "mozaiks.refinement_harness.tools.v1",
-            "tools": []
-          },
+          "tools_yaml": null,
           "policies_yaml": null,
           "prompt_files": []
         },
         "code_files": [
           { "filename": "app/config/refinement_policy.yaml", "content": "..." },
-          { "filename": "refinement_harness/config/harness.yaml", "content": "..." },
-          { "filename": "refinement_harness/config/tools.yaml", "content": "..." }
+          { "filename": "refinement_harness/config/harness.yaml", "content": "..." }
         ],
         "agent_message": "Generated refinement harness."
       }

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -3030,6 +3030,20 @@ models:
         items: RefinementHarnessArtifactRouting
         description: Artifact routing policies for the harness.
 
+  RefinementHarnessRoutingOverlay:
+    type: model
+    fields:
+      default_artifact_kind:
+        type: union
+        variants:
+        - str
+        - 'null'
+        description: Optional default artifact kind override. Use null when unchanged.
+      artifacts:
+        type: optional_list
+        items: RefinementHarnessArtifactRouting
+        description: Optional artifact route overrides merged by artifact_kind.
+
   RefinementHarnessCheckpointManifestOutput:
     type: model
     fields:
@@ -3051,6 +3065,10 @@ models:
         type: optional_list
         items: str
         description: Tool ids from refinement_harness/config/tools.yaml available to this checkpoint.
+      append_tool_ids:
+        type: optional_list
+        items: str
+        description: Tool ids appended to the packaged checkpoint tool list without replacing defaults.
 
   RefinementHarnessManifestOutput:
     type: model
@@ -3060,15 +3078,37 @@ models:
         values:
         - mozaiks.refinement_harness.v1
         description: Refinement harness manifest schema version.
+      extends:
+        type: literal
+        values:
+        - mozaiks.default_refinement_harness
+        description: >
+          Required default harness marker. Generated apps must extend the
+          packaged default harness instead of copying it.
+      overrides:
+        type: union
+        variants:
+        - RefinementHarnessOverlayOverrides
+        - 'null'
+        description: >
+          App-specific routing/checkpoint overrides only. Use null when the
+          packaged default is sufficient.
+
+  RefinementHarnessOverlayOverrides:
+    type: model
+    fields:
       routing:
-        type: RefinementHarnessRoutingManifest
-        description: Artifact routing policy. Routes may contain workflow_sequence only.
+        type: union
+        variants:
+        - RefinementHarnessRoutingOverlay
+        - 'null'
+        description: Optional artifact routing overrides. Routes may contain workflow_sequence only.
       checkpoints:
-        type: list
+        type: optional_list
         items: RefinementHarnessCheckpointManifestOutput
         description: >
-          LLM-backed checkpoint prompts/tools. Do not declare deterministic
-          handler checkpoints; Mozaiks supplies them in runtime.
+          Optional LLM-backed checkpoint prompt/tool overrides. Do not declare
+          deterministic handler checkpoints; Mozaiks supplies them in runtime.
 
   RefinementHarnessToolDefinition:
     type: model
@@ -3151,8 +3191,11 @@ models:
         type: RefinementHarnessManifestOutput
         description: Serialized to refinement_harness/config/harness.yaml.
       tools_yaml:
-        type: RefinementHarnessToolsManifestOutput
-        description: Serialized to refinement_harness/config/tools.yaml.
+        type: union
+        variants:
+        - RefinementHarnessToolsManifestOutput
+        - 'null'
+        description: Optional manifest serialized to refinement_harness/config/tools.yaml.
       policies_yaml:
         type: union
         variants:

--- a/factory_app/workflows/AppGenerator/tools/app_build_plan.py
+++ b/factory_app/workflows/AppGenerator/tools/app_build_plan.py
@@ -29,6 +29,7 @@ _FRONTEND_JS_TS_SEGMENTS = (
     "/src/components/",
 )
 _OBSOLETE_HOST_ADMIN_CONFIG_PATH = "app/config/admin.json"
+_REFINEMENT_POLICY_CODE_FILE_PATH = "app/config/refinement_policy.yaml"
 _APP_SERVICE_ADMIN_PATHS = {"services/admin_config.py", "services/routes/admin.py"}
 _INTEGRATIONS_PREFIX = "services/integrations/"
 _ADAPTERS_PREFIX = "services/adapters/"
@@ -1415,7 +1416,8 @@ def _validate_build_tasks(build_tasks: list[dict[str, Any]], managed_capability_
                 f"and {APP_SECURITY_SECRETS_PATH}."
             )
 
-        invalid_roots = noncanonical_app_root_paths(owned_paths)
+        root_guard_paths = [path for path in owned_paths if path != _REFINEMENT_POLICY_CODE_FILE_PATH]
+        invalid_roots = noncanonical_app_root_paths(root_guard_paths)
         if invalid_roots:
             raise ValueError(
                 "Build task "
@@ -1478,6 +1480,7 @@ def _validate_build_tasks(build_tasks: list[dict[str, Any]], managed_capability_
 
         if task_type == "refinement_harness":
             allowed_config_paths = {
+                _REFINEMENT_POLICY_CODE_FILE_PATH,
                 "refinement_harness/config/harness.yaml",
                 "refinement_harness/config/tools.yaml",
                 "refinement_harness/config/policies.yaml",
@@ -1507,12 +1510,12 @@ def _validate_build_tasks(build_tasks: list[dict[str, Any]], managed_capability_
                 raise ValueError(
                     "Build task "
                     f"'{task_id}' owns invalid refinement harness paths: {invalid}. "
-                    "Refinement harness tasks may only own refinement_harness/config/* and "
-                    "refinement_harness/prompts/*.yaml."
+                    "Refinement harness tasks may only own app/config/refinement_policy.yaml, "
+                    "refinement_harness/config/*, and refinement_harness/prompts/*.yaml."
                 )
             required = {
+                _REFINEMENT_POLICY_CODE_FILE_PATH,
                 "refinement_harness/config/harness.yaml",
-                "refinement_harness/config/tools.yaml",
             }
             missing = sorted(required.difference(owned_paths))
             if missing:

--- a/factory_app/workflows/AppGenerator/tools/refinement_harness_codegen.py
+++ b/factory_app/workflows/AppGenerator/tools/refinement_harness_codegen.py
@@ -1,20 +1,26 @@
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
 
 import yaml
-from pydantic import ValidationError
 
 from factory_app.workflows.AppGenerator.tools.default_runtime_configs import (
     load_default_refinement_policy_config,
 )
 
+DEFAULT_REFINEMENT_HARNESS_EXTENDS = "mozaiks.default_refinement_harness"
+REFINEMENT_HARNESS_SCHEMA_VERSION = "mozaiks.refinement_harness.v1"
+REFINEMENT_HARNESS_TOOLS_SCHEMA_VERSION = "mozaiks.refinement_harness.tools.v1"
+REFINEMENT_HARNESS_POLICIES_SCHEMA_VERSION = "mozaiks.refinement_harness.policies.v1"
 _HARNESS_CONFIG = "refinement_harness/config/harness.yaml"
 _REFINEMENT_POLICY = "app/config/refinement_policy.yaml"
 _HARNESS_TOOLS = "refinement_harness/config/tools.yaml"
 _HARNESS_POLICIES = "refinement_harness/config/policies.yaml"
+_OVERLAY_TOP_LEVEL_KEYS = {"schema_version", "extends", "overrides"}
+_OVERLAY_OVERRIDE_KEYS = {"routing", "checkpoints", "prompts"}
 
 
 def _dump_yaml(data: dict[str, Any]) -> str:
@@ -46,26 +52,84 @@ def _safe_prompt_path(raw: Any, prompt_id: str) -> str:
     return str(path)
 
 
-def _validate_refinement_harness_manifest(manifest_dict: dict[str, Any]) -> None:
-    """Parse the generated harness.yaml through the runtime schema.
+def _drop_none(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _drop_none(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [_drop_none(item) for item in value]
+    return value
 
-    This catches structural errors (extra fields, wrong field names, missing
-    required fields) at generation time rather than when the app loads the pack.
-    Sequence cross-checking against extension_registry.json is intentionally
-    deferred to the loader — the generator may run before the registry is stable.
 
-    The import is deferred to avoid a circular import:
-    refinement_harness_codegen → mozaiksai.control_plane → coding_worker →
-    app_validation → code_file_utils → refinement_harness_codegen.
-    """
-    from mozaiksai.control_plane.schema import ControlPlaneManifest  # noqa: PLC0415
-
-    try:
-        ControlPlaneManifest.model_validate(manifest_dict)
-    except ValidationError as exc:
+def _validate_refinement_harness_overlay(manifest_dict: dict[str, Any]) -> None:
+    unknown_keys = set(manifest_dict) - _OVERLAY_TOP_LEVEL_KEYS
+    if unknown_keys:
         raise ValueError(
-            f"Generated refinement_harness/config/harness.yaml failed schema validation: {exc}"
-        ) from exc
+            "Generated refinement_harness/config/harness.yaml must be an extends overlay; "
+            f"unsupported top-level keys: {', '.join(sorted(unknown_keys))}"
+        )
+    if manifest_dict.get("schema_version") != REFINEMENT_HARNESS_SCHEMA_VERSION:
+        raise ValueError(
+            "Generated refinement_harness/config/harness.yaml must set "
+            f"schema_version to {REFINEMENT_HARNESS_SCHEMA_VERSION!r}"
+        )
+    if manifest_dict.get("extends") != DEFAULT_REFINEMENT_HARNESS_EXTENDS:
+        raise ValueError(
+            "Generated refinement_harness/config/harness.yaml must extend "
+            f"{DEFAULT_REFINEMENT_HARNESS_EXTENDS!r}"
+        )
+    overrides = manifest_dict.get("overrides")
+    if overrides is None:
+        manifest_dict["overrides"] = {}
+        return
+    if not isinstance(overrides, dict):
+        raise ValueError("Generated refinement harness overrides must be an object")
+    overrides = _drop_none(overrides)
+    manifest_dict["overrides"] = overrides
+    unknown_override_keys = set(overrides) - _OVERLAY_OVERRIDE_KEYS
+    if unknown_override_keys:
+        raise ValueError(
+            "Generated refinement harness overrides may only declare "
+            f"{', '.join(sorted(_OVERLAY_OVERRIDE_KEYS))}; "
+            f"found {', '.join(sorted(unknown_override_keys))}"
+        )
+
+
+def _validate_optional_manifest(
+    data: Any,
+    *,
+    expected_schema: str,
+    label: str,
+) -> dict[str, Any] | None:
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        raise ValueError(f"refinement_harness.{label} must be an object when provided")
+    if data.get("schema_version") != expected_schema:
+        raise ValueError(
+            f"refinement_harness.{label} must set schema_version to {expected_schema!r}"
+        )
+    return data
+
+
+def _normalize_prompt_files(raw_prompts: Any) -> tuple[dict[str, str], dict[str, str]]:
+    files: dict[str, str] = {}
+    prompt_refs: dict[str, str] = {}
+    if raw_prompts is None:
+        return files, prompt_refs
+    if not isinstance(raw_prompts, list):
+        raise ValueError("refinement_harness.prompt_files must be a list when provided")
+    for prompt in raw_prompts:
+        if not isinstance(prompt, dict):
+            continue
+        prompt_id = str(prompt.get("id") or "").strip()
+        content = str(prompt.get("content") or "").strip()
+        if not prompt_id or not content:
+            continue
+        safe_id = _safe_prompt_id(prompt_id)
+        filename = _safe_prompt_path(prompt.get("filename"), safe_id)
+        files[filename] = _dump_yaml({"id": safe_id, "content": content})
+        prompt_refs[safe_id] = filename
+    return files, prompt_refs
 
 
 def build_refinement_harness_code_files(raw: Any) -> list[dict[str, str]]:
@@ -78,32 +142,39 @@ def build_refinement_harness_code_files(raw: Any) -> list[dict[str, str]]:
     tools_yaml = raw.get("tools_yaml")
     if not isinstance(harness_yaml, dict):
         raise ValueError("refinement_harness.harness_yaml must be an object")
-    if not isinstance(tools_yaml, dict):
-        raise ValueError("refinement_harness.tools_yaml must be an object")
 
-    _validate_refinement_harness_manifest(harness_yaml)
+    harness_yaml = deepcopy(harness_yaml)
+    _validate_refinement_harness_overlay(harness_yaml)
+    prompt_files, prompt_refs = _normalize_prompt_files(raw.get("prompt_files"))
+    if prompt_refs:
+        overrides = harness_yaml.setdefault("overrides", {})
+        prompts = overrides.setdefault("prompts", {})
+        if not isinstance(prompts, dict):
+            raise ValueError("refinement_harness.harness_yaml.overrides.prompts must be an object")
+        prompts.update(prompt_refs)
 
     files: dict[str, str] = {
         _HARNESS_CONFIG: _dump_yaml(harness_yaml),
         _REFINEMENT_POLICY: _dump_yaml(load_default_refinement_policy_config()),
-        _HARNESS_TOOLS: _dump_yaml(tools_yaml),
     }
 
-    policies_yaml = raw.get("policies_yaml")
-    if isinstance(policies_yaml, dict) and policies_yaml:
+    tools_yaml = _validate_optional_manifest(
+        tools_yaml,
+        expected_schema=REFINEMENT_HARNESS_TOOLS_SCHEMA_VERSION,
+        label="tools_yaml",
+    )
+    if tools_yaml:
+        files[_HARNESS_TOOLS] = _dump_yaml(tools_yaml)
+
+    policies_yaml = _validate_optional_manifest(
+        raw.get("policies_yaml"),
+        expected_schema=REFINEMENT_HARNESS_POLICIES_SCHEMA_VERSION,
+        label="policies_yaml",
+    )
+    if policies_yaml:
         files[_HARNESS_POLICIES] = _dump_yaml(policies_yaml)
 
-    prompt_files = raw.get("prompt_files")
-    if isinstance(prompt_files, list):
-        for prompt in prompt_files:
-            if not isinstance(prompt, dict):
-                continue
-            prompt_id = str(prompt.get("id") or "").strip()
-            content = str(prompt.get("content") or "").strip()
-            if not prompt_id or not content:
-                continue
-            filename = _safe_prompt_path(prompt.get("filename"), prompt_id)
-            files[filename] = _dump_yaml({"id": prompt_id, "content": content})
+    files.update(prompt_files)
 
     return [{"filename": name, "content": content} for name, content in sorted(files.items())]
 

--- a/mozaiksai/control_plane/__init__.py
+++ b/mozaiksai/control_plane/__init__.py
@@ -82,6 +82,7 @@ from .implementations import (
 )
 from .invalidation import ArtifactInvalidationService, get_artifact_invalidation_service
 from .loader import (
+    DEFAULT_REFINEMENT_HARNESS_EXTENDS,
     ControlPlanePackLoadError,
     load_refinement_harness,
     load_selected_refinement_harness,
@@ -167,6 +168,7 @@ __all__ = [
     "ControlPlaneLLMProfileConfig",
     "ControlPlaneManifest",
     "ControlPlanePackLoadError",
+    "DEFAULT_REFINEMENT_HARNESS_EXTENDS",
     "ControlPlanePoliciesManifest",
     "ControlPlanePromptDefinition",
     "ControlPlanePromptsManifest",

--- a/mozaiksai/control_plane/loader.py
+++ b/mozaiksai/control_plane/loader.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
@@ -25,6 +27,12 @@ class ControlPlanePackLoadError(Exception):
 
 
 CONTROL_PLANE_TOOL_TARGETS: set[str] = {"harness", *ControlPlaneCheckpointEvent.__args__}  # type: ignore[attr-defined]
+DEFAULT_REFINEMENT_HARNESS_EXTENDS = "mozaiks.default_refinement_harness"
+REFINEMENT_HARNESS_SCHEMA_VERSION = "mozaiks.refinement_harness.v1"
+REFINEMENT_HARNESS_TOOLS_SCHEMA_VERSION = "mozaiks.refinement_harness.tools.v1"
+REFINEMENT_HARNESS_POLICIES_SCHEMA_VERSION = "mozaiks.refinement_harness.policies.v1"
+_HARNESS_OVERLAY_TOP_LEVEL_KEYS = {"schema_version", "extends", "overrides"}
+_HARNESS_OVERRIDE_KEYS = {"routing", "checkpoints", "prompts"}
 
 
 def resolve_factory_refinement_harness_root() -> Path:
@@ -70,7 +78,24 @@ def load_refinement_harness(
     app_root: Path | None = None,
     factory_root: Path | None = None,
 ) -> LoadedControlPlanePack:
+    app_candidate = resolve_app_refinement_harness_root(app_root)
+    factory_candidate = factory_root or resolve_factory_refinement_harness_root()
+    app_manifest_path = app_candidate / "config" / "harness.yaml"
+    if app_manifest_path.exists():
+        app_manifest_data = _load_yaml_file(app_manifest_path)
+        if app_manifest_data.get("extends"):
+            return _load_extended_refinement_harness(
+                overlay_path=app_candidate,
+                overlay_manifest=app_manifest_data,
+                factory_path=factory_candidate,
+            )
+        return _load_refinement_harness_pack(app_candidate)
+
     pack_path = resolve_refinement_harness_path(app_root=app_root, factory_root=factory_root)
+    return _load_refinement_harness_pack(pack_path)
+
+
+def _load_refinement_harness_pack(pack_path: Path) -> LoadedControlPlanePack:
     try:
         manifest = ControlPlaneManifest.model_validate(_load_yaml_file(pack_path / "config" / "harness.yaml"))
     except ValidationError as exc:
@@ -85,6 +110,66 @@ def load_refinement_harness(
     )
     _validate_pack(manifest=manifest, prompts=prompts, tools=tools, pack_path=pack_path)
     return LoadedControlPlanePack(path=pack_path, manifest=manifest, prompts=prompts, tools=tools, policies=policies)
+
+
+def _load_extended_refinement_harness(
+    *,
+    overlay_path: Path,
+    overlay_manifest: dict[str, Any],
+    factory_path: Path,
+) -> LoadedControlPlanePack:
+    if overlay_manifest.get("extends") != DEFAULT_REFINEMENT_HARNESS_EXTENDS:
+        raise ControlPlanePackLoadError(
+            "refinement_harness/config/harness.yaml extends must be "
+            f"'{DEFAULT_REFINEMENT_HARNESS_EXTENDS}'"
+        )
+    _validate_overlay_manifest_shape(overlay_manifest, overlay_path=overlay_path)
+
+    if not (factory_path / "config" / "harness.yaml").exists():
+        raise ControlPlanePackLoadError(
+            f"Default refinement harness was not found at {factory_path / 'config' / 'harness.yaml'}"
+        )
+
+    base_manifest_data = _load_yaml_file(factory_path / "config" / "harness.yaml")
+    manifest_data = _merge_harness_manifest_overlay(
+        base_manifest_data,
+        overlay_manifest.get("overrides") or {},
+    )
+    base_tools_data = _load_yaml_file(factory_path / "config" / "tools.yaml")
+    tools_data = _merge_tools_overlay(base_tools_data, overlay_path=overlay_path)
+    base_policies_data = (
+        _load_yaml_file(factory_path / "config" / "policies.yaml", required=False)
+        or {"schema_version": REFINEMENT_HARNESS_POLICIES_SCHEMA_VERSION}
+    )
+    policies_data = _merge_policies_overlay(base_policies_data, overlay_path=overlay_path)
+
+    try:
+        manifest = ControlPlaneManifest.model_validate(manifest_data)
+        tools = ControlPlaneToolsManifest.model_validate(tools_data)
+        policies = ControlPlanePoliciesManifest.model_validate(policies_data)
+    except ValidationError as exc:
+        raise ControlPlanePackLoadError(
+            f"Invalid extended refinement harness manifest {overlay_path / 'config' / 'harness.yaml'}: {exc}"
+        ) from exc
+
+    try:
+        prompts = _merge_prompt_overlay(
+            _load_prompt_manifest(factory_path / "prompts"),
+            overlay_manifest.get("overrides") or {},
+            overlay_path=overlay_path,
+        )
+    except ValidationError as exc:
+        raise ControlPlanePackLoadError(
+            f"Invalid extended refinement harness prompts {overlay_path / 'config' / 'harness.yaml'}: {exc}"
+        ) from exc
+    _validate_pack(manifest=manifest, prompts=prompts, tools=tools, pack_path=overlay_path)
+    return LoadedControlPlanePack(
+        path=overlay_path,
+        manifest=manifest,
+        prompts=prompts,
+        tools=tools,
+        policies=policies,
+    )
 
 
 def _load_yaml_file(path: Path, *, required: bool = True) -> dict:
@@ -116,6 +201,301 @@ def _load_prompt_manifest(prompts_root: Path) -> ControlPlanePromptsManifest:
         schema_version="mozaiks.refinement_harness.v1.prompts",
         prompts=prompts,
     )
+
+
+def _validate_overlay_manifest_shape(overlay_manifest: dict[str, Any], *, overlay_path: Path) -> None:
+    unknown_keys = set(overlay_manifest) - _HARNESS_OVERLAY_TOP_LEVEL_KEYS
+    if unknown_keys:
+        raise ControlPlanePackLoadError(
+            "Extended refinement harness overlays may only declare "
+            f"{', '.join(sorted(_HARNESS_OVERLAY_TOP_LEVEL_KEYS))}; "
+            f"found {', '.join(sorted(unknown_keys))} in {overlay_path / 'config' / 'harness.yaml'}"
+        )
+    schema_version = overlay_manifest.get("schema_version")
+    if schema_version != REFINEMENT_HARNESS_SCHEMA_VERSION:
+        raise ControlPlanePackLoadError(
+            f"Extended refinement harness overlay schema_version must be {REFINEMENT_HARNESS_SCHEMA_VERSION!r}"
+        )
+    overrides = overlay_manifest.get("overrides") or {}
+    if not isinstance(overrides, dict):
+        raise ControlPlanePackLoadError("Extended refinement harness overrides must be a YAML object")
+    unknown_overrides = set(overrides) - _HARNESS_OVERRIDE_KEYS
+    if unknown_overrides:
+        raise ControlPlanePackLoadError(
+            "Extended refinement harness overrides may only declare "
+            f"{', '.join(sorted(_HARNESS_OVERRIDE_KEYS))}; "
+            f"found {', '.join(sorted(unknown_overrides))}"
+        )
+
+
+def _merge_harness_manifest_overlay(
+    base_manifest_data: dict[str, Any],
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    merged = deepcopy(base_manifest_data)
+    if merged.get("schema_version") != REFINEMENT_HARNESS_SCHEMA_VERSION:
+        raise ControlPlanePackLoadError(
+            f"Default refinement harness schema_version must be {REFINEMENT_HARNESS_SCHEMA_VERSION!r}"
+        )
+
+    if "routing" in overrides:
+        routing_override = overrides["routing"]
+        if not isinstance(routing_override, dict):
+            raise ControlPlanePackLoadError("overrides.routing must be a YAML object")
+        merged["routing"] = _merge_routing(merged.get("routing") or {}, routing_override)
+
+    if "checkpoints" in overrides:
+        checkpoint_overrides = overrides["checkpoints"]
+        if not isinstance(checkpoint_overrides, list):
+            raise ControlPlanePackLoadError("overrides.checkpoints must be a YAML list")
+        merged["checkpoints"] = _merge_list_by_key(
+            merged.get("checkpoints") or [],
+            checkpoint_overrides,
+            key="event",
+            item_label="checkpoint",
+            merge_item=_merge_checkpoint,
+        )
+
+    return merged
+
+
+def _merge_routing(base_routing: dict[str, Any], routing_override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base_routing)
+    if "default_artifact_kind" in routing_override:
+        merged["default_artifact_kind"] = routing_override["default_artifact_kind"]
+    if "artifacts" in routing_override:
+        artifact_overrides = routing_override["artifacts"]
+        if not isinstance(artifact_overrides, list):
+            raise ControlPlanePackLoadError("overrides.routing.artifacts must be a YAML list")
+        merged["artifacts"] = _merge_list_by_key(
+            merged.get("artifacts") or [],
+            artifact_overrides,
+            key="artifact_kind",
+            item_label="artifact route",
+            merge_item=_deep_merge_mapping,
+        )
+    unknown_keys = set(routing_override) - {"default_artifact_kind", "artifacts"}
+    if unknown_keys:
+        raise ControlPlanePackLoadError(
+            f"overrides.routing contains unsupported key(s): {', '.join(sorted(unknown_keys))}"
+        )
+    return merged
+
+
+def _merge_checkpoint(base_item: dict[str, Any], override_item: dict[str, Any]) -> dict[str, Any]:
+    append_tool_ids = override_item.get("append_tool_ids")
+    clean_override = {key: value for key, value in override_item.items() if key != "append_tool_ids"}
+    merged = _deep_merge_mapping(base_item, clean_override)
+    if append_tool_ids is not None:
+        if not isinstance(append_tool_ids, list):
+            raise ControlPlanePackLoadError("checkpoint append_tool_ids must be a YAML list")
+        existing_tool_ids = list(merged.get("tool_ids") or [])
+        for tool_id in append_tool_ids:
+            normalized = str(tool_id or "").strip()
+            if normalized and normalized not in existing_tool_ids:
+                existing_tool_ids.append(normalized)
+        merged["tool_ids"] = existing_tool_ids
+    return merged
+
+
+def _merge_tools_overlay(base_tools_data: dict[str, Any], *, overlay_path: Path) -> dict[str, Any]:
+    tools_path = overlay_path / "config" / "tools.yaml"
+    if not tools_path.exists():
+        return deepcopy(base_tools_data)
+
+    overlay_tools_data = _load_yaml_file(tools_path)
+    _validate_schema_lock(
+        base_tools_data,
+        overlay_tools_data,
+        expected=REFINEMENT_HARNESS_TOOLS_SCHEMA_VERSION,
+        path=tools_path,
+    )
+    merged = deepcopy(base_tools_data)
+    merged["tools"] = _merge_list_by_key(
+        base_tools_data.get("tools") or [],
+        overlay_tools_data.get("tools") or [],
+        key="id",
+        item_label="tool",
+        merge_item=_deep_merge_mapping,
+    )
+    return merged
+
+
+def _merge_policies_overlay(base_policies_data: dict[str, Any], *, overlay_path: Path) -> dict[str, Any]:
+    policies_path = overlay_path / "config" / "policies.yaml"
+    if not policies_path.exists():
+        return deepcopy(base_policies_data)
+
+    overlay_policies_data = _load_yaml_file(policies_path)
+    _validate_schema_lock(
+        base_policies_data,
+        overlay_policies_data,
+        expected=REFINEMENT_HARNESS_POLICIES_SCHEMA_VERSION,
+        path=policies_path,
+    )
+    return _deep_merge_mapping(base_policies_data, overlay_policies_data)
+
+
+def _merge_prompt_overlay(
+    base_prompts: ControlPlanePromptsManifest,
+    overrides: dict[str, Any],
+    *,
+    overlay_path: Path,
+) -> ControlPlanePromptsManifest:
+    prompt_overrides = overrides.get("prompts") or {}
+    if not isinstance(prompt_overrides, dict):
+        raise ControlPlanePackLoadError("overrides.prompts must be a YAML object")
+
+    prompts = [prompt.model_dump() for prompt in base_prompts.prompts]
+    for prompt_id, prompt_ref in prompt_overrides.items():
+        normalized_id = str(prompt_id or "").strip()
+        if not normalized_id:
+            raise ControlPlanePackLoadError("overrides.prompts contains an empty prompt id")
+        prompt_path = _resolve_overlay_file(overlay_path=overlay_path, value=prompt_ref)
+        prompt_data = _load_yaml_file(prompt_path)
+        prompt_data["id"] = str(prompt_data.get("id") or normalized_id).strip()
+        if prompt_data["id"] != normalized_id:
+            raise ControlPlanePackLoadError(
+                f"Prompt override {prompt_path} declares id {prompt_data['id']!r}, expected {normalized_id!r}"
+            )
+        prompts = _upsert_by_key(
+            prompts,
+            prompt_data,
+            key="id",
+            item_label="prompt",
+            merge_item=_deep_merge_mapping,
+        )
+
+    return ControlPlanePromptsManifest.model_validate(
+        {
+            "schema_version": "mozaiks.refinement_harness.v1.prompts",
+            "prompts": prompts,
+        }
+    )
+
+
+def _resolve_overlay_file(*, overlay_path: Path, value: Any) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ControlPlanePackLoadError("Prompt override path must be a non-empty string")
+    raw_path = Path(value.strip())
+    if raw_path.is_absolute():
+        raise ControlPlanePackLoadError("Prompt override paths must be app-workspace relative")
+    workspace_root = overlay_path.parent
+    candidates = []
+    if raw_path.parts and raw_path.parts[0] == "refinement_harness":
+        candidates.append((workspace_root / raw_path).resolve())
+    else:
+        candidates.append((overlay_path / raw_path).resolve())
+    resolved = candidates[0]
+    allowed_root = overlay_path.resolve()
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError as exc:
+        raise ControlPlanePackLoadError(
+            f"Prompt override path must stay inside refinement_harness/: {value}"
+        ) from exc
+    if not resolved.exists():
+        raise ControlPlanePackLoadError(f"Prompt override path not found: {resolved}")
+    return resolved
+
+
+def _validate_schema_lock(
+    base_data: dict[str, Any],
+    overlay_data: dict[str, Any],
+    *,
+    expected: str,
+    path: Path,
+) -> None:
+    if base_data.get("schema_version") != expected:
+        raise ControlPlanePackLoadError(f"Default manifest schema_version must be {expected!r}")
+    if overlay_data.get("schema_version") != expected:
+        raise ControlPlanePackLoadError(f"{path} schema_version must be {expected!r}")
+
+
+def _merge_list_by_key(
+    base_items: list[Any],
+    overlay_items: list[Any],
+    *,
+    key: str,
+    item_label: str,
+    merge_item: Any,
+) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    positions: dict[str, int] = {}
+    for item in base_items:
+        normalized = _normalize_keyed_mapping(item, key=key, item_label=item_label)
+        item_key = str(normalized[key]).strip()
+        if item_key in positions:
+            raise ControlPlanePackLoadError(f"Default refinement harness contains duplicate {item_label} {item_key!r}")
+        positions[item_key] = len(merged)
+        merged.append(normalized)
+
+    for item in overlay_items:
+        normalized = _normalize_keyed_mapping(item, key=key, item_label=item_label)
+        item_key = str(normalized[key]).strip()
+        if normalized.get("remove") is True:
+            if item_key in positions:
+                index = positions.pop(item_key)
+                merged.pop(index)
+                positions = {str(entry[key]).strip(): idx for idx, entry in enumerate(merged)}
+            continue
+        normalized.pop("remove", None)
+        merged = _upsert_by_key(
+            merged,
+            normalized,
+            key=key,
+            item_label=item_label,
+            merge_item=merge_item,
+        )
+        positions = {str(entry[key]).strip(): idx for idx, entry in enumerate(merged)}
+
+    return merged
+
+
+def _upsert_by_key(
+    items: list[dict[str, Any]],
+    overlay_item: dict[str, Any],
+    *,
+    key: str,
+    item_label: str,
+    merge_item: Any,
+) -> list[dict[str, Any]]:
+    item_key = str(overlay_item[key]).strip()
+    for index, item in enumerate(items):
+        if str(item[key]).strip() == item_key:
+            updated = list(items)
+            updated[index] = merge_item(item, overlay_item)
+            return updated
+    return [*items, overlay_item]
+
+
+def _normalize_keyed_mapping(item: Any, *, key: str, item_label: str) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ControlPlanePackLoadError(f"Refinement harness {item_label} entries must be YAML objects")
+    normalized = deepcopy(item)
+    item_key = str(normalized.get(key) or "").strip()
+    if not item_key:
+        raise ControlPlanePackLoadError(f"Refinement harness {item_label} entries must declare {key}")
+    normalized[key] = item_key
+    return normalized
+
+
+def _deep_merge_mapping(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        raise ControlPlanePackLoadError("Refinement harness merge values must be YAML objects")
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if (
+            key == "schema_version"
+            and key in merged
+            and str(value or "").strip() != str(merged.get(key) or "").strip()
+        ):
+            raise ControlPlanePackLoadError("refinement harness overlay cannot change schema_version")
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_mapping(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
 
 
 def _validate_pack(

--- a/mozaiksai/core/workflow/execution/lifecycle.py
+++ b/mozaiksai/core/workflow/execution/lifecycle.py
@@ -46,7 +46,7 @@ from logs.logging_config import get_workflow_logger
 from logs.tools_logs import get_tool_logger, log_tool_event
 
 from ..declarative import parse_tools_config
-from ..paths import primary_workflows_root as _primary_workflows_root
+from ..paths import resolve_workflow_path
 
 logger = logging.getLogger(__name__)
 
@@ -88,8 +88,8 @@ class LifecycleToolManager:
         if self._loaded:
             return
 
-        base_dir = _primary_workflows_root() / self.workflow_name
-        if not base_dir.is_dir():
+        base_dir = resolve_workflow_path(self.workflow_name)
+        if base_dir is None or not base_dir.is_dir():
             logger.debug("[LIFECYCLE] Workflow path not found for '%s'", self.workflow_name)
             self._loaded = True
             return

--- a/mozaiksai/core/workflow/pack/config.py
+++ b/mozaiksai/core/workflow/pack/config.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from mozaiksai.resources import resolve_factory_workflows_root
 
 from ..paths import primary_workflows_root
 from .schema import (
@@ -26,6 +29,7 @@ class _CacheEntry:
 
 
 _GLOBAL_CACHE: _CacheEntry | None = None
+DEFAULT_WORKFLOW_REGISTRY_EXTENDS = "mozaiks.default_workflow_registry"
 
 def _workflows_root() -> Path:
     """Resolve canonical workflows root.
@@ -69,20 +73,141 @@ def load_global_pack_graph(workflows_root: Path | None = None) -> GlobalPackGrap
     if not path.exists():
         return None
 
-    signature = ((str(path), path.stat().st_mtime),)
+    raw = _load_json_file(path)
+    if raw is None:
+        return None
+    base_path = _resolve_default_registry_path(path, raw)
+    signature_items = [(str(path), path.stat().st_mtime)]
+    if base_path is not None:
+        signature_items.append((str(base_path), base_path.stat().st_mtime))
+    signature = tuple(signature_items)
     cached = _GLOBAL_CACHE
     if cached and cached.source == signature:
         payload = cached.payload
         if isinstance(payload, GlobalPackGraph):
             return payload
 
-    raw = _load_json_file(path)
-    if raw is None:
-        return None
+    if base_path is not None:
+        base_raw = _load_json_file(base_path)
+        if base_raw is None:
+            raise ValueError(f"Default workflow registry could not be loaded: {base_path}")
+        raw = _merge_registry_overlay(base_raw, raw)
 
     graph = parse_global_pack_graph(raw)
     _GLOBAL_CACHE = _CacheEntry(source=signature, payload=graph)
     return graph
+
+
+def _resolve_default_registry_path(path: Path, raw: dict[str, Any]) -> Path | None:
+    extends = str(raw.get("extends") or "").strip()
+    if not extends:
+        return None
+    if extends != DEFAULT_WORKFLOW_REGISTRY_EXTENDS:
+        raise ValueError(
+            f"extension_registry.json extends must be {DEFAULT_WORKFLOW_REGISTRY_EXTENDS!r}"
+        )
+    factory_root = resolve_factory_workflows_root()
+    if factory_root is None:
+        raise ValueError("Default workflow registry was not found in the installed mozaiks package")
+    base_path = get_global_pack_graph_path(factory_root)
+    if base_path.resolve() == path.resolve():
+        raise ValueError("Default workflow registry cannot extend itself")
+    return base_path
+
+
+def _merge_registry_overlay(base_raw: dict[str, Any], overlay_raw: dict[str, Any]) -> dict[str, Any]:
+    base = deepcopy(base_raw)
+    overlay = deepcopy(overlay_raw)
+    overlay.pop("extends", None)
+
+    base_version = base.get("version")
+    overlay_version = overlay.get("version", base_version)
+    if overlay_version != base_version:
+        raise ValueError("extension_registry.json overlay cannot change version")
+
+    merged = base
+    for key in ("pack_name", "description"):
+        if key in overlay:
+            merged[key] = overlay[key]
+
+    merged["artifact_dependency_graph"] = _merge_artifact_dependency_graph(
+        base.get("artifact_dependency_graph") or {},
+        overlay.get("artifact_dependency_graph") or {},
+    )
+    for key in ("workflows", "entrypoints", "workflow_sequences", "transitions"):
+        merged[key] = _merge_registry_list_by_id(base.get(key) or [], overlay.get(key) or [])
+    return merged
+
+
+def _merge_artifact_dependency_graph(
+    base_graph: dict[str, Any],
+    overlay_graph: dict[str, Any],
+) -> dict[str, list[str]]:
+    merged: dict[str, list[str]] = {
+        str(family): [str(dep) for dep in dependencies]
+        for family, dependencies in base_graph.items()
+        if isinstance(dependencies, list)
+    }
+    for raw_family, raw_dependencies in overlay_graph.items():
+        family = str(raw_family or "").strip()
+        if not family:
+            raise ValueError("artifact_dependency_graph overlay family ids must be non-empty")
+        if not isinstance(raw_dependencies, list):
+            raise ValueError(f"artifact_dependency_graph family {family!r} dependencies must be a list")
+        dependencies = merged.setdefault(family, [])
+        for raw_dependency in raw_dependencies:
+            dependency = str(raw_dependency or "").strip()
+            if dependency and dependency not in dependencies:
+                dependencies.append(dependency)
+    return merged
+
+
+def _merge_registry_list_by_id(base_items: list[Any], overlay_items: list[Any]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    positions: dict[str, int] = {}
+    for item in base_items:
+        normalized = _normalize_registry_item(item)
+        item_id = normalized["id"]
+        positions[item_id] = len(merged)
+        merged.append(normalized)
+
+    for item in overlay_items:
+        normalized = _normalize_registry_item(item)
+        item_id = normalized["id"]
+        if normalized.get("remove") is True:
+            if item_id in positions:
+                index = positions.pop(item_id)
+                merged.pop(index)
+                positions = {entry["id"]: idx for idx, entry in enumerate(merged)}
+            continue
+        normalized.pop("remove", None)
+        if item_id in positions:
+            merged[positions[item_id]] = _deep_merge_mapping(merged[positions[item_id]], normalized)
+        else:
+            positions[item_id] = len(merged)
+            merged.append(normalized)
+    return merged
+
+
+def _normalize_registry_item(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValueError("extension_registry.json list entries must be objects")
+    normalized = deepcopy(item)
+    item_id = str(normalized.get("id") or "").strip()
+    if not item_id:
+        raise ValueError("extension_registry.json list entries must declare id")
+    normalized["id"] = item_id
+    return normalized
+
+
+def _deep_merge_mapping(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_mapping(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
 
 
 def list_workflow_ids(pack: GlobalPackGraph) -> list[str]:
@@ -228,6 +353,7 @@ def journey_next_step(journey: GlobalJourney, current_workflow: str) -> str | No
 __all__ = [
     "get_global_pack_graph_path",
     "load_global_pack_graph",
+    "DEFAULT_WORKFLOW_REGISTRY_EXTENDS",
     "list_workflow_ids",
     "get_workflow_entry",
     "list_workflow_sequences",

--- a/mozaiksai/core/workflow/paths.py
+++ b/mozaiksai/core/workflow/paths.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 from mozaiksai.resources import resolve_factory_workflows_root
+
+DEFAULT_WORKFLOW_REGISTRY_EXTENDS = "mozaiks.default_workflow_registry"
 
 
 def repo_root() -> Path:
@@ -103,6 +106,38 @@ def primary_workflows_root(
     return resolve_workflows_root(root)
 
 
+def _registry_extends_default(workflows_root: Path) -> bool:
+    registry_path = workflows_root / "extended_orchestration" / "extension_registry.json"
+    if not registry_path.exists():
+        return False
+    try:
+        raw = json.loads(registry_path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    return str(raw.get("extends") or "").strip() == DEFAULT_WORKFLOW_REGISTRY_EXTENDS
+
+
+def workflow_resolution_roots(
+    root: str | os.PathLike[str] | None = None,
+) -> tuple[Path, ...]:
+    """Return workflow roots searched for declarative workflow folders.
+
+    A registry overlay can extend the packaged default workflow registry. In
+    that case the active app root owns app-local workflows and the installed
+    package owns the default Factory workflows referenced by the effective
+    registry.
+    """
+    primary_root = resolve_workflows_root(root)
+    roots = [primary_root]
+    if _registry_extends_default(primary_root):
+        factory_root = _repo_factory_workflows_root()
+        if factory_root.is_dir() and factory_root.resolve() != primary_root.resolve():
+            roots.append(factory_root)
+    return tuple(roots)
+
+
 def resolve_workflow_path(
     workflow_name: str,
     root: str | os.PathLike[str] | None = None,
@@ -111,40 +146,38 @@ def resolve_workflow_path(
     if not wf:
         return None
 
-    root_path = resolve_workflows_root(root)
-    candidate = (root_path / wf).resolve()
-    if candidate.is_dir() and (candidate / "orchestrator.yaml").exists():
-        return candidate
+    for root_path in workflow_resolution_roots(root):
+        candidate = (root_path / wf).resolve()
+        if candidate.is_dir() and (candidate / "orchestrator.yaml").exists():
+            return candidate
     return None
 
 
 def discover_workflow_paths(
     root: str | os.PathLike[str] | None = None,
 ) -> dict[str, Path]:
-    discovered: dict[str, Path] = {}
-    seen: set[str] = set()
-    root_path = resolve_workflows_root(root)
-    if not root_path.exists():
-        return discovered
-    for item in sorted(root_path.iterdir(), key=lambda value: value.name.lower()):
-        if not item.is_dir() or item.name.startswith(".") or item.name == "extended_orchestration":
+    discovered: dict[str, tuple[str, Path]] = {}
+    for root_path in reversed(workflow_resolution_roots(root)):
+        if not root_path.exists():
             continue
-        if not (item / "orchestrator.yaml").exists():
-            continue
-        normalized = item.name.lower()
-        if normalized in seen:
-            continue
-        seen.add(normalized)
-        discovered[item.name] = item.resolve()
-    return discovered
+        for item in sorted(root_path.iterdir(), key=lambda value: value.name.lower()):
+            if not item.is_dir() or item.name.startswith(".") or item.name == "extended_orchestration":
+                continue
+            if not (item / "orchestrator.yaml").exists():
+                continue
+            normalized = item.name.lower()
+            discovered[normalized] = (item.name, item.resolve())
+    return {name: path for name, path in discovered.values()}
 
 
 __all__ = [
     "candidate_app_workflows_roots",
     "discover_workflow_paths",
+    "DEFAULT_WORKFLOW_REGISTRY_EXTENDS",
     "primary_workflows_root",
     "repo_root",
     "resolve_active_app_root",
     "resolve_workflow_path",
     "resolve_workflows_root",
+    "workflow_resolution_roots",
 ]

--- a/tests/test_appgenerator_module_contracts.py
+++ b/tests/test_appgenerator_module_contracts.py
@@ -356,8 +356,8 @@ def test_appgenerator_prompts_emit_modules_contract_instead_of_removed_operation
     assert refinement_harness["required_outputs"] == [
         "app/config/refinement_policy.yaml",
         "refinement_harness/config/harness.yaml",
-        "refinement_harness/config/tools.yaml",
     ]
+    assert "refinement_harness/config/tools.yaml" in refinement_harness["optional_outputs"]
     assert "modules/{pack_name}/contracts/reactions.yaml" in module_contract["optional_outputs"]
     assert "modules/{pack_name}/contracts/subscriptions.yaml" not in module_contract["optional_outputs"]
     assert "modules/{pack_name}/contracts/admin.yaml" in module_contract["optional_outputs"]
@@ -425,15 +425,8 @@ def test_refinement_harness_codegen_seeds_refinement_policy_yaml() -> None:
         {
             "harness_yaml": {
                 "schema_version": "mozaiks.refinement_harness.v1",
-                "routing": {
-                    "default_artifact_kind": "app_bundle",
-                    "artifacts": [],
-                },
-                "checkpoints": [],
-            },
-            "tools_yaml": {
-                "schema_version": "mozaiks.refinement_harness.tools.v1",
-                "tools": [],
+                "extends": "mozaiks.default_refinement_harness",
+                "overrides": None,
             },
         }
     )
@@ -444,6 +437,13 @@ def test_refinement_harness_codegen_seeds_refinement_policy_yaml() -> None:
     runtime_yaml = yaml.safe_load(file_map["app/config/refinement_policy.yaml"])
     assert runtime_yaml["schema_version"] == "mozaiks.refinement.policy.v1"
     assert runtime_yaml["classifier"]["llm_profile"] == "classifier"
+    harness_yaml = yaml.safe_load(file_map["refinement_harness/config/harness.yaml"])
+    assert harness_yaml == {
+        "schema_version": "mozaiks.refinement_harness.v1",
+        "extends": "mozaiks.default_refinement_harness",
+        "overrides": {},
+    }
+    assert "refinement_harness/config/tools.yaml" not in file_map
 
 
 def test_appgenerator_download_tool_does_not_inject_removed_admin_surfaces() -> None:

--- a/tests/test_capability_pack_contracts.py
+++ b/tests/test_capability_pack_contracts.py
@@ -833,8 +833,8 @@ def test_app_build_plan_tool_accepts_refinement_harness_task() -> None:
                 "description": "Generate app-local refinement harness pack.",
                 "initial_message": "Route scoped refinements to app_revision.",
                 "owned_paths": [
+                    "app/config/refinement_policy.yaml",
                     "refinement_harness/config/harness.yaml",
-                    "refinement_harness/config/tools.yaml",
                     "refinement_harness/prompts/change_classifier_system.yaml",
                 ],
                 "depends_on": [],
@@ -868,8 +868,8 @@ def test_app_build_plan_tool_rejects_refinement_harness_with_capability_pack_id(
                     "description": "Generate app-local refinement harness pack.",
                     "initial_message": "Route scoped refinements to app_revision.",
                     "owned_paths": [
+                        "app/config/refinement_policy.yaml",
                         "refinement_harness/config/harness.yaml",
-                        "refinement_harness/config/tools.yaml",
                     ],
                     "depends_on": [],
                     "acceptance_criteria": ["Routes use workflow_sequence only"],
@@ -899,8 +899,8 @@ def test_app_build_plan_tool_rejects_refinement_harness_wrong_initial_agent() ->
                     "description": "Generate app-local refinement harness pack.",
                     "initial_message": "Route scoped refinements to app_revision.",
                     "owned_paths": [
+                        "app/config/refinement_policy.yaml",
                         "refinement_harness/config/harness.yaml",
-                        "refinement_harness/config/tools.yaml",
                     ],
                     "depends_on": [],
                     "acceptance_criteria": ["Routes use workflow_sequence only"],
@@ -930,8 +930,8 @@ def test_app_build_plan_tool_rejects_refinement_harness_invalid_owned_path() -> 
                     "description": "Generate app-local refinement harness pack.",
                     "initial_message": "Route scoped refinements to app_revision.",
                     "owned_paths": [
+                        "app/config/refinement_policy.yaml",
                         "refinement_harness/config/harness.yaml",
-                        "refinement_harness/config/tools.yaml",
                         "backend/refinement_harness/custom.py",
                     ],
                     "depends_on": [],
@@ -992,8 +992,8 @@ def test_app_build_plan_tool_rejects_refinement_harness_non_yaml_prompt() -> Non
                     "description": "Generate app-local refinement harness pack.",
                     "initial_message": "Route scoped refinements to app_revision.",
                     "owned_paths": [
+                        "app/config/refinement_policy.yaml",
                         "refinement_harness/config/harness.yaml",
-                        "refinement_harness/config/tools.yaml",
                         "refinement_harness/prompts/change_classifier_system.txt",
                     ],
                     "depends_on": [],

--- a/tests/test_control_plane_loader.py
+++ b/tests/test_control_plane_loader.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from mozaiksai.control_plane import (
+    DEFAULT_REFINEMENT_HARNESS_EXTENDS,
     ControlPlanePackLoadError,
     load_refinement_harness,
     load_selected_refinement_harness,
@@ -23,6 +24,10 @@ def test_load_default_factory_refinement_harness() -> None:
     assert app_bundle is not None
     assert app_bundle.routes.core.workflow_sequence == "full_rebuild"
     assert app_bundle.routes.patch.workflow_sequence == "app_revision"
+    theme_config = pack.routing_for_artifact("theme_config")
+    assert theme_config is not None
+    assert theme_config.routes.patch.workflow_sequence == "theme_patch"
+    assert theme_config.routes.design.workflow_sequence == "theme_revision"
     request_intake = pack.checkpoint_by_event("request_submitted")
     assert request_intake is not None
     assert request_intake.mode == "ag2_structured_agent"
@@ -34,6 +39,14 @@ def test_load_default_factory_refinement_harness() -> None:
         "get_app_intelligence_context",
         "get_stale_artifact_families",
     ]
+    route = pack.checkpoint_by_event("route_requested")
+    assert route is not None
+    assert route.mode == "deterministic_handler"
+    assert route.tool_ids == []
+    decision = pack.checkpoint_by_event("decision_requested")
+    assert decision is not None
+    assert decision.mode == "deterministic_handler"
+    assert decision.tool_ids == []
     scope = pack.checkpoint_by_event("scope_requested")
     assert scope is not None
     assert scope.mode == "ag2_structured_agent"
@@ -155,6 +168,139 @@ def test_load_selected_refinement_harness_uses_app_override(tmp_path: Path) -> N
 
     assert pack.path == (workspace_root / "refinement_harness").resolve()
     assert pack.policies.scope.max_selected_paths == 2
+
+
+def test_load_selected_refinement_harness_extends_default_with_overlay(tmp_path: Path) -> None:
+    app_root = tmp_path / "app"
+    workspace_root = tmp_path
+    overlay_root = workspace_root / "refinement_harness"
+    (app_root / "config").mkdir(parents=True)
+    (overlay_root / "config").mkdir(parents=True)
+    (overlay_root / "prompts").mkdir(parents=True)
+
+    (app_root / "config" / "ai.json").write_text(
+        json.dumps(
+            {
+                "control_plane": {
+                    "enabled": True,
+                    "classifier": {"enabled": True, "llm_config": {"model": "gpt-5-nano"}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (overlay_root / "config" / "harness.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "mozaiks.refinement_harness.v1",
+                "extends": DEFAULT_REFINEMENT_HARNESS_EXTENDS,
+                "overrides": {
+                    "routing": {
+                        "artifacts": [
+                            {
+                                "artifact_kind": "app_bundle",
+                                "label": "App Zero app bundle",
+                            }
+                        ]
+                    },
+                    "checkpoints": [
+                        {
+                            "event": "route_requested",
+                            "tool_ids": ["get_carry_forward_candidates"],
+                        },
+                        {
+                            "event": "coding_requested",
+                            "append_tool_ids": ["read_artifact_file", "app_local_context"],
+                        },
+                    ],
+                    "prompts": {
+                        "coding_refinement_system": "refinement_harness/prompts/coding_refinement_system.yaml"
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (overlay_root / "prompts" / "coding_refinement_system.yaml").write_text(
+        "\n".join(
+            [
+                "id: coding_refinement_system",
+                "content: App-local coding prompt override.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (overlay_root / "config" / "tools.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "mozaiks.refinement_harness.tools.v1",
+                "tools": [
+                    {
+                        "id": "app_local_context",
+                        "kind": "context_tool",
+                        "description": "App-local context tool.",
+                        "entrypoint": "app.refinement_tools:app_local_context",
+                        "available_to": ["coding_requested"],
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (overlay_root / "config" / "policies.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "mozaiks.refinement_harness.policies.v1",
+                "scope": {
+                    "max_selected_paths": 5,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    pack = load_selected_refinement_harness(app_root=app_root)
+
+    assert pack.path == overlay_root.resolve()
+    app_bundle = pack.routing_for_artifact("app_bundle")
+    assert app_bundle is not None
+    assert app_bundle.label == "App Zero app bundle"
+    assert app_bundle.routes.patch.workflow_sequence == "app_revision"
+    assert pack.routing_for_artifact("theme_config") is not None
+    route = pack.checkpoint_by_event("route_requested")
+    assert route is not None
+    assert route.tool_ids == ["get_carry_forward_candidates"]
+    coding = pack.checkpoint_by_event("coding_requested")
+    assert coding is not None
+    assert coding.tool_ids[-2:] == ["read_artifact_file", "app_local_context"]
+    assert pack.tool_by_id("app_local_context") is not None
+    assert pack.prompt_by_id("coding_refinement_system").content == "App-local coding prompt override."
+    assert pack.policies.scope.max_selected_paths == 5
+    assert pack.policies.scope.auto_apply_max_paths == 1
+
+
+def test_extended_refinement_harness_rejects_whole_pack_fields(tmp_path: Path) -> None:
+    app_root = tmp_path / "app"
+    overlay_root = tmp_path / "refinement_harness"
+    (app_root / "config").mkdir(parents=True)
+    (overlay_root / "config").mkdir(parents=True)
+    (overlay_root / "config" / "harness.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "mozaiks.refinement_harness.v1",
+                "extends": DEFAULT_REFINEMENT_HARNESS_EXTENDS,
+                "routing": {"default_artifact_kind": "app_bundle"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ControlPlanePackLoadError, match="may only declare"):
+        load_selected_refinement_harness(app_root=app_root)
 
 
 def test_load_refinement_harness_validates_prompt_references(tmp_path: Path) -> None:

--- a/tests/test_generator_code_file_materialization.py
+++ b/tests/test_generator_code_file_materialization.py
@@ -397,26 +397,35 @@ def test_appgenerator_extract_code_file_map_materializes_typed_refinement_harnes
         "refinement_harness": {
             "harness_yaml": {
                 "schema_version": "mozaiks.refinement_harness.v1",
-                "routing": {
-                    "default_artifact_kind": "app_bundle",
-                    "artifacts": [
+                "extends": "mozaiks.default_refinement_harness",
+                "overrides": {
+                    "routing": {
+                        "artifacts": [
+                            {
+                                "artifact_kind": "app_bundle",
+                                "label": "custom app bundle",
+                            }
+                        ],
+                    },
+                    "checkpoints": [
                         {
-                            "artifact_kind": "app_bundle",
-                            "label": "app bundle",
-                            "routes": {
-                                "patch": {"workflow_sequence": "app_revision"},
-                                "design": {"workflow_sequence": "app_surface_revision"},
-                                "feature": {"workflow_sequence": "app_revision"},
-                                "core": {"workflow_sequence": "full_rebuild"},
-                            },
+                            "event": "coding_requested",
+                            "append_tool_ids": ["app_local_context"],
                         }
                     ],
                 },
-                "checkpoints": [],
             },
             "tools_yaml": {
                 "schema_version": "mozaiks.refinement_harness.tools.v1",
-                "tools": [],
+                "tools": [
+                    {
+                        "id": "app_local_context",
+                        "kind": "context_tool",
+                        "description": "Load app-local refinement context.",
+                        "entrypoint": "app.refinement_tools:app_local_context",
+                        "available_to": ["coding_requested"],
+                    }
+                ],
             },
             "policies_yaml": {
                 "schema_version": "mozaiks.refinement_harness.policies.v1",
@@ -428,9 +437,9 @@ def test_appgenerator_extract_code_file_map_materializes_typed_refinement_harnes
             },
             "prompt_files": [
                 {
-                    "id": "change classifier system",
+                    "id": "coding_refinement_system",
                     "filename": "",
-                    "content": "Classify the refinement request.",
+                    "content": "Use app-local coding guidance.",
                 }
             ],
         },
@@ -449,18 +458,30 @@ def test_appgenerator_extract_code_file_map_materializes_typed_refinement_harnes
         "refinement_harness/config/harness.yaml",
         "refinement_harness/config/tools.yaml",
         "refinement_harness/config/policies.yaml",
-        "refinement_harness/prompts/change_classifier_system.yaml",
+        "refinement_harness/prompts/coding_refinement_system.yaml",
     }
-    assert yaml.safe_load(file_map["refinement_harness/config/harness.yaml"])["routing"]["artifacts"][0]["routes"]["patch"] == {
-        "workflow_sequence": "app_revision",
+    harness_yaml = yaml.safe_load(file_map["refinement_harness/config/harness.yaml"])
+    assert harness_yaml["extends"] == "mozaiks.default_refinement_harness"
+    assert harness_yaml["overrides"]["routing"]["artifacts"][0]["label"] == "custom app bundle"
+    assert harness_yaml["overrides"]["checkpoints"][0]["append_tool_ids"] == ["app_local_context"]
+    assert harness_yaml["overrides"]["prompts"] == {
+        "coding_refinement_system": "refinement_harness/prompts/coding_refinement_system.yaml"
     }
     assert yaml.safe_load(file_map["refinement_harness/config/tools.yaml"]) == {
         "schema_version": "mozaiks.refinement_harness.tools.v1",
-        "tools": [],
+        "tools": [
+            {
+                "id": "app_local_context",
+                "kind": "context_tool",
+                "description": "Load app-local refinement context.",
+                "entrypoint": "app.refinement_tools:app_local_context",
+                "available_to": ["coding_requested"],
+            }
+        ],
     }
-    assert yaml.safe_load(file_map["refinement_harness/prompts/change_classifier_system.yaml"]) == {
-        "id": "change classifier system",
-        "content": "Classify the refinement request.",
+    assert yaml.safe_load(file_map["refinement_harness/prompts/coding_refinement_system.yaml"]) == {
+        "id": "coding_refinement_system",
+        "content": "Use app-local coding guidance.",
     }
 
 
@@ -469,12 +490,8 @@ def test_appgenerator_refinement_harness_rejects_prompt_paths_outside_pack() -> 
         "refinement_harness": {
             "harness_yaml": {
                 "schema_version": "mozaiks.refinement_harness.v1",
-                "routing": {"default_artifact_kind": "app_bundle", "artifacts": []},
-                "checkpoints": [],
-            },
-            "tools_yaml": {
-                "schema_version": "mozaiks.refinement_harness.tools.v1",
-                "tools": [],
+                "extends": "mozaiks.default_refinement_harness",
+                "overrides": None,
             },
             "prompt_files": [
                 {
@@ -490,45 +507,22 @@ def test_appgenerator_refinement_harness_rejects_prompt_paths_outside_pack() -> 
         extract_appgenerator_code_file_map(payload)
 
 
-def test_appgenerator_refinement_harness_rejects_schema_violations() -> None:
-    """Schema round-trip in codegen catches extra fields and wrong field names at generation time."""
+def test_appgenerator_refinement_harness_rejects_missing_extends() -> None:
     payload = {
         "refinement_harness": {
             "harness_yaml": {
                 "schema_version": "mozaiks.refinement_harness.v1",
-                "routing": {
-                    "default_artifact_kind": "app_bundle",
-                    "artifacts": [
-                        {
-                            "artifact_kind": "app_bundle",
-                            "label": "app bundle",
-                            "routes": {
-                                "patch": {
-                                    # Wrong field name: route_to instead of workflow_sequence
-                                    "route_to": "app_revision",
-                                },
-                                "design": {"workflow_sequence": "app_surface_revision"},
-                                "feature": {"workflow_sequence": "app_revision"},
-                                "core": {"workflow_sequence": "full_rebuild"},
-                            },
-                        }
-                    ],
-                },
-                "checkpoints": [],
-            },
-            "tools_yaml": {
-                "schema_version": "mozaiks.refinement_harness.tools.v1",
-                "tools": [],
+                "extends": "app.local_refinement_harness",
+                "overrides": {},
             },
         }
     }
 
-    with pytest.raises(ValueError, match="schema validation"):
+    with pytest.raises(ValueError, match="must extend"):
         extract_appgenerator_code_file_map(payload)
 
 
-def test_appgenerator_refinement_harness_rejects_extra_route_fields() -> None:
-    """Extra fields on route objects are rejected by the strict runtime schema."""
+def test_appgenerator_refinement_harness_rejects_full_pack_manifest() -> None:
     payload = {
         "refinement_harness": {
             "harness_yaml": {
@@ -554,14 +548,10 @@ def test_appgenerator_refinement_harness_rejects_extra_route_fields() -> None:
                 },
                 "checkpoints": [],
             },
-            "tools_yaml": {
-                "schema_version": "mozaiks.refinement_harness.tools.v1",
-                "tools": [],
-            },
         }
     }
 
-    with pytest.raises(ValueError, match="schema validation"):
+    with pytest.raises(ValueError, match="extends overlay"):
         extract_appgenerator_code_file_map(payload)
 
 

--- a/tests/test_pack_config_paths.py
+++ b/tests/test_pack_config_paths.py
@@ -14,6 +14,10 @@ _resources = import_module_directly("mozaiksai.resources")
 get_global_pack_graph_path = _config.get_global_pack_graph_path
 load_global_pack_graph = _config.load_global_pack_graph
 list_workflow_sequences = _config.list_workflow_sequences
+DEFAULT_WORKFLOW_REGISTRY_EXTENDS = _config.DEFAULT_WORKFLOW_REGISTRY_EXTENDS
+discover_workflow_paths = _paths.discover_workflow_paths
+resolve_workflow_path = _paths.resolve_workflow_path
+workflow_resolution_roots = _paths.workflow_resolution_roots
 
 
 def _use_repo_factory_workflows(monkeypatch) -> None:
@@ -96,6 +100,117 @@ def test_single_root_registry_path_uses_explicit_override_without_factory_merge(
     assert graph is not None
     assert {workflow.id for workflow in graph.workflows} == {"HostedOnly"}
     assert graph.journeys == []
+
+
+def test_registry_extends_packaged_default_with_app_overlay(monkeypatch, tmp_path: Path) -> None:
+    _use_repo_factory_workflows(monkeypatch)
+
+    workflows_root = tmp_path / "workflows"
+    registry_dir = workflows_root / "extended_orchestration"
+    registry_dir.mkdir(parents=True)
+    hosted_workflow_dir = workflows_root / "HostedOnly"
+    hosted_workflow_dir.mkdir()
+    (hosted_workflow_dir / "orchestrator.yaml").write_text(
+        "workflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
+        encoding="utf-8",
+    )
+    target_registry = registry_dir / "extension_registry.json"
+    target_registry.write_text(
+        json.dumps(
+            {
+                "pack_name": "AppOverlay",
+                "version": 3,
+                "extends": DEFAULT_WORKFLOW_REGISTRY_EXTENDS,
+                "workflows": [
+                    {"id": "HostedOnly", "description": "Product workflow"},
+                ],
+                "entrypoints": [
+                    {"id": "create_app", "remove": True},
+                    {
+                        "id": "hosted_only",
+                        "workflow": "HostedOnly",
+                        "path": "/hosted-only",
+                        "label": "Hosted Only",
+                    },
+                ],
+                "workflow_sequences": [
+                    {
+                        "id": "hosted_sequence",
+                        "affected_declarative_families": ["hosted_artifact"],
+                        "steps": [{"workflows": ["HostedOnly"]}],
+                    }
+                ],
+                "artifact_dependency_graph": {
+                    "hosted_artifact": [],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(workflows_root))
+    _config._GLOBAL_CACHE = None
+
+    graph = load_global_pack_graph()
+
+    assert graph is not None
+    workflow_ids = {workflow.id for workflow in graph.workflows}
+    assert {"ValueEngine", "AppGenerator", "HostedOnly"} <= workflow_ids
+    entrypoint_ids = {entrypoint.id for entrypoint in graph.entrypoints}
+    assert "create_app" not in entrypoint_ids
+    assert "hosted_only" in entrypoint_ids
+    sequence_ids = {sequence.id for sequence in graph.journeys}
+    assert {"app_revision", "theme_patch", "hosted_sequence"} <= sequence_ids
+    assert graph.artifact_dependency_graph["hosted_artifact"] == []
+
+    roots = workflow_resolution_roots(workflows_root)
+    assert roots[0] == workflows_root.resolve()
+    assert roots[1] == _resources.resolve_factory_workflows_root()
+    workflow_paths = discover_workflow_paths(workflows_root)
+    assert workflow_paths["HostedOnly"] == hosted_workflow_dir.resolve()
+    assert workflow_paths["AppGenerator"] == (
+        _resources.resolve_factory_workflows_root() / "AppGenerator"
+    ).resolve()
+    assert resolve_workflow_path("HostedOnly", workflows_root) == hosted_workflow_dir.resolve()
+    assert resolve_workflow_path("AppGenerator", workflows_root) == (
+        _resources.resolve_factory_workflows_root() / "AppGenerator"
+    ).resolve()
+
+
+def test_explicit_app_registry_without_extends_does_not_discover_factory_workflows(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _use_repo_factory_workflows(monkeypatch)
+
+    workflows_root = tmp_path / "workflows"
+    registry_dir = workflows_root / "extended_orchestration"
+    registry_dir.mkdir(parents=True)
+    hosted_workflow_dir = workflows_root / "HostedOnly"
+    hosted_workflow_dir.mkdir()
+    (hosted_workflow_dir / "orchestrator.yaml").write_text(
+        "workflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
+        encoding="utf-8",
+    )
+    (registry_dir / "extension_registry.json").write_text(
+        json.dumps(
+            {
+                "pack_name": "AppOnly",
+                "version": 3,
+                "workflows": [
+                    {"id": "HostedOnly", "description": "Product workflow"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(workflows_root))
+
+    workflow_paths = discover_workflow_paths(workflows_root)
+
+    assert workflow_paths == {"HostedOnly": hosted_workflow_dir.resolve()}
+    assert resolve_workflow_path("AppGenerator", workflows_root) is None
 
 
 def test_declared_global_workflows_match_physical_workflow_folders(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add `extends: mozaiks.default_refinement_harness` support to the refinement harness loader
- make the OSS default harness cover theme_config routing plus deterministic route/decision checkpoints
- document app-local harnesses as overlays instead of copied packs

## Validation
- `python -m pytest --no-cov tests/test_control_plane_loader.py tests/test_refinement_routing_contracts.py tests/test_config_guides.py -q`
- `python -m ruff check mozaiksai/control_plane/loader.py mozaiksai/control_plane/__init__.py tests/test_control_plane_loader.py`
- `git diff --check -- mozaiksai/control_plane/loader.py mozaiksai/control_plane/__init__.py factory_app/refinement_harness/config/harness.yaml docs/guides/configs/refinement.md docs/guides/platform-intelligence/03-refinement.md docs/guides/extending-ai-functionality/01-overview.md docs/guides/configs/index.md docs/architecture/workflows/refinement-harness-architecture.md docs/architecture/app/refinement-harness.md tests/test_control_plane_loader.py`