### PR TITLE
feat(app-intelligence): add AppIntelligenceInlineBrief to ExistingAppDiscovery chat feed

### DIFF
--- a/chat-ui/src/@chat-workflows/index.js
+++ b/chat-ui/src/@chat-workflows/index.js
@@ -80,10 +80,12 @@ export const initializeWorkflows = async (registerComponent) => {
       const namespacedComponentName = `${workflowName}:${componentName}`;
       registerComponent(namespacedComponentName, component, {
         description: `${workflowName} workflow component (namespaced)`,
+        override: true,
       });
       // Plain registration is retained for route/transition components and developer ergonomics.
       registerComponent(componentName, component, {
         description: `${workflowName} workflow component`,
+        override: true,
       });
     }
   }

--- a/chat-ui/src/pages/ChatPage.js
+++ b/chat-ui/src/pages/ChatPage.js
@@ -1516,7 +1516,7 @@ const ChatPage = () => {
       if (debugFlag('mozaiks.debug_pipeline')) console.warn('[PIPELINE] failed to unwrap nested envelope', e);
     }
     
-    if (!data.type.startsWith('chat.') && data.type !== 'unknown') return;
+    if (!data.type.startsWith('chat.') && !data.type.startsWith('ui.') && data.type !== 'unknown') return;
 
     // Some events may arrive already as { type:'chat.text', data:{ ...actualFields... } } (no double-serialization)
     // or after the above unwrap we can still retain an inner data object we need to promote.
