### PR TITLE
feat(factory): wire brownfield adoption context into generation workflows

### DIFF
--- a/factory_app/workflows/AgentGenerator/context_variables.yaml
+++ b/factory_app/workflows/AgentGenerator/context_variables.yaml
@@ -254,6 +254,47 @@ definitions:
     source:
       type: state
       default: null
+  brownfield_build_path:
+    type: string
+    description: >
+      Selected brownfield build path from brownfield_path_selector. One of
+      "light_integration" (overlay-only generation via AgentGenerator +
+      AppGenerator) or "full_migration" (DesignDocs + full pipeline grounded
+      in AdoptionPlan scope). Null for greenfield builds.
+    source:
+      type: state
+      default: null
+  adoption_plan:
+    type: object
+    description: >
+      Canonical AdoptionPlan from ExistingAppDiscovery — recommended_path,
+      phases, candidate_overlays, candidate_adapters, candidate_migrations, and
+      human_decisions_required. Present only for brownfield builds. Planning
+      agents scope generation work to approved surfaces declared here.
+    source:
+      type: state
+      default: null
+  ownership_boundary:
+    type: object
+    description: >
+      Canonical ownership_boundary artifact from ExistingAppDiscovery —
+      app_id and ownership_boundaries[] listing each discovered surface with
+      its ownership class (read_only_discovered, generated_overlay, etc.),
+      allowed_operations, and requires_review flag. Present only for brownfield
+      builds. Agents must not propose changes to read_only_discovered surfaces.
+    source:
+      type: state
+      default: null
+  brownfield_registration:
+    type: object
+    description: >
+      BrownfieldRegistration record from ExistingAppDiscovery — registration_id,
+      app_id, source_refs, context_version_id, scan_policy_ref, and status.
+      Present only for brownfield builds. Used as the provenance anchor for
+      generated overlays and adapters.
+    source:
+      type: state
+      default: null
   context_aware:
     type: boolean
     description: Flag indicating if the application is opensource (in which the llm
@@ -749,6 +790,10 @@ agents:
     - pack_name
     - pack_partition_reason
     - workflows_spec
+    - brownfield_build_path
+    - adoption_plan
+    - ownership_boundary
+    - brownfield_registration
   ProjectOverviewAgent:
     variables:
     - concept_overview
@@ -776,6 +821,10 @@ agents:
     - experience_spec_document
     - pack_name
     - is_multi_workflow
+    - brownfield_build_path
+    - adoption_plan
+    - ownership_boundary
+    - brownfield_registration
   PackMetadataAgent:
     variables:
     - build_mode

--- a/factory_app/workflows/AgentGenerator/middleware.yaml
+++ b/factory_app/workflows/AgentGenerator/middleware.yaml
@@ -30,6 +30,12 @@ prompt_middleware:
 - agent: WorkflowBundleBuilderAgent
   filename: tools/hook_workflow_archetypes_context.py
   function: inject_workflow_archetypes_context
+- agent: PatternAgent
+  filename: ../_shared/brownfield_adoption_context.py
+  function: inject_brownfield_adoption_context
+- agent: WorkflowBundleBuilderAgent
+  filename: ../_shared/brownfield_adoption_context.py
+  function: inject_brownfield_adoption_context
 
 
 

--- a/factory_app/workflows/AppGenerator/context_variables.yaml
+++ b/factory_app/workflows/AppGenerator/context_variables.yaml
@@ -306,6 +306,47 @@ definitions:
     source:
       type: state
       default: null
+  brownfield_build_path:
+    type: string
+    description: >
+      Selected brownfield build path from brownfield_path_selector. One of
+      "light_integration" (overlay-only generation via AgentGenerator +
+      AppGenerator) or "full_migration" (DesignDocs + full pipeline grounded
+      in AdoptionPlan scope). Null for greenfield builds.
+    source:
+      type: state
+      default: null
+  adoption_plan:
+    type: object
+    description: >
+      Canonical AdoptionPlan from ExistingAppDiscovery — recommended_path,
+      phases, candidate_overlays, candidate_adapters, candidate_migrations, and
+      human_decisions_required. Present only for brownfield builds. Planning
+      agents scope generation work to approved surfaces declared here.
+    source:
+      type: state
+      default: null
+  ownership_boundary:
+    type: object
+    description: >
+      Canonical ownership_boundary artifact from ExistingAppDiscovery —
+      app_id and ownership_boundaries[] listing each discovered surface with
+      its ownership class (read_only_discovered, generated_overlay, etc.),
+      allowed_operations, and requires_review flag. Present only for brownfield
+      builds. Agents must not propose changes to read_only_discovered surfaces.
+    source:
+      type: state
+      default: null
+  brownfield_registration:
+    type: object
+    description: >
+      BrownfieldRegistration record from ExistingAppDiscovery — registration_id,
+      app_id, source_refs, context_version_id, scan_policy_ref, and status.
+      Present only for brownfield builds. Used as the provenance anchor for
+      generated overlays and adapters.
+    source:
+      type: state
+      default: null
   app_type:
     type: string
     description: >
@@ -1367,6 +1408,10 @@ agents:
     - subscription_contract_artifact
     - revenue_model
     - interview_complete
+    - brownfield_build_path
+    - adoption_plan
+    - ownership_boundary
+    - brownfield_registration
   AppPlanAgent:
     variables:
     - platform_user_email
@@ -1421,6 +1466,10 @@ agents:
     - ready_connector_services
     - missing_connector_services
     - capability_packs
+    - brownfield_build_path
+    - adoption_plan
+    - ownership_boundary
+    - brownfield_registration
   AppSchemaAgent:
     variables:
     - concept_overview

--- a/factory_app/workflows/AppGenerator/middleware.yaml
+++ b/factory_app/workflows/AppGenerator/middleware.yaml
@@ -17,9 +17,15 @@ prompt_middleware:
 - agent: InterviewAgent
   filename: hook_agent_backend_context.py
   function: inject_agent_backend_context
+- agent: InterviewAgent
+  filename: ../_shared/brownfield_adoption_context.py
+  function: inject_brownfield_adoption_context
 - agent: AppPlanAgent
   filename: hook_agent_backend_context.py
   function: inject_agent_backend_context
+- agent: AppPlanAgent
+  filename: ../_shared/brownfield_adoption_context.py
+  function: inject_brownfield_adoption_context
 - agent: AppPlanAgent
   filename: hook_workflow_integration_contract.py
   function: inject_workflow_integration_contract

--- a/factory_app/workflows/_shared/brownfield_adoption_context.py
+++ b/factory_app/workflows/_shared/brownfield_adoption_context.py
@@ -1,0 +1,161 @@
+"""
+Hook: Inject Brownfield Adoption Context
+
+Fires as prompt middleware on planning agents in AgentGenerator and AppGenerator
+when the active session is a brownfield build (brownfield_build_path is set).
+
+Targeted agents:
+  AgentGenerator  — PatternAgent, WorkflowBundleBuilderAgent
+  AppGenerator    — InterviewAgent, AppPlanAgent
+
+Reads from context variables set by ExistingAppDiscovery's
+save_existing_app_artifacts tool:
+  - brownfield_build_path    "light_integration" | "full_migration"
+  - adoption_plan            canonical AdoptionPlan from discovery
+  - ownership_boundary       ownership_boundary artifact (boundaries list)
+  - brownfield_registration  BrownfieldRegistration record
+
+Returns an empty string when brownfield_build_path is absent or null so there
+is no prompt noise for greenfield builds.
+
+Rule: agents must not propose changes to surfaces whose ownership_class is
+read_only_discovered unless the user explicitly approves a staged patch.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HEADER = "[BROWNFIELD ADOPTION CONTEXT]"
+
+
+def _get(context_variables: Any, key: str, default: Any = None) -> Any:
+    if context_variables is None:
+        return default
+    try:
+        if hasattr(context_variables, "get"):
+            return context_variables.get(key, default)
+        return context_variables[key]
+    except (KeyError, TypeError):
+        return default
+
+
+def _format_adoption_plan(plan: dict[str, Any]) -> str:
+    lines: list[str] = []
+    path = plan.get("recommended_path") or plan.get("adoption_level") or ""
+    if path:
+        lines.append(f"  Recommended path: {path}")
+    overlays = plan.get("candidate_overlays") or []
+    if overlays:
+        lines.append(f"  Candidate overlays ({len(overlays)}): {', '.join(str(o) for o in overlays[:8])}")
+        if len(overlays) > 8:
+            lines.append(f"    ... and {len(overlays) - 8} more")
+    adapters = plan.get("candidate_adapters") or []
+    if adapters:
+        lines.append(f"  Candidate adapters: {', '.join(str(a) for a in adapters[:5])}")
+    migrations = plan.get("candidate_migrations") or []
+    if migrations:
+        lines.append(f"  Migration candidates: {', '.join(str(m) for m in migrations[:5])}")
+    decisions = plan.get("human_decisions_required") or []
+    if decisions:
+        lines.append("  Required human decisions:")
+        for decision in decisions[:4]:
+            lines.append(f"    - {decision}")
+    not_in_scope = plan.get("not_in_scope") or []
+    if not_in_scope:
+        lines.append("  NOT in scope:")
+        for item in not_in_scope[:3]:
+            lines.append(f"    - {item}")
+    return "\n".join(lines)
+
+
+def _format_ownership_summary(boundary_artifact: dict[str, Any]) -> str:
+    boundaries = boundary_artifact.get("ownership_boundaries") or []
+    if not boundaries:
+        return "  No ownership boundaries declared."
+
+    class_counts: dict[str, int] = {}
+    read_only_examples: list[str] = []
+    overlay_examples: list[str] = []
+
+    for b in boundaries:
+        cls = b.get("ownership") or b.get("ownership_class") or "unknown"
+        class_counts[cls] = class_counts.get(cls, 0) + 1
+        path = b.get("path_or_artifact") or ""
+        if cls == "read_only_discovered" and len(read_only_examples) < 4:
+            read_only_examples.append(path)
+        elif cls == "generated_overlay" and len(overlay_examples) < 4:
+            overlay_examples.append(path)
+
+    lines: list[str] = []
+    for cls, count in sorted(class_counts.items()):
+        lines.append(f"  {cls}: {count} surface(s)")
+
+    if read_only_examples:
+        lines.append(
+            "  read_only examples (DO NOT modify without explicit approval): "
+            + ", ".join(read_only_examples)
+        )
+    if overlay_examples:
+        lines.append(
+            "  overlay targets (safe to generate): "
+            + ", ".join(overlay_examples)
+        )
+    return "\n".join(lines)
+
+
+def inject_brownfield_adoption_context(
+    agent_name: str | None = None,
+    context_variables: Any = None,
+    **_kwargs: Any,
+) -> str:
+    """Return a brownfield adoption context block for planning agents.
+
+    Returns empty string for greenfield builds so there is no prompt noise.
+    """
+    build_path = _get(context_variables, "brownfield_build_path")
+    if not build_path:
+        return ""
+
+    adoption_plan = _get(context_variables, "adoption_plan") or {}
+    ownership_boundary = _get(context_variables, "ownership_boundary") or {}
+    registration = _get(context_variables, "brownfield_registration") or {}
+
+    app_id = (
+        registration.get("app_id")
+        or ownership_boundary.get("app_id")
+        or adoption_plan.get("app_id")
+        or "unknown"
+    )
+
+    sections: list[str] = [
+        _HEADER,
+        f"Build path: {build_path}",
+        f"App: {app_id}",
+    ]
+
+    reg_status = registration.get("status") or ""
+    if reg_status:
+        sections.append(f"Registration status: {reg_status}")
+
+    if adoption_plan:
+        sections.append("")
+        sections.append("Adoption Plan:")
+        sections.append(_format_adoption_plan(adoption_plan))
+
+    if ownership_boundary:
+        sections.append("")
+        sections.append("Ownership Boundaries:")
+        sections.append(_format_ownership_summary(ownership_boundary))
+
+    sections.append("")
+    sections.append(
+        "RULE: Agents must not propose code changes to read_only_discovered surfaces "
+        "without explicit user approval. Generate only overlays, adapters, and workflows "
+        "that the AdoptionPlan marks as candidate_overlays or candidate_adapters."
+    )
+
+    return "\n".join(sections)

--- a/tests/test_brownfield_adoption_generation_contract.py
+++ b/tests/test_brownfield_adoption_generation_contract.py
@@ -1,0 +1,392 @@
+"""Contract tests for brownfield adoption context wiring in generation workflows.
+
+Verifies that:
+- AgentGenerator and AppGenerator declare the canonical brownfield context
+  variables (brownfield_build_path, adoption_plan, ownership_boundary,
+  brownfield_registration) in their context_variables.yaml definitions.
+- The planning agents in each workflow (PatternAgent + WorkflowBundleBuilderAgent
+  in AgentGenerator; InterviewAgent + AppPlanAgent in AppGenerator) expose the
+  brownfield context variables.
+- Both workflows wire inject_brownfield_adoption_context middleware for their
+  planning agents.
+- The inject_brownfield_adoption_context hook returns empty for greenfield builds
+  and a labelled context block for brownfield builds.
+- The brownfield overlay and module generation sequences are correctly declared
+  in the extension registry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AGENT_GENERATOR_CV = ROOT / "factory_app/workflows/AgentGenerator/context_variables.yaml"
+APP_GENERATOR_CV = ROOT / "factory_app/workflows/AppGenerator/context_variables.yaml"
+AGENT_GENERATOR_MW = ROOT / "factory_app/workflows/AgentGenerator/middleware.yaml"
+APP_GENERATOR_MW = ROOT / "factory_app/workflows/AppGenerator/middleware.yaml"
+REGISTRY_PATH = ROOT / "factory_app/workflows/extended_orchestration/extension_registry.json"
+HOOK_PATH = ROOT / "factory_app/workflows/_shared/brownfield_adoption_context.py"
+
+BROWNFIELD_CONTEXT_VARS = (
+    "brownfield_build_path",
+    "adoption_plan",
+    "ownership_boundary",
+    "brownfield_registration",
+)
+
+# AgentGenerator planning agents that need brownfield context
+AGENT_GENERATOR_PLANNING_AGENTS = {"PatternAgent", "WorkflowBundleBuilderAgent"}
+
+# AppGenerator planning agents that need brownfield context
+APP_GENERATOR_PLANNING_AGENTS = {"InterviewAgent", "AppPlanAgent"}
+
+BROWNFIELD_HOOK_FUNCTION = "inject_brownfield_adoption_context"
+BROWNFIELD_HOOK_FILE = "../_shared/brownfield_adoption_context.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_cv(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _load_mw(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _load_registry() -> dict:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def _definitions(cv: dict) -> dict:
+    return cv.get("definitions") or {}
+
+
+def _agent_vars(cv: dict, agent_name: str) -> set[str]:
+    agents = cv.get("agents") or {}
+    agent = agents.get(agent_name) or {}
+    return set(agent.get("variables") or [])
+
+
+def _mw_entries(mw: dict) -> list[dict]:
+    return mw.get("prompt_middleware") or []
+
+
+def _wired_agents_for_function(mw: dict, function_name: str) -> set[str]:
+    return {
+        str(entry.get("agent") or "")
+        for entry in _mw_entries(mw)
+        if entry.get("function") == function_name
+    }
+
+
+# ---------------------------------------------------------------------------
+# Context variable declarations
+# ---------------------------------------------------------------------------
+
+def test_agent_generator_declares_brownfield_context_vars() -> None:
+    defs = _definitions(_load_cv(AGENT_GENERATOR_CV))
+    for var in BROWNFIELD_CONTEXT_VARS:
+        assert var in defs, f"AgentGenerator context_variables.yaml missing definition: {var}"
+
+
+def test_app_generator_declares_brownfield_context_vars() -> None:
+    defs = _definitions(_load_cv(APP_GENERATOR_CV))
+    for var in BROWNFIELD_CONTEXT_VARS:
+        assert var in defs, f"AppGenerator context_variables.yaml missing definition: {var}"
+
+
+def test_agent_generator_brownfield_vars_have_null_default() -> None:
+    defs = _definitions(_load_cv(AGENT_GENERATOR_CV))
+    for var in BROWNFIELD_CONTEXT_VARS:
+        source = (defs.get(var) or {}).get("source") or {}
+        assert source.get("default") is None, (
+            f"AgentGenerator {var} must default to null — it is only present for brownfield builds"
+        )
+
+
+def test_app_generator_brownfield_vars_have_null_default() -> None:
+    defs = _definitions(_load_cv(APP_GENERATOR_CV))
+    for var in BROWNFIELD_CONTEXT_VARS:
+        source = (defs.get(var) or {}).get("source") or {}
+        assert source.get("default") is None, (
+            f"AppGenerator {var} must default to null — it is only present for brownfield builds"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Planning agent variable exposure
+# ---------------------------------------------------------------------------
+
+def test_agent_generator_planning_agents_expose_brownfield_vars() -> None:
+    cv = _load_cv(AGENT_GENERATOR_CV)
+    for agent in sorted(AGENT_GENERATOR_PLANNING_AGENTS):
+        agent_vars = _agent_vars(cv, agent)
+        for var in BROWNFIELD_CONTEXT_VARS:
+            assert var in agent_vars, (
+                f"AgentGenerator {agent} missing brownfield context var: {var}"
+            )
+
+
+def test_app_generator_planning_agents_expose_brownfield_vars() -> None:
+    cv = _load_cv(APP_GENERATOR_CV)
+    for agent in sorted(APP_GENERATOR_PLANNING_AGENTS):
+        agent_vars = _agent_vars(cv, agent)
+        for var in BROWNFIELD_CONTEXT_VARS:
+            assert var in agent_vars, (
+                f"AppGenerator {agent} missing brownfield context var: {var}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Middleware wiring
+# ---------------------------------------------------------------------------
+
+def test_agent_generator_wires_brownfield_hook_for_planning_agents() -> None:
+    mw = _load_mw(AGENT_GENERATOR_MW)
+    wired = _wired_agents_for_function(mw, BROWNFIELD_HOOK_FUNCTION)
+    for agent in sorted(AGENT_GENERATOR_PLANNING_AGENTS):
+        assert agent in wired, (
+            f"AgentGenerator middleware.yaml does not wire {BROWNFIELD_HOOK_FUNCTION} for {agent}"
+        )
+
+
+def test_app_generator_wires_brownfield_hook_for_planning_agents() -> None:
+    mw = _load_mw(APP_GENERATOR_MW)
+    wired = _wired_agents_for_function(mw, BROWNFIELD_HOOK_FUNCTION)
+    for agent in sorted(APP_GENERATOR_PLANNING_AGENTS):
+        assert agent in wired, (
+            f"AppGenerator middleware.yaml does not wire {BROWNFIELD_HOOK_FUNCTION} for {agent}"
+        )
+
+
+def test_agent_generator_brownfield_hook_references_shared_file() -> None:
+    mw = _load_mw(AGENT_GENERATOR_MW)
+    entries = [
+        e for e in _mw_entries(mw)
+        if e.get("function") == BROWNFIELD_HOOK_FUNCTION
+    ]
+    assert entries, "No brownfield hook entries found in AgentGenerator middleware.yaml"
+    for entry in entries:
+        assert entry.get("filename") == BROWNFIELD_HOOK_FILE, (
+            f"Expected filename '{BROWNFIELD_HOOK_FILE}', got '{entry.get('filename')}'"
+        )
+
+
+def test_app_generator_brownfield_hook_references_shared_file() -> None:
+    mw = _load_mw(APP_GENERATOR_MW)
+    entries = [
+        e for e in _mw_entries(mw)
+        if e.get("function") == BROWNFIELD_HOOK_FUNCTION
+    ]
+    assert entries, "No brownfield hook entries found in AppGenerator middleware.yaml"
+    for entry in entries:
+        assert entry.get("filename") == BROWNFIELD_HOOK_FILE, (
+            f"Expected filename '{BROWNFIELD_HOOK_FILE}', got '{entry.get('filename')}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared hook implementation
+# ---------------------------------------------------------------------------
+
+def test_brownfield_adoption_context_hook_file_exists() -> None:
+    assert HOOK_PATH.exists(), f"Missing shared hook: {HOOK_PATH}"
+
+
+def test_brownfield_hook_returns_empty_for_greenfield() -> None:
+    from factory_app.workflows._shared.brownfield_adoption_context import (
+        inject_brownfield_adoption_context,
+    )
+
+    result = inject_brownfield_adoption_context(
+        agent_name="PatternAgent",
+        context_variables={"brownfield_build_path": None},
+    )
+    assert result == ""
+
+
+def test_brownfield_hook_returns_empty_when_no_context() -> None:
+    from factory_app.workflows._shared.brownfield_adoption_context import (
+        inject_brownfield_adoption_context,
+    )
+
+    result = inject_brownfield_adoption_context(
+        agent_name="AppPlanAgent",
+        context_variables={},
+    )
+    assert result == ""
+
+
+def test_brownfield_hook_returns_block_for_light_integration() -> None:
+    from factory_app.workflows._shared.brownfield_adoption_context import (
+        inject_brownfield_adoption_context,
+    )
+
+    ctx = {
+        "brownfield_build_path": "light_integration",
+        "adoption_plan": {
+            "recommended_path": "overlay",
+            "candidate_overlays": ["workflow:ChatSupport", "workflow:OnboardingFlow"],
+            "candidate_adapters": ["adapter:stripe"],
+            "candidate_migrations": [],
+            "human_decisions_required": ["Approve which surfaces may be augmented."],
+            "not_in_scope": ["Automatic takeover of existing source."],
+        },
+        "ownership_boundary": {
+            "app_id": "my_existing_app",
+            "ownership_boundaries": [
+                {
+                    "path_or_artifact": "/api/users",
+                    "ownership": "read_only_discovered",
+                    "allowed_operations": ["inspect", "explain"],
+                    "requires_review": True,
+                },
+                {
+                    "path_or_artifact": "workflow:ChatSupport",
+                    "ownership": "generated_overlay",
+                    "allowed_operations": ["generate_overlay"],
+                    "requires_review": True,
+                },
+            ],
+        },
+        "brownfield_registration": {
+            "registration_id": "reg_123",
+            "app_id": "my_existing_app",
+            "status": "pending",
+        },
+    }
+
+    result = inject_brownfield_adoption_context(
+        agent_name="PatternAgent",
+        context_variables=ctx,
+    )
+
+    assert "[BROWNFIELD ADOPTION CONTEXT]" in result
+    assert "light_integration" in result
+    assert "my_existing_app" in result
+    assert "overlay" in result
+    assert "ChatSupport" in result
+    assert "read_only_discovered" in result
+    assert "generated_overlay" in result
+    assert "RULE" in result
+    assert "read_only_discovered" in result
+
+
+def test_brownfield_hook_returns_block_for_full_migration() -> None:
+    from factory_app.workflows._shared.brownfield_adoption_context import (
+        inject_brownfield_adoption_context,
+    )
+
+    ctx = {
+        "brownfield_build_path": "full_migration",
+        "adoption_plan": {
+            "recommended_path": "gradual_modernization",
+            "candidate_overlays": [],
+            "candidate_adapters": [],
+            "candidate_migrations": ["module:billing", "module:auth"],
+            "human_decisions_required": ["Approve migration scope."],
+        },
+        "ownership_boundary": {
+            "app_id": "legacy_app",
+            "ownership_boundaries": [],
+        },
+        "brownfield_registration": {
+            "app_id": "legacy_app",
+            "status": "pending",
+        },
+    }
+
+    result = inject_brownfield_adoption_context(
+        agent_name="AppPlanAgent",
+        context_variables=ctx,
+    )
+
+    assert "[BROWNFIELD ADOPTION CONTEXT]" in result
+    assert "full_migration" in result
+    assert "gradual_modernization" in result
+
+
+# ---------------------------------------------------------------------------
+# Extension registry — brownfield sequences
+# ---------------------------------------------------------------------------
+
+def test_registry_declares_brownfield_overlay_generation_sequence() -> None:
+    registry = _load_registry()
+    sequences = {s["id"]: s for s in registry.get("workflow_sequences", [])}
+    assert "brownfield_overlay_generation" in sequences
+    seq = sequences["brownfield_overlay_generation"]
+    workflows = [
+        w for step in seq.get("steps", []) for w in step.get("workflows", [])
+    ]
+    assert "AgentGenerator" in workflows
+    assert "AppGenerator" in workflows
+    assert "DesignDocs" not in workflows
+
+
+def test_registry_declares_brownfield_module_generation_sequence() -> None:
+    registry = _load_registry()
+    sequences = {s["id"]: s for s in registry.get("workflow_sequences", [])}
+    assert "brownfield_module_generation" in sequences
+    seq = sequences["brownfield_module_generation"]
+    workflows = [
+        w for step in seq.get("steps", []) for w in step.get("workflows", [])
+    ]
+    assert "DesignDocs" in workflows
+    assert "AgentGenerator" in workflows
+    assert "AppGenerator" in workflows
+
+
+def test_registry_brownfield_sequences_affect_canonical_families() -> None:
+    registry = _load_registry()
+    sequences = {s["id"]: s for s in registry.get("workflow_sequences", [])}
+
+    overlay_families = set(
+        sequences["brownfield_overlay_generation"].get("affected_declarative_families") or []
+    )
+    assert "workflow_bundle" in overlay_families
+    assert "app_bundle" in overlay_families
+
+    module_families = set(
+        sequences["brownfield_module_generation"].get("affected_declarative_families") or []
+    )
+    assert "design_docs" in module_families
+    assert "workflow_bundle" in module_families
+    assert "app_bundle" in module_families
+
+
+def test_registry_brownfield_path_selector_routes_correctly() -> None:
+    registry = _load_registry()
+    transitions = {t["id"]: t for t in registry.get("transitions", [])}
+
+    assert "brownfield_path_selector" in transitions
+    selector = transitions["brownfield_path_selector"]
+    options = {o["id"]: o for o in selector.get("options", [])}
+
+    assert "light_integration" in options
+    assert options["light_integration"]["route_to"] == "AgentGenerator"
+    assert options["light_integration"]["sequence"] == "brownfield_overlay_generation"
+    assert options["light_integration"]["context_variables"]["brownfield_build_path"] == "light_integration"
+
+    assert "full_migration" in options
+    assert options["full_migration"]["route_to"] == "DesignDocs"
+    assert options["full_migration"]["sequence"] == "brownfield_module_generation"
+    assert options["full_migration"]["context_variables"]["brownfield_build_path"] == "full_migration"
+
+
+def test_brownfield_context_vars_not_declared_in_greenfield_only_artifacts() -> None:
+    """Brownfield vars should default to null — they must not pollute greenfield builds."""
+    cv = _load_cv(APP_GENERATOR_CV)
+    defs = _definitions(cv)
+    for var in BROWNFIELD_CONTEXT_VARS:
+        source = (defs.get(var) or {}).get("source") or {}
+        # Must be state-backed (session-carried), not config or data_reference
+        assert source.get("type") == "state", (
+            f"{var} must be type: state so it only appears in brownfield sessions"
+        )


### PR DESCRIPTION
## Summary

- `AgentGenerator` and `AppGenerator` context_variables.yaml now declare `brownfield_build_path`, `adoption_plan`, `ownership_boundary`, and `brownfield_registration` — the canonical brownfield adoption context carried from `ExistingAppDiscovery`
- New shared hook `factory_app/workflows/_shared/brownfield_adoption_context.py` formats a `[BROWNFIELD ADOPTION CONTEXT]` prompt block for planning agents; returns empty string for greenfield builds (no noise)
- Hook wired in AgentGenerator middleware for `PatternAgent` and `WorkflowBundleBuilderAgent`
- Hook wired in AppGenerator middleware for `InterviewAgent` and `AppPlanAgent`
- 20-test contract suite covers declarations, agent variable exposure, middleware wiring, hook behavior (greenfield empty / brownfield formatted), and registry sequence correctness

## Why

When `ExistingAppDiscovery` completes and the user selects `brownfield_path_selector → light_integration`, AgentGenerator runs inside `brownfield_overlay_generation`. Without this change, AgentGenerator's `PatternAgent` and `WorkflowBundleBuilderAgent` had no knowledge of the `adoption_plan` or `ownership_boundary` from discovery. The hook is a no-op for greenfield sessions so there is zero impact on the default build path.

## Test plan

- [x] `tests/test_brownfield_adoption_generation_contract.py` — 20 tests, all passing
- [x] `tests/test_brownfield_discovery_refresh_sequence.py` — 15 tests, still passing
- [x] `tests/test_brownfield_app_context_graph_edges.py` — still passing
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)