### PR TITLE
fix(packaging): ship default refinement harness

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include mozaiks_cli/agent_guidance *.md
 recursive-include factory_app/app *
 recursive-include factory_app/build_context *
+recursive-include factory_app/refinement_harness *
 recursive-include factory_app/workflows *
 recursive-include mozaiksai/core/usage/catalogs *.json
 include pricing/catalogs/usage-pricing.generated.json

--- a/tests/test_release_packaging_contract.py
+++ b/tests/test_release_packaging_contract.py
@@ -26,3 +26,12 @@ def test_manifest_includes_packaged_frontend_sources() -> None:
     assert "recursive-include web_shell *.js *.jsx *.css *.html *.json *.md" in manifest
     assert "recursive-include chat-ui/src *" in manifest
     assert "include chat-ui/package.json" in manifest
+
+
+def test_manifest_includes_factory_defaults_used_by_app_overlays() -> None:
+    manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "recursive-include factory_app/app *" in manifest
+    assert "recursive-include factory_app/build_context *" in manifest
+    assert "recursive-include factory_app/refinement_harness *" in manifest
+    assert "recursive-include factory_app/workflows *" in manifest


### PR DESCRIPTION
## Summary
- include factory_app/refinement_harness in packaged mozaiks distributions
- add release packaging guard for Factory defaults consumed by app overlays

## Validation
- python -m pytest --no-cov tests/test_release_packaging_contract.py tests/test_control_plane_loader.py -q
- python -m ruff check tests/test_release_packaging_contract.py
- python -m build --wheel --outdir .tmp\\package-verify
- inspected the built wheel for factory_app/refinement_harness/config/harness.yaml, tools.yaml, policies.yaml, and coding_refinement_system.yaml