### PR TITLE
refactor: separate studio and app shell identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ superset chain. Studio is not the CLI's UI. CLI owns developer tooling (filesyst
 scaffolding, process management). Studio owns the management interface (workspace
 status, build lifecycle, artifacts, run history, config).
 
+Profile stays person-scoped. Studio / Workspace Shell is the org/workspace home
+base. App shells remain separate and brandable per app; do not collapse org
+management into `/me`.
+
 The current repo layout is transitional. The canonical target is documented in
 [docs/architecture/foundations/distribution-and-workspace-model.md](docs/architecture/foundations/distribution-and-workspace-model.md).
 Do not reintroduce a hybrid root that mixes the starter app bundle with shared

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ This repo uses layered FastAPI hosts as the canonical OSS server composition:
 
 **CLI and Studio are parallel interfaces**, not a superset chain. CLI owns developer tooling (filesystem, scaffolding, process management). Studio owns the management interface (workspace status, build lifecycle, artifacts, run history, config). Do not conflate them.
 
+Profile stays person-scoped. Studio / Workspace Shell is the org/workspace home base. App shells remain separate and brandable per app; do not collapse org management into `/me`.
+
 **`mozaiks gen` is a developer convenience**, not the canonical build lifecycle. Do not expand CLI commands to duplicate Studio surfaces (artifact review, diff, run history, promotion, build state). Those belong in Studio. The CLI hands off to Studio — it does not grow a parallel project-management surface.
 
 The current repo layout is transitional. The canonical target architecture is

--- a/docs/architecture/app/platform-navigation-contract.md
+++ b/docs/architecture/app/platform-navigation-contract.md
@@ -9,8 +9,8 @@ object being managed, then route to the surface that owns that object.
 | Surface | Owns | Examples | Must not own |
 | --- | --- | --- | --- |
 | Profile | The signed-in person | identity, avatar, display name, email, personal preferences, personal social graph, personal invitations, personal votes and delegations | app builds, app access, app billing, deployments, workspace settings, team or org operations |
+| Studio / Workspace Shell | The tenant/org home base for a portfolio of apps | app directory, workspace branding, workspace settings, team controls, aggregate usage, create app, app switching | personal identity, personal preferences, app-domain work, app build internals |
 | Admin Portal | An app, workspace, team, or org | access, roles, usage, health, integrations, billing, governance, collaborators, revenue participation, audit, deployment and domain posture | personal identity, personal preferences, direct app creation |
-| Studio | Build lifecycle and generated artifacts | create app, import app, build runs, artifact review, promotion, refinement, build history | user profile data, app runtime business behavior, hosted-only provider operations |
 | App Shell | The app's domain work | dashboards, module pages, customer workflows, operational records | account identity, Studio build state, app/workspace administration |
 | Chat Route | A specific conversation or workflow session | direct `chat_id` resume, live workflow interaction, replay of a selected session | global create intent, app portfolio management |
 
@@ -50,13 +50,22 @@ Profile must not render app/workspace management. Billing plans, subscriptions,
 entitlements, collaborators, deployments, build runs, app access, audit logs, and
 team/org settings belong in Admin Portal or Studio.
 
+Profile is never the org/workspace home. The org/workspace home belongs to
+Studio / Workspace Shell and can carry its own brand, app portfolio, and team
+management entries.
+
+My Apps, app switching, and workspace branding belong in Studio / Workspace
+Shell, not in `/me`.
+
 ## Admin And Studio Boundary
 
-Admin Portal owns durable app/workspace operations. Studio owns build lifecycle.
-They can link to each other, but they do not replace each other.
+Admin Portal owns durable app/workspace operations. Studio / Workspace Shell
+owns the portfolio home and build lifecycle. They can link to each other, but
+they do not replace each other.
 
-- Use Studio for build runs, generated artifacts, refinement, promotion, and
-  unfinished app creation.
+- Use Studio / Workspace Shell for app portfolio navigation, workspace branding,
+  build runs, generated artifacts, refinement, promotion, and unfinished app
+  creation.
 - Use Admin Portal for app access, roles, health, usage, integrations,
   governance, billing, and deployment posture.
 - Use App Shell for the app's normal domain workflow once the app is running.

--- a/docs/architecture/app/tenant-auth-and-scope.md
+++ b/docs/architecture/app/tenant-auth-and-scope.md
@@ -11,15 +11,16 @@ The key separation is simple:
   or managed provider means.
 
 `mozaiks-app` uses this split for the hosted product: it owns
-`tenant_identity`, workspace memberships, MozaiksPay access, and hosted provider
-defaults. The OSS repo should not copy that product logic.
+`tenant_identity`, workspace memberships, MozaiksPay access, hosted provider
+defaults, and the branded org/workspace home. The OSS repo should not copy that
+product logic.
 
 ## Terms
 
 - User: the authenticated person or service principal.
 - Tenant: the account or organization boundary for product data.
 - Workspace: the working area under a tenant. Hosted products can use it for
-  teams, billing assignment, and app ownership.
+  teams, billing assignment, app ownership, and the Studio/workspace shell.
 - App: the Mozaiks app bundle or generated customer app being hosted.
 - Principal: provider-neutral identity facts decoded from auth.
 - Identity scope: the resolved `{app_id, tenant_id, workspace_id, user_id}`
