### PR TITLE
fix(ci): satisfy strict mypy on app intelligence media paths

### DIFF
--- a/mozaiksai/control_plane/app_validation.py
+++ b/mozaiksai/control_plane/app_validation.py
@@ -815,12 +815,12 @@ def _aggregate_status(
     command_results: Sequence[AppValidationCommandResult],
     fallback_checks: Sequence[AppValidationFallbackCheckResult],
 ) -> AppValidationStatus:
-    results = [*list(command_results), *list(fallback_checks)]
-    if any(item.status == "failed" for item in results):
+    statuses = [item.status for item in command_results] + [item.status for item in fallback_checks]
+    if any(status == "failed" for status in statuses):
         return "failed"
-    if any(item.status == "passed" for item in results):
+    if any(status == "passed" for status in statuses):
         return "passed"
-    if any(item.status == "warning" for item in results):
+    if any(status == "warning" for status in statuses):
         return "warning"
     return "skipped"
 

--- a/mozaiksai/control_plane/implementations/coding_worker.py
+++ b/mozaiksai/control_plane/implementations/coding_worker.py
@@ -8,7 +8,7 @@ import zipfile
 
 logger = logging.getLogger(__name__)
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, cast
 
 from mozaiksai.control_plane.app_validation import run_current_app_source_validation
 from mozaiksai.control_plane.config import ControlPlaneConfig, load_control_plane_config
@@ -411,7 +411,7 @@ class ScopedRefinementCodingWorker:
             copy_workspace=True,
         )
         if hasattr(result, "model_dump"):
-            payload = result.model_dump(mode="json")
+            payload = cast(dict[str, Any], result.model_dump(mode="json"))
         elif isinstance(result, dict):
             payload = dict(result)
         else:

--- a/mozaiksai/core/app_context/framework_detection.py
+++ b/mozaiksai/core/app_context/framework_detection.py
@@ -14,6 +14,7 @@ FRAMEWORK_DETECTION_SCHEMA_VERSION: Literal["mozaiks.framework_detection.v1"] = 
 
 FrameworkCategory = Literal["app_runtime", "frontend", "backend", "fullstack", "build_tool", "test", "mozaiks"]
 FrameworkEvidenceKind = Literal["manifest", "dependency", "script", "source", "path"]
+FrameworkValidationKind = Literal["install", "lint", "test", "build", "typecheck", "dev", "start"]
 
 
 class FrameworkEvidence(BaseModel):
@@ -46,7 +47,7 @@ class FrameworkEntrypoint(BaseModel):
 class FrameworkValidationCommand(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    kind: Literal["install", "lint", "test", "build", "typecheck", "dev", "start"]
+    kind: FrameworkValidationKind
     command: str
     working_directory: str = "."
     confidence: float = Field(ge=0.0, le=1.0)
@@ -145,7 +146,12 @@ def _detect_node(
         if not data:
             continue
         workdir = _dirname(package_path)
-        scripts = data.get("scripts") if isinstance(data.get("scripts"), dict) else {}
+        scripts_raw = data.get("scripts")
+        scripts = (
+            {str(key): value for key, value in scripts_raw.items()}
+            if isinstance(scripts_raw, dict)
+            else {}
+        )
         deps = _dependencies(data)
         evidence["node"].append(_ev("manifest", package_path, "Node package manifest"))
         _script_commands(scripts, workdir, _node_pm(package_managers), validation_commands)
@@ -278,7 +284,7 @@ def _script_commands(
     package_manager: str,
     commands: list[FrameworkValidationCommand],
 ) -> None:
-    script_map = {
+    script_map: dict[str, FrameworkValidationKind] = {
         "lint": "lint",
         "test": "test",
         "build": "build",

--- a/mozaiksai/core/media/store.py
+++ b/mozaiksai/core/media/store.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 from uuid import uuid4
 
 from logs.logging_config import get_core_logger
@@ -399,7 +399,7 @@ class AzureBlobMediaContentStore:
         blob_client = client.get_blob_client(container=self._container_name, blob=blob_name)
         try:
             stream = await blob_client.download_blob()
-            return await stream.readall()
+            return cast(bytes, await stream.readall())
         except Exception as exc:
             raise MediaContentNotFoundError(
                 f"Azure Blob media content not found: {content_ref!r}"
@@ -410,7 +410,7 @@ class AzureBlobMediaContentStore:
         blob_name = self._blob_name_from_ref(content_ref)
         blob_client = client.get_blob_client(container=self._container_name, blob=blob_name)
         try:
-            return await blob_client.exists()
+            return bool(await blob_client.exists())
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary
- narrow framework-detection script command typing
- cast Azure Blob byte reads and normalize blob existence return values
- aggregate app-validation statuses without losing concrete result types
- type the coding-worker validation payload from model_dump

## Validation
- python -m ruff check mozaiksai/core/app_context/framework_detection.py mozaiksai/core/media/store.py mozaiksai/control_plane/app_validation.py mozaiksai/control_plane/implementations/coding_worker.py
- python -m mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped
- python -m pytest --no-cov tests/test_framework_detection.py tests/test_app_validation_helpers.py tests/test_app_validation_extended_helpers.py tests/test_app_source_validation.py tests/test_media_multimodal.py tests/test_coding_worker.py -q
- python -m pytest --no-cov tests/test_release_packaging_contract.py tests/test_pack_config_paths.py tests/test_lifecycle_manager_contract.py tests/test_control_plane_loader.py -q
- git diff --check