### PR TITLE
docs: human-first contributor onboarding path + community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report unexpected or incorrect behavior in Mozaiks.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please search
+        [existing issues](https://github.com/BlocUnited-LLC/mozaiks/issues) first
+        to avoid duplicates.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so a maintainer can reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: mozaiks-version
+    attributes:
+      label: Mozaiks version or commit
+      placeholder: e.g. 0.3.0, or a commit SHA if running from source
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: e.g. 3.11.9
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any relevant terminal output, stack traces, or logs. This will be rendered as code automatically.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This report is about the open-source `mozaiks` repository, not a privately hosted product built on top of it.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/BlocUnited-LLC/mozaiks/security
+    about: Please use GitHub's private vulnerability reporting instead of a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,31 @@
+name: Documentation Improvement
+description: Report unclear, incorrect, or missing documentation.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for gaps, errors, or unclear guidance in
+        `README.md`, `CONTRIBUTING.md`, or anything under `docs/`.
+  - type: input
+    id: location
+    attributes:
+      label: Page or file
+      description: The doc page URL (e.g. https://docs.mozaiks.ai/...) or repo path (e.g. docs/getting-started.md).
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong, unclear, or missing?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: If you have a specific wording or structure in mind, share it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Propose a new capability or improvement for Mozaiks.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Please search
+        [existing issues](https://github.com/BlocUnited-LLC/mozaiks/issues) first
+        to avoid duplicates.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the problem or limitation you're running into. Avoid jumping straight to a solution here.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches or workarounds you've considered.
+    validations:
+      required: false
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This request is about the open-source `mozaiks` repository, not a privately hosted product or business feature built on top of it.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+  Thanks for contributing to Mozaiks! Please fill out this template so
+  maintainers have what they need to review efficiently. See CONTRIBUTING.md
+  for the full contribution path.
+-->
+
+## Related issue
+
+<!-- Link the issue this PR addresses, e.g. "Closes #123". Write "N/A" if none. -->
+
+## Summary
+
+<!-- What does this PR change, and why? Keep the diff focused on one thing. -->
+
+## Tests run
+
+<!--
+  List the commands you ran and their result, e.g.:
+  `pytest tests/test_foo.py -v` -> 12 passed
+  For docs-only changes: `python -m mkdocs build --strict` -> succeeded
+-->
+
+## Screenshots (if applicable)
+
+<!-- Include before/after screenshots or a short clip for any UI-visible change. Delete this section if not applicable. -->
+
+## Boundary confirmation
+
+- [ ] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+The Mozaiks project maintainers are responsible for clarifying and enforcing
+our standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+The maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, issues, and other contributions that are not aligned
+to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces of this repository
+(issues, pull requests, discussions, and code review), and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the Mozaiks project maintainers by opening a private report
+through this repository's [GitHub private vulnerability reporting form](https://github.com/BlocUnited-LLC/mozaiks/security)
+(select **Report a vulnerability**, then describe the conduct concern in the
+report body) or by contacting a listed maintainer of the
+[BlocUnited-LLC/mozaiks](https://github.com/BlocUnited-LLC/mozaiks) repository
+directly through their GitHub profile. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers,
+providing clarity around the nature of the violation and an explanation of
+why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -58,16 +58,17 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the Mozaiks project maintainers by opening a private report
-through this repository's [GitHub private vulnerability reporting form](https://github.com/BlocUnited-LLC/mozaiks/security)
-(select **Report a vulnerability**, then describe the conduct concern in the
-report body) or by contacting a listed maintainer of the
-[BlocUnited-LLC/mozaiks](https://github.com/BlocUnited-LLC/mozaiks) repository
-directly through their GitHub profile. All complaints will be reviewed and
-investigated promptly and fairly.
+reported to the Mozaiks project maintainers at **conduct@blocunited.com**.
+All complaints will be reviewed and investigated promptly and fairly.
 
 All project maintainers are obligated to respect the privacy and security of
 the reporter of any incident.
+
+GitHub's private security vulnerability reporting channel (the **Report a
+vulnerability** form under this repository's Security tab) is reserved
+exclusively for security vulnerabilities. Do not use it to report Code of
+Conduct violations — use the email address above instead. See
+[SECURITY.md](SECURITY.md) for how to report a security vulnerability.
 
 ## Enforcement Guidelines
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -58,7 +58,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the Mozaiks project maintainers at **conduct@blocunited.com**.
+reported to the Mozaiks project maintainers at **info@blocunited.com**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All project maintainers are obligated to respect the privacy and security of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,64 @@ Mozaiks is the OSS runtime, platform, Studio, and factory framework repo.
 `factory_app` is the first-party builder/reference app workspace that dogfoods
 the same contracts external app workspaces consume.
 
-## Start Here
+All participation in this repository is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Quickstart: Your First Pull Request
+
+Follow this path for any human-authored contribution — a bug fix, a docs
+change, a new test, or a small feature:
+
+1. **Fork** the repository and clone your fork.
+2. **Create a branch** for your change, e.g. `git checkout -b fix/short-description`.
+3. **Install development dependencies**:
+
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+4. **Make a focused change.** Keep the diff scoped to one thing and avoid unrelated refactors.
+5. **Run the relevant tests** for what you changed. Use the narrowest test slice that covers your change (see [Focused Tests](#focused-tests) below), or run the full suite with `pytest`.
+6. **Open a pull request** against `main` using the pull request template. Describe what changed, why, and what you tested.
+
+Using an AI coding agent (Claude Code, Cursor, Copilot, or similar)? See
+[Working With an AI Coding Agent](#working-with-an-ai-coding-agent-optional)
+below — it is optional tooling this repo supports, not a prerequisite for
+contributing.
+
+## What You Can Contribute Without Extra Setup
+
+Running the full Mozaiks Studio stack needs MongoDB, Node.js, and an LLM API
+key. Most first contributions need none of that:
+
+- **Documentation** changes (`docs/`, `README.md`, `CONTRIBUTING.md`, and other
+  Markdown) only need Python and the docs extra to preview locally:
+
+  ```bash
+  pip install -e ".[docs]"
+  python -m mkdocs serve
+  ```
+
+- **Most Python tests** run with no external services. `tests/conftest.py`
+  automatically skips the tests that need a real app workspace
+  (`MOZAIKS_APP_WORKSPACE_PATH` or `PLATFORM_PATH`) — you do not need to set
+  those to add or fix an ordinary test.
+- **Many `mozaiks_cli` changes** can be developed and verified through the
+  CLI's own unit tests without MongoDB, Node.js, or a running Studio instance.
+
+You only need Docker/MongoDB, Node.js 18+, and an LLM API key when you are
+changing or manually verifying behavior that talks to a real database, a real
+frontend build, or a real LLM call. See [Local Setup](docs/local-setup.md) when
+you get there.
+
+## Working With an AI Coding Agent (Optional)
+
+This repo also maintains a skill/rule routing system that AI coding agents
+(Claude Code, Cursor, Copilot, and similar tools) use to find the right
+context before nontrivial changes. Human contributors may use it too, but
+nothing below is required to complete the Quickstart above.
+
+### Start Here
 
 Use this order before nontrivial work:
 
@@ -15,7 +72,7 @@ Use this order before nontrivial work:
 If scope spans layers or the right owner is unclear, start with the
 `oss-contribution-review` skill.
 
-## Common Task Map
+### Common Task Map
 
 - Runtime or platform change: use `runtime-change` plus the runtime and architecture-boundary rules. Use `runtime-architecture-review` when you need a review-only scope or boundary pass before or after edits.
 - Auth change: use `runtime-change` unless the task is purely docs or tests.
@@ -36,7 +93,7 @@ If scope spans layers or the right owner is unclear, start with the
 - Managed-capability support change: use `oss-contribution-review` plus the managed-capabilities rule for now; no dedicated `managed-capability-change` skill exists yet.
 - Unsure: use `oss-contribution-review` first.
 
-## Build And Refinement Truth
+### Build And Refinement Truth
 
 - Build is `workflow_sequence`-driven through `factory_app/workflows/extended_orchestration/extension_registry.json`.
 - `AppGenerator` is one workflow inside that build system, not the whole build.
@@ -45,7 +102,7 @@ If scope spans layers or the right owner is unclear, start with the
 - Refinement today is checkpoint-driven re-entry through `app/config/refinement_policy.yaml` runtime policy and the selected `refinement_harness/config/harness.yaml` pack, with normal chat/workflow startup still in `app/config/ai.json`; it is not a dedicated `RefinementWorkflow`.
 - `workflow_sequence` is not a human-in-the-loop handoff. Keep sequences, transitions, entrypoints, and workflow-local `transition_graph.yaml` separate.
 
-## Final Report Requirements
+### Final Report Requirements
 
 Every nontrivial change should include `Tests run` plus the relevant sections
 from [.claude/rules/testing.md](.claude/rules/testing.md):
@@ -56,7 +113,7 @@ from [.claude/rules/testing.md](.claude/rules/testing.md):
 - `Module Contract Impact` when module contracts or module loader expectations changed
 - `Managed Capability Boundary Check` when managed-capability, facade, or adapter boundaries changed
 
-## Focused Tests
+### Focused Tests
 
 Prefer the narrowest test slice that matches the layer you changed.
 
@@ -80,13 +137,12 @@ python -m pytest tests/test_contributor_guidance_framing.py tests/test_module_re
 - Do not author `contracts/subscriptions.yaml`; use `contracts/reactions.yaml`.
 - Do not route contributors toward `app/capability_packs`, `transport.py`, or direct provider internals as current canonical extension points.
 
-## Development Setup
-
-```bash
-pip install -e .[dev]
-```
-
 ## Pull Request Expectations
+
+Opening a pull request uses the repository's pull request template, which asks
+for the related issue (if any), a summary, the tests you ran, screenshots for
+UI changes, and confirmation that no private hosted-product logic was
+introduced. In addition:
 
 - Explain scope and motivation.
 - Call out public API changes in `mozaiksai/`.
@@ -101,5 +157,6 @@ pip install -e .[dev]
 
 ## Security
 
-Do not commit secrets, production tokens, or private keys.
+Do not commit secrets, production tokens, or private keys. To report a security
+vulnerability, see [SECURITY.md](SECURITY.md) instead of opening a public issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ change, a new test, or a small feature:
    ```
 
 4. **Make a focused change.** Keep the diff scoped to one thing and avoid unrelated refactors.
-5. **Run the relevant tests** for what you changed. Use the narrowest test slice that covers your change (see [Focused Tests](#focused-tests) below), or run the full suite with `pytest`.
+5. **Run the relevant tests** for what you changed. Use the narrowest test slice that covers your change (see [Running Tests Locally](#running-tests-locally) below), or run the full suite with `pytest`.
 6. **Open a pull request** against `main` using the pull request template. Describe what changed, why, and what you tested.
 
 Using an AI coding agent (Claude Code, Cursor, Copilot, or similar)? See
@@ -53,6 +53,35 @@ You only need Docker/MongoDB, Node.js 18+, and an LLM API key when you are
 changing or manually verifying behavior that talks to a real database, a real
 frontend build, or a real LLM call. See [Local Setup](docs/local-setup.md) when
 you get there.
+
+## Running Tests Locally
+
+You do not need to run the entire test suite for every change. Pick the
+focused test file(s) that cover what you touched:
+
+```bash
+python -m pytest tests/test_your_file.py -q
+```
+
+**Coverage gate note:** This repo's shared `pytest` configuration enforces a
+repository-wide minimum coverage threshold (`--cov-fail-under=30`, measured
+against `mozaiksai`). Running a narrow test file against that global
+threshold will often report a coverage failure even when every test you ran
+passes. That failure reflects the coverage math for the whole package, not a
+problem with your change.
+
+To run a focused slice without tripping the repository-wide coverage gate,
+use the verified command:
+
+```bash
+python -m pytest tests/test_your_file.py -q --no-cov
+```
+
+**CI remains authoritative.** `--no-cov` is a local convenience for fast
+iteration on a narrow slice. It does not weaken what is enforced in CI — the
+full test suite still runs in CI with the project's coverage requirements
+enforced, and your pull request must pass CI regardless of what you ran
+locally.
 
 ## Working With an AI Coding Agent (Optional)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ Build the docs locally with `pip install -r requirements-docs.txt` and `./script
 
 ## Contributing
 
-See `CONTRIBUTING.md`.
+Fork, branch, install development dependencies with `pip install -e ".[dev]"`,
+make a focused change, run the relevant tests, and open a pull request.
+Documentation, most tests, and many CLI changes don't need MongoDB, Node.js,
+or an LLM API key. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full path.
+This project follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+Mozaiks is pre-launch software (see [AGENTS.md](AGENTS.md)). We still take
+security reports seriously and ask that you report vulnerabilities privately
+so they can be assessed before any public disclosure.
+
+## Reporting a Vulnerability
+
+Please use GitHub's private vulnerability reporting for this repository
+instead of opening a public issue or pull request:
+
+1. Go to the [Security tab](https://github.com/BlocUnited-LLC/mozaiks/security).
+2. Select **Report a vulnerability**.
+3. Describe the issue, including affected version/commit, reproduction steps,
+   and potential impact.
+
+This opens a private advisory visible only to you and the repository
+maintainers, who will respond and coordinate a fix and disclosure timeline
+with you.
+
+Do not include exploit details, credentials, or other sensitive information
+in a public GitHub issue, discussion, or pull request.
+
+## Supported Versions
+
+This project is pre-1.0 and does not yet maintain long-term-supported
+release branches. Security fixes are applied to the latest release on
+`main`. If you are running an older version, please upgrade before or
+alongside reporting an issue.
+
+## Scope
+
+This policy covers the `mozaiks` OSS repository (runtime, platform, Studio,
+CLI, and factory workflows). It does not cover privately hosted products
+built on top of Mozaiks; report issues in those products to their own
+maintainers.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -7,6 +7,16 @@ improving Studio, or maintaining the release pipeline.
 If you are building an app with Mozaiks, you do not need this section.
 Start with [Getting Started](../getting-started.md) instead.
 
+## Your First Pull Request
+
+The full mechanical path — fork, branch, install development dependencies,
+make a focused change, run the relevant tests, and open a pull request — plus
+what you can contribute **without** MongoDB, Node.js, a running Studio
+instance, or an LLM API key (documentation, most Python tests, and many CLI
+changes) is documented once, in
+[CONTRIBUTING.md](https://github.com/BlocUnited-LLC/mozaiks/blob/main/CONTRIBUTING.md#quickstart-your-first-pull-request).
+Start there.
+
 ## Where to start
 
 - **[Local Setup](../local-setup.md)** — source checkout, editable install, and how to run the builder stack from repo

--- a/tests/test_contributor_onboarding_community_health.py
+++ b/tests/test_contributor_onboarding_community_health.py
@@ -21,6 +21,21 @@ def test_contributing_has_human_first_quickstart() -> None:
     assert "**Open a pull request** against `main` using the pull request template." in contributing
 
 
+def test_contributing_documents_focused_test_coverage_gate_in_human_section() -> None:
+    contributing = _read("CONTRIBUTING.md")
+
+    assert "## Running Tests Locally" in contributing
+    assert "--cov-fail-under=30" in contributing
+    assert "python -m pytest tests/test_your_file.py -q --no-cov" in contributing
+    assert "CI remains authoritative" in contributing
+
+    # This guidance must live in the human-first path, not be deferred behind
+    # the optional AI-agent section or left as a future contributor task.
+    running_tests_index = contributing.index("## Running Tests Locally")
+    ai_agent_section_index = contributing.index("## Working With an AI Coding Agent (Optional)")
+    assert running_tests_index < ai_agent_section_index
+
+
 def test_contributing_explains_no_extra_setup_paths() -> None:
     contributing = _read("CONTRIBUTING.md")
 
@@ -79,14 +94,24 @@ def test_security_md_prefers_private_reporting_and_invents_no_email() -> None:
     assert "Report a vulnerability" in security
     assert "@" not in security
 
+    # SECURITY.md must stay scoped to vulnerability reporting only.
+    assert "Code of Conduct" not in security
 
-def test_code_of_conduct_is_contributor_covenant_with_no_individual_contact() -> None:
+
+def test_code_of_conduct_uses_confirmed_email_and_not_security_channel() -> None:
     coc = _read("CODE_OF_CONDUCT.md")
 
     assert "Contributor Covenant" in coc
     assert "project maintainers" in coc
-    # No invented individual person or email address as the enforcement contact.
-    assert "@" not in coc
+    # Enforcement contact is the confirmed maintainer email, not an invented
+    # individual contact.
+    assert "conduct@blocunited.com" in coc
+    # GitHub's security-vulnerability reporting channel must not be offered
+    # as a Code of Conduct reporting method — it is reserved for security
+    # vulnerabilities only.
+    assert "github.com/BlocUnited-LLC/mozaiks/security" not in coc
+    assert "exclusively for security vulnerabilities" in coc
+    assert "Do not use it to report Code of" in coc
 
 
 def test_issue_templates_cover_bug_feature_and_docs() -> None:

--- a/tests/test_contributor_onboarding_community_health.py
+++ b/tests/test_contributor_onboarding_community_health.py
@@ -105,7 +105,7 @@ def test_code_of_conduct_uses_confirmed_email_and_not_security_channel() -> None
     assert "project maintainers" in coc
     # Enforcement contact is the confirmed maintainer email, not an invented
     # individual contact.
-    assert "conduct@blocunited.com" in coc
+    assert "info@blocunited.com" in coc
     # GitHub's security-vulnerability reporting channel must not be offered
     # as a Code of Conduct reporting method — it is reserved for security
     # vulnerabilities only.

--- a/tests/test_contributor_onboarding_community_health.py
+++ b/tests/test_contributor_onboarding_community_health.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_contributing_has_human_first_quickstart() -> None:
+    contributing = _read("CONTRIBUTING.md")
+
+    assert "## Quickstart: Your First Pull Request" in contributing
+    assert "**Fork** the repository" in contributing
+    assert "**Create a branch**" in contributing
+    assert 'pip install -e ".[dev]"' in contributing
+    assert "**Make a focused change.**" in contributing
+    assert "**Run the relevant tests**" in contributing
+    assert "**Open a pull request** against `main` using the pull request template." in contributing
+
+
+def test_contributing_explains_no_extra_setup_paths() -> None:
+    contributing = _read("CONTRIBUTING.md")
+
+    assert "## What You Can Contribute Without Extra Setup" in contributing
+    assert "MongoDB" in contributing
+    assert "Node.js" in contributing
+    assert "an LLM API key" in contributing
+    assert 'pip install -e ".[docs]"' in contributing
+    assert "python -m mkdocs serve" in contributing
+    assert "tests/conftest.py" in contributing
+    assert "mozaiks_cli" in contributing
+
+
+def test_ai_agent_guidance_is_clearly_optional_and_preserved() -> None:
+    contributing = _read("CONTRIBUTING.md")
+
+    assert "## Working With an AI Coding Agent (Optional)" in contributing
+    assert "nothing below is required to complete the Quickstart above" in contributing
+    assert "### Start Here" in contributing
+    assert "### Common Task Map" in contributing
+    assert "### Build And Refinement Truth" in contributing
+    assert "### Final Report Requirements" in contributing
+    assert "### Focused Tests" in contributing
+
+    # These must no longer be top-level headings once nested under the
+    # AI-agent-optional section.
+    assert "\n## Build And Refinement Truth" not in contributing
+    assert "\n## Final Report Requirements" not in contributing
+    assert "\n## Focused Tests" not in contributing
+    assert "\n## Development Setup" not in contributing
+
+
+def test_contributing_links_to_new_community_health_files() -> None:
+    contributing = _read("CONTRIBUTING.md")
+
+    assert "[Code of Conduct](CODE_OF_CONDUCT.md)" in contributing
+    assert "[SECURITY.md](SECURITY.md)" in contributing
+    assert "pull request template" in contributing
+
+
+def test_readme_and_docs_index_point_to_same_contribution_path() -> None:
+    readme = _read("README.md")
+    docs_index = _read("docs/contributing/index.md")
+
+    assert "[CONTRIBUTING.md](CONTRIBUTING.md)" in readme
+    assert "[Code of Conduct](CODE_OF_CONDUCT.md)" in readme
+    assert "#quickstart-your-first-pull-request" in docs_index
+    assert "Contributor Guidance Readiness" in docs_index
+
+
+def test_security_md_prefers_private_reporting_and_invents_no_email() -> None:
+    security = _read("SECURITY.md")
+
+    assert "private vulnerability reporting" in security
+    assert "github.com/BlocUnited-LLC/mozaiks/security" in security
+    assert "Report a vulnerability" in security
+    assert "@" not in security
+
+
+def test_code_of_conduct_is_contributor_covenant_with_no_individual_contact() -> None:
+    coc = _read("CODE_OF_CONDUCT.md")
+
+    assert "Contributor Covenant" in coc
+    assert "project maintainers" in coc
+    # No invented individual person or email address as the enforcement contact.
+    assert "@" not in coc
+
+
+def test_issue_templates_cover_bug_feature_and_docs() -> None:
+    template_dir = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+
+    bug = yaml.safe_load((template_dir / "bug_report.yml").read_text(encoding="utf-8"))
+    feature = yaml.safe_load((template_dir / "feature_request.yml").read_text(encoding="utf-8"))
+    docs = yaml.safe_load((template_dir / "documentation.yml").read_text(encoding="utf-8"))
+    config = yaml.safe_load((template_dir / "config.yml").read_text(encoding="utf-8"))
+
+    assert bug["name"] == "Bug Report"
+    assert any(field.get("id") == "repro" for field in bug["body"])
+
+    assert feature["name"] == "Feature Request"
+    assert any(field.get("id") == "problem" for field in feature["body"])
+
+    assert docs["name"] == "Documentation Improvement"
+    assert any(field.get("id") == "location" for field in docs["body"])
+
+    assert config["blank_issues_enabled"] is False
+    assert any(
+        "security" in link["url"]
+        for link in config["contact_links"]
+    )
+
+
+def test_pull_request_template_requests_required_fields() -> None:
+    pr_template = _read(".github/PULL_REQUEST_TEMPLATE.md")
+
+    assert "## Related issue" in pr_template
+    assert "## Summary" in pr_template
+    assert "## Tests run" in pr_template
+    assert "## Screenshots" in pr_template
+    assert "## Boundary confirmation" in pr_template
+    assert "private hosted-product logic" in pr_template


### PR DESCRIPTION
## Related issue

N/A - implements the maintainer-owned follow-up to a prior read-only contributor-onboarding audit.

## Summary

Makes the repo's contribution path easy to follow for a human contributor with no AI agent, while keeping the existing AI-agent skill/rule routing system fully intact for those who use it.

- Rewrites the top of CONTRIBUTING.md around: fork -> branch -> install dev deps -> focused change -> run relevant tests -> open PR.
- Moves the existing AI-agent skill/rule routing content (Start Here, Common Task Map, Build And Refinement Truth, Final Report Requirements, Focused Tests) verbatim into a clearly labeled '## Working With an AI Coding Agent (Optional)' section. No wording in that content changed, only heading level and position.
- Adds a 'What You Can Contribute Without Extra Setup' section explaining that docs, most Python tests, and many mozaiks_cli changes need no MongoDB, Node.js, running Studio instance, or LLM API key.
- **New `## Running Tests Locally` section in the human-first path** (not deferred as a future issue) explaining that a narrow local test run can trip the repo-wide `--cov-fail-under=30` gate even when every selected test passes, giving the verified command `python -m pytest tests/test_your_file.py -q --no-cov` to run a focused slice without that gate, and stating plainly that CI remains authoritative and still enforces the full coverage requirement regardless of local `--no-cov` usage.
- Adds SECURITY.md using GitHub private vulnerability reporting as the only reporting method (no email invented). SECURITY.md stays scoped exclusively to vulnerability reporting - it does not mention Code of Conduct.
- Adds CODE_OF_CONDUCT.md (Contributor Covenant v2.1). Enforcement contact is **info@blocunited.com**; GitHub's private security vulnerability reporting channel is explicitly called out as reserved for security vulnerabilities only and is not offered as a Code of Conduct reporting path.
- Adds .github/ISSUE_TEMPLATE/ forms for bug reports, feature requests, and documentation improvements, plus a template chooser config.
- Adds .github/PULL_REQUEST_TEMPLATE.md requesting: related issue, summary, tests run, screenshots when applicable, and OSS/private-product boundary confirmation.
- Updates README.md and docs/contributing/index.md to point at the same CONTRIBUTING.md quickstart path.
- Updates tests/test_contributor_onboarding_community_health.py to protect all of the above, including the new focused-test/coverage-gate guidance and the CoC/security-channel separation.

No application/runtime behavior changed. This does not create the other public GitHub issues from the earlier audit; those remain a separate, explicit follow-up.

`info@blocunited.com` is confirmed by the maintainer as a live, monitored inbox, and GitHub private vulnerability reporting is confirmed enabled for this repository.

## Tests run

```
python -m pytest tests/test_contributor_onboarding_community_health.py -q --no-cov
-> 10 passed

python -m pytest tests/test_contributor_guidance_framing.py tests/test_module_reactions_docs_contract.py tests/test_admin_ui_two_tier_contract.py tests/test_claude_guidance_operating_system.py tests/test_contributor_quickstart.py tests/test_runtime_change_skill.py tests/test_factory_build_workflow_skill.py tests/test_control_plane_refinement_skill.py tests/test_existing_app_discovery_skill.py tests/test_appgenerator_change_skill.py tests/test_agentgenerator_change_skill.py tests/test_contributor_skill_routing_map.py tests/test_contributor_onboarding_community_health.py -q --no-cov
-> 92 passed

python -m mkdocs build --strict
-> succeeded, no warnings
```

`--no-cov` is used deliberately here to demonstrate the exact focused-run workflow now documented in CONTRIBUTING.md's new "Running Tests Locally" section; CI still runs the full suite with the repository's coverage gate enforced.

All new YAML issue-template files were also validated with a PyYAML parse check.

## Screenshots (if applicable)

N/A - documentation-only change, no UI.

## Boundary confirmation

- [x] This change stays within the open-source mozaiks repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.
