### PR TITLE
feat(runtime): enforce permission consistency and notification_id at module load time

### DIFF
--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -39,6 +39,26 @@ module_yaml_schema_notes:
     runtime reports. Do not conflate the schema_version (always
     "mozaiks.module.v1") with the module identity version.
 
+# Constraints enforced by ModuleLoader at startup for every archetype.
+# Violations cause a hard ModuleLoadError before the app accepts traffic.
+# List them here once rather than duplicating across every archetype block.
+universal_hard_constraints:
+  permission_consistency: >
+    Every permission ID listed in action.permissions[] must be declared in the
+    module-level permissions block. The loader validates this at startup and
+    raises ModuleLoadError on any undeclared reference. Generate all permission
+    IDs that actions reference — including special scopes such as access_as_user
+    — as explicit entries in the top-level permissions block before referencing
+    them in any action.
+  notification_id_consistency: >
+    Every reactions.yaml reaction with target.kind=notification must have a
+    target.notification_id that matches an id declared in
+    contracts/notifications.yaml. The loader validates this at startup and
+    raises ModuleLoadError when notification_id is missing or undeclared, and
+    also when a notification reaction exists but contracts/notifications.yaml
+    does not. Generate contracts/notifications.yaml whenever any reaction
+    dispatches to target.kind=notification.
+
 archetypes:
   standard:
     summary: Default deterministic module for CRUD and ordinary business logic.

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -308,6 +308,17 @@ class ModuleDefinition(ModuleContractModel):
                 raise ValueError(
                     f"action capability {capability.capability_id!r} targets unknown action {capability.target!r}"
                 )
+
+        # Check 3: every permission ID referenced in action.permissions[] must be
+        # declared in the module-level permissions block.
+        declared_permission_ids = set(permission_ids)
+        for action in self.actions:
+            for perm_id in action.permissions:
+                if perm_id not in declared_permission_ids:
+                    raise ValueError(
+                        f"action {action.id!r} references undeclared permission {perm_id!r}; "
+                        "add it to the module-level permissions block"
+                    )
         return self
 
 
@@ -1338,6 +1349,27 @@ class ModuleLoader:
                     raise ModuleLoadError(
                         f"notifications.yaml references non-canonical event {event_type!r}"
                     )
+
+        # Check 6: notification reactions must reference a notification_id
+        # declared in contracts/notifications.yaml.
+        if manifests.reactions is not None:
+            notification_reactions = [
+                r for r in manifests.reactions.reactions if r.target.kind == "notification"
+            ]
+            if notification_reactions:
+                if manifests.notifications is None:
+                    raise ModuleLoadError(
+                        f"reactions.yaml reaction {notification_reactions[0].id!r} has "
+                        "target.kind=notification but contracts/notifications.yaml does not exist"
+                    )
+                declared_notification_ids = {n.id for n in manifests.notifications.notifications}
+                for reaction in notification_reactions:
+                    nid = reaction.target.notification_id
+                    if nid and nid not in declared_notification_ids:
+                        raise ModuleLoadError(
+                            f"reactions.yaml reaction {reaction.id!r} target.notification_id "
+                            f"{nid!r} is not declared in contracts/notifications.yaml"
+                        )
 
     @staticmethod
     def _is_known_or_canonical_event(event_type: str, declared_events: set[str]) -> bool:

--- a/tests/test_module_loader_contracts.py
+++ b/tests/test_module_loader_contracts.py
@@ -981,3 +981,118 @@ def test_module_yaml_rejects_unknown_top_level_field(tmp_path: Path) -> None:
     with pytest.raises(ModuleLoadError):
         ModuleLoader(str(tmp_path)).load("tasks")
 
