### PR TITLE
feat(workflows): add BrandAssetGeneratorWorkflow with promote_brand_asset tool

### DIFF
--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
@@ -1,0 +1,18 @@
+agents:
+  - name: BrandDesignerAgent
+    role: >
+      You are a professional brand designer. Your job is to generate high-quality
+      logo and brand imagery for apps built on the Mozaiks platform.
+      When given a brand brief, generate one or more logo images using the
+      image generation tool, then present the options to the user for review.
+      After the user selects a preferred image, call promote_brand_asset with
+      the asset_id and role="logo" to commit it to the app's brand manifest.
+    multimodal_inputs_enabled: true
+    image_generation:
+      quality: high
+      size: "1024x1024"
+      background: opaque
+      output_format: png
+    promotion_targets:
+      - app_asset
+      - brand_asset

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/context_variables.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/context_variables.yaml
@@ -1,0 +1,36 @@
+variables:
+  - name: app_id
+    type: str
+    default: ""
+    description: ID of the app whose brand assets are being generated.
+
+  - name: chat_id
+    type: str
+    default: ""
+    description: Active workflow chat/session ID.
+
+  - name: brand_brief
+    type: str
+    default: ""
+    description: >
+      User-supplied brand brief describing the app identity, style, and
+      visual direction for logo generation.
+
+  - name: generated_brand_assets
+    type: list
+    default: []
+    description: >
+      List of asset records generated in this session. Each entry has
+      asset_id, role, content_url, and promoted flag.
+
+  - name: promoted_brand_assets
+    type: list
+    default: []
+    description: >
+      Subset of generated_brand_assets that have been promoted to
+      asset_manifest.json.
+
+  - name: brand_assets_complete
+    type: bool
+    default: false
+    description: Set to true when the user confirms brand assets are finalized.

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
@@ -1,0 +1,6 @@
+workflow_name: BrandAssetGeneratorWorkflow
+max_turns: 30
+human_in_the_loop: true
+workflow_startup_mode: AgentDriven
+orchestration_pattern: DefaultPattern
+initial_agent: BrandDesignerAgent

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/tools.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/tools.yaml
@@ -1,0 +1,28 @@
+tools:
+  - id: promote_brand_asset
+    kind: Agent_Tool
+    auto_tool_call: false
+    description: >
+      Promote a generated brand asset to the deterministic asset_manifest.json,
+      making it the canonical brand asset for this role (logo, icon, hero, etc.).
+    input_schema:
+      - name: asset_id
+        type: str
+        required: true
+        description: asset_id from generated_brand_assets to promote.
+      - name: role
+        type: str
+        required: true
+        description: Asset role — logo, icon, hero, splash, or og_image.
+      - name: alt_text
+        type: str
+        required: false
+        description: Optional alt text for the asset.
+
+  - id: on_workflow_start
+    kind: Lifecycle_Tool
+    trigger: workflow_start
+
+  - id: on_workflow_end
+    kind: Lifecycle_Tool
+    trigger: workflow_end

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/tools/promote_brand_asset.py
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/tools/promote_brand_asset.py
@@ -1,0 +1,105 @@
+"""promote_brand_asset — promote a generated brand asset to asset_manifest.json."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Annotated, Any
+
+
+async def promote_brand_asset(
+    asset_id: Annotated[str, "asset_id from generated_brand_assets to promote"],
+    role: Annotated[str, "Asset role: logo, icon, hero, splash, or og_image"],
+    context_variables: Annotated[Any | None, "Runtime context"] = None,
+    alt_text: Annotated[str | None, "Optional alt text for the asset"] = None,
+) -> dict[str, Any]:
+    """Promote a generated brand asset to asset_manifest.json."""
+    workspace = os.getenv("MOZAIKS_APP_WORKSPACE_PATH", "").strip()
+    if not workspace:
+        return {"ok": False, "error": "MOZAIKS_APP_WORKSPACE_PATH not set"}
+
+    app_id = ""
+    if context_variables is not None:
+        if isinstance(context_variables, dict):
+            app_id = context_variables.get("app_id", "") or ""
+        else:
+            app_id = getattr(context_variables, "app_id", "") or ""
+
+    # idempotency guard
+    if context_variables is not None:
+        promoted: list = []
+        if isinstance(context_variables, dict):
+            promoted = context_variables.get("promoted_brand_assets", []) or []
+        else:
+            promoted = getattr(context_variables, "promoted_brand_assets", []) or []
+        if any(e.get("asset_id") == asset_id and e.get("role") == role for e in promoted):
+            content_url = (
+                f"/api/media/assets/{app_id}/{asset_id}/content"
+                if app_id
+                else f"/api/media/assets/{asset_id}/content"
+            )
+            return {
+                "ok": True,
+                "already_promoted": True,
+                "asset_id": asset_id,
+                "role": role,
+                "content_url": content_url,
+            }
+
+    content_url = (
+        f"/api/media/assets/{app_id}/{asset_id}/content"
+        if app_id
+        else f"/api/media/assets/{asset_id}/content"
+    )
+
+    # write asset_manifest.json
+    config_dir = Path(workspace) / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = config_dir / "asset_manifest.json"
+
+    manifest: dict = {}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            manifest = {}
+
+    manifest.setdefault("assets", {})
+    manifest["assets"][role] = {
+        "asset_id": asset_id,
+        "content_url": content_url,
+        "alt_text": alt_text or "",
+        "promoted": True,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    # mark asset promoted in store (best-effort)
+    try:
+        from mozaiksai.core.media.store import get_media_asset_store
+        from mozaiksai.core.media import MediaPromotionTarget
+
+        store = get_media_asset_store()
+        await store.mark_asset_promoted(asset_id, MediaPromotionTarget.BRAND_ASSET)
+    except Exception:
+        pass
+
+    # update context_variables
+    if context_variables is not None:
+        entry = {"asset_id": asset_id, "role": role, "content_url": content_url}
+        if isinstance(context_variables, dict):
+            context_variables.setdefault("promoted_brand_assets", []).append(entry)
+        else:
+            lst = getattr(context_variables, "promoted_brand_assets", None) or []
+            lst.append(entry)
+            try:
+                context_variables.promoted_brand_assets = lst
+            except AttributeError:
+                pass
+
+    return {
+        "ok": True,
+        "asset_id": asset_id,
+        "role": role,
+        "content_url": content_url,
+        "manifest_path": str(manifest_path),
+    }

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/transition_graph.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/transition_graph.yaml
@@ -1,0 +1,5 @@
+transitions:
+  - after_turn: user
+    terminate_if:
+      variable: brand_assets_complete
+      equals: true


### PR DESCRIPTION
## Summary

- Adds `BrandAssetGeneratorWorkflow` — the OSS factory workflow for AI-driven brand logo and image generation
- `BrandDesignerAgent` uses `image_generation` (high quality, 1024x1024, opaque PNG) with `[app_asset, brand_asset]` promotion targets
- `promote_brand_asset` tool writes idempotent role-keyed entries to `{workspace}/config/asset_manifest.json` and calls `store.mark_asset_promoted(MediaPromotionTarget.BRAND_ASSET)`
- Standard workflow scaffolding: `orchestrator.yaml`, `context_variables.yaml`, `transition_graph.yaml`, `tools.yaml`

## Verification

Smoke-tested end-to-end in `mozaiks-app` via `scripts/smoke_brand_asset_pipeline.py`:
- AG2 `BrandDesignerAgent` + real OpenAI Responses API generated a 759KB PNG logo
- `harvest_generated_media_response` stored bytes on disk
- `promote_brand_asset` wrote `asset_manifest.json` with correct `content_url`
- Bytes confirmed on disk, manifest verified — exit code 0

## Test plan

- [ ] `python scripts/smoke_brand_asset_pipeline.py --model gpt-4o` in `mozaiks-app` (requires `OPENAI_API_KEY`)
- [ ] Verify `factory_app/workflows/BrandAssetGeneratorWorkflow/` appears in workflow catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)