### PR TITLE
feat(runtime): add check_missing_emits for events.yaml ↔ service.py alignment (Lane 4)

### DIFF
--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -131,6 +131,35 @@ drift_guard_test_guidance:
                 f"backend/service.py calls ctx.emit() for undeclared events: "
                 + ", ".join(f"{{e!r}} (line {{ln}})" for e, ln in orphans)
             )
+    events_yaml_service_alignment:
+      description: >
+        Lane 4 — contracts/events.yaml ↔ service.py alignment. Use the OSS
+        emit_drift utility to check that every event type declared in
+        module.yaml action.emits[] (and therefore in contracts/events.yaml,
+        since the loader enforces that subset relationship at startup) has a
+        matching ctx.emit("event_type", ...) string-literal call somewhere in
+        backend/service.py. Catches "declared but dead" events — events added
+        to the contract during design but whose ctx.emit() call was never
+        written, or an emit removed from service.py without cleaning up
+        module.yaml and events.yaml. Import check_missing_emits from
+        mozaiksai.core.runtime.app.emit_drift — available in any app that
+        has the mozaiksai package installed. Note: only literal string
+        arguments are detected; a declared event emitted only via a dynamic
+        variable will appear as missing — suppress with a skip marker or
+        convert to a string literal.
+      template: |
+        from pathlib import Path
+        from mozaiksai.core.runtime.app.emit_drift import check_missing_emits
+
+        def test_{module_id}_declared_events_are_emitted():
+            module_dir = (
+                Path(__file__).resolve().parents[1] / "app" / "modules" / "{module_id}"
+            )
+            missing = check_missing_emits(module_dir)
+            assert missing == [], (
+                "Events declared in module.yaml/events.yaml but never emitted "
+                "by backend/service.py: " + ", ".join(repr(e) for e in missing)
+            )
     user_data_scope_handler_completeness:
       description: >
         When user_data_scope=true, assert backend/account_data_handler.py exists

--- a/mozaiksai/core/runtime/app/emit_drift.py
+++ b/mozaiksai/core/runtime/app/emit_drift.py
@@ -10,14 +10,17 @@ The ModuleLoader enforces at startup that every event type in
 scan ``backend/service.py`` source code to verify that:
 
 1. Every ``ctx.emit()`` call in service.py uses an event type that is
-   declared in ``module.yaml action.emits[]`` / ``contracts/events.yaml``.
-2. Every event type declared in ``module.yaml action.emits[]`` is actually
-   emitted by service.py (optional completeness check).
+   declared in ``module.yaml action.emits[]`` / ``contracts/events.yaml``
+   (Lane 3 — orphaned emits).
+2. Every event type declared in ``module.yaml action.emits[]`` and
+   ``contracts/events.yaml`` is actually emitted somewhere in service.py
+   (Lane 4 — missing emits / contracts/events.yaml ↔ service.py).
 
-These two checks together close the "orphaned emit" and "declared-but-missing
-emit" drift classes. They are intentionally test-time / CI checks — not
-startup validators — because service.py may legitimately use dynamic event
-types via variables (which the AST cannot statically resolve to a declaration).
+Both checks close drift classes that are invisible to the loader. They are
+intentionally test-time / CI checks — not startup validators — because
+service.py may use dynamic event types via variables that cannot be resolved
+statically, and because a module might legitimately emit a declared event from
+a background worker rather than service.py directly.
 
 Public API
 ----------
@@ -29,26 +32,44 @@ Public API
     Return the set of event types declared in ``actions[].emits[]`` across
     all actions in a module.yaml file.
 
-``check_orphaned_emits(module_dir)``
-    Return a list of ``(event_type, line_no)`` pairs for ``ctx.emit()``
-    calls whose event type is not declared in the module contract.
-    Returns an empty list when service.py does not exist or when no
-    orphaned emits are found.
+``load_declared_events_from_yaml(events_yaml)``
+    Return the set of event types declared in a ``contracts/events.yaml``
+    file. Complements ``load_declared_emits``; both sets are equal for a
+    well-formed module because the loader enforces
+    ``module.yaml emits[] ⊆ events.yaml`` as a hard startup error.
 
-Typical usage in a generated app's drift-guard test
-----------------------------------------------------
+``check_orphaned_emits(module_dir)``
+    Lane 3. Return ``(event_type, line_no)`` pairs for ``ctx.emit()`` calls
+    in service.py whose event type is absent from ``module.yaml emits[]``.
+    Returns an empty list when service.py does not exist or all emits are
+    declared.
+
+``check_missing_emits(module_dir)``
+    Lane 4. Return a sorted list of event types declared in
+    ``module.yaml emits[]`` (backed by ``contracts/events.yaml``) that are
+    absent from service.py ``ctx.emit()`` string literals. Returns an empty
+    list when events.yaml does not exist, when no events are declared, or
+    when all declared events have a matching emit in service.py.
+
+Typical usage in a generated app's drift-guard tests
+-----------------------------------------------------
 ::
 
-    from mozaiksai.core.runtime.app.emit_drift import check_orphaned_emits
+    from mozaiksai.core.runtime.app.emit_drift import (
+        check_orphaned_emits,
+        check_missing_emits,
+    )
     from pathlib import Path
 
+    MODULE_DIR = Path(__file__).resolve().parents[1] / "app" / "modules" / "tasks"
+
     def test_tasks_service_emits_match_contract():
-        orphans = check_orphaned_emits(
-            Path(__file__).resolve().parents[1] / "app" / "modules" / "tasks"
-        )
-        assert orphans == [], (
-            f"service.py calls ctx.emit() for undeclared events: {orphans}"
-        )
+        orphans = check_orphaned_emits(MODULE_DIR)
+        assert orphans == [], f"undeclared emits: {orphans}"
+
+    def test_tasks_declared_events_are_emitted():
+        missing = check_missing_emits(MODULE_DIR)
+        assert missing == [], f"declared but never emitted: {missing}"
 """
 
 from __future__ import annotations
@@ -142,6 +163,71 @@ def load_declared_emits(module_yaml: Path) -> set[str]:
             if isinstance(event_type, str):
                 declared.add(event_type)
     return declared
+
+
+def load_declared_events_from_yaml(events_yaml: Path) -> set[str]:
+    """Return the set of event types declared in ``contracts/events.yaml``.
+
+    The loader enforces ``module.yaml emits[] ⊆ events.yaml`` at startup, so
+    this set equals ``load_declared_emits(module.yaml)`` for any well-formed
+    module.  Use this function when you want to read directly from the events
+    catalog rather than through module.yaml.
+
+    Returns an empty set when ``events_yaml`` does not exist or contains no
+    events.
+    """
+    if not events_yaml.exists():
+        return set()
+
+    raw: Any = yaml.safe_load(events_yaml.read_text(encoding="utf-8")) or {}
+    declared: set[str] = set()
+    for event in raw.get("events", []):
+        if isinstance(event, dict):
+            event_type = event.get("type")
+            if isinstance(event_type, str) and event_type:
+                declared.add(event_type)
+    return declared
+
+
+def check_missing_emits(module_dir: Path) -> list[str]:
+    """Return event types declared in module.yaml but absent from service.py.
+
+    Lane 4 — contracts/events.yaml ↔ service.py alignment.
+
+    An event is *missing* when ``module.yaml action.emits[]`` declares it
+    (meaning it is also declared in ``contracts/events.yaml``, enforced by the
+    loader) but ``backend/service.py`` contains no ``ctx.emit("event_type",
+    ...)`` string-literal call for it.
+
+    This catches "declared but never emitted" drift — e.g. an event added to
+    module.yaml and events.yaml during design but whose ctx.emit() call was
+    never written, or an emit that was removed from service.py without cleaning
+    up the declaration.
+
+    Returns an empty list when:
+    - ``module.yaml`` declares no emits (nothing to check)
+    - ``backend/service.py`` does not exist and no events are declared
+    - all declared events have a matching ctx.emit() literal in service.py
+
+    When ``backend/service.py`` does not exist but events are declared, all
+    declared events are returned as missing — they cannot be emitted by a
+    non-existent service layer.
+
+    Note: only string-literal ``ctx.emit("event_type", ...)`` calls are
+    detected. Dynamic emit calls using variables are not captured, so a
+    declared event emitted dynamically will appear as missing. In that case,
+    suppress the check for that event by excluding it from the assertion or by
+    adding a ``# emit: event_type`` marker comment as documentation.
+    """
+    module_yaml = module_dir / "module.yaml"
+    service_py = module_dir / "backend" / "service.py"
+
+    declared = load_declared_emits(module_yaml)
+    if not declared:
+        return []
+
+    actual = scan_service_emit_literals(service_py)
+    return sorted(declared - actual)
 
 
 def check_orphaned_emits(module_dir: Path) -> list[tuple[str, int]]:

--- a/tests/test_module_emit_drift.py
+++ b/tests/test_module_emit_drift.py
@@ -5,13 +5,14 @@ enforce at startup:
 
 Lane 3 — emits ↔ service.py alignment:
   service.py calls ctx.emit("event_A") but event_A is absent from
-  module.yaml action.emits[]. The loader only checks the declaration
-  direction (module.yaml → events.yaml) — it does not read service.py.
+  module.yaml action.emits[]. Covered by check_orphaned_emits.
 
 Lane 4 — contracts/events.yaml ↔ service.py alignment:
-  Same gap viewed from events.yaml: since the loader already enforces
-  module.yaml emits[] → events.yaml (hard error), an orphan in service.py
-  implies a missing declaration in BOTH module.yaml and events.yaml.
+  module.yaml declares event_A in action.emits[] (backed by events.yaml)
+  but service.py never calls ctx.emit("event_A"). Covered by
+  check_missing_emits. This catches "declared but dead" events — added to
+  the contract during design but whose emit call was never written, or an
+  emit removed from service.py without cleaning up the declaration.
 
 The fix for both lanes is the same: every ctx.emit() string literal in
 service.py must be declared in module.yaml action.emits[].
@@ -28,8 +29,10 @@ import pytest
 import yaml
 
 from mozaiksai.core.runtime.app.emit_drift import (
+    check_missing_emits,
     check_orphaned_emits,
     load_declared_emits,
+    load_declared_events_from_yaml,
     scan_service_emit_literals,
     scan_service_emit_literals_with_lines,
 )
@@ -45,10 +48,17 @@ def _write_module(
     *,
     declared_emits: list[str] | None = None,
     service_src: str | None = None,
+    write_events_yaml: bool = False,
 ) -> Path:
-    """Write a minimal module directory under root/modules/tasks/."""
+    """Write a minimal module directory under root/modules/tasks/.
+
+    When ``write_events_yaml=True``, a ``contracts/events.yaml`` is created
+    that mirrors ``declared_emits`` so the module is well-formed with respect
+    to the loader's events.yaml requirement.
+    """
     module_dir = root / "modules" / "tasks"
     (module_dir / "backend").mkdir(parents=True, exist_ok=True)
+    (module_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     emits_yaml = (
         "    emits: [" + ", ".join(declared_emits) + "]"
@@ -77,6 +87,16 @@ actions:
 """.lstrip(),
         encoding="utf-8",
     )
+
+    if write_events_yaml and declared_emits:
+        events_entries = "\n".join(
+            f"  - type: {et}\n    version: 1\n    producer: tasks\n    payload_schema: {{}}"
+            for et in declared_emits
+        )
+        module_dir.joinpath("contracts", "events.yaml").write_text(
+            f"schema_version: mozaiks.events.v1\nevents:\n{events_entries}\n",
+            encoding="utf-8",
+        )
 
     if service_src is not None:
         module_dir.joinpath("backend", "service.py").write_text(
@@ -410,3 +430,232 @@ def test_drift_guard_pattern_used_by_generated_app_tests(tmp_path: Path) -> None
     )
     orphaned_types = {e for e, _ in orphans}
     assert "domain.tasks.task_queued_for_indexing" in orphaned_types
+
+
+# ---------------------------------------------------------------------------
+# load_declared_events_from_yaml — contracts/events.yaml reader
+# ---------------------------------------------------------------------------
+
+
+def test_load_declared_events_from_yaml_reads_event_types(tmp_path: Path) -> None:
+    events_yaml = tmp_path / "events.yaml"
+    events_yaml.write_text(
+        """
+schema_version: mozaiks.events.v1
+events:
+  - type: domain.tasks.task_created
+    version: 1
+    producer: tasks
+    payload_schema: {}
+  - type: domain.tasks.task_deleted
+    version: 1
+    producer: tasks
+    payload_schema: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = load_declared_events_from_yaml(events_yaml)
+    assert result == {"domain.tasks.task_created", "domain.tasks.task_deleted"}
+
+
+def test_load_declared_events_from_yaml_returns_empty_when_absent(
+    tmp_path: Path,
+) -> None:
+    result = load_declared_events_from_yaml(tmp_path / "nonexistent.yaml")
+    assert result == set()
+
+
+def test_load_declared_events_from_yaml_returns_empty_for_no_events(
+    tmp_path: Path,
+) -> None:
+    events_yaml = tmp_path / "events.yaml"
+    events_yaml.write_text(
+        "schema_version: mozaiks.events.v1\nevents: []\n", encoding="utf-8"
+    )
+    assert load_declared_events_from_yaml(events_yaml) == set()
+
+
+def test_load_declared_events_matches_load_declared_emits_for_well_formed_module(
+    tmp_path: Path,
+) -> None:
+    """For a well-formed module (loader invariant holds), the event types in
+    events.yaml and module.yaml emits[] must be the same set.
+
+    The loader enforces module.yaml emits[] ⊆ events.yaml as a hard error, so
+    for any module that loads successfully, these two sets are equal.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created", "domain.tasks.task_deleted"],
+        write_events_yaml=True,
+    )
+    from_module_yaml = load_declared_emits(module_dir / "module.yaml")
+    from_events_yaml = load_declared_events_from_yaml(
+        module_dir / "contracts" / "events.yaml"
+    )
+    assert from_module_yaml == from_events_yaml
+
+
+# ---------------------------------------------------------------------------
+# Lane 4: check_missing_emits — contracts/events.yaml ↔ service.py alignment
+# ---------------------------------------------------------------------------
+
+
+def test_check_missing_emits_returns_empty_when_no_declared_emits(
+    tmp_path: Path,
+) -> None:
+    """No declared emits in module.yaml → nothing can be missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[],
+        service_src="async def create_task(self, ctx, *, title):\n    return {}\n",
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_check_missing_emits_returns_empty_when_service_emits_all_declared(
+    tmp_path: Path,
+) -> None:
+    """service.py emits every declared event → no missing emits."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        service_src=(
+            'async def create_task(self, ctx, *, title):\n'
+            '    await ctx.emit("domain.tasks.task_created", {"title": title})\n'
+            '    return {"task_id": "t1"}\n'
+        ),
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_check_missing_emits_catches_declared_event_never_emitted(
+    tmp_path: Path,
+) -> None:
+    """Declared event absent from service.py → reported as missing.
+
+    Regression guard for Lane 4: this exact pattern appeared in the App Zero
+    sweep where module.yaml and events.yaml declared an event (e.g.
+    hosted.wallet.payout.failed) but service.py never called ctx.emit() for it.
+    The loader cannot catch this because it only enforces the declaration
+    direction; the check requires reading service.py.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "domain.tasks.task_created",
+            "domain.tasks.task_failed",  # declared but never emitted
+        ],
+        service_src=(
+            'async def create_task(self, ctx, *, title):\n'
+            '    await ctx.emit("domain.tasks.task_created", {"title": title})\n'
+            '    return {"task_id": "t1"}\n'
+            '    # NOTE: task_failed is declared but the emit call was never written\n'
+        ),
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert missing == ["domain.tasks.task_failed"]
+
+
+def test_check_missing_emits_reports_all_missing_events(tmp_path: Path) -> None:
+    """All missing events are returned, not just the first."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "domain.tasks.task_created",
+            "domain.tasks.task_deleted",
+            "domain.tasks.task_archived",
+        ],
+        service_src="async def noop(self, ctx): return {}\n",
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert set(missing) == {
+        "domain.tasks.task_created",
+        "domain.tasks.task_deleted",
+        "domain.tasks.task_archived",
+    }
+    # Result must be sorted for deterministic output
+    assert missing == sorted(missing)
+
+
+def test_check_missing_emits_returns_all_when_no_service_py(tmp_path: Path) -> None:
+    """No service.py + declared emits → all declared events are missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        # service_src intentionally absent
+    )
+    assert check_missing_emits(module_dir) == ["domain.tasks.task_created"]
+
+
+def test_check_missing_emits_ignores_dynamic_emits_as_non_matching(
+    tmp_path: Path,
+) -> None:
+    """Dynamic ctx.emit(variable, ...) does not count as covering a declared event.
+
+    A declared event emitted dynamically still appears as missing. The
+    developer must either use a string literal or suppress the assertion.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        service_src=(
+            'async def create_task(self, ctx, *, event_name):\n'
+            '    await ctx.emit(event_name, {})\n'  # dynamic — not captured
+        ),
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert "domain.tasks.task_created" in missing
+
+
+def test_check_missing_emits_returns_empty_when_no_module_yaml(
+    tmp_path: Path,
+) -> None:
+    """No module.yaml → no declared emits → nothing to report."""
+    module_dir = tmp_path / "modules" / "tasks"
+    (module_dir / "backend").mkdir(parents=True, exist_ok=True)
+    # module.yaml intentionally absent
+    assert check_missing_emits(module_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: drift-guard pattern for contracts/events.yaml ↔ service.py
+# ---------------------------------------------------------------------------
+
+
+def test_drift_guard_pattern_for_events_yaml_service_alignment(tmp_path: Path) -> None:
+    """The events_yaml_service_alignment pattern from module_archetypes.yaml
+    drift_guard_test_guidance must correctly catch declared-but-never-emitted
+    events in a freshly-generated module.
+
+    This test mimics what AppGenerator scaffolds into
+    tests/test_{module_id}_module_drift.py for the Lane 4 check.
+    """
+    # Simulate a module where events.yaml and module.yaml declare an event
+    # that was added during design but whose ctx.emit() call was never written.
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "hosted.schema_migrations.migration.applied",
+            "hosted.schema_migrations.migration.failed",  # declared but missing
+        ],
+        service_src=(
+            'async def run_migration(self, ctx, *, migration_id):\n'
+            '    await ctx.emit("hosted.schema_migrations.migration.applied", {})\n'
+            '    # migration.failed was declared in module.yaml but the\n'
+            '    # except branch and its ctx.emit were never implemented\n'
+            '    return {"success": True}\n'
+        ),
+    )
+
+    # Exact assertion a generated drift-guard test would make:
+    missing = check_missing_emits(module_dir)
+    assert missing != [], (
+        "Expected the drift-guard to catch the declared-but-missing emit; "
+        "the events_yaml_service_alignment pattern is broken"
+    )
+    assert "hosted.schema_migrations.migration.failed" in missing


### PR DESCRIPTION
## Summary

Closes the final module-contract lane after #208:

**Lane 4 — contracts/events.yaml ↔ service.py alignment**

`module.yaml action.emits[]` declares an event (which must also be in `contracts/events.yaml`, enforced by the loader as a hard startup error) but `backend/service.py` has no matching `ctx.emit("event_type", ...)` string-literal call. These are "declared but dead" events — added during design but whose emit call was never written, or removed from service.py without cleaning up the contract.

### New in `emit_drift.py`

- **`load_declared_events_from_yaml(events_yaml)`** — reads `type` fields directly from `contracts/events.yaml`; for a well-formed module the result equals `load_declared_emits(module.yaml)` since the loader enforces the subset invariant

- **`check_missing_emits(module_dir)`** → `list[str]` (sorted) — returns event types declared in `module.yaml emits[]` that are absent from `backend/service.py` ctx.emit() string literals; returns `[]` when nothing declared or all emits are present

### 12 new tests in `test_module_emit_drift.py` (29 total)

Covers `load_declared_events_from_yaml` edge cases, the events.yaml == module.yaml invariant, and all `check_missing_emits` paths including the end-to-end regression for the exact App Zero bug pattern (e.g. `migration.failed` declared but never emitted).

### `module_archetypes.yaml` drift_guard_test_guidance

New `events_yaml_service_alignment` pattern — one-liner using `check_missing_emits`:

```python
from mozaiksai.core.runtime.app.emit_drift import check_missing_emits

def test_{module_id}_declared_events_are_emitted():
    module_dir = Path(__file__).resolve().parents[1] / "app" / "modules" / "{module_id}"
    missing = check_missing_emits(module_dir)
    assert missing == [], ...
```

## Test plan

- [ ] 86 tests pass: `pytest tests/test_module_loader_contracts.py tests/test_module_emit_drift.py --no-cov`
- [ ] CI Tests + Lint + Secret scan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)