### PR TITLE
fix(profile): handle profile sections lists

### DIFF
--- a/chat-ui/src/pages/ProfilePage.jsx
+++ b/chat-ui/src/pages/ProfilePage.jsx
@@ -718,7 +718,7 @@ export default function ProfilePage() {
         const res = await fetchWithAuth(`${backendUrl}/api/me/profile-pages${subjectSuffix}`, {}, auth);
         if (res.ok) {
           const body = await res.json();
-          if (body?.sections && typeof body.sections === 'object') {
+          if (body?.sections && !Array.isArray(body.sections) && typeof body.sections === 'object') {
             sections = body.sections;
             profileTrace('pages:v2:sections', { sectionIds: Object.keys(sections) });
           } else if (Array.isArray(body?.pages)) {

--- a/tests/test_profile_contract.py
+++ b/tests/test_profile_contract.py
@@ -736,4 +736,5 @@ def test_profile_page_fetches_profile_pages() -> None:
     assert "/api/users/" in source
     assert "subjectParams.set('username', username)" in source
     assert "componentRegistry" in source
+    assert "!Array.isArray(body.sections)" in source
 


### PR DESCRIPTION
## Summary
- fix ProfilePage to distinguish section maps from section lists returned by /api/me/profile-pages
- add a contract guard so array sections do not get treated as object maps

## Validation
- python -m pytest tests\\test_profile_contract.py -q --no-cov
- git diff --check
- ruff check tests\\test_profile_contract.py