### PR TITLE
fix(social)+fix(agents)+test(packs): events.yaml emit gap, agent self-validation cross-checks

### DIFF
--- a/factory_app/build_context/social/templates/modules/activity_feed/backend/service.py
+++ b/factory_app/build_context/social/templates/modules/activity_feed/backend/service.py
@@ -74,6 +74,12 @@ class ActivityFeedService:
             **app_scope(ctx),
         }
         await self._repo.insert(ctx, doc)
+        await ctx.emit("domain.social.activity.recorded", {
+            "event_id": doc["event_id"],
+            "activity_type": doc["activity_type"],
+            "actor_id": doc["actor_id"],
+            "created_at": doc["created_at"],
+        })
         return {"success": True, "event_id": doc["event_id"]}
 
     # ── Reaction handlers (called by reactions.yaml routing) ──────────────────

--- a/factory_app/build_context/social/templates/modules/activity_feed/module.yaml
+++ b/factory_app/build_context/social/templates/modules/activity_feed/module.yaml
@@ -84,6 +84,7 @@ actions:
         success: { type: boolean }
         event_id: { type: string }
     permissions: [activity_feed.admin]
+    emits: [domain.social.activity.recorded]
 
 capabilities:
   - capability_id: social.feed.read

--- a/factory_app/workflows/AppGenerator/agents.yaml
+++ b/factory_app/workflows/AppGenerator/agents.yaml
@@ -2221,6 +2221,11 @@ agents:
       1. Write content to `/tmp/validate_config_<stem>.yaml`.
       2. Run `python -c "import yaml,sys; yaml.safe_load(open('/tmp/validate_config_<stem>.yaml'))"` — fix parse errors before continuing.
 
+      Cross-reference checks (run after all files parse cleanly):
+      3. Permission consistency — every permission id referenced in `module.yaml.actions[].permissions` and `module.yaml.capabilities[].permissions` must be declared in `module.yaml.permissions[].id`. If any reference is missing, add the declaration or fix the reference before emitting.
+      4. Notification id consistency — every `notification_id` value in `reactions.yaml` targets must appear as an `id` in `notifications.yaml.notifications[]`. If `notifications.yaml` is absent, create it with the required definitions before emitting.
+      5. Emits/events alignment — every event type string in `module.yaml.actions[].emits` must appear as a `type` in `events.yaml.events[]`. Conversely, every `events.yaml.events[].type` must appear in at least one action's `emits` list or be a reaction-only event with a documented source. Flag and resolve any orphaned declarations before emitting.
+
       Emit ConfigMiddlewareOutput only after all files pass. Do not include validation shell output in the JSON.
   max_consecutive_auto_reply: 10
   structured_outputs_required: true
@@ -2813,6 +2818,9 @@ agents:
       3. Run `ruff check --select E,F /tmp/validate_handler.py` — fix any undefined-name or import errors before continuing.
 
       Emit ServiceOutput only after all files pass both checks. Do not include validation shell output in ServiceOutput.
+
+      Cross-reference check (run after syntax and lint pass):
+      4. Events.yaml coverage — for every event type declared in `contracts/events.yaml.events[].type`, verify that the exact string literal appears in at least one of `service.py`, `base_handler.py`, or `handler.py` as a `ctx.emit(...)` argument. If any declared event type is absent, add the missing emit call before emitting ServiceOutput.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |-