@@ -47,6 +48,10 @@ Hosted products and app workspaces own:
 - hosted provider defaults such as Mozaiks-hosted auth, hosted AI, MozaiksPay,
   or managed hosting
 - whether a workspace can use proprietary managed capabilities
+- workspace-level branding and shell composition
+
+Tenant/workspace records are not person profiles. Person profile state belongs
+to `/me`; tenant/workspace state belongs to Studio / Workspace Shell.
 
 ## Current Contract
 

--- a/docs/architecture/foundations/platform-information-architecture.md
+++ b/docs/architecture/foundations/platform-information-architecture.md
@@ -49,8 +49,15 @@ Owns:
 - create-app entry
 - aggregate usage
 - aggregate operations and health
+- workspace branding and shell defaults
 - host-provided billing or commercial controls when the host exposes them
 - workspace-level settings and team controls
+
+Does not own as a visible concept:
+
+- personal profile fields
+- user-specific identity editing
+- app-domain pages that belong in App Studio
 
 ### App Studio
 

--- a/docs/architecture/foundations/platform-terminology-and-brand-language.md
+++ b/docs/architecture/foundations/platform-terminology-and-brand-language.md
@@ -64,8 +64,9 @@ These are the preferred visible terms.
 | Term | Use For | Notes |
 | --- | --- | --- |
 | `Mozaiks` | the overall product | product name |
-| `Mozaiks Studio` | browser product for creating and managing apps | canonical visible product term |
-| `Workspace` | the tenant/account context | not the name of the app builder |
+| `Mozaiks Studio` | browser product for creating and managing a workspace or portfolio of apps | canonical visible product term |
+| `Workspace` | the tenant/org context | brandable home base for a portfolio of apps, not a person profile |
+| `Profile` | the signed-in person | personal identity and preferences only |
 | `Apps` | the multi-app directory and default landing area | canonical workspace landing area |
 | `App Studio` | the single-app management context | prose and IA term, not necessarily a literal heading on every screen |
 | `Build` | app creation and revision surface | canonical creation and revision surface |
@@ -146,12 +147,16 @@ Do not use these as visible product concepts:
 - `Refinement Engine`
 - `workflow_sequence`
 - `Adapters`
+- `Org Profile`
+- `Workspace Profile`
+- `Company Profile`
 
 Preferred replacements:
 
 - `Hub` -> `Apps`
 - `Adapters` -> `Integrations`
 - `Activity` -> `Operations` when the scope is health, incidents, runtime state, or deployment state
+- `Org Profile` / `Workspace Profile` -> `Studio` or `Workspace`, depending on whether the surface is the management shell or the managed container
 
 ## Documentation Rule
 

--- a/docs/architecture/foundations/profile-panel-contract.md
+++ b/docs/architecture/foundations/profile-panel-contract.md
@@ -4,12 +4,13 @@ The profile contract lets modules declare account-scoped panels and profile
 tabs they contribute to the user profile page. Profile is the signed-in
 person's surface: identity, personal preferences, personal relationship
 inventory, safe personal summaries, and social sections such as friends, posts,
-activity, and messages. It is not an app/workspace management surface.
+activity, and messages. It is not an app/workspace management surface and it is
+not the org/workspace home.
 
 Billing, subscriptions, entitlements, app access, collaborators, deployments,
 governance, build runs, and revenue participation belong in Admin Portal or
-Studio. Do not use profile panels or tabs to continue app builds or manage
-app/workspace operations.
+Studio / Workspace Shell. Do not use profile panels or tabs to continue app
+builds or manage app/workspace operations.
 
 ## Design Goals
 
@@ -244,7 +245,7 @@ Forbidden examples:
 - deployments, domains, hosting, health, incidents, or audit logs
 - app/workspace integrations or provider configuration
 
-Those belong in Admin Portal or Studio.
+Those belong in Admin Portal or Studio / Workspace Shell.
 
 Do not add profile-owned social surfaces to `config/shell.json` shortcuts or
 global navigation by default. Generate a separate `/feed`, `/friends`,

