### PR TITLE
feat(emit-drift): detect ternary, delegate-helper, and marker-comment emit patterns

### DIFF
--- a/mozaiksai/core/runtime/app/emit_drift.py
+++ b/mozaiksai/core/runtime/app/emit_drift.py
@@ -25,8 +25,9 @@ a background worker rather than service.py directly.
 Public API
 ----------
 ``scan_service_emit_literals(service_py)``
-    Return the set of string-literal event types found in
-    ``ctx.emit("event_type", ...)`` calls in the given file.
+    Return the set of string-literal event types found in the given file via
+    four patterns: direct ``ctx.emit("event", ...)``, ternary first arg,
+    ``_emit_*`` delegate helpers (second-arg string), and ``# emit:`` comments.
 
 ``load_declared_emits(module_yaml)``
     Return the set of event types declared in ``actions[].emits[]`` across
@@ -75,6 +76,7 @@ Typical usage in a generated app's drift-guard tests
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 from typing import Any
 
@@ -86,12 +88,28 @@ import yaml
 
 
 def scan_service_emit_literals(service_py: Path) -> set[str]:
-    """Return string-literal event types from ``ctx.emit("...", ...)`` calls.
+    """Return string-literal event types emitted anywhere in ``service_py``.
 
-    Only captures calls of the form ``<expr>.emit(<string_literal>, ...)``.
-    Dynamic calls such as ``ctx.emit(event_var, ...)`` are intentionally
-    ignored — they cannot be resolved statically and should not produce
-    false positives.
+    Detects four patterns:
+
+    1. **Direct**: ``ctx.emit("event", ...)`` — first positional arg is a string
+       literal.
+    2. **Ternary**: ``ctx.emit("a" if cond else "b", ...)`` — both branches of
+       an inline conditional in the first positional arg are extracted.
+    3. **Delegate helper**: ``self._emit_best_effort(ctx, "event", ...)`` or
+       any method whose name starts with ``_emit`` where the second positional
+       argument is a string literal.  Covers common "fire-and-forget with error
+       handling" wrappers such as ``_emit_if_available``.
+    4. **Marker comment**: ``# emit: event_type`` anywhere in the file.  Use
+       this form to document events emitted via dynamic variables, background
+       workers, or other files that cannot be detected by static analysis::
+
+           # emit: hosted.billing.subscription.activated
+           # emit: hosted.billing.subscription.updated
+           await ctx.emit(event_type, payload)  # event_type is set above
+
+    Dynamic calls such as ``ctx.emit(event_var, ...)`` (no literal) continue to
+    be ignored to avoid false positives.
 
     Returns an empty set when ``service_py`` does not exist.
     """
@@ -105,16 +123,35 @@ def scan_service_emit_literals(service_py: Path) -> set[str]:
         return set()
 
     found: set[str] = set()
+
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "emit"
-            and node.args
-            and isinstance(node.args[0], ast.Constant)
-            and isinstance(node.args[0].value, str)
-        ):
-            found.add(node.args[0].value)
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        attr = node.func.attr
+        args = node.args
+
+        # Pattern 1 & 2: <expr>.emit(<literal_or_ternary>, ...)
+        if attr == "emit" and args:
+            first = args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                found.add(first.value)
+            elif isinstance(first, ast.IfExp):
+                for branch in (first.body, first.orelse):
+                    if isinstance(branch, ast.Constant) and isinstance(branch.value, str):
+                        found.add(branch.value)
+
+        # Pattern 3: <expr>._emit*(ctx, <literal>, ...)
+        elif attr.startswith("_emit") and len(args) >= 2:
+            second = args[1]
+            if isinstance(second, ast.Constant) and isinstance(second.value, str):
+                found.add(second.value)
+
+    # Pattern 4: # emit: event_type
+    for line in source.splitlines():
+        m = re.search(r"#\s*emit:\s*(\S+)", line)
+        if m:
+            found.add(m.group(1))
+
     return found
 
 
@@ -122,6 +159,10 @@ def scan_service_emit_literals_with_lines(service_py: Path) -> list[tuple[str, i
     """Like ``scan_service_emit_literals`` but returns ``(event_type, line_no)`` pairs.
 
     Used internally by ``check_orphaned_emits`` for diagnostic output.