--- a/tests/test_build_context_events_yaml_alignment.py
+++ b/tests/test_build_context_events_yaml_alignment.py
@@ -1,0 +1,124 @@
+"""Cross-pack drift guard: events.yaml declared event types must appear in service files.
+
+Each generated module that produces domain events ships a
+``contracts/events.yaml`` that declares the event type strings it emits.
+These declarations are the contract that downstream subscribers (other
+modules' ``reactions.yaml``, notification configs, external integrations)
+rely on.
+
+If a declared event type is never actually emitted by the module's backend
+service — because the emit call was forgotten, renamed, or removed without
+updating the declaration — the contract promises an event that never fires.
+Subscribers register for a ghost event with no startup warning.
+
+This test file walks every ``contracts/events.yaml`` in every pack template
+and asserts that each declared event type string appears as a literal in the
+corresponding module's backend service files (``service.py``,
+``base_handler.py``, or ``handler.py``).
+
+Tests are parametrized so a mismatch names the exact pack, module, and
+event type — not just a bulk assertion failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import json
+import pytest
+import yaml
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+BUILD_CONTEXT = WORKSPACE / "factory_app" / "build_context"
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _backend_source(module_dir: Path) -> str | None:
+    """Return concatenated source of all backend handler/service files."""
+    sources: list[str] = []
+    for name in ("service.py", "base_handler.py", "handler.py"):
+        f = module_dir / "backend" / name
+        if f.exists():
+            sources.append(f.read_text(encoding="utf-8"))
+    return "\n".join(sources) if sources else None
+
+
+def _collect_cases() -> list[tuple[str, str, str]]:
+    """Return (pack_id, module_id, event_type) for every events.yaml declaration."""
+    cases: list[tuple[str, str, str]] = []
+    for events_file in sorted(BUILD_CONTEXT.rglob("events.yaml")):
+        if "__pycache__" in events_file.parts:
+            continue
+        # Accept both YAML and JSON (some packs use .json migrations, events.yaml is always YAML)
+        try:
+            pack_id = events_file.relative_to(BUILD_CONTEXT).parts[0]
+        except ValueError:
+            continue
+
+        data = _read_yaml(events_file)
+        events = data.get("events") or []
+        if not events:
+            continue
+
+        # Module directory is two levels up from contracts/events.yaml
+        module_dir = events_file.parent.parent
+        module_id = module_dir.name
+
+        for evt in events:
+            # Support both {type: ...} and {event_type: ...} shapes
+            etype = evt.get("type") or evt.get("event_type") or evt.get("id")
+            if etype:
+                cases.append((pack_id, module_id, etype))
+
+    return cases
+
+
+_CASES = _collect_cases()
+
+
+@pytest.mark.parametrize(
+    "pack_id,module_id,event_type",
+    _CASES,
+    ids=[f"{p}/{m}/event={e}" for p, m, e in _CASES],
+)
+def test_events_yaml_event_type_appears_in_service(
+    pack_id: str, module_id: str, event_type: str
+) -> None:
+    """Every event type declared in contracts/events.yaml must appear in the backend service.
+
+    A declaration without a matching emit call means the contract promises
+    an event that never fires — downstream subscribers register for a ghost.
+    """
+    module_dir = BUILD_CONTEXT / pack_id / "templates" / "modules" / module_id
+
+    # Fallback: glob for the module dir in case the path segment differs
+    if not module_dir.is_dir():
+        candidates = list(
+            (BUILD_CONTEXT / pack_id / "templates" / "modules").glob(f"*{module_id}*")
+        )
+        exact = [d for d in candidates if d.name == module_id]
+        module_dir = (exact or candidates)[0] if (exact or candidates) else module_dir
+
+    assert module_dir.is_dir(), (
+        f"Could not locate module directory for {pack_id}/{module_id}"
+    )
+
+    src = _backend_source(module_dir)
+    assert src is not None, (
+        f"{pack_id}/{module_id}: events.yaml declares {event_type!r} but no "
+        f"service.py / base_handler.py / handler.py found at {module_dir / 'backend'}"
+    )
+
+    assert event_type in src, (
+        f"{pack_id}/{module_id}: contracts/events.yaml declares event type "
+        f"{event_type!r} but that string does not appear in any backend service file. "
+        f"Either add the ctx.emit() call or remove the stale event declaration."
+    )


### PR DESCRIPTION
## Summary

**Bug fix — activity_feed:** `contracts/events.yaml` declared `domain.social.activity.recorded` but `service.py` never called `ctx.emit()` for it. Added the emit in `record_activity()` and `emits:` in `module.yaml`.

**Agent prompt hardening — ConfigMiddlewareAgent + ServiceAgent:** Five bugs found across recent PRs (#193, #198, #199) were all the same failure mode: a string key declared in one file wasn't validated against the file that consumes it. The `[SELF-VALIDATION]` sections for both agents had only YAML parse checks. Added explicit numbered checklist items:

- **ConfigMiddlewareAgent check 3**: every `actions[].permissions` and `capabilities[].permissions` id must be declared in `permissions[]` (would have caught `access_as_user` in support pack, PR #193)
- **ConfigMiddlewareAgent check 4**: every `reactions.yaml` `notification_id` must appear in `notifications.yaml` (would have caught missing commerce notifications, PR #198)
- **ConfigMiddlewareAgent check 5**: every `module.yaml` `emits[]` string must appear in `events.yaml`, and vice versa (catches ghost event declarations in either direction)
- **ServiceAgent check 4**: every `events.yaml` event type must appear as a literal `ctx.emit()` argument in the service files (would have caught activity_feed missing emit, PR #199)

**New drift guard:** `tests/test_build_context_events_yaml_alignment.py` — 27 parametrized tests pinning every `events.yaml` declaration against the backend service. Uses `rglob`.

## Test plan
- [ ] `pytest tests/test_build_context_events_yaml_alignment.py` — 27 passed (verified locally)
- [ ] `python -c "import yaml; yaml.safe_load(open('factory_app/workflows/AppGenerator/agents.yaml'))"` — parses cleanly (19 agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)