### PR TITLE
feat(factory): add brownfield adoption scope guidance to generation agent prompts

### DIFF
--- a/factory_app/workflows/AgentGenerator/agents.yaml
+++ b/factory_app/workflows/AgentGenerator/agents.yaml
@@ -210,6 +210,43 @@ agents:
     heading: '[AG2 NETWORK PATTERNBOOK]'
     content: '{{PATTERN_GUIDANCE_AND_EXAMPLES}}'
 
+  - id: brownfield_scope
+    heading: '[BROWNFIELD ADOPTION SCOPE]'
+    content: |-
+      **This section is active only when `[BROWNFIELD ADOPTION CONTEXT]` is present in your prompt.**
+
+      When brownfield adoption context is injected:
+
+      1. **Scope to approved overlays and adapters only.**
+         - `adoption_plan.candidate_overlays` is the authoritative list of workflows you may generate.
+           For each overlay candidate (e.g. `workflow:ChatSupport`), generate exactly one workflow.
+           Do NOT invent workflows outside this list — the adoption plan is the scope contract.
+         - `adoption_plan.candidate_adapters` are integration workflows (e.g. `adapter:stripe`).
+           These become adapter-pattern supporting workflows where explicitly in scope.
+         - If `candidate_overlays` is empty, emit `is_multi_workflow: false` with one lightweight
+           integration workflow and note the adoption plan scope in `pack_partition_reason`.
+
+      2. **Select overlay-appropriate AG2 patterns.**
+         - Overlay workflows typically augment existing product flows. Prefer patterns that
+           compose well with external systems: Pipeline (6), Star (8), or Coordinator (5).
+         - Avoid patterns that assume standalone ownership of a full user journey (Triage with Tasks 9)
+           unless the adoption plan explicitly calls for a migration surface.
+
+      3. **Carry adoption constraints into `initial_message`.**
+         - For every workflow entry in `workflows[]`, the `initial_message` to WorkflowBundleBuilderAgent
+           MUST include:
+           - `brownfield_build_path`: the active path ("light_integration" or "full_migration")
+           - `ownership_boundary`: the list of known surfaces with their ownership class
+           - A clear directive: "Do not write tools or agents that mutate read_only_discovered surfaces."
+         - Name which ownership classes each generated agent/tool is allowed to operate on.
+
+      4. **Respect ownership boundaries in pack partitioning.**
+         - Surfaces with `ownership: read_only_discovered` must NEVER be assigned as module owners
+           or workflow primary concerns. They are context inputs only.
+         - Surfaces with `ownership: generated_overlay` are the only surfaces you may generate
+           new workflows for.
+         - `pack_partition_reason` must reference the adoption plan when explaining scope.
+
   - id: instructions_continued
     heading: '[INSTRUCTIONS CONTINUED]'
     content: |-
@@ -823,6 +860,40 @@ agents:
   - id: pattern_guidance_and_examples
     heading: '[PATTERN GUIDANCE]'
     content: '{{PATTERN_GUIDANCE_AND_EXAMPLES}}'
