### PR TITLE
feat(runtime): harden remaining module contract lanes 1-4

### DIFF
--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -58,6 +58,121 @@ universal_hard_constraints:
     also when a notification reaction exists but contracts/notifications.yaml
     does not. Generate contracts/notifications.yaml whenever any reaction
     dispatches to target.kind=notification.
+  user_data_scope_file_required: >
+    When module.yaml declares module.user_data_scope=true, the loader raises
+    ModuleLoadError at startup if backend/account_data_handler.py is absent.
+    Generate backend/account_data_handler.py implementing the AccountDataHandler
+    protocol (delete_user_data + export_user_data) whenever user_data_scope=true
+    is declared. Omit user_data_scope=true for modules that only reference
+    user_id as a foreign key without owning the user's primary records.
+  handler_method_required: >
+    Every action.handler_method value declared in module.yaml must exist as a
+    callable method on the handler class. The loader raises ModuleLoadError for
+    any undeclared or renamed method. Generated handler classes must implement
+    every method listed in module.yaml before the module can load.
+  emits_events_declared: >
+    Every event type listed in action.emits[] must be declared in
+    contracts/events.yaml. The loader raises ModuleLoadError for any undeclared
+    emit reference. backend/service.py must call ctx.emit() only for event types
+    declared in module.yaml emits[] and contracts/events.yaml — orphaned
+    ctx.emit() calls for events removed from the contract are not caught by the
+    loader and must be covered by module drift-guard tests (see
+    drift_guard_test_guidance below).
+
+# Advisory test-scaffold guidance for AppGenerator. When generating a new
+# module, scaffold tests/test_{module_id}_module_drift.py using these patterns
+# so the app's CI suite catches module contract drift at test time — before
+# the module is deployed or loaded by the runtime.
+drift_guard_test_guidance:
+  summary: >
+    Drift-guard test file pattern for generated app modules. Scaffold once per
+    module at generation time. Tests are intentionally lightweight — they load
+    the module or inspect source, they do not mock business logic or run handler
+    methods. The file should sit in the app-bundle tests/ directory alongside
+    other module tests.
+  patterns:
+    handler_method_alignment:
+      description: >
+        Load the module via ModuleLoader and assert it succeeds. This triggers
+        the handler_method reflection check at test time, catching any
+        module.yaml/handler.py drift on every CI run rather than only at app
+        startup.
+      template: |
+        def test_{module_id}_handler_methods_align_with_module_yaml(tmp_path):
+            # Verify every module.yaml handler_method exists on the handler class.
+            # ModuleLoader raises ModuleLoadError if any method is missing.
+            loader = ModuleLoader(str(Path(__file__).resolve().parents[1] / "app"))
+            loaded = loader.load("{module_id}")
+            declared = {{a.handler_method for a in loaded.definition.actions}}
+            handler_methods = {{m for m in dir(loaded.handler) if not m.startswith("_")}}
+            assert declared <= handler_methods
+    emits_service_alignment:
+      description: >
+        AST-scan backend/service.py for ctx.emit() calls with string-literal
+        first arguments and assert each found event type is declared in the
+        module's action.emits[] lists. Catches service.py calling ctx.emit()
+        for events that were never declared or were removed from the contract —
+        a gap the ModuleLoader does not statically enforce.
+      template: |
+        import ast, yaml
+        from pathlib import Path
+
+        def test_{module_id}_service_emits_match_declared_events():
+            app_root = Path(__file__).resolve().parents[1] / "app"
+            module_dir = app_root / "modules" / "{module_id}"
+            service_py = module_dir / "backend" / "service.py"
+            manifest = yaml.safe_load((module_dir / "module.yaml").read_text())
+
+            declared_emits = set()
+            for action in manifest.get("actions", []):
+                declared_emits.update(action.get("emits", []))
+
+            if not service_py.exists():
+                return  # module has no service layer — no emits to check
+
+            tree = ast.parse(service_py.read_text())
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "emit"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                ):
+                    event_type = node.args[0].value
+                    assert event_type in declared_emits, (
+                        f"service.py calls ctx.emit({{event_type!r}}) but "
+                        f"{{event_type!r}} is not declared in module.yaml emits[]"
+                    )
+    user_data_scope_handler_completeness:
+      description: >
+        When user_data_scope=true, assert backend/account_data_handler.py exists
+        and that AccountDataHandler implements both required methods. The loader
+        enforces file existence as a hard error; this test additionally catches
+        accidental removal of methods from a previously correct implementation.
+      template: |
+        import inspect, yaml
+        from pathlib import Path
+
+        def test_{module_id}_account_data_handler_complete():
+            app_root = Path(__file__).resolve().parents[1] / "app"
+            module_dir = app_root / "modules" / "{module_id}"
+            manifest = yaml.safe_load((module_dir / "module.yaml").read_text())
+            if not manifest.get("module", {{}}).get("user_data_scope"):
+                return  # not a user-data-scoped module
+
+            handler_file = module_dir / "backend" / "account_data_handler.py"
+            assert handler_file.exists(), "account_data_handler.py must exist when user_data_scope=true"
+
+            import importlib.util
+            spec = importlib.util.spec_from_file_location("adh", handler_file)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            cls = getattr(mod, "AccountDataHandler", None)
+            assert cls is not None, "AccountDataHandler class must be defined"
+            assert callable(getattr(cls, "delete_user_data", None)), "delete_user_data must be implemented"
+            assert callable(getattr(cls, "export_user_data", None)), "export_user_data must be implemented"
 
 archetypes:
   standard:

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -1181,19 +1181,19 @@ class ModuleLoader:
         Protocol).  It is registered under ``module_id`` with the process-global
         ``account_data_registry``.
 
-        Failure to load the handler logs a warning (not a hard error) so a
-        missing handler file does not prevent the rest of the module from loading.
-        Generated modules must declare the file; the warning makes the gap visible.
+        A missing backend/account_data_handler.py raises ModuleLoadError — the
+        module will not load. Generated modules must declare this file whenever
+        user_data_scope=true is set.
         """
         handler_file = module_dir / "backend" / "account_data_handler.py"
         if not handler_file.exists():
-            logger.warning(
-                "ACCOUNT_HANDLER_MISSING: module %r declares user_data_scope=true "
-                "but backend/account_data_handler.py was not found. "
-                "Account deletion and data export will NOT cover this module's data.",
-                module_id,
+            raise ModuleLoadError(
+                f"module {module_id!r} declares user_data_scope=true but "
+                "backend/account_data_handler.py was not found. "
+                "Generate backend/account_data_handler.py implementing the "
+                "AccountDataHandler protocol (delete_user_data + export_user_data), "
+                "or remove user_data_scope=true from module.yaml."
             )
-            return
 
         try:
             import importlib.util as _ilu

--- a/tests/test_module_loader_contracts.py
+++ b/tests/test_module_loader_contracts.py
@@ -983,6 +983,66 @@ def test_module_yaml_rejects_unknown_top_level_field(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Lane 1 — user_data_scope requires account_data_handler.py (hard error)
+# ---------------------------------------------------------------------------
+
+
+def test_module_loader_rejects_user_data_scope_without_account_data_handler(
+    tmp_path: Path,
+) -> None:
+    """Loader must raise ModuleLoadError when user_data_scope=true but
+    backend/account_data_handler.py is absent.
+
+    Regression guard: declaring user_data_scope=true is a compliance contract —
+    account deletion and data export must be implemented. A silent warning
+    allowed this gap to ship undetected; hard error ensures generated modules
+    scaffold the file before the module can load.
+    """
+    module_dir = _write_canonical_module(tmp_path)
+    yaml_path = module_dir / "module.yaml"
+    yaml_path.write_text(
+        yaml_path.read_text(encoding="utf-8").replace(
+            "  handler: backend.handler:TasksModule",
+            "  handler: backend.handler:TasksModule\n  user_data_scope: true",
+        ),
+        encoding="utf-8",
+    )
+    # account_data_handler.py intentionally absent
+
+    with pytest.raises(ModuleLoadError, match="account_data_handler"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+
+
+# ---------------------------------------------------------------------------
+# Lane 2 — handler_method alignment (hard error, explicit rejection test)
+# ---------------------------------------------------------------------------
+
+
+def test_module_loader_rejects_missing_handler_method(tmp_path: Path) -> None:
+    """Loader must raise ModuleLoadError when module.yaml declares a
+    handler_method that does not exist on the handler class.
+
+    Regression guard: this is the primary module.yaml/handler.py drift —
+    renaming a handler method without updating module.yaml (or vice versa)
+    produces a module that appears valid from YAML alone but fails at runtime.
+    Catching it at module-load time ensures CI finds the drift before deploy.
+    """
+    module_dir = _write_canonical_module(tmp_path)
+    module_dir.joinpath("backend", "handler.py").write_text(
+        """
+class TasksModule:
+    # create_task deliberately absent — module.yaml declares handler_method: create_task
+    async def renamed_create_task(self, ctx, *, title):
+        return {"task_id": "task_1"}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModuleLoadError, match="missing action method"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+
+
+# ---------------------------------------------------------------------------
 # Check 3 — permission consistency (action.permissions[] vs. top-level block)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Completes the OSS module-contract hardening after #206 (permission consistency + notification_id consistency).

### Lane 1 — user_data_scope + account_data_handler.py (hard error)
`_register_account_data_handler` now raises `ModuleLoadError` when `user_data_scope=true` but `backend/account_data_handler.py` is absent. Previously a soft warning that let compliance gaps ship silently. Test: `test_module_loader_rejects_user_data_scope_without_account_data_handler`.

### Lane 2 — handler_method alignment (explicit test)
The loader already hard-errors on missing handler methods. Added `test_module_loader_rejects_missing_handler_method` to explicitly document and pin that error path.

### Lanes 1–4 — `module_archetypes.yaml`
- Three new `universal_hard_constraints` entries: `user_data_scope_file_required`, `handler_method_required`, `emits_events_declared`
- New `drift_guard_test_guidance` section with three test patterns the AppGenerator can scaffold per-module:
  - **handler_method_alignment** — load via `ModuleLoader` at test time (catches module.yaml/handler.py drift in CI)
  - **emits_service_alignment** — AST-scan `backend/service.py` for `ctx.emit()` string literals vs. declared emits (fills the gap the loader does not enforce)
  - **user_data_scope_handler_completeness** — verify `AccountDataHandler` methods exist after the file check

## Test plan

- [ ] 57 tests pass: `pytest tests/test_module_loader_contracts.py --no-cov`
- [ ] CI Tests + Lint + Secret scan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)