### PR TITLE
feat(build-context): add notifications capability pack contract

### DIFF
--- a/factory_app/build_context/AppGenerator/capability_directory.yaml
+++ b/factory_app/build_context/AppGenerator/capability_directory.yaml
@@ -276,3 +276,44 @@ capabilities:
       - files.upload
       - files.read
       - files.delete
+
+  - id: notifications_pack
+    label: External Notification Delivery
+    capability_kind: operator_pack
+    recommendation_rank: 4
+    domains:
+      - notifications
+      - email
+      - push
+      - sms
+      - alerts
+    capabilities_provided:
+      - notifications.email.send
+      - notifications.push.send
+      - notifications.preferences.read
+      - notifications.preferences.write
+    intent_signals:
+      - App delivers email alerts, push notifications, or SMS messages to users.
+      - Users need to opt in or out of notification channels.
+      - Domain events should trigger transactional email or mobile push delivery.
+    selection_aliases:
+      - notifications
+      - email notifications
+      - push notifications
+      - sms notifications
+      - transactional email
+      - mobile push
+      - email delivery
+      - external notifications
+    generator_notes:
+      - Generate the notification_settings facade module for user preferences and a provider-neutral adapter stub under services/adapters/notifications/.
+      - Do not re-implement in-app notification storage or websocket delivery — the runtime handles those via contracts/notifications.yaml on event-producing modules.
+      - Do not embed provider SDK calls in module service.py — delivery mechanics belong in services/adapters/notifications/{channel}.py.
+      - Generated adapter stubs must not include credential values — load from env vars (EMAIL_API_KEY, FCM_SERVER_KEY, etc.).
+    alternatives:
+      - id: managed_notification_platform
+        capability_kind: managed_capability
+        use_when: User brings a managed notification platform (Courier, Knock, Novu) with its own delivery API.
+        generator_notes:
+          - Generate a thin services/integrations/{platform}_client.py and a notification_settings facade module only.
+          - Do not generate provider adapter stubs — the managed platform owns delivery.

--- a/factory_app/build_context/notifications/context.yaml
+++ b/factory_app/build_context/notifications/context.yaml
@@ -1,0 +1,19 @@
+context_id: notifications
+applies_to_workflows:
+  - AppGenerator
+assets:
+  - path: contract.yaml
+    kind: contract
+pack:
+  id: notifications
+  status: active
+  capability_source: generated_module
+capabilities:
+  - capability_id: notifications.email.send
+    facade_recommended: notification_settings
+  - capability_id: notifications.push.send
+    facade_recommended: notification_settings
+  - capability_id: notifications.preferences.read
+    facade_recommended: notification_settings
+  - capability_id: notifications.preferences.write
+    facade_recommended: notification_settings