+
+# ---------------------------------------------------------------------------
+# Check 3 — permission consistency (action.permissions[] vs. top-level block)
+# ---------------------------------------------------------------------------
+
+
+def test_module_loader_rejects_action_referencing_undeclared_permission(tmp_path: Path) -> None:
+    """Loader must reject an action whose permissions[] list references a
+    permission ID not declared in the module-level permissions block.
+
+    Regression guard: this bug class appeared in workspace_support where
+    access_as_user was used in action.permissions but was absent from the
+    top-level permissions block.
+    """
+    module_dir = _write_canonical_module(tmp_path)
+    yaml_path = module_dir / "module.yaml"
+    yaml_path.write_text(
+        """
+schema_version: mozaiks.module.v1
+module:
+  id: tasks
+  display_name: Tasks
+  version: 1.0.0
+  description: Task management
+  handler: backend.handler:TasksModule
+permissions:
+  - id: tasks.write
+    description: Create and update tasks
+actions:
+  - id: create
+    description: Create a task
+    handler_method: create_task
+    permissions: [tasks.write, undeclared.permission]
+    emits: [domain.tasks.task_created]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModuleLoadError, match="undeclared permission"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+
+
+# ---------------------------------------------------------------------------
+# Check 6 — notification_id consistency (reactions.yaml vs notifications.yaml)
+# ---------------------------------------------------------------------------
+
+
+def test_module_loader_rejects_reaction_notification_id_not_in_notifications_yaml(
+    tmp_path: Path,
+) -> None:
+    """Loader must reject a notification reaction whose notification_id is not
+    declared in contracts/notifications.yaml.
+
+    Regression guard: this bug class can silently wire a reaction to a
+    non-existent notification template, resulting in a runtime dispatch error
+    that only appears at event-emission time rather than at startup.
+    """
+    module_dir = _write_canonical_module(tmp_path)
+    module_dir.joinpath("contracts", "reactions.yaml").write_text(
+        """
+schema_version: mozaiks.reactions.v1
+reactions:
+  - id: task_created_notify
+    event_type: domain.tasks.task_created
+    target:
+      kind: notification
+      notification_id: nonexistent_notification
+""".lstrip(),
+        encoding="utf-8",
+    )
+    # notifications.yaml only declares 'task_created', not 'nonexistent_notification'
+    module_dir.joinpath("contracts", "notifications.yaml").write_text(
+        """
+schema_version: mozaiks.notifications.v1
+notifications:
+  - id: task_created
+    event_type: domain.tasks.task_created
+    channels: [in_app]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModuleLoadError, match="nonexistent_notification"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+
+
+def test_module_loader_rejects_notification_reaction_without_notifications_yaml(
+    tmp_path: Path,
+) -> None:
+    """Loader must reject a notification reaction when notifications.yaml is absent.
+
+    A reaction that dispatches to a notification template requires the template
+    to be declared — missing notifications.yaml is a hard contract gap.
+    """
+    module_dir = _write_canonical_module(tmp_path)
+    module_dir.joinpath("contracts", "reactions.yaml").write_text(
+        """
+schema_version: mozaiks.reactions.v1
+reactions:
+  - id: task_created_notify
+    event_type: domain.tasks.task_created
+    target:
+      kind: notification
+      notification_id: task_created
+""".lstrip(),
+        encoding="utf-8",
+    )
+    # Remove notifications.yaml so the reaction target has no backing declaration
+    notif_path = module_dir / "contracts" / "notifications.yaml"
+    if notif_path.exists():
+        notif_path.unlink()
+
+    with pytest.raises(ModuleLoadError, match="notifications.yaml"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+


### PR DESCRIPTION
## Summary

- **Check 3 — permission consistency**: `ModuleDefinition._validate_unique_ids` now raises `ValueError` when an action's `permissions[]` list references a permission ID not declared in the module-level `permissions` block. Hard error at load time, before the app accepts traffic. Catches the `workspace_support` / `access_as_user` pattern from mozaiks-app#151.

- **Check 6 — notification_id consistency**: `ModuleLoader._validate_manifest_event_references` now raises `ModuleLoadError` when a `reactions.yaml` reaction with `target.kind=notification` has a `target.notification_id` that is not declared in `contracts/notifications.yaml`, and also when a notification reaction exists but `notifications.yaml` is absent entirely. Prevents silent dispatch to non-existent notification templates.

- **3 regression tests** added to `tests/test_module_loader_contracts.py`:
  - `test_module_loader_rejects_action_referencing_undeclared_permission`
  - `test_module_loader_rejects_reaction_notification_id_not_in_notifications_yaml`
  - `test_module_loader_rejects_notification_reaction_without_notifications_yaml`

- **`module_archetypes.yaml`** gets a top-level `universal_hard_constraints` block documenting both rules as generator-time guidance so scaffolded modules start compliant.

## Test plan

- [ ] All 55 tests in `tests/test_module_loader_contracts.py` pass (`pytest tests/test_module_loader_contracts.py --no-cov`)
- [ ] CI Tests + Lint + Secret scan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)