### PR TITLE
fix(packs)+test(packs): add user_data_scope and account_data_handler to commerce and support

### DIFF
--- a/factory_app/build_context/commerce/contract.yaml
+++ b/factory_app/build_context/commerce/contract.yaml
@@ -41,6 +41,8 @@ required_outputs:
     owner: templates
   - path: modules/commerce/backend/__init__.py
     owner: templates
+  - path: modules/commerce/backend/account_data_handler.py
+    owner: templates
   - path: modules/commerce/backend/base_handler.py
     owner: templates
   - path: modules/commerce/backend/handler.py

--- a/factory_app/build_context/commerce/templates/modules/commerce/backend/account_data_handler.py
+++ b/factory_app/build_context/commerce/templates/modules/commerce/backend/account_data_handler.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class AccountDataHandler:
+    """GDPR data handler for commerce module records.
+
+    Commerce stores user-linked data in three collections:
+      - carts (actor_id = the shopper)
+      - orders (actor_id = the buyer)
+      - checkout_requests (actor_id = the buyer)
+
+    Products are catalog data — not user-owned — and are excluded.
+
+    Note on order retention: tax and accounting regulations in many jurisdictions
+    require order records to be retained for 5–7 years even after a user data
+    deletion request. App operators should review applicable regulations and may
+    need to anonymise rather than hard-delete completed order records.
+    """
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    async def delete_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Delete cart, order, and checkout request records owned by this user."""
+        query = {"app_id": app_id, "actor_id": user_id}
+
+        carts_coll = self._db.get_collection("commerce", "carts")
+        carts_result = await carts_coll.delete_many(query)
+        carts_deleted = int(getattr(carts_result, "deleted_count", 0) or 0)
+
+        orders_coll = self._db.get_collection("commerce", "orders")
+        orders_result = await orders_coll.delete_many(query)
+        orders_deleted = int(getattr(orders_result, "deleted_count", 0) or 0)
+
+        checkout_coll = self._db.get_collection("commerce", "checkout_requests")
+        checkout_result = await checkout_coll.delete_many(query)
+        checkout_deleted = int(getattr(checkout_result, "deleted_count", 0) or 0)
+
+        return {
+            "module": "commerce",
+            "carts_deleted": carts_deleted,
+            "orders_deleted": orders_deleted,
+            "checkout_requests_deleted": checkout_deleted,
+        }
+
+    async def export_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Export cart, order, and checkout request records owned by this user."""
+        query = {"app_id": app_id, "actor_id": user_id}
+
+        carts_coll = self._db.get_collection("commerce", "carts")
+        cart = await carts_coll.find_one(query)
+
+        orders_coll = self._db.get_collection("commerce", "orders")
+        orders = await orders_coll.find_many(query)
+
+        checkout_coll = self._db.get_collection("commerce", "checkout_requests")
+        checkout_requests = await checkout_coll.find_many(query)
+
+        return {
+            "module": "commerce",
+            "cart": dict(cart) if cart else None,
+            "orders": [dict(o) for o in (orders or [])],
+            "checkout_requests": [dict(c) for c in (checkout_requests or [])],
+        }

--- a/factory_app/build_context/commerce/templates/modules/commerce/module.yaml
+++ b/factory_app/build_context/commerce/templates/modules/commerce/module.yaml
@@ -8,6 +8,7 @@ module:
   visibility: app
   type: standard
   handler: backend.handler:CommerceHandler
+  user_data_scope: true
 
 permissions:
   - id: commerce.catalog.read

--- a/factory_app/build_context/support/contract.yaml
+++ b/factory_app/build_context/support/contract.yaml
@@ -37,6 +37,8 @@ required_outputs:
     owner: templates
   - path: modules/support/backend/__init__.py
     owner: templates
+  - path: modules/support/backend/account_data_handler.py
+    owner: templates
   - path: modules/support/backend/base_handler.py
     owner: templates
   - path: modules/support/backend/handler.py