--- a/factory_app/build_context/notifications/contract.yaml
+++ b/factory_app/build_context/notifications/contract.yaml
@@ -1,0 +1,183 @@
+contract_id: notifications
+contract_type: build_pack_instructions
+
+# The notifications operator_pack is for EXTERNAL notification delivery
+# (email, push, SMS) beyond the runtime in-app notification record.
+#
+# The runtime already provides in-app notification storage and websocket
+# delivery — modules declare these in contracts/notifications.yaml on the
+# event-producing module. Select this pack only when the app must deliver
+# domain-event alerts through a provider-backed external channel.
+#
+# Generated outputs are all owner: generator because external delivery
+# adapters are highly provider-specific and must be customized per-app.
+# AppGenerator generates provider-neutral stubs; operators fill in their
+# chosen provider (SendGrid, AWS SES, Firebase, Twilio, etc.).
+
+selection_rules:
+  - id: select_for_external_delivery
+    when:
+      intent_any:
+        - email notifications
+        - push notifications
+        - sms notifications
+        - email alerts
+        - email delivery
+        - transactional email
+        - push alerts
+        - mobile push
+        - text message alerts
+        - external notification delivery
+    action: select_pack
+  - id: confirm_for_generic_notifications
+    when:
+      intent_any:
+        - notifications
+        - alerts
+        - in-app notifications
+        - notification center
+    action: require_explicit_user_confirmation
+
+recommended_domains:
+  - saas
+  - community
+  - marketplace
+  - social
+  - ecommerce
+
+avoid_when:
+  - App only needs in-app alerts and notification center — declare contracts/notifications.yaml on the event-producing module instead.
+  - App uses a managed notification platform that handles external delivery — use that platform's client as a managed_capability or service integration.
+
+# All required outputs are owner: generator because external delivery adapters
+# are provider-specific and must be customized per deployment target.
+# AppGenerator produces provider-neutral stubs. Operators select their
+# provider and fill in credentials + API calls in the adapter.
+required_outputs:
+  - path: modules/notification_settings/module.yaml
+    owner: generator
+    notes: >
+      User-facing notification preference module. Actions:
+      get_notification_preferences (reads user opt-ins for email, push, sms),
+      update_notification_preferences (sets per-channel opt-in).
+      user_data_scope: true. No entitlement_gate — all users may manage
+      their own preferences.
+
+  - path: modules/notification_settings/backend/handler.py
+    owner: workspace
+    notes: Preserved across regeneration. Thin dispatch only.
+
+  - path: modules/notification_settings/backend/service.py
+    owner: generator
+
+  - path: modules/notification_settings/backend/repo.py
+    owner: generator
+    notes: Persists preference records to notifications.preferences data alias.
+
+  - path: modules/notification_settings/backend/schemas.py
+    owner: generator
+    notes: NotificationPreferences typed shape with per-channel opt-in booleans.
+
+  - path: modules/notification_settings/contracts/reactions.yaml
+    owner: generator
+    notes: >
+      Observes domain events declared as external-delivery targets and
+      routes them to the channel-appropriate adapter. One reaction per
+      event type that should trigger external delivery.
+
+  - path: services/adapters/notifications/email.py
+    owner: generator
+    notes: >
+      Provider-neutral email adapter stub. Declares send_email(to, subject, body, template_id).
+      Operators replace the stub body with their chosen provider SDK (SendGrid,
+      AWS SES, Postmark, Mailgun). No provider credentials committed.
+
+  - path: services/adapters/notifications/push.py
+    owner: generator
+    notes: >
+      Provider-neutral push adapter stub. Declares send_push(token, title, body, data).
+      Operators fill in their chosen push provider (Firebase FCM, APNs, OneSignal).
+
+  - path: data/migrations/001_notification_preferences_collection.json
+    owner: generator
+    notes: >
+      Declares notifications.preferences data alias for the notification_settings
+      module. Does NOT create notification delivery log collections — those belong
+      in the external provider.
+
+forbidden_outputs:
+  - path_prefix: modules/notifications/
+    reason: >
+      The module must be named notification_settings (user preferences), not notifications.
+      The runtime already owns in-app notification delivery under the notifications namespace.
+  - path_prefix: services/notification_delivery/
+    reason: External delivery mechanics belong in services/adapters/notifications/ only.
+  - path_prefix: modules/notification_delivery/
+    reason: Delivery logic belongs in service adapters, not a separate module.
+  - path_prefix: services/email/
+    reason: Email mechanics belong in services/adapters/notifications/email.py.
+  - path_prefix: services/push/
+    reason: Push mechanics belong in services/adapters/notifications/push.py.
+
+runtime_boundaries:
+  - id: no_duplicate_in_app_channel
+    rule: >
+      Do not re-implement in-app notification storage or websocket delivery.
+      The runtime provides these. Generated code must not create a custom
+      notification repo, custom websocket worker, or custom notification center.
+      In-app alerts are declared in contracts/notifications.yaml on the
+      event-producing module and handled by the runtime.
+
+  - id: adapter_pattern_only
+    rule: >
+      External delivery mechanics live in services/adapters/notifications/{channel}.py.
+      The notification_settings module calls these adapters from reactions; it does not
+      embed provider SDK calls directly in service.py.
+
+  - id: preferences_are_user_data
+    rule: >
+      Notification preferences (email opt-in, push opt-in, sms opt-in) are
+      user-owned PII. notification_settings module must declare user_data_scope: true
+      and generate backend/account_data_handler.py.
+
+  - id: no_credentials_in_adapters
+    rule: >
+      Generated adapter stubs must not include provider API keys, secrets,
+      or credential values. Credentials are loaded from env vars
+      (EMAIL_API_KEY, FCM_SERVER_KEY, etc.) at adapter initialization.
+      env.example must list required credential names.
+
+  - id: reactions_not_service_calls
+    rule: >
+      External delivery is triggered by reactions in contracts/reactions.yaml
+      that observe well-known domain events. Service.py must not poll for
+      events or call delivery adapters on every action — reactions decouple
+      delivery from module business logic.
+
+  - id: provider_neutral_interface
+    rule: >
+      Adapter methods (send_email, send_push) must accept only provider-neutral
+      arguments (to, subject, body, data). Provider SDK details are encapsulated
+      in the adapter. Generated service code depends only on the adapter interface,
+      not on a specific SDK.
+
+facades: []
+
+cross_pack_integrations:
+  - pack_id: messaging
+    description: >
+      When the messaging pack is selected alongside notifications, message_sent
+      events may trigger email or push delivery for offline participants.
+      The messaging module's contracts/notifications.yaml covers in-app delivery;
+      the notification_settings reactions.yaml covers external delivery for
+      the same events.
+  - pack_id: social
+    description: >
+      Friend request accepted, post liked, and comment received events may trigger
+      push notifications. Social pack reactions are the source; notification_settings
+      reactions route to the external adapter.
+  - pack_id: commerce
+    description: >
+      Order placed, shipped, and delivered events are common transactional email
+      triggers. Commerce reactions are the source; notification_settings routes
+      domain.commerce.* events to the email adapter.

