### PR TITLE
feat(build-context): add files capability pack

### DIFF
--- a/factory_app/build_context/AppGenerator/capability_directory.yaml
+++ b/factory_app/build_context/AppGenerator/capability_directory.yaml
@@ -243,3 +243,36 @@ capabilities:
       - onboarding.tour.show
       - onboarding.tour.dismiss
       - onboarding.tour.progress.read
+
+  - id: files_pack
+    label: Files & Media Storage
+    capability_kind: operator_pack
+    recommendation_rank: 3
+    domains:
+      - files
+      - media
+      - storage
+      - documents
+    intent_signals:
+      - App needs file upload, media storage, or document management.
+      - Users upload images, documents, or attachments.
+      - App stores user-generated files, photos, or media assets.
+      - Product spec mentions file upload, document management, attachments, media library, or photo upload.
+    selection_aliases:
+      - files
+      - file upload
+      - media
+      - storage
+      - document management
+      - attachments
+      - photo upload
+      - image upload
+    generator_notes:
+      - Generate the files module with metadata-only storage. Actual blobs are stored by the app's storage adapter.
+      - Do not generate cloud storage SDK calls in the module backend.
+      - Generate services/adapters/storage/{provider}.py when the app declares a specific cloud storage provider.
+      - The storage_url field is an opaque provider URL returned by the storage adapter; the module does not validate or proxy it.
+    capabilities_provided:
+      - files.upload
+      - files.read
+      - files.delete

--- a/factory_app/build_context/files/context.yaml
+++ b/factory_app/build_context/files/context.yaml
@@ -1,0 +1,19 @@
+context_id: files
+applies_to_workflows:
+  - AppGenerator
+assets:
+  - path: contract.yaml
+    kind: contract
+  - path: templates/
+    kind: templates
+pack:
+  id: files
+  status: active
+  capability_source: generated_module
+capabilities:
+  - capability_id: files.upload
+    facade_recommended: file_manager
+  - capability_id: files.read
+    facade_recommended: file_manager
+  - capability_id: files.delete
+    facade_recommended: file_manager

--- a/factory_app/build_context/files/contract.yaml
+++ b/factory_app/build_context/files/contract.yaml
@@ -1,0 +1,87 @@
+contract_id: files
+contract_type: build_pack_instructions
+
+selection_rules:
+  - id: select_for_file_storage_apps
+    when:
+      intent_any:
+        - file upload
+        - file storage
+        - media management
+        - document management
+        - user files
+        - attachments
+        - photo upload
+        - image upload
+        - file sharing
+        - document storage
+        - media upload
+        - upload files
+    action: select_pack
+
+recommended_domains:
+  - files
+  - media
+  - storage
+  - documents
+  - attachments
+
+required_outputs:
+  - path: data/migrations/001_files_collections.json
+    owner: templates
+  - path: modules/files/module.yaml
+    owner: templates
+  - path: modules/files/backend/__init__.py
+    owner: templates
+  - path: modules/files/backend/base_handler.py
+    owner: templates
+  - path: modules/files/backend/handler.py
+    owner: workspace  # preserved across regeneration; subclasses base_handler.py
+  - path: modules/files/backend/service.py
+    owner: templates
+  - path: modules/files/backend/repo.py
+    owner: templates
+  - path: modules/files/backend/policy.py
+    owner: templates
+  - path: modules/files/backend/schemas.py
+    owner: templates
+  - path: modules/files/backend/account_data_handler.py
+    owner: templates
+  - path: modules/files/contracts/events.yaml
+    owner: templates
+  - path: modules/files/contracts/notifications.yaml
+    owner: templates
+
+forbidden_outputs:
+  - path_prefix: modules/storage/
+  - path_prefix: modules/media/
+  - path_prefix: modules/uploads/
+  - path_prefix: services/cloud_storage/
+
+runtime_boundaries:
+  - id: metadata_only
+    rule: >
+      Generated module stores file metadata only (file_id, filename, mime_type,
+      size_bytes, storage_url, is_public, created_by). The actual blob belongs in
+      a provider storage service. Do not generate AWS/GCP/Azure SDK calls in the
+      module backend.
+  - id: storage_url_is_opaque
+    rule: >
+      The storage_url field is an opaque provider URL. The module does not validate,
+      sign, or proxy it. The app's storage adapter manages blob lifecycle.
+  - id: user_data_scope
+    rule: >
+      File records are user-owned PII. The module declares user_data_scope: true
+      and ships account_data_handler.py implementing delete_user_data and
+      export_user_data.
+  - id: no_direct_sdk_calls
+    rule: >
+      Generated repo.py must use ctx.persistence.collection("files", entity_name).
+      No direct cloud storage SDK calls in module backend. Storage mechanics belong
+      in services/adapters/storage/{provider}.py.
+  - id: event_emission
+    rule: >
+      Events must be emitted via ctx.emit() from service.py, not from handler.py
+      or repo.py.
+
+facades: []

