### PR TITLE
chore(deps): bump ag2 to 1.0.1 and azure-storage-blob to >=12.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 keywords = ["mozaiks", "ag2", "ai", "agents", "workflows", "multi-tenant", "runtime"]
 
 dependencies = [
-    "ag2[a2a,openai,tracing]==1.0.0",
+    "ag2[a2a,openai,tracing]==1.0.1",
     "a2a-sdk[grpc]>=1.1.0,<2",
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.20.0",
@@ -52,10 +52,10 @@ dependencies = [
 
 [project.optional-dependencies]
 gemini = [
-    "ag2[gemini]==1.0.0",
+    "ag2[gemini]==1.0.1",
 ]
 anthropic = [
-    "ag2[anthropic]==1.0.0",
+    "ag2[anthropic]==1.0.1",
 ]
 azure = [
     "azure-identity>=1.15.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ﻿# mozaiksai Requirements
 # Core runtime
-ag2[a2a,openai,tracing]==1.0.0
+ag2[a2a,openai,tracing]==1.0.1
 a2a-sdk[grpc]>=1.1.0,<2
 fastapi>=0.100.0
 uvicorn[standard]>=0.20.0
@@ -28,5 +28,5 @@ python-multipart>=0.0.6
 azure-identity>=1.15.0
 azure-keyvault-secrets>=4.7.0
 # Azure Blob Storage (optional — used when MOZAIKS_MEDIA_CONTENT_BACKEND=azure_blob)
-azure-storage-blob>=12.19.0
+azure-storage-blob>=12.30.0
 


### PR DESCRIPTION
Supersedes Dependabot PRs #171 and #172 — both were failing CI due to a pre-existing mypy error that was fixed in #175. Applied cleanly on top of current main.

## Changes
- `ag2[a2a,openai,tracing]` 1.0.0 → 1.0.1 in `requirements.txt` and `pyproject.toml` (all three extras)
- `azure-storage-blob` >=12.19.0 → >=12.30.0 in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)