--- a/tests/test_build_context_notifications_pack.py
+++ b/tests/test_build_context_notifications_pack.py
@@ -1,0 +1,307 @@
+"""Contract tests for the notifications build context pack.
+
+This pack is for EXTERNAL notification delivery (email, push, SMS) beyond the
+runtime in-app notification record. It is a contract-first pack: all required
+outputs are owner: generator (provider-neutral stubs produced at build time)
+with no pre-built templates, because external delivery adapters are highly
+provider-specific.
+
+Verifies that:
+- context.yaml registers the pack as generated_module for AppGenerator
+- context.yaml declares 4 capabilities (email.send, push.send, preferences.read/write)
+- No templates/ directory ships (all output is generator-produced)
+- contract.yaml required_outputs are all generator-owned
+- Forbidden outputs prevent namespace collision with the runtime in-app channel
+- 6 runtime boundaries cover: no duplicate in-app channel, adapter pattern,
+  preferences as user data, no credentials in adapters, reactions-not-service-calls,
+  provider-neutral interface
+- avoid_when is documented
+- Cross-pack integrations declared (messaging, social, commerce)
+- AppGenerator capability_directory has notifications_pack entry
+- capability_directory entry has an alternative for managed notification platforms
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+BUILD_CONTEXT = WORKSPACE / "factory_app" / "build_context"
+NOTIFICATIONS = BUILD_CONTEXT / "notifications"
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Pack registration
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_context_registers_active_appgenerator_pack() -> None:
+    context = _read_yaml(NOTIFICATIONS / "context.yaml")
+
+    assert context["context_id"] == "notifications"
+    assert "AppGenerator" in context["applies_to_workflows"]
+    assert context["pack"]["id"] == "notifications"
+    assert context["pack"]["status"] == "active"
+    assert context["pack"]["capability_source"] == "generated_module"
+
+
+def test_notifications_context_declares_four_capabilities() -> None:
+    context = _read_yaml(NOTIFICATIONS / "context.yaml")
+    capability_ids = {cap["capability_id"] for cap in (context.get("capabilities") or [])}
+
+    assert capability_ids == {
+        "notifications.email.send",
+        "notifications.push.send",
+        "notifications.preferences.read",
+        "notifications.preferences.write",
+    }
+
+
+def test_notifications_context_capabilities_recommend_notification_settings_facade() -> None:
+    context = _read_yaml(NOTIFICATIONS / "context.yaml")
+    for cap in (context.get("capabilities") or []):
+        assert cap.get("facade_recommended") == "notification_settings", (
+            f"capability {cap['capability_id']} must recommend notification_settings facade"
+        )
+
+
+def test_notifications_context_declares_no_facades_at_pack_level() -> None:
+    """notification_settings is a generated module, not a managed facade."""
+    context = _read_yaml(NOTIFICATIONS / "context.yaml")
+    # facades field not expected at context level for generated_module packs
+    assert "facades" not in context or not context.get("facades"), (
+        "notifications context.yaml must not declare managed facades at pack level"
+    )
+
+
+# ---------------------------------------------------------------------------
+# No templates directory
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_pack_has_no_templates_directory() -> None:
+    """External delivery adapters are provider-specific — no pre-built templates ship."""
+    templates_dir = NOTIFICATIONS / "templates"
+    assert not templates_dir.exists(), (
+        "notifications pack must not ship a templates/ directory — "
+        "all output is generator-produced with provider-neutral stubs customized per deployment"
+    )
+
+
+def test_notifications_context_only_declares_contract_asset() -> None:
+    """Without templates, only the contract asset should be declared."""
+    context = _read_yaml(NOTIFICATIONS / "context.yaml")
+    asset_kinds = {asset["kind"] for asset in (context.get("assets") or [])}
+    assert asset_kinds == {"contract"}, (
+        "notifications context.yaml must only declare the contract asset (no templates)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract structure
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_contract_all_required_outputs_are_generator_owned() -> None:
+    """External delivery adapters are provider-specific — no fixed templates."""
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+
+    template_owned = [
+        output["path"]
+        for output in contract["required_outputs"]
+        if output.get("owner") == "templates"
+    ]
+    assert template_owned == [], (
+        f"notifications pack must have no template-owned outputs — "
+        f"all provider-specific adapters are generator-produced. Got: {template_owned}"
+    )
+
+
+def test_notifications_contract_required_outputs_include_preferences_module_and_adapters() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    output_paths = {output["path"] for output in contract["required_outputs"]}
+
+    assert "modules/notification_settings/module.yaml" in output_paths, (
+        "contract must declare notification_settings module — user preferences for external channels"
+    )
+    assert "services/adapters/notifications/email.py" in output_paths, (
+        "contract must declare email adapter stub"
+    )
+    assert "services/adapters/notifications/push.py" in output_paths, (
+        "contract must declare push adapter stub"
+    )
+
+
+def test_notifications_contract_declares_preferences_migration() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    output_paths = {output["path"] for output in contract["required_outputs"]}
+
+    assert any("migration" in p and "notification" in p for p in output_paths), (
+        "contract must declare a data migration for the notification preferences collection"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forbidden outputs
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_contract_forbids_wrong_module_name() -> None:
+    """Module must be named notification_settings, not notifications (runtime namespace collision)."""
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    forbidden_prefixes = {o.get("path_prefix") for o in (contract.get("forbidden_outputs") or [])}
+    assert "modules/notifications/" in forbidden_prefixes, (
+        "contract must forbid modules/notifications/ — runtime owns this namespace for in-app delivery"
+    )
+
+
+def test_notifications_contract_forbids_delivery_module() -> None:
+    """Delivery logic belongs in service adapters, not a separate module."""
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    forbidden_prefixes = {o.get("path_prefix") for o in (contract.get("forbidden_outputs") or [])}
+    assert "modules/notification_delivery/" in forbidden_prefixes
+
+
+def test_notifications_contract_forbids_wrong_adapter_paths() -> None:
+    """Adapters must live under services/adapters/notifications/, not services/email/ or services/push/."""
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    forbidden_prefixes = {o.get("path_prefix") for o in (contract.get("forbidden_outputs") or [])}
+    assert "services/email/" in forbidden_prefixes
+    assert "services/push/" in forbidden_prefixes
+
+
+# ---------------------------------------------------------------------------
+# Runtime boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_contract_runtime_boundary_no_duplicate_in_app_channel() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "no_duplicate_in_app_channel" in boundary_ids, (
+        "runtime_boundaries must declare no_duplicate_in_app_channel — "
+        "the runtime provides websocket and notification record; generated pack must not re-implement it"
+    )
+
+
+def test_notifications_contract_runtime_boundary_adapter_pattern() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "adapter_pattern_only" in boundary_ids, (
+        "runtime_boundaries must declare adapter_pattern_only — "
+        "provider SDK calls belong in services/adapters/notifications/, not in service.py"
+    )
+
+
+def test_notifications_contract_runtime_boundary_preferences_are_user_data() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "preferences_are_user_data" in boundary_ids, (
+        "runtime_boundaries must declare preferences_are_user_data — "
+        "opt-in preferences are user PII requiring account_data_handler.py"
+    )
+
+
+def test_notifications_contract_runtime_boundary_no_credentials() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "no_credentials_in_adapters" in boundary_ids, (
+        "runtime_boundaries must declare no_credentials_in_adapters — "
+        "API keys and secrets must come from env vars, never committed to source"
+    )
+
+
+def test_notifications_contract_runtime_boundary_reactions_not_service_calls() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "reactions_not_service_calls" in boundary_ids, (
+        "runtime_boundaries must declare reactions_not_service_calls — "
+        "external delivery is triggered by reactions observing domain events, not by service.py calls"
+    )
+
+
+def test_notifications_contract_runtime_boundary_provider_neutral_interface() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    boundary_ids = {b["id"] for b in (contract.get("runtime_boundaries") or [])}
+    assert "provider_neutral_interface" in boundary_ids, (
+        "runtime_boundaries must declare provider_neutral_interface — "
+        "adapters must accept provider-neutral args; SDK details are internal to the adapter"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Selection guidance
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_contract_declares_avoid_when() -> None:
+    """Pack must document when NOT to select it (in-app only → use contracts/notifications.yaml)."""
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    assert contract.get("avoid_when"), (
+        "contract.yaml must declare avoid_when — "
+        "important to distinguish from runtime in-app notifications which need no pack"
+    )
+    avoid_text = " ".join(str(a) for a in (contract.get("avoid_when") or []))
+    assert "contracts/notifications.yaml" in avoid_text or "in-app" in avoid_text, (
+        "avoid_when must explain that in-app alerts use contracts/notifications.yaml, not this pack"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-pack integrations
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_contract_declares_cross_pack_integrations() -> None:
+    contract = _read_yaml(NOTIFICATIONS / "contract.yaml")
+    integration_pack_ids = {
+        i["pack_id"] for i in (contract.get("cross_pack_integrations") or [])
+    }
+    assert "messaging" in integration_pack_ids, (
+        "contract must document integration with messaging — "
+        "message_sent events can trigger push/email for offline participants"
+    )
+    assert "commerce" in integration_pack_ids, (
+        "contract must document integration with commerce — "
+        "order events are common transactional email triggers"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AppGenerator wiring
+# ---------------------------------------------------------------------------
+
+
+def test_appgenerator_capability_directory_wires_notifications_as_operator_pack() -> None:
+    directory = _read_yaml(BUILD_CONTEXT / "AppGenerator" / "capability_directory.yaml")
+    by_id = {entry["id"]: entry for entry in directory["capabilities"]}
+
+    assert "notifications_pack" in by_id, "capability_directory must have 'notifications_pack' entry"
+    entry = by_id["notifications_pack"]
+    assert entry["capability_kind"] == "operator_pack"
+    assert "notifications" in entry.get("domains", [])
+
+
+def test_appgenerator_capability_directory_notifications_has_managed_platform_alternative() -> None:
+    """Apps using Courier/Knock/Novu should use a managed_capability alternative."""
+    directory = _read_yaml(BUILD_CONTEXT / "AppGenerator" / "capability_directory.yaml")
+    by_id = {entry["id"]: entry for entry in directory["capabilities"]}
+
+    entry = by_id["notifications_pack"]
+    alternatives = entry.get("alternatives") or []
+    alt_kinds = {a.get("capability_kind") for a in alternatives}
+    assert "managed_capability" in alt_kinds, (
+        "notifications_pack directory entry must declare a managed_capability alternative "
+        "for apps using a managed notification platform (Courier, Knock, Novu)"
+    )


### PR DESCRIPTION
## Summary

Fills the gap where `capability_routing.yaml` referenced a `notifications` operator_pack but had no corresponding build context.

Contract-first pack (no templates) — external delivery adapters (SendGrid, Firebase, Twilio, etc.) are provider-specific and must be customized per deployment. AppGenerator generates provider-neutral stubs at build time.

- **4 capabilities**: `notifications.email.send`, `notifications.push.send`, `notifications.preferences.read/write`
- **All `owner: generator`**: notification_settings module, `services/adapters/notifications/email.py` + `push.py`, preferences data migration
- **Forbidden paths**: `modules/notifications/` (runtime namespace), `modules/notification_delivery/`, `services/email/`, `services/push/`
- **6 runtime boundaries**: no_duplicate_in_app_channel (runtime owns websocket/in-app), adapter_pattern_only (SDK in adapters not service.py), preferences_are_user_data (user PII → account_data_handler.py), no_credentials_in_adapters (env vars only), reactions_not_service_calls (domain events → reactions → adapters), provider_neutral_interface
- **Cross-pack integrations**: messaging (offline push for DMs), social (activity notifications), commerce (transactional order email)
- **capability_directory**: adds `notifications_pack` with `managed_capability` alternative for Courier/Knock/Novu
- **22 contract tests** — all passing

## Test plan

- [ ] `pytest tests/test_build_context_notifications_pack.py` — 22 passed
- [ ] `pytest tests/test_factory_build_context_contract.py` — 17 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)