@@ -1544,7 +1544,7 @@ const ChatPage = () => {
         if (inner.structured_output !== undefined && data.structured_output === undefined) data.structured_output = inner.structured_output;
         if (inner.structured_schema !== undefined && data.structured_schema === undefined) data.structured_schema = inner.structured_schema;
         // UI tool / component hints (input_request etc.) + error messages
-        ['component_type','tool_name','tool_call_id','request_id','progress_percent','prompt','success','interaction_type','status','corr','call_id','payload','message','error_code','ui_visibility','trace_reason','trace_agent','sequence','stream_id','full_content','metadata','role','replay','index','timestamp'].forEach(f => {
+        ['component_type','tool_name','tool_call_id','request_id','progress_percent','prompt','success','interaction_type','activity_type','status','status_message','workflow_name','corr','call_id','payload','message','error_code','ui_visibility','trace_reason','trace_agent','sequence','stream_id','full_content','metadata','role','replay','index','timestamp'].forEach(f => {
           if (inner[f] !== undefined && data[f] === undefined) data[f] = inner[f];
         });
       }
@@ -2503,6 +2503,14 @@ const ChatPage = () => {
         const activityMessage = data.message
           || `${activityAgent} is working in the background.`;
         const activityKey = `${activityType}:${activityAgent}`;
+        const normalizedActivityStatus = String(activityStatus || '').trim().toLowerCase();
+        const activityCompleteStatuses = ['complete', 'completed', 'ready', 'success', 'succeeded', 'done'];
+        const activityFailedStatuses = ['failed', 'error', 'unavailable'];
+        const activityIcon = activityCompleteStatuses.includes(normalizedActivityStatus)
+          ? '✓'
+          : activityFailedStatuses.includes(normalizedActivityStatus)
+            ? '⚠'
+            : '⏳';
         if (showInitSpinner) {
           setShowInitSpinner(false);
           initSpinnerHiddenOnceRef.current = true;
@@ -2516,7 +2524,7 @@ const ChatPage = () => {
               : `activity-${Date.now()}`,
             sender: 'system',
             agentName: 'System',
-            content: `⏳ ${activityMessage}`,
+            content: `${activityIcon} ${activityMessage}`,
             isStreaming: false,
             metadata: {
               event_type: 'activity',
@@ -2524,6 +2532,7 @@ const ChatPage = () => {
               activity_status: activityStatus,
               activity_agent: activityAgent,
               activity_key: activityKey,
+              progress_percent: data.progress_percent,
               workflow_name: data.workflow_name || currentWorkflowName || null,
             },
           };
@@ -2541,22 +2550,32 @@ const ChatPage = () => {
       }
       case 'tool_progress': {
         // Update or append progress for a long-running tool
-        const progress = data.progress_percent;
+        const progress = Number(data.progress_percent || 0);
         const tool = data.tool_name || 'tool';
-        if (!showSystemMessages) {
+        const userVisibleToolProgress = (
+          tool === 'App Intelligence'
+          || tool === 'app_intelligence'
+          || data.ui_visibility === 'user'
+          || data.metadata?.ui_visibility === 'user'
+        );
+        if (!showSystemMessages && !userVisibleToolProgress) {
           return;
         }
+        const statusText = data.status_message || data.message || `${tool} progress`;
+        const progressComplete = progress >= 100 || ['complete', 'completed', 'ready', 'success', 'succeeded'].includes(String(data.status || '').toLowerCase());
+        const progressIcon = progressComplete ? '✓' : '⏳';
+        const progressContent = `${progressIcon} ${statusText}${Number.isFinite(progress) ? ` (${Math.round(progress)}%)` : ''}`;
         setMessagesWithLogging(prev => {
           const updated = [...prev];
           for (let i = updated.length - 1; i >=0; i--) {
             const m = updated[i];
-            if (m.metadata && m.metadata.event_type === 'tool_call' && m.metadata.tool_name === tool) {
-              m.content = `🔧 ${tool} progress: ${progress}%`;
+            if (m.metadata && m.metadata.event_type === 'tool_progress' && m.metadata.tool_name === tool) {
+              m.content = progressContent;
               m.metadata.progress_percent = progress;
               return updated;
             }
           }
-          updated.push({ id:`tool-progress-${Date.now()}`, sender:'system', agentName:'System', content:`🔧 ${tool} progress: ${progress}%`, isStreaming:false, metadata:{ event_type:'tool_progress', tool_name: tool, progress_percent: progress }});
+          updated.push({ id:`tool-progress-${Date.now()}`, sender:'system', agentName:'System', content: progressContent, isStreaming:false, metadata:{ event_type:'tool_progress', tool_name: tool, progress_percent: progress }});
           return updated;
         });
         return;

--- a/docs/architecture/foundations/app-intelligence-plane.md
+++ b/docs/architecture/foundations/app-intelligence-plane.md
@@ -145,7 +145,11 @@ operator validation override that is recorded in artifact metadata.
 
 ## Studio Surface
 
-Studio must show a visible App Intelligence panel before source-editing work:
+Studio must show visible App Intelligence state before source-editing work.
+Workflow startup emits a chat-feed activity row such as "Obtaining app
+context..." and updates it through ready or failed. When indexing completes,
+the workflow emits a compact inline App Intelligence brief into the chat feed
+and keeps the detailed App Intelligence overview in the artifact panel.
 
 - readiness: missing, queued, indexing, ready, stale, degraded, or failed
 - current indexing phase and progress
@@ -156,7 +160,9 @@ Studio must show a visible App Intelligence panel before source-editing work:
 - validation commands available to the refinement harness
 - warnings from scan, parser, graph, health, and stale-context checks
 
-This makes indexing a visible transition state instead of a silent chat delay.
+This makes indexing a visible transition state instead of a silent chat delay
+or a side-panel-only flash, and it leaves a durable transcript record of what
+agents could see before they edited or advised on the app.
 
 ## Workflow Journey
 

--- a/docs/architecture/foundations/app-intelligence-user-journey.md
+++ b/docs/architecture/foundations/app-intelligence-user-journey.md
@@ -86,6 +86,14 @@ Studio shows a source-context panel before edit-heavy workflows proceed:
 This panel is not documentation text inside the build workflow. It is the
 operational status of the app context that agents can use.
 
+During Existing App Discovery startup, Studio must also show a chat-feed status
+row while App Intelligence is indexing. The status row updates from obtaining
+context to ready or failed so the user is not left on a blank chat while source
+selection, parsing, graph build, and snapshot synthesis run. After the ready
+state, Studio emits an inline App Intelligence brief in the chat transcript and
+the full overview in the artifact panel so the user can see the context agents
+received.
+
 ## Generate Or Refine
 
 Once the current context is ready, AppGenerator, AgentGenerator, existing-app

--- a/factory_app/workflows/ExistingAppDiscovery/tools.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/tools.yaml
@@ -1,9 +1,11 @@
 # ExistingAppDiscovery Tools
 #
 # before_chat collector builds deterministic App Intelligence context.
-# ExistingAppDiscovery first emits an AppIntelligenceOverviewCard so users can
-# see the compact context agents receive, then the DiscoveryArtifactAssemblerAgent
-# persists canonical artifacts and emits the final DiscoveryBriefCard.
+# ExistingAppDiscovery emits a durable inline AppIntelligenceInlineBrief in the
+# chat feed and the full AppIntelligenceOverviewCard in the artifact panel so
+# users can see the compact context agents receive before the agent speaks.
+# DiscoveryArtifactAssemblerAgent later persists canonical artifacts and emits
+# the final DiscoveryBriefCard.
 
 tools:
 - agent: DiscoveryHostAgent
@@ -139,10 +141,23 @@ lifecycle_tools:
 - trigger: before_chat
   agent: null
   file: emit_app_intelligence_overview.py
+  function: emit_app_intelligence_inline_brief
+  description: >
+    Show the compact App Intelligence brief inline in chat after indexing and
+    before the agent speaks.
+  tool_type: UI_Surface
+  ui:
+    component: AppIntelligenceInlineBrief
+    mode: inline
+    workflow_primitive: document_preview
+    realization: generated_component
+- trigger: before_chat
+  agent: null
+  file: emit_app_intelligence_overview.py
   function: emit_app_intelligence_overview_card
   description: >
-    Show the deterministic App Intelligence overview after indexing and before
-    the agent speaks.
+    Show the deterministic App Intelligence overview in the artifact panel
+    after indexing and before the agent speaks.
   tool_type: UI_Surface
   ui:
     component: AppIntelligenceOverviewCard

--- a/factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py
@@ -37,7 +37,7 @@ async def emit_app_intelligence_overview_card(
     context_variables: Any | None = None,
     **_: Any,
 ) -> dict[str, Any]:
-    """Show the user the compact context available to discovery agents."""
+    """Show the full App Intelligence artifact available to discovery agents."""
     ctx = context_variables if context_variables is not None else {}
     preload_status = str(_ctx_get(ctx, "preload_status") or "none")
     catalog = _dict_value(_ctx_get(ctx, "app_intelligence_catalog"))
@@ -49,7 +49,7 @@ async def emit_app_intelligence_overview_card(
     chat_id = _ctx_get(ctx, "chat_id")
 
     try:
-        await emit_ui_surface(
+        event_id = await emit_ui_surface(
             "AppIntelligenceOverviewCard",
             payload,
             chat_id=str(chat_id) if chat_id else None,
@@ -70,6 +70,49 @@ async def emit_app_intelligence_overview_card(
         "success": True,
         "preload_status": preload_status,
         "app_intelligence_snapshot_id": payload.get("app_intelligence_snapshot_id"),
+        "ui_event_id": event_id if "event_id" in locals() else None,
+    }
+
+
+async def emit_app_intelligence_inline_brief(
+    context_variables: Any | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    """Show a durable compact App Intelligence brief in the chat transcript."""
+    ctx = context_variables if context_variables is not None else {}
+    preload_status = str(_ctx_get(ctx, "preload_status") or "none")
+    catalog = _dict_value(_ctx_get(ctx, "app_intelligence_catalog"))
+
+    if preload_status == "none" and not catalog:
+        return {"skipped": True, "reason": "no_app_intelligence_data"}
+
+    overview_payload = _overview_payload(ctx=ctx, preload_status=preload_status, catalog=catalog)
+    payload = _inline_brief_payload(overview_payload)
+    chat_id = _ctx_get(ctx, "chat_id")
+
+    try:
+        event_id = await emit_ui_surface(
+            "AppIntelligenceInlineBrief",
+            payload,
+            chat_id=str(chat_id) if chat_id else None,
+            workflow_name="ExistingAppDiscovery",
+            agent_name="App Intelligence",
+            display="inline",
+        )
+        logger.info(
+            "[ExistingAppDiscovery] App Intelligence inline brief emitted: status=%s app=%s files=%s",
+            preload_status,
+            payload.get("app_name") or payload.get("repo_name") or payload.get("github_repo") or "unknown",
+            ((payload.get("coverage") or {}).get("file_count") or 0),
+        )
+    except Exception as exc:
+        logger.warning("[ExistingAppDiscovery] App Intelligence inline brief emission failed: %s", exc)
+
+    return {
+        "success": True,
+        "preload_status": preload_status,
+        "app_intelligence_snapshot_id": payload.get("app_intelligence_snapshot_id"),
+        "ui_event_id": event_id if "event_id" in locals() else None,
     }
 
 
@@ -134,6 +177,134 @@ def _overview_payload(*, ctx: Any, preload_status: str, catalog: dict[str, Any])
             ]
         )[:12],
     }
+
+
+def _inline_brief_payload(overview_payload: dict[str, Any]) -> dict[str, Any]:
+    catalog = _dict_value(overview_payload.get("app_intelligence_catalog"))
+    coverage = _dict_value(catalog.get("coverage"))
+    architecture = _dict_value(catalog.get("architecture"))
+    warnings = _dedupe(
+        [
+            *_list_value(overview_payload.get("warnings")),
+            *_list_value(catalog.get("warnings")),
+        ]
+    )
+    source_refs = [
+        *_surface_samples(_list_value(architecture.get("module_roots")), limit=3),
+        *_surface_samples(_list_value(architecture.get("service_roots")), limit=2),
+        *_surface_samples(_list_value(architecture.get("ui_surfaces")), limit=3),
+        *_surface_samples(_list_value(architecture.get("workflow_roots")), limit=2),
+    ]
+    risk_hints = _list_value(catalog.get("risk_hints"))[:4]
+    capability_samples = _surface_samples(_list_value(catalog.get("capabilities")), limit=5)
+    app_name = (
+        str(
+            overview_payload.get("app_name")
+            or overview_payload.get("repo_name")
+            or overview_payload.get("github_repo")
+            or ""
+        ).strip()
+        or "Indexed app"
+    )
+
+    return {
+        "status": str(overview_payload.get("status") or "partial"),
+        "app_name": app_name,
+        "github_repo": str(overview_payload.get("github_repo") or "").strip(),
+        "repo_name": str(overview_payload.get("repo_name") or "").strip(),
+        "source": str(overview_payload.get("source") or "none").strip(),
+        "tech_stack": str(overview_payload.get("tech_stack") or "").strip(),
+        "summary": _inline_summary(
+            overview_payload=overview_payload,
+            coverage=coverage,
+            warning_count=len(warnings),
+        ),
+        "app_intelligence_snapshot_id": overview_payload.get("app_intelligence_snapshot_id"),
+        "current_app_context_version_id": overview_payload.get("current_app_context_version_id"),
+        "coverage": {
+            "file_count": int(coverage.get("file_count") or overview_payload.get("total_files_scanned") or 0),
+            "chunk_count": int(coverage.get("chunk_count") or 0),
+            "symbol_count": int(coverage.get("symbol_count") or 0),
+            "node_count": int(coverage.get("node_count") or 0),
+            "edge_count": int(coverage.get("edge_count") or 0),
+            "language_counts": _dict_value(coverage.get("language_counts")),
+            "role_counts": _dict_value(coverage.get("role_counts")),
+        },
+        "architecture": {
+            "module_count": len(_list_value(architecture.get("module_roots"))),
+            "service_count": len(_list_value(architecture.get("service_roots"))),
+            "ui_surface_count": len(_list_value(architecture.get("ui_surfaces"))),
+            "workflow_count": len(_list_value(architecture.get("workflow_roots"))),
+            "source_refs": _dedupe_surface_samples(source_refs)[:8],
+        },
+        "capabilities": capability_samples,
+        "integration_count": len(_list_value(catalog.get("integration_surfaces"))),
+        "data_surface_count": len(_list_value(catalog.get("data_surfaces"))),
+        "risk_hints": risk_hints,
+        "warnings": warnings[:4],
+    }
+
+
+def _inline_summary(
+    *,
+    overview_payload: dict[str, Any],
+    coverage: dict[str, Any],
+    warning_count: int,
+) -> str:
+    existing_summary = str(overview_payload.get("app_intelligence_summary") or "").strip()
+    if existing_summary:
+        return existing_summary
+
+    file_count = int(coverage.get("file_count") or overview_payload.get("total_files_scanned") or 0)
+    symbol_count = int(coverage.get("symbol_count") or 0)
+    edge_count = int(coverage.get("edge_count") or 0)
+    status = str(overview_payload.get("status") or "partial")
+    warning_clause = f" with {warning_count} warning(s)" if warning_count else ""
+    return (
+        f"App Intelligence is {status}: indexed {file_count} file(s), "
+        f"{symbol_count} symbol(s), and {edge_count} relationship(s){warning_clause}."
+    )
+
+
+def _surface_samples(items: list[Any], *, limit: int) -> list[dict[str, str]]:
+    samples: list[dict[str, str]] = []
+    for item in items:
+        if isinstance(item, str):
+            label = item.strip()
+            detail = ""
+        elif isinstance(item, dict):
+            label = str(
+                item.get("label")
+                or item.get("capability_id")
+                or item.get("module_id")
+                or item.get("service_id")
+                or item.get("workflow_id")
+                or item.get("path")
+                or item.get("root")
+                or ""
+            ).strip()
+            paths = _list_value(item.get("paths"))
+            detail = str(item.get("path") or (paths[0] if paths else "") or "").strip()
+        else:
+            continue
+        if not label:
+            continue
+        samples.append({"label": label, "detail": detail})
+        if len(samples) >= limit:
+            break
+    return samples
+
+
+def _dedupe_surface_samples(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, str]] = []
+    for item in items:
+        label = str(item.get("label") or "").strip()
+        if not label or label in seen:
+            continue
+        seen.add(label)
+        deduped.append(item)
+    return deduped
 
 
 def _overview_status(*, ctx: Any, preload_status: str, catalog: dict[str, Any]) -> str:
@@ -270,4 +441,4 @@ def _dedupe(values: list[Any]) -> list[str]:
     return out
 
 
-__all__ = ["emit_app_intelligence_overview_card"]
+__all__ = ["emit_app_intelligence_inline_brief", "emit_app_intelligence_overview_card"]

--- a/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
@@ -332,6 +332,67 @@ def _default_app_intelligence_progress_message(stage: str) -> str:
     }.get(stage, "Updating App Intelligence status.")
 
 
+def _app_intelligence_activity_status(progress: dict[str, Any]) -> str:
+    status = str(progress.get("status") or "").strip().lower()
+    stage = str(progress.get("stage") or "").strip().lower()
+    if status in {"ready"} or stage in {"ready"}:
+        return "complete"
+    if status in {"failed", "unavailable"} or stage in {"failed", "unavailable"}:
+        return "failed"
+    if status in {"partial"} or stage in {"partial"}:
+        return "complete"
+    return "working"
+
+
+def _app_intelligence_activity_message(progress: dict[str, Any]) -> str:
+    status = str(progress.get("status") or "").strip().lower()
+    stage = str(progress.get("stage") or "").strip().lower()
+    percent = int(progress.get("percent") or 0)
+    message = str(progress.get("message") or "").strip()
+    if status == "ready" or stage == "ready":
+        return "App context ready. Starting the discovery agent."
+    if status == "partial" or stage == "partial":
+        return "App context is partially ready. The discovery agent may ask follow-up questions."
+    if status in {"failed", "unavailable"} or stage in {"failed", "unavailable"}:
+        return message or "App context could not be fully indexed."
+    return f"Obtaining app context... {message or 'Indexing repository evidence.'} ({percent}%)"
+
+
+async def _emit_app_intelligence_activity(context_variables: Any) -> dict[str, Any]:
+    progress = _coerce_mapping(_ctx_get(context_variables, "app_intelligence_progress"))
+    chat_id = str(_ctx_get(context_variables, "chat_id") or "").strip()
+    if not chat_id:
+        return {"skipped": True, "reason": "missing_chat_id"}
+    if not progress:
+        return {"skipped": True, "reason": "missing_app_intelligence_progress"}
+
+    activity_status = _app_intelligence_activity_status(progress)
+    event = {
+        "kind": "activity",
+        "activity_type": "app_intelligence_indexing",
+        "agent": "App Intelligence",
+        "agent_name": "App Intelligence",
+        "status": activity_status,
+        "message": _app_intelligence_activity_message(progress),
+        "workflow_name": "ExistingAppDiscovery",
+        "progress_percent": progress.get("percent"),
+        "metadata": {
+            "source": "existing_app_discovery_preload",
+            "progress_stage": progress.get("stage"),
+            "progress_status": progress.get("status"),
+        },
+    }
+    try:
+        from mozaiksai.core.transport.simple_transport import SimpleTransport
+
+        transport = await SimpleTransport.get_instance()
+        await transport.send_event_to_ui(event, chat_id)
+        return {"success": True, "status": activity_status, "stage": progress.get("stage")}
+    except Exception as exc:
+        logger.debug("[ExistingAppDiscovery] App Intelligence activity emission failed: %s", exc)
+        return {"skipped": True, "reason": "activity_emit_failed", "error": str(exc)}
+
+
 def _coerce_mapping(value: Any) -> dict[str, Any]:
     if value is None:
         return {}
@@ -1325,12 +1386,15 @@ async def _preload_context_graph_pack(
             "github_source_count": len(github_sources or []),
         },
     )
+    await _emit_app_intelligence_activity(context_variables)
     if not roots and not github_sources:
-        return await _preload_prior_context_graph_pack(
+        result = await _preload_prior_context_graph_pack(
             context_variables=context_variables,
             discovery_inputs=discovery_inputs,
             unavailable_reason="no_local_source_roots",
         )
+        await _emit_app_intelligence_activity(context_variables)
+        return result
 
     try:
         from factory_app.workflows._shared.context_graph.prompt_pack import (
@@ -1378,6 +1442,7 @@ async def _preload_context_graph_pack(
             details=health,
             warnings=[warning],
         )
+        await _emit_app_intelligence_activity(context_variables)
         return {"present": False, "reason": "context_graph_import_failed", "warnings": [warning]}
 
     scan_policy_inputs = _context_graph_scan_policy_inputs(context_variables, discovery_inputs)
@@ -1418,6 +1483,7 @@ async def _preload_context_graph_pack(
             details=dict(scan_result.health),
             warnings=warnings,
         )
+        await _emit_app_intelligence_activity(context_variables)
         return {"present": False, "reason": "no_supported_source_files", "warnings": warnings}
 
     app_id = str(
@@ -1444,6 +1510,7 @@ async def _preload_context_graph_pack(
         },
         warnings=warnings,
     )
+    await _emit_app_intelligence_activity(context_variables)
     indexed_at = datetime.now(UTC)
     source_ref = _build_preload_source_ref(
         app_id=app_id,
@@ -1474,6 +1541,7 @@ async def _preload_context_graph_pack(
         },
         warnings=warnings,
     )
+    await _emit_app_intelligence_activity(context_variables)
     source_corpus = source_index.source_corpus
     app_intelligence_snapshot = source_index.app_intelligence_snapshot
     source_file_map = source_index.safe_file_map
@@ -1541,6 +1609,7 @@ async def _preload_context_graph_pack(
         },
         warnings=warnings,
     )
+    await _emit_app_intelligence_activity(context_variables)
     return {
         "present": True,
         "source": "existing_app_discovery_preload",
@@ -1725,6 +1794,7 @@ async def _preload_prior_context_graph_pack(
         },
         warnings=combined_warnings,
     )
+    await _emit_app_intelligence_activity(context_variables)
     return {
         "present": True,
         "source": "previous_app_context_graph",
@@ -2301,6 +2371,7 @@ async def collect_prechat_discovery_context(context_variables: Any | None = None
         "resolving_sources",
         details={"host_app_source": host_app_source, "discovery_mode": discovery_mode},
     )
+    await _emit_app_intelligence_activity(ctx)
 
     repo_path = _first_nonempty(_ctx_get(ctx, "repo_path"), discovery_inputs.get("repo_path"))
     frontend_repo_path = _first_nonempty(_ctx_get(ctx, "frontend_repo_path"), discovery_inputs.get("frontend_repo_path"))
@@ -2358,6 +2429,7 @@ async def collect_prechat_discovery_context(context_variables: Any | None = None
             "has_api_input": bool(backend_base_url or openapi_url or uploaded_openapi_path),
         },
     )
+    await _emit_app_intelligence_activity(ctx)
 
     if frontend_repo_path or frontend_github_repo:
         frontend_repo_summary = await _scan_repo_source(frontend_repo_path, frontend_github_repo, github_ref, github_token=github_token)

--- a/factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceInlineBrief.jsx
+++ b/factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceInlineBrief.jsx
@@ -1,0 +1,186 @@
+/**
+ * AppIntelligenceInlineBrief - compact App Intelligence result in the chat feed.
+ *
+ * This is the durable transcript companion to AppIntelligenceOverviewCard. It
+ * shows the prompt-safe context summary without exposing raw source contents.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  FileCode2,
+  GitBranch,
+  Network,
+} from 'lucide-react';
+
+const EMPTY_ARRAY = Object.freeze([]);
+const EMPTY_OBJECT = Object.freeze({});
+
+const STATUS_STYLES = {
+  ready: 'border-success/25 bg-success/10 text-success',
+  partial: 'border-warning/30 bg-warning/10 text-warning',
+  none: 'border-border bg-muted/45 text-muted-foreground',
+};
+
+function asArray(value) {
+  return Array.isArray(value) ? value : EMPTY_ARRAY;
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : EMPTY_OBJECT;
+}
+
+function formatCount(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? number.toLocaleString() : '0';
+}
+
+function labelize(value) {
+  return String(value || '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function splitTechStack(value) {
+  if (Array.isArray(value)) return value.filter(Boolean).slice(0, 6);
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+function firstLabel(item) {
+  if (typeof item === 'string') return item;
+  if (!item || typeof item !== 'object') return '';
+  return (
+    item.label ||
+    item.capability_id ||
+    item.module_id ||
+    item.service_id ||
+    item.workflow_id ||
+    item.path ||
+    item.root ||
+    ''
+  );
+}
+
+function CountItem({ icon: Icon, label, value }) {
+  return (
+    <div className="min-w-0 border-l border-border/60 pl-3 first:border-l-0 first:pl-0">
+      <div className="flex items-center gap-1.5 text-muted-foreground">
+        <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate text-[11px] font-medium">{label}</span>
+      </div>
+      <p className="mt-1 text-base font-semibold tabular-nums text-foreground">{formatCount(value)}</p>
+    </div>
+  );
+}
+
+function ChipRow({ label, items, emptyLabel }) {
+  const visible = asArray(items).map(firstLabel).filter(Boolean).slice(0, 5);
+  if (!visible.length && !emptyLabel) return null;
+  return (
+    <div className="min-w-0">
+      <p className="text-[11px] font-medium text-muted-foreground">{label}</p>
+      {visible.length > 0 ? (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {visible.map((item) => (
+            <span
+              key={item}
+              className="max-w-full truncate rounded-md border border-border/55 bg-background/70 px-2 py-1 text-[11px] text-foreground"
+            >
+              {labelize(item)}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-1.5 text-xs text-muted-foreground">{emptyLabel}</p>
+      )}
+    </div>
+  );
+}
+
+export default function AppIntelligenceInlineBrief({ payload = {} }) {
+  const coverage = asObject(payload.coverage);
+  const architecture = asObject(payload.architecture);
+  const status = String(payload.status || 'partial');
+  const statusStyle = STATUS_STYLES[status] || STATUS_STYLES.partial;
+  const appName = payload.app_name || payload.repo_name || payload.github_repo || 'Indexed app';
+  const techStack = splitTechStack(payload.tech_stack || payload.frameworks);
+  const warnings = asArray(payload.warnings);
+  const risks = asArray(payload.risk_hints);
+  const capabilities = asArray(payload.capabilities);
+  const sourceRefs = asArray(architecture.source_refs);
+  const graphEdges = coverage.edge_count || coverage.relationship_count || 0;
+  const healthWarningCount = warnings.length + risks.length;
+
+  return (
+    <div className="w-full overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm">
+      <div className="border-b border-border bg-muted/20 px-4 py-3">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase text-muted-foreground">
+                <Network className="h-3.5 w-3.5" aria-hidden="true" />
+                App Intelligence
+              </span>
+              <span className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${statusStyle}`}>
+                {labelize(status)}
+              </span>
+            </div>
+            <p className="mt-1 truncate text-sm font-semibold text-foreground">{appName}</p>
+            {payload.github_repo && (
+              <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{payload.github_repo}</p>
+            )}
+          </div>
+          <div className="shrink-0 pt-0.5">
+            {status === 'ready' ? (
+              <CheckCircle2 className="h-5 w-5 text-success" aria-label="Ready" />
+            ) : (
+              <AlertTriangle className="h-5 w-5 text-warning" aria-label="Partial" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3 px-4 py-3">
+        <div className="grid grid-cols-4 gap-3">
+          <CountItem icon={FileCode2} label="Files" value={coverage.file_count || payload.total_files_scanned} />
+          <CountItem icon={GitBranch} label="Symbols" value={coverage.symbol_count} />
+          <CountItem icon={Network} label="Links" value={graphEdges} />
+          <CountItem icon={AlertTriangle} label="Flags" value={healthWarningCount} />
+        </div>
+
+        {payload.summary && (
+          <p className="text-xs leading-5 text-foreground/85">{payload.summary}</p>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <ChipRow label="Tech stack" items={techStack} emptyLabel="No framework signals detected yet." />
+          <ChipRow label="Likely code surfaces" items={sourceRefs} emptyLabel="No source surfaces indexed yet." />
+        </div>
+
+        {capabilities.length > 0 && (
+          <ChipRow label="Capability signals" items={capabilities} />
+        )}
+
+        {(payload.integration_count > 0 || payload.data_surface_count > 0) && (
+          <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+            <span>Integrations: {formatCount(payload.integration_count)}</span>
+            <span>Data surfaces: {formatCount(payload.data_surface_count)}</span>
+          </div>
+        )}
+
+        {warnings.length > 0 && (
+          <div className="rounded-md border border-warning/25 bg-warning/10 px-3 py-2">
+            <p className="text-[11px] font-medium text-warning">Indexing warnings</p>
+            <p className="mt-1 line-clamp-2 text-[11px] leading-5 text-foreground/80">
+              {warnings.slice(0, 3).join(' | ')}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/factory_app/workflows/ExistingAppDiscovery/ui/index.js
+++ b/factory_app/workflows/ExistingAppDiscovery/ui/index.js
@@ -5,5 +5,6 @@
 // Artifact component - displays in artifact panel
 export { default as DiscoveryBriefCard } from './DiscoveryBriefCard.jsx';
 
-// App Intelligence overview - emitted after before_chat indexing completes
+// App Intelligence progress and overview - emitted during and after before_chat indexing
+export { default as AppIntelligenceInlineBrief } from './AppIntelligenceInlineBrief.jsx';
 export { default as AppIntelligenceOverviewCard } from './AppIntelligenceOverviewCard.jsx';

--- a/mozaiksai/core/events/unified_event_dispatcher.py
+++ b/mozaiksai/core/events/unified_event_dispatcher.py
@@ -545,6 +545,7 @@ class UnifiedEventDispatcher:
             'print': 'chat.print', 'text': 'chat.text', 'input_ack': 'chat.input_ack',
             'input_timeout': 'chat.input_timeout', 'select_speaker': 'chat.select_speaker', 'resume_boundary': 'chat.resume_boundary',
             'usage_delta': 'chat.usage_delta', 'usage_summary': 'chat.usage_summary', 'run_complete': 'chat.run_complete', 'error': 'chat.error', 'tool_call': 'chat.tool_call', 'tool_response': 'chat.tool_response',
+            'tool_progress': 'chat.tool_progress',
             'token_budget_alert': 'chat.token_budget_alert',
             'agent_output_validated': 'chat.agent_output_validated', 'run_start': 'chat.run_start', 'tool_call_dismiss': 'chat.tool_call_dismiss',
             'awaiting_reply': 'chat.awaiting_reply', 'activity': 'chat.activity',

--- a/tests/test_event_dispatcher_domain_event.py
+++ b/tests/test_event_dispatcher_domain_event.py
@@ -124,6 +124,28 @@ def test_build_outbound_event_envelope_marks_hidden_initial_seed_messages() -> N
     assert envelope["data"]["_mozaiks_seed_kind"] == "initial_message"
 
 
+def test_build_outbound_event_envelope_maps_tool_progress_to_chat_namespace() -> None:
+    dispatcher = UnifiedEventDispatcher()
+
+    envelope = dispatcher.build_outbound_event_envelope(
+        raw_event={
+            "kind": "tool_progress",
+            "tool_name": "App Intelligence",
+            "progress_percent": 58,
+            "status_message": "Extracting symbols.",
+            "ui_visibility": "user",
+        },
+        chat_id="chat-progress",
+        workflow_name="ExistingAppDiscovery",
+    )
+
+    assert envelope is not None
+    assert envelope["type"] == "chat.tool_progress"
+    assert envelope["data"]["tool_name"] == "App Intelligence"
+    assert envelope["data"]["progress_percent"] == 58
+    assert envelope["data"]["ui_visibility"] == "user"
+
+
 def test_serialize_event_content_normalizes_enum_to_value() -> None:
     class WorkflowName(Enum):
         SMOKE_CHILD = "SmokeChild"

--- a/tests/test_existing_app_discovery_contracts.py
+++ b/tests/test_existing_app_discovery_contracts.py
@@ -210,12 +210,19 @@ def test_existing_app_discovery_runs_app_intelligence_overview_after_repository_
 
     assert [(item["file"], item["function"]) for item in before_chat] == [
         ("preload_discovery_context.py", "collect_prechat_discovery_context"),
+        ("emit_app_intelligence_overview.py", "emit_app_intelligence_inline_brief"),
         ("emit_app_intelligence_overview.py", "emit_app_intelligence_overview_card"),
     ]
-    overview_tool = before_chat[1]
+    inline_tool = before_chat[1]
+    overview_tool = before_chat[2]
+    assert inline_tool["tool_type"] == "UI_Surface"
+    assert inline_tool["ui"]["component"] == "AppIntelligenceInlineBrief"
+    assert inline_tool["ui"]["mode"] == "inline"
     assert overview_tool["tool_type"] == "UI_Surface"
     assert overview_tool["ui"]["component"] == "AppIntelligenceOverviewCard"
-    assert "AppIntelligenceOverviewCard" in _read_text("factory_app/workflows/ExistingAppDiscovery/ui/index.js")
+    ui_index = _read_text("factory_app/workflows/ExistingAppDiscovery/ui/index.js")
+    assert "AppIntelligenceInlineBrief" in ui_index
+    assert "AppIntelligenceOverviewCard" in ui_index
     assert "get_preloaded_app_intelligence" in manifest_text
     assert "search_preloaded_source_context" in manifest_text
     assert "read_preloaded_source_file" in manifest_text
@@ -293,6 +300,68 @@ def test_app_intelligence_overview_emitter_surfaces_agent_visible_catalog() -> N
     assert "file_contents" not in str(emitted["payload"])
     assert emitted["kwargs"]["workflow_name"] == "ExistingAppDiscovery"
     assert emitted["kwargs"]["display"] == "artifact"
+
+
+def test_app_intelligence_inline_brief_emitter_surfaces_compact_chat_payload() -> None:
+    module = _load_module(
+        "factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py",
+        "tests.emit_app_intelligence_inline_direct",
+    )
+
+    emitted = {}
+
+    async def _fake_emit(component, payload, **kwargs):
+        emitted["component"] = component
+        emitted["payload"] = payload
+        emitted["kwargs"] = kwargs
+
+    module.emit_ui_surface = _fake_emit
+    context = _Context(
+        chat_id="chat_inline",
+        preload_status="ready",
+        app_id="app_1",
+        github_repo="acme/app",
+        repo_summary={"repo_name": "acme/app", "source": "github_repo_scan"},
+        app_intelligence_catalog={
+            "present": True,
+            "snapshot_id": "app_intelligence_1",
+            "coverage": {
+                "file_count": 3,
+                "chunk_count": 4,
+                "symbol_count": 5,
+                "node_count": 6,
+                "edge_count": 7,
+            },
+            "architecture": {
+                "module_roots": [{"module_id": "billing", "paths": ["app/modules/billing/module.yaml"]}],
+                "service_roots": [{"service_id": "github", "path": "app/services/integrations/github_client.py"}],
+                "ui_surfaces": [{"label": "Dashboard", "path": "app/ui/pages/dashboard.yaml"}],
+                "workflow_roots": [],
+            },
+            "capabilities": [{"capability_id": "module:billing", "label": "billing"}],
+            "integration_surfaces": [{"label": "GitHub"}],
+            "data_surfaces": [{"label": "billing_events"}],
+            "risk_hints": [{"risk_id": "missing_tests", "severity": "low"}],
+            "agent_context_policy": {"policy": "retrieve_not_dump", "authority": {}, "surfaces": []},
+            "warnings": ["scan warning"],
+        },
+        source_context_bundle={"file_contents": {"app.py": "secret source must not be emitted"}},
+    )
+
+    result = asyncio.run(module.emit_app_intelligence_inline_brief(context_variables=context))
+
+    assert result["success"] is True
+    assert emitted["component"] == "AppIntelligenceInlineBrief"
+    assert emitted["payload"]["coverage"]["file_count"] == 3
+    assert emitted["payload"]["coverage"]["symbol_count"] == 5
+    assert emitted["payload"]["architecture"]["source_refs"][0]["label"] == "billing"
+    assert emitted["payload"]["integration_count"] == 1
+    assert emitted["payload"]["data_surface_count"] == 1
+    assert "app_intelligence_catalog" not in emitted["payload"]
+    assert "file_contents" not in str(emitted["payload"])
+    assert emitted["kwargs"]["workflow_name"] == "ExistingAppDiscovery"
+    assert emitted["kwargs"]["agent_name"] == "App Intelligence"
+    assert emitted["kwargs"]["display"] == "inline"
 
 
 def test_app_intelligence_overview_uses_real_workflow_ui_surface(monkeypatch) -> None:
@@ -375,6 +444,149 @@ def test_app_intelligence_overview_uses_real_workflow_ui_surface(monkeypatch) ->
     assert event["payload"]["component_type"] == "AppIntelligenceOverviewCard"
     assert event["payload"]["workflow_primitive"] == "document_preview"
     assert event["payload"]["ui_realization"] == "generated_component"
+
+
+def test_app_intelligence_inline_brief_uses_real_workflow_ui_surface(monkeypatch) -> None:
+    module = _load_module(
+        "factory_app/workflows/ExistingAppDiscovery/tools/emit_app_intelligence_overview.py",
+        "tests.emit_app_intelligence_inline_transport",
+    )
+
+    from mozaiksai.core.transport import simple_transport as transport_mod
+
+    class _FakeTransport:
+        def __init__(self) -> None:
+            self.events = []
+
+        async def send_tool_call_event(
+            self,
+            *,
+            event_id,
+            chat_id,
+            tool_name,
+            component_name,
+            display_type,
+            payload,
+            awaiting_response=True,
+            agent_name=None,
+        ):
+            self.events.append(
+                {
+                    "event_id": event_id,
+                    "chat_id": chat_id,
+                    "tool_name": tool_name,
+                    "component_name": component_name,
+                    "display_type": display_type,
+                    "payload": payload,
+                    "awaiting_response": awaiting_response,
+                    "agent_name": agent_name,
+                }
+            )
+
+    fake_transport = _FakeTransport()
+
+    async def _get_instance():
+        return fake_transport
+
+    monkeypatch.setattr(transport_mod.SimpleTransport, "get_instance", staticmethod(_get_instance))
+
+    context = _Context(
+        chat_id="chat_inline_ui_surface",
+        app_id="app_1",
+        preload_status="ready",
+        github_repo="acme/app",
+        repo_summary={"repo_name": "acme/app", "source": "github_repo_scan"},
+        app_intelligence_catalog={
+            "present": True,
+            "snapshot_id": "app_intelligence_1",
+            "coverage": {"file_count": 8, "symbol_count": 21, "node_count": 13, "edge_count": 34},
+            "architecture": {"module_roots": [], "service_roots": [], "ui_surfaces": [], "workflow_roots": []},
+            "capabilities": [],
+            "integration_surfaces": [],
+            "data_surfaces": [],
+            "risk_hints": [],
+            "agent_context_policy": {"policy": "retrieve_not_dump", "authority": {}, "surfaces": []},
+            "warnings": [],
+        },
+    )
+
+    result = asyncio.run(module.emit_app_intelligence_inline_brief(context_variables=context))
+
+    assert result["success"] is True
+    assert len(fake_transport.events) == 1
+    event = fake_transport.events[0]
+    assert event["chat_id"] == "chat_inline_ui_surface"
+    assert event["tool_name"] == "AppIntelligenceInlineBrief"
+    assert event["component_name"] == "AppIntelligenceInlineBrief"
+    assert event["display_type"] == "inline"
+    assert event["awaiting_response"] is False
+    assert event["agent_name"] == "App Intelligence"
+    assert event["payload"]["workflow_name"] == "ExistingAppDiscovery"
+    assert event["payload"]["interaction_type"] == "ui_surface"
+    assert event["payload"]["component_type"] == "AppIntelligenceInlineBrief"
+    assert event["payload"]["workflow_primitive"] == "document_preview"
+    assert event["payload"]["ui_realization"] == "generated_component"
+
+
+def test_existing_app_preload_activity_emits_visible_indexing_status(monkeypatch) -> None:
+    module = _load_module(
+        "factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py",
+        "tests.preload_activity_emit",
+    )
+    transport_mod = __import__("mozaiksai.core.transport.simple_transport", fromlist=["SimpleTransport"])
+
+    class _FakeTransport:
+        def __init__(self) -> None:
+            self.events: list[tuple[dict[str, Any], str | None]] = []
+
+        async def send_event_to_ui(self, event: dict[str, Any], chat_id: str | None = None) -> None:
+            self.events.append((event, chat_id))
+
+    fake_transport = _FakeTransport()
+
+    async def _get_instance():
+        return fake_transport
+
+    monkeypatch.setattr(transport_mod.SimpleTransport, "get_instance", staticmethod(_get_instance))
+
+    context = _Context(chat_id="chat_app_intelligence_progress", app_id="app_1")
+    module._set_app_intelligence_progress(context, "collecting_evidence")
+    result = asyncio.run(module._emit_app_intelligence_activity(context))
+
+    assert result["success"] is True
+    assert fake_transport.events
+    event, chat_id = fake_transport.events[-1]
+    assert chat_id == "chat_app_intelligence_progress"
+    assert event["kind"] == "activity"
+    assert event["activity_type"] == "app_intelligence_indexing"
+    assert event["agent"] == "App Intelligence"
+    assert event["status"] == "working"
+    assert event["progress_percent"] == 25
+    assert "Obtaining app context" in event["message"]
+
+    module._set_app_intelligence_progress(context, "ready")
+    result = asyncio.run(module._emit_app_intelligence_activity(context))
+
+    assert result["status"] == "complete"
+    ready_event, _ = fake_transport.events[-1]
+    assert ready_event["status"] == "complete"
+    assert ready_event["message"] == "App context ready. Starting the discovery agent."
+
+
+def test_chat_page_renders_user_visible_app_intelligence_progress() -> None:
+    source = _read_text("chat-ui/src/pages/ChatPage.js")
+
+    assert "!data.type.startsWith('ui.')" in source
+    assert "activityCompleteStatuses" in source
+    assert "progress_percent: data.progress_percent" in source
+    assert "const userVisibleToolProgress = (" in source
+    assert "tool === 'App Intelligence'" in source
+
+
+def test_workflow_component_registration_is_hmr_safe() -> None:
+    source = _read_text("chat-ui/src/@chat-workflows/index.js")
+
+    assert "override: true" in source
 
 
 def test_existing_app_preload_mutates_an_empty_context_container() -> None:

--- a/tests/test_workflow_ui_tool_contracts.py
+++ b/tests/test_workflow_ui_tool_contracts.py
@@ -520,6 +520,7 @@ def test_core_ui_index_exports_shipped_workflow_components() -> None:
 
 def test_workflow_ui_components_use_payload_prop_contract() -> None:
     files = [
+        "factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceInlineBrief.jsx",
         "factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceOverviewCard.jsx",
         "factory_app/workflows/ExistingAppDiscovery/ui/DiscoveryBriefCard.jsx",
         "factory_app/workflows/AppGenerator/ui/AppWorkbench.js",


### PR DESCRIPTION
## Summary

- Adds a durable compact App Intelligence brief in the chat feed (inline mode) alongside the existing artifact-panel `AppIntelligenceOverviewCard`
- New `emit_app_intelligence_inline_brief` before_chat lifecycle tool emits a condensed payload (coverage counts, source_refs, capabilities, warnings) without raw source file contents
- New `AppIntelligenceInlineBrief.jsx` component with status badge, coverage counts, tech stack/capability chips, and indexing warning row
- Maps `tool_progress` → `chat.tool_progress` in `UnifiedEventDispatcher` so progress events reach the chat client
- `ChatPage.js`: handles `ui.*` event namespace, promotes `activity_type`/`status_message` from inner envelope, uses status-aware icons (✓/⚠/⏳) on activity rows
- Docs: updated `app-intelligence-plane.md` and `app-intelligence-user-journey.md` for the dual-surface pattern

## Test plan

- [x] `test_existing_app_discovery_contracts.py` — 24 tests pass, including new inline brief emitter tests
- [x] `test_event_dispatcher_domain_event.py` — new `tool_progress` namespace mapping test passes
- [x] `test_workflow_ui_tool_contracts.py` — new component added to payload-prop contract check

🤖 Generated with [Claude Code](https://claude.com/claude-code)