### PR TITLE
fix(tests): align CI-failing tests to canonical build-record field names

### DIFF
--- a/tests/test_carry_forward_report_persistence.py
+++ b/tests/test_carry_forward_report_persistence.py
@@ -144,8 +144,8 @@ def test_artifact_version_doc_model_dump_includes_commit_metadata_metadata() -> 
         {
             "_id": "av_test_01",
             "app_id": _APP_ID,
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 1,
             "lineage_root_id": "av_test_01",
             "commit_metadata": {"metadata": {"carry_forward_report": _MINIMAL_REPORT}},
@@ -164,8 +164,8 @@ def test_artifact_version_doc_report_survives_model_dump_roundtrip() -> None:
         {
             "_id": "av_test_02",
             "app_id": _APP_ID,
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 1,
             "lineage_root_id": "av_test_02",
             "commit_metadata": {"metadata": {"carry_forward_report": _MINIMAL_REPORT}},
@@ -288,8 +288,8 @@ def test_studio_build_history_includes_commit_metadata_in_model_dump() -> None:
         {
             "_id": "av_hist_01",
             "app_id": _APP_ID,
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 1,
             "lineage_root_id": "av_hist_01",
             "commit_metadata": {
@@ -317,8 +317,8 @@ def test_studio_build_history_report_nested_correctly() -> None:
         {
             "_id": "av_hist_02",
             "app_id": _APP_ID,
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 2,
             "lineage_root_id": "av_hist_02",
             "commit_metadata": {

--- a/tests/test_refinement_staging_workspace.py
+++ b/tests/test_refinement_staging_workspace.py
@@ -18,7 +18,7 @@ def _build_plan(
 ) -> dry_run.RefinementExecutionPlan:
     return dry_run.build_refinement_execution_plan_from_route(
         request="Update the dashboard review surface.",
-        artifact_kind="app_bundle",
+        build_family="app_bundle",
         change_class="patch",
         workflow_id="AppGenerator",
         workflow_sequence="app_revision",

--- a/tests/test_staging_pure_helpers.py
+++ b/tests/test_staging_pure_helpers.py
@@ -53,7 +53,7 @@ def _plan(**kwargs) -> RefinementExecutionPlan:
     defaults = {
         "request_id": "req-abc123",
         "request": "Add a search feature",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "feature",
         "workflow_id": "AppGenerator",
         "workflow_sequence": "full_build",

--- a/tests/test_studio_artifact_restore.py
+++ b/tests/test_studio_artifact_restore.py
@@ -39,7 +39,7 @@ def _version(
     *,
     artifact_version_id: str,
     zip_path: Path,
-    artifact_kind: str = "app_bundle",
+    build_family: str = "app_bundle",
     lifecycle_status: ArtifactLifecycleStatus = ArtifactLifecycleStatus.CURRENT,
     validation_status: ArtifactValidationStatus = ArtifactValidationStatus.PASSED,
     refinement_request_id: str | None = None,
@@ -60,8 +60,8 @@ def _version(
         {
             "_id": artifact_version_id,
             "app_id": "app_1",
-            "artifact_kind": artifact_kind,
-            "artifact_key": "app_bundle",
+            "build_family": build_family,
+            "build_key": "app_bundle",
             "version_number": 2,
             "parent_version_id": "av_parent_1" if artifact_version_id != "av_parent_1" else None,
             "lineage_root_id": "av_parent_1",
@@ -106,13 +106,13 @@ class _PromoteStore:
         self.sessions = list(sessions or [])
         self.updated_sessions: list[dict[str, object]] = []
 
-    async def get_artifact_version(self, *, app_id: str, artifact_version_id: str):
-        if artifact_version_id == self.version.id:
+    async def get_build_record(self, *, app_id: str, build_record_id: str):
+        if build_record_id == self.version.id:
             return self.version
         return None
 
-    async def list_refinement_sessions(self, *, app_id: str, result_artifact_version_id: str, limit: int = 20):
-        if result_artifact_version_id == self.version.id:
+    async def list_refinement_sessions(self, *, app_id: str, result_build_record_id: str, limit: int = 20):
+        if result_build_record_id == self.version.id:
             return list(self.sessions[:limit])
         return []
 
@@ -494,7 +494,7 @@ def test_promote_rejects_non_app_bundle_artifact(monkeypatch, tmp_path: Path) ->
     version = _version(
         artifact_version_id="av_workflow_1",
         zip_path=bundle_zip,
-        artifact_kind="workflow_bundle",
+        build_family="workflow_bundle",
         lifecycle_status=ArtifactLifecycleStatus.CURRENT,
     )
     store = _PromoteStore(version)
@@ -511,8 +511,8 @@ def test_promote_rejects_missing_artifact_path(monkeypatch, tmp_path: Path) -> N
         {
             "_id": "av_missing_1",
             "app_id": "app_1",
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 2,
             "lineage_root_id": "av_missing_1",
             "canonical_inputs_version": {},

--- a/tests/test_studio_workflow_trigger.py
+++ b/tests/test_studio_workflow_trigger.py
@@ -33,8 +33,8 @@ def _artifact_version(
     *,
     artifact_version_id: str,
     zip_path: Path,
-    artifact_kind: str = "app_bundle",
-    artifact_key: str = "app_bundle",
+    build_family: str = "app_bundle",
+    build_key: str = "app_bundle",
     version_number: int = 1,
     parent_version_id: str | None = None,
     lifecycle_status: ArtifactLifecycleStatus = ArtifactLifecycleStatus.DRAFT,
@@ -53,8 +53,8 @@ def _artifact_version(
         {
             "_id": artifact_version_id,
             "app_id": "app_1",
-            "artifact_kind": artifact_kind,
-            "artifact_key": artifact_key,
+            "build_family": build_family,
+            "build_key": build_key,
             "version_number": version_number,
             "parent_version_id": parent_version_id,
             "lineage_root_id": parent_version_id or artifact_version_id,
@@ -79,15 +79,15 @@ def _change_request_doc(*, artifact_version_id: str) -> ChangeRequestDoc:
         {
             "_id": "cr_review_1",
             "app_id": "app_1",
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
-            "artifact_version_id": artifact_version_id,
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
+            "build_record_id": artifact_version_id,
             "raw_user_request": "Update the dashboard title and export controls.",
             "classification": ChangeClassification.PATCH.value,
             "refinement_request": RefinementRequestPayload(
-                artifact_kind="app_bundle",
-                artifact_key="app_bundle",
-                artifact_version_id=artifact_version_id,
+                build_family="app_bundle",
+                build_key="app_bundle",
+                build_record_id=artifact_version_id,
                 raw_user_request="Update the dashboard title and export controls.",
                 source_surface="app_build",
             ).model_dump(mode="python"),
@@ -293,16 +293,16 @@ def test_studio_trigger_endpoint_accepts_refinement_trigger_payload(monkeypatch)
     assert captured_prepare["extra_trigger_meta"] == {
         "action_id": None,
         "change_class": "feature",
-        "artifact_version_id": "av_123",
-        "artifact_kind": "app_bundle",
+        "build_record_id": "av_123",
+        "build_family": "app_bundle",
         "workflow_sequence": "app_revision",
     }
     assert persisted_changes == [
         {
             "app_id": captured_prepare["app_id"],
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
-            "artifact_version_id": "av_123",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
+            "build_record_id": "av_123",
             "raw_user_request": "Add an export action",
             "classification": studio_app.ChangeClassification.FEATURE,
             "refinement_request": {
@@ -669,9 +669,9 @@ def test_studio_trigger_endpoint_can_short_circuit_to_coding_worker(monkeypatch)
     assert persisted_sessions == [
         {
             "app_id": persisted_changes[0]["app_id"],
-            "artifact_version_id": "av_456",
+            "build_record_id": "av_456",
             "change_request_id": "cr_code_1",
-            "result_artifact_version_id": "av_child_code_1",
+            "result_build_record_id": "av_child_code_1",
             "provider": "control_plane_coding",
             "status": studio_app.RefinementSessionStatus.VALIDATED,
             "preview_url": None,
@@ -1380,12 +1380,12 @@ def test_app_review_revision_trigger_preserves_staged_bundle_context(monkeypatch
     assert body["execution_mode"] == "harness_decision"
     assert body["workflow_id"] == "ValueEngine"
     assert body["harness_decision"]["decision_type"] == "core_restart"
-    assert create_calls[0]["artifact_version_id"] == "av_review_1"
+    assert create_calls[0]["build_record_id"] == "av_review_1"
     assert create_calls[0]["refinement_request"]["source_surface"] == "app_review"
     assert create_calls[0]["refinement_request"]["extra"]["bundle_path"] == staged_bundle_path
 
     seed = captured_pending["decision_context_seed"]
-    assert seed["artifact_version_id"] == "av_review_1"
+    assert seed["build_record_id"] == "av_review_1"
     assert seed["artifact_root"] == staged_bundle_path
     assert seed["lifecycle_state"] == "review"
     assert seed["refinement_request_meta"]["source_surface"] == "app_review"
@@ -1412,16 +1412,16 @@ class _ReviewArtifactStore:
         self.session = session
         self.update_calls: list[dict] = []
 
-    async def get_artifact_version(self, **kwargs):  # noqa: ANN003
-        artifact_version_id = kwargs.get("artifact_version_id")
-        if artifact_version_id == self.child_version.id:
+    async def get_build_record(self, **kwargs):  # noqa: ANN003
+        build_record_id = kwargs.get("build_record_id")
+        if build_record_id == self.child_version.id:
             return self.child_version
-        if artifact_version_id == self.parent_version.id:
+        if build_record_id == self.parent_version.id:
             return self.parent_version
         return None
 
     async def list_refinement_sessions(self, **kwargs):  # noqa: ANN003
-        if kwargs.get("result_artifact_version_id") == self.child_version.id:
+        if kwargs.get("result_build_record_id") == self.child_version.id:
             return [self.session]
         return []
 
@@ -1431,11 +1431,11 @@ class _ReviewArtifactStore:
         return None
 
     async def list_change_requests(self, **kwargs):  # noqa: ANN003
-        if kwargs.get("artifact_version_id") == self.parent_version.id:
+        if kwargs.get("build_record_id") == self.parent_version.id:
             return [self.change_request]
         return []
 
-    async def accept_artifact_version(self, **kwargs):  # noqa: ANN003
+    async def accept_build_record(self, **kwargs):  # noqa: ANN003
         self.child_version = self.child_version.model_copy(
             update={"lifecycle_status": ArtifactLifecycleStatus.CURRENT}
         )
@@ -1538,11 +1538,11 @@ def test_studio_artifact_bundle_endpoint_returns_workbench_payload(monkeypatch, 
     assert response.status_code == 200
     body = response.json()
     assert body["artifact_version_id"] == "av_child_1"
-    assert body["artifact_kind"] == "app_bundle"
+    assert body["build_family"] == "app_bundle"
     assert body["generated_files"]["src/App.jsx"].startswith("export default function App")
     assert body["generated_files"]["package.json"] == '{"name":"demo"}\n'
     assert body["workbench"]["artifact_version_id"] == "av_child_1"
-    assert body["workbench"]["artifact_kind"] == "app_bundle"
+    assert body["workbench"]["build_family"] == "app_bundle"
     assert body["review"]["changed_file_count"] == 1
     assert body["review"]["selected_paths"] == ["src/App.jsx"]
     assert body["change_request"]["classification"] == "patch"
@@ -1846,5 +1846,5 @@ def test_studio_trigger_endpoint_invokes_surface_regeneration_for_feature_change
     assert body["refinement_session_id"] == "rs_surface_1"
     assert len(persisted_sessions) == 1
     assert persisted_sessions[0]["provider"] == "contract_surface_regeneration"
-    assert persisted_sessions[0]["artifact_version_id"] == "av_456"
+    assert persisted_sessions[0]["build_record_id"] == "av_456"
     assert persisted_sessions[0]["change_request_id"] == "cr_surface_1"

--- a/tests/test_summary_artifacts.py
+++ b/tests/test_summary_artifacts.py
@@ -16,12 +16,12 @@ class _FakeArtifactStore:
     def __init__(self) -> None:
         self.create_calls = []
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str | None = None,
+        build_family: str,
+        build_key: str | None = None,
         lifecycle_status: ArtifactLifecycleStatus | None = None,
         limit: int = 1,
     ):
@@ -30,8 +30,8 @@ class _FakeArtifactStore:
                 ArtifactVersionDoc(
                     _id="av_design_docs_1",
                     app_id=app_id,
-                    artifact_kind="design_docs",
-                    artifact_key="design_docs",
+                    build_family="design_docs",
+                    build_key="design_docs",
                     version_number=1,
                     lineage_root_id="av_design_docs_1",
                     lifecycle_status=ArtifactLifecycleStatus.CURRENT,
@@ -43,11 +43,11 @@ class _FakeArtifactStore:
                 ArtifactVersionDoc(
                     _id="av_concept_2",
                     app_id=app_id,
-                    artifact_kind="concept",
-                    artifact_key="concept",
+                    build_family="concept",
+                    build_key="concept",
                     version_number=2,
                     lineage_root_id="av_concept_1",
-                    parent_version_id="av_concept_1",
+                    parent_build_record_id="av_concept_1",
                     lifecycle_status=ArtifactLifecycleStatus.CURRENT,
                     validation_status=ArtifactValidationStatus.SKIPPED,
                     commit_metadata={"metadata": {"summary_payload": {"app_name": "Demo"}}},
@@ -57,8 +57,8 @@ class _FakeArtifactStore:
                 ArtifactVersionDoc(
                     _id="av_build_plan_1",
                     app_id=app_id,
-                    artifact_kind="build_plan",
-                    artifact_key="build_plan",
+                    build_family="build_plan",
+                    build_key="build_plan",
                     version_number=1,
                     lineage_root_id="av_build_plan_1",
                     lifecycle_status=ArtifactLifecycleStatus.CURRENT,
@@ -67,21 +67,21 @@ class _FakeArtifactStore:
                 )
             ],
         }
-        rows = data.get((artifact_kind, artifact_key), [])
+        rows = data.get((build_family, build_key), [])
         # Honour lifecycle_status filter so tests verify the CURRENT-only contract.
         if lifecycle_status is not None:
             rows = [r for r in rows if r.lifecycle_status == lifecycle_status]
         return rows
 
-    async def create_artifact_version(self, **kwargs):
+    async def create_build_record(self, **kwargs):
         self.create_calls.append(dict(kwargs))
         return ArtifactVersionDoc(
             _id="av_design_docs_2",
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=2,
-            parent_version_id=kwargs.get("parent_version_id"),
+            parent_build_record_id=kwargs.get("parent_build_record_id"),
             lineage_root_id="av_design_docs_1",
             canonical_inputs_version=dict(kwargs.get("canonical_inputs_version") or {}),
             lifecycle_status=kwargs["lifecycle_status"],
@@ -121,7 +121,7 @@ async def test_persist_summary_artifact_registers_parent_inputs_and_summary_payl
         artifact_store=store,
     )
 
-    assert store.create_calls[0]["parent_version_id"] == "av_design_docs_1"
+    assert store.create_calls[0]["parent_build_record_id"] == "av_design_docs_1"
     assert store.create_calls[0]["canonical_inputs_version"] == {
         "concept": "av_concept_2",
         "build_plan": "av_build_plan_1",
@@ -140,12 +140,12 @@ class _DraftOnlyArtifactStore:
     def __init__(self) -> None:
         self.create_calls: list = []
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str | None = None,
+        build_family: str,
+        build_key: str | None = None,
         lifecycle_status: ArtifactLifecycleStatus | None = None,
         limit: int = 1,
     ):
@@ -153,27 +153,27 @@ class _DraftOnlyArtifactStore:
             ArtifactVersionDoc(
                 _id="av_concept_draft_1",
                 app_id=app_id,
-                artifact_kind="concept",
-                artifact_key="concept",
+                build_family="concept",
+                build_key="concept",
                 version_number=2,
                 lineage_root_id="av_concept_1",
-                parent_version_id="av_concept_1",
+                parent_build_record_id="av_concept_1",
                 lifecycle_status=ArtifactLifecycleStatus.DRAFT,
                 validation_status=ArtifactValidationStatus.SKIPPED,
                 commit_metadata={"metadata": {}},
             )
-        ] if artifact_kind == "concept" else []
+        ] if build_family == "concept" else []
         if lifecycle_status is not None:
             return [v for v in all_versions if v.lifecycle_status == lifecycle_status]
         return all_versions
 
-    async def create_artifact_version(self, **kwargs):
+    async def create_build_record(self, **kwargs):
         self.create_calls.append(dict(kwargs))
         return ArtifactVersionDoc(
             _id="av_new",
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=1,
             lineage_root_id="av_new",
             lifecycle_status=kwargs["lifecycle_status"],
@@ -185,7 +185,7 @@ class _DraftOnlyArtifactStore:
 class _EmptyArtifactStore(_DraftOnlyArtifactStore):
     """Returns no versions — simulates first-run state."""
 
-    async def list_artifact_versions(self, **kwargs):
+    async def list_build_records(self, **kwargs):
         return []
 
 
@@ -216,7 +216,7 @@ async def test_resolve_latest_artifact_version_refs_returns_empty_on_first_run()
 
 @pytest.mark.asyncio
 async def test_persist_summary_artifact_first_run_has_no_parent() -> None:
-    """On first run the parent lookup returns nothing; parent_version_id must be None."""
+    """On first run the parent lookup returns nothing; parent_build_record_id must be None."""
     store = _EmptyArtifactStore()
 
     await persist_summary_artifact(
@@ -226,5 +226,4 @@ async def test_persist_summary_artifact_first_run_has_no_parent() -> None:
         artifact_store=store,
     )
 
-    assert store.create_calls[0]["parent_version_id"] is None
-
+    assert store.create_calls[0]["parent_build_record_id"] is None


### PR DESCRIPTION
## Summary

- Repairs 6 test files broken by the artifact→build-record migration (PRs #192/#195) that were not updated in the same pass
- All 6 files previously caused CI failures on `main` (committed 2026-08-07 push: 49 test failures, 12 errors)

## Files changed

| File | Fix |
|------|-----|
| `test_summary_artifacts.py` | Fake stores now implement `list_build_records`/`create_build_record`; field names canonical |
| `test_refinement_staging_workspace.py` | `artifact_kind=` → `build_family=` in `build_refinement_execution_plan_from_route` |
| `test_staging_pure_helpers.py` | Same `artifact_kind` → `build_family` in `_plan()` |
| `test_studio_artifact_restore.py` | `_version()` uses `build_family`/`build_key`; `_PromoteStore` uses `get_build_record`/`list_refinement_sessions(result_build_record_id=)` |
| `test_studio_workflow_trigger.py` | Full set: `_artifact_version`, `_change_request_doc`, `_ReviewArtifactStore`, and all assertion field names aligned |
| `test_carry_forward_report_persistence.py` | `artifact_kind`/`artifact_key` → `build_family`/`build_key` in `model_validate` calls |

## Test plan

- [x] All 6 repaired test files: 90 passed locally
- [x] No runtime code changed — test-only fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)