### PR TITLE
feat(studio): add dashboard portal renderer

### DIFF
--- a/docs/architecture/app/app-dashboard-contract.md
+++ b/docs/architecture/app/app-dashboard-contract.md
@@ -2,7 +2,7 @@
 title: App Dashboard Contract
 status: Authoritative - Pre-Production
 created: 2026-07-28
-updated: 2026-07-29
+updated: 2026-07-30
 depends_on: surface-model.md, platform-navigation-contract.md, ../workflows/workflow-routing-transitions.md
 ---
 
@@ -158,10 +158,21 @@ The OSS runtime provides:
 - `build_dashboard_shell_routes(manifest)`
 - `validate_dashboard_manifest_routes(manifest, route_pages)`
 - `GET /api/studio/dashboard`
+- `DashboardPortalPage`, the generic factory UI renderer for
+  manifest-declared portal panels
 
 `build_dashboard_shell_routes()` is a migration bridge for clients that still
 consume route-manifest-shaped entries. Existing `ui/route_manifest.json` pages
 remain valid while the Dashboard Portal renderer is adopted.
+
+`DashboardPortalPage` reads the active `mozaiks.dashboard.v1` manifest through
+`/api/studio/dashboard`, matches the current route to an enabled portal, then
+renders known panel types against Studio data. The generic renderer currently
+covers summary, next step, portal links, build threads, artifact timelines,
+approval queues/votes, and workflow launch panels. Apps should mount it by
+declaring a normal route-manifest entry with `component: DashboardPortalPage`;
+they should not copy the factory page into their workspace to activate a
+default portal.
 
 `validate_dashboard_manifest_routes()` is the CI contract for apps that mount
 concrete Studio pages. It validates that every enabled dashboard portal points

--- a/docs/architecture/builder/studio-product-model.md
+++ b/docs/architecture/builder/studio-product-model.md
@@ -12,6 +12,7 @@ Use these terms in visible product copy:
 - `Apps`
 - `App Studio`
 - `Overview`
+- `Building`
 - `Access`
 - `Usage`
 - `Integrations`
@@ -19,8 +20,9 @@ Use these terms in visible product copy:
 Hosted deployments may add provider-owned sections such as billing or hosting,
 but those routes are not owned by the OSS first-party Studio.
 
-Workflow-owned concepts like `Build` may still appear in lifecycle copy, but
-they are not standalone Studio pages in the current production surface.
+Workflow-owned concepts like `Build` may still appear in lifecycle copy. The
+canonical persistent surface is the `Building` portal, not a standalone
+`/build` page.
 
 ## Internal Terminology
 
@@ -64,6 +66,7 @@ App-level routes:
 
 - `/apps/:appId` -> redirects to `/apps/:appId/overview`
 - `/apps/:appId/overview` -> App Studio overview with operational health summary
+- `/apps/:appId/building` -> manifest-backed Building portal for build threads, artifacts, approvals, and workflow launch
 - `/apps/:appId/health` -> deep app health diagnostics, hidden from primary navigation
 - `/apps/:appId/access` -> app access
 - `/apps/:appId/usage` -> app usage
@@ -74,6 +77,7 @@ App-level routes:
 Primary app navigation is:
 
 - Overview
+- Building
 - Access
 - Usage
 - Support
@@ -97,6 +101,7 @@ product billing routes.
 | `/create` | Workflow entrypoint | Workflow-owned fresh create path; not part of the persistent Studio nav and never an implicit resume surface |
 | `/apps/:appId` | App Studio | Redirects to app overview |
 | `/apps/:appId/overview` | App Overview | App-scoped summary, next actions, operational health, connected services, build state, and activity |
+| `/apps/:appId/building` | Building | Generic dashboard portal rendered from `dashboard/dashboard.yaml`; build threads, artifacts, approvals, and workflow launch |
 | `/apps/:appId/health` | App Health Diagnostics | Deep diagnostics across runtime, workflows, hosting, and integrations; routable but hidden from primary navigation |
 | `/apps/:appId/access` | App Access | App-scoped account access, plan assignment, and access blockers |
 | `/apps/:appId/usage` | App Usage | App-scoped input/output token usage, cost signals, totals, and averages |
@@ -137,6 +142,7 @@ Behavior expectations:
 `App Studio` is single-app scope:
 
 - overview
+- building
 - access
 - usage
 - support

--- a/docs/guides/studio/01-overview.md
+++ b/docs/guides/studio/01-overview.md
@@ -30,6 +30,8 @@ Dashboard structure comes from `app/dashboard/dashboard.yaml`. When that file is
 missing, Studio uses the OSS default dashboard manifest. CI can validate that
 enabled dashboard portals resolve to mounted routes and that visible Studio
 navigation routes are represented in the dashboard manifest.
+Manifest-backed portals can use the factory `DashboardPortalPage` route
+component, starting with the canonical `/apps/:appId/building` Building lane.
 
 ## Coming Back to a Build
 

--- a/docs/studio/app-dashboard.md
+++ b/docs/studio/app-dashboard.md
@@ -44,6 +44,11 @@ The default App Dashboard has these portal lanes:
 Apps may hide or extend portals through the dashboard manifest. Capability packs
 can contribute panels without taking over the whole dashboard.
 
+The generic factory `DashboardPortalPage` renders manifest-backed lanes such as
+Building. Mount it from `ui/route_manifest.json` with
+`component: DashboardPortalPage` and keep portal content in
+`dashboard/dashboard.yaml`; do not copy the factory page into an app workspace.
+
 Apps that mount concrete Studio routes should run the dashboard route validator
 in CI. Enabled portals must point to registered routes, and visible Studio
 navigation routes must be declared as enabled dashboard portals.
