### PR TITLE
fix(entitlement): check v2 products[].plans in undeclared-gate warning

### DIFF
--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -162,8 +162,13 @@ def _warn_undeclared_entitlement_gates(
     almost always a misconfiguration rather than intentional behaviour.
     """
     declared_capabilities: set[str] = set()
+    # v1: flat top-level plans
     for plan in subscriptions_config.plans:
         declared_capabilities.update(plan.capabilities or [])
+    # v2: plans nested under products
+    for product in (subscriptions_config.products or []):
+        for plan in product.plans:
+            declared_capabilities.update(plan.capabilities or [])
 
     for loaded_module in modules:
         for action_id, capability_id in loaded_module.action_entitlement_map.items():


### PR DESCRIPTION
## Summary

- `_warn_undeclared_entitlement_gates` in `mozaiksai/hosts/platform.py` was only scanning the v1 flat `subscriptions_config.plans` list, which is **empty** when the app uses the v2 `products[].plans` schema
- Every entitlement gate appeared undeclared at startup — ~25 `ENTITLEMENT_GATE_UNDECLARED` warnings on mozaiks-app boot even though `subscriptions.yaml` was correct
- Fix: collect declared capabilities from both v1 flat plans and v2 nested `products[].plans`; the warning now only fires for capabilities that are genuinely absent from all plan tiers

## Root cause

```python
# Before — v2 subscriptions_config.plans is always empty
for plan in subscriptions_config.plans:
    declared_capabilities.update(plan.capabilities or [])

# After — checks both schemas
for plan in subscriptions_config.plans:
    declared_capabilities.update(plan.capabilities or [])
for product in (subscriptions_config.products or []):
    for plan in product.plans:
        declared_capabilities.update(plan.capabilities or [])
```

## Test plan

- [ ] Start mozaiks-app backend with a v2 `subscriptions.yaml` (uses `products[].plans`) — confirm zero `ENTITLEMENT_GATE_UNDECLARED` warnings at startup
- [ ] Confirm warning still fires when a gate capability is genuinely missing from `subscriptions.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)