### PR TITLE
fix(social): add missing user_data_scope=true to activity_feed module.yaml

### DIFF
--- a/factory_app/build_context/social/templates/modules/activity_feed/module.yaml
+++ b/factory_app/build_context/social/templates/modules/activity_feed/module.yaml
@@ -8,6 +8,7 @@ module:
     as structured activity records and surfaces them as personalized feeds
     or per-user activity timelines on the profile page.
   handler: backend.handler:ActivityFeedHandler
+  user_data_scope: true
 
 permissions:
   - id: activity_feed.read

--- a/tests/test_build_context_social_pack.py
+++ b/tests/test_build_context_social_pack.py
@@ -177,6 +177,25 @@ def test_activity_feed_module_capabilities_target_existing_actions() -> None:
     assert _capability_ids(module_yaml) == {"social.feed.read"}
 
 
+def test_activity_feed_declares_user_data_scope() -> None:
+    """activity_feed stores actor_id/about_user_id/feed_user_ids — user-owned PII.
+
+    Without user_data_scope=true the module_loader skips AccountDataHandler
+    registration, so GDPR delete and export silently miss this module's data.
+    """
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "activity_feed" / "module.yaml")
+    assert module_yaml.get("module", {}).get("user_data_scope") is True
+
+
+def test_activity_feed_backend_ships_account_data_handler() -> None:
+    handler = TEMPLATES / "modules" / "activity_feed" / "backend" / "account_data_handler.py"
+    assert handler.exists(), "account_data_handler.py must exist alongside user_data_scope=true"
+    source = handler.read_text(encoding="utf-8")
+    assert "class AccountDataHandler" in source
+    assert "async def delete_user_data" in source
+    assert "async def export_user_data" in source
+
+
 def test_activity_feed_populated_via_reactions_not_direct_calls() -> None:
     """activity_feed populates via domain event reactions, not direct service calls."""
     reactions = _read_yaml(


### PR DESCRIPTION
## Summary

- `activity_feed/module.yaml` was missing `user_data_scope: true` even though a fully-implemented `AccountDataHandler` already existed in the pack template.
- `activity_feed` stores `actor_id`, `about_user_id`, and `feed_user_ids` — clearly user-owned PII — so the flag is required.
- Without the flag, `module_loader._register_account_data_handler` is never called at startup, so GDPR account deletion and data export silently skip all activity feed records for every generated app using the social pack.
- `friends` and `user_posts` in the same pack already had the flag and tests; `activity_feed` was the odd one out.
- Added two regression tests mirroring the existing `friends` coverage so this class of omission is caught immediately.

## Test plan
- [ ] `pytest tests/test_build_context_social_pack.py -k activity_feed` — all 5 tests pass (verified locally)
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)