### PR TITLE
fix(ci): align lifecycle fixtures with workflow contracts

### DIFF
--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/tools/promote_brand_asset.py
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/tools/promote_brand_asset.py
@@ -75,8 +75,8 @@ async def promote_brand_asset(
 
     # mark asset promoted in store (best-effort)
     try:
-        from mozaiksai.core.media.store import get_media_asset_store
         from mozaiksai.core.media import MediaPromotionTarget
+        from mozaiksai.core.media.store import get_media_asset_store
 
         store = get_media_asset_store()
         await store.mark_asset_promoted(asset_id, MediaPromotionTarget.BRAND_ASSET)

--- a/tests/test_lifecycle_manager_contract.py
+++ b/tests/test_lifecycle_manager_contract.py
@@ -15,12 +15,21 @@ class _Context:
         self.data = {"order": []}
 
 
+def _write_orchestrator(workflow_dir: Path) -> None:
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "orchestrator.yaml").write_text(
+        f"workflow_name: {workflow_dir.name}\nworkflow_startup_mode: BackendOnly\n",
+        encoding="utf-8",
+    )
+
+
 @pytest.mark.asyncio
 async def test_lifecycle_tools_execute_in_declared_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # Redirect _workflows_root() to tmp_path via the env override.
     monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(tmp_path))
 
     wf_dir = tmp_path / "FlowA"
+    _write_orchestrator(wf_dir)
     tools_dir = wf_dir / "tools"
     tools_dir.mkdir(parents=True)
 
@@ -66,6 +75,7 @@ async def test_lifecycle_tool_receives_empty_context_container(monkeypatch: pyte
     monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(tmp_path))
 
     workflow_dir = tmp_path / "EmptyContext"
+    _write_orchestrator(workflow_dir)
     tools_dir = workflow_dir / "tools"
     tools_dir.mkdir(parents=True)
     (tools_dir / "preload.py").write_text(
@@ -96,7 +106,7 @@ def test_lifecycle_manager_skips_missing_tool_files(monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(tmp_path))
 
     wf_dir = tmp_path / "FlowB"
-    wf_dir.mkdir(parents=True)
+    _write_orchestrator(wf_dir)
     (wf_dir / "tools.yaml").write_text(
         "lifecycle_tools:\n"
         "  - trigger: before_chat\n"
@@ -117,6 +127,7 @@ async def test_lifecycle_manager_executes_run_level_hooks(monkeypatch: pytest.Mo
     monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(tmp_path))
 
     wf_dir = tmp_path / "FlowRun"
+    _write_orchestrator(wf_dir)
     tools_dir = wf_dir / "tools"
     tools_dir.mkdir(parents=True)
 


### PR DESCRIPTION
## Summary
- sort the BrandAssetGeneratorWorkflow promotion imports to satisfy Ruff
- update lifecycle manager tests to create canonical workflow fixtures with orchestrator.yaml
- keep workflow path resolution strict; no legacy fallback for partial workflow folders

## Validation
- python -m ruff check factory_app/workflows/BrandAssetGeneratorWorkflow/tools/promote_brand_asset.py tests/test_lifecycle_manager_contract.py
- python -m pytest --no-cov tests/test_lifecycle_manager_contract.py -q
- python -m pytest --no-cov tests/test_release_packaging_contract.py tests/test_pack_config_paths.py tests/test_lifecycle_manager_contract.py tests/test_control_plane_loader.py -q
- git diff --check