### PR TITLE
fix(test): register AppIntelligenceInlineBrief in mobile surface classification

### DIFF
--- a/tests/test_mobile_surface_contracts.py
+++ b/tests/test_mobile_surface_contracts.py
@@ -265,7 +265,8 @@ def test_factory_app_react_files_are_classified() -> None:
         "factory_app/app/ui/components/OnboardingTour.jsx",
         "factory_app/app/ui/installOnboardingTour.jsx",
         "factory_app/workflows/ExistingAppDiscovery/ui/DiscoveryBriefCard.jsx",
-        # ExistingAppDiscovery App Intelligence overview — emitted before agent speaks
+        # ExistingAppDiscovery App Intelligence surfaces — emitted before and after agent speaks
+        "factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceInlineBrief.jsx",
         "factory_app/workflows/ExistingAppDiscovery/ui/AppIntelligenceOverviewCard.jsx",
         # AppReview workflow agentic UI artifact — emitted by present_review_summary
         "factory_app/workflows/AppReview/ui/AppReview/AppReviewSummary.jsx",


### PR DESCRIPTION
## Summary

- Registers `AppIntelligenceInlineBrief.jsx` in the `support_files` set of `test_factory_app_react_files_are_classified`
- This component was added in #161 but not added to the classification test, causing a CI failure

## Test plan

- [x] `test_mobile_surface_contracts.py::test_factory_app_react_files_are_classified` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)