@@ -81,4 +86,4 @@ investigation. They are not listed in primary navigation.
 | --- | --- | --- |
 | Health diagnostics | `/apps/:appId/health` | Overview when a runtime or integration issue needs investigation |
 | Integration setup | `/apps/:appId/integrations` | Overview when a required service is not connected, or workspace Integrations |
-| Build history | `/apps/:appId/activity` | Overview or Support when you need artifact versions or build audit detail |
+| Build history | `/apps/:appId/activity` | Building when you need the full artifact preservation audit detail |

--- a/factory_app/app/admin/index.js
+++ b/factory_app/app/admin/index.js
@@ -19,6 +19,7 @@ const AppsPage           = lazy(() => import('./pages/AppsPage.jsx'))
 const WorkspaceUsagePage         = lazy(() => import('./pages/WorkspaceUsagePage.jsx'))
 const WorkspaceIntegrationsPage  = lazy(() => import('./pages/WorkspaceIntegrationsPage.jsx'))
 const CreateAppRedirectPage = lazy(() => import('./pages/CreateAppRedirectPage.jsx'))
+const DashboardPortalPage = lazy(() => import('./pages/DashboardPortalPage.jsx'))
 const AppOverviewPage    = lazy(() => import('./pages/AppOverviewPage.jsx'))
 const AppHealthPage      = lazy(() => import('./pages/AppHealthPage.jsx'))
 const AppAccessPage      = lazy(() => import('./pages/AppAccessPage.jsx'))
