### PR TITLE
refactor(shell): rename app_studio → app; propagate user surface to chat-ui and AppGenerator

### DIFF
--- a/chat-ui/src/config/validateConfig.js
+++ b/chat-ui/src/config/validateConfig.js
@@ -14,7 +14,7 @@
 const ICON_FILE_RE = /\.(svg|png|jpe?g|gif|webp|ico)$/i;
 const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 const URL_RE = /^(https?:\/\/|\/)/;
-const SHELL_ACTION_SURFACES = new Set(['studio', 'app_studio', 'workflow_session', 'transition', 'public', 'page']);
+const SHELL_ACTION_SURFACES = new Set(['studio', 'app', 'user', 'workflow_session', 'transition', 'public', 'page']);
 const SHELL_MODES = new Set(['standard', 'workspace', 'conversation', 'focused', 'immersive', 'public', 'social']);
 const SHELL_ACTION_WHEN_FIELDS = new Set([
   'surface',

--- a/chat-ui/src/navigation/shellActions.js
+++ b/chat-ui/src/navigation/shellActions.js
@@ -101,11 +101,12 @@ const deriveSurface = ({ pathname, searchParams, route, shellMode }) => {
   const group = navigation.group || null;
   const hasWorkflowSearch = searchParams.has('workflow') || searchParams.has('workflow_id');
 
+  if (pathname === '/me' || pathname.startsWith('/u/')) return 'user';
   if (pathname === '/' && hasWorkflowSearch) return 'workflow_session';
   if (pathname === '/chat' || pathname.startsWith('/chat/') || pathname === '/app' || pathname.startsWith('/app/')) {
     return 'workflow_session';
   }
-  if (group === 'app-studio' || (pathname.startsWith('/apps/') && pathname !== '/apps/new')) return 'app_studio';
+  if (group === 'app-studio' || (pathname.startsWith('/apps/') && pathname !== '/apps/new')) return 'app';
   if (group === 'workspace-studio' || pathname === '/apps') return 'studio';
   if (route?.transition || route?.sequence) return 'transition';
   if (shellMode === 'conversation') return 'workflow_session';

--- a/docs/architecture/frontend/chat-ui/shell-system.md
+++ b/docs/architecture/frontend/chat-ui/shell-system.md
@@ -221,7 +221,7 @@ header and mobile shell chrome.
 
 Supported variant context:
 
-- `surface`: `studio`, `app_studio`, `workflow_session`, `transition`, `public`, or `page`
+- `surface`: `studio`, `app`, `user`, `workflow_session`, `transition`, `public`, or `page`
 - `shellMode`: `standard`, `workspace`, `conversation`, `focused`, `immersive`, or `public`
 - `workflow_sequence`: a workflow sequence id such as `build`
 - `transition`: a transition id

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -5466,7 +5466,8 @@ models:
     type: literal
     values:
     - studio
-    - app_studio
+    - app
+    - user
     - workflow_session
     - transition
     - public

--- a/factory_app/workflows/AppGenerator/tools/save_app_schema.py
+++ b/factory_app/workflows/AppGenerator/tools/save_app_schema.py
@@ -443,7 +443,7 @@ VALID_SELECTION_MODES = {"none", "single", "multi"}
 VALID_ASSET_SOURCES = {"local", "remote", "uploaded", "generated", "stock"}
 VALID_CUSTOM_PAGE_EXTENSIONS = {".jsx"}
 VALID_SHELL_MODES = {"standard", "workspace", "conversation", "focused", "immersive", "public"}
-VALID_SHELL_ACTION_SURFACES = {"studio", "app_studio", "workflow_session", "transition", "public", "page"}
+VALID_SHELL_ACTION_SURFACES = {"studio", "app", "user", "workflow_session", "transition", "public", "page"}
 VALID_SHELL_ACTION_WHEN_FIELDS = {
     "surface",
     "surfaces",

--- a/tests/test_appgenerator_module_contracts.py
+++ b/tests/test_appgenerator_module_contracts.py
@@ -202,7 +202,8 @@ def test_appgenerator_structured_outputs_include_canonical_module_contract_model
     assert models["AppShellHeaderAction"]["fields"]["variants"]["items"] == "AppShellHeaderActionVariant"
     assert models["AppShellActionSurface"]["values"] == [
         "studio",
-        "app_studio",
+        "app",
+        "user",
         "workflow_session",
         "transition",
         "public",

--- a/tests/test_config_consolidation.py
+++ b/tests/test_config_consolidation.py
@@ -252,11 +252,26 @@ class TestValidateConfigUpdated:
     def test_validates_shell_config(self, source):
         assert "validateShellConfig" in source
 
+    def test_shell_action_surfaces_include_app_and_user(self, source):
+        assert "'studio', 'app', 'user'" in source
+        assert "app_studio" not in source
+
     def test_fetches_from_api(self, source):
         assert "/api/theme-config" in source
 
     def test_fetches_shell_config_api(self, source):
         assert "/api/shell-config" in source
+
+
+class TestShellActionsUpdated:
+    @pytest.fixture
+    def source(self):
+        return _framework_file("chat-ui/src/navigation/shellActions.js")
+
+    def test_app_and_user_surfaces_are_derived(self, source):
+        assert "return 'user';" in source
+        assert "return 'app';" in source
+        assert "return 'app_studio';" not in source
 
 
 class TestNavigationProviderUpdated:

--- a/tests/test_mobile_surface_contracts.py
+++ b/tests/test_mobile_surface_contracts.py
@@ -181,7 +181,7 @@ def test_web_shell_has_responsive_smoke_harness() -> None:
     assert "npm run test:responsive-smoke" in ci_source
 
 
-def test_factory_app_studio_routes_are_all_covered_by_smoke() -> None:
+def test_factory_app_surface_routes_are_all_covered_by_smoke() -> None:
     manifest = json.loads(_read("factory_app/app/ui/route_manifest.json"))
     smoke_source = _read("web_shell/playwright/apps.responsive.smoke.spec.js")
     console_components = {


### PR DESCRIPTION
## Summary
- `app_studio` surface token renamed to `app` everywhere for consistency with the three-surface model (`studio` / `app` / `user`)
- `user` surface added to chat-ui surface derivation (`/me`, `/u/*` paths) and AppGenerator structured outputs
- Surface taxonomy is now consistent across runtime, chat-ui frontend, AppGenerator, and docs

## Files changed
| File | Change |
|---|---|
| `chat-ui/src/navigation/shellActions.js` | `/me` + `/u/*` → `user`; `app_studio` → `app` |
| `chat-ui/src/config/validateConfig.js` | accept `app`, `user`; remove `app_studio` |
| `factory_app/workflows/AppGenerator/structured_outputs.yaml` | `ShellActionSurface` adds `user`, renames `app_studio` → `app` |
| `factory_app/workflows/AppGenerator/tools/save_app_schema.py` | `VALID_SHELL_ACTION_SURFACES` aligned |
| `docs/architecture/frontend/chat-ui/shell-system.md` | surface enum updated |
| `tests/test_config_consolidation.py` | assert `app` + `user` present; assert `app_studio` absent |
| `tests/test_appgenerator_module_contracts.py` | update expected `AppShellActionSurface` values |
| `tests/test_mobile_surface_contracts.py` | rename test to use `surface` terminology |

## Surface taxonomy (final)
`studio` | `app` | `user` | `workflow_session` | `transition` | `public` | `page`

## Test plan
- 40 passed, 30 skipped (focused suite)
- Builds on PR #217 (user surface runtime additions — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)