### PR TITLE
fix(build-record): repair broken legacy artifact-store calls in summary_artifacts and generate_and_download

### DIFF
--- a/factory_app/workflows/AgentGenerator/tools/generate_and_download.py
+++ b/factory_app/workflows/AgentGenerator/tools/generate_and_download.py
@@ -180,11 +180,11 @@ async def _register_workflow_bundle_artifact_version(
         artifact_kinds=("concept", "build_plan", "design_docs"),
         artifact_store=artifact_store,
     )
-    artifact_version = await artifact_store.create_artifact_version(
+    artifact_version = await artifact_store.create_build_record(
         app_id=str(app_id),
-        artifact_kind="workflow_bundle",
-        artifact_key=bundle_name,
-        parent_version_id=str(parent_version_id) if parent_version_id else None,
+        build_family="workflow_bundle",
+        build_key=bundle_name,
+        parent_build_record_id=str(parent_version_id) if parent_version_id else None,
         canonical_inputs_version=canonical_inputs_version,
         files_manifest=files_manifest,
         source_workflow=workflow_name,

--- a/factory_app/workflows/AppGenerator/tools/generate_and_download.py
+++ b/factory_app/workflows/AppGenerator/tools/generate_and_download.py
@@ -708,11 +708,11 @@ async def _register_app_bundle_artifact_version(
         artifact_kinds=("concept", "build_plan", "design_docs", "workflow_bundle", "theme_capture"),
         artifact_store=artifact_store,
     )
-    artifact_version = await artifact_store.create_artifact_version(
+    artifact_version = await artifact_store.create_build_record(
         app_id=str(app_id),
-        artifact_kind="app_bundle",
-        artifact_key="app_bundle",
-        parent_version_id=str(parent_version_id) if parent_version_id else None,
+        build_family="app_bundle",
+        build_key="app_bundle",
+        parent_build_record_id=str(parent_version_id) if parent_version_id else None,
         canonical_inputs_version=canonical_inputs_version,
         files_manifest=files_manifest,
         source_workflow=workflow_name,

--- a/mozaiksai/core/artifacts/summary_artifacts.py
+++ b/mozaiksai/core/artifacts/summary_artifacts.py
@@ -78,17 +78,17 @@ async def resolve_latest_artifact_version_refs(
         seen_kinds.add(artifact_kind)
 
         artifact_key = str((artifact_key_by_kind or {}).get(artifact_kind) or artifact_kind).strip() or None
-        versions = await store.list_artifact_versions(
+        versions = await store.list_build_records(
             app_id=resolved_app_id,
-            artifact_kind=artifact_kind,
-            artifact_key=artifact_key,
+            build_family=artifact_kind,
+            build_key=artifact_key,
             lifecycle_status=ArtifactLifecycleStatus.CURRENT,
             limit=1,
         )
         if not versions and artifact_key is not None:
-            versions = await store.list_artifact_versions(
+            versions = await store.list_build_records(
                 app_id=resolved_app_id,
-                artifact_kind=artifact_kind,
+                build_family=artifact_kind,
                 lifecycle_status=ArtifactLifecycleStatus.CURRENT,
                 limit=1,
             )
@@ -134,10 +134,10 @@ async def persist_summary_artifact(
     store = artifact_store or get_artifact_store()
     resolved_parent_version_id = str(parent_version_id or "").strip() or None
     if not resolved_parent_version_id:
-        prior_versions = await store.list_artifact_versions(
+        prior_versions = await store.list_build_records(
             app_id=resolved_app_id,
-            artifact_kind=resolved_artifact_kind,
-            artifact_key=resolved_artifact_key,
+            build_family=resolved_artifact_kind,
+            build_key=resolved_artifact_key,
             lifecycle_status=ArtifactLifecycleStatus.CURRENT,
             limit=1,
         )
@@ -163,11 +163,11 @@ async def persist_summary_artifact(
     )
     summary_file_name = f"{resolved_artifact_key}.json"
 
-    return await store.create_artifact_version(
+    return await store.create_build_record(
         app_id=resolved_app_id,
-        artifact_kind=resolved_artifact_kind,
-        artifact_key=resolved_artifact_key,
-        parent_version_id=resolved_parent_version_id,
+        build_family=resolved_artifact_kind,
+        build_key=resolved_artifact_key,
+        parent_build_record_id=resolved_parent_version_id,
         canonical_inputs_version=resolved_inputs,
         files_manifest=[
             {

--- a/tests/test_app_context_registration.py
+++ b/tests/test_app_context_registration.py
@@ -26,104 +26,103 @@ from mozaiksai.core.app_context.store import (
     set_current_app_context_version,
 )
 from mozaiksai.core.artifacts.models import (
-    ArtifactLifecycleStatus,
-    ArtifactValidationStatus,
-    ArtifactVersionDoc,
+    BuildRecord,
+    BuildRecordStatus,
+    BuildRecordValidationStatus,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-class _MemoryArtifactStore:
+class _MemoryBuildRecordStore:
     def __init__(self) -> None:
-        self.versions: dict[str, ArtifactVersionDoc] = {}
+        self.versions: dict[str, BuildRecord] = {}
         self.create_calls: list[dict[str, Any]] = []
         self._counter = 0
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> BuildRecord:
         self._counter += 1
-        version_id = f"av_{self._counter}"
+        record_id = f"br_{self._counter}"
         self.create_calls.append(kwargs)
-        doc = ArtifactVersionDoc(
-            _id=version_id,
+        doc = BuildRecord(
+            _id=record_id,
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=self._counter,
-            parent_version_id=kwargs.get("parent_version_id"),
-            lineage_root_id=version_id,
+            lineage_root_id=record_id,
             source_workflow=kwargs.get("source_workflow"),
             source_chat_id=kwargs.get("source_chat_id"),
             canonical_inputs_version=kwargs.get("canonical_inputs_version") or {},
-            lifecycle_status=kwargs.get("lifecycle_status", ArtifactLifecycleStatus.DRAFT),
-            validation_status=kwargs.get("validation_status", ArtifactValidationStatus.PENDING),
+            lifecycle_status=kwargs.get("lifecycle_status", BuildRecordStatus.DRAFT),
+            validation_status=kwargs.get("validation_status", BuildRecordValidationStatus.PENDING),
             files_manifest=kwargs.get("files_manifest") or [],
             commit_metadata=kwargs.get("commit_metadata") or {},
         )
-        if doc.lifecycle_status is ArtifactLifecycleStatus.CURRENT:
+        if doc.lifecycle_status is BuildRecordStatus.CURRENT:
             self._supersede_current_siblings(doc)
         self.versions[doc.id] = doc
         return doc
 
-    async def get_artifact_version(
+    async def get_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
-    ) -> ArtifactVersionDoc | None:
-        doc = self.versions.get(artifact_version_id)
+        build_record_id: str,
+    ) -> BuildRecord | None:
+        doc = self.versions.get(build_record_id)
         if doc is None or doc.app_id != app_id:
             return None
         return doc
 
-    async def accept_artifact_version(
+    async def accept_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
         commit_metadata: dict[str, Any] | None = None,
-    ) -> ArtifactVersionDoc | None:
-        doc = await self.get_artifact_version(
+    ) -> BuildRecord | None:
+        doc = await self.get_build_record(
             app_id=app_id,
-            artifact_version_id=artifact_version_id,
+            build_record_id=build_record_id,
         )
         if doc is None:
             return None
         self._supersede_current_siblings(doc)
-        doc.lifecycle_status = ArtifactLifecycleStatus.CURRENT
+        doc.lifecycle_status = BuildRecordStatus.CURRENT
         if commit_metadata is not None:
             doc.commit_metadata = commit_metadata
         return doc
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str | None = None,
-        artifact_key: str | None = None,
-        lifecycle_status: ArtifactLifecycleStatus | None = None,
+        build_family: str | None = None,
+        build_key: str | None = None,
+        lifecycle_status: BuildRecordStatus | None = None,
         limit: int = 50,
         **_kwargs: Any,
-    ) -> list[ArtifactVersionDoc]:
+    ) -> list[BuildRecord]:
         rows = [doc for doc in self.versions.values() if doc.app_id == app_id]
-        if artifact_kind is not None:
-            rows = [doc for doc in rows if doc.artifact_kind == artifact_kind]
-        if artifact_key is not None:
-            rows = [doc for doc in rows if doc.artifact_key == artifact_key]
+        if build_family is not None:
+            rows = [doc for doc in rows if doc.build_family == build_family]
+        if build_key is not None:
+            rows = [doc for doc in rows if doc.build_key == build_key]
         if lifecycle_status is not None:
             rows = [doc for doc in rows if doc.lifecycle_status is lifecycle_status]
         return sorted(rows, key=lambda doc: doc.version_number, reverse=True)[:limit]
 
-    def _supersede_current_siblings(self, target: ArtifactVersionDoc) -> None:
+    def _supersede_current_siblings(self, target: BuildRecord) -> None:
         for doc in self.versions.values():
             if (
                 doc.app_id == target.app_id
-                and doc.artifact_kind == target.artifact_kind
-                and doc.artifact_key == target.artifact_key
+                and doc.build_family == target.build_family
+                and doc.build_key == target.build_key
                 and doc.id != target.id
-                and doc.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+                and doc.lifecycle_status is BuildRecordStatus.CURRENT
             ):
-                doc.lifecycle_status = ArtifactLifecycleStatus.SUPERSEDED
+                doc.lifecycle_status = BuildRecordStatus.SUPERSEDED
 
 
 def _source_ref() -> SourceRef:
@@ -198,7 +197,7 @@ def test_missing_required_artifact_refs_fail_clearly() -> None:
 
 
 async def test_registers_app_context_version_as_artifact_kind() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     context_version = build_brownfield_app_context_version(
         app_id="ops_studio",
         artifact_version_refs=_artifact_refs(),
@@ -215,14 +214,14 @@ async def test_registers_app_context_version_as_artifact_kind() -> None:
         source_chat_id="chat_1",
     )
 
-    assert registered.artifact_version.artifact_kind == APP_CONTEXT_VERSION_ARTIFACT_KIND
-    assert registered.artifact_version.artifact_key == APP_CONTEXT_VERSION_ARTIFACT_KEY
-    assert registered.artifact_version.lifecycle_status is ArtifactLifecycleStatus.DRAFT
-    assert store.create_calls[0]["artifact_kind"] == "app_context_version"
+    assert registered.artifact_version.build_family == APP_CONTEXT_VERSION_ARTIFACT_KIND
+    assert registered.artifact_version.build_key == APP_CONTEXT_VERSION_ARTIFACT_KEY
+    assert registered.artifact_version.lifecycle_status is BuildRecordStatus.DRAFT
+    assert store.create_calls[0]["build_family"] == "app_context_version"
 
 
 async def test_current_context_selection_can_be_set_and_retrieved() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     context_version = build_brownfield_app_context_version(
         app_id="ops_studio",
         artifact_version_refs=_artifact_refs(),
@@ -237,7 +236,7 @@ async def test_current_context_selection_can_be_set_and_retrieved() -> None:
 
     current_artifact = await set_current_app_context_version(
         app_id="ops_studio",
-        artifact_version_id=registered.artifact_version.id,
+        build_record_id=registered.artifact_version.id,
         artifact_store=store,
     )
     current_context = await get_current_app_context_version(
@@ -246,13 +245,13 @@ async def test_current_context_selection_can_be_set_and_retrieved() -> None:
     )
 
     assert current_artifact is not None
-    assert current_artifact.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+    assert current_artifact.lifecycle_status is BuildRecordStatus.CURRENT
     assert current_context is not None
     assert current_context.context_version_id == "ctx_ops_1"
 
 
 async def test_new_current_context_supersedes_prior_current_context() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     first = build_brownfield_app_context_version(
         app_id="ops_studio",
         artifact_version_refs=_artifact_refs("1"),
@@ -285,8 +284,8 @@ async def test_new_current_context_supersedes_prior_current_context() -> None:
         artifact_store=store,
     )
 
-    assert first_registered.artifact_version.lifecycle_status is ArtifactLifecycleStatus.SUPERSEDED
-    assert second_registered.artifact_version.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+    assert first_registered.artifact_version.lifecycle_status is BuildRecordStatus.SUPERSEDED
+    assert second_registered.artifact_version.lifecycle_status is BuildRecordStatus.CURRENT
     assert current_context is not None
     assert current_context.context_version_id == "ctx_ops_2"
 

--- a/tests/test_appgenerator_generate_and_download_persistence.py
+++ b/tests/test_appgenerator_generate_and_download_persistence.py
@@ -57,7 +57,7 @@ class _FakeArtifactStore:
     def __init__(self) -> None:
         self.calls = []
 
-    async def create_artifact_version(self, **kwargs):
+    async def create_build_record(self, **kwargs):
         self.calls.append(dict(kwargs))
         return type("ArtifactVersion", (), {"id": "av_bundle_1"})()
 
@@ -170,9 +170,9 @@ def test_register_app_bundle_artifact_version_sets_context_and_parent(monkeypatc
     )
 
     assert artifact_version.id == "av_bundle_1"
-    assert fake_artifact_store.calls[0]["artifact_kind"] == "app_bundle"
-    assert fake_artifact_store.calls[0]["artifact_key"] == "app_bundle"
-    assert fake_artifact_store.calls[0]["parent_version_id"] == "av_parent_1"
+    assert fake_artifact_store.calls[0]["build_family"] == "app_bundle"
+    assert fake_artifact_store.calls[0]["build_key"] == "app_bundle"
+    assert fake_artifact_store.calls[0]["parent_build_record_id"] == "av_parent_1"
     assert fake_artifact_store.calls[0]["canonical_inputs_version"] == {
         "concept": "av_concept_1",
         "build_plan": "av_build_plan_1",

--- a/tests/test_appgenerator_greenfield_app_context_registration.py
+++ b/tests/test_appgenerator_greenfield_app_context_registration.py
@@ -61,9 +61,9 @@ class _MemoryArtifactStore:
         self.create_calls: list[dict[str, Any]] = []
         self._counter = 0
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> ArtifactVersionDoc:
         self._counter += 1
-        artifact_kind = kwargs["artifact_kind"]
+        artifact_kind = kwargs["build_family"]
         version_id = (
             "av_app_bundle_1"
             if artifact_kind == "app_bundle"
@@ -73,8 +73,8 @@ class _MemoryArtifactStore:
         doc = ArtifactVersionDoc(
             _id=version_id,
             app_id=kwargs["app_id"],
-            artifact_kind=artifact_kind,
-            artifact_key=kwargs["artifact_key"],
+            build_family=artifact_kind,
+            build_key=kwargs["build_key"],
             version_number=self._counter,
             parent_version_id=kwargs.get("parent_version_id"),
             lineage_root_id=version_id,
@@ -91,27 +91,27 @@ class _MemoryArtifactStore:
         self.versions[doc.id] = doc
         return doc
 
-    async def get_artifact_version(
+    async def get_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
     ) -> ArtifactVersionDoc | None:
-        doc = self.versions.get(artifact_version_id)
+        doc = self.versions.get(build_record_id)
         if doc is None or doc.app_id != app_id:
             return None
         return doc
 
-    async def accept_artifact_version(
+    async def accept_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
         commit_metadata: dict[str, Any] | None = None,
     ) -> ArtifactVersionDoc | None:
-        doc = await self.get_artifact_version(
+        doc = await self.get_build_record(
             app_id=app_id,
-            artifact_version_id=artifact_version_id,
+            build_record_id=build_record_id,
         )
         if doc is None:
             return None
@@ -121,21 +121,21 @@ class _MemoryArtifactStore:
             doc.commit_metadata = commit_metadata
         return doc
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str | None = None,
-        artifact_key: str | None = None,
+        build_family: str | None = None,
+        build_key: str | None = None,
         lifecycle_status: ArtifactLifecycleStatus | None = None,
         limit: int = 50,
         **_kwargs: Any,
     ) -> list[ArtifactVersionDoc]:
         rows = [doc for doc in self.versions.values() if doc.app_id == app_id]
-        if artifact_kind is not None:
-            rows = [doc for doc in rows if doc.artifact_kind == artifact_kind]
-        if artifact_key is not None:
-            rows = [doc for doc in rows if doc.artifact_key == artifact_key]
+        if build_family is not None:
+            rows = [doc for doc in rows if doc.build_family == build_family]
+        if build_key is not None:
+            rows = [doc for doc in rows if doc.build_key == build_key]
         if lifecycle_status is not None:
             rows = [doc for doc in rows if doc.lifecycle_status is lifecycle_status]
         return sorted(rows, key=lambda doc: doc.version_number, reverse=True)[:limit]
@@ -144,8 +144,8 @@ class _MemoryArtifactStore:
         for doc in self.versions.values():
             if (
                 doc.app_id == target.app_id
-                and doc.artifact_kind == target.artifact_kind
-                and doc.artifact_key == target.artifact_key
+                and doc.build_family == target.build_family
+                and doc.build_key == target.build_key
                 and doc.id != target.id
                 and doc.lifecycle_status is ArtifactLifecycleStatus.CURRENT
             ):
@@ -219,7 +219,7 @@ async def test_appgenerator_app_bundle_save_registers_greenfield_context(
         artifact_store=store,
     )
 
-    persisted_kinds = {call["artifact_kind"] for call in store.create_calls}
+    persisted_kinds = {call["build_family"] for call in store.create_calls}
     assert persisted_kinds == {
         "app_bundle",
         "source_context_bundle",
@@ -243,7 +243,7 @@ async def test_appgenerator_app_bundle_save_registers_greenfield_context(
     inventory_payload = next(
         doc.commit_metadata.metadata["summary_payload"]
         for doc in store.versions.values()
-        if doc.artifact_kind == "application_inventory"
+        if doc.build_family == "application_inventory"
     )
     assert any(page["location"] == "ui/pages/home.yaml" for page in inventory_payload["pages"])
     assert any(
@@ -257,7 +257,7 @@ async def test_appgenerator_app_bundle_save_registers_greenfield_context(
     ownership_payload = next(
         doc.commit_metadata.metadata["summary_payload"]
         for doc in store.versions.values()
-        if doc.artifact_kind == "ownership_boundary"
+        if doc.build_family == "ownership_boundary"
     )
     file_ownership = {
         boundary["ownership"]
@@ -320,7 +320,7 @@ async def test_appgenerator_greenfield_context_registration_failure_is_nonfatal(
     assert app_bundle.id == "av_app_bundle_1"
     assert context.data["artifact_version_id"] == "av_app_bundle_1"
     assert "context store unavailable" in context.data["app_context_registration_warning"]
-    assert {call["artifact_kind"] for call in store.create_calls} == {"app_bundle"}
+    assert {call["build_family"] for call in store.create_calls} == {"app_bundle"}
 
 
 async def test_appgenerator_greenfield_context_contract_errors_can_be_strict() -> None:

--- a/tests/test_context_refresh_result_handling.py
+++ b/tests/test_context_refresh_result_handling.py
@@ -27,94 +27,93 @@ from mozaiksai.core.app_context.store import (
     register_app_context_version,
 )
 from mozaiksai.core.artifacts.models import (
-    ArtifactLifecycleStatus,
-    ArtifactValidationStatus,
-    ArtifactVersionDoc,
+    BuildRecord,
+    BuildRecordStatus,
+    BuildRecordValidationStatus,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-class _MemoryArtifactStore:
+class _MemoryBuildRecordStore:
     def __init__(self) -> None:
-        self.versions: dict[str, ArtifactVersionDoc] = {}
+        self.versions: dict[str, BuildRecord] = {}
         self._counter = 0
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> BuildRecord:
         self._counter += 1
-        version_id = f"av_{self._counter}"
-        doc = ArtifactVersionDoc(
-            _id=version_id,
+        record_id = f"br_{self._counter}"
+        doc = BuildRecord(
+            _id=record_id,
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=self._counter,
-            parent_version_id=kwargs.get("parent_version_id"),
-            lineage_root_id=version_id,
+            lineage_root_id=record_id,
             source_workflow=kwargs.get("source_workflow"),
             source_chat_id=kwargs.get("source_chat_id"),
             canonical_inputs_version=kwargs.get("canonical_inputs_version") or {},
-            lifecycle_status=kwargs.get("lifecycle_status", ArtifactLifecycleStatus.DRAFT),
-            validation_status=kwargs.get("validation_status", ArtifactValidationStatus.PENDING),
+            lifecycle_status=kwargs.get("lifecycle_status", BuildRecordStatus.DRAFT),
+            validation_status=kwargs.get("validation_status", BuildRecordValidationStatus.PENDING),
             files_manifest=kwargs.get("files_manifest") or [],
             commit_metadata=kwargs.get("commit_metadata") or {},
         )
         self.versions[doc.id] = doc
         return doc
 
-    async def get_artifact_version(
+    async def get_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
-    ) -> ArtifactVersionDoc | None:
-        doc = self.versions.get(artifact_version_id)
+        build_record_id: str,
+    ) -> BuildRecord | None:
+        doc = self.versions.get(build_record_id)
         if doc is None or doc.app_id != app_id:
             return None
         return doc
 
-    async def accept_artifact_version(
+    async def accept_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
         commit_metadata: dict[str, Any] | None = None,
-    ) -> ArtifactVersionDoc | None:
-        doc = await self.get_artifact_version(
+    ) -> BuildRecord | None:
+        doc = await self.get_build_record(
             app_id=app_id,
-            artifact_version_id=artifact_version_id,
+            build_record_id=build_record_id,
         )
         if doc is None:
             return None
         for candidate in self.versions.values():
             if (
                 candidate.app_id == app_id
-                and candidate.artifact_kind == doc.artifact_kind
-                and candidate.artifact_key == doc.artifact_key
+                and candidate.build_family == doc.build_family
+                and candidate.build_key == doc.build_key
                 and candidate.id != doc.id
-                and candidate.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+                and candidate.lifecycle_status is BuildRecordStatus.CURRENT
             ):
-                candidate.lifecycle_status = ArtifactLifecycleStatus.SUPERSEDED
-        doc.lifecycle_status = ArtifactLifecycleStatus.CURRENT
+                candidate.lifecycle_status = BuildRecordStatus.SUPERSEDED
+        doc.lifecycle_status = BuildRecordStatus.CURRENT
         if commit_metadata is not None:
             doc.commit_metadata = commit_metadata
         return doc
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str | None = None,
-        artifact_key: str | None = None,
-        lifecycle_status: ArtifactLifecycleStatus | None = None,
+        build_family: str | None = None,
+        build_key: str | None = None,
+        lifecycle_status: BuildRecordStatus | None = None,
         limit: int = 50,
         **_kwargs: Any,
-    ) -> list[ArtifactVersionDoc]:
+    ) -> list[BuildRecord]:
         rows = [doc for doc in self.versions.values() if doc.app_id == app_id]
-        if artifact_kind is not None:
-            rows = [doc for doc in rows if doc.artifact_kind == artifact_kind]
-        if artifact_key is not None:
-            rows = [doc for doc in rows if doc.artifact_key == artifact_key]
+        if build_family is not None:
+            rows = [doc for doc in rows if doc.build_family == build_family]
+        if build_key is not None:
+            rows = [doc for doc in rows if doc.build_key == build_key]
         if lifecycle_status is not None:
             rows = [doc for doc in rows if doc.lifecycle_status is lifecycle_status]
         return sorted(rows, key=lambda doc: doc.version_number, reverse=True)[:limit]
@@ -185,7 +184,7 @@ def _plan(previous_context_version_id: str | None = "ctx_previous") -> ContextRe
 
 @pytest.mark.asyncio
 async def test_new_current_context_version_resolves_stale_context() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_previous", suffix="1"),
         artifact_store=store,
@@ -211,7 +210,7 @@ async def test_new_current_context_version_resolves_stale_context() -> None:
 
 @pytest.mark.asyncio
 async def test_same_context_version_does_not_resolve_stale_context() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_previous", suffix="1"),
         artifact_store=store,
@@ -233,7 +232,7 @@ async def test_same_context_version_does_not_resolve_stale_context() -> None:
 async def test_missing_current_context_returns_missing_context_status() -> None:
     result = await refresh_execution.complete_context_refresh(
         _plan("ctx_previous"),
-        artifact_store=_MemoryArtifactStore(),
+        artifact_store=_MemoryBuildRecordStore(),
         app_id="field_service",
     )
 
@@ -245,7 +244,7 @@ async def test_missing_current_context_returns_missing_context_status() -> None:
 
 @pytest.mark.asyncio
 async def test_stale_new_context_does_not_resolve_stale_context() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_previous", suffix="1"),
         artifact_store=store,
@@ -275,7 +274,7 @@ async def test_stale_new_context_does_not_resolve_stale_context() -> None:
 
 @pytest.mark.asyncio
 async def test_result_lists_artifacts_from_app_context_version_refs() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_new", suffix="2"),
         artifact_store=store,
@@ -295,7 +294,7 @@ async def test_result_lists_artifacts_from_app_context_version_refs() -> None:
 
 @pytest.mark.asyncio
 async def test_completion_helper_does_not_run_workflows(monkeypatch) -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_new", suffix="2"),
         artifact_store=store,
@@ -317,7 +316,7 @@ async def test_completion_helper_does_not_run_workflows(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_completion_helper_does_not_mutate_current_context() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     await register_app_context_version(
         _context_version(context_version_id="ctx_new", suffix="2"),
         artifact_store=store,

--- a/tests/test_greenfield_app_context_registration.py
+++ b/tests/test_greenfield_app_context_registration.py
@@ -12,96 +12,95 @@ from mozaiksai.core.app_context.store import (
     register_greenfield_app_context_version,
 )
 from mozaiksai.core.artifacts.models import (
-    ArtifactLifecycleStatus,
-    ArtifactValidationStatus,
-    ArtifactVersionDoc,
+    BuildRecord,
+    BuildRecordStatus,
+    BuildRecordValidationStatus,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-class _MemoryArtifactStore:
+class _MemoryBuildRecordStore:
     def __init__(self) -> None:
-        self.versions: dict[str, ArtifactVersionDoc] = {}
+        self.versions: dict[str, BuildRecord] = {}
         self.create_calls: list[dict[str, Any]] = []
         self._counter = 0
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> BuildRecord:
         self._counter += 1
-        version_id = f"av_{self._counter}"
+        record_id = f"br_{self._counter}"
         self.create_calls.append(kwargs)
-        doc = ArtifactVersionDoc(
-            _id=version_id,
+        doc = BuildRecord(
+            _id=record_id,
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=self._counter,
-            parent_version_id=kwargs.get("parent_version_id"),
-            lineage_root_id=version_id,
+            lineage_root_id=record_id,
             source_workflow=kwargs.get("source_workflow"),
             source_chat_id=kwargs.get("source_chat_id"),
             canonical_inputs_version=kwargs.get("canonical_inputs_version") or {},
-            lifecycle_status=kwargs.get("lifecycle_status", ArtifactLifecycleStatus.DRAFT),
-            validation_status=kwargs.get("validation_status", ArtifactValidationStatus.PENDING),
+            lifecycle_status=kwargs.get("lifecycle_status", BuildRecordStatus.DRAFT),
+            validation_status=kwargs.get("validation_status", BuildRecordValidationStatus.PENDING),
             files_manifest=kwargs.get("files_manifest") or [],
             commit_metadata=kwargs.get("commit_metadata") or {},
         )
         self.versions[doc.id] = doc
         return doc
 
-    async def get_artifact_version(
+    async def get_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
-    ) -> ArtifactVersionDoc | None:
-        doc = self.versions.get(artifact_version_id)
+        build_record_id: str,
+    ) -> BuildRecord | None:
+        doc = self.versions.get(build_record_id)
         if doc is None or doc.app_id != app_id:
             return None
         return doc
 
-    async def accept_artifact_version(
+    async def accept_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
         commit_metadata: dict[str, Any] | None = None,
-    ) -> ArtifactVersionDoc | None:
-        doc = await self.get_artifact_version(
+    ) -> BuildRecord | None:
+        doc = await self.get_build_record(
             app_id=app_id,
-            artifact_version_id=artifact_version_id,
+            build_record_id=build_record_id,
         )
         if doc is None:
             return None
         for version in self.versions.values():
             if (
                 version.app_id == app_id
-                and version.artifact_kind == doc.artifact_kind
-                and version.artifact_key == doc.artifact_key
+                and version.build_family == doc.build_family
+                and version.build_key == doc.build_key
                 and version.id != doc.id
-                and version.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+                and version.lifecycle_status is BuildRecordStatus.CURRENT
             ):
-                version.lifecycle_status = ArtifactLifecycleStatus.SUPERSEDED
-        doc.lifecycle_status = ArtifactLifecycleStatus.CURRENT
+                version.lifecycle_status = BuildRecordStatus.SUPERSEDED
+        doc.lifecycle_status = BuildRecordStatus.CURRENT
         if commit_metadata is not None:
             doc.commit_metadata = commit_metadata
         return doc
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str | None = None,
-        artifact_key: str | None = None,
-        lifecycle_status: ArtifactLifecycleStatus | None = None,
+        build_family: str | None = None,
+        build_key: str | None = None,
+        lifecycle_status: BuildRecordStatus | None = None,
         limit: int = 50,
         **_kwargs: Any,
-    ) -> list[ArtifactVersionDoc]:
+    ) -> list[BuildRecord]:
         rows = [doc for doc in self.versions.values() if doc.app_id == app_id]
-        if artifact_kind is not None:
-            rows = [doc for doc in rows if doc.artifact_kind == artifact_kind]
-        if artifact_key is not None:
-            rows = [doc for doc in rows if doc.artifact_key == artifact_key]
+        if build_family is not None:
+            rows = [doc for doc in rows if doc.build_family == build_family]
+        if build_key is not None:
+            rows = [doc for doc in rows if doc.build_key == build_key]
         if lifecycle_status is not None:
             rows = [doc for doc in rows if doc.lifecycle_status is lifecycle_status]
         return sorted(rows, key=lambda doc: doc.version_number, reverse=True)[:limit]
@@ -135,16 +134,16 @@ def _file_manifest() -> list[dict[str, Any]]:
     ]
 
 
-def _app_bundle_artifact() -> ArtifactVersionDoc:
-    return ArtifactVersionDoc(
+def _app_bundle_artifact() -> BuildRecord:
+    return BuildRecord(
         _id="av_app_bundle_1",
         app_id="field_service",
-        artifact_kind="app_bundle",
-        artifact_key="app_bundle",
+        build_family="app_bundle",
+        build_key="app_bundle",
         version_number=1,
         lineage_root_id="av_app_bundle_1",
-        lifecycle_status=ArtifactLifecycleStatus.CURRENT,
-        validation_status=ArtifactValidationStatus.PASSED,
+        lifecycle_status=BuildRecordStatus.CURRENT,
+        validation_status=BuildRecordValidationStatus.PASSED,
         files_manifest=_file_manifest(),
         commit_metadata={
             "metadata": {
@@ -223,7 +222,7 @@ def test_greenfield_app_context_graph_is_deterministic_and_source_ref_backed() -
 
 
 async def test_register_greenfield_app_context_version_persists_and_sets_current() -> None:
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
     app_bundle = _app_bundle_artifact()
 
     registered = await register_greenfield_app_context_version(
@@ -237,13 +236,13 @@ async def test_register_greenfield_app_context_version_persists_and_sets_current
         artifact_store=store,
     )
 
-    persisted_kinds = {call["artifact_kind"] for call in store.create_calls}
+    persisted_kinds = {call["build_family"] for call in store.create_calls}
     assert persisted_kinds == {
         *GREENFIELD_APP_CONTEXT_ARTIFACT_KINDS,
         APP_CONTEXT_VERSION_ARTIFACT_KIND,
     }
     assert registered.context_version.mode is AppContextMode.GREENFIELD
-    assert registered.artifact_version.lifecycle_status is ArtifactLifecycleStatus.CURRENT
+    assert registered.artifact_version.lifecycle_status is BuildRecordStatus.CURRENT
     assert current is not None
     assert current.mode is AppContextMode.GREENFIELD
     assert any(ref.artifact_kind == "app_bundle" for ref in current.artifact_refs)
@@ -263,15 +262,15 @@ async def test_register_greenfield_app_context_version_indexes_source_workspace(
         encoding="utf-8",
     )
     (workspace / "app" / "app.json").write_text('{"app_id": "field_service"}\n', encoding="utf-8")
-    app_bundle = ArtifactVersionDoc(
+    app_bundle = BuildRecord(
         _id="av_app_bundle_1",
         app_id="field_service",
-        artifact_kind="app_bundle",
-        artifact_key="app_bundle",
+        build_family="app_bundle",
+        build_key="app_bundle",
         version_number=1,
         lineage_root_id="av_app_bundle_1",
-        lifecycle_status=ArtifactLifecycleStatus.CURRENT,
-        validation_status=ArtifactValidationStatus.PASSED,
+        lifecycle_status=BuildRecordStatus.CURRENT,
+        validation_status=BuildRecordValidationStatus.PASSED,
         files_manifest=_file_manifest(),
         commit_metadata={
             "metadata": {
@@ -280,7 +279,7 @@ async def test_register_greenfield_app_context_version_indexes_source_workspace(
             }
         },
     )
-    store = _MemoryArtifactStore()
+    store = _MemoryBuildRecordStore()
 
     registered = await register_greenfield_app_context_version(
         app_bundle_artifact=app_bundle,
@@ -289,14 +288,14 @@ async def test_register_greenfield_app_context_version_indexes_source_workspace(
         source_chat_id="chat_greenfield_1",
     )
 
-    persisted_kinds = [call["artifact_kind"] for call in store.create_calls]
+    persisted_kinds = [call["build_family"] for call in store.create_calls]
     assert "source_context_bundle" in persisted_kinds
     assert registered.context_version.graph_snapshot_ref
     assert any(ref.artifact_kind == "source_context_bundle" for ref in registered.context_version.artifact_refs)
     source_payload = next(
         doc.commit_metadata.metadata["summary_payload"]
         for doc in store.versions.values()
-        if doc.artifact_kind == "source_context_bundle"
+        if doc.build_family == "source_context_bundle"
     )
     assert source_payload["file_contents"]["ui/components/Home.jsx"]
     assert source_payload["schema_version"] == "mozaiks.source_context.bundle.v1"


### PR DESCRIPTION
## What broke

After the artifact_kind/key legacy bridge was removed from \BuildRecordStore\ (#187), two widely-used functions in \mozaiksai/core/artifacts/summary_artifacts.py\ -- \esolve_latest_artifact_version_refs\ and \persist_summary_artifact\ -- kept calling \store.list_artifact_versions\ / \store.create_artifact_version\, methods that no longer exist. These are called (directly or via \persist_summary_artifact\) from ~8 factory workflow tools: DesignDocs, SubscriptionContractDesigner, ThemeCapture, ValueEngine, AgentGenerator, and AppGenerator. Any real invocation would raise \AttributeError\ at runtime.

\generate_and_download.py\ in both AgentGenerator and AppGenerator also called \rtifact_store.create_artifact_version(...)\ directly with legacy kwargs, same bug.

## Fix

- Fixed the internals of \esolve_latest_artifact_version_refs\/\persist_summary_artifact\ to call \list_build_records\/\create_build_record\ with \uild_family\/\uild_key\ kwargs. Their own external parameter names (\rtifact_kind\, \rtifact_key\) are unchanged, so none of the ~8 callers need to change.
- Fixed both \generate_and_download.py\ files to call \create_build_record\ with \uild_family\/\uild_key\/\parent_build_record_id\.
- Fixed matching test fakes/assertions that referenced the removed method/kwarg names or used the wrong \ArtifactRef\ field names (\ArtifactRef\ intentionally still uses \rtifact_kind\/\rtifact_version_id\, distinct from \BuildRecord\'s \uild_family\/\uild_key\).

## Tests

\\\
python -m pytest tests/test_app_context_refresh_contract.py tests/test_app_context_registration.py tests/test_context_refresh_result_handling.py tests/test_greenfield_app_context_registration.py tests/test_appgenerator_greenfield_app_context_registration.py tests/test_greenfield_app_context_graph_edges.py tests/test_existing_app_discovery_app_context_persistence.py tests/test_summary_artifacts.py tests/test_appgenerator_generate_and_download_persistence.py tests/test_agentgenerator_generate_and_download_persistence.py -q --no-cov
\\\
65 passed.