### PR TITLE
fix(workflows): align brand asset agent schema

### DIFF
--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
@@ -1,6 +1,6 @@
 agents:
   - name: BrandDesignerAgent
-    role: >
+    system_message: >
       You are a professional brand designer. Your job is to generate high-quality
       logo and brand imagery for apps built on the Mozaiks platform.
       When given a brand brief, generate one or more logo images using the
@@ -13,6 +13,6 @@ agents:
       size: "1024x1024"
       background: opaque
       output_format: png
-    promotion_targets:
-      - app_asset
-      - brand_asset
+      promotion_targets:
+        - app_asset
+        - brand_asset

--- a/tests/test_workflow_declarative_contracts.py
+++ b/tests/test_workflow_declarative_contracts.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from tests.import_utils import import_module_directly
 
 _workflow_manager_mod = import_module_directly("mozaiksai.core.workflow.workflow_manager")
+from mozaiksai.core.workflow.declarative import parse_agents_config  # noqa: E402
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -685,3 +688,18 @@ def test_build_workflows_load_from_workspace_bundle() -> None:
     assert discovery_config.get("tools")
     assert app_generator_config.get("tools")
     assert (agent_generator_config.get("structured_outputs") or {}).get("registry")
+
+
+def test_factory_workflow_agent_manifests_match_current_schema() -> None:
+    workflows_root = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
+    failures: list[str] = []
+
+    for agents_path in sorted(workflows_root.rglob("agents.yaml")):
+        raw = yaml.safe_load(agents_path.read_text(encoding="utf-8")) or {}
+        try:
+            parse_agents_config(raw)
+        except ValueError as exc:
+            rel_path = agents_path.relative_to(workflows_root.parent.parent)
+            failures.append(f"{rel_path.as_posix()}: {exc}")
+
+    assert not failures, "Factory workflow agents.yaml schema drift:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
- update BrandAssetGeneratorWorkflow agents.yaml to current declarative schema
- keep media promotion targets under image_generation where the AgentSpec contract already supports them
- add a drift guard that validates every packaged Factory agents.yaml against the current schema

## Validation
- python -m pytest --no-cov tests/test_workflow_declarative_contracts.py tests/test_media_multimodal.py tests/test_release_packaging_contract.py -q
- python -m ruff check tests/test_workflow_declarative_contracts.py
- git diff --check