--- a/factory_app/build_context/files/templates/data/migrations/001_files_collections.json
+++ b/factory_app/build_context/files/templates/data/migrations/001_files_collections.json
@@ -1,0 +1,33 @@
+{
+  "migration_id": "files_001_collections",
+  "description": "Declare the files.records collection for the files module.",
+  "surfaces": [
+    {
+      "surface_id": "files",
+      "collections": [
+        {
+          "mongo_collection": "files_records",
+          "data_alias": "files.records",
+          "description": "File metadata records. Blobs are stored externally; this collection tracks metadata and the opaque storage_url.",
+          "indexes": [
+            {
+              "name": "files_by_app_user",
+              "keys": [
+                {"field": "app_id", "order": 1},
+                {"field": "created_by", "order": 1}
+              ]
+            },
+            {
+              "name": "files_by_app_file_id",
+              "keys": [
+                {"field": "app_id", "order": 1},
+                {"field": "file_id", "order": 1}
+              ],
+              "unique": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/factory_app/build_context/files/templates/modules/files/backend/account_data_handler.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/account_data_handler.py
@@ -1,0 +1,57 @@
+"""AccountDataHandler for the files module.
+
+GDPR deletion and export for user-uploaded file records.
+
+Deletion policy:
+  - File records where created_by == deleted user: soft-deleted (deleted flag set).
+    The storage_url is an opaque provider reference; blob cleanup is handled by the
+    app's storage adapter using domain.files.file_deleted events or a separate
+    retention sweep. This handler marks metadata records as deleted so they are
+    excluded from queries.
+
+Note: actual blob data lives outside this module in provider storage. This handler
+only operates on metadata records in the files.records collection.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+_RECORDS = "files_records"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class AccountDataHandler:
+    """GDPR delete + export handler for the files module."""
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    async def delete_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Soft-delete all file records created by the user."""
+        result = await self._db[_RECORDS].update_many(
+            {"app_id": app_id, "created_by": user_id, "deleted": {"$ne": True}},
+            {
+                "$set": {
+                    "deleted": True,
+                    "deleted_at": _now(),
+                    "deleted_by": "__gdpr_deletion__",
+                }
+            },
+        )
+        return {
+            "files_deleted": getattr(result, "modified_count", 0),
+        }
+
+    async def export_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Export all non-deleted file records created by the user."""
+        files = await self._db[_RECORDS].find(
+            {"app_id": app_id, "created_by": user_id, "deleted": {"$ne": True}},
+            {"_id": 0, "app_id": 0},
+        ).to_list(length=None)
+        return {
+            "files": files,
+        }

--- a/factory_app/build_context/files/templates/modules/files/backend/base_handler.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/base_handler.py
@@ -1,0 +1,73 @@
+"""
+OSS-generated base handler for the files module.
+DO NOT EDIT — regenerated on framework upgrades.
+Put app-specific customizations in handler.py (the workspace subclass).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from mozaiksai.core.runtime.composition.module_context import ModuleContext
+
+from .service import FilesService
+
+
+class FilesBaseHandler:
+    def __init__(self, service: FilesService | None = None) -> None:
+        self._service = service or FilesService()
+
+    async def upload_file(
+        self,
+        ctx: ModuleContext,
+        *,
+        filename: str,
+        mime_type: str,
+        size_bytes: int,
+        storage_url: str,
+        is_public: bool = False,
+        metadata: dict[str, Any] | None = None,
+        **_: object,
+    ) -> dict[str, Any]:
+        return await self._service.upload_file(
+            ctx,
+            filename=filename,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            storage_url=storage_url,
+            is_public=is_public,
+            metadata=metadata,
+        )
+
+    async def get_file(
+        self,
+        ctx: ModuleContext,
+        *,
+        file_id: str,
+        **_: object,
+    ) -> dict[str, Any]:
+        return await self._service.get_file(ctx, file_id=file_id)
+
+    async def list_files(
+        self,
+        ctx: ModuleContext,
+        *,
+        is_public: bool | None = None,
+        mime_type: str | None = None,
+        limit: int = 50,
+        **_: object,
+    ) -> dict[str, Any]:
+        return await self._service.list_files(
+            ctx,
+            is_public=is_public,
+            mime_type=mime_type,
+            limit=limit,
+        )
+
+    async def delete_file(
+        self,
+        ctx: ModuleContext,
+        *,
+        file_id: str,
+        **_: object,
+    ) -> dict[str, Any]:
+        return await self._service.delete_file(ctx, file_id=file_id)

--- a/factory_app/build_context/files/templates/modules/files/backend/handler.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/handler.py
@@ -1,0 +1,12 @@
+"""
+Workspace handler for the files module.
+Subclasses FilesBaseHandler — add overrides and extra methods here.
+This file is preserved across regeneration.
+"""
+from __future__ import annotations
+
+from .base_handler import FilesBaseHandler
+
+
+class FilesHandler(FilesBaseHandler):
+    """App-local handler — extend or override base methods below."""

--- a/factory_app/build_context/files/templates/modules/files/backend/policy.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/policy.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def files_scope(ctx, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return a base query scope keyed by app_id, optionally merged with extra fields."""
+    scope: dict[str, Any] = {"app_id": getattr(ctx, "app_id", None)}
+    if extra:
+        scope.update({key: value for key, value in extra.items() if value is not None})
+    return scope

--- a/factory_app/build_context/files/templates/modules/files/backend/repo.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/repo.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+Document = dict[str, Any]
+
+
+def _collection(ctx, entity_name: str):
+    persistence = getattr(ctx, "persistence", None)
+    if persistence is None:
+        raise RuntimeError("Persistence is not available for this app context.")
+    return persistence.collection("files", entity_name)
+
+
+def _document(value: Any) -> Document | None:
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _documents(values: list[Any] | None) -> list[Document]:
+    return [dict(item) for item in values or [] if isinstance(item, Mapping)]
+
+
+async def register_file(
+    ctx,
+    *,
+    file_id: str,
+    filename: str,
+    mime_type: str,
+    size_bytes: int,
+    storage_url: str,
+    is_public: bool,
+    created_by: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    app_id = getattr(ctx, "app_id", None)
+    record = {
+        "file_id": file_id,
+        "app_id": app_id,
+        "filename": filename,
+        "mime_type": mime_type,
+        "size_bytes": size_bytes,
+        "storage_url": storage_url,
+        "is_public": is_public,
+        "created_by": created_by,
+        "deleted": False,
+        "deleted_at": None,
+        "deleted_by": None,
+        "metadata": dict(metadata or {}),
+    }
+    await _collection(ctx, "records").insert_one(record)
+
+
+async def get_file(ctx, *, file_id: str) -> Document | None:
+    app_id = getattr(ctx, "app_id", None)
+    return _document(
+        await _collection(ctx, "records").find_one(
+            {"app_id": app_id, "file_id": file_id, "deleted": {"$ne": True}}
+        )
+    )
+
+
+async def list_files(
+    ctx,
+    *,
+    created_by: str | None = None,
+    is_public: bool | None = None,
+    mime_type: str | None = None,
+    limit: int = 50,
+) -> list[Document]:
+    app_id = getattr(ctx, "app_id", None)
+    query: dict[str, Any] = {"app_id": app_id, "deleted": {"$ne": True}}
+    if created_by is not None:
+        query["created_by"] = created_by
+    if is_public is not None:
+        query["is_public"] = is_public
+    if mime_type is not None:
+        query["mime_type"] = mime_type
+    return _documents(
+        await _collection(ctx, "records").find_many(
+            query,
+            limit=max(1, min(int(limit), 200)),
+            sort=[("created_at", -1)],
+        )
+    )
+
+
+async def soft_delete_file(ctx, *, file_id: str, deleted_by: str) -> int:
+    from .schemas import timestamp_now
+
+    app_id = getattr(ctx, "app_id", None)
+    result = await _collection(ctx, "records").update_one(
+        {"app_id": app_id, "file_id": file_id, "deleted": {"$ne": True}},
+        {
+            "$set": {
+                "deleted": True,
+                "deleted_at": timestamp_now(),
+                "deleted_by": deleted_by,
+            }
+        },
+    )
+    return int(getattr(result, "matched_count", 0) or 0)

--- a/factory_app/build_context/files/templates/modules/files/backend/schemas.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/schemas.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, TypedDict
+from uuid import uuid4
+
+
+class FileRecord(TypedDict, total=False):
+    file_id: str
+    app_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    storage_url: str
+    is_public: bool
+    created_by: str
+    created_at: str
+    deleted: bool
+    deleted_at: str | None
+    deleted_by: str | None
+    metadata: dict[str, Any]
+
+
+def timestamp_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def new_file_id() -> str:
+    return f"file_{uuid4().hex}"
+
+
+def build_file_record(
+    *,
+    app_id: str,
+    filename: str,
+    mime_type: str,
+    size_bytes: int,
+    storage_url: str,
+    is_public: bool = False,
+    created_by: str,
+    metadata: dict[str, Any] | None = None,
+) -> FileRecord:
+    now = timestamp_now()
+    return {
+        "file_id": new_file_id(),
+        "app_id": app_id,
+        "filename": str(filename or "").strip(),
+        "mime_type": str(mime_type or "").strip(),
+        "size_bytes": int(size_bytes),
+        "storage_url": str(storage_url or "").strip(),
+        "is_public": bool(is_public),
+        "created_by": created_by,
+        "created_at": now,
+        "deleted": False,
+        "deleted_at": None,
+        "deleted_by": None,
+        "metadata": dict(metadata or {}),
+    }
+
+
+def safe_file_record(doc: Any) -> dict[str, Any]:
+    """Return a safe dict of file fields, excluding internal storage fields."""
+    if not doc:
+        return {}
+    return {
+        "file_id": doc.get("file_id"),
+        "filename": doc.get("filename"),
+        "mime_type": doc.get("mime_type"),
+        "size_bytes": doc.get("size_bytes"),
+        "storage_url": doc.get("storage_url"),
+        "is_public": doc.get("is_public", False),
+        "created_by": doc.get("created_by"),
+        "created_at": doc.get("created_at"),
+    }

--- a/factory_app/build_context/files/templates/modules/files/backend/service.py
+++ b/factory_app/build_context/files/templates/modules/files/backend/service.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from .policy import files_scope
+from .repo import get_file, list_files, register_file, soft_delete_file
+from .schemas import build_file_record, safe_file_record
+
+
+class FilesService:
+    async def _emit(self, ctx, event_type: str, payload: dict[str, Any]) -> None:
+        emit = getattr(ctx, "emit", None)
+        if emit is None:
+            return
+        result = emit(event_type, payload)
+        if inspect.isawaitable(result):
+            await result
+
+    async def upload_file(
+        self,
+        ctx,
+        *,
+        filename: str,
+        mime_type: str,
+        size_bytes: int,
+        storage_url: str,
+        is_public: bool = False,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        filename = str(filename or "").strip()
+        if not filename:
+            return {"success": False, "error": "filename is required"}
+
+        mime_type = str(mime_type or "").strip()
+        if not mime_type:
+            return {"success": False, "error": "mime_type is required"}
+
+        try:
+            size_bytes = int(size_bytes)
+        except (TypeError, ValueError):
+            return {"success": False, "error": "size_bytes must be an integer"}
+        if size_bytes <= 0:
+            return {"success": False, "error": "size_bytes must be greater than zero"}
+
+        storage_url = str(storage_url or "").strip()
+        if not storage_url:
+            return {"success": False, "error": "storage_url is required"}
+
+        created_by = str(getattr(ctx, "user_id", None) or "anonymous").strip() or "anonymous"
+        app_id = getattr(ctx, "app_id", None)
+
+        record = build_file_record(
+            app_id=app_id,
+            filename=filename,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            storage_url=storage_url,
+            is_public=is_public,
+            created_by=created_by,
+            metadata=metadata,
+        )
+
+        await register_file(
+            ctx,
+            file_id=record["file_id"],
+            filename=record["filename"],
+            mime_type=record["mime_type"],
+            size_bytes=record["size_bytes"],
+            storage_url=record["storage_url"],
+            is_public=record["is_public"],
+            created_by=record["created_by"],
+            metadata=record.get("metadata"),
+        )
+
+        await self._emit(
+            ctx,
+            "domain.files.file_uploaded",
+            {
+                "file_id": record["file_id"],
+                "filename": record["filename"],
+                "mime_type": record["mime_type"],
+                "size_bytes": record["size_bytes"],
+                "is_public": record["is_public"],
+                "created_by": record["created_by"],
+                "app_id": app_id,
+            },
+        )
+
+        return {"success": True, "file": safe_file_record(record)}
+
+    async def get_file(self, ctx, *, file_id: str) -> dict[str, Any]:
+        doc = await get_file(ctx, file_id=file_id)
+        return {"file": safe_file_record(doc) if doc else None}
+
+    async def list_files(
+        self,
+        ctx,
+        *,
+        is_public: bool | None = None,
+        mime_type: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        created_by = str(getattr(ctx, "user_id", None) or "").strip() or None
+        docs = await list_files(
+            ctx,
+            created_by=created_by,
+            is_public=is_public,
+            mime_type=mime_type,
+            limit=limit,
+        )
+        files = [safe_file_record(doc) for doc in docs]
+        return {"files": files, "total": len(files)}
+
+    async def delete_file(self, ctx, *, file_id: str) -> dict[str, Any]:
+        deleted_by = str(getattr(ctx, "user_id", None) or "anonymous").strip() or "anonymous"
+        app_id = getattr(ctx, "app_id", None)
+
+        matched = await soft_delete_file(ctx, file_id=file_id, deleted_by=deleted_by)
+        if not matched:
+            return {"success": False, "error": "file not found"}
+
+        await self._emit(
+            ctx,
+            "domain.files.file_deleted",
+            {
+                "file_id": file_id,
+                "deleted_by": deleted_by,
+                "app_id": app_id,
+            },
+        )
+
+        return {"success": True}

--- a/factory_app/build_context/files/templates/modules/files/contracts/events.yaml
+++ b/factory_app/build_context/files/templates/modules/files/contracts/events.yaml
@@ -1,0 +1,29 @@
+schema_version: mozaiks.events.v1
+events:
+  - type: domain.files.file_uploaded
+    version: 1
+    description: Emitted after a file metadata record is registered following external blob upload.
+    producer: files
+    payload_schema:
+      type: object
+      required: [file_id, filename, mime_type, size_bytes, created_by, app_id]
+      properties:
+        file_id: { type: string }
+        filename: { type: string }
+        mime_type: { type: string }
+        size_bytes: { type: integer }
+        is_public: { type: boolean }
+        created_by: { type: string }
+        app_id: { type: string }
+
+  - type: domain.files.file_deleted
+    version: 1
+    description: Emitted after a file metadata record is soft-deleted. Storage adapters may use this to schedule blob cleanup.
+    producer: files
+    payload_schema:
+      type: object
+      required: [file_id, deleted_by, app_id]
+      properties:
+        file_id: { type: string }
+        deleted_by: { type: string }
+        app_id: { type: string }

--- a/factory_app/build_context/files/templates/modules/files/contracts/notifications.yaml
+++ b/factory_app/build_context/files/templates/modules/files/contracts/notifications.yaml
@@ -1,0 +1,20 @@
+schema_version: mozaiks.notifications.v1
+
+notifications:
+  - id: public_file_uploaded
+    description: Notify relevant users when a public file is uploaded and available for viewing.
+    event_type: domain.files.file_uploaded
+    condition:
+      field: is_public
+      value: true
+    channels:
+      - in_app
+    audience:
+      strategy: app_admins
+    template:
+      title: "New file available"
+      body: "{{filename}} has been uploaded."
+    context_fields:
+      - file_id
+      - filename
+      - mime_type

--- a/factory_app/build_context/files/templates/modules/files/module.yaml
+++ b/factory_app/build_context/files/templates/modules/files/module.yaml
@@ -1,0 +1,132 @@
+schema_version: mozaiks.module.v1
+module:
+  id: files
+  display_name: Files
+  version: 1.0.0
+  description: User-generated file upload, storage metadata, retrieval, and deletion. Stores file metadata only; blobs are managed by the app's storage adapter.
+  owner: app
+  visibility: private
+  handler: backend.handler:FilesHandler
+  user_data_scope: true
+
+permissions:
+  - id: files.read
+    description: Read file records and metadata.
+  - id: files.write
+    description: Upload and delete files.
+
+actions:
+  - id: upload_file
+    description: Register a file record after the blob has been stored externally.
+    handler_method: upload_file
+    input_schema:
+      type: object
+      required: [filename, mime_type, size_bytes, storage_url]
+      properties:
+        filename:
+          type: string
+        mime_type:
+          type: string
+        size_bytes:
+          type: integer
+        storage_url:
+          type: string
+          description: Opaque provider URL returned by the storage adapter after blob upload.
+        is_public:
+          type: boolean
+          default: false
+        metadata:
+          type: object
+    output_schema:
+      type: object
+      required: [success, file]
+      properties:
+        success:
+          type: boolean
+        file:
+          type: object
+    permissions:
+      - files.write
+    emits:
+      - domain.files.file_uploaded
+
+  - id: get_file
+    description: Fetch a single file record by file_id.
+    handler_method: get_file
+    input_schema:
+      type: object
+      required: [file_id]
+      properties:
+        file_id:
+          type: string
+    output_schema:
+      type: object
+      required: [file]
+      properties:
+        file:
+          type: object
+    permissions:
+      - files.read
+
+  - id: list_files
+    description: List file records for the current user.
+    handler_method: list_files
+    input_schema:
+      type: object
+      properties:
+        is_public:
+          type: boolean
+        mime_type:
+          type: string
+        limit:
+          type: integer
+    output_schema:
+      type: object
+      required: [files, total]
+      properties:
+        files:
+          type: array
+        total:
+          type: integer
+    permissions:
+      - files.read
+
+  - id: delete_file
+    description: Soft-delete a file record by file_id.
+    handler_method: delete_file
+    input_schema:
+      type: object
+      required: [file_id]
+      properties:
+        file_id:
+          type: string
+    output_schema:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+    permissions:
+      - files.write
+    emits:
+      - domain.files.file_deleted
+
+capabilities:
+  - capability_id: files.upload
+    kind: action
+    target: upload_file
+    title: Upload file
+    permissions:
+      - files.write
+  - capability_id: files.read
+    kind: action
+    target: list_files
+    title: List files
+    permissions:
+      - files.read
+  - capability_id: files.delete
+    kind: action
+    target: delete_file
+    title: Delete file
+    permissions:
+      - files.write

--- a/tests/test_build_context_files_pack.py
+++ b/tests/test_build_context_files_pack.py
@@ -1,0 +1,285 @@
+"""Contract tests for the files build context pack.
+
+Verifies that:
+- context.yaml registers the pack correctly for AppGenerator
+- contract.yaml required_outputs all exist under templates; forbidden paths absent
+- The files module declares expected actions and capabilities with alignment
+- user_data_scope declared and account_data_handler.py ships (file records = user PII)
+- Data migration declares the stable files.records collection alias
+- Backend files compile and use canonical persistence pattern
+- Service emits domain.files.* events
+- Service does not deliver notifications directly
+- Notification contract covers file_uploaded
+- AppGenerator capability_directory has files_pack entry
+- No modules/storage/, modules/media/, or modules/uploads/ generated
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+BUILD_CONTEXT = WORKSPACE / "factory_app" / "build_context"
+FILES = BUILD_CONTEXT / "files"
+TEMPLATES = FILES / "templates"
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _action_ids(module_yaml: dict[str, Any]) -> set[str]:
+    return {action["id"] for action in module_yaml.get("actions") or []}
+
+
+def _capability_ids(module_yaml: dict[str, Any]) -> set[str]:
+    return {cap["capability_id"] for cap in module_yaml.get("capabilities") or []}
+
+
+def _capability_targets(module_yaml: dict[str, Any]) -> set[str]:
+    return {cap["target"] for cap in module_yaml.get("capabilities") or []}
+
+
+# ---------------------------------------------------------------------------
+# Pack registration
+# ---------------------------------------------------------------------------
+
+def test_files_context_registers_active_appgenerator_pack() -> None:
+    context = _read_yaml(FILES / "context.yaml")
+
+    assert context["context_id"] == "files"
+    assert "AppGenerator" in context["applies_to_workflows"]
+    assert context["pack"]["id"] == "files"
+    assert context["pack"]["status"] == "active"
+    assert context["pack"]["capability_source"] == "generated_module"
+    assert {asset["kind"] for asset in context["assets"]} == {"contract", "templates"}
+
+    capability_ids = {cap["capability_id"] for cap in context["capabilities"]}
+    assert capability_ids == {
+        "files.upload",
+        "files.read",
+        "files.delete",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Required / forbidden outputs
+# ---------------------------------------------------------------------------
+
+def test_files_contract_required_outputs_exist_under_templates() -> None:
+    contract = _read_yaml(FILES / "contract.yaml")
+
+    assert contract["contract_id"] == "files"
+    assert contract["contract_type"] == "build_pack_instructions"
+    assert contract["facades"] == []
+
+    missing = [
+        output["path"]
+        for output in contract["required_outputs"]
+        if output.get("owner") == "templates" and not (TEMPLATES / output["path"]).exists()
+    ]
+    assert missing == [], f"Missing required template outputs: {missing}"
+
+
+def test_files_pack_forbidden_outputs_are_absent() -> None:
+    contract = _read_yaml(FILES / "contract.yaml")
+
+    generated_paths = {
+        str(path.relative_to(TEMPLATES)).replace("\\", "/")
+        for path in TEMPLATES.rglob("*")
+        if path.is_file()
+    }
+
+    for forbidden in contract.get("forbidden_outputs", []):
+        if "path_prefix" in forbidden:
+            assert not any(p.startswith(forbidden["path_prefix"]) for p in generated_paths), (
+                f"Forbidden prefix found: {forbidden['path_prefix']}"
+            )
+        elif "path" in forbidden:
+            assert forbidden["path"] not in generated_paths, (
+                f"Forbidden path found: {forbidden['path']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Module: files
+# ---------------------------------------------------------------------------
+
+def test_files_module_declares_expected_actions() -> None:
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "files" / "module.yaml")
+
+    assert _action_ids(module_yaml) == {
+        "upload_file",
+        "get_file",
+        "list_files",
+        "delete_file",
+    }
+
+
+def test_files_module_capabilities_target_existing_actions() -> None:
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "files" / "module.yaml")
+    actions = _action_ids(module_yaml)
+    targets = _capability_targets(module_yaml)
+
+    assert targets <= actions, f"Capability targets not in actions: {targets - actions}"
+    assert _capability_ids(module_yaml) == {
+        "files.upload",
+        "files.read",
+        "files.delete",
+    }
+
+
+def test_files_module_declares_user_data_scope() -> None:
+    """File records are user-owned PII — module must declare user_data_scope."""
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "files" / "module.yaml")
+    assert module_yaml.get("module", {}).get("user_data_scope") is True, (
+        "files module stores user-generated file records (PII) and must declare "
+        "user_data_scope: true under the module: key"
+    )
+
+
+def test_files_module_ships_account_data_handler() -> None:
+    """File records require GDPR delete + export support."""
+    handler = TEMPLATES / "modules" / "files" / "backend" / "account_data_handler.py"
+    assert handler.exists(), (
+        "files module must ship account_data_handler.py — "
+        "file records are user-owned PII"
+    )
+    source = handler.read_text(encoding="utf-8")
+    assert "delete_user_data" in source
+    assert "export_user_data" in source
+
+
+def test_files_contract_declares_account_data_handler_as_required_output() -> None:
+    contract = _read_yaml(FILES / "contract.yaml")
+    output_paths = {output["path"] for output in contract["required_outputs"]}
+    assert "modules/files/backend/account_data_handler.py" in output_paths, (
+        "contract.yaml must declare account_data_handler.py as a required output "
+        "since file records are user PII"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data migration
+# ---------------------------------------------------------------------------
+
+def test_files_data_migration_declares_files_records_alias() -> None:
+    migration_path = TEMPLATES / "data" / "migrations" / "001_files_collections.json"
+    assert migration_path.exists()
+    migration = json.loads(migration_path.read_text(encoding="utf-8"))
+
+    aliases = {
+        collection["data_alias"]
+        for surface in migration.get("surfaces", [])
+        for collection in surface.get("collections", [])
+    }
+    assert "files.records" in aliases, f"Expected files.records in aliases, got: {aliases}"
+
+
+# ---------------------------------------------------------------------------
+# Backend template contracts
+# ---------------------------------------------------------------------------
+
+def test_files_backend_templates_compile() -> None:
+    backend_root = TEMPLATES / "modules" / "files" / "backend"
+    for path in backend_root.glob("*.py"):
+        compile(path.read_text(encoding="utf-8"), str(path), "exec")
+
+
+def test_files_backend_repo_uses_canonical_persistence_pattern() -> None:
+    repo_text = _read_text(TEMPLATES / "modules" / "files" / "backend" / "repo.py")
+
+    assert "persistence.collection" in repo_text or "_collection(ctx" in repo_text, (
+        "files/repo.py must use canonical persistence.collection() pattern"
+    )
+    assert "get_mongo_client" not in repo_text, "repo.py must not use get_mongo_client"
+    assert "ctx.db" not in repo_text, "repo.py must not use ctx.db"
+
+
+def test_files_service_emits_domain_events() -> None:
+    service_text = _read_text(TEMPLATES / "modules" / "files" / "backend" / "service.py")
+
+    assert "domain.files.file_uploaded" in service_text, (
+        "service.py must emit domain.files.file_uploaded"
+    )
+    assert "domain.files.file_deleted" in service_text, (
+        "service.py must emit domain.files.file_deleted"
+    )
+
+
+def test_files_service_does_not_deliver_notifications_directly() -> None:
+    """Notification delivery is declared in notifications.yaml, not implemented in service.py."""
+    service_text = _read_text(TEMPLATES / "modules" / "files" / "backend" / "service.py")
+
+    assert "notification_client" not in service_text
+    assert "send_notification" not in service_text
+    assert "push_notification" not in service_text
+
+
+# ---------------------------------------------------------------------------
+# Event / notification contracts
+# ---------------------------------------------------------------------------
+
+def test_files_declares_canonical_domain_events() -> None:
+    events = _read_yaml(
+        TEMPLATES / "modules" / "files" / "contracts" / "events.yaml"
+    )
+    event_types = {e["type"] for e in events.get("events") or []}
+
+    assert "domain.files.file_uploaded" in event_types
+    assert "domain.files.file_deleted" in event_types
+
+
+def test_files_notification_covers_file_uploaded() -> None:
+    notifications = _read_yaml(
+        TEMPLATES / "modules" / "files" / "contracts" / "notifications.yaml"
+    )
+    assert notifications.get("schema_version") == "mozaiks.notifications.v1"
+    notif_event_types = {n["event_type"] for n in notifications.get("notifications") or []}
+    assert "domain.files.file_uploaded" in notif_event_types
+
+
+# ---------------------------------------------------------------------------
+# AppGenerator selection wiring
+# ---------------------------------------------------------------------------
+
+def test_appgenerator_capability_directory_has_files_pack_entry() -> None:
+    directory = _read_yaml(BUILD_CONTEXT / "AppGenerator" / "capability_directory.yaml")
+    by_id = {entry["id"]: entry for entry in directory["capabilities"]}
+
+    assert "files_pack" in by_id, "capability_directory.yaml must have a files_pack entry"
+    files_entry = by_id["files_pack"]
+    assert files_entry["capability_kind"] == "operator_pack"
+    assert "files.upload" in files_entry["capabilities_provided"]
+    assert "files.read" in files_entry["capabilities_provided"]
+    assert "files.delete" in files_entry["capabilities_provided"]
+
+
+# ---------------------------------------------------------------------------
+# No wrong module names generated
+# ---------------------------------------------------------------------------
+
+def test_files_pack_does_not_generate_wrong_module_names() -> None:
+    """Module must be named 'files', not storage, media, or uploads."""
+    generated_paths = {
+        str(path.relative_to(TEMPLATES)).replace("\\", "/")
+        for path in TEMPLATES.rglob("*")
+        if path.is_file()
+    }
+    assert not any(p.startswith("modules/storage/") for p in generated_paths), (
+        "modules/storage/ is a forbidden output — module must be named 'files'"
+    )
+    assert not any(p.startswith("modules/media/") for p in generated_paths), (
+        "modules/media/ is a forbidden output — module must be named 'files'"
+    )
+    assert not any(p.startswith("modules/uploads/") for p in generated_paths), (
+        "modules/uploads/ is a forbidden output — module must be named 'files'"
+    )


### PR DESCRIPTION
## Summary

Fills the gap where `capability_routing.yaml` referenced a `files` operator_pack but had no corresponding build context directory.

- New `factory_app/build_context/files/` with full contract + templates
- **Module**: `files` with 4 actions — `upload_file`, `get_file`, `list_files`, `delete_file` (soft-delete)
- **Metadata-only pattern**: module stores file metadata (filename, mime_type, size_bytes, storage_url as opaque URL, is_public, created_by). Actual blob storage belongs in `services/adapters/storage/{provider}.py`
- **GDPR**: `user_data_scope: true` + `account_data_handler.py` with `delete_user_data` / `export_user_data` for `files.records`
- **Events**: `domain.files.file_uploaded` + `domain.files.file_deleted` via `ctx.emit()` in service.py
- **Persistence**: `ctx.persistence.collection("files", entity_name)` — no Motor, no `ctx.db`
- **base_handler/handler split** following the reference implementation contract
- **Capability directory**: adds `files_pack` entry to `AppGenerator/capability_directory.yaml`
- **17 contract tests** covering registration, required/forbidden outputs, module actions, capability alignment, user_data_scope, GDPR handler, migration alias, backend compile, persistence pattern, event emission, notification contract, capability_directory wiring, no forbidden module paths

## Test plan

- [ ] `pytest tests/test_build_context_files_pack.py` — 17 passed
- [ ] `pytest tests/test_factory_build_context_contract.py` — all passed (no regressions from context.yaml structure rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)