### PR TITLE
fix: complete BuildRecord artifact_kind/build_family migration cleanup

### DIFF
--- a/factory_app/workflows/_shared/workflow_integration.py
+++ b/factory_app/workflows/_shared/workflow_integration.py
@@ -333,25 +333,25 @@ async def hydrate_workflow_integration_context_from_latest_artifact(
     candidates: list[Any] = []
     refs = _context_get(context_variables, "artifact_version_refs", {})
     workflow_ref = refs.get("workflow_bundle") if isinstance(refs, dict) else None
-    if workflow_ref and hasattr(artifact_store, "get_artifact_version"):
+    if workflow_ref and hasattr(artifact_store, "get_build_record"):
         try:
-            artifact = await artifact_store.get_artifact_version(
+            artifact = await artifact_store.get_build_record(
                 app_id=app_id,
-                artifact_version_id=str(workflow_ref),
+                build_record_id=str(workflow_ref),
             )
             if artifact is not None:
                 candidates.append(artifact)
         except Exception:
             pass
 
-    if hasattr(artifact_store, "list_artifact_versions"):
+    if hasattr(artifact_store, "list_build_records"):
         try:
             from mozaiksai.core.artifacts import ArtifactLifecycleStatus
 
             candidates.extend(
-                await artifact_store.list_artifact_versions(
+                await artifact_store.list_build_records(
                     app_id=app_id,
-                    artifact_kind="workflow_bundle",
+                    build_family="workflow_bundle",
                     lifecycle_status=ArtifactLifecycleStatus.CURRENT,
                     limit=5,
                 )

--- a/mozaiksai/core/session/router.py
+++ b/mozaiksai/core/session/router.py
@@ -308,7 +308,7 @@ class SessionRouter:
         # refinement requests — even after a normal (non-revision) workflow run.
         try:
             from mozaiksai.core.artifacts.store import get_artifact_store
-            current_refs = await get_artifact_store().get_current_artifact_version_refs(app_id=app)
+            current_refs = await get_artifact_store().get_current_build_record_refs(app_id=app)
             if current_refs:
                 state.artifact_version_refs.update(current_refs)
         except Exception as exc:

--- a/scripts/smoke_factory_artifact_lineage.py
+++ b/scripts/smoke_factory_artifact_lineage.py
@@ -66,47 +66,47 @@ class MemoryArtifactStore:
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str | None = None,
+        build_family: str,
+        build_key: str | None = None,
         summary_payload: dict[str, Any] | None = None,
     ) -> ArtifactVersionDoc:
-        artifact_key = artifact_key or artifact_kind
+        build_key = build_key or build_family
         self._counter += 1
         artifact = ArtifactVersionDoc(
-            _id=f"av_{artifact_kind}_{self._counter}",
+            _id=f"av_{build_family}_{self._counter}",
             app_id=app_id,
-            artifact_kind=artifact_kind,
-            artifact_key=artifact_key,
+            build_family=build_family,
+            build_key=build_key,
             version_number=1,
-            lineage_root_id=f"av_{artifact_kind}_{self._counter}",
+            lineage_root_id=f"av_{build_family}_{self._counter}",
             lifecycle_status=ArtifactLifecycleStatus.CURRENT,
             validation_status=ArtifactValidationStatus.SKIPPED,
             commit_metadata={
                 "metadata": {
-                    "summary_payload": summary_payload or {"seeded": artifact_kind},
+                    "summary_payload": summary_payload or {"seeded": build_family},
                     "summary_format": "json",
                 }
             },
         )
-        self._versions.setdefault((artifact_kind, artifact_key), []).insert(0, artifact)
+        self._versions.setdefault((build_family, build_key), []).insert(0, artifact)
         return artifact
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str | None = None,
-        artifact_key: str | None = None,
+        build_family: str | None = None,
+        build_key: str | None = None,
         lifecycle_status: ArtifactLifecycleStatus | None = None,
         limit: int = 50,
         **_: Any,
     ) -> list[ArtifactVersionDoc]:
-        if artifact_kind is None:
+        if build_family is None:
             keys = list(self._versions)
-        elif artifact_key is None:
-            keys = [key for key in self._versions if key[0] == artifact_kind]
+        elif build_key is None:
+            keys = [key for key in self._versions if key[0] == build_family]
         else:
-            keys = [(artifact_kind, artifact_key)]
+            keys = [(build_family, build_key)]
 
         versions: list[ArtifactVersionDoc] = []
         for key in keys:
@@ -116,37 +116,37 @@ class MemoryArtifactStore:
             versions = [item for item in versions if item.lifecycle_status == lifecycle_status]
         return versions[: max(1, int(limit))]
 
-    async def get_artifact_version(
+    async def get_build_record(
         self,
         *,
         app_id: str,
-        artifact_version_id: str,
+        build_record_id: str,
     ) -> ArtifactVersionDoc | None:
         for versions in self._versions.values():
             for artifact in versions:
-                if artifact.app_id == app_id and artifact.id == artifact_version_id:
+                if artifact.app_id == app_id and artifact.id == build_record_id:
                     return artifact
         return None
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> ArtifactVersionDoc:
         self.create_calls.append(dict(kwargs))
         self._counter += 1
-        artifact_kind = str(kwargs["artifact_kind"])
-        artifact_key = str(kwargs["artifact_key"])
+        build_family = str(kwargs["build_family"])
+        build_key = str(kwargs["build_key"])
         lifecycle_status = kwargs["lifecycle_status"]
         if lifecycle_status == ArtifactLifecycleStatus.CURRENT:
-            for item in self._versions.get((artifact_kind, artifact_key), []):
+            for item in self._versions.get((build_family, build_key), []):
                 if item.app_id == kwargs["app_id"] and item.lifecycle_status == ArtifactLifecycleStatus.CURRENT:
                     item.lifecycle_status = ArtifactLifecycleStatus.SUPERSEDED
 
         artifact = ArtifactVersionDoc(
-            _id=f"av_{artifact_kind}_{self._counter}",
+            _id=f"av_{build_family}_{self._counter}",
             app_id=kwargs["app_id"],
-            artifact_kind=artifact_kind,
-            artifact_key=artifact_key,
-            version_number=len(self._versions.get((artifact_kind, artifact_key), [])) + 1,
-            parent_version_id=kwargs.get("parent_version_id"),
-            lineage_root_id=f"av_{artifact_kind}_{self._counter}",
+            build_family=build_family,
+            build_key=build_key,
+            version_number=len(self._versions.get((build_family, build_key), [])) + 1,
+            parent_build_record_id=kwargs.get("parent_build_record_id"),
+            lineage_root_id=f"av_{build_family}_{self._counter}",
             canonical_inputs_version=dict(kwargs.get("canonical_inputs_version") or {}),
             lifecycle_status=lifecycle_status,
             validation_status=kwargs["validation_status"],
@@ -155,15 +155,15 @@ class MemoryArtifactStore:
             source_chat_id=kwargs.get("source_chat_id"),
             commit_metadata=kwargs["commit_metadata"],
         )
-        self._versions.setdefault((artifact.artifact_kind, artifact.artifact_key), []).insert(0, artifact)
+        self._versions.setdefault((artifact.build_family, artifact.build_key), []).insert(0, artifact)
         return artifact
 
-    async def get_current_artifact_version_refs(self, *, app_id: str) -> dict[str, str]:
+    async def get_current_build_record_refs(self, *, app_id: str) -> dict[str, str]:
         refs: dict[str, str] = {}
-        for (artifact_kind, _artifact_key), versions in self._versions.items():
+        for (build_family, _build_key), versions in self._versions.items():
             for artifact in versions:
                 if artifact.app_id == app_id and artifact.lifecycle_status == ArtifactLifecycleStatus.CURRENT:
-                    refs.setdefault(artifact_kind, artifact.id)
+                    refs.setdefault(build_family, artifact.id)
                     break
         return refs
 
@@ -399,14 +399,14 @@ async def _run_lineage_smoke_with_store(
         artifact_store=store,
     )
 
-    current_refs = await store.get_current_artifact_version_refs(app_id=app_id)
-    workflow_bundle = await store.get_artifact_version(
+    current_refs = await store.get_current_build_record_refs(app_id=app_id)
+    workflow_bundle = await store.get_build_record(
         app_id=app_id,
-        artifact_version_id=current_refs["workflow_bundle"],
+        build_record_id=current_refs["workflow_bundle"],
     )
-    app_bundle = await store.get_artifact_version(
+    app_bundle = await store.get_build_record(
         app_id=app_id,
-        artifact_version_id=current_refs["app_bundle"],
+        build_record_id=current_refs["app_bundle"],
     )
     if workflow_bundle is None or app_bundle is None:
         return {"success": False, "validation_errors": ["Expected current workflow_bundle and app_bundle artifacts."]}
@@ -415,7 +415,7 @@ async def _run_lineage_smoke_with_store(
         (
             call
             for call in reversed(create_calls)
-            if call["artifact_kind"] == "workflow_bundle"
+            if call["build_family"] == "workflow_bundle"
         ),
         {
             "source_workflow": workflow_bundle.source_workflow,
@@ -426,7 +426,7 @@ async def _run_lineage_smoke_with_store(
         (
             call
             for call in reversed(create_calls)
-            if call["artifact_kind"] == "app_bundle"
+            if call["build_family"] == "app_bundle"
         ),
         {
             "source_workflow": app_bundle.source_workflow,
@@ -565,12 +565,12 @@ async def run_offline_factory_artifact_lineage_smoke(
     store = MemoryArtifactStore()
     design_docs = store.seed(
         app_id=app_id,
-        artifact_kind="design_docs",
+        build_family="design_docs",
         summary_payload={"surface_map": {"surfaces": [{"surface_id": "support_tickets"}]}},
     )
     subscription_contract = store.seed(
         app_id=app_id,
-        artifact_kind="subscription_contract",
+        build_family="subscription_contract",
         summary_payload={
             "contract_required": False,
             "rationale": "No generated-app SaaS subscription contract required.",
@@ -579,7 +579,7 @@ async def run_offline_factory_artifact_lineage_smoke(
     )
     theme_capture = store.seed(
         app_id=app_id,
-        artifact_kind="theme_capture",
+        build_family="theme_capture",
         summary_payload={"theme": {"name": "Support Operations"}},
     )
     return await _run_lineage_smoke_with_store(

--- a/scripts/smoke_refinement_live_coding_worker.py
+++ b/scripts/smoke_refinement_live_coding_worker.py
@@ -105,7 +105,7 @@ class _SmokeArtifactStore:
         self.created_versions: list[ArtifactVersionDoc] = []
         self.calls: list[dict[str, Any]] = []
 
-    async def create_artifact_version(self, **kwargs):  # noqa: ANN003
+    async def create_build_record(self, **kwargs):  # noqa: ANN003
         self.calls.append(dict(kwargs))
         version_id = "av_refinement_live_worker_smoke_persisted"
         validation_status = kwargs.get("validation_status") or ArtifactValidationStatus.PENDING
@@ -121,11 +121,11 @@ class _SmokeArtifactStore:
             {
                 "_id": version_id,
                 "app_id": kwargs.get("app_id") or APP_ID,
-                "artifact_kind": kwargs.get("artifact_kind") or "app_bundle",
-                "artifact_key": kwargs.get("artifact_key") or "app_bundle",
+                "build_family": kwargs.get("build_family") or "app_bundle",
+                "build_key": kwargs.get("build_key") or "app_bundle",
                 "version_number": len(self.created_versions) + 1,
-                "parent_version_id": kwargs.get("parent_version_id"),
-                "lineage_root_id": kwargs.get("parent_version_id") or version_id,
+                "parent_build_record_id": kwargs.get("parent_build_record_id"),
+                "lineage_root_id": kwargs.get("parent_build_record_id") or version_id,
                 "source_workflow": kwargs.get("source_workflow"),
                 "source_chat_id": kwargs.get("source_chat_id"),
                 "canonical_inputs_version": dict(kwargs.get("canonical_inputs_version") or {}),
@@ -138,14 +138,14 @@ class _SmokeArtifactStore:
         self.created_versions.append(version)
         return version
 
-    async def get_artifact_version(self, **kwargs):  # noqa: ANN003
-        version_id = str(kwargs.get("artifact_version_id") or "")
+    async def get_build_record(self, **kwargs):  # noqa: ANN003
+        build_record_id = str(kwargs.get("build_record_id") or "")
         for version in self.created_versions:
-            if version.id == version_id:
+            if version.id == build_record_id:
                 return version
         return None
 
-    async def list_artifact_versions(self, **kwargs):  # noqa: ANN003
+    async def list_build_records(self, **kwargs):  # noqa: ANN003
         return list(self.created_versions)
 
     async def list_change_requests(self, **kwargs):  # noqa: ANN003
@@ -361,7 +361,7 @@ def _select_scenarios(choice: str) -> list[SmokeScenarioSpec]:
 def _build_plan(*, spec: SmokeScenarioSpec, staging_root: Path) -> RefinementExecutionPlan:
     return dry_run.build_refinement_execution_plan_from_route(
         request=spec.request_text,
-        artifact_kind=spec.artifact_kind,
+        build_family=spec.artifact_kind,
         change_class=spec.change_class,
         workflow_id=spec.workflow_id,
         workflow_sequence=spec.workflow_sequence,

--- a/tests/fixtures/refinement_live_coding_worker_matrix_output.json
+++ b/tests/fixtures/refinement_live_coding_worker_matrix_output.json
@@ -32,7 +32,7 @@
           "applied_paths": [
             "ui/pages/dashboard.yaml"
           ],
-          "artifact_kind": "app_bundle",
+          "build_family": "app_bundle",
           "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmpfc9qwd6l\\generated_refinements\\refinement-live-worker-smoke\\app_bundle\\app_bundle\\a2f6f697e6bf\\artifact.zip",
           "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
           "bundle_mode": "staged_refinement_bundle",
@@ -91,7 +91,7 @@
         "app_context_policy_override": null,
         "app_context_summary": null,
         "app_id": "refinement-live-worker-smoke",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "patch",
         "context_policy_decision": {
           "allowed": true,
@@ -216,8 +216,8 @@
       ],
       "worker_request": {
         "app_id": "refinement-live-worker-smoke",
-        "artifact_key": "app_bundle",
-        "artifact_kind": "app_bundle",
+        "build_key": "app_bundle",
+        "build_family": "app_bundle",
         "artifact_version_id": "av_refinement_live_worker_smoke_001",
         "change_class": "patch",
         "context_seed": {
@@ -284,7 +284,7 @@
           "applied_paths": [
             "modules/projects/backend/service.py"
           ],
-          "artifact_kind": "app_bundle",
+          "build_family": "app_bundle",
           "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmpt1s54zvu\\generated_refinements\\refinement-live-worker-smoke-module\\app_bundle\\app_bundle\\a8c36a458c56\\artifact.zip",
           "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
           "bundle_mode": "staged_refinement_bundle",
@@ -343,7 +343,7 @@
         "app_context_policy_override": null,
         "app_context_summary": null,
         "app_id": "refinement-live-worker-smoke-module",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "patch",
         "context_policy_decision": {
           "allowed": false,
@@ -472,8 +472,8 @@
       ],
       "worker_request": {
         "app_id": "refinement-live-worker-smoke-module",
-        "artifact_key": "app_bundle",
-        "artifact_kind": "app_bundle",
+        "build_key": "app_bundle",
+        "build_family": "app_bundle",
         "artifact_version_id": "av_refinement_live_worker_module_backend_001",
         "change_class": "patch",
         "context_seed": {
@@ -540,7 +540,7 @@
           "applied_paths": [
             "backend/integrations/analytics_provider_client.py"
           ],
-          "artifact_kind": "app_bundle",
+          "build_family": "app_bundle",
           "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmpcyx10vx3\\generated_refinements\\refinement-live-worker-smoke-integration\\app_bundle\\app_bundle\\84523ca4f1e5\\artifact.zip",
           "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
           "bundle_mode": "staged_refinement_bundle",
@@ -599,7 +599,7 @@
         "app_context_policy_override": null,
         "app_context_summary": null,
         "app_id": "refinement-live-worker-smoke-integration",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "patch",
         "context_policy_decision": {
           "allowed": false,
@@ -734,8 +734,8 @@
       ],
       "worker_request": {
         "app_id": "refinement-live-worker-smoke-integration",
-        "artifact_key": "app_bundle",
-        "artifact_kind": "app_bundle",
+        "build_key": "app_bundle",
+        "build_family": "app_bundle",
         "artifact_version_id": "av_refinement_live_worker_integration_001",
         "change_class": "patch",
         "context_seed": {
@@ -802,7 +802,7 @@
           "applied_paths": [
             "modules/projects/backend/schemas.py"
           ],
-          "artifact_kind": "app_bundle",
+          "build_family": "app_bundle",
           "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmp6n5lt4pa\\generated_refinements\\refinement-live-worker-smoke-data-model\\app_bundle\\app_bundle\\d35940cc857a\\artifact.zip",
           "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
           "bundle_mode": "staged_refinement_bundle",
@@ -861,7 +861,7 @@
         "app_context_policy_override": null,
         "app_context_summary": null,
         "app_id": "refinement-live-worker-smoke-data-model",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "patch",
         "context_policy_decision": {
           "allowed": false,
@@ -998,8 +998,8 @@
       ],
       "worker_request": {
         "app_id": "refinement-live-worker-smoke-data-model",
-        "artifact_key": "app_bundle",
-        "artifact_kind": "app_bundle",
+        "build_key": "app_bundle",
+        "build_family": "app_bundle",
         "artifact_version_id": "av_refinement_live_worker_data_model_001",
         "change_class": "patch",
         "context_seed": {
@@ -1066,7 +1066,7 @@
           "applied_paths": [
             "modules/analytics_dashboard/backend/service.py"
           ],
-          "artifact_kind": "app_bundle",
+          "build_family": "app_bundle",
           "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmph16tbjf8\\generated_refinements\\refinement-live-worker-smoke-managed\\app_bundle\\app_bundle\\4c636f58cedb\\artifact.zip",
           "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
           "bundle_mode": "staged_refinement_bundle",
@@ -1125,7 +1125,7 @@
         "app_context_policy_override": null,
         "app_context_summary": null,
         "app_id": "refinement-live-worker-smoke-managed",
-        "artifact_kind": "app_bundle",
+        "build_family": "app_bundle",
         "change_class": "patch",
         "context_policy_decision": {
           "allowed": false,
@@ -1260,8 +1260,8 @@
       ],
       "worker_request": {
         "app_id": "refinement-live-worker-smoke-managed",
-        "artifact_key": "app_bundle",
-        "artifact_kind": "app_bundle",
+        "build_key": "app_bundle",
+        "build_family": "app_bundle",
         "artifact_version_id": "av_refinement_live_worker_managed_001",
         "change_class": "patch",
         "context_seed": {

--- a/tests/fixtures/refinement_live_coding_worker_output.json
+++ b/tests/fixtures/refinement_live_coding_worker_output.json
@@ -23,7 +23,7 @@
       "applied_paths": [
         "ui/pages/dashboard.yaml"
       ],
-      "artifact_kind": "app_bundle",
+      "build_family": "app_bundle",
       "artifact_path": "C:\\Users\\mbari\\AppData\\Local\\Temp\\tmpfc9qwd6l\\generated_refinements\\refinement-live-worker-smoke\\app_bundle\\app_bundle\\a2f6f697e6bf\\artifact.zip",
       "artifact_version_id": "av_refinement_live_worker_smoke_persisted",
       "bundle_mode": "staged_refinement_bundle",
@@ -76,7 +76,7 @@
     "app_context_policy_override": null,
     "app_context_summary": null,
     "app_id": "refinement-live-worker-smoke",
-    "artifact_kind": "app_bundle",
+    "build_family": "app_bundle",
     "change_class": "patch",
     "context_policy_decision": {
       "allowed": true,
@@ -194,8 +194,8 @@
   },
   "worker_request": {
     "app_id": "refinement-live-worker-smoke",
-    "artifact_key": "app_bundle",
-    "artifact_kind": "app_bundle",
+    "build_key": "app_bundle",
+    "build_family": "app_bundle",
     "artifact_version_id": "av_refinement_live_worker_smoke_001",
     "change_class": "patch",
     "context_seed": {

--- a/tests/test_factory_bundle_promotion_to_host_load.py
+++ b/tests/test_factory_bundle_promotion_to_host_load.py
@@ -73,8 +73,8 @@ def _build_source_artifact(*, app_id: str, source_zip: Path) -> ArtifactVersionD
         {
             "_id": "av_factory_source_1",
             "app_id": app_id,
-            "artifact_kind": "app_bundle",
-            "artifact_key": "app_bundle",
+            "build_family": "app_bundle",
+            "build_key": "app_bundle",
             "version_number": 1,
             "lineage_root_id": "av_factory_source_1",
             "canonical_inputs_version": {"design_docs": "av_design_docs_1"},
@@ -93,7 +93,7 @@ def _build_refinement_plan(*, request_id: str, app_id: str, staging_area: Path) 
         request_id=request_id,
         app_id=app_id,
         request="Add a resolved_at field to the support ticket module.",
-        artifact_kind="app_bundle",
+        build_family="app_bundle",
         change_class="patch",
         refinement_lane="module_patch",
         workflow_id="workflow_app",
@@ -134,31 +134,31 @@ class _FakeArtifactStore:
         self._source = source_version
         self._draft: ArtifactVersionDoc | None = None
 
-    async def get_artifact_version(self, *, app_id: str, artifact_version_id: str) -> ArtifactVersionDoc | None:
-        if app_id == self._source.app_id and artifact_version_id == self._source.id:
+    async def get_build_record(self, *, app_id: str, build_record_id: str) -> ArtifactVersionDoc | None:
+        if app_id == self._source.app_id and build_record_id == self._source.id:
             return self._source
-        if self._draft is not None and app_id == self._draft.app_id and artifact_version_id == self._draft.id:
+        if self._draft is not None and app_id == self._draft.app_id and build_record_id == self._draft.id:
             return self._draft
         return None
 
-    async def list_artifact_versions(self, **kwargs: Any) -> list[ArtifactVersionDoc]:
+    async def list_build_records(self, **kwargs: Any) -> list[ArtifactVersionDoc]:
         if (
             kwargs.get("app_id") == self._source.app_id
-            and kwargs.get("artifact_kind") == "app_bundle"
+            and kwargs.get("build_family") == "app_bundle"
             and kwargs.get("lifecycle_status") == ArtifactLifecycleStatus.CURRENT
         ):
             return [self._source]
         return []
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> ArtifactVersionDoc:
         self._draft = ArtifactVersionDoc.model_validate(
             {
                 "_id": "av_draft_promotion_1",
                 "app_id": kwargs["app_id"],
-                "artifact_kind": kwargs["artifact_kind"],
-                "artifact_key": kwargs["artifact_key"],
+                "build_family": kwargs["build_family"],
+                "build_key": kwargs["build_key"],
                 "version_number": 2,
-                "parent_version_id": kwargs.get("parent_version_id"),
+                "parent_build_record_id": kwargs.get("parent_build_record_id"),
                 "lineage_root_id": self._source.lineage_root_id,
                 "canonical_inputs_version": dict(kwargs.get("canonical_inputs_version") or {}),
                 "lifecycle_status": kwargs["lifecycle_status"].value,
@@ -179,8 +179,8 @@ class _FakeArtifactStore:
             )
         return True
 
-    async def accept_artifact_version(self, *, app_id: str, artifact_version_id: str, commit_metadata: dict | None = None) -> ArtifactVersionDoc | None:
-        if self._draft is not None and self._draft.id == artifact_version_id and self._draft.app_id == app_id:
+    async def accept_build_record(self, *, app_id: str, build_record_id: str, commit_metadata: dict | None = None) -> ArtifactVersionDoc | None:
+        if self._draft is not None and self._draft.id == build_record_id and self._draft.app_id == app_id:
             self._draft = self._draft.model_copy(
                 update={
                     "lifecycle_status": ArtifactLifecycleStatus.CURRENT,

--- a/tests/test_live_conceptual_replan_carry_forward.py
+++ b/tests/test_live_conceptual_replan_carry_forward.py
@@ -104,8 +104,8 @@ def _run_preservation(tmp_path: Path) -> dict:
     doc = ArtifactVersionDoc.model_validate({
         "_id": "av_safety_v1",
         "app_id": "smoke-safety-app",
-        "artifact_kind": "app_bundle",
-        "artifact_key": "app_bundle",
+        "build_family": "app_bundle",
+        "build_key": "app_bundle",
         "version_number": 1,
         "lineage_root_id": "av_safety_v1",
         "commit_metadata": ArtifactCommitMetadata(
@@ -113,7 +113,7 @@ def _run_preservation(tmp_path: Path) -> dict:
         ).model_dump(),
     })
     mock_store = MagicMock()
-    mock_store.get_artifact_version = AsyncMock(return_value=doc)
+    mock_store.get_build_record = AsyncMock(return_value=doc)
 
     context_variables: dict = {
         "app_id": "smoke-safety-app",

--- a/tests/test_live_refinement_coding_worker_smoke.py
+++ b/tests/test_live_refinement_coding_worker_smoke.py
@@ -51,7 +51,7 @@ def _write_source_bundle(root: Path, *, title: str = "Dashboard") -> None:
 def _build_plan(*, request_id: str, staging_root: Path, request: str, app_id: str) -> RefinementExecutionPlan:
     return dry_run.build_refinement_execution_plan_from_route(
         request=request,
-        artifact_kind="app_bundle",
+        build_family="app_bundle",
         change_class="patch",
         workflow_id="AppGenerator",
         workflow_sequence="app_revision",
@@ -261,7 +261,7 @@ async def test_smoke_artifact_store_records_expected_artifact_save(tmp_path: Pat
     assert "artifact_persistence_error" not in result.metadata
     assert result.metadata["build_record_id"] == "av_refinement_live_worker_smoke_persisted"
     assert len(store.created_versions) == 1
-    assert store.calls and store.calls[0]["artifact_kind"] == "app_bundle"
+    assert store.calls and store.calls[0]["build_family"] == "app_bundle"
     assert store.created_versions[0].app_id == APP_ID
-    assert store.created_versions[0].artifact_kind == "app_bundle"
+    assert store.created_versions[0].build_family == "app_bundle"
 

--- a/tests/test_offline_factory_build_sequence_smoke.py
+++ b/tests/test_offline_factory_build_sequence_smoke.py
@@ -45,36 +45,36 @@ class _MemoryArtifactStore:
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str | None = None,
+        build_family: str,
+        build_key: str | None = None,
     ) -> ArtifactVersionDoc:
-        artifact_key = artifact_key or artifact_kind
+        build_key = build_key or build_family
         self._counter += 1
         artifact = ArtifactVersionDoc(
-            _id=f"av_{artifact_kind}_{self._counter}",
+            _id=f"av_{build_family}_{self._counter}",
             app_id=app_id,
-            artifact_kind=artifact_kind,
-            artifact_key=artifact_key,
+            build_family=build_family,
+            build_key=build_key,
             version_number=1,
-            lineage_root_id=f"av_{artifact_kind}_{self._counter}",
+            lineage_root_id=f"av_{build_family}_{self._counter}",
             lifecycle_status=ArtifactLifecycleStatus.CURRENT,
             validation_status=ArtifactValidationStatus.SKIPPED,
-            commit_metadata={"metadata": {"summary_payload": {"seeded": artifact_kind}}},
+            commit_metadata={"metadata": {"summary_payload": {"seeded": build_family}}},
         )
-        self._versions.setdefault((artifact_kind, artifact_key), []).insert(0, artifact)
+        self._versions.setdefault((build_family, build_key), []).insert(0, artifact)
         return artifact
 
-    async def list_artifact_versions(
+    async def list_build_records(
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str | None = None,
+        build_family: str,
+        build_key: str | None = None,
         lifecycle_status: ArtifactLifecycleStatus | None = None,
         limit: int = 1,
     ) -> list[ArtifactVersionDoc]:
-        keys = [(artifact_kind, artifact_key)] if artifact_key else [
-            key for key in self._versions if key[0] == artifact_kind
+        keys = [(build_family, build_key)] if build_key else [
+            key for key in self._versions if key[0] == build_family
         ]
         versions: list[ArtifactVersionDoc] = []
         for key in keys:
@@ -84,23 +84,23 @@ class _MemoryArtifactStore:
             versions = [item for item in versions if item.lifecycle_status == lifecycle_status]
         return versions[:limit]
 
-    async def create_artifact_version(self, **kwargs: Any) -> ArtifactVersionDoc:
+    async def create_build_record(self, **kwargs: Any) -> ArtifactVersionDoc:
         self.create_calls.append(dict(kwargs))
         self._counter += 1
         artifact = ArtifactVersionDoc(
-            _id=f"av_{kwargs['artifact_kind']}_{self._counter}",
+            _id=f"av_{kwargs['build_family']}_{self._counter}",
             app_id=kwargs["app_id"],
-            artifact_kind=kwargs["artifact_kind"],
-            artifact_key=kwargs["artifact_key"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
             version_number=1,
-            parent_version_id=kwargs.get("parent_version_id"),
-            lineage_root_id=f"av_{kwargs['artifact_kind']}_{self._counter}",
+            parent_build_record_id=kwargs.get("parent_build_record_id"),
+            lineage_root_id=f"av_{kwargs['build_family']}_{self._counter}",
             canonical_inputs_version=dict(kwargs.get("canonical_inputs_version") or {}),
             lifecycle_status=kwargs["lifecycle_status"],
             validation_status=kwargs["validation_status"],
             commit_metadata=kwargs["commit_metadata"],
         )
-        self._versions.setdefault((artifact.artifact_kind, artifact.artifact_key), []).insert(0, artifact)
+        self._versions.setdefault((artifact.build_family, artifact.build_key), []).insert(0, artifact)
         return artifact
 
 
@@ -147,9 +147,9 @@ async def test_offline_build_sequence_smoke_persists_agent_and_app_artifact_chai
 
     store = _MemoryArtifactStore()
     app_id = "offline-build-sequence-smoke"
-    design_docs = store.seed(app_id=app_id, artifact_kind="design_docs")
-    subscription_contract = store.seed(app_id=app_id, artifact_kind="subscription_contract")
-    theme_capture = store.seed(app_id=app_id, artifact_kind="theme_capture")
+    design_docs = store.seed(app_id=app_id, build_family="design_docs")
+    subscription_contract = store.seed(app_id=app_id, build_family="subscription_contract")
+    theme_capture = store.seed(app_id=app_id, build_family="theme_capture")
 
     from factory_app.workflows.AgentGenerator.tools.platform.build_lifecycle import (
         _persist_workflow_bundle_artifact,
@@ -175,8 +175,8 @@ async def test_offline_build_sequence_smoke_persists_agent_and_app_artifact_chai
         artifact_store=store,
     )
 
-    workflow_call = next(call for call in store.create_calls if call["artifact_kind"] == "workflow_bundle")
-    app_call = next(call for call in store.create_calls if call["artifact_kind"] == "app_bundle")
+    workflow_call = next(call for call in store.create_calls if call["build_family"] == "workflow_bundle")
+    app_call = next(call for call in store.create_calls if call["build_family"] == "app_bundle")
     workflow_bundle = store._versions[("workflow_bundle", "workflow_bundle")][0]
 
     assert workflow_call["source_workflow"] == "AgentGenerator"

--- a/tests/test_refinement_review_flow.py
+++ b/tests/test_refinement_review_flow.py
@@ -25,7 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def _build_plan(staging_root: Path, *, request_id: str = "req_review_001") -> dry_run.RefinementExecutionPlan:
     return dry_run.build_refinement_execution_plan_from_route(
         request="Update the dashboard review surface.",
-        artifact_kind="app_bundle",
+        build_family="app_bundle",
         change_class="patch",
         workflow_id="AppGenerator",
         workflow_sequence="app_revision",

--- a/tests/test_refinement_staged_coding_worker.py
+++ b/tests/test_refinement_staged_coding_worker.py
@@ -32,7 +32,7 @@ def _source_bundle(tmp_path: Path) -> Path:
 def _build_plan(tmp_path: Path, *, request_id: str = 'req_worker_001', affected_paths: list[str] | None = None):
     return dry_run.build_refinement_execution_plan_from_route(
         request='Update the dashboard title.',
-        artifact_kind='app_bundle',
+        build_family='app_bundle',
         change_class='patch',
         workflow_id='AppGenerator',
         workflow_sequence='app_revision',

--- a/tests/test_workflow_integration_metadata.py
+++ b/tests/test_workflow_integration_metadata.py
@@ -38,7 +38,7 @@ class _FakeArtifactStore:
         self.artifact = artifact
         self.list_calls = []
 
-    async def list_artifact_versions(self, **kwargs):
+    async def list_build_records(self, **kwargs):
         self.list_calls.append(dict(kwargs))
         return [self.artifact]
 
@@ -127,4 +127,4 @@ def test_hydrate_workflow_integration_context_from_latest_artifact() -> None:
     }
     assert context["workflow_bundle_artifact_version_id"] == "av_workflow_bundle_1"
     assert context["generated_workflow_capability_id"] == "ticket-batch-triage-workflow"
-    assert store.list_calls[0]["artifact_kind"] == "workflow_bundle"
+    assert store.list_calls[0]["build_family"] == "workflow_bundle"


### PR DESCRIPTION
Finishes the remaining stale BuildRecord/ArtifactVersionDoc rtifact_kind/rtifact_key references left after #212, plus 2 previously-undiscovered production bugs.

## Production fixes
- mozaiksai/core/session/router.py: called nonexistent get_current_artifact_version_refs() -> get_current_build_record_refs() (silently swallowed by a try/except, so artifact_version_refs sync never actually ran).
- actory_app/workflows/_shared/workflow_integration.py: hasattr() guards checked for nonexistent get_artifact_version/list_artifact_versions on the real store -> fixed to get_build_record/list_build_records (dead code was never activating hydration against the real store).

## Test-support script fixes
Fake in-memory ArtifactStore method renames to create_build_record/get_build_record/list_build_records/get_current_build_record_refs with uild_family/uild_key/parent_build_record_id kwargs:
- scripts/smoke_refinement_live_coding_worker.py
- scripts/smoke_factory_artifact_lineage.py

## Test fixes
- 	ests/test_factory_bundle_promotion_to_host_load.py
- 	ests/test_live_conceptual_replan_carry_forward.py (MagicMock stubbed get_artifact_version, but production calls get_build_record via load_artifact_workspace())
- 	ests/test_live_refinement_coding_worker_smoke.py
- 	ests/test_offline_factory_build_sequence_smoke.py
- 	ests/test_refinement_review_flow.py
- 	ests/test_refinement_staged_coding_worker.py
- 	ests/test_workflow_integration_metadata.py (surfaced only after the workflow_integration.py production fix activated a previously-dead code path)

## Fixture cleanup
- 	ests/fixtures/refinement_live_coding_worker_output.json
- 	ests/fixtures/refinement_live_coding_worker_matrix_output.json

## Testing
Full \pytest -q --no-cov\ run: 12139 passed, 77 skipped, 7 failed. All 7 remaining failures are pre-existing/unrelated (\	est_build_context_onboarding_pack.py\, \	est_production_readiness_gate.py\, \	est_ui_surface_taxonomy.py\, \	est_workspace_support_module.py\) and match the documented exclusion list from prior migration work. Zero regressions.