### PR TITLE
fix(discovery): resolve ExistingAppDiscovery UX pipeline bugs

### DIFF
--- a/chat-ui/src/pages/ChatPage.js
+++ b/chat-ui/src/pages/ChatPage.js
@@ -2511,10 +2511,6 @@ const ChatPage = () => {
           : activityFailedStatuses.includes(normalizedActivityStatus)
             ? '⚠'
             : '⏳';
-        if (showInitSpinner) {
-          setShowInitSpinner(false);
-          initSpinnerHiddenOnceRef.current = true;
-        }
         setMessagesWithLogging(prev => {
           const updated = [...prev];
           const last = updated.length ? updated[updated.length - 1] : null;

--- a/factory_app/workflows/ExistingAppDiscovery/agents.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/agents.yaml
@@ -196,13 +196,18 @@ agents:
          - capabilities that would require deeper migration before agents should touch them
 
       5. Summarize the capability map and emit NEXT only once the user confirms the important pieces.
+
+      CRITICAL FIRST-TURN RULE: Your FIRST response after entering this stage MUST
+      be a conversational capability summary. Do NOT include NEXT in your first
+      response. NEXT may only appear as a standalone response AFTER the user has
+      read and explicitly responded to your capability summary.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |
       Your output at each turn MUST be exactly ONE of:
       - A conversational response (string)
       - EXACTLY `NEXT` (uppercase, no extra text) when the capability map is confirmed
-  max_consecutive_auto_reply: 10
+  max_consecutive_auto_reply: 1
   structured_outputs_required: false
 
 - name: IntegrationPlannerAgent
@@ -312,13 +317,18 @@ agents:
          Mozaiks shell deliberately.
 
       8. Emit NEXT only when the recommended adoption path is confirmed.
+
+      CRITICAL FIRST-TURN RULE: Your FIRST response after entering this stage MUST
+      be a conversational adoption recommendation. Do NOT include NEXT in your first
+      response. NEXT may only appear as a standalone response AFTER the user has
+      read and explicitly responded to your recommendation.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |
       Your output at each turn MUST be exactly ONE of:
       - A conversational response (string)
       - EXACTLY `NEXT` (uppercase, no extra text) when the adoption plan is confirmed
-  max_consecutive_auto_reply: 12
+  max_consecutive_auto_reply: 1
   structured_outputs_required: false
 
 # ---------------------------------------------------------------------------
@@ -442,13 +452,18 @@ agents:
          Do not reference proprietary app logic. This is a design brief, not code.
 
       10. Confirm your decomposition with the user, invite corrections, then emit NEXT.
+
+      CRITICAL FIRST-TURN RULE: Your FIRST response after entering this stage MUST
+      be a conversational decomposition plan. Do NOT include NEXT in your first
+      response. NEXT may only appear as a standalone response AFTER the user has
+      read and explicitly responded to your decomposition plan.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |
       Your output at each turn MUST be exactly ONE of:
       - A conversational response presenting the decomposition plan
       - EXACTLY `NEXT` (uppercase, no extra text) when the decomposition is confirmed
-  max_consecutive_auto_reply: 12
+  max_consecutive_auto_reply: 1
   structured_outputs_required: false
 
 - name: DiscoveryArtifactAssemblerAgent

--- a/factory_app/workflows/ExistingAppDiscovery/ui_config.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/ui_config.yaml
@@ -4,5 +4,6 @@ visual_agents:
   - DiscoveryHostAgent
   - CapabilityMapperAgent
   - IntegrationPlannerAgent
+  - ModuleDecomposerAgent
   - DiscoveryArtifactAssemblerAgent
   - user

--- a/factory_app/workflows/extended_orchestration/extension_registry.json
+++ b/factory_app/workflows/extended_orchestration/extension_registry.json
@@ -139,7 +139,7 @@
     {
       "id": "ExistingAppDiscovery",
       "description": "Discovery workflow for existing-app adopters",
-      "startup_mode": "UserDriven"
+      "startup_mode": "AgentDriven"
     },
     {
       "id": "AppReview",


### PR DESCRIPTION
## Summary

- **agents.yaml**: add `CRITICAL FIRST-TURN RULE` to `CapabilityMapperAgent`, `IntegrationPlannerAgent`, and `ModuleDecomposerAgent` — agents must present their analysis conversationally before emitting `NEXT`; reduce `max_consecutive_auto_reply` from 10/12 → 1 to prevent the pipeline racing to completion on a single user reply
- **ui_config.yaml**: add `ModuleDecomposerAgent` to `visual_agents` so its messages are rendered in the chat UI (was silently hidden)
- **extension_registry.json**: correct `ExistingAppDiscovery` `startup_mode` from `UserDriven` → `AgentDriven` to match `orchestrator.yaml` (mismatch caused missing typing indicator on first load)
- **ChatPage.js**: remove `setShowInitSpinner(false)` from `case 'activity':` — the init spinner was being cleared by before_chat preload activity events before `DiscoveryHostAgent` spoke, leaving no typing indicator visible to the user; spinner now persists until first agent text message

## Test plan

- [ ] Run ExistingAppDiscovery against a brownfield repo — verify typing indicator (`...`) is visible before DiscoveryHostAgent's first message
- [ ] After answering DiscoveryHostAgent, verify CapabilityMapperAgent presents a capability summary (not immediate NEXT)
- [ ] After confirming the capability map, verify IntegrationPlannerAgent presents an adoption recommendation (not immediate NEXT)
- [ ] For ecosystem/gradual_modernization paths, verify ModuleDecomposerAgent messages appear in the chat UI
- [ ] Verify the workflow does NOT show a "workflow completed" transition card mid-run — BrownfieldPathSelector should appear only after full pipeline completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)