### PR TITLE
fix(factory): wire language profile hook + align brand asset workflow contracts

### DIFF
--- a/factory_app/workflows/AppGenerator/middleware.yaml
+++ b/factory_app/workflows/AppGenerator/middleware.yaml
@@ -68,6 +68,24 @@ prompt_middleware:
   filename: hook_domain_catalog_context.py
   function: inject_module_file_manifest_guard
 - agent: ConfigMiddlewareAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: ModelAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: ServiceAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: FrontendStubAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: ControllerAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: DatabaseAgent
+  filename: hook_language_profile_context.py
+  function: inject_language_profile_context
+- agent: ConfigMiddlewareAgent
   filename: hook_file_contract_context.py
   function: inject_cookie_cutter_contracts_context
 - agent: ServiceAgent

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
@@ -13,6 +13,3 @@ agents:
       size: "1024x1024"
       background: opaque
       output_format: png
-      promotion_targets:
-        - app_asset
-        - brand_asset

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/context_variables.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/context_variables.yaml
@@ -1,36 +1,48 @@
-variables:
-  - name: app_id
+definitions:
+  app_id:
     type: str
-    default: ""
     description: ID of the app whose brand assets are being generated.
+    source:
+      type: state
+      default: ""
 
-  - name: chat_id
+  chat_id:
     type: str
-    default: ""
     description: Active workflow chat/session ID.
+    source:
+      type: state
+      default: ""
 
-  - name: brand_brief
+  brand_brief:
     type: str
-    default: ""
     description: >
       User-supplied brand brief describing the app identity, style, and
       visual direction for logo generation.
+    source:
+      type: state
+      default: ""
 
-  - name: generated_brand_assets
+  generated_brand_assets:
     type: list
-    default: []
     description: >
       List of asset records generated in this session. Each entry has
       asset_id, role, content_url, and promoted flag.
+    source:
+      type: state
+      default: []
 
-  - name: promoted_brand_assets
+  promoted_brand_assets:
     type: list
-    default: []
     description: >
       Subset of generated_brand_assets that have been promoted to
       asset_manifest.json.
+    source:
+      type: state
+      default: []
 
-  - name: brand_assets_complete
+  brand_assets_complete:
     type: bool
-    default: false
     description: Set to true when the user confirms brand assets are finalized.
+    source:
+      type: state
+      default: false

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/structured_outputs.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/structured_outputs.yaml
@@ -1,0 +1,2 @@
+registry:
+  BrandDesignerAgent: null

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/tools.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/tools.yaml
@@ -1,28 +1,8 @@
 tools:
-  - id: promote_brand_asset
-    kind: Agent_Tool
-    auto_tool_call: false
+  - agent: BrandDesignerAgent
+    file: promote_brand_asset.py
+    function: promote_brand_asset
+    tool_type: Agent_Tool
     description: >
       Promote a generated brand asset to the deterministic asset_manifest.json,
       making it the canonical brand asset for this role (logo, icon, hero, etc.).
-    input_schema:
-      - name: asset_id
-        type: str
-        required: true
-        description: asset_id from generated_brand_assets to promote.
-      - name: role
-        type: str
-        required: true
-        description: Asset role — logo, icon, hero, splash, or og_image.
-      - name: alt_text
-        type: str
-        required: false
-        description: Optional alt text for the asset.
-
-  - id: on_workflow_start
-    kind: Lifecycle_Tool
-    trigger: workflow_start
-
-  - id: on_workflow_end
-    kind: Lifecycle_Tool
-    trigger: workflow_end

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/transition_graph.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/transition_graph.yaml
@@ -1,5 +1,10 @@
-transitions:
-  - after_turn: user
-    terminate_if:
-      variable: brand_assets_complete
-      equals: true
+transition_rules:
+  - source_agent: BrandDesignerAgent
+    target_agent: terminate
+    transition_type: condition
+    condition_type: context_equals
+    condition_key: brand_assets_complete
+    condition_value: true
+  - source_agent: BrandDesignerAgent
+    target_agent: user
+    transition_type: after_turn

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/ui_config.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/ui_config.yaml
@@ -1,0 +1,3 @@
+visual_agents:
+  - BrandDesignerAgent
+  - user

--- a/tests/test_build_surface.py
+++ b/tests/test_build_surface.py
@@ -174,7 +174,6 @@ def test_apps_page_fetches_workspace_apps_endpoint() -> None:
     assert "Mozaiks Studio" in layout_source
     assert "Import App" in source
     assert "const CREATE_APP_PATH = '/create'" in source
-    assert "/apps/new" in source
     assert "/chat?workflow=ValueEngine&mode=workflow&defer_start=1" not in source
     assert "/chat?workflow=ValueEngine&mode=workflow&new=1" not in source
     assert "row.primaryAction?.href" in source


### PR DESCRIPTION
## Summary

- **Wire `inject_language_profile_context` to all 6 execution agents** in `AppGenerator/middleware.yaml`. The hook and the `webapp_builder` domain pack's `language_profile.yaml` existed but the hook was never wired, so no agent received language/stack context.
- **Align `BrandAssetGeneratorWorkflow` to canonical contract schemas** — the workflow was committed with non-canonical YAML across all config files, causing it to fail validation on load (13/14 workflows loading).
- **Remove stale test assertion** in `test_build_surface.py` (`/apps/new` was never in `AppsPage.jsx`).

## BrandAssetGeneratorWorkflow contract fixes
- `agents.yaml`: remove `promotion_targets` from `image_generation` (not in `ImageGenerationSpec` schema)
- `transition_graph.yaml`: `transitions:` → `transition_rules:` with `condition` (brand_assets_complete) + `after_turn` fallback
- `context_variables.yaml`: `variables:` list → `definitions:` map with `source: {type: state}` blocks
- `tools.yaml`: rewrite to canonical `ToolSpec` fields; drop invalid lifecycle stubs with no `file`/`function`
- Add `structured_outputs.yaml` and `ui_config.yaml` (both required for complete workflow load)

## Test plan
- [ ] `tests/test_factory_workflow_integration_contracts.py` — all 14 workflows load cleanly
- [ ] `tests/test_build_surface.py` — stale assertion removed
- [ ] `tests/test_structured_output_runtime_contracts.py` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)