### PR TITLE
fix(tests): update routing contracts test to use build_family key

### DIFF
--- a/tests/test_refinement_routing_contracts.py
+++ b/tests/test_refinement_routing_contracts.py
@@ -44,11 +44,11 @@ def test_refinement_routes_reference_declared_workflow_sequences() -> None:
 
     missing: list[str] = []
     for artifact in harness["routing"]["artifacts"]:
-        artifact_kind = artifact["artifact_kind"]
+        build_family = artifact["build_family"]
         for change_class, route in artifact["routes"].items():
             sequence_id = str(route.get("workflow_sequence") or "").strip()
             if sequence_id not in sequence_ids:
-                missing.append(f"{artifact_kind}.{change_class}->{sequence_id}")
+                missing.append(f"{build_family}.{change_class}->{sequence_id}")
 
     assert missing == []
 


### PR DESCRIPTION
## Summary

- `test_refinement_routes_reference_declared_workflow_sequences` was reading `artifact["artifact_kind"]` but `harness.yaml` was renamed to `build_family` in #174/#178
- This was the one test file missed in the PR #178 batch update, causing main CI test job to fail

## Test plan
- [ ] CI test job passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)