### PR TITLE
fix(workflows): align brand asset transition graph

### DIFF
--- a/tests/test_workflow_declarative_contracts.py
+++ b/tests/test_workflow_declarative_contracts.py
@@ -7,7 +7,10 @@ import yaml
 from tests.import_utils import import_module_directly
 
 _workflow_manager_mod = import_module_directly("mozaiksai.core.workflow.workflow_manager")
-from mozaiksai.core.workflow.declarative import parse_agents_config  # noqa: E402
+from mozaiksai.core.workflow.declarative import (  # noqa: E402
+    parse_agents_config,
+    parse_transition_graph_config,
+)
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -703,3 +706,18 @@ def test_factory_workflow_agent_manifests_match_current_schema() -> None:
             failures.append(f"{rel_path.as_posix()}: {exc}")
 
     assert not failures, "Factory workflow agents.yaml schema drift:\n" + "\n".join(failures)
+
+
+def test_factory_workflow_transition_graphs_match_current_schema() -> None:
+    workflows_root = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
+    failures: list[str] = []
+
+    for graph_path in sorted(workflows_root.rglob("transition_graph.yaml")):
+        raw = yaml.safe_load(graph_path.read_text(encoding="utf-8")) or {}
+        try:
+            parse_transition_graph_config(raw)
+        except ValueError as exc:
+            rel_path = graph_path.relative_to(workflows_root.parent.parent)
+            failures.append(f"{rel_path.as_posix()}: {exc}")
+
+    assert not failures, "Factory workflow transition_graph.yaml schema drift:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
- update BrandAssetGeneratorWorkflow transition_graph.yaml to the current transition_rules schema
- preserve designer/user loop and terminate when brand_assets_complete is true
- add a drift guard that validates every packaged Factory transition_graph.yaml against the current declarative schema

## Validation
- python -m pytest --no-cov tests/test_workflow_declarative_contracts.py tests/test_media_multimodal.py tests/test_release_packaging_contract.py -q
- python -m ruff check tests/test_workflow_declarative_contracts.py
- git diff --check