+
+    Detects the same patterns as ``scan_service_emit_literals`` (direct, ternary,
+    delegate helper, and ``# emit:`` marker comments) and associates each with
+    its source line number.
     """
     if not service_py.exists():
         return []
@@ -133,16 +174,35 @@ def scan_service_emit_literals_with_lines(service_py: Path) -> list[tuple[str, i
         return []
 
     found: list[tuple[str, int]] = []
+
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "emit"
-            and node.args
-            and isinstance(node.args[0], ast.Constant)
-            and isinstance(node.args[0].value, str)
-        ):
-            found.append((node.args[0].value, node.lineno))
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        attr = node.func.attr
+        args = node.args
+
+        # Pattern 1 & 2: <expr>.emit(<literal_or_ternary>, ...)
+        if attr == "emit" and args:
+            first = args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                found.append((first.value, node.lineno))
+            elif isinstance(first, ast.IfExp):
+                for branch in (first.body, first.orelse):
+                    if isinstance(branch, ast.Constant) and isinstance(branch.value, str):
+                        found.append((branch.value, node.lineno))
+
+        # Pattern 3: <expr>._emit*(ctx, <literal>, ...)
+        elif attr.startswith("_emit") and len(args) >= 2:
+            second = args[1]
+            if isinstance(second, ast.Constant) and isinstance(second.value, str):
+                found.append((second.value, node.lineno))
+
+    # Pattern 4: # emit: event_type (with line number)
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        m = re.search(r"#\s*emit:\s*(\S+)", line)
+        if m:
+            found.append((m.group(1), lineno))
+
     return found
 
 

--- a/tests/test_module_emit_drift.py
+++ b/tests/test_module_emit_drift.py
@@ -655,3 +655,201 @@ def test_drift_guard_pattern_for_events_yaml_service_alignment(tmp_path: Path) -
         "the events_yaml_service_alignment pattern is broken"
     )
     assert "hosted.schema_migrations.migration.failed" in missing
+
+
+# ---------------------------------------------------------------------------
+# New pattern: ternary in ctx.emit() first arg
+# ---------------------------------------------------------------------------
+
+
+def test_scan_detects_ternary_emit(tmp_path: Path) -> None:
+    """Both branches of a ternary in ctx.emit() must be captured.
+
+    Pattern:
+        await ctx.emit("evt.a" if cond else "evt.b", payload)
+
+    Both "evt.a" and "evt.b" are string literals that the module contract
+    must declare.  This pattern appears when service.py branches between two
+    related event types in a single expression.
+    """
+    service_py = tmp_path / "service.py"
+    service_py.write_text(
+        """
+async def upsert(self, ctx, *, existing):
+    await ctx.emit(
+        "tasks.task_created" if existing is None else "tasks.task_updated",
+        {"id": 1},
+    )
+""",
+        encoding="utf-8",
+    )
+
+    result = scan_service_emit_literals(service_py)
+    assert result == {"tasks.task_created", "tasks.task_updated"}
+
+
+def test_scan_detects_ternary_emit_with_lines(tmp_path: Path) -> None:
+    """scan_service_emit_literals_with_lines must capture both ternary branches."""
+    service_py = tmp_path / "service.py"
+    service_py.write_text(
+        'async def upsert(self, ctx, *, existing):\n'
+        '    await ctx.emit(\n'
+        '        "tasks.task_created" if existing is None else "tasks.task_updated",\n'
+        '        {},\n'
+        '    )\n',
+        encoding="utf-8",
+    )
+
+    result = scan_service_emit_literals_with_lines(service_py)
+    event_types = {e for e, _ in result}
+    assert event_types == {"tasks.task_created", "tasks.task_updated"}
+    assert all(ln > 0 for _, ln in result)
+
+
+def test_check_missing_emits_resolves_ternary(tmp_path: Path) -> None:
+    """Both ternary branches satisfy declared emits — neither is reported missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["tasks.task_created", "tasks.task_updated"],
+        service_src=(
+            'async def upsert(self, ctx, *, existing):\n'
+            '    await ctx.emit(\n'
+            '        "tasks.task_created" if existing is None else "tasks.task_updated",\n'
+            '        {},\n'
+            '    )\n'
+        ),
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# New pattern: _emit_* delegate helpers
+# ---------------------------------------------------------------------------
+
+
+def test_scan_detects_emit_delegate_helper(tmp_path: Path) -> None:
+    """String literals in _emit_* helper calls must be captured.
+
+    Pattern:
+        await self._emit_best_effort(ctx, "event_type", payload)
+        await self._emit_if_available(ctx, "event_type", payload)
+
+    These wrappers forward to ctx.emit() with timeout/error handling.
+    The event type string is the second positional argument.
+    """
+    service_py = tmp_path / "service.py"
+    service_py.write_text(
+        """
+async def create(self, ctx, *, data):
+    await self._emit_if_available(ctx, "tasks.task_created", {"id": data["id"]})
+    return {"success": True}
+
+async def delete(self, ctx, *, task_id):
+    await self._emit_best_effort(ctx, "tasks.task_deleted", {"id": task_id})
+    return {"success": True}
+""",
+        encoding="utf-8",
+    )
+
+    result = scan_service_emit_literals(service_py)
+    assert result == {"tasks.task_created", "tasks.task_deleted"}
+
+
+def test_check_missing_emits_resolves_delegate_helper(tmp_path: Path) -> None:
+    """Events emitted via _emit_* helpers satisfy declared emits."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=["tasks.task_created"],
+        service_src=(
+            'async def create(self, ctx, *, data):\n'
+            '    await self._emit_if_available(ctx, "tasks.task_created", {})\n'
+            '    return {"success": True}\n'
+        ),
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_check_orphaned_emits_catches_undeclared_delegate_emit(
+    tmp_path: Path,
+) -> None:
+    """Undeclared event in _emit_* helper is reported as orphaned."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[],
+        service_src=(
+            'async def create(self, ctx, *, data):\n'
+            '    await self._emit_best_effort(ctx, "tasks.task_created", {})\n'
+        ),
+    )
+    orphans = check_orphaned_emits(module_dir)
+    orphaned_types = {e for e, _ in orphans}
+    assert "tasks.task_created" in orphaned_types
+
+
+# ---------------------------------------------------------------------------
+# New pattern: # emit: marker comments
+# ---------------------------------------------------------------------------
+
+
+def test_scan_detects_emit_marker_comment(tmp_path: Path) -> None:
+    """``# emit: event_type`` comments must be captured by the scanner.
+
+    Use this pattern to document events that are emitted via dynamic variables,
+    background workers, or other files that the AST scanner cannot reach::
+
+        # emit: hosted.billing.subscription.activated
+        # emit: hosted.billing.subscription.updated
+        await ctx.emit(event_type, payload)  # event_type set above
+    """
+    service_py = tmp_path / "service.py"
+    service_py.write_text(
+        """
+async def assign_plan(self, ctx, *, app_id, plan_id, existing):
+    if existing is None:
+        event_type = "hosted.billing.subscription.activated"
+    else:
+        event_type = "hosted.billing.subscription.updated"
+    # emit: hosted.billing.subscription.activated
+    # emit: hosted.billing.subscription.updated
+    await ctx.emit(event_type, {"app_id": app_id, "plan_id": plan_id})
+""",
+        encoding="utf-8",
+    )
+
+    result = scan_service_emit_literals(service_py)
+    assert "hosted.billing.subscription.activated" in result
+    assert "hosted.billing.subscription.updated" in result
+
+
+def test_check_missing_emits_resolves_marker_comment(tmp_path: Path) -> None:
+    """Declared events covered only by # emit: comments are not reported missing."""
+    module_dir = _write_module(
+        tmp_path,
+        declared_emits=[
+            "hosted.billing.subscription.activated",
+            "hosted.billing.subscription.updated",
+        ],
+        service_src=(
+            'async def assign_plan(self, ctx, *, existing):\n'
+            '    event_type = "activated" if existing is None else "updated"\n'
+            '    # emit: hosted.billing.subscription.activated\n'
+            '    # emit: hosted.billing.subscription.updated\n'
+            '    await ctx.emit(event_type, {})\n'
+        ),
+    )
+    assert check_missing_emits(module_dir) == []
+
+
+def test_scan_detects_marker_comment_with_lines(tmp_path: Path) -> None:
+    """scan_service_emit_literals_with_lines must include # emit: comment events."""
+    service_py = tmp_path / "service.py"
+    service_py.write_text(
+        "async def run(self, ctx):\n"
+        "    # emit: domain.tasks.worker_done\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    result = scan_service_emit_literals_with_lines(service_py)
+    event_types = {e for e, _ in result}
+    assert "domain.tasks.worker_done" in event_types
+    assert all(ln > 0 for _, ln in result)


### PR DESCRIPTION
## Summary

- Extends `scan_service_emit_literals` (and the with-lines variant) with three new detection patterns beyond plain `ctx.emit("string", ...)`
- **Ternary**: `ctx.emit("evt.a" if cond else "evt.b", ...)` — both branches extracted (covers upsert-style create/update bifurcation like `investor_marketplace`)
- **Delegate helpers**: `self._emit_best_effort(ctx, "event", ...)` / `self._emit_if_available(ctx, "event", ...)` — second positional string extracted (covers fire-and-forget emit wrappers like `hosted_billing` and `app_registry`)
- **Marker comments**: `# emit: event_type` — event type extracted from comment (covers dynamic variable emits, background workers, cross-file emits that static AST cannot reach)
- Adds 9 new regression tests for all three patterns, both scanner functions, and end-to-end `check_missing_emits` / `check_orphaned_emits`

## Test plan

- [ ] `python -m pytest tests/test_module_emit_drift.py --no-cov` → 38 passed
- [ ] All existing App Zero drift-guard tests pass after App Zero fixes land

🤖 Generated with [Claude Code](https://claude.com/claude-code)