### PR TITLE
feat(shell): add user surface as third recognized shell surface

### DIFF
--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -468,7 +468,7 @@ def _append_page_once(pages: list[dict], page: dict) -> None:
 
 def _normalize_shell_surface(surface: str | None) -> str:
     candidate = str(surface or "platform").strip().lower()
-    return candidate if candidate in {"platform", "studio"} else "platform"
+    return candidate if candidate in {"platform", "studio", "user"} else "platform"
 
 
 def _page_targets_surface(page: dict, *, surface: str) -> bool:
@@ -1130,7 +1130,11 @@ async def build_shell_config(*, surface: str = "platform") -> dict:
 
     shell_surface = _normalize_shell_surface(surface)
     is_studio = shell_surface == "studio"
-    result: dict = {"chat_startup_mode": "ask", "landing_spot": "/apps" if is_studio else "/"}
+    is_user = shell_surface == "user"
+    result: dict = {
+        "chat_startup_mode": "ask",
+        "landing_spot": "/apps" if is_studio else "/me" if is_user else "/",
+    }
     app_manifest = _load_app_manifest()
     shell_shortcuts: dict[str, Any] | None = None
     shell_navigation: dict[str, Any] | None = None
@@ -1148,7 +1152,7 @@ async def build_shell_config(*, surface: str = "platform") -> dict:
                 if isinstance(value, str) and value.strip():
                     result["appId"] = value.strip()
                     break
-            if not is_studio:
+            if not is_studio and not is_user:
                 startup = app_manifest.get("startup") if isinstance(app_manifest.get("startup"), dict) else {}
                 landing_spot = startup.get("landing_spot")
                 if isinstance(landing_spot, str) and landing_spot.startswith("/"):
@@ -1279,9 +1283,11 @@ async def build_shell_config(*, surface: str = "platform") -> dict:
     )
     result["chrome"] = _normalize_chrome_policy(shell_chrome)
 
-    # Admin Portal is a Studio guarantee, not an app-shell guarantee.
+    # Admin Portal is a Studio guarantee — not injected into app or user surfaces.
     if is_studio:
         _inject_admin_portal(result)
+
+    result["surface"] = shell_surface
 
     return result
 
@@ -1309,8 +1315,8 @@ async def health_check(request: Request):
 
 
 @app.get("/api/shell-config")
-async def get_shell_config():
-    return await build_shell_config(surface="platform")
+async def get_shell_config(surface: str | None = None):
+    return await build_shell_config(surface=surface or "platform")
 
 
 @app.get("/api/me")

--- a/tests/test_platform_shell_p0_fixes.py
+++ b/tests/test_platform_shell_p0_fixes.py
@@ -282,3 +282,72 @@ def test_build_shell_config_studio_injects_admin_portal(monkeypatch, tmp_path: P
     ids = [item.get("id") for item in menu if isinstance(item, dict)]
     assert "admin-portal" in ids, "admin-portal must appear in the Studio profile menu"
 
+
+# ---------------------------------------------------------------------------
+# User surface (surface="user")
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_app_root(tmp_path: Path) -> Path:
+    app_root = tmp_path / "app"
+    (app_root / "config").mkdir(parents=True, exist_ok=True)
+    (app_root / "ui").mkdir(parents=True, exist_ok=True)
+    (app_root / "app.json").write_text(
+        json.dumps({"appName": "My App", "startup": {"landing_spot": "/home"}}),
+        encoding="utf-8",
+    )
+    (app_root / "config" / "ai.json").write_text(
+        json.dumps({"chat": {"chat_startup_mode": "ask"}, "workflows": {"entry_point": "Chat"}}),
+        encoding="utf-8",
+    )
+    (app_root / "config" / "shell.json").write_text(json.dumps({}), encoding="utf-8")
+    (app_root / "ui" / "route_manifest.json").write_text(
+        json.dumps({"pages": []}), encoding="utf-8"
+    )
+    return app_root
+
+
+def test_user_surface_landing_spot_is_me(monkeypatch, tmp_path: Path) -> None:
+    """User surface must land on /me, not / or /apps."""
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = _make_minimal_app_root(tmp_path)
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+    shell = asyncio.run(platform_app.build_shell_config(surface="user"))
+    assert shell["landing_spot"] == "/me", "User surface landing_spot must be /me"
+
+
+def test_user_surface_does_not_inject_admin_portal(monkeypatch, tmp_path: Path) -> None:
+    """User surface must never receive admin-portal."""
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = _make_minimal_app_root(tmp_path)
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+    shell = asyncio.run(platform_app.build_shell_config(surface="user"))
+    menu = shell.get("profile", {}).get("menu", [])
+    ids = [item.get("id") for item in menu if isinstance(item, dict)]
+    assert "admin-portal" not in ids, "admin-portal must not appear in the user surface"
+
+
+def test_shell_config_response_includes_surface_field(monkeypatch, tmp_path: Path) -> None:
+    """build_shell_config must echo back the resolved surface in the response."""
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = _make_minimal_app_root(tmp_path)
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+    for surface, expected in (("platform", "platform"), ("studio", "studio"), ("user", "user"), (None, "platform")):
+        shell = asyncio.run(platform_app.build_shell_config(surface=surface))
+        assert shell.get("surface") == expected, (
+            f"surface={surface!r} → response.surface must be {expected!r}, got {shell.get('surface')!r}"
+        )
+
+
+def test_unknown_surface_falls_back_to_platform(monkeypatch, tmp_path: Path) -> None:
+    """An unrecognized surface value must normalize to 'platform'."""
+    from mozaiksai.hosts import platform as platform_app
+
+    app_root = _make_minimal_app_root(tmp_path)
+    monkeypatch.setattr(platform_app, "resolve_app_root", lambda: app_root)
+    shell = asyncio.run(platform_app.build_shell_config(surface="bogus"))
+    assert shell.get("surface") == "platform", "Unknown surface must normalize to 'platform'"
+


### PR DESCRIPTION
## Summary
- `_normalize_shell_surface()` now accepts `user` alongside `platform` and `studio`
- `build_shell_config()` sets `landing_spot` to `/me` for the user surface (not overridden by `app.json`)
- User surface never receives `admin-portal` injection
- `/api/shell-config` now accepts `?surface=` query param; defaults to `platform`
- Shell config response always includes a `surface` field echoing the resolved value

## Surfaces recognized
| Value | Landing spot | Admin portal | Factory routes |
|---|---|---|---|
| `platform` (default) | app.json startup | no | no |
| `studio` | `/apps` | yes | yes |
| `user` | `/me` | no | no |

## Test plan
- `test_user_surface_landing_spot_is_me`
- `test_user_surface_does_not_inject_admin_portal`
- `test_shell_config_response_includes_surface_field`
- `test_unknown_surface_falls_back_to_platform`
- 64 passed, 30 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)