+
+  - id: brownfield_scope
+    heading: '[BROWNFIELD ADOPTION SCOPE]'
+    content: |-
+      **This section is active only when `[BROWNFIELD ADOPTION CONTEXT]` is present in your prompt
+      (injected from the `initial_message` provided by PatternAgent).**
+
+      When brownfield adoption context is present:
+
+      1. **Generate overlay-style bundles, not greenfield replacements.**
+         - Your workflow MUST operate as an augmentation layer on top of the existing app.
+           Do NOT generate tools that overwrite, delete, or replace data owned by
+           `read_only_discovered` surfaces.
+         - Every tool that writes data MUST target only surfaces with `ownership: generated_overlay`
+           or `ownership: generated_adapter`.
+
+      2. **Honor ownership in tool design.**
+         - `read_only_discovered` surfaces: tools may READ from them (e.g. list users, fetch products)
+           but MUST NOT write, mutate, or delete their records.
+         - `generated_overlay` surfaces: full CRUD is allowed — these are new overlay surfaces.
+         - If a tool would mutate a `read_only_discovered` surface, comment in the stub docstring
+           that the operation is forbidden and raise `NotImplementedError` with a message referencing
+           the ownership boundary.
+
+      3. **Scope agents to overlay responsibilities.**
+         - Agent roles must reference the overlay target (e.g. "You augment the existing CRM's
+           contact flow by adding a follow-up recommendation layer — you do NOT own CRM contacts").
+         - The `context` section of each agent's prompt_sections must explain which surfaces
+           it reads (read_only) and which it owns (generated_overlay).
+
+      4. **context_variables must reflect the brownfield state.**
+         - Declare `brownfield_build_path` and `adoption_plan` as context variables accessible
+           to planning agents in the generated `context_variables.yaml`.
+         - This allows the overlay workflow to be aware of the adoption scope at runtime.
 
   - id: contract_check
     heading: '[CONTRACT CHECK]'

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -91,6 +91,38 @@ agents:
       If the user mentions these as framework infrastructure, acknowledge they are built-in and move on.
       If the user wants their generated app to sell plans, expose a billing portal, or gate end-user features, treat those as app-owned SaaS modules/config that can be generated on top of the built-in entitlement, runtime usage, and token wallet primitives. Do not generate a second AI-token usage or balance ledger.
       If the product needs domain-specific profile records (for example investor profiles, seller profiles, creator profiles, or member profiles), treat those as module-owned domain entities rather than replacements for the host-owned account/profile primitive.
+  - id: brownfield_scope
+    heading: '[BROWNFIELD ADOPTION SCOPE]'
+    content: |-
+      **This section is active only when `[BROWNFIELD ADOPTION CONTEXT]` is present in your prompt.**
+
+      When brownfield adoption context is injected, the app scope is NOT open-ended.
+      The adoption plan already determines what gets built. Adjust your interview accordingly:
+
+      1. **Do NOT restart as a blank-slate product interview.**
+         The `adoption_plan` declares `candidate_overlays`, `candidate_adapters`, and
+         `candidate_migrations`. These are the bounded scope of what AppGenerator will build.
+         Do not ask about unrelated product features, pricing models, or page count.
+
+      2. **For `light_integration` path (overlay):**
+         - The existing app is not being replaced. Overlays add NEW surfaces only.
+         - Confirm only: which of the `candidate_overlays` the user wants to proceed with,
+           and whether any integration constraints apply to the listed `candidate_adapters`.
+         - Do NOT ask about the existing app's architecture, database, or current tech stack —
+           that is already captured in `ownership_boundary`.
+         - Emit NEXT as soon as the overlay selection is confirmed (usually 0–1 questions).
+
+      3. **For `full_migration` path:**
+         - `candidate_migrations` lists the modules to migrate. Confirm module priorities
+           and any data-migration constraints if the user has not already provided them.
+         - Do NOT redesign the existing app from scratch — migration scope is bounded by
+           the adoption plan.
+         - Emit NEXT once module priorities are clear (usually 1–2 questions maximum).
+
+      4. **Ownership boundaries are fixed.**
+         - `read_only_discovered` surfaces are NOT available for new module generation.
+           Do not ask the user to describe or scope those surfaces further.
+         - Only `generated_overlay` and migration-scoped surfaces are in scope for this build.
   max_consecutive_auto_reply: 8
   structured_outputs_required: false
 - name: AppPlanAgent
@@ -581,6 +613,47 @@ agents:
           trigger token-metered work must detect `INSUFFICIENT_TOKENS`, route to
           the configured top-up/billing recovery path, and return without
           retrying the failed action or workflow.
+  - id: brownfield_scope
+    heading: '[BROWNFIELD ADOPTION SCOPE]'
+    content: |-
+      **This section is active only when `[BROWNFIELD ADOPTION CONTEXT]` is present in your prompt.**
+
+      When brownfield adoption context is injected, the app bundle scope is constrained by the
+      adoption plan. Apply all of the following rules before planning capability packs or pages:
+
+      1. **Scope capability packs to adoption plan only.**
+         - `adoption_plan.candidate_overlays` lists the workflow overlays approved for generation
+           (e.g. `workflow:ChatSupport`). Do NOT plan capability packs or modules that fall outside
+           this list.
+         - `adoption_plan.candidate_adapters` lists integration adapters in scope
+           (e.g. `adapter:stripe`). Include these as `external_integration` surface entries only.
+         - `adoption_plan.candidate_migrations` lists modules approved for migration to Mozaiks
+           ownership. These and only these may become `module` surfaces.
+         - Do NOT invent capability packs or modules beyond what the adoption plan declares.
+
+      2. **Map ownership boundaries to surface_map ownership.**
+         - For every entry in `ownership_boundary.ownership_boundaries[]`:
+           - `ownership: read_only_discovered` → surface_kind must be `external_integration` or
+             `ui_only`; owner must be `"external"`. NEVER plan a `module_contract` task for these.
+           - `ownership: generated_overlay` → surface_kind may be `workflow` or `ui_only`;
+             owner is `"app"`. Plan overlay-style surfaces only.
+           - `ownership: generated_adapter` → surface_kind is `external_integration`; owner
+             is `"app"`. Plan a thin facade module or integration task.
+         - Set `requires_review: true` surfaces as advisory context notes in the build plan
+           rationale — do NOT block on them, but document the human decision required.
+
+      3. **Do NOT plan module_contract tasks for read_only_discovered surfaces.**
+         - These surfaces are discovered read-only from the existing app. Generating module
+           contracts for them would violate the ownership boundary. Reference them in
+           `service_scope` as existing external capabilities instead.
+
+      4. **Set app_kind to reflect the brownfield path.**
+         - For `brownfield_build_path: "light_integration"`: set `app_kind: "brownfield_overlay"`.
+         - For `brownfield_build_path: "full_migration"`: set `app_kind: "brownfield_migration"`.
+
+      5. **Carry brownfield registration as provenance.**
+         - Include `brownfield_registration.registration_id` and `brownfield_registration.app_id`
+           in the build plan `rationale` field so downstream agents have the provenance anchor.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |-

--- a/factory_app/workflows/DesignDocs/agents.yaml
+++ b/factory_app/workflows/DesignDocs/agents.yaml
@@ -289,6 +289,49 @@ agents:
       - Do NOT describe custom full-page React in experience_spec — mark those as explicit escape-hatch needs in prose.
       - Do NOT include header/profile/notification/footer content — those belong in `config/shell.json`.
       - Do NOT encode raw visual token values — those belong in `brand/theme_config.json`.
+  - id: brownfield_scope
+    heading: '[BROWNFIELD ADOPTION SCOPE]'
+    content: |-
+      **This section is active only when `[BROWNFIELD ADOPTION CONTEXT]` is present in your prompt.**
+
+      When brownfield adoption context is injected, DesignDocs scopes its design output to the
+      approved adoption surfaces only. Apply all rules below before generating design documents:
+
+      1. **Scope the design to adoption plan surfaces only.**
+         - `adoption_plan.candidate_overlays` and `adoption_plan.candidate_migrations` define
+           the bounded set of surfaces you may design. Generate frontend, backend, and UI schema
+           only for these surfaces.
+         - Do NOT design modules, pages, or entities for `read_only_discovered` surfaces —
+           those are owned by the existing app and may not be modified.
+         - Do NOT redesign or describe the existing app's full product. Design only the new
+           Mozaiks-owned overlay or migration surfaces.
+
+      2. **Apply ownership rules to surface_map entries.**
+         - For each entry in `ownership_boundary.ownership_boundaries[]`:
+           - `ownership: read_only_discovered` → If it appears in surface_map at all, it must
+             have `surface_kind: external_integration` and `owner: "external"`.
+             Do NOT declare owned_mutations, primary_entities, or module-level events for it.
+           - `ownership: generated_overlay` → surface_kind may be `workflow` or `ui_only`;
+             owner is `"app"`. Design new overlay pages and any lightweight associated data.
+           - `ownership: generated_adapter` → surface_kind is `external_integration`;
+             owner is `"app"`. Design only the facade boundary, not the provider internals.
+
+      3. **Write an explicit brownfield context section in the Backend doc.**
+         - Include a `## Brownfield Adoption Context` section in the backend design document that:
+           - States the active `brownfield_build_path` ("light_integration" or "full_migration")
+           - Lists which surfaces are `read_only_discovered` and what read access is permitted
+           - Lists which surfaces are `generated_overlay` and what Mozaiks owns
+           - Notes any `human_decisions_required` from the adoption plan that affect design
+
+      4. **Carry the brownfield registration as provenance in the data_contract.**
+         - If `brownfield_registration.registration_id` is present, include it as a
+           `provenance_anchor` note in the `data_contract`. This links designed collections
+           back to the BrownfieldRegistration record from ExistingAppDiscovery.
+
+      5. **Do NOT generate a fresh concept-level brand or experience direction.**
+         - The existing app already has a brand identity. Do NOT invent a greenfield brand
+           direction from scratch. Use only surfaces and experience intents declared in the
+           adoption plan's candidate overlays, and align to the existing app's product domain.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |-


### PR DESCRIPTION
## Summary

- Adds `[BROWNFIELD ADOPTION SCOPE]` prompt sections to all five planning agents that receive the `inject_brownfield_adoption_context` middleware hook
- **PatternAgent** (AgentGenerator): scopes workflow pack to `candidate_overlays`/`candidate_adapters` from the adoption plan, selects overlay-appropriate AG2 patterns, carries ownership constraints into each `initial_message` to WorkflowBundleBuilderAgent
- **WorkflowBundleBuilderAgent** (AgentGenerator): generates overlay-style bundles, forbids tool mutations on `read_only_discovered` surfaces, scopes agent roles to overlay responsibilities
- **InterviewAgent** (AppGenerator): short-circuits the standard product interview when brownfield context is present, confirms only overlay selection (light_integration) or module priorities (full_migration)
- **AppPlanAgent** (AppGenerator): scopes capability packs to adoption plan surfaces only, maps `ownership_boundary` entries to `surface_map` ownership classes, sets `app_kind` to `brownfield_overlay` or `brownfield_migration`
- **DesignDocsAgent** (DesignDocs): scopes design output to adoption plan surfaces, enforces `read_only_discovered` as `external_integration` in `surface_map`, adds a brownfield context section to the backend design doc, carries `brownfield_registration.registration_id` as provenance anchor

All sections are guarded by the injected `[BROWNFIELD ADOPTION CONTEXT]` heading — they are no-ops for greenfield builds.

## Test plan

- [x] All 26 brownfield adoption contract tests pass (`tests/test_brownfield_adoption_generation_contract.py`)
- [x] No changes to context_variables.yaml, middleware.yaml, or hook implementations — contract tests cover those separately
- [x] Prompt sections are documentation/guidance only, no runtime code path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)