--- a/docs/reviews/org-shell-and-identity-refactor-plan.md
+++ b/docs/reviews/org-shell-and-identity-refactor-plan.md
@@ -1,0 +1,108 @@
+# Org Shell And Identity Refactor Plan
+
+## Purpose
+
+This repo should stop treating profile, workspace management, and app shell as
+one blended surface. The target model is deterministic and scope-driven:
+
+- `Profile` is the signed-in person.
+- `Studio` is the workspace/org management shell.
+- `App Shell` is one branded app/product.
+
+No legacy compatibility branches are required for this refactor. The repo is
+not in production, so the clean replacement wins over preservation.
+
+## Problem Statement
+
+The current UI and shell composition still leak management affordances across
+surfaces:
+
+- profile menus can surface workspace-management items
+- app shells can inherit studio-style controls
+- the same account surface can read as if it belongs to every app
+
+That creates a vague UX and makes shell composition feel heuristic instead of
+deterministic.
+
+## Target Model
+
+### 1. Person
+
+The person surface is a normal account profile:
+
+- identity
+- avatar
+- display name
+- bio
+- personal preferences
+- user-scoped module tabs and panels
+
+### 2. Studio
+
+The org/workspace shell is the management base for a portfolio of apps:
+
+- app directory
+- workspace branding
+- workspace settings
+- aggregate usage
+- team/member management
+- shared integrations
+- app-level entrypoints
+
+Studio is the branded home base. It is not a person profile.
+
+### 3. App Shell
+
+Each app gets its own branded shell:
+
+- app overview
+- build and revision
+- app usage
+- app operations
+- app integrations
+- app users
+- app admin
+
+## Deterministic Rules
+
+1. Select the surface first.
+2. Compose only the contracts for that surface.
+3. Add module contributions only where the contract allows them.
+4. Never infer a cross-surface menu item from the presence of a module or an
+   admin role alone.
+5. Never inject Studio items into a customer app shell unless the app shell
+   contract explicitly allows it.
+
+## Workstream Split
+
+### Codex Ownership
+
+Doc and terminology alignment only:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/architecture/foundations/platform-terminology-and-brand-language.md`
+- `docs/architecture/foundations/platform-information-architecture.md`
+- `docs/architecture/app/platform-navigation-contract.md`
+- `docs/architecture/app/tenant-auth-and-scope.md`
+- `docs/architecture/foundations/profile-panel-contract.md`
+
+### Claude Code Ownership
+
+Runtime and shell-composition refactor only:
+
+- explicit surface selection in shell composition
+- removal of cross-surface menu injection
+- app-shell vs studio-shell route and menu separation
+- profile surface cleanup so app shells do not expose workspace tools by default
+
+The two workstreams should not edit the same files.
+
+## Acceptance Criteria
+
+- `Profile` never reads as an org/workspace surface.
+- `Studio` is the org/workspace shell and can carry branding.
+- `My Apps` appears only in the Studio/workspace context.
+- App shells keep their own branded navigation and admin affordances.
+- Shell output is deterministic for a given surface and config set.
+

--- a/factory_app/app/modules/workspace_support/module.yaml
+++ b/factory_app/app/modules/workspace_support/module.yaml
@@ -8,6 +8,8 @@ module:
   visibility: private
   handler: backend.handler:WorkspaceSupportModule
 permissions:
+  - id: access_as_user
+    description: Access the current user context.
   - id: workspace_support.read
     description: View support requests.
   - id: workspace_support.manage

--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -131,6 +131,35 @@ drift_guard_test_guidance:
                 f"backend/service.py calls ctx.emit() for undeclared events: "
                 + ", ".join(f"{{e!r}} (line {{ln}})" for e, ln in orphans)
             )
+    events_yaml_service_alignment:
+      description: >
+        Lane 4 — contracts/events.yaml ↔ service.py alignment. Use the OSS
+        emit_drift utility to check that every event type declared in
+        module.yaml action.emits[] (and therefore in contracts/events.yaml,
+        since the loader enforces that subset relationship at startup) has a
+        matching ctx.emit("event_type", ...) string-literal call somewhere in
+        backend/service.py. Catches "declared but dead" events — events added
+        to the contract during design but whose ctx.emit() call was never
+        written, or an emit removed from service.py without cleaning up
+        module.yaml and events.yaml. Import check_missing_emits from
+        mozaiksai.core.runtime.app.emit_drift — available in any app that
+        has the mozaiksai package installed. Note: only literal string
+        arguments are detected; a declared event emitted only via a dynamic
+        variable will appear as missing — suppress with a skip marker or
+        convert to a string literal.
+      template: |
+        from pathlib import Path
+        from mozaiksai.core.runtime.app.emit_drift import check_missing_emits
+
+        def test_{module_id}_declared_events_are_emitted():
+            module_dir = (
+                Path(__file__).resolve().parents[1] / "app" / "modules" / "{module_id}"
+            )
+            missing = check_missing_emits(module_dir)
+            assert missing == [], (
+                "Events declared in module.yaml/events.yaml but never emitted "
+                "by backend/service.py: " + ", ".join(repr(e) for e in missing)
+            )
     user_data_scope_handler_completeness:
       description: >
         When user_data_scope=true, assert backend/account_data_handler.py exists

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
           - Context Graph & Code Intelligence: architecture/foundations/context-graph-and-code-intelligence.md
           - Graph Authority Boundaries: architecture/foundations/graph-authority-boundaries.md
           - App Context & Brownfield Adoption: architecture/foundations/app-context-and-brownfield-adoption.md
+          - Profile Panel Contract: architecture/foundations/profile-panel-contract.md
           - Event System: architecture/foundations/events-and-data/event-system.md
           - Event Contracts: architecture/foundations/events-and-data/event-contracts.md
           - Persistence & Artifact Storage: architecture/foundations/events-and-data/persistence-and-artifact-storage.md

--- a/mozaiksai/core/runtime/app/emit_drift.py
+++ b/mozaiksai/core/runtime/app/emit_drift.py
@@ -10,14 +10,17 @@ The ModuleLoader enforces at startup that every event type in
 scan ``backend/service.py`` source code to verify that:
 
 1. Every ``ctx.emit()`` call in service.py uses an event type that is
-   declared in ``module.yaml action.emits[]`` / ``contracts/events.yaml``.
-2. Every event type declared in ``module.yaml action.emits[]`` is actually
-   emitted by service.py (optional completeness check).
+   declared in ``module.yaml action.emits[]`` / ``contracts/events.yaml``
+   (Lane 3 — orphaned emits).
+2. Every event type declared in ``module.yaml action.emits[]`` and
+   ``contracts/events.yaml`` is actually emitted somewhere in service.py
+   (Lane 4 — missing emits / contracts/events.yaml ↔ service.py).
 
-These two checks together close the "orphaned emit" and "declared-but-missing
-emit" drift classes. They are intentionally test-time / CI checks — not
-startup validators — because service.py may legitimately use dynamic event
-types via variables (which the AST cannot statically resolve to a declaration).
+Both checks close drift classes that are invisible to the loader. They are
+intentionally test-time / CI checks — not startup validators — because
+service.py may use dynamic event types via variables that cannot be resolved
+statically, and because a module might legitimately emit a declared event from
+a background worker rather than service.py directly.
 
 Public API
 ----------
@@ -29,26 +32,44 @@ Public API
     Return the set of event types declared in ``actions[].emits[]`` across
     all actions in a module.yaml file.
 
-``check_orphaned_emits(module_dir)``
-    Return a list of ``(event_type, line_no)`` pairs for ``ctx.emit()``
-    calls whose event type is not declared in the module contract.
-    Returns an empty list when service.py does not exist or when no
-    orphaned emits are found.
+``load_declared_events_from_yaml(events_yaml)``
+    Return the set of event types declared in a ``contracts/events.yaml``
+    file. Complements ``load_declared_emits``; both sets are equal for a
+    well-formed module because the loader enforces
+    ``module.yaml emits[] ⊆ events.yaml`` as a hard startup error.
 
-Typical usage in a generated app's drift-guard test
-----------------------------------------------------
+``check_orphaned_emits(module_dir)``
+    Lane 3. Return ``(event_type, line_no)`` pairs for ``ctx.emit()`` calls
+    in service.py whose event type is absent from ``module.yaml emits[]``.
+    Returns an empty list when service.py does not exist or all emits are
+    declared.
+
+``check_missing_emits(module_dir)``
+    Lane 4. Return a sorted list of event types declared in
+    ``module.yaml emits[]`` (backed by ``contracts/events.yaml``) that are
+    absent from service.py ``ctx.emit()`` string literals. Returns an empty
+    list when events.yaml does not exist, when no events are declared, or
+    when all declared events have a matching emit in service.py.
+
+Typical usage in a generated app's drift-guard tests
+-----------------------------------------------------
 ::
 
-    from mozaiksai.core.runtime.app.emit_drift import check_orphaned_emits
+    from mozaiksai.core.runtime.app.emit_drift import (
+        check_orphaned_emits,
+        check_missing_emits,
+    )
     from pathlib import Path
 
+    MODULE_DIR = Path(__file__).resolve().parents[1] / "app" / "modules" / "tasks"
+
     def test_tasks_service_emits_match_contract():
-        orphans = check_orphaned_emits(
-            Path(__file__).resolve().parents[1] / "app" / "modules" / "tasks"
-        )
-        assert orphans == [], (
-            f"service.py calls ctx.emit() for undeclared events: {orphans}"
-        )
+        orphans = check_orphaned_emits(MODULE_DIR)
+        assert orphans == [], f"undeclared emits: {orphans}"
+
+    def test_tasks_declared_events_are_emitted():
+        missing = check_missing_emits(MODULE_DIR)
+        assert missing == [], f"declared but never emitted: {missing}"
 """
 
 from __future__ import annotations
@@ -142,6 +163,71 @@ def load_declared_emits(module_yaml: Path) -> set[str]:
             if isinstance(event_type, str):
                 declared.add(event_type)
     return declared
+
+
+def load_declared_events_from_yaml(events_yaml: Path) -> set[str]:
+    """Return the set of event types declared in ``contracts/events.yaml``.
+
+    The loader enforces ``module.yaml emits[] ⊆ events.yaml`` at startup, so
+    this set equals ``load_declared_emits(module.yaml)`` for any well-formed
+    module.  Use this function when you want to read directly from the events
+    catalog rather than through module.yaml.
+
+    Returns an empty set when ``events_yaml`` does not exist or contains no
+    events.
+    """
+    if not events_yaml.exists():
+        return set()
+
+    raw: Any = yaml.safe_load(events_yaml.read_text(encoding="utf-8")) or {}
+    declared: set[str] = set()
+    for event in raw.get("events", []):
+        if isinstance(event, dict):
+            event_type = event.get("type")
+            if isinstance(event_type, str) and event_type:
+                declared.add(event_type)
+    return declared
+
+
+def check_missing_emits(module_dir: Path) -> list[str]:
+    """Return event types declared in module.yaml but absent from service.py.
+
+    Lane 4 — contracts/events.yaml ↔ service.py alignment.
+
+    An event is *missing* when ``module.yaml action.emits[]`` declares it
+    (meaning it is also declared in ``contracts/events.yaml``, enforced by the
+    loader) but ``backend/service.py`` contains no ``ctx.emit("event_type",
+    ...)`` string-literal call for it.
+
+    This catches "declared but never emitted" drift — e.g. an event added to
+    module.yaml and events.yaml during design but whose ctx.emit() call was
+    never written, or an emit that was removed from service.py without cleaning
+    up the declaration.
+
+    Returns an empty list when:
+    - ``module.yaml`` declares no emits (nothing to check)
+    - ``backend/service.py`` does not exist and no events are declared
+    - all declared events have a matching ctx.emit() literal in service.py
+
+    When ``backend/service.py`` does not exist but events are declared, all
+    declared events are returned as missing — they cannot be emitted by a
+    non-existent service layer.
+
+    Note: only string-literal ``ctx.emit("event_type", ...)`` calls are
+    detected. Dynamic emit calls using variables are not captured, so a
+    declared event emitted dynamically will appear as missing. In that case,
+    suppress the check for that event by excluding it from the assertion or by
+    adding a ``# emit: event_type`` marker comment as documentation.
+    """
+    module_yaml = module_dir / "module.yaml"
+    service_py = module_dir / "backend" / "service.py"
+
+    declared = load_declared_emits(module_yaml)
+    if not declared:
+        return []
+
+    actual = scan_service_emit_literals(service_py)
+    return sorted(declared - actual)
 
 
 def check_orphaned_emits(module_dir: Path) -> list[tuple[str, int]]:

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -986,7 +986,7 @@ _ADMIN_PORTAL_MENU_ITEM = {
 
 
 def _inject_admin_portal(result: dict) -> None:
-    """Guarantee Admin Portal appears in the profile menu for admin users.
+    """Guarantee Admin Portal appears in the Studio profile menu for admin users.
 
     Called after the full shell config pipeline so nothing can suppress it.
     Inserts before signout, or appends if signout is absent.
@@ -1279,9 +1279,9 @@ async def build_shell_config(*, surface: str = "platform") -> dict:
     )
     result["chrome"] = _normalize_chrome_policy(shell_chrome)
 
-    # Admin Portal is a framework guarantee — inject after the full pipeline so
-    # no app config or route processing can accidentally suppress it.
-    _inject_admin_portal(result)
+    # Admin Portal is a Studio guarantee, not an app-shell guarantee.
+    if is_studio:
+        _inject_admin_portal(result)
 
     return result
 
@@ -1865,7 +1865,6 @@ async def get_profile_pages(
     - Platform built-in pages (always present)
     - Module-contributed pages from modules/*/contracts/profile.yaml (v2 native
       pages, or v1 tabs automatically promoted to pages)
-    - A "my-apps" page when the app registry module is available
 
     Each module-contributed page with an ``action`` is hydrated by calling the
     module executor. Pages whose action fails are still returned with
@@ -1984,33 +1983,6 @@ async def get_profile_pages(
                 "source": "platform_builtin",
             }
         )
-
-    # Inject "my-apps" when no module has already claimed that id and the
-    # app registry module is accessible.
-    if "my-apps" not in builtin_ids:
-        _app_registry_accessible = False
-        try:
-            if module_executor is not None:
-                module_names = getattr(module_executor, "_modules", {})
-                _app_registry_accessible = "app_registry" in module_names
-        except Exception:
-            pass
-        if _app_registry_accessible:
-            hydrated.append(
-                {
-                    "id": "my-apps",
-                    "label": "My Apps",
-                    "route": "apps",
-                    "section": "platform",
-                    "order": 50,
-                    "renderer": "custom_component",
-                    "component": "MyAppsPage",
-                    "visibility": "owner_only",
-                    "data": None,
-                    "error": None,
-                    "source": "platform_builtin",
-                }
-            )
 
     hydrated.sort(key=lambda p: (p.get("order") if p.get("order") is not None else 100,))
 

--- a/tests/test_config_consolidation.py
+++ b/tests/test_config_consolidation.py
@@ -198,6 +198,10 @@ class TestShellConfig:
         ids = [item["id"] for item in result["profile"]["menu"]]
         assert ids == ["profile", "admin-portal", "signout"]
 
+    def test_platform_shell_profile_menu_stays_person_scoped(self, shell):
+        ids = shell["shortcuts"]["profile"]
+        assert ids == ["profile", "signout"]
+
 
 # ── Framework-only tests (no app workspace needed) ──────────────────────────
 

--- a/tests/test_module_emit_drift.py
+++ b/tests/test_module_emit_drift.py
@@ -5,13 +5,14 @@ enforce at startup:
 
 Lane 3 — emits ↔ service.py alignment:
   service.py calls ctx.emit("event_A") but event_A is absent from
-  module.yaml action.emits[]. The loader only checks the declaration
-  direction (module.yaml → events.yaml) — it does not read service.py.
+  module.yaml action.emits[]. Covered by check_orphaned_emits.
 
 Lane 4 — contracts/events.yaml ↔ service.py alignment:
-  Same gap viewed from events.yaml: since the loader already enforces
-  module.yaml emits[] → events.yaml (hard error), an orphan in service.py
-  implies a missing declaration in BOTH module.yaml and events.yaml.
+  module.yaml declares event_A in action.emits[] (backed by events.yaml)
+  but service.py never calls ctx.emit("event_A"). Covered by
+  check_missing_emits. This catches "declared but dead" events — added to
+  the contract during design but whose emit call was never written, or an
+  emit removed from service.py without cleaning up the declaration.
 
 The fix for both lanes is the same: every ctx.emit() string literal in
 service.py must be declared in module.yaml action.emits[].
@@ -28,8 +29,10 @@ import pytest
 import yaml
 
 from mozaiksai.core.runtime.app.emit_drift import (
+    check_missing_emits,
     check_orphaned_emits,
     load_declared_emits,
+    load_declared_events_from_yaml,
     scan_service_emit_literals,
     scan_service_emit_literals_with_lines,
 )
@@ -45,10 +48,17 @@ def _write_module(
     *,
     declared_emits: list[str] | None = None,
     service_src: str | None = None,
+    write_events_yaml: bool = False,
 ) -> Path:
-    """Write a minimal module directory under root/modules/tasks/."""
+    """Write a minimal module directory under root/modules/tasks/.
+
+    When ``write_events_yaml=True``, a ``contracts/events.yaml`` is created
+    that mirrors ``declared_emits`` so the module is well-formed with respect
+    to the loader's events.yaml requirement.
+    """
     module_dir = root / "modules" / "tasks"
     (module_dir / "backend").mkdir(parents=True, exist_ok=True)
+    (module_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     emits_yaml = (
         "    emits: [" + ", ".join(declared_emits) + "]"
@@ -77,6 +87,16 @@ actions:
 """.lstrip(),
         encoding="utf-8",
     )
+
+    if write_events_yaml and declared_emits:
+        events_entries = "\n".join(
+            f"  - type: {et}\n    version: 1\n    producer: tasks\n    payload_schema: {{}}"
+            for et in declared_emits
+        )
+        module_dir.joinpath("contracts", "events.yaml").write_text(
+            f"schema_version: mozaiks.events.v1\nevents:\n{events_entries}\n",
+            encoding="utf-8",
+        )
 
     if service_src is not None:
         module_dir.joinpath("backend", "service.py").write_text(
@@ -410,3 +430,232 @@ def test_drift_guard_pattern_used_by_generated_app_tests(tmp_path: Path) -> None
     )
     orphaned_types = {e for e, _ in orphans}
     assert "domain.tasks.task_queued_for_indexing" in orphaned_types
+
+
+# ---------------------------------------------------------------------------
+# load_declared_events_from_yaml — contracts/events.yaml reader
+# ---------------------------------------------------------------------------
+
+
+def test_load_declared_events_from_yaml_reads_event_types(tmp_path: Path) -> None:
+    events_yaml = tmp_path / "events.yaml"
+    events_yaml.write_text(
+        """
+schema_version: mozaiks.events.v1
+events:
+  - type: domain.tasks.task_created
+    version: 1
+    producer: tasks
+    payload_schema: {}
+  - type: domain.tasks.task_deleted
+    version: 1
+    producer: tasks
+    payload_schema: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = load_declared_events_from_yaml(events_yaml)
+    assert result == {"domain.tasks.task_created", "domain.tasks.task_deleted"}
+
+
+def test_load_declared_events_from_yaml_returns_empty_when_absent(
+    tmp_path: Path,
+) -> None:
+    result = load_declared_events_from_yaml(tmp_path / "nonexistent.yaml")
+    assert result == set()
+
+
+def test_load_declared_events_from_yaml_returns_empty_for_no_events(
+    tmp_path: Path,
+) -> None:
+    events_yaml = tmp_path / "events.yaml"
+    events_yaml.write_text(
+        "schema_version: mozaiks.events.v1\nevents: []\n", encoding="utf-8"
+    )
+    assert load_declared_events_from_yaml(events_yaml) == set()
+
+
+def test_load_declared_events_matches_load_declared_emits_for_well_formed_module(
+    tmp_path: Path,
+) -> None:
+    """For a well-formed module (loader invariant holds), the event types in
+    events.yaml and module.yaml emits[] must be the same set.
+
+    The loader enforces module.yaml emits[] ⊆ events.yaml as a hard error, so
+    for any module that loads successfully, these two sets are equal.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created", "domain.tasks.task_deleted"],
+        write_events_yaml=True,
+    )
+    from_module_yaml = load_declared_emits(module_dir / "module.yaml")
+    from_events_yaml = load_declared_events_from_yaml(
+        module_dir / "contracts" / "events.yaml"
+    )
+    assert from_module_yaml == from_events_yaml
+
+
+# ---------------------------------------------------------------------------
+# Lane 4: check_missing_emits — contracts/events.yaml ↔ service.py alignment
+# ---------------------------------------------------------------------------
+
+
+def test_check_missing_emits_returns_empty_when_no_declared_emits(
+    tmp_path: Path,
+) -> None:
+    """No declared emits in module.yaml → nothing can be missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[],
+        service_src="async def create_task(self, ctx, *, title):\n    return {}\n",
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_check_missing_emits_returns_empty_when_service_emits_all_declared(
+    tmp_path: Path,
+) -> None:
+    """service.py emits every declared event → no missing emits."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        service_src=(
+            'async def create_task(self, ctx, *, title):\n'
+            '    await ctx.emit("domain.tasks.task_created", {"title": title})\n'
+            '    return {"task_id": "t1"}\n'
+        ),
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_check_missing_emits_catches_declared_event_never_emitted(
+    tmp_path: Path,
+) -> None:
+    """Declared event absent from service.py → reported as missing.
+
+    Regression guard for Lane 4: this exact pattern appeared in the App Zero
+    sweep where module.yaml and events.yaml declared an event (e.g.
+    hosted.wallet.payout.failed) but service.py never called ctx.emit() for it.
+    The loader cannot catch this because it only enforces the declaration
+    direction; the check requires reading service.py.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "domain.tasks.task_created",
+            "domain.tasks.task_failed",  # declared but never emitted
+        ],
+        service_src=(
+            'async def create_task(self, ctx, *, title):\n'
+            '    await ctx.emit("domain.tasks.task_created", {"title": title})\n'
+            '    return {"task_id": "t1"}\n'
+            '    # NOTE: task_failed is declared but the emit call was never written\n'
+        ),
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert missing == ["domain.tasks.task_failed"]
+
+
+def test_check_missing_emits_reports_all_missing_events(tmp_path: Path) -> None:
+    """All missing events are returned, not just the first."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "domain.tasks.task_created",
+            "domain.tasks.task_deleted",
+            "domain.tasks.task_archived",
+        ],
+        service_src="async def noop(self, ctx): return {}\n",
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert set(missing) == {
+        "domain.tasks.task_created",
+        "domain.tasks.task_deleted",
+        "domain.tasks.task_archived",
+    }
+    # Result must be sorted for deterministic output
+    assert missing == sorted(missing)
+
+
+def test_check_missing_emits_returns_all_when_no_service_py(tmp_path: Path) -> None:
+    """No service.py + declared emits → all declared events are missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        # service_src intentionally absent
+    )
+    assert check_missing_emits(module_dir) == ["domain.tasks.task_created"]
+
+
+def test_check_missing_emits_ignores_dynamic_emits_as_non_matching(
+    tmp_path: Path,
+) -> None:
+    """Dynamic ctx.emit(variable, ...) does not count as covering a declared event.
+
+    A declared event emitted dynamically still appears as missing. The
+    developer must either use a string literal or suppress the assertion.
+    """
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["domain.tasks.task_created"],
+        service_src=(
+            'async def create_task(self, ctx, *, event_name):\n'
+            '    await ctx.emit(event_name, {})\n'  # dynamic — not captured
+        ),
+    )
+
+    missing = check_missing_emits(module_dir)
+    assert "domain.tasks.task_created" in missing
+
+
+def test_check_missing_emits_returns_empty_when_no_module_yaml(
+    tmp_path: Path,
+) -> None:
+    """No module.yaml → no declared emits → nothing to report."""
+    module_dir = tmp_path / "modules" / "tasks"
+    (module_dir / "backend").mkdir(parents=True, exist_ok=True)
+    # module.yaml intentionally absent
+    assert check_missing_emits(module_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: drift-guard pattern for contracts/events.yaml ↔ service.py
+# ---------------------------------------------------------------------------
+
+
+def test_drift_guard_pattern_for_events_yaml_service_alignment(tmp_path: Path) -> None:
+    """The events_yaml_service_alignment pattern from module_archetypes.yaml
+    drift_guard_test_guidance must correctly catch declared-but-never-emitted
+    events in a freshly-generated module.
+
+    This test mimics what AppGenerator scaffolds into
+    tests/test_{module_id}_module_drift.py for the Lane 4 check.
+    """
+    # Simulate a module where events.yaml and module.yaml declare an event
+    # that was added during design but whose ctx.emit() call was never written.
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "hosted.schema_migrations.migration.applied",
+            "hosted.schema_migrations.migration.failed",  # declared but missing
+        ],
+        service_src=(
+            'async def run_migration(self, ctx, *, migration_id):\n'
+            '    await ctx.emit("hosted.schema_migrations.migration.applied", {})\n'
+            '    # migration.failed was declared in module.yaml but the\n'
+            '    # except branch and its ctx.emit were never implemented\n'
+            '    return {"success": True}\n'
+        ),
+    )
+
+    # Exact assertion a generated drift-guard test would make:
+    missing = check_missing_emits(module_dir)
+    assert missing != [], (
+        "Expected the drift-guard to catch the declared-but-missing emit; "
+        "the events_yaml_service_alignment pattern is broken"
+    )
+    assert "hosted.schema_migrations.migration.failed" in missing

--- a/tests/test_platform_shell_p0_fixes.py
+++ b/tests/test_platform_shell_p0_fixes.py
@@ -150,7 +150,7 @@ def test_explicit_appshell_false_not_overridden(monkeypatch, tmp_path: Path) -> 
 
 
 # ---------------------------------------------------------------------------
-# Fix 3 – _inject_admin_portal guarantee
+# Fix 3 – Studio-only admin portal injection
 # ---------------------------------------------------------------------------
 
 
@@ -222,8 +222,8 @@ def test_inject_admin_portal_creates_profile_when_missing() -> None:
     assert "admin-portal" in ids
 
 
-def test_build_shell_config_always_injects_admin_portal(monkeypatch, tmp_path: Path) -> None:
-    """build_shell_config must inject admin-portal even with no shortcuts configured."""
+def test_build_shell_config_platform_does_not_inject_admin_portal(monkeypatch, tmp_path: Path) -> None:
+    """App/platform shell config must not auto-inject admin-portal."""
     from mozaiksai.hosts import platform as platform_app
 
     # Minimal app with no shell.json shortcuts at all
@@ -249,7 +249,36 @@ def test_build_shell_config_always_injects_admin_portal(monkeypatch, tmp_path: P
     profile = shell.get("profile", {})
     menu = profile.get("menu", [])
     ids = [item.get("id") for item in menu if isinstance(item, dict)]
-    assert "admin-portal" in ids, (
-        "admin-portal must appear in profile menu even when no shortcuts are configured"
+    assert "admin-portal" not in ids, (
+        "admin-portal must not appear in the app/platform profile menu"
     )
+
+
+def test_build_shell_config_studio_injects_admin_portal(monkeypatch, tmp_path: Path) -> None:
+    """Studio shell config should still inject admin-portal for admins."""
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = tmp_path / "app"
+    (app_root / "config").mkdir(parents=True)
+    (app_root / "ui").mkdir(parents=True)
+    (app_root / "app.json").write_text(
+        json.dumps({"appName": "Studio App", "startup": {"landing_spot": "/apps"}}),
+        encoding="utf-8",
+    )
+    (app_root / "config" / "ai.json").write_text(
+        json.dumps({"chat": {"chat_startup_mode": "ask"}, "workflows": {"entry_point": "Chat"}}),
+        encoding="utf-8",
+    )
+    (app_root / "config" / "shell.json").write_text(json.dumps({}), encoding="utf-8")
+    (app_root / "ui" / "route_manifest.json").write_text(
+        json.dumps({"pages": []}), encoding="utf-8"
+    )
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+
+    shell = asyncio.run(platform_app.build_shell_config(surface="studio"))
+
+    profile = shell.get("profile", {})
+    menu = profile.get("menu", [])
+    ids = [item.get("id") for item in menu if isinstance(item, dict)]
+    assert "admin-portal" in ids, "admin-portal must appear in the Studio profile menu"
 

--- a/tests/test_profile_contract.py
+++ b/tests/test_profile_contract.py
@@ -721,6 +721,42 @@ tabs:
     assert by_module["messages"].user_id == "viewer-user"
 
 
+@pytest.mark.asyncio
+async def test_profile_pages_do_not_inject_my_apps(monkeypatch, tmp_path: Path) -> None:
+    from mozaiksai.core.auth.dependencies import UserPrincipal
+    from mozaiksai.hosts import platform as platform_app
+
+    (tmp_path / "app.json").write_text('{"appName": "Test"}', encoding="utf-8")
+    monkeypatch.setenv("PLATFORM_PATH", str(tmp_path))
+
+    class _FakeExecutor:
+        _modules = {"app_registry": object()}
+
+    class _FakeRegistry:
+        @property
+        def module_executor(self):
+            return _FakeExecutor()
+
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry())
+
+    principal = UserPrincipal(
+        user_id="viewer-user",
+        email="viewer@example.com",
+        name="Viewer",
+        roles=[],
+        scopes=[],
+        raw_claims={},
+        app_id="app_1",
+    )
+
+    result = await platform_app.get_profile_pages(app_id=None, principal=principal)
+
+    ids = [page["id"] for page in result["pages"]]
+    assert "my-apps" not in ids
+    assert "overview" in ids
+    assert "settings" in ids
+
+
 # ---------------------------------------------------------------------------
 # ProfilePage.jsx — page contract surface check
 # ---------------------------------------------------------------------------

--- a/tests/test_shell_shortcuts.py
+++ b/tests/test_shell_shortcuts.py
@@ -69,7 +69,6 @@ def test_platform_shell_config_expands_shortcuts(monkeypatch, tmp_path: Path) ->
     assert [item["id"] for item in shell["profile"]["menu"]] == [
         "profile",
         "wallet",
-        "admin-portal",
         "signout",
     ]
     assert [item["path"] for item in shell["mobile"]["bottomBar"]["items"]] == ["/", "/apps", "/me"]


### PR DESCRIPTION
## Summary\n- Split the shared profile/menu model into distinct studio, app, and user surfaces\n- Remove implicit \'my apps\' injection from the person profile surface\n- Scope admin portal injection to Studio-only shell config\n- Add the refactor plan and terminology docs needed for the larger shell split\n\n## Validation\n- pytest tests/test_platform_shell_p0_fixes.py tests/test_shell_shortcuts.py tests/test_config_consolidation.py tests/test_profile_contract.py -q --no-cov\n- mkdocs build --strict\n\n## Notes\n- This PR intentionally covers only the first isolated slice of the broader shell refactor.