### PR TITLE
feat(transport+discovery): allow UI_Surface events to bypass visual_agents filter; add GitHub fetch progress

### DIFF
--- a/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/preload_discovery_context.py
@@ -27,7 +27,7 @@ import os
 import tomllib
 import xml.etree.ElementTree as ET
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -279,6 +279,7 @@ _APP_INTELLIGENCE_STAGE_PROGRESS = {
     "resolving_sources": ("indexing", 10),
     "collecting_evidence": ("indexing", 25),
     "selecting_source_files": ("indexing", 40),
+    "fetching_source_files": ("indexing", 45),
     "extracting_symbols": ("indexing", 58),
     "building_graph": ("indexing", 72),
     "building_snapshot": ("indexing", 86),
@@ -294,15 +295,20 @@ def _set_app_intelligence_progress(
     stage: str,
     *,
     message: str | None = None,
+    percent: int | None = None,
     details: dict[str, Any] | None = None,
     warnings: list[str] | None = None,
 ) -> dict[str, Any]:
-    status, percent = _APP_INTELLIGENCE_STAGE_PROGRESS.get(stage, ("indexing", 0))
+    status, default_percent = _APP_INTELLIGENCE_STAGE_PROGRESS.get(stage, ("indexing", 0))
+    if percent is None:
+        resolved_percent = default_percent
+    else:
+        resolved_percent = max(0, min(100, int(percent)))
     payload = {
         "schema_version": _APP_INTELLIGENCE_PROGRESS_SCHEMA,
         "stage": stage,
         "status": status,
-        "percent": percent,
+        "percent": resolved_percent,
         "message": message or _default_app_intelligence_progress_message(stage),
         "details": dict(details or {}),
         "warnings": list(warnings or []),
@@ -322,6 +328,7 @@ def _default_app_intelligence_progress_message(stage: str) -> str:
         "resolving_sources": "Resolving repository and AppContext inputs.",
         "collecting_evidence": "Collecting deterministic intake evidence.",
         "selecting_source_files": "Selecting safe source files for indexing.",
+        "fetching_source_files": "Downloading selected source files from GitHub.",
         "extracting_symbols": "Extracting symbols, imports, and source chunks.",
         "building_graph": "Building the AppContext graph.",
         "building_snapshot": "Building the App Intelligence snapshot.",
@@ -858,17 +865,37 @@ def _scan_local_repo(repo_path: str) -> dict[str, Any]:
     return summary
 
 
-async def _github_request(url: str, token: str | None) -> httpx.Response:
+def _github_headers(token: str | None) -> dict[str, str]:
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+async def _github_request(
+    url: str,
+    token: str | None,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> httpx.Response:
+    headers = _github_headers(token)
+    if client is not None:
+        return await client.get(url, headers=headers)
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=10.0)) as client:
         return await client.get(url, headers=headers)
 
 
-async def _fetch_github_file(owner: str, repo: str, path: str, ref: str, token: str | None) -> bytes | None:
+async def _fetch_github_file(
+    owner: str,
+    repo: str,
+    path: str,
+    ref: str,
+    token: str | None,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> bytes | None:
     url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={ref}"
-    resp = await _github_request(url, token)
+    resp = await _github_request(url, token, client=client)
     if resp.status_code != 200:
         return None
     try:
@@ -914,47 +941,52 @@ async def _scan_github_repo(github_repo: str, github_ref: str | None, github_tok
 
     owner, repo = normalized_repo.split("/", 1)
     token = github_token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
-    repo_resp = await _github_request(f"https://api.github.com/repos/{owner}/{repo}", token)
-    if repo_resp.status_code != 200:
-        return {
-            "success": False,
-            "error": f"GitHub repo lookup failed with HTTP {repo_resp.status_code}",
-        }
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(15.0, connect=10.0),
+        limits=httpx.Limits(max_connections=20, max_keepalive_connections=20),
+    ) as client:
+        repo_resp = await _github_request(f"https://api.github.com/repos/{owner}/{repo}", token, client=client)
+        if repo_resp.status_code != 200:
+            return {
+                "success": False,
+                "error": f"GitHub repo lookup failed with HTTP {repo_resp.status_code}",
+            }
 
-    repo_info = repo_resp.json()
-    ref = github_ref or repo_info.get("default_branch") or "main"
-    tree_resp = await _github_request(
-        f"https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}?recursive=1",
-        token,
-    )
-    if tree_resp.status_code != 200:
-        return {
-            "success": False,
-            "error": f"GitHub tree lookup failed with HTTP {tree_resp.status_code}",
-        }
+        repo_info = repo_resp.json()
+        ref = github_ref or repo_info.get("default_branch") or "main"
+        tree_resp = await _github_request(
+            f"https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}?recursive=1",
+            token,
+            client=client,
+        )
+        if tree_resp.status_code != 200:
+            return {
+                "success": False,
+                "error": f"GitHub tree lookup failed with HTTP {tree_resp.status_code}",
+            }
 
-    tree = tree_resp.json().get("tree", []) or []
-    file_paths = [item.get("path", "") for item in tree if item.get("type") == "blob"]
-    summary = _summarise_file_tree(file_paths)
-    languages = list(summary["languages"])
-    frameworks = list(summary["frameworks"])
-    target_frameworks: list[str] = []
+        tree = tree_resp.json().get("tree", []) or []
+        file_paths = [item.get("path", "") for item in tree if item.get("type") == "blob"]
+        summary = _summarise_file_tree(file_paths)
+        languages = list(summary["languages"])
+        frameworks = list(summary["frameworks"])
+        target_frameworks: list[str] = []
 
-    for rel_path in summary["manifest_paths"][:10]:
-        raw_bytes = await _fetch_github_file(owner, repo, rel_path, ref, token)
-        if not raw_bytes:
-            continue
-        try:
-            if rel_path.endswith("package.json"):
-                _parse_package_json(raw_bytes.decode("utf-8"), frameworks, languages)
-            elif rel_path.endswith("pyproject.toml"):
-                _parse_pyproject(raw_bytes, frameworks, languages)
-            elif rel_path.endswith("requirements.txt"):
-                _append_unique(languages, "Python")
-            elif rel_path.lower().endswith(".csproj"):
-                target_frameworks.extend(_parse_csproj(raw_bytes.decode("utf-8"), frameworks, languages))
-        except Exception as exc:
-            logger.debug("[ExistingAppDiscovery] Failed to parse GitHub manifest %s: %s", rel_path, exc)
+        for rel_path in summary["manifest_paths"][:10]:
+            raw_bytes = await _fetch_github_file(owner, repo, rel_path, ref, token, client=client)
+            if not raw_bytes:
+                continue
+            try:
+                if rel_path.endswith("package.json"):
+                    _parse_package_json(raw_bytes.decode("utf-8"), frameworks, languages)
+                elif rel_path.endswith("pyproject.toml"):
+                    _parse_pyproject(raw_bytes, frameworks, languages)
+                elif rel_path.endswith("requirements.txt"):
+                    _append_unique(languages, "Python")
+                elif rel_path.lower().endswith(".csproj"):
+                    target_frameworks.extend(_parse_csproj(raw_bytes.decode("utf-8"), frameworks, languages))
+            except Exception as exc:
+                logger.debug("[ExistingAppDiscovery] Failed to parse GitHub manifest %s: %s", rel_path, exc)
 
     summary.update(
         {
@@ -1060,6 +1092,7 @@ async def _collect_github_context_graph_file_map(
     github_ref: str | None,
     github_token: str | None,
     scan_policy_inputs: dict[str, Any] | None = None,
+    progress_callback: Callable[[int, int], Awaitable[None]] | None = None,
 ) -> Any:
     from mozaiksai.core.app_context.scan_policy import (
         SourceScanResult,
@@ -1149,21 +1182,49 @@ async def _collect_github_context_graph_file_map(
 
     semaphore = asyncio.Semaphore(12)
 
-    async def _fetch_candidate(candidate: tuple[int, int, str, str, str, str, str, str]):
+    if progress_callback and fetch_candidates:
+        await progress_callback(0, len(fetch_candidates))
+
+    async def _fetch_candidate(
+        index: int,
+        candidate: tuple[int, int, str, str, str, str, str, str],
+        client: httpx.AsyncClient,
+    ):
         _priority, _depth, graph_path, priority_label, owner, repo, github_path, ref = candidate
         try:
             async with semaphore:
-                raw_bytes = await _fetch_github_file(owner, repo, github_path, ref, token)
-            return graph_path, priority_label, raw_bytes, None
+                raw_bytes = await _fetch_github_file(owner, repo, github_path, ref, token, client=client)
+            return index, graph_path, priority_label, raw_bytes, None
         except Exception as exc:
-            return graph_path, priority_label, None, f"{type(exc).__name__}:{graph_path}"
+            return index, graph_path, priority_label, None, f"{type(exc).__name__}:{graph_path}"
 
-    fetched_candidates = await asyncio.gather(
-        *(_fetch_candidate(candidate) for candidate in fetch_candidates)
-    )
+    fetched_candidates: list[tuple[int, str, str, bytes | None, str | None] | None] = [None] * len(fetch_candidates)
+    if fetch_candidates:
+        progress_interval = max(1, len(fetch_candidates) // 12)
+        completed_count = 0
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(20.0, connect=10.0),
+            limits=httpx.Limits(max_connections=24, max_keepalive_connections=24),
+        ) as client:
+            tasks = [
+                asyncio.create_task(_fetch_candidate(index, candidate, client))
+                for index, candidate in enumerate(fetch_candidates)
+            ]
+            for task in asyncio.as_completed(tasks):
+                result = await task
+                fetched_candidates[result[0]] = result
+                completed_count += 1
+                if progress_callback and (
+                    completed_count == len(fetch_candidates)
+                    or completed_count % progress_interval == 0
+                ):
+                    await progress_callback(completed_count, len(fetch_candidates))
 
     fetch_error_warnings = 0
-    for graph_path, priority_label, raw_bytes, fetch_error in fetched_candidates:
+    for fetched_candidate in fetched_candidates:
+        if fetched_candidate is None:
+            continue
+        _index, graph_path, priority_label, raw_bytes, fetch_error = fetched_candidate
         if len(file_map) >= policy.max_files:
             limit_reached = True
             break
@@ -1452,11 +1513,29 @@ async def _preload_context_graph_pack(
             scan_policy_inputs=scan_policy_inputs,
         )
     else:
+        async def _github_fetch_progress(completed: int, total: int) -> None:
+            if total <= 0:
+                return
+            percent = 42 + int((min(completed, total) / total) * 13)
+            _set_app_intelligence_progress(
+                context_variables,
+                "fetching_source_files",
+                message=f"Downloading selected source files from GitHub ({completed}/{total}).",
+                percent=percent,
+                details={
+                    "source": "github_source_scan",
+                    "downloaded_file_count": completed,
+                    "fetch_candidate_count": total,
+                },
+            )
+            await _emit_app_intelligence_activity(context_variables)
+
         scan_result = await _collect_github_context_graph_file_map(
             list(github_sources or []),
             github_ref=github_ref,
             github_token=github_token,
             scan_policy_inputs=scan_policy_inputs,
+            progress_callback=_github_fetch_progress,
         )
     file_map = scan_result.file_map
     warnings = list(scan_result.warnings)

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -652,14 +652,16 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                 data_payload["trace_agent"] = agent
                 return True
             
-            # Determine if this is a UI tool event (requires user interaction)
+            # Determine if this is a workflow UI render event. Both
+            # response-required UI_Tool events and one-way UI_Surface events
+            # must bypass visual_agents filtering; the workflow UI contract
+            # already declared them as user-visible surfaces.
             is_ui_tool_event = False
             if envelope_type == 'chat.tool_call' and isinstance(envelope.get('data'), dict):
                 data_payload = envelope.get('data')
-                # UI tool events have awaiting_response=True and component_type
-                is_ui_tool_event = data_payload.get('awaiting_response') and data_payload.get('component_type')
+                is_ui_tool_event = bool(data_payload.get('component_type'))
             
-            # Skip visibility filtering for select_speaker and response-required UI tool events
+            # Skip visibility filtering for select_speaker and declared UI surfaces.
             skip_visibility_filter = (
                 envelope_type == 'chat.select_speaker'
                 or envelope_type == 'chat.run_complete'

--- a/tests/test_existing_app_discovery_contracts.py
+++ b/tests/test_existing_app_discovery_contracts.py
@@ -572,6 +572,20 @@ def test_existing_app_preload_activity_emits_visible_indexing_status(monkeypatch
     assert ready_event["status"] == "complete"
     assert ready_event["message"] == "App context ready. Starting the discovery agent."
 
+    module._set_app_intelligence_progress(
+        context,
+        "fetching_source_files",
+        message="Downloading selected source files from GitHub (60/120).",
+        percent=48,
+    )
+    result = asyncio.run(module._emit_app_intelligence_activity(context))
+
+    assert result["status"] == "working"
+    download_event, _ = fake_transport.events[-1]
+    assert download_event["status"] == "working"
+    assert download_event["progress_percent"] == 48
+    assert "Downloading selected source files from GitHub (60/120)." in download_event["message"]
+
 
 def test_chat_page_renders_user_visible_app_intelligence_progress() -> None:
     source = _read_text("chat-ui/src/pages/ChatPage.js")
@@ -1063,7 +1077,7 @@ def test_existing_app_preload_builds_context_graph_pack_for_github_repo_url(
         "README.md": b"# Demo\nExisting app repository.\n",
     }
 
-    async def _fake_github_request(url: str, token: str | None):
+    async def _fake_github_request(url: str, token: str | None, **kwargs):
         assert token is None
         if "/git/trees/" in url:
             return _FakeResponse(200, tree)
@@ -1077,11 +1091,12 @@ def test_existing_app_preload_builds_context_graph_pack_for_github_repo_url(
             )
         return _FakeResponse(404, {})
 
-    async def _fake_fetch_github_file(owner: str, repo: str, path: str, ref: str, token: str | None):
+    async def _fake_fetch_github_file(owner: str, repo: str, path: str, ref: str, token: str | None, **kwargs):
         assert owner == "Example"
         assert repo == "demo"
         assert ref == "main"
         assert token is None
+        assert "client" in kwargs
         return contents.get(path)
 
     monkeypatch.setattr(module, "_github_request", _fake_github_request)

--- a/tests/test_simple_transport_serialization.py
+++ b/tests/test_simple_transport_serialization.py
@@ -253,3 +253,69 @@ def test_send_event_to_ui_does_not_filter_activity_for_non_visual_agent(monkeypa
         )
     ]
 
+
+def test_send_event_to_ui_does_not_filter_one_way_ui_surface_for_non_visual_agent(monkeypatch):
+    transport = SimpleTransport()
+    transport.connections = {"chat-1": {"workflow_name": "ExistingAppDiscovery", "user_id": "user-1"}}
+    sent = []
+
+    class _FakeDispatcher:
+        def build_outbound_event_envelope(self, *, raw_event, chat_id, get_sequence_cb, workflow_name):  # noqa: ANN001
+            return {
+                "type": "chat.tool_call",
+                "data": {
+                    "kind": "tool_call",
+                    "agent": "App Intelligence",
+                    "tool_name": "AppIntelligenceInlineBrief",
+                    "component_type": "AppIntelligenceInlineBrief",
+                    "tool_call_id": "ui_surface_1",
+                    "display": "inline",
+                    "awaiting_response": False,
+                    "interaction_type": "ui_surface",
+                    "payload": {"status": "ready"},
+                },
+            }
+
+    monkeypatch.setattr(_dispatcher_mod, "get_event_dispatcher", lambda: _FakeDispatcher())
+    monkeypatch.setattr(transport, "should_show_to_user", lambda agent_name, chat_id: False)
+    monkeypatch.setattr(
+        transport,
+        "_broadcast_to_websockets",
+        lambda event, chat_id=None: _record_broadcast(sent, event, chat_id),
+    )
+
+    import asyncio
+
+    asyncio.run(
+        transport.send_event_to_ui(
+            {
+                "kind": "tool_call",
+                "agent": "App Intelligence",
+                "tool_name": "AppIntelligenceInlineBrief",
+                "component_type": "AppIntelligenceInlineBrief",
+                "awaiting_response": False,
+            },
+            "chat-1",
+        )
+    )
+
+    assert sent == [
+        (
+            {
+                "type": "chat.tool_call",
+                "data": {
+                    "kind": "tool_call",
+                    "agent": "App Intelligence",
+                    "tool_name": "AppIntelligenceInlineBrief",
+                    "component_type": "AppIntelligenceInlineBrief",
+                    "tool_call_id": "ui_surface_1",
+                    "display": "inline",
+                    "awaiting_response": False,
+                    "interaction_type": "ui_surface",
+                    "payload": {"status": "ready"},
+                },
+            },
+            "chat-1",
+        )
+    ]
+


### PR DESCRIPTION
## Summary

**Transport (`simple_transport.py`)**
- Removes the `awaiting_response` requirement from `is_ui_tool_event` check so that one-way `UI_Surface` events (like `AppIntelligenceInlineBrief`) bypass visual_agents filtering — the workflow UI contract already declared them as user-visible surfaces
- Adds test verifying a `UI_Surface` tool_call with `component_type` but `awaiting_response=False` reaches the WebSocket even when the emitting agent is not in `visual_agents`

**Discovery preload (`preload_discovery_context.py`)**
- Adds `fetching_source_files` progress stage (42–55%) with per-file progress callback emitted live during GitHub file downloads
- Refactors `_collect_github_context_graph_file_map` to accept a `progress_callback` and share a single `httpx.AsyncClient` across concurrent fetches (12-worker semaphore, 24-connection pool)
- Adds explicit `percent` override to `_set_app_intelligence_progress` for granular mid-stage progress reporting

## Test plan

- [x] `test_simple_transport_serialization.py` — new UI_Surface bypass test passes
- [x] `test_existing_app_discovery_contracts.py` — all 24 existing tests pass with refactored preload; mock updated to accept `**kwargs` from new client-passing calling convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)