### PR TITLE
feat(dashboard): validate portal route contracts

### DIFF
--- a/docs/architecture/app/app-dashboard-contract.md
+++ b/docs/architecture/app/app-dashboard-contract.md
@@ -156,11 +156,19 @@ The OSS runtime provides:
 - `load_dashboard_manifest(app_root)`
 - `build_default_dashboard_manifest()`
 - `build_dashboard_shell_routes(manifest)`
+- `validate_dashboard_manifest_routes(manifest, route_pages)`
 - `GET /api/studio/dashboard`
 
 `build_dashboard_shell_routes()` is a migration bridge for clients that still
 consume route-manifest-shaped entries. Existing `ui/route_manifest.json` pages
 remain valid while the Dashboard Portal renderer is adopted.
+
+`validate_dashboard_manifest_routes()` is the CI contract for apps that mount
+concrete Studio pages. It validates that every enabled dashboard portal points
+to a registered route, every portal intended for navigation is visible in the
+matching `workspace-studio` or `app-studio` route group, and every visible
+Studio navigation route has a matching enabled dashboard portal. Planned portals
+should stay `enabled: false` until their route and product surface exist.
 
 ## Multimodal Integration
 

--- a/docs/guides/studio/01-overview.md
+++ b/docs/guides/studio/01-overview.md
@@ -27,7 +27,9 @@ In-progress builds stay in **Apps** so you can return any time.
 | **App Usage** | Single-app chats, workflows, tokens, and cost detail |
 
 Dashboard structure comes from `app/dashboard/dashboard.yaml`. When that file is
-missing, Studio uses the OSS default dashboard manifest.
+missing, Studio uses the OSS default dashboard manifest. CI can validate that
+enabled dashboard portals resolve to mounted routes and that visible Studio
+navigation routes are represented in the dashboard manifest.
 
 ## Coming Back to a Build
 

--- a/docs/studio/app-dashboard.md
+++ b/docs/studio/app-dashboard.md
@@ -10,7 +10,8 @@ app/dashboard/dashboard.yaml
 ```
 
 See [App Dashboard Contract](../architecture/app/app-dashboard-contract.md) for
-the runtime schema, manifest overlay rules, and ownership boundaries.
+the runtime schema, manifest overlay rules, route-alignment validator, and
+ownership boundaries.
 
 ## Overview
 
@@ -42,6 +43,10 @@ The default App Dashboard has these portal lanes:
 
 Apps may hide or extend portals through the dashboard manifest. Capability packs
 can contribute panels without taking over the whole dashboard.
+
+Apps that mount concrete Studio routes should run the dashboard route validator
+in CI. Enabled portals must point to registered routes, and visible Studio
+navigation routes must be declared as enabled dashboard portals.
 
 ## Support
 

--- a/factory_app/app/admin/pages/AppsPage.jsx
+++ b/factory_app/app/admin/pages/AppsPage.jsx
@@ -2,7 +2,7 @@
  * AppsPage — curated workspace app directory.
  */
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import {
@@ -21,6 +21,12 @@ import {
 } from '../../ui/components/StudioShared.jsx'
 import { WorkspaceStudioHero, formatCompactNumber } from './AppStudioChrome.jsx'
 import { API_BASE } from './studioApi.js'
+import {
+  buildAppDashboardHref,
+  fetchDashboardConfig,
+  getDefaultPortalRoute,
+  getSurfaceRoutePattern,
+} from './dashboardRoutes.js'
 import buildWorkspacePortfolio from './workspaceStudioModel.js'
 import { useWorkspaceApps } from './useWorkspaceApps.js'
 
@@ -269,13 +275,38 @@ function ImportAppOverlay({ open, onClose, onImport, error, busy }) {
 export default function AppsPage() {
   const navigate = useNavigate()
   const { apps, loading, error, deleteApp } = useWorkspaceApps('Could not load your apps.')
+  const [dashboardConfig, setDashboardConfig] = useState(null)
   const [searchValue, setSearchValue] = useState('')
   const [activeFilter, setActiveFilter] = useState('all')
   const [importOpen, setImportOpen] = useState(false)
   const [importBusy, setImportBusy] = useState(false)
   const [importError, setImportError] = useState(null)
 
-  const portfolio = useMemo(() => buildWorkspacePortfolio(apps), [apps])
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchDashboardConfig({ signal: controller.signal })
+      .then((payload) => setDashboardConfig(payload))
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          console.error('[AppsPage] dashboard manifest load failed:', err)
+        }
+      })
+    return () => controller.abort()
+  }, [])
+
+  const appDashboardRoute = useMemo(
+    () => getDefaultPortalRoute(dashboardConfig, 'app'),
+    [dashboardConfig],
+  )
+  const appRootRoute = useMemo(
+    () => getSurfaceRoutePattern(dashboardConfig, 'app'),
+    [dashboardConfig],
+  )
+
+  const portfolio = useMemo(
+    () => buildWorkspacePortfolio(apps, { appDashboardRoute }),
+    [appDashboardRoute, apps],
+  )
 
   const visibleRows = useMemo(() => {
     const search = searchValue.trim().toLowerCase()
@@ -372,7 +403,11 @@ export default function AppsPage() {
       })
       if (!importRes.ok) throw new Error('Source import job could not be started.')
       setImportOpen(false)
-      navigate(`/apps/${encodeURIComponent(appId)}/overview`)
+      navigate(
+        buildAppDashboardHref(appDashboardRoute, appId) ||
+        buildAppDashboardHref(appRootRoute, appId) ||
+        '/apps',
+      )
     } catch (err) {
       setImportError(err instanceof Error ? err.message : 'Repository import could not be started.')
     } finally {

--- a/factory_app/app/admin/pages/StudioPage.jsx
+++ b/factory_app/app/admin/pages/StudioPage.jsx
@@ -2,19 +2,67 @@
  * StudioPage — redirect helper for first-party Studio paths.
  *
  * Concrete Studio pages are declared in app/ui/route_manifest.json. This
- * component only preserves the app-root redirect from /apps/:appId to the
- * canonical overview route.
+ * component preserves the app-root redirect from /apps/:appId to the
+ * manifest-declared default App Dashboard portal.
  */
 
+import { useEffect, useMemo, useState } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { StudioLoadingState } from '../../ui/components/StudioShared.jsx'
+import {
+  buildAppDashboardHref,
+  fetchDashboardConfig,
+  getDefaultPortalRoute,
+} from './dashboardRoutes.js'
+
+function decodeRouteSegment(value) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
 
 export default function StudioPage() {
   const location = useLocation()
+  const appRootMatch = useMemo(() => /^\/apps\/([^/]+)$/.exec(location.pathname), [location.pathname])
+  const appId = appRootMatch ? decodeRouteSegment(appRootMatch[1]) : null
+  const [redirectState, setRedirectState] = useState({
+    loaded: !appId,
+    href: null,
+  })
 
-  if (/^\/apps\/[^/]+$/.test(location.pathname)) {
-    return <Navigate replace to={`${location.pathname}/overview`} />
+  useEffect(() => {
+    if (!appId) {
+      setRedirectState({ loaded: true, href: null })
+      return undefined
+    }
+
+    const controller = new AbortController()
+    setRedirectState({ loaded: false, href: null })
+    fetchDashboardConfig({ signal: controller.signal })
+      .then((payload) => {
+        const route = getDefaultPortalRoute(payload, 'app')
+        setRedirectState({
+          loaded: true,
+          href: buildAppDashboardHref(route, appId),
+        })
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          console.error('[StudioPage] dashboard manifest load failed:', err)
+          setRedirectState({ loaded: true, href: null })
+        }
+      })
+    return () => controller.abort()
+  }, [appId])
+
+  if (appId && !redirectState.loaded) {
+    return <StudioLoadingState label="Opening app dashboard..." />
   }
+
+  if (appId && redirectState.href) return <Navigate replace to={redirectState.href} />
 
   return <Navigate replace to="/apps" />
 }

--- a/factory_app/app/admin/pages/dashboardRoutes.js
+++ b/factory_app/app/admin/pages/dashboardRoutes.js
@@ -1,0 +1,44 @@
+import { API_BASE } from './studioApi.js'
+
+export function getDashboardSurface(payload, scope = 'app') {
+  if (payload?.surface?.scope === scope) return payload.surface
+  const surface = payload?.[scope]
+  return surface && typeof surface === 'object' ? surface : null
+}
+
+export function getDefaultPortalRoute(payload, scope = 'app') {
+  const surface = getDashboardSurface(payload, scope)
+  const defaultPortalId = surface?.default_portal
+  const portals = Array.isArray(surface?.portals) ? surface.portals : []
+  const portal = portals.find((item) => (
+    item?.id === defaultPortalId &&
+    item?.enabled !== false &&
+    typeof item?.route === 'string' &&
+    item.route.startsWith('/')
+  ))
+  return portal?.route || null
+}
+
+export function getSurfaceRoutePattern(payload, scope = 'app') {
+  const surface = getDashboardSurface(payload, scope)
+  const routePattern = surface?.route_pattern
+  return typeof routePattern === 'string' && routePattern.startsWith('/') ? routePattern : null
+}
+
+export function buildAppDashboardHref(routePattern, appId) {
+  if (!routePattern || !appId) return null
+  return String(routePattern).replace(':appId', encodeURIComponent(appId))
+}
+
+export async function fetchDashboardConfig({ signal } = {}) {
+  const response = await fetch(`${API_BASE}/api/studio/dashboard`, {
+    headers: {
+      Accept: 'application/json',
+    },
+    signal,
+  })
+  if (!response.ok) {
+    throw new Error(`Dashboard manifest unavailable: ${response.status}`)
+  }
+  return response.json()
+}

--- a/factory_app/app/admin/pages/workspaceStudioModel.js
+++ b/factory_app/app/admin/pages/workspaceStudioModel.js
@@ -6,6 +6,7 @@ import {
   isAppInBuild,
   normalizeAppStatus,
 } from './appStudioModel.js'
+import { buildAppDashboardHref } from './dashboardRoutes.js'
 
 function parseTimestamp(value) {
   if (!value) return 0
@@ -155,7 +156,7 @@ function getFilterBucket(status, operationsState) {
   return 'other'
 }
 
-function buildRow(app) {
+function buildRow(app, options = {}) {
   const status = normalizeAppStatus(app?.status || app?.lifecycle_state)
   const snapshot = getAppRecordSnapshot(app)
   const operationsState = getOperationsState(status)
@@ -166,9 +167,9 @@ function buildRow(app) {
   const description = getAppDisplayDescription(app) || snapshot.guidance
 
   const appId = app?.app_id || app?.id || null
-  // Build-state apps expose an "Access Dashboard" secondary action pointing at the
-  // overview page. The dashboard may be incomplete during build, but still navigable.
-  const dashboardHref = appId && isAppInBuild(status) ? `/apps/${encodeURIComponent(appId)}/overview` : null
+  const dashboardHref = appId && isAppInBuild(status)
+    ? buildAppDashboardHref(options.appDashboardRoute, appId)
+    : null
 
   return {
     app,
@@ -194,8 +195,10 @@ function sortRowsByUpdatedAt(rows) {
   return [...rows].sort((left, right) => right.updatedAt - left.updatedAt || left.name.localeCompare(right.name))
 }
 
-export function buildWorkspacePortfolio(apps) {
-  const rows = sortRowsByUpdatedAt((Array.isArray(apps) ? apps : []).map(buildRow))
+export function buildWorkspacePortfolio(apps, options = {}) {
+  const rows = sortRowsByUpdatedAt(
+    (Array.isArray(apps) ? apps : []).map((app) => buildRow(app, options)),
+  )
   const totalApps = rows.length
   const activeCount = rows.filter((row) => row.status === 'active').length
   const buildCount = rows.filter((row) => isAppInBuild(row.status)).length

--- a/mozaiksai/core/dashboard/__init__.py
+++ b/mozaiksai/core/dashboard/__init__.py
@@ -7,11 +7,14 @@ from .manifest import (
     DashboardManifest,
     DashboardPanel,
     DashboardPortal,
+    DashboardRouteValidationIssue,
+    DashboardRouteValidationResult,
     DashboardSurface,
     build_dashboard_shell_routes,
     build_default_dashboard_manifest,
     load_dashboard_manifest,
     merge_dashboard_manifest_overlay,
+    validate_dashboard_manifest_routes,
 )
 
 __all__ = [
@@ -21,9 +24,12 @@ __all__ = [
     "DashboardManifest",
     "DashboardPanel",
     "DashboardPortal",
+    "DashboardRouteValidationIssue",
+    "DashboardRouteValidationResult",
     "DashboardSurface",
     "build_dashboard_shell_routes",
     "build_default_dashboard_manifest",
     "load_dashboard_manifest",
     "merge_dashboard_manifest_overlay",
+    "validate_dashboard_manifest_routes",
 ]

--- a/mozaiksai/core/dashboard/manifest.py
+++ b/mozaiksai/core/dashboard/manifest.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal
@@ -23,6 +23,12 @@ DASHBOARD_MANIFEST_RELATIVE_PATH = Path("dashboard") / "dashboard.yaml"
 DashboardScope = Literal["workspace", "app"]
 DashboardActionType = Literal["route", "workflow_sequence", "workflow", "module_action", "external_url"]
 DashboardPanelSource = Literal["runtime", "module", "workflow", "media", "custom"]
+DashboardRouteValidationCode = Literal[
+    "enabled_portal_route_missing",
+    "enabled_portal_route_hidden",
+    "enabled_portal_route_group_mismatch",
+    "visible_route_missing_enabled_portal",
+]
 DashboardPanelType = Literal[
     "summary_strip",
     "kpi_grid",
@@ -187,6 +193,7 @@ class DashboardPortal(BaseModel):
     id: str
     label: str
     route: str
+    description: str | None = None
     icon: str = "dashboard"
     order: int = 0
     enabled: bool = True
@@ -205,6 +212,11 @@ class DashboardPortal(BaseModel):
     @classmethod
     def _required_text(cls, value: Any, info: Any) -> str:
         return _clean_text(value, field_name=f"dashboard portal {info.field_name}")
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _description(cls, value: Any) -> str | None:
+        return _clean_optional_text(value)
 
     @field_validator("capabilities", mode="before")
     @classmethod
@@ -300,6 +312,34 @@ class DashboardManifest(BaseModel):
         return self.workspace if scope == "workspace" else self.app
 
 
+class DashboardRouteValidationIssue(BaseModel):
+    """A dashboard/route-manifest alignment issue."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: DashboardRouteValidationCode
+    scope: DashboardScope
+    route: str
+    message: str
+    portal_id: str | None = None
+    page_id: str | None = None
+
+
+class DashboardRouteValidationResult(BaseModel):
+    """Result from validating a dashboard manifest against mounted routes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issues: list[DashboardRouteValidationIssue] = Field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def messages(self) -> list[str]:
+        return [issue.message for issue in self.issues]
+
+
 def _default_manifest_dict() -> dict[str, Any]:
     return {
         "schema_version": DASHBOARD_SCHEMA_VERSION,
@@ -315,6 +355,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "portfolio",
                     "label": "Apps",
                     "route": "/apps",
+                    "description": "Portfolio-level list of apps in the workspace.",
                     "icon": "apps",
                     "order": 0,
                     "panels": [
@@ -325,6 +366,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "usage",
                     "label": "Usage",
                     "route": "/usage",
+                    "description": "Workspace-level usage, cost, and activity signals.",
                     "icon": "chart",
                     "order": 20,
                     "panels": [
@@ -335,6 +377,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "integrations",
                     "label": "Integrations",
                     "route": "/integrations",
+                    "description": "Shared integration readiness across workspace apps.",
                     "icon": "plug",
                     "order": 30,
                     "panels": [
@@ -358,6 +401,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "overview",
                     "label": "Overview",
                     "route": "/apps/:appId/overview",
+                    "description": "App identity, lifecycle, metrics, alerts, and next step.",
                     "icon": "dashboard",
                     "order": 0,
                     "panels": [
@@ -370,6 +414,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "building",
                     "label": "Building",
                     "route": "/apps/:appId/building",
+                    "description": "Build threads, artifact versions, approvals, and workflow launch actions.",
                     "icon": "hammer",
                     "order": 10,
                     "capabilities": ["build_threads", "artifact_versions", "approval_votes"],
@@ -399,6 +444,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "branding",
                     "label": "Branding",
                     "route": "/apps/:appId/branding",
+                    "description": "Brand kit, generated media, themes, and promoted brand assets.",
                     "icon": "palette",
                     "order": 20,
                     "capabilities": ["brand_kit", "media_assets"],
@@ -411,6 +457,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "launch",
                     "label": "Launch",
                     "route": "/apps/:appId/launch",
+                    "description": "Landing page status, hosting, domains, and launch readiness.",
                     "icon": "rocket",
                     "order": 30,
                     "capabilities": ["landing_page", "hosting", "domains"],
@@ -424,6 +471,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "growth",
                     "label": "Growth",
                     "route": "/apps/:appId/growth",
+                    "description": "Marketing campaigns, growth experiments, and campaign assets.",
                     "icon": "megaphone",
                     "order": 40,
                     "capabilities": ["marketing_campaigns"],
@@ -435,6 +483,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "users",
                     "label": "Users",
                     "route": "/apps/:appId/access",
+                    "description": "App users, roles, invitations, and access policy summaries.",
                     "icon": "users",
                     "order": 50,
                     "panels": [
@@ -445,6 +494,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "usage",
                     "label": "Usage",
                     "route": "/apps/:appId/usage",
+                    "description": "App-scoped chats, workflow usage, token consumption, and cost.",
                     "icon": "chart",
                     "order": 60,
                     "panels": [
@@ -455,6 +505,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "support",
                     "label": "Support",
                     "route": "/apps/:appId/support",
+                    "description": "App-specific support threads, follow-up, and service diagnostics.",
                     "icon": "support",
                     "order": 70,
                     "panels": [
@@ -465,6 +516,7 @@ def _default_manifest_dict() -> dict[str, Any]:
                     "id": "settings",
                     "label": "Settings",
                     "route": "/apps/:appId/settings",
+                    "description": "App-level settings and configuration forms.",
                     "icon": "settings",
                     "order": 90,
                     "panels": [
@@ -563,6 +615,159 @@ def load_dashboard_manifest(app_root: Path) -> DashboardManifest:
         return build_default_dashboard_manifest()
 
 
+def _dashboard_route_group(scope: DashboardScope) -> str:
+    return "workspace-studio" if scope == "workspace" else "app-studio"
+
+
+def _route_page_navigation(page: Mapping[str, Any]) -> Mapping[str, Any]:
+    navigation = page.get("navigation")
+    if isinstance(navigation, Mapping):
+        return navigation
+
+    meta = page.get("meta")
+    if isinstance(meta, Mapping):
+        nested_navigation = meta.get("navigation")
+        if isinstance(nested_navigation, Mapping):
+            return nested_navigation
+    return {}
+
+
+def _route_page_id(page: Mapping[str, Any]) -> str | None:
+    value = page.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    value = page.get("component")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _route_pages_by_path(route_pages: Iterable[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    pages_by_path: dict[str, Mapping[str, Any]] = {}
+    for page in route_pages:
+        path = page.get("path")
+        if not isinstance(path, str) or not path.startswith("/"):
+            continue
+        pages_by_path.setdefault(path, page)
+    return pages_by_path
+
+
+def validate_dashboard_manifest_routes(
+    manifest: DashboardManifest,
+    route_pages: Iterable[Mapping[str, Any]],
+    *,
+    scopes: Iterable[DashboardScope] | None = None,
+    require_visible_route_portals: bool = True,
+) -> DashboardRouteValidationResult:
+    """Validate dashboard portals against concrete route-manifest pages.
+
+    The dashboard manifest owns Studio portal semantics, while
+    ``ui/route_manifest.json`` owns concrete React route mounting. This validator
+    makes the boundary executable for CI:
+
+    - every enabled portal must resolve to a mounted route;
+    - every enabled portal shown in navigation must be visible in the expected
+      Studio navigation group;
+    - every visible Studio navigation route must be represented by an enabled
+      portal when ``require_visible_route_portals`` is true.
+
+    Route pages may use either top-level ``navigation`` or nested
+    ``meta.navigation`` metadata. The returned issue list is deterministic and
+    safe to render in CI output.
+    """
+
+    selected_scopes = set(scopes or ("workspace", "app"))
+    pages_by_path = _route_pages_by_path(route_pages)
+    issues: list[DashboardRouteValidationIssue] = []
+
+    for surface in (manifest.workspace, manifest.app):
+        if surface.scope not in selected_scopes:
+            continue
+
+        expected_group = _dashboard_route_group(surface.scope)
+        enabled_portal_routes: set[str] = set()
+
+        for portal in surface.enabled_portals():
+            enabled_portal_routes.add(portal.route)
+            route_page = pages_by_path.get(portal.route)
+            if route_page is None:
+                issues.append(
+                    DashboardRouteValidationIssue(
+                        code="enabled_portal_route_missing",
+                        scope=surface.scope,
+                        portal_id=portal.id,
+                        route=portal.route,
+                        message=(
+                            f"{surface.scope} dashboard portal '{portal.id}' points to "
+                            f"unregistered route '{portal.route}'."
+                        ),
+                    )
+                )
+                continue
+
+            if not portal.show_in_navigation:
+                continue
+
+            navigation = _route_page_navigation(route_page)
+            if navigation.get("include") is False:
+                issues.append(
+                    DashboardRouteValidationIssue(
+                        code="enabled_portal_route_hidden",
+                        scope=surface.scope,
+                        portal_id=portal.id,
+                        page_id=_route_page_id(route_page),
+                        route=portal.route,
+                        message=(
+                            f"{surface.scope} dashboard portal '{portal.id}' points to "
+                            f"route '{portal.route}', but that route is hidden from navigation."
+                        ),
+                    )
+                )
+
+            actual_group = navigation.get("group")
+            if actual_group != expected_group:
+                issues.append(
+                    DashboardRouteValidationIssue(
+                        code="enabled_portal_route_group_mismatch",
+                        scope=surface.scope,
+                        portal_id=portal.id,
+                        page_id=_route_page_id(route_page),
+                        route=portal.route,
+                        message=(
+                            f"{surface.scope} dashboard portal '{portal.id}' points to "
+                            f"route '{portal.route}' in navigation group {actual_group!r}; "
+                            f"expected {expected_group!r}."
+                        ),
+                    )
+                )
+
+        if not require_visible_route_portals:
+            continue
+
+        for route, route_page in sorted(pages_by_path.items()):
+            navigation = _route_page_navigation(route_page)
+            if navigation.get("include") is False:
+                continue
+            if navigation.get("group") != expected_group:
+                continue
+            if route in enabled_portal_routes:
+                continue
+            issues.append(
+                DashboardRouteValidationIssue(
+                    code="visible_route_missing_enabled_portal",
+                    scope=surface.scope,
+                    page_id=_route_page_id(route_page),
+                    route=route,
+                    message=(
+                        f"visible {surface.scope} Studio route '{route}' is not represented "
+                        "by an enabled dashboard portal."
+                    ),
+                )
+            )
+
+    return DashboardRouteValidationResult(issues=issues)
+
+
 def build_dashboard_shell_routes(
     manifest: DashboardManifest,
     *,
@@ -615,9 +820,12 @@ __all__ = [
     "DashboardManifest",
     "DashboardPanel",
     "DashboardPortal",
+    "DashboardRouteValidationIssue",
+    "DashboardRouteValidationResult",
     "DashboardSurface",
     "build_dashboard_shell_routes",
     "build_default_dashboard_manifest",
     "load_dashboard_manifest",
     "merge_dashboard_manifest_overlay",
+    "validate_dashboard_manifest_routes",
 ]

--- a/tests/test_build_surface.py
+++ b/tests/test_build_surface.py
@@ -160,11 +160,22 @@ def test_app_overview_does_not_link_to_removed_routes() -> None:
 
 def test_apps_page_fetches_workspace_apps_endpoint() -> None:
     source = _read("factory_app/app/admin/pages/AppsPage.jsx")
+    studio_page_source = _read("factory_app/app/admin/pages/StudioPage.jsx")
+    model_source = _read("factory_app/app/admin/pages/workspaceStudioModel.js")
     hook_source = _read("factory_app/app/admin/pages/useWorkspaceApps.js")
     create_hook_source = _read("factory_app/workflows/ValueEngine/tools/create_app_record.py")
     update_hook_source = _read("factory_app/workflows/AppGenerator/tools/update_app_record.py")
     layout_source = _read("chat-ui/src/workspace/WorkspaceLayout.jsx")
     assert "/api/studio/apps" in hook_source
+    assert "/api/studio/dashboard" in _read("factory_app/app/admin/pages/dashboardRoutes.js")
+    assert "getDefaultPortalRoute(dashboardConfig, 'app')" in source
+    assert "buildWorkspacePortfolio(apps, { appDashboardRoute })" in source
+    assert "buildAppDashboardHref(options.appDashboardRoute, appId)" in model_source
+    assert "/apps/${encodeURIComponent(appId)}/overview" not in source
+    assert "/apps/${encodeURIComponent(appId)}/overview" not in model_source
+    assert "manifest-declared default App Dashboard portal" in studio_page_source
+    assert "getDefaultPortalRoute(payload, 'app')" in studio_page_source
+    assert "location.pathname}/overview" not in studio_page_source
     assert "/api/studio/apps" in create_hook_source
     assert "_provisional_build_app_id" in create_hook_source
     assert "No persisted user build intent" not in create_hook_source

--- a/tests/test_dashboard_manifest.py
+++ b/tests/test_dashboard_manifest.py
@@ -14,12 +14,50 @@ from mozaiksai.core.dashboard import (
     build_default_dashboard_manifest,
     load_dashboard_manifest,
     merge_dashboard_manifest_overlay,
+    validate_dashboard_manifest_routes,
 )
 from mozaiksai.core.runtime.app.paths import noncanonical_app_root_paths
 
 
 def _portal_ids(manifest: DashboardManifest, scope: str) -> list[str]:
     return [portal.id for portal in manifest.surface_for_scope(scope).enabled_portals()]
+
+
+def _minimal_dashboard_manifest() -> DashboardManifest:
+    return DashboardManifest.model_validate(
+        {
+            "schema_version": "mozaiks.dashboard.v1",
+            "extends": None,
+            "workspace": {
+                "id": "workspace",
+                "label": "Workspace Dashboard",
+                "scope": "workspace",
+                "route_pattern": "/apps",
+                "default_portal": "portfolio",
+                "portals": [
+                    {
+                        "id": "portfolio",
+                        "label": "Apps",
+                        "route": "/apps",
+                    },
+                ],
+            },
+            "app": {
+                "id": "app",
+                "label": "App Dashboard",
+                "scope": "app",
+                "route_pattern": "/apps/:appId",
+                "default_portal": "overview",
+                "portals": [
+                    {
+                        "id": "overview",
+                        "label": "Overview",
+                        "route": "/apps/:appId/overview",
+                    },
+                ],
+            },
+        }
+    )
 
 
 def test_default_dashboard_manifest_declares_workspace_and_app_scopes() -> None:
@@ -134,6 +172,92 @@ def test_dashboard_shell_routes_are_route_manifest_compatible() -> None:
         "panel_count": 2,
     }
     assert by_path["/apps/:appId/branding"]["meta"]["navigation"]["group"] == "app-studio"
+
+
+def test_dashboard_route_alignment_accepts_top_level_and_nested_navigation() -> None:
+    manifest = _minimal_dashboard_manifest()
+    route_pages = [
+        {
+            "id": "workspace-studio",
+            "path": "/apps",
+            "navigation": {"group": "workspace-studio", "scope": "local"},
+        },
+        {
+            "id": "app-overview",
+            "path": "/apps/:appId/overview",
+            "meta": {"navigation": {"group": "app-studio", "scope": "local"}},
+        },
+    ]
+
+    result = validate_dashboard_manifest_routes(manifest, route_pages)
+
+    assert result.ok
+    assert result.issues == []
+
+
+def test_dashboard_route_alignment_reports_enabled_portal_without_route() -> None:
+    manifest = _minimal_dashboard_manifest()
+    route_pages = [
+        {
+            "id": "workspace-studio",
+            "path": "/apps",
+            "navigation": {"group": "workspace-studio", "scope": "local"},
+        },
+    ]
+
+    result = validate_dashboard_manifest_routes(manifest, route_pages)
+
+    assert [issue.code for issue in result.issues] == ["enabled_portal_route_missing"]
+    assert result.issues[0].portal_id == "overview"
+    assert result.issues[0].route == "/apps/:appId/overview"
+
+
+def test_dashboard_route_alignment_reports_hidden_enabled_portal_route() -> None:
+    manifest = _minimal_dashboard_manifest()
+    route_pages = [
+        {
+            "id": "workspace-studio",
+            "path": "/apps",
+            "navigation": {"group": "workspace-studio", "scope": "local"},
+        },
+        {
+            "id": "app-overview",
+            "path": "/apps/:appId/overview",
+            "navigation": {"group": "app-studio", "scope": "local", "include": False},
+        },
+    ]
+
+    result = validate_dashboard_manifest_routes(manifest, route_pages)
+
+    assert [issue.code for issue in result.issues] == ["enabled_portal_route_hidden"]
+    assert result.issues[0].page_id == "app-overview"
+
+
+def test_dashboard_route_alignment_reports_visible_route_without_enabled_portal() -> None:
+    manifest = _minimal_dashboard_manifest()
+    route_pages = [
+        {
+            "id": "workspace-studio",
+            "path": "/apps",
+            "navigation": {"group": "workspace-studio", "scope": "local"},
+        },
+        {
+            "id": "app-overview",
+            "path": "/apps/:appId/overview",
+            "navigation": {"group": "app-studio", "scope": "local"},
+        },
+        {
+            "id": "app-usage",
+            "path": "/apps/:appId/usage",
+            "navigation": {"group": "app-studio", "scope": "local"},
+        },
+    ]
+
+    result = validate_dashboard_manifest_routes(manifest, route_pages)
+
+    assert [issue.code for issue in result.issues] == ["visible_route_missing_enabled_portal"]
+    assert result.issues[0].page_id == "app-usage"
+    assert result.issues[0].route == "/apps/:appId/usage"
 
 
 def test_generator_file_contract_keeps_dashboard_separate_from_workflow_routing() -> None:

--- a/tests/test_mobile_surface_contracts.py
+++ b/tests/test_mobile_surface_contracts.py
@@ -162,7 +162,7 @@ def test_web_shell_has_responsive_smoke_harness() -> None:
     assert "create app transition overlay can return to Apps" in smoke_source
     assert "workspace billing route stays responsive across desktop and mobile widths" not in smoke_source
     assert "workspace hosting route stays responsive across desktop and mobile widths" not in smoke_source
-    assert "app Studio root redirects to overview" in smoke_source
+    assert "app Studio root redirects to manifest default portal" in smoke_source
     assert "app overview route stays responsive across desktop and mobile widths" in smoke_source
     assert "app health route stays responsive across desktop and mobile widths" in smoke_source
     assert "app integrations route stays responsive across desktop and mobile widths" in smoke_source
@@ -192,7 +192,7 @@ def test_factory_app_studio_routes_are_all_covered_by_smoke() -> None:
         "WorkspaceUsagePage": "workspace usage route stays responsive across desktop and mobile widths",
         "WorkspaceIntegrationsPage": "workspace integrations route stays responsive across desktop and mobile widths",
         "UserSupportPage": "workspace support route stays responsive across desktop and mobile widths",
-        "StudioPage": "app Studio root redirects to overview",
+        "StudioPage": "app Studio root redirects to manifest default portal",
         "AppOverviewPage": "app overview route stays responsive across desktop and mobile widths",
         "AppHealthPage": "app health route stays responsive across desktop and mobile widths",
         "AppAccessPage": "app access route stays responsive across desktop and mobile widths",

--- a/web_shell/playwright/apps.responsive.smoke.spec.js
+++ b/web_shell/playwright/apps.responsive.smoke.spec.js
@@ -35,6 +35,35 @@ const composedShellConfig = {
   ...shellConfig,
   pages: [...(routeManifest.pages || []), ...transitionRoutes],
 };
+const dashboardPayload = {
+  schema_version: 'mozaiks.dashboard.v1',
+  workspace: {
+    scope: 'workspace',
+    route_pattern: '/apps',
+    default_portal: 'portfolio',
+    portals: [
+      {
+        id: 'portfolio',
+        label: 'Apps',
+        route: '/apps',
+        enabled: true,
+      },
+    ],
+  },
+  app: {
+    scope: 'app',
+    route_pattern: '/apps/:appId',
+    default_portal: 'overview',
+    portals: [
+      {
+        id: 'overview',
+        label: 'Overview',
+        route: '/apps/:appId/overview',
+        enabled: true,
+      },
+    ],
+  },
+};
 const APP_ID = 'campaign-revision-workbench';
 const INTEGRATIONS_QA_DIR = process.env.INTEGRATIONS_UI_QA_DIR
   || path.join(repoRoot, '.logs', 'ui-qa', 'integrations-health-check');
@@ -658,6 +687,14 @@ async function mockStudioApis(page) {
     });
   });
 
+  await page.route('**/api/studio/dashboard', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(dashboardPayload),
+    });
+  });
+
   await page.route('**/api/studio/overview?**', async (route) => {
     const url = new URL(route.request().url());
     const payload = buildAppStudioPayload(url.searchParams.get('app_id') || APP_ID);
@@ -1030,7 +1067,7 @@ test('workspace support route stays responsive across desktop and mobile widths'
   }
 });
 
-test('app Studio root redirects to overview', async ({ page }) => {
+test('app Studio root redirects to manifest default portal', async ({ page }) => {
   await page.goto(`/apps/${APP_ID}`);
 
   await expect(page).toHaveURL(new RegExp(`/apps/${APP_ID}/overview$`));


### PR DESCRIPTION
## Summary
- add an OSS dashboard/route alignment validator with deterministic issue codes
- add schema-native portal descriptions for manifest-driven portal cards
- make factory AppsPage and /apps/:appId redirect resolve the default dashboard portal from /api/studio/dashboard
- update dashboard docs and responsive smoke fixtures

## Validation
- python -m pytest tests/test_dashboard_manifest.py tests/test_build_surface.py tests/test_mobile_surface_contracts.py tests/test_studio_overview_surface.py -q --no-cov
- ruff check mozaiksai/core/dashboard/manifest.py mozaiksai/core/dashboard/__init__.py tests/test_dashboard_manifest.py tests/test_build_surface.py tests/test_mobile_surface_contracts.py
- python -m mypy mozaiksai/core/dashboard/manifest.py mozaiksai/core/dashboard/__init__.py --ignore-missing-imports --disable-error-code=import-untyped
- npm --prefix web_shell run build
- npm --prefix web_shell run test:ui-primitives
- npm --prefix web_shell run test:responsive-smoke