@@ -55,6 +56,10 @@ export function registerAdminComponents(registerComponent) {
 
   registerComponent('CreateAppRedirectPage', CreateAppRedirectPage, {
     description: 'Create app redirect helper — opens the deferred ValueEngine create flow without creating a draft app record first.',
+  })
+
+  registerComponent('DashboardPortalPage', DashboardPortalPage, {
+    description: 'Dashboard portal surface — renders enabled mozaiks.dashboard.v1 portal panels using generic Studio data.',
   })
 
   registerComponent('AppOverviewPage', AppOverviewPage, {

--- a/factory_app/app/admin/pages/DashboardPortalPage.jsx
+++ b/factory_app/app/admin/pages/DashboardPortalPage.jsx
@@ -1,0 +1,612 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useParams } from 'react-router-dom'
+
+import { SummaryStrip } from '@mozaiks/chat-ui/ui'
+import { WorkspaceLayout } from '@mozaiks/chat-ui/workspace'
+import {
+  LinkButton,
+  Panel,
+  StatusPill,
+  StudioErrorState,
+  StudioInlineEmptyState,
+  StudioLoadingState,
+} from '../../ui/components/StudioShared.jsx'
+import AppStudioHero, {
+  formatCompactNumber,
+  formatDateTimeLabel,
+} from './AppStudioChrome.jsx'
+import { getAppStudioSnapshot, toArray } from './appStudioDataHelpers.js'
+import {
+  getApprovalStateLabel,
+  getAppPrimaryAction,
+  getLifecycleGuidance,
+  getPlanStateLabel,
+  normalizeAppStatus,
+} from './appStudioModel.js'
+import CarryForwardReportSummary from './CarryForwardReportSummary.jsx'
+import { fetchDashboardConfig, getDashboardSurface } from './dashboardRoutes.js'
+import { useAppStudioData } from './useAppStudioData.js'
+
+function decodePathSegment(value) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function splitPath(value) {
+  return String(value || '')
+    .split('?')[0]
+    .split('#')[0]
+    .replace(/\/+$/, '')
+    .split('/')
+    .filter(Boolean)
+}
+
+function routePatternMatches(pattern, pathname) {
+  const patternParts = splitPath(pattern)
+  const pathParts = splitPath(pathname)
+  if (patternParts.length !== pathParts.length) return false
+  return patternParts.every((part, index) => part.startsWith(':') || part === pathParts[index])
+}
+
+function routeForApp(route, appId) {
+  if (!route) return null
+  return String(route).replace(':appId', encodeURIComponent(appId || ''))
+}
+
+function titleForPanel(panel, fallback) {
+  return panel?.title || fallback || String(panel?.type || 'Panel').replace(/_/g, ' ')
+}
+
+function formatRelativeTime(value) {
+  if (!value) return 'Not recorded'
+  try {
+    const timestamp = new Date(value).getTime()
+    const diff = Date.now() - timestamp
+    if (!Number.isFinite(diff)) return formatDateTimeLabel(value)
+    const mins = Math.floor(diff / 60000)
+    if (mins < 1) return 'just now'
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    const days = Math.floor(hrs / 24)
+    if (days < 7) return `${days}d ago`
+    return formatDateTimeLabel(value)
+  } catch {
+    return formatDateTimeLabel(value)
+  }
+}
+
+function validationTone(status) {
+  if (status === 'passed') return 'success'
+  if (status === 'failed') return 'destructive'
+  return 'warning'
+}
+
+function lifecycleTone(status) {
+  if (status === 'current' || status === 'deployed') return 'success'
+  if (status === 'draft') return 'default'
+  if (status === 'rejected' || status === 'failed') return 'destructive'
+  return 'warning'
+}
+
+function approvalTone(state) {
+  if (state === 'approved') return 'success'
+  if (state === 'rejected') return 'destructive'
+  if (state === 'pending') return 'warning'
+  return 'default'
+}
+
+function runTone(status) {
+  if (status === 2 || status === 'completed' || status === 'success') return 'success'
+  if (status === 'failed' || status === 'error') return 'destructive'
+  if (status === 1 || status === 'running') return 'primary'
+  return 'default'
+}
+
+function runLabel(status) {
+  if (status === 2) return 'Completed'
+  if (status === 1) return 'Running'
+  return String(status || 'Unknown').replace(/_/g, ' ')
+}
+
+function appStatusLabel(status) {
+  const normalized = normalizeAppStatus(status)
+  return normalized === 'draft' ? 'Draft' : normalized.replace(/_/g, ' ')
+}
+
+function appStatusTone(status) {
+  const normalized = normalizeAppStatus(status)
+  if (['active', 'hosted'].includes(normalized)) return 'success'
+  if (['failed', 'needs_revision'].includes(normalized)) return 'destructive'
+  if (['review', 'configuring', 'deploying'].includes(normalized)) return 'warning'
+  return 'default'
+}
+
+function useDashboardPortal(scope, appId, pathname) {
+  const [state, setState] = useState({
+    loading: true,
+    error: null,
+    surface: null,
+    portal: null,
+  })
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setState({ loading: true, error: null, surface: null, portal: null })
+    fetchDashboardConfig({ scope, appId, signal: controller.signal })
+      .then((payload) => {
+        const surface = getDashboardSurface(payload, scope)
+        const portals = Array.isArray(surface?.portals) ? surface.portals : []
+        const portal = portals.find((item) => (
+          item?.enabled !== false &&
+          routePatternMatches(item.route, pathname)
+        )) || null
+        setState({ loading: false, error: null, surface, portal })
+      })
+      .catch((err) => {
+        if (err?.name === 'AbortError') return
+        setState({
+          loading: false,
+          error: err instanceof Error ? err.message : 'Dashboard portal could not be loaded.',
+          surface: null,
+          portal: null,
+        })
+      })
+    return () => controller.abort()
+  }, [appId, pathname, scope])
+
+  return state
+}
+
+function buildHeroSummaryItems(portal, snapshot, data) {
+  const build = data?.buildState?.build || {}
+  const latestArtifact = snapshot.buildHistory[0] || null
+  return [
+    {
+      id: 'status',
+      label: 'App status',
+      value: appStatusLabel(snapshot.lifecycleState),
+      detail: portal?.label || 'Dashboard',
+    },
+    {
+      id: 'artifacts',
+      label: 'Artifacts',
+      value: formatCompactNumber(snapshot.buildHistory.length, '0'),
+      detail: latestArtifact ? `Latest v${latestArtifact.version_number}` : 'No saved versions',
+    },
+    {
+      id: 'runs',
+      label: 'Runs',
+      value: formatCompactNumber(snapshot.runs.length, '0'),
+      detail: snapshot.runs[0] ? formatRelativeTime(snapshot.runs[0].started_at) : 'No runs yet',
+    },
+    {
+      id: 'approval',
+      label: 'Approval',
+      value: getApprovalStateLabel(build.approval_state),
+      detail: getPlanStateLabel(build.plan_state),
+    },
+  ]
+}
+
+function SummaryStripPanel({ panel, portal, snapshot, data }) {
+  return (
+    <div>
+      <SummaryStrip items={buildHeroSummaryItems(portal, snapshot, data)} />
+      {panel.description ? (
+        <p className="mt-2 px-1 text-xs leading-5 text-muted-foreground">{panel.description}</p>
+      ) : null}
+    </div>
+  )
+}
+
+function NextStepPanel({ panel, snapshot }) {
+  const lifecycle = normalizeAppStatus(snapshot.lifecycleState)
+  const guidance = getLifecycleGuidance(lifecycle)
+  const action = getAppPrimaryAction(snapshot.app)
+
+  return (
+    <Panel title={titleForPanel(panel, 'Next step')} subtitle={panel.description || 'Recommended next action for this app.'}>
+      <StudioInlineEmptyState
+        title={guidance || 'No immediate action'}
+        description={action?.label ? 'Open the recommended surface when you are ready to continue.' : 'The app has no required next action at this stage.'}
+      />
+      {action?.href && action?.label ? (
+        <div className="mt-4">
+          <LinkButton to={action.href} size="sm">{action.label}</LinkButton>
+        </div>
+      ) : null}
+    </Panel>
+  )
+}
+
+function PortalLinkGridPanel({ panel, surface, currentPortal, appId }) {
+  const portals = toArray(surface?.portals).filter((portal) => portal.enabled !== false)
+  return (
+    <Panel title={titleForPanel(panel, 'Portal map')} subtitle={panel.description || 'Enabled dashboard portals declared for this surface.'}>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {portals.map((portal) => {
+          const current = portal.id === currentPortal?.id
+          const href = routeForApp(portal.route, appId)
+          return (
+            <Link
+              key={portal.id}
+              to={href || '#'}
+              className={[
+                'rounded-lg border px-4 py-3 transition',
+                current
+                  ? 'border-primary/35 bg-primary/8'
+                  : 'border-border/50 bg-card/45 hover:border-primary/30 hover:bg-primary/5',
+              ].join(' ')}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold text-foreground">{portal.label}</span>
+                <StatusPill tone={current ? 'primary' : 'default'}>{current ? 'Current' : 'Open'}</StatusPill>
+              </div>
+              {portal.description ? (
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">{portal.description}</p>
+              ) : null}
+            </Link>
+          )
+        })}
+      </div>
+    </Panel>
+  )
+}
+
+function BuildThreadsPanel({ panel, build, snapshot, appId }) {
+  const currentRequest = build.current_request || {}
+  const recentRequests = toArray(build.recent_requests)
+  const recentRuns = snapshot.runs.slice(0, 4)
+  const workflowId = build.initial_compile_workflow || snapshot.workflowNames[0] || 'ValueEngine'
+  const chatHref = `/chat?${new URLSearchParams({
+    workflow: workflowId,
+    mode: 'workflow',
+    app_id: appId || '',
+  }).toString()}`
+
+  return (
+    <Panel title={titleForPanel(panel, 'Build threads')} subtitle={panel.description || 'Current request, saved build prompts, and recent workflow activity.'}>
+      {currentRequest.text ? (
+        <div className="rounded-lg border border-primary/25 bg-primary/6 px-4 py-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-primary/65">Current request</div>
+          <p className="mt-1 text-sm leading-6 text-foreground">{currentRequest.text}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {currentRequest.request_kind ? <StatusPill tone="default">{String(currentRequest.request_kind).replace(/_/g, ' ')}</StatusPill> : null}
+            {currentRequest.change_class ? <StatusPill tone="primary">{String(currentRequest.change_class).replace(/_/g, ' ')}</StatusPill> : null}
+            {currentRequest.updated_at ? <StatusPill tone="default">{formatRelativeTime(currentRequest.updated_at)}</StatusPill> : null}
+          </div>
+        </div>
+      ) : (
+        <StudioInlineEmptyState
+          title="No build request saved"
+          description="Start or continue a build workflow to attach the current request to this app."
+        />
+      )}
+
+      {recentRequests.length > 0 ? (
+        <div className="mt-4 space-y-2">
+          {recentRequests.slice(0, 3).map((request, index) => (
+            <div key={`${request.saved_at || index}:${request.text}`} className="rounded-lg border border-border/45 bg-card/35 px-3 py-2.5">
+              <div className="text-sm font-medium text-foreground">{request.text}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{formatRelativeTime(request.saved_at)}</div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {recentRuns.length > 0 ? (
+        <>
+          <div className="my-4 border-t border-border/35" />
+          <div className="space-y-2">
+            {recentRuns.map((run, index) => (
+              <div key={run.run_id || run.chat_id || index} className="flex items-center justify-between gap-3 rounded-lg border border-border/45 bg-background/30 px-3 py-2.5">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-foreground">{run.workflow_name || 'Workflow run'}</div>
+                  <div className="text-xs text-muted-foreground">{formatRelativeTime(run.started_at)}</div>
+                </div>
+                {run.status != null ? <StatusPill tone={runTone(run.status)}>{runLabel(run.status)}</StatusPill> : null}
+              </div>
+            ))}
+          </div>
+        </>
+      ) : null}
+
+      <div className="mt-4">
+        <LinkButton to={chatHref} size="sm">Open build workflow</LinkButton>
+      </div>
+    </Panel>
+  )
+}
+
+function ArtifactTimelinePanel({ panel, snapshot }) {
+  const artifacts = snapshot.buildHistory
+
+  return (
+    <Panel title={titleForPanel(panel, 'Artifact timeline')} subtitle={panel.description || 'Saved app bundle versions and validation status.'}>
+      {artifacts.length === 0 ? (
+        <StudioInlineEmptyState
+          title="No artifacts yet"
+          description="Artifact versions appear after generation or refinement saves an app bundle."
+        />
+      ) : (
+        <div className="space-y-3">
+          {artifacts.slice(0, 6).map((artifact) => {
+            const cfReport = artifact?.commit_metadata?.metadata?.carry_forward_report || null
+            return (
+              <div key={artifact.id || artifact.version_number} className="rounded-lg border border-border/50 bg-card/35 px-4 py-3">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-foreground">Build v{artifact.version_number}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">{formatDateTimeLabel(artifact.created_at)}</div>
+                    {artifact.commit_metadata?.message ? (
+                      <div className="mt-1 truncate text-xs text-muted-foreground/75">{artifact.commit_metadata.message}</div>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusPill tone={validationTone(artifact.validation_status)}>{artifact.validation_status || 'pending'}</StatusPill>
+                    <StatusPill tone={lifecycleTone(artifact.lifecycle_status)}>{artifact.lifecycle_status || 'draft'}</StatusPill>
+                  </div>
+                </div>
+                {cfReport ? <CarryForwardReportSummary report={cfReport} /> : null}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </Panel>
+  )
+}
+
+function ApprovalPanel({ panel, build, latestArtifact }) {
+  const currentPlan = build.current_plan || {}
+  const approvals = toArray(currentPlan.approvals_required)
+  const acceptance = toArray(currentPlan.acceptance_criteria)
+  const validationStatus = latestArtifact?.validation_status || 'pending'
+
+  return (
+    <Panel title={titleForPanel(panel, 'Approvals')} subtitle={panel.description || 'Human review state, artifact validation, and acceptance notes.'}>
+      <div className="flex flex-wrap gap-2">
+        <StatusPill tone={approvalTone(build.approval_state)}>
+          {getApprovalStateLabel(build.approval_state)}
+        </StatusPill>
+        <StatusPill tone="default">{getPlanStateLabel(build.plan_state)}</StatusPill>
+        <StatusPill tone={validationTone(validationStatus)}>{validationStatus}</StatusPill>
+      </div>
+
+      {currentPlan.summary ? (
+        <p className="mt-4 text-sm leading-6 text-foreground">{currentPlan.summary}</p>
+      ) : null}
+
+      {approvals.length > 0 || acceptance.length > 0 ? (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/65">Approvals</div>
+            <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+              {(approvals.length ? approvals : ['No approval blockers recorded.']).slice(0, 4).map((item) => (
+                <li key={item} className="rounded-lg border border-border/40 bg-background/28 px-3 py-2">{item}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/65">Acceptance</div>
+            <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+              {(acceptance.length ? acceptance : ['Acceptance criteria will appear with the current plan.']).slice(0, 4).map((item) => (
+                <li key={item} className="rounded-lg border border-border/40 bg-background/28 px-3 py-2">{item}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <StudioInlineEmptyState
+          title="No review checklist yet"
+          description="Review tasks appear once a build plan or artifact version has been prepared."
+          className="mt-4"
+        />
+      )}
+    </Panel>
+  )
+}
+
+function workflowHref({ action, panel, build, appId }) {
+  if (action?.type === 'route') return routeForApp(action.target, appId)
+  if (action?.type === 'external_url') return action.target
+
+  const workflow = action?.type === 'workflow'
+    ? action.target
+    : build.initial_compile_workflow || panel.workflow_id || 'ValueEngine'
+  const params = new URLSearchParams({
+    workflow,
+    mode: 'workflow',
+  })
+  if (appId) params.set('app_id', appId)
+  if (action?.type === 'workflow_sequence' && action.target) {
+    params.set('sequence', action.target)
+  }
+  if (action?.id) params.set('action_id', action.id)
+  return `/chat?${params.toString()}`
+}
+
+function WorkflowLauncherPanel({ panel, build, appId }) {
+  const actions = toArray(panel.actions)
+  const support = build.refinement_support || {}
+  const availableModes = Object.entries(support)
+    .filter(([, value]) => value?.available)
+    .map(([key, value]) => ({ key, workflowId: value.workflow_id }))
+
+  return (
+    <Panel title={titleForPanel(panel, 'Workflow launcher')} subtitle={panel.description || 'Open the workflow path declared for this portal.'}>
+      {actions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {actions.map((action) => {
+            const href = workflowHref({ action, panel, build, appId })
+            const external = action.type === 'external_url'
+            if (external) {
+              return (
+                <a
+                  key={action.id}
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex h-9 items-center justify-center rounded-lg border border-border bg-card px-3 text-sm font-semibold text-foreground transition hover:bg-muted"
+                >
+                  {action.label}
+                </a>
+              )
+            }
+            return (
+              <LinkButton
+                key={action.id}
+                to={href}
+                variant={action.variant === 'primary' ? 'primary' : 'outline'}
+                size="sm"
+              >
+                {action.label}
+              </LinkButton>
+            )
+          })}
+        </div>
+      ) : (
+        <StudioInlineEmptyState
+          title="No workflow action declared"
+          description="Add a dashboard action to this panel to expose a deterministic launch target."
+        />
+      )}
+
+      {availableModes.length > 0 ? (
+        <>
+          <div className="my-4 border-t border-border/35" />
+          <div className="grid gap-2 sm:grid-cols-2">
+            {availableModes.map((mode) => (
+              <div key={mode.key} className="rounded-lg border border-border/45 bg-background/30 px-3 py-2.5">
+                <div className="text-sm font-semibold capitalize text-foreground">{mode.key}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{mode.workflowId}</div>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </Panel>
+  )
+}
+
+function GenericPanelFallback({ panel }) {
+  return (
+    <Panel title={titleForPanel(panel)} subtitle={panel.description || `Declared dashboard panel type: ${panel.type}.`}>
+      <StudioInlineEmptyState
+        title="Generic renderer pending"
+        description="This dashboard panel is valid, but it needs a reusable renderer before it can show live data."
+      />
+    </Panel>
+  )
+}
+
+function DashboardPanelRenderer({ panel, portal, surface, snapshot, data, appId }) {
+  const build = data?.buildState?.build || {}
+  const latestArtifact = snapshot.buildHistory[0] || null
+
+  switch (panel.type) {
+    case 'summary_strip':
+    case 'kpi_grid':
+      return <SummaryStripPanel panel={panel} portal={portal} snapshot={snapshot} data={data} />
+    case 'next_step':
+      return <NextStepPanel panel={panel} snapshot={snapshot} />
+    case 'portal_link_grid':
+      return <PortalLinkGridPanel panel={panel} surface={surface} currentPortal={portal} appId={appId} />
+    case 'build_threads':
+      return <BuildThreadsPanel panel={panel} build={build} snapshot={snapshot} appId={appId} />
+    case 'artifact_timeline':
+      return <ArtifactTimelinePanel panel={panel} snapshot={snapshot} />
+    case 'approval_queue':
+    case 'approval_votes':
+      return <ApprovalPanel panel={panel} build={build} latestArtifact={latestArtifact} />
+    case 'workflow_launcher':
+      return <WorkflowLauncherPanel panel={panel} build={build} appId={appId} />
+    default:
+      return <GenericPanelFallback panel={panel} />
+  }
+}
+
+function isWidePanel(type) {
+  return ['summary_strip', 'kpi_grid', 'portal_link_grid', 'artifact_timeline'].includes(type)
+}
+
+export default function DashboardPortalPage() {
+  const params = useParams()
+  const location = useLocation()
+  const appId = params.appId ? decodePathSegment(params.appId) : null
+  const scope = appId ? 'app' : 'workspace'
+  const manifest = useDashboardPortal(scope, appId, location.pathname)
+  const { data, loading: appLoading, error: appError, dataMode, refresh } = useAppStudioData(appId || 'workspace-app')
+  const snapshot = useMemo(() => getAppStudioSnapshot(appId, data, dataMode), [appId, data, dataMode])
+
+  if (manifest.loading || appLoading) {
+    return <StudioLoadingState label="Loading dashboard portal..." />
+  }
+  if (manifest.error) {
+    return <StudioErrorState title="Dashboard Portal Unavailable" message={manifest.error} />
+  }
+  if (!manifest.portal) {
+    return <StudioErrorState title="Dashboard Portal Not Registered" message="The current route is not represented by an enabled dashboard portal." />
+  }
+  if (appError || !data?.summary) {
+    return <StudioErrorState title={`${manifest.portal.label} Unavailable`} message={appError || 'No app summary returned.'} />
+  }
+
+  const portal = manifest.portal
+  const panels = toArray(portal.panels).slice().sort((left, right) => (
+    Number(left.order || 0) - Number(right.order || 0) || String(left.id).localeCompare(String(right.id))
+  ))
+
+  return (
+    <WorkspaceLayout>
+      <div className="space-y-6">
+        <AppStudioHero
+          appId={appId}
+          summary={data.summary}
+          dataMode={dataMode}
+          title={portal.label}
+          subtitle={portal.description || `${portal.label} portal for this app.`}
+          summaryItems={buildHeroSummaryItems(portal, snapshot, data)}
+          actions={[{ id: 'refresh', label: 'Refresh', variant: 'outline' }]}
+          onAction={(id) => id === 'refresh' && refresh()}
+        />
+
+        {portal.capabilities?.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {portal.capabilities.map((capability) => (
+              <StatusPill key={capability} tone="default">{String(capability).replace(/_/g, ' ')}</StatusPill>
+            ))}
+          </div>
+        ) : null}
+
+        {panels.length === 0 ? (
+          <Panel title="No panels declared" subtitle="This portal is enabled but does not declare dashboard panels.">
+            <StudioInlineEmptyState
+              title="Portal content pending"
+              description="Add dashboard panels to the manifest to render this portal with live Studio data."
+            />
+          </Panel>
+        ) : (
+          <div className="grid gap-5 lg:grid-cols-2">
+            {panels.map((panel) => (
+              <div key={panel.id} className={isWidePanel(panel.type) ? 'lg:col-span-2' : 'min-w-0'}>
+                <DashboardPanelRenderer
+                  panel={panel}
+                  portal={portal}
+                  surface={manifest.surface}
+                  snapshot={snapshot}
+                  data={data}
+                  appId={appId}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </WorkspaceLayout>
+  )
+}

--- a/factory_app/app/admin/pages/dashboardRoutes.js
+++ b/factory_app/app/admin/pages/dashboardRoutes.js
@@ -30,8 +30,12 @@ export function buildAppDashboardHref(routePattern, appId) {
   return String(routePattern).replace(':appId', encodeURIComponent(appId))
 }
 
-export async function fetchDashboardConfig({ signal } = {}) {
-  const response = await fetch(`${API_BASE}/api/studio/dashboard`, {
+export async function fetchDashboardConfig({ scope = null, appId = null, signal } = {}) {
+  const params = new URLSearchParams()
+  if (scope) params.set('scope', scope)
+  if (appId) params.set('app_id', appId)
+  const suffix = params.toString() ? `?${params.toString()}` : ''
+  const response = await fetch(`${API_BASE}/api/studio/dashboard${suffix}`, {
     headers: {
       Accept: 'application/json',
     },

--- a/factory_app/app/ui/route_manifest.json
+++ b/factory_app/app/ui/route_manifest.json
@@ -125,6 +125,24 @@
       }
     },
     {
+      "path": "/apps/:appId/building",
+      "component": "DashboardPortalPage",
+      "label": "Building",
+      "order": 21,
+      "meta": {
+        "surfaces": ["studio"],
+        "requiresRole": "admin",
+        "title": "Building",
+        "appShell": true,
+        "ai_context": "The user is on the App Building portal. It renders dashboard.yaml build panels for build threads, artifact versions, approval state, and workflow launch actions.",
+        "navigation": {
+          "group": "app-studio",
+          "scope": "local",
+          "icon": "hammer"
+        }
+      }
+    },
+    {
       "path": "/apps/:appId/health",
       "component": "AppHealthPage",
       "label": "Health",

--- a/tests/test_build_surface.py
+++ b/tests/test_build_surface.py
@@ -47,6 +47,8 @@ def test_studio_host_exposes_build_endpoint_and_console_routes() -> None:
     assert '"component": "AppsPage"' in manifest_source
     assert '"path": "/apps/:appId/access"' in manifest_source
     assert '"component": "AppAccessPage"' in manifest_source
+    assert '"path": "/apps/:appId/building"' in manifest_source
+    assert '"component": "DashboardPortalPage"' in manifest_source
     assert '"path": "/apps/:appId/users"' not in manifest_source
     assert '"path": "/apps/:appId/usage"' in manifest_source
     assert '"path": "/apps/:appId/health"' in manifest_source
@@ -78,6 +80,7 @@ def test_factory_app_ui_barrel_registers_admin_pages_and_omits_removed_pages() -
     assert "registerComponent('WorkspaceHostingPage'" not in source
     assert "registerComponent('AppsPage'" in admin_source
     assert "registerComponent('WorkspaceIntegrationsPage'" in admin_source
+    assert "registerComponent('DashboardPortalPage'" in admin_source
     assert "registerComponent('WorkspaceHostingPage'" not in admin_source
     assert "registerComponent('AppHealthPage'" in admin_source
     assert "registerComponent('AppAccessPage'" in admin_source
@@ -87,6 +90,7 @@ def test_factory_app_ui_barrel_registers_admin_pages_and_omits_removed_pages() -
     assert "registerComponent('AppHostingPage'" not in admin_source
     assert "./pages/AppHealthPage.jsx" in admin_source
     assert "./pages/AppAccessPage.jsx" in admin_source
+    assert "./pages/DashboardPortalPage.jsx" in admin_source
     assert "./pages/AppHostingPage.jsx" not in admin_source
     assert "AppBuildPage" not in source
     assert "AppDeployPage" not in source
@@ -156,6 +160,21 @@ def test_app_overview_does_not_link_to_removed_routes() -> None:
     assert 'to={`/apps/${appId}/deploy`}' not in source
     assert 'to={`/apps/${appId}/operations`}' not in source
     assert 'to={`/apps/${appId}/settings`}' not in source
+
+
+def test_dashboard_portal_page_renders_manifest_build_panels() -> None:
+    source = _read("factory_app/app/admin/pages/DashboardPortalPage.jsx")
+    manifest_source = _read("factory_app/app/ui/route_manifest.json")
+
+    assert "fetchDashboardConfig({ scope, appId" in source
+    assert "routePatternMatches(item.route, pathname)" in source
+    assert "case 'build_threads':" in source
+    assert "case 'artifact_timeline':" in source
+    assert "case 'approval_queue':" in source
+    assert "case 'workflow_launcher':" in source
+    assert "GenericPanelFallback" in source
+    assert '"/apps/:appId/building"' in manifest_source
+    assert '"component": "DashboardPortalPage"' in manifest_source
 
 
 def test_apps_page_fetches_workspace_apps_endpoint() -> None:

--- a/tests/test_mobile_surface_contracts.py
+++ b/tests/test_mobile_surface_contracts.py
@@ -164,6 +164,7 @@ def test_web_shell_has_responsive_smoke_harness() -> None:
     assert "workspace hosting route stays responsive across desktop and mobile widths" not in smoke_source
     assert "app Studio root redirects to manifest default portal" in smoke_source
     assert "app overview route stays responsive across desktop and mobile widths" in smoke_source
+    assert "app building route stays responsive across desktop and mobile widths" in smoke_source
     assert "app health route stays responsive across desktop and mobile widths" in smoke_source
     assert "app integrations route stays responsive across desktop and mobile widths" in smoke_source
     assert "app usage route stays responsive across desktop and mobile widths" in smoke_source
@@ -194,6 +195,7 @@ def test_factory_app_studio_routes_are_all_covered_by_smoke() -> None:
         "UserSupportPage": "workspace support route stays responsive across desktop and mobile widths",
         "StudioPage": "app Studio root redirects to manifest default portal",
         "AppOverviewPage": "app overview route stays responsive across desktop and mobile widths",
+        "DashboardPortalPage": "app building route stays responsive across desktop and mobile widths",
         "AppHealthPage": "app health route stays responsive across desktop and mobile widths",
         "AppAccessPage": "app access route stays responsive across desktop and mobile widths",
         "AppUsagePage": "app usage route stays responsive across desktop and mobile widths",

--- a/tests/test_studio_host_smoke.py
+++ b/tests/test_studio_host_smoke.py
@@ -17,6 +17,7 @@ async def test_studio_shell_config_injects_studio_routes():
 
     assert "/apps" in page_paths
     assert "/apps/:appId/overview" in page_paths
+    assert "/apps/:appId/building" in page_paths
     assert "/apps/:appId/billing" not in page_paths
     assert "/apps/:appId/hosting" not in page_paths
     assert "/apps/:appId/integrations" in page_paths

--- a/tests/test_unified_admin_surface.py
+++ b/tests/test_unified_admin_surface.py
@@ -60,7 +60,13 @@ def test_platform_shell_registers_admin_section_routes() -> None:
 
     # First-party Studio product routes live in route_manifest.json.
     assert "pages: []" in registry_source
-    for path in ["/apps/:appId/overview", "/apps/:appId/access", "/apps/:appId/usage", "/apps/:appId/activity"]:
+    for path in [
+        "/apps/:appId/overview",
+        "/apps/:appId/building",
+        "/apps/:appId/access",
+        "/apps/:appId/usage",
+        "/apps/:appId/activity",
+    ]:
         assert path in route_manifest
         assert path not in registry_source
 

--- a/web_shell/playwright/apps.responsive.smoke.spec.js
+++ b/web_shell/playwright/apps.responsive.smoke.spec.js
@@ -60,6 +60,39 @@ const dashboardPayload = {
         label: 'Overview',
         route: '/apps/:appId/overview',
         enabled: true,
+        panels: [
+          { id: 'summary', type: 'summary_strip', title: 'Summary' },
+          { id: 'next_step', type: 'next_step', title: 'Next step' },
+        ],
+      },
+      {
+        id: 'building',
+        label: 'Building',
+        route: '/apps/:appId/building',
+        description: 'Build threads, artifact versions, approvals, and workflow launch actions.',
+        enabled: true,
+        capabilities: ['build_threads', 'artifact_versions', 'approval_votes'],
+        panels: [
+          { id: 'threads', type: 'build_threads', title: 'Threads' },
+          { id: 'artifacts', type: 'artifact_timeline', title: 'Artifacts' },
+          { id: 'approvals', type: 'approval_queue', title: 'Approvals' },
+          {
+            id: 'continue_build',
+            type: 'workflow_launcher',
+            title: 'Continue build',
+            source: 'workflow',
+            workflow_id: 'extended_orchestration',
+            actions: [
+              {
+                id: 'continue_build',
+                label: 'Continue Build',
+                type: 'workflow_sequence',
+                target: 'build',
+                variant: 'primary',
+              },
+            ],
+          },
+        ],
       },
     ],
   },
@@ -170,7 +203,38 @@ function buildAppStudioPayload(appId = APP_ID) {
     },
     buildState: {
       build: {
+        current_request: {
+          text: 'Revise the campaign approval workspace and preserve marketplace reporting.',
+          request_kind: 'refinement',
+          change_class: 'feature',
+          updated_at: '2025-02-05T08:45:00Z',
+        },
+        current_plan: {
+          summary: 'Build the next app bundle while preserving existing hosted capability boundaries.',
+          build_tasks: [],
+          owned_paths: ['app/modules', 'app/ui/pages'],
+          acceptance_criteria: ['Artifact validates', 'Owner review is complete'],
+          approvals_required: ['Owner approval before promotion'],
+          cost_implications: [],
+          runtime_implications: [],
+        },
+        recent_requests: [
+          {
+            text: 'Add stakeholder review notes to the campaign workbench.',
+            request_kind: 'refinement',
+            change_class: 'patch',
+            saved_at: '2025-02-04T16:10:00Z',
+          },
+        ],
+        plan_state: 'plan_ready',
         approval_state: 'pending',
+        initial_compile_workflow: 'ValueEngine',
+        refinement_support: {
+          patch: { available: true, workflow_id: 'AppGenerator' },
+          design: { available: true, workflow_id: 'DesignDocs' },
+          feature: { available: true, workflow_id: 'AppGenerator' },
+          core: { available: true, workflow_id: 'ValueEngine' },
+        },
       },
     },
     buildHistory: {
@@ -687,7 +751,7 @@ async function mockStudioApis(page) {
     });
   });
 
-  await page.route('**/api/studio/dashboard', async (route) => {
+  await page.route('**/api/studio/dashboard**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -1086,8 +1150,33 @@ test('app overview route stays responsive across desktop and mobile widths', asy
   await expect(main.getByRole('heading', { name: 'Activity' })).toBeVisible();
   await expect(main.getByText('Runtime cost').first()).toBeVisible();
   await expect(main.getByText('Active users').first()).toBeVisible();
-  await expect(main.getByText('Build v17').first()).toBeVisible();
+  await expect(main.getByText('Revise the campaign approval workspace')).toBeVisible();
   await expect(main.getByText('Approval required')).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+
+  if (viewport.width < 768) {
+    await expect(page.getByRole('button', { name: 'Open Studio navigation' })).toBeVisible();
+  } else {
+    await expect(page.getByRole('button', { name: 'Open Studio navigation' })).toBeHidden();
+  }
+});
+
+test('app building route stays responsive across desktop and mobile widths', async ({ page }) => {
+  await page.goto(`/apps/${APP_ID}/building`);
+  const main = page.locator('main');
+
+  await expect(main.getByRole('heading', { name: 'Building', exact: true })).toBeVisible();
+  await expect(main.getByRole('heading', { name: 'Threads' })).toBeVisible();
+  await expect(main.getByText('Revise the campaign approval workspace')).toBeVisible();
+  await expect(main.getByRole('heading', { name: 'Artifacts' })).toBeVisible();
+  await expect(main.getByText('Build v17').first()).toBeVisible();
+  await expect(main.getByRole('heading', { name: 'Approvals' })).toBeVisible();
+  await expect(main.getByText('Owner approval before promotion')).toBeVisible();
+  await expect(main.getByRole('heading', { name: 'Continue build' })).toBeVisible();
+  await expect(main.getByRole('link', { name: 'Continue Build' })).toBeVisible();
   await expectNoHorizontalOverflow(page);
 
   const viewport = page.viewportSize();
@@ -1308,6 +1397,11 @@ test('mobile app Studio navigation keeps route transitions stable', async ({ pag
   await page.goto(`/apps/${APP_ID}/overview`);
   const main = page.locator('main');
   const routeChecks = [
+    {
+      href: `/apps/${APP_ID}/building`,
+      heading: 'Building',
+      detail: async () => expect(main.getByRole('heading', { name: 'Threads' })).toBeVisible(),
+    },
     {
       href: `/apps/${APP_ID}/usage`,
       heading: 'Usage',


### PR DESCRIPTION
## Summary

- add a generic `DashboardPortalPage` renderer for enabled `mozaiks.dashboard.v1` portal panels
- mount the OSS Building route at `/apps/:appId/building` through the factory route manifest
- document the portal renderer contract and extend responsive/Python contract coverage

## Impact

This gives downstream Mozaiks app workspaces a stable Studio component for dashboard portal lanes without copying App Zero pages or workflow packs. App-specific repos can enable a portal by declaring the route and dashboard overlay while inheriting generic panels from OSS defaults.

## Validation

- `python -m pytest tests/test_build_surface.py tests/test_dashboard_manifest.py tests/test_mobile_surface_contracts.py tests/test_studio_host_smoke.py tests/test_unified_admin_surface.py -q --no-cov`
- `python -m ruff check tests/test_build_surface.py tests/test_mobile_surface_contracts.py tests/test_studio_host_smoke.py tests/test_unified_admin_surface.py`
- `npm --prefix web_shell run build`
- `npm --prefix web_shell run test:ui-primitives`
- `npm --prefix web_shell run test:responsive-smoke`
- `git diff --check`