### PR TITLE
fix(transport): validate Redis connectivity at init and fail open on transient errors

### DIFF
--- a/mozaiksai/core/transport/rate_limit.py
+++ b/mozaiksai/core/transport/rate_limit.py
@@ -104,7 +104,15 @@ def _select_path_limit(path: str, parsed_limits: dict[str, Any], global_limit: A
 
 
 def _build_storage():
-    """Return Redis storage when REDIS_URL is configured, otherwise in-memory."""
+    """Return Redis storage when REDIS_URL is configured, otherwise in-memory.
+
+    RedisStorage uses a lazy connection internally; the constructor does not
+    attempt to connect.  We call ``store.check()`` (a synchronous ping) to
+    verify the server is reachable before handing the storage to the limiter.
+    If the ping fails we fall back to per-worker in-memory storage so that a
+    misconfigured or temporarily unavailable Redis does not make the whole rate
+    limiter raise on every request.
+    """
     from limits.storage import MemoryStorage
 
     redis_url = os.getenv("REDIS_URL", "").strip()
@@ -113,6 +121,8 @@ def _build_storage():
             from limits.storage import RedisStorage
 
             store = RedisStorage(redis_url)
+            if not store.check():
+                raise ConnectionError("Redis ping returned False — server unreachable")
             # Mask credentials in the log.
             safe_url = redis_url.split("@")[-1] if "@" in redis_url else redis_url
             logger.info("Rate limiter: using Redis storage (%s)", safe_url)
@@ -192,10 +202,18 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         )
 
         # Namespace (client_key, matched_prefix) keeps per-path buckets independent.
-        allowed = self._limiter.hit(active_limit, client_key, matched_prefix)
-        stats = self._limiter.get_window_stats(active_limit, client_key, matched_prefix)
-        remaining = max(0, stats.remaining)
-        reset_in = max(0, int(stats.reset_time - time.time()))
+        # Fail open: if the backing storage is transiently unavailable (e.g. Redis
+        # connection refused) allow the request through rather than returning 500.
+        try:
+            allowed = self._limiter.hit(active_limit, client_key, matched_prefix)
+            stats = self._limiter.get_window_stats(active_limit, client_key, matched_prefix)
+            remaining = max(0, stats.remaining)
+            reset_in = max(0, int(stats.reset_time - time.time()))
+        except Exception as exc:
+            logger.warning(
+                "Rate limiter: storage error — allowing request through: %s", exc
+            )
+            return await call_next(request)  # type: ignore[no-any-return]
 
         if not allowed:
             logger.warning(
@@ -267,7 +285,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             self._global_limit,
         )
 
-        allowed = self._limiter.hit(active_limit, client_key, matched_prefix)
+        try:
+            allowed = self._limiter.hit(active_limit, client_key, matched_prefix)
+        except Exception as exc:
+            logger.warning(
+                "Rate limiter: storage error (websocket) — allowing through: %s", exc
+            )
+            await super().__call__(scope, receive, send)
+            return
 
         if not allowed:
             logger.warning(


### PR DESCRIPTION
## Summary

Two-layer fix for rate limiter stability when Redis is configured but unreachable:

- **`_build_storage()`**: call `store.check()` (synchronous ping) immediately after creating `RedisStorage`. `RedisStorage` uses a lazy connection internally, so the constructor never throws even when the server is down. Without this ping the limiter silently holds a broken storage object and every `hit()` call raises `ConnectionError` → HTTP 500. On ping failure we catch and fall back to per-worker `MemoryStorage` so the limiter degrades gracefully at startup.

- **`dispatch()` / `__call__`**: wrap `hit()` and `get_window_stats()` in `try/except` and fail open (allow the request through) on any storage exception. Prevents transient Redis unavailability from turning into 500s for all non-excluded paths after the server was initially healthy.

**Root cause**: When `REDIS_URL` is set but the Redis server is unreachable inside the container, every rate-limited request threw `ConnectionError` → unhandled in `BaseHTTPMiddleware.dispatch()` → HTTP 500. `/api/health` was already excluded (no `hit()` call), but `/api/health/readiness` was not, hence the staging readiness check failing. PR #182 added the path exclusion; this PR adds the proper resilience so misconfigured Redis never makes the limiter return 500s.

## Test plan

- [ ] Existing rate limit tests pass
- [ ] Staging deploy readiness check passes after mozaiks-app pin bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)