### PR TITLE
refactor(studio): clarify nav labels, show Health, fix nav ordering

### DIFF
--- a/factory_app/app/admin/pages/AppAccessPage.jsx
+++ b/factory_app/app/admin/pages/AppAccessPage.jsx
@@ -97,7 +97,7 @@ export default function AppAccessPage() {
 
   if (loading) return <StudioLoadingState label="Loading app access..." />
   if (error || !data || !snapshot) {
-    return <StudioErrorState title="App Access Unavailable" message={error || 'No access data returned.'} />
+    return <StudioErrorState title="App Users Unavailable" message={error || 'No access data returned.'} />
   }
 
   const activeUsers = users.filter((user) => String(user.status || '').toLowerCase() === 'active').length
@@ -144,9 +144,9 @@ export default function AppAccessPage() {
           appId={appId}
           summary={snapshot.summary}
           dataMode={dataMode}
-          title="Access"
-          currentSection="Access"
-          subtitle="Manage app accounts, access state, and plan assignment context."
+          title="Users"
+          currentSection="Users"
+          subtitle="Manage app accounts, user access state, and plan assignment."
           summaryItems={summaryItems}
           actions={[
             {

--- a/factory_app/app/admin/pages/AppUsagePage.jsx
+++ b/factory_app/app/admin/pages/AppUsagePage.jsx
@@ -159,7 +159,7 @@ export default function AppUsagePage() {
   }
 
   if (loading) return <StudioLoadingState label="Loading app usage..." />
-  if (error || !data) return <StudioErrorState title="Usage Unavailable" message={error || 'No usage data returned.'} />
+  if (error || !data) return <StudioErrorState title="Token Usage Unavailable" message={error || 'No usage data returned.'} />
 
   const snapshot = getAppStudioSnapshot(appId, data, dataMode)
   const usageTotals = snapshot.usage?.totals || {}
@@ -235,9 +235,9 @@ export default function AppUsagePage() {
           appId={appId}
           summary={snapshot.summary}
           dataMode={dataMode}
-          title="Usage"
-          currentSection="Usage"
-          subtitle="Review measured runtime token usage and cost estimates."
+          title="Token Usage"
+          currentSection="Token Usage"
+          subtitle="Measured runtime token usage and cost estimates for this app."
           actions={null}
           onAction={null}
         />

--- a/factory_app/app/admin/pages/WorkspaceUsagePage.jsx
+++ b/factory_app/app/admin/pages/WorkspaceUsagePage.jsx
@@ -370,14 +370,14 @@ export default function WorkspaceUsagePage() {
   ]
 
   if (loading) return <StudioLoadingState label="Loading workspace usage…" />
-  if (error) return <StudioErrorState title="Workspace Usage Unavailable" message={error} />
+  if (error) return <StudioErrorState title="Workspace Token Usage Unavailable" message={error} />
 
   return (
     <WorkspaceLayout>
       <div className="space-y-6">
         <WorkspaceStudioHero
-          title="Usage"
-          subtitle="Track workspace metering, model spend, and workflow activity."
+          title="Token Usage"
+          subtitle="Track workspace LLM metering, model spend, and workflow activity."
           actions={null}
           onAction={null}
         />

--- a/factory_app/app/ui/route_manifest.json
+++ b/factory_app/app/ui/route_manifest.json
@@ -38,14 +38,14 @@
     {
       "path": "/usage",
       "component": "WorkspaceUsagePage",
-      "label": "Usage",
+      "label": "Token Usage",
       "order": 5,
       "meta": {
         "surfaces": ["studio"],
         "requiresRole": "admin",
-        "title": "Usage",
+        "title": "Token Usage",
         "appShell": true,
-        "ai_context": "The user is on the Workspace Usage page. It shows LLM token consumption, cost estimates, and chat activity across all apps in this workspace.",
+        "ai_context": "The user is on the Workspace Token Usage page. It shows LLM token consumption, cost estimates, and chat activity across all apps in this workspace.",
         "navigation": {
           "group": "workspace-studio",
           "scope": "local",
@@ -75,7 +75,7 @@
       "path": "/integrations",
       "component": "WorkspaceIntegrationsPage",
       "label": "Integrations",
-      "order": 6,
+      "order": 7,
       "meta": {
         "surfaces": ["studio"],
         "requiresRole": "admin",
@@ -161,35 +161,16 @@
       }
     },
     {
-      "path": "/apps/:appId/health",
-      "component": "AppHealthPage",
-      "label": "Health",
-      "order": 21,
-      "meta": {
-        "surfaces": ["studio"],
-        "requiresRole": "admin",
-        "title": "App Health",
-        "appShell": true,
-        "ai_context": "The user is on the App Health page. It shows runtime signals, connector status, and any warnings or errors for this app.",
-        "navigation": {
-          "group": "app-studio",
-          "include": false,
-          "scope": "local",
-          "icon": "pulse"
-        }
-      }
-    },
-    {
       "path": "/apps/:appId/access",
       "component": "AppAccessPage",
-      "label": "Access",
+      "label": "Users",
       "order": 22,
       "meta": {
         "surfaces": ["studio"],
         "requiresRole": "admin",
-        "title": "App Access",
+        "title": "App Users",
         "appShell": true,
-        "ai_context": "The user is on the App Access page. It shows users, roles, permission posture, plan assignment context, and support-access handoff for this app.",
+        "ai_context": "The user is on the App Users page. It shows accounts, access status, subscription plan assignment, and last-activity for this app's users.",
         "navigation": {
           "group": "app-studio",
           "scope": "local",
@@ -198,10 +179,46 @@
       }
     },
     {
+      "path": "/apps/:appId/usage",
+      "component": "AppUsagePage",
+      "label": "Token Usage",
+      "order": 23,
+      "meta": {
+        "surfaces": ["studio"],
+        "requiresRole": "admin",
+        "title": "Token Usage",
+        "appShell": true,
+        "ai_context": "The user is on the App Token Usage page. It shows LLM token consumption, cost estimates, and per-workflow chat breakdowns for this specific app.",
+        "navigation": {
+          "group": "app-studio",
+          "scope": "local",
+          "icon": "chart"
+        }
+      }
+    },
+    {
+      "path": "/apps/:appId/health",
+      "component": "AppHealthPage",
+      "label": "Health",
+      "order": 24,
+      "meta": {
+        "surfaces": ["studio"],
+        "requiresRole": "admin",
+        "title": "App Health",
+        "appShell": true,
+        "ai_context": "The user is on the App Health page. It shows runtime signals, connector status, and any warnings or errors for this app.",
+        "navigation": {
+          "group": "app-studio",
+          "scope": "local",
+          "icon": "pulse"
+        }
+      }
+    },
+    {
       "path": "/apps/:appId/integrations",
       "component": "AppIntegrationsPage",
       "label": "App Integrations",
-      "order": 23,
+      "order": 26,
       "meta": {
         "surfaces": ["studio"],
         "requiresRole": "admin",
@@ -213,24 +230,6 @@
           "include": false,
           "scope": "local",
           "icon": "plug"
-        }
-      }
-    },
-    {
-      "path": "/apps/:appId/usage",
-      "component": "AppUsagePage",
-      "label": "Usage",
-      "order": 24,
-      "meta": {
-        "surfaces": ["studio"],
-        "requiresRole": "admin",
-        "title": "Usage",
-        "appShell": true,
-        "ai_context": "The user is on the App Usage page. It shows LLM token consumption, cost estimates, and per-workflow chat breakdowns for this specific app.",
-        "navigation": {
-          "group": "app-studio",
-          "scope": "local",
-          "icon": "chart"
         }
       }
     },


### PR DESCRIPTION
## Summary

- **Token Usage** replaces "Usage" everywhere (workspace nav + per-app nav + page heroes) — makes it clear this is LLM cost data, not user engagement
- **Users** replaces "Access" in the per-app nav and `AppAccessPage` hero — more intuitive label for what the page actually shows (the user list)
- **Health** is now visible in the per-app nav (was `include: false`) — operators need runtime signals without hunting for a hidden route
- Per-app nav reordered: Overview → Building → Users → Token Usage → Health → Support
- Fixed workspace nav order conflict: Integrations was order 6 (same as Users), now 7

## Test plan
- [ ] Verify workspace nav shows: Apps, Token Usage, Users, Integrations, Support
- [ ] Verify per-app nav shows: Overview, Building, Users, Token Usage, Health, Support
- [ ] Confirm App Users page hero says "Users" / "Manage app accounts…"
- [ ] Confirm App Token Usage page hero says "Token Usage"
- [ ] Confirm Health page is reachable from per-app nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)