--- a/factory_app/build_context/support/templates/modules/support/backend/account_data_handler.py
+++ b/factory_app/build_context/support/templates/modules/support/backend/account_data_handler.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class AccountDataHandler:
+    """GDPR data handler for support module records.
+
+    Support requests carry requester_id (the user who submitted the request)
+    and subject_app_id (the app context). Both are user-linked PII.
+
+    Note: support requests may also be linked to a messages thread
+    (message_thread_id). The messages module owns thread content; deleting
+    the support record here removes the metadata but the messages module's
+    account_data_handler handles the conversation bodies.
+    """
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    async def delete_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Delete all support request records submitted by this user."""
+        coll = self._db.get_collection("support", "requests")
+        result = await coll.delete_many({"app_id": app_id, "requester_id": user_id})
+        deleted = int(getattr(result, "deleted_count", 0) or 0)
+        return {"module": "support", "requests_deleted": deleted}
+
+    async def export_user_data(self, *, app_id: str, user_id: str) -> dict[str, Any]:
+        """Export all support request records submitted by this user."""
+        coll = self._db.get_collection("support", "requests")
+        requests = await coll.find_many({"app_id": app_id, "requester_id": user_id})
+        return {
+            "module": "support",
+            "requests": [dict(r) for r in (requests or [])],
+        }

--- a/factory_app/build_context/support/templates/modules/support/module.yaml
+++ b/factory_app/build_context/support/templates/modules/support/module.yaml
@@ -7,6 +7,7 @@ module:
   owner: app
   visibility: private
   handler: backend.handler:SupportHandler
+  user_data_scope: true
 
 permissions:
   - id: support.submit

--- a/tests/test_build_context_commerce_pack.py
+++ b/tests/test_build_context_commerce_pack.py
@@ -254,6 +254,27 @@ def test_appgenerator_selection_wiring_includes_commerce_pack() -> None:
     assert "commerce_pack" in app_outputs["models"]["AppCapabilityPack"]["fields"]["pack_type"]["values"]
 
 
+def test_commerce_module_declares_user_data_scope() -> None:
+    """Commerce stores user-linked carts and orders — user_data_scope must be true."""
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "commerce" / "module.yaml")
+    assert module_yaml["module"].get("user_data_scope") is True, (
+        "commerce/module.yaml must declare user_data_scope: true — "
+        "carts (actor_id) and orders (actor_id) are user-owned PII"
+    )
+
+
+def test_commerce_backend_ships_account_data_handler() -> None:
+    """user_data_scope: true requires a matching account_data_handler.py."""
+    handler = TEMPLATES / "modules" / "commerce" / "backend" / "account_data_handler.py"
+    assert handler.exists(), (
+        "commerce/backend/account_data_handler.py is missing — "
+        "module declares user_data_scope: true but ships no GDPR handler"
+    )
+    src = handler.read_text(encoding="utf-8")
+    assert "delete_user_data" in src
+    assert "export_user_data" in src
+
+
 def test_commerce_pack_does_not_generate_payment_provider_or_marketplace_modules() -> None:
     generated_paths = {
         str(path.relative_to(TEMPLATES)).replace("\\", "/")

--- a/tests/test_build_context_support_pack.py
+++ b/tests/test_build_context_support_pack.py
@@ -305,6 +305,27 @@ def test_appgenerator_selection_wiring_includes_support_pack() -> None:
     assert packs["support"]["capability_kind"] == "operator_pack"
 
 
+def test_support_module_declares_user_data_scope() -> None:
+    """Support stores user-linked request records — user_data_scope must be true."""
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "support" / "module.yaml")
+    assert module_yaml["module"].get("user_data_scope") is True, (
+        "support/module.yaml must declare user_data_scope: true — "
+        "support requests carry requester_id (user-owned PII)"
+    )
+
+
+def test_support_backend_ships_account_data_handler() -> None:
+    """user_data_scope: true requires a matching account_data_handler.py."""
+    handler = TEMPLATES / "modules" / "support" / "backend" / "account_data_handler.py"
+    assert handler.exists(), (
+        "support/backend/account_data_handler.py is missing — "
+        "module declares user_data_scope: true but ships no GDPR handler"
+    )
+    src = handler.read_text(encoding="utf-8")
+    assert "delete_user_data" in src
+    assert "export_user_data" in src
+
+
 def test_support_pack_does_not_generate_messaging_module() -> None:
     """Support must not generate its own messages module — it uses the messaging pack."""
     generated_paths = {


### PR DESCRIPTION
## What

Same gap as PRs #189/#190 — two more modules that store user-linked data but were missing `user_data_scope: true` and `account_data_handler.py`.

### commerce

Carts (`actor_id`) and orders (`actor_id`) are user-owned PII. `account_data_handler` deletes/exports carts, orders, and checkout_requests scoped to the requesting user. Products are catalog data (not user-owned) and are excluded. Includes a retention note — tax/accounting regulations may require order records to be retained even after a deletion request.

### support

Support requests carry `requester_id` (user-owned PII). `account_data_handler` deletes/exports request records scoped to the requester. Includes a boundary note: message thread bodies are owned by the messages module and handled by its own handler.

## Changes

- `commerce/module.yaml` — added `user_data_scope: true`
- `commerce/backend/account_data_handler.py` — new, GDPR delete + export for carts/orders/checkout_requests
- `commerce/contract.yaml` — added account_data_handler.py to required_outputs
- `support/module.yaml` — added `user_data_scope: true`
- `support/backend/account_data_handler.py` — new, GDPR delete + export for requests
- `support/contract.yaml` — added account_data_handler.py to required_outputs
- 2 tests added to each pack test file

## Test plan
- [x] `pytest tests/test_build_context_commerce_pack.py tests/test_build_context_support_pack.py -v --no-cov` — 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)