### PR TITLE
feat(refinement): wire contract surface planner path in Studio trigger

### DIFF
--- a/mozaiksai/hosts/studio.py
+++ b/mozaiksai/hosts/studio.py
@@ -2146,6 +2146,8 @@ async def trigger_workflow(
     coding_request = None
     coding_result = None
     coding_session = None
+    contract_surface_plan = None
+    surface_result = None
     persisted_change_request_id = str(trigger_payload.get("change_request_id") or "").strip() or None
     persisted_revision_id = str(trigger_payload.get("revision_id") or "").strip() or None
 
@@ -2208,6 +2210,29 @@ async def trigger_workflow(
             logger.error("refinement_classification_failed: %s", exc, exc_info=True)
             raise HTTPException(status_code=503, detail="Refinement classification unavailable") from exc
         harness_decision = orchestration_control.build_harness_decision(refinement_decision)
+        if (
+            orchestration_control.contract_surface_enabled()
+            and refinement_decision.change_intent.change_class.value in {"feature", "design"}
+            and refinement_request.artifact_kind in {"app_bundle", "workflow_bundle"}
+        ):
+            try:
+                contract_surface_plan, harness_decision = (
+                    await orchestration_control.prepare_contract_surface_request(
+                        refinement_request=refinement_request,
+                        routing_decision=refinement_decision,
+                    )
+                )
+                if contract_surface_plan is not None:
+                    surface_result = await orchestration_control.execute_surface_plan(
+                        plan=contract_surface_plan,
+                        refinement_request=refinement_request,
+                        routing_decision=refinement_decision,
+                    )
+            except Exception as exc:
+                logger.warning("contract_surface_planner_failed, falling back to workflow: %s", exc)
+                contract_surface_plan = None
+                surface_result = None
+                harness_decision = orchestration_control.build_harness_decision(refinement_decision)
         resolved_change_class = refinement_decision.change_intent.change_class.value
         resolved_artifact_kind = refinement_request.artifact_kind
         resolved_artifact_version_id = refinement_request.artifact_version_id
@@ -2451,6 +2476,46 @@ async def trigger_workflow(
             "refinement_session_id": coding_session.id if coding_session is not None else None,
             "harness_decision": harness_decision.model_dump(mode="python") if harness_decision is not None else None,
             "coding_worker": coding_result.model_dump(mode="python"),
+        }
+
+    if surface_result is not None:
+        surface_session = None
+        if (
+            artifact_store is not None
+            and persisted_change_request_id is not None
+            and refinement_request.artifact_version_id
+        ):
+            try:
+                surface_session_status = {
+                    "success": RefinementSessionStatus.VALIDATED,
+                    "partial": RefinementSessionStatus.PENDING,
+                    "failed": RefinementSessionStatus.FAILED,
+                }.get(surface_result.status, RefinementSessionStatus.PENDING)
+                surface_session = await artifact_store.create_refinement_session(
+                    app_id=app_id,
+                    artifact_version_id=refinement_request.artifact_version_id,
+                    change_request_id=persisted_change_request_id,
+                    provider="contract_surface_regeneration",
+                    status=surface_session_status,
+                    metadata={
+                        "surface_result": surface_result.model_dump(mode="python"),
+                        "workflow_id": refinement_decision.workflow_id,
+                    },
+                )
+            except Exception as persist_err:
+                logger.warning("Failed to persist surface RefinementSession: %s", persist_err)
+        return {
+            "execution_mode": "surface_regeneration",
+            "chat_id": None,
+            "workflow_id": refinement_decision.workflow_id,
+            "requested_workflow_id": body.workflow_id or refinement_decision.workflow_id,
+            "websocket_url": None,
+            "trigger_source": body.trigger_source,
+            "routing_explanation": refinement_decision.explanation,
+            "rerouted_by_dependency": False,
+            "refinement_session_id": surface_session.id if surface_session is not None else None,
+            "harness_decision": harness_decision.model_dump(mode="python") if harness_decision is not None else None,
+            "surface_result": surface_result.model_dump(mode="python"),
         }
 
     try:

--- a/tests/test_studio_workflow_trigger.py
+++ b/tests/test_studio_workflow_trigger.py
@@ -206,6 +206,11 @@ def test_studio_trigger_endpoint_accepts_refinement_trigger_payload(monkeypatch)
             )
         ),
     )
+    monkeypatch.setattr(
+        studio_app.get_orchestration_control_harness(),
+        "contract_surface_enabled",
+        lambda: False,
+    )
 
     client = TestClient(studio_app.app)
     response = client.post(
@@ -1688,3 +1693,145 @@ def _async_coding_worker(result: dict):
 
     return _run
 
+
+
+def test_studio_trigger_endpoint_invokes_surface_regeneration_for_feature_changes(monkeypatch):
+    from mozaiksai.control_plane.contracts import (
+        ContractSurfacePlan,
+        ContractSurfaceUpdate,
+        HarnessDecision,
+        HarnessDecisionAction,
+        SurfaceExecutionRecord,
+        SurfacePlanExecutionResult,
+    )
+    from mozaiksai.core.auth import reset_auth_adapter
+
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    reset_auth_adapter()
+    sys.modules.pop("factory_app", None)
+
+    from mozaiksai.hosts import studio as studio_app
+
+    _plan = ContractSurfacePlan(
+        summary="Add export action to product module",
+        change_class="feature",
+        artifact_kind="app_bundle",
+        confidence=0.92,
+        surfaces=[
+            ContractSurfaceUpdate(
+                kind="module_action",
+                target_id="product",
+                target_kind="module",
+                affected_paths=["app/modules/product/backend/handler.py"],
+                dependency_order=0,
+                rationale="Add export action handler",
+                confidence=0.92,
+            )
+        ],
+    )
+    _harness_decision = HarnessDecision(
+        decision_type="targeted_regeneration",
+        message="Executing targeted surface regeneration.",
+        rationale="Adding an export action extends the existing app bundle.",
+        confidence=0.92,
+        recommended_workflow_id=None,
+        actions=[
+            HarnessDecisionAction(
+                action_id="review_surface",
+                label="Review surface changes",
+                action_type="review_surface",
+            )
+        ],
+        metadata={"contract_surface_plan": _plan.model_dump(mode="python")},
+    )
+    _surface_result = SurfacePlanExecutionResult(
+        status="success",
+        surfaces_executed=[
+            SurfaceExecutionRecord(
+                kind="module_action",
+                target_id="product",
+                status="success",
+                applied_files={"app/modules/product/backend/handler.py": "# updated handler"},
+            )
+        ],
+        all_files={"app/modules/product/backend/handler.py": "# updated handler"},
+        requires_schema_migration=False,
+    )
+
+    persisted_sessions: list[dict] = []
+    persisted_changes: list[dict] = []
+
+    class _ArtifactStore:
+        async def create_change_request(self, **kwargs):
+            persisted_changes.append(kwargs)
+            return SimpleNamespace(id="cr_surface_1")
+
+        async def create_refinement_session(self, **kwargs):
+            persisted_sessions.append(kwargs)
+            return SimpleNamespace(id="rs_surface_1")
+
+        async def invalidate_artifact_version_refs(self, **kwargs):
+            return []
+
+        async def update_change_request_router_decision(self, **kwargs):
+            return True
+
+    monkeypatch.setattr(studio_app, "get_artifact_store", lambda: _ArtifactStore())
+    monkeypatch.setattr(
+        studio_app.get_orchestration_control_harness()._refinement_resolver,
+        "_classifier",
+        SimpleNamespace(
+            classify=_async_classifier(
+                change_class="feature",
+                rationale="Adding an export action extends the existing app bundle.",
+                confidence=0.92,
+                signals=["new_capability", "app_extension"],
+            )
+        ),
+    )
+
+    async def _fake_prepare_contract_surface(**kwargs):
+        return _plan, _harness_decision
+
+    async def _fake_execute_surface_plan(**kwargs):
+        return _surface_result
+
+    harness = studio_app.get_orchestration_control_harness()
+    monkeypatch.setattr(harness, "contract_surface_enabled", lambda: True)
+    monkeypatch.setattr(harness, "prepare_contract_surface_request", _fake_prepare_contract_surface)
+    monkeypatch.setattr(harness, "execute_surface_plan", _fake_execute_surface_plan)
+
+    client = TestClient(studio_app.app)
+    response = client.post(
+        "/api/workflows/trigger",
+        json={
+            "trigger_source": "refinement",
+            "trigger_payload": {
+                "refinement_request": {
+                    "artifact_kind": "app_bundle",
+                    "artifact_key": "app_bundle",
+                    "artifact_version_id": "av_456",
+                    "raw_user_request": "Add an export action to the product module",
+                    "source_surface": "app_build",
+                },
+            },
+            "context_variables": {"screen": "studio-create"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["execution_mode"] == "surface_regeneration"
+    assert body["chat_id"] is None
+    assert body["websocket_url"] is None
+    assert body["trigger_source"] == "refinement"
+    assert body["rerouted_by_dependency"] is False
+    assert body["harness_decision"]["decision_type"] == "targeted_regeneration"
+    assert body["surface_result"]["status"] == "success"
+    assert "app/modules/product/backend/handler.py" in body["surface_result"]["all_files"]
+    assert body["refinement_session_id"] == "rs_surface_1"
+    assert len(persisted_sessions) == 1
+    assert persisted_sessions[0]["provider"] == "contract_surface_regeneration"
+    assert persisted_sessions[0]["artifact_version_id"] == "av_456"
+    assert persisted_sessions[0]["change_request_id"] == "cr_surface_1"


### PR DESCRIPTION
## Summary

- **Connects the contract surface planner** in the Studio workflow trigger endpoint for `feature`/`design` change classes on `app_bundle`/`workflow_bundle` artifacts. Previously, these changes always fell through to a full workflow re-run even though the planner, surface execution worker, and harness decision policy were all fully implemented.
- **Adds `surface_regeneration` execution mode** — when the planner finds a targeted plan, Studio returns `all_files` per surface (analogous to `coding_worker` for patches), persisting a `RefinementSession` with `provider: contract_surface_regeneration`.
- **Graceful fallback** — planner exceptions and `fallback_to_workflow` results fall back silently to the normal workflow launch path.

## What was missing

`prepare_contract_surface_request()` and `execute_surface_plan()` both existed on `OrchestrationControlHarness` but were never called from `studio.py`. The only refinement paths wired were:
- `patch` → coding worker (already wired)
- all others → workflow re-run (unchanged for non-feature/design changes)

The `targeted_regeneration` decision type and `SurfacePlanExecutionResult` contract were complete but had no caller.

## Test plan
- [x] `test_studio_trigger_endpoint_accepts_refinement_trigger_payload` — existing feature-class test updated to guard against calling real planner (`contract_surface_enabled=False`)
- [x] `test_studio_trigger_endpoint_invokes_surface_regeneration_for_feature_changes` — new test covering full surface_regeneration path, harness_decision shape, and RefinementSession persistence
- [x] `test_contract_surface_planner.py` — 21 tests, no regressions
- [x] `test_surface_regeneration_worker.py` — 16 tests, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)