### PR TITLE
docs: fix branch cleanup guidance in agent-guidance template

### DIFF
--- a/mozaiks_cli/agent_guidance/rules/multi-agent-coordination.md
+++ b/mozaiks_cli/agent_guidance/rules/multi-agent-coordination.md
@@ -34,23 +34,34 @@ Auto-merge fires once required CI checks pass. No human action needed.
 
 ## Branch Cleanup
 
-Feature branches are temporary work queues, not permanent project state. A
-branch is safe to delete once its PR is merged or closed — deleting it does
-not remove any code, since the changes already live on `main` (or were
-abandoned). Always merge with `--delete-branch` so this happens automatically:
+Feature branches are temporary work queues, not permanent project state. Always
+merge with `--delete-branch` so cleanup happens automatically:
 
 ```bash
 gh pr merge <number> --squash --delete-branch --auto
 ```
 
-If branches were merged without `--delete-branch`, clean them up afterward:
+Two structural safety nets should also be in place at the repo level so cleanup
+does not depend on every agent remembering `--delete-branch`:
+
+1. Enable **"Automatically delete head branches"** in repo settings (or via
+   `gh api -X PATCH repos/<org>/<repo> -f delete_branch_on_merge=true`). This
+   deletes a branch the instant its PR merges, regardless of how it was merged.
+2. Add a scheduled cleanup Action (e.g. weekly) that sweeps branches whose PR
+   was closed without merging — those are not covered by delete-on-merge.
+   Give it a grace period (a few days) before deleting a closed branch, and
+   leave branches with no PR history at all for manual review.
+
+If you ever need to audit branches by hand, do NOT rely on
+`git branch -r --merged origin/main` if the repo squash-merges — squash-merged
+branches never show up as git-ancestors of `main`, so that command will miss
+almost all of them. Cross-reference against PR history directly instead:
 
 ```bash
 git fetch origin --prune
-gh pr list --state merged --limit 200 --json headRefName \
-  | jq -r '.[].headRefName' > merged_branches.txt
-# delete only remote branches confirmed merged/closed via `gh pr list --state all`
-# and that are not main or an active in-flight branch
+gh pr list --state all --limit 300 --json headRefName,state,number,updatedAt
+# delete only remote branches whose latest PR is MERGED, or CLOSED well past
+# a grace period, and that are not main or an active in-flight branch
 ```
 
 Do not delete a branch tied to an open PR or with no PR history at all —


### PR DESCRIPTION
Fixes the manual branch-audit command (git branch --merged misses squash-merged branches) and documents the delete_branch_on_merge repo setting plus scheduled branch-cleanup Action as structural safety nets, in the OSS-packaged multi-agent-coordination.md template shipped to every generated app.