### PR TITLE
fix(lint): resolve 3 independent lint errors unrelated to BuildRecord migration

### DIFF
--- a/tests/test_build_context_events_yaml_alignment.py
+++ b/tests/test_build_context_events_yaml_alignment.py
@@ -22,10 +22,10 @@ event type — not just a bulk assertion failure.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
-import json
 import pytest
 import yaml
 

--- a/tests/test_build_context_files_pack.py
+++ b/tests/test_build_context_files_pack.py
@@ -271,12 +271,6 @@ def test_appgenerator_capability_directory_has_files_pack_entry() -> None:
 # Account-data (GDPR) contract
 # ---------------------------------------------------------------------------
 
-def test_files_module_declares_user_data_scope() -> None:
-    """files module owns user-uploaded records (created_by == user_id) — must register handler."""
-    module_yaml = _read_yaml(TEMPLATES / "modules" / "files" / "module.yaml")
-    assert module_yaml.get("module", {}).get("user_data_scope") is True
-
-
 def test_files_backend_ships_account_data_handler() -> None:
     handler = TEMPLATES / "modules" / "files" / "backend" / "account_data_handler.py"
     assert handler.exists(), "account_data_handler.py must exist alongside user_data_scope=true"

--- a/tests/test_build_context_messaging_pack.py
+++ b/tests/test_build_context_messaging_pack.py
@@ -307,12 +307,6 @@ def test_appgenerator_selection_wiring_includes_messaging_pack() -> None:
 # Account-data (GDPR) contract
 # ---------------------------------------------------------------------------
 
-def test_messages_module_declares_user_data_scope() -> None:
-    """messages module owns message content and thread membership — user-scoped PII."""
-    module_yaml = _read_yaml(TEMPLATES / "modules" / "messages" / "module.yaml")
-    assert module_yaml.get("module", {}).get("user_data_scope") is True
-
-
 def test_messages_backend_ships_account_data_handler() -> None:
     handler = TEMPLATES / "modules" / "messages" / "backend" / "account_data_handler.py"
     assert handler.exists(), "account_data_handler.py must exist alongside user_data_scope=true"


### PR DESCRIPTION
Fixes 3 of the lint errors currently failing on main's lint job. These are unrelated to the in-flight BuildRecord/artifact_kind->build_family migration and the events.yaml/emit_drift work happening in parallel.

- tests/test_build_context_events_yaml_alignment.py: fix unsorted import block (I001)
- tests/test_build_context_files_pack.py: remove duplicate test_files_module_declares_user_data_scope definition (F811)
- tests/test_build_context_messaging_pack.py: remove duplicate test_messages_module_declares_user_data_scope definition (F811)

Does NOT touch mozaiksai/control_plane/__init__.py, scope_proposer.py, emit_drift.py, or test_module_emit_drift.py, which have their own in-flight lint issues owned by other concurrent work.

Verified: ran the 3 affected test files locally (69 passed). Ruff confirms these 3 errors are resolved and no new ones introduced.