### PR TITLE
feat(entitlement-drift): add entitlement gate ↔ subscriptions.yaml drift-guard utility

### DIFF
--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -189,6 +189,31 @@ drift_guard_test_guidance:
             assert callable(getattr(cls, "delete_user_data", None)), "delete_user_data must be implemented"
             assert callable(getattr(cls, "export_user_data", None)), "export_user_data must be implemented"
 
+    entitlement_gate_coverage:
+      description: >
+        Use the OSS entitlement_drift utility to check that every
+        entitlement_gate capability_id declared in module actions is granted
+        by at least one plan in config/subscriptions.yaml.  A gate that
+        references a capability not in any plan causes silent always-deny for
+        non-trusted callers — the platform startup logs a soft warning, but
+        this test makes it a hard CI failure so the misconfiguration is caught
+        before deploy.  Import check_entitlement_gate_coverage from
+        mozaiksai.core.runtime.app.entitlement_drift.
+      template: |
+        from pathlib import Path
+        from mozaiksai.core.runtime.app.entitlement_drift import check_entitlement_gate_coverage
+
+        def test_entitlement_gates_covered_by_subscription_plan():
+            app_root = Path(__file__).resolve().parents[1] / "app"
+            uncovered = check_entitlement_gate_coverage(app_root)
+            assert uncovered == [], (
+                "Actions gate on capabilities not granted by any plan in subscriptions.yaml:\n"
+                + "\n".join(
+                    f"  {mod}.{action}: '{cap}' not in subscriptions.yaml"
+                    for mod, action, cap in uncovered
+                )
+            )
+
 archetypes:
   standard:
     summary: Default deterministic module for CRUD and ordinary business logic.

--- a/mozaiksai/core/runtime/app/entitlement_drift.py
+++ b/mozaiksai/core/runtime/app/entitlement_drift.py
@@ -1,0 +1,178 @@
+"""entitlement_drift — entitlement gate ↔ subscriptions.yaml alignment checker.
+
+This module is a development and test-time utility.  It is NOT loaded at app
+startup and has no effect on the runtime hot path.
+
+Purpose
+-------
+The platform warms up ``_warn_undeclared_entitlement_gates`` at startup which
+logs a WARNING when a module action's ``entitlement_gate`` capability_id is not
+granted by any plan in ``config/subscriptions.yaml``.  That warning is soft —
+no exception is raised — because an app may be in development with plans not
+yet finalised.
+
+This module provides the same check as a hard assertion so CI drift-guard tests
+can fail immediately when a gate references a capability that no plan grants.
+
+An undeclared gate causes **silent always-deny** for callers who are not
+trusted/admin: every action check returns ``denied`` even for fully subscribed
+users.  This is almost always a misconfiguration rather than intentional
+behaviour and should be caught before deploy.
+
+Public API
+----------
+``scan_module_entitlement_gates(modules_dir)``
+    Return a mapping ``{(module_id, action_id): capability_id}`` for every
+    module action that declares an ``entitlement_gate``.
+
+``load_plan_capabilities(subscriptions_yaml)``
+    Return the set of ``capability_id`` strings granted by any plan in a
+    ``config/subscriptions.yaml`` file.  Supports both v1 (flat
+    ``plans[]``) and v2 (``products[].plans[]``) formats.
+
+``check_entitlement_gate_coverage(app_dir)``
+    Return ``[(module_id, action_id, capability_id)]`` triples for gated
+    actions whose capability_id is not granted by any plan.  Returns an
+    empty list when all gates are covered or no modules gate on entitlements.
+
+Typical usage in a generated app's drift-guard tests
+-----------------------------------------------------
+::
+
+    from mozaiksai.core.runtime.app.entitlement_drift import (
+        check_entitlement_gate_coverage,
+    )
+    from pathlib import Path
+
+    APP_ROOT = Path(__file__).resolve().parents[1] / "app"
+
+    def test_entitlement_gates_covered_by_plan():
+        uncovered = check_entitlement_gate_coverage(APP_ROOT)
+        assert uncovered == [], (
+            "Actions gate on capabilities not granted by any plan:\\n"
+            + "\\n".join(
+                f"  {mod}.{action}: '{cap}' not in subscriptions.yaml"
+                for mod, action, cap in uncovered
+            )
+        )
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def scan_module_entitlement_gates(
+    modules_dir: Path,
+) -> dict[tuple[str, str], str]:
+    """Return ``{(module_id, action_id): capability_id}`` for all gated actions.
+
+    Walks every ``<modules_dir>/<module_id>/module.yaml`` and collects actions
+    whose ``entitlement_gate`` field is a non-empty string.
+
+    Returns an empty dict when ``modules_dir`` does not exist or no modules
+    declare entitlement gates.
+    """
+    if not modules_dir.exists():
+        return {}
+
+    result: dict[tuple[str, str], str] = {}
+    for module_yaml in sorted(modules_dir.glob("*/module.yaml")):
+        module_id = module_yaml.parent.name
+        raw: Any = yaml.safe_load(module_yaml.read_text(encoding="utf-8")) or {}
+        for action in raw.get("actions", []):
+            gate = action.get("entitlement_gate")
+            if gate and isinstance(gate, str):
+                result[(module_id, action["id"])] = gate
+    return result
+
+
+def load_plan_capabilities(subscriptions_yaml: Path) -> set[str]:
+    """Return all capability_ids granted by any plan in subscriptions.yaml.
+
+    Supports two formats:
+
+    v1 — flat plans list::
+
+        plans:
+          - plan_id: free
+            capabilities: [cap.a, cap.b]
+
+    v2 — plans nested under products::
+
+        products:
+          - product_id: platform
+            plans:
+              - plan_id: builder
+                capabilities: [cap.a, cap.b]
+
+    Returns an empty set when ``subscriptions_yaml`` does not exist or no
+    plans declare capabilities.
+    """
+    if not subscriptions_yaml.exists():
+        return set()
+
+    raw: Any = yaml.safe_load(subscriptions_yaml.read_text(encoding="utf-8")) or {}
+    capabilities: set[str] = set()
+
+    # v1: flat top-level plans
+    for plan in raw.get("plans", []):
+        for cap in plan.get("capabilities", []):
+            if isinstance(cap, str):
+                capabilities.add(cap)
+
+    # v2: plans nested under products
+    for product in raw.get("products", []):
+        for plan in product.get("plans", []):
+            for cap in plan.get("capabilities", []):
+                if isinstance(cap, str):
+                    capabilities.add(cap)
+
+    return capabilities
+
+
+def check_entitlement_gate_coverage(
+    app_dir: Path,
+) -> list[tuple[str, str, str]]:
+    """Return ``[(module_id, action_id, capability_id)]`` for uncovered gates.
+
+    An entitlement gate is *uncovered* when the capability_id it references is
+    not granted by any plan in ``app/config/subscriptions.yaml``.  Such a gate
+    causes silent always-deny for all non-trusted callers regardless of their
+    subscription, which is almost always a misconfiguration.
+
+    ``app_dir`` is the app workspace root (the directory containing
+    ``modules/`` and ``config/``).
+
+    Returns an empty list when:
+    - No module actions declare ``entitlement_gate``
+    - All declared gates reference a capability granted by at least one plan
+    - ``config/subscriptions.yaml`` does not exist (no subscription config
+      means entitlements are not enforced; gates are effectively no-ops)
+
+    Result is sorted for deterministic output: ``(module_id, action_id, cap)``.
+    """
+    modules_dir = app_dir / "modules"
+    subscriptions_yaml = app_dir / "config" / "subscriptions.yaml"
+
+    gates = scan_module_entitlement_gates(modules_dir)
+    if not gates:
+        return []
+
+    if not subscriptions_yaml.exists():
+        return []
+
+    plan_caps = load_plan_capabilities(subscriptions_yaml)
+
+    return sorted(
+        (module_id, action_id, cap)
+        for (module_id, action_id), cap in gates.items()
+        if cap not in plan_caps
+    )

--- a/tests/test_entitlement_drift.py
+++ b/tests/test_entitlement_drift.py
@@ -1,0 +1,341 @@
+"""Tests for entitlement_drift.py — entitlement gate ↔ subscriptions.yaml alignment.
+
+The platform startup function _warn_undeclared_entitlement_gates logs a soft
+warning when an action's entitlement_gate does not appear in any plan.
+This module provides the same check as a hard assertion for CI drift-guard
+tests that want to fail immediately on misconfiguration.
+
+An undeclared gate causes silent always-deny for non-trusted callers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.runtime.app.entitlement_drift import (
+    check_entitlement_gate_coverage,
+    load_plan_capabilities,
+    scan_module_entitlement_gates,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_module(
+    modules_dir: Path,
+    module_id: str,
+    *,
+    actions: list[dict] | None = None,
+) -> Path:
+    module_dir = modules_dir / module_id
+    (module_dir / "backend").mkdir(parents=True, exist_ok=True)
+
+    actions_yaml = ""
+    for action in actions or []:
+        gate_line = ""
+        if action.get("entitlement_gate"):
+            gate_line = f"\n    entitlement_gate: {action['entitlement_gate']}"
+        actions_yaml += f"""
+  - id: {action['id']}
+    description: {action.get('description', 'test action')}
+    handler_method: {action['id']}{gate_line}
+    permissions: []"""
+
+    module_dir.joinpath("module.yaml").write_text(
+        f"""schema_version: mozaiks.module.v1
+module:
+  id: {module_id}
+  display_name: {module_id.title()}
+  version: 1.0.0
+  description: Test module
+  handler: backend.handler:Handler
+permissions: []
+actions:{actions_yaml or " []"}
+""",
+        encoding="utf-8",
+    )
+    return module_dir
+
+
+def _write_subscriptions(
+    config_dir: Path,
+    *,
+    v2: bool = True,
+    capabilities: list[str] | None = None,
+) -> Path:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    caps = capabilities or []
+
+    if v2:
+        if caps:
+            caps_lines = "\n".join(f"          - {c}" for c in caps)
+            caps_block = f"        capabilities:\n{caps_lines}"
+        else:
+            caps_block = "        capabilities: []"
+        content = (
+            "schema_version: mozaiks.subscriptions.v2\n"
+            "label: Test App\n"
+            "default_product_id: platform\n"
+            "products:\n"
+            "  - product_id: platform\n"
+            "    label: Platform\n"
+            "    plans:\n"
+            "      - plan_id: free\n"
+            "        label: Free\n"
+            "        description: Free plan\n"
+            f"{caps_block}\n"
+            "      - plan_id: pro\n"
+            "        label: Pro\n"
+            "        description: Pro plan\n"
+            "        capabilities:\n"
+            "          - extra.cap\n"
+        )
+    else:
+        if caps:
+            caps_lines = "\n".join(f"    - {c}" for c in caps)
+            caps_block = f"    capabilities:\n{caps_lines}"
+        else:
+            caps_block = "    capabilities: []"
+        content = (
+            "schema_version: mozaiks.subscriptions.v1\n"
+            "plans:\n"
+            "  - plan_id: free\n"
+            "    label: Free\n"
+            f"{caps_block}\n"
+        )
+
+    config_dir.joinpath("subscriptions.yaml").write_text(content, encoding="utf-8")
+    return config_dir.joinpath("subscriptions.yaml")
+
+
+# ---------------------------------------------------------------------------
+# scan_module_entitlement_gates
+# ---------------------------------------------------------------------------
+
+
+def test_scan_finds_gated_actions(tmp_path: Path) -> None:
+    """scan_module_entitlement_gates must return all gated (module, action) pairs."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir,
+        "tasks",
+        actions=[
+            {"id": "create", "entitlement_gate": "tasks.create"},
+            {"id": "list"},  # no gate
+        ],
+    )
+
+    result = scan_module_entitlement_gates(modules_dir)
+    assert result == {("tasks", "create"): "tasks.create"}
+
+
+def test_scan_returns_empty_for_no_gates(tmp_path: Path) -> None:
+    modules_dir = tmp_path / "modules"
+    _write_module(modules_dir, "tasks", actions=[{"id": "list"}, {"id": "get"}])
+
+    assert scan_module_entitlement_gates(modules_dir) == {}
+
+
+def test_scan_returns_empty_when_modules_dir_absent(tmp_path: Path) -> None:
+    assert scan_module_entitlement_gates(tmp_path / "nonexistent") == {}
+
+
+def test_scan_collects_across_multiple_modules(tmp_path: Path) -> None:
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir, "marketplace", actions=[{"id": "browse", "entitlement_gate": "marketplace.browse"}]
+    )
+    _write_module(
+        modules_dir, "wallet", actions=[{"id": "payout", "entitlement_gate": "wallet.payout"}]
+    )
+
+    result = scan_module_entitlement_gates(modules_dir)
+    assert result == {
+        ("marketplace", "browse"): "marketplace.browse",
+        ("wallet", "payout"): "wallet.payout",
+    }
+
+
+# ---------------------------------------------------------------------------
+# load_plan_capabilities — v2 format
+# ---------------------------------------------------------------------------
+
+
+def test_load_capabilities_v2(tmp_path: Path) -> None:
+    """load_plan_capabilities reads capabilities from v2 products[].plans[]."""
+    subs = _write_subscriptions(
+        tmp_path / "config",
+        v2=True,
+        capabilities=["marketplace.browse", "wallet.payout"],
+    )
+    result = load_plan_capabilities(subs)
+    assert "marketplace.browse" in result
+    assert "wallet.payout" in result
+    assert "extra.cap" in result  # from the Pro plan in _write_subscriptions
+
+
+def test_load_capabilities_v1(tmp_path: Path) -> None:
+    """load_plan_capabilities reads capabilities from v1 flat plans[]."""
+    subs = _write_subscriptions(
+        tmp_path / "config",
+        v2=False,
+        capabilities=["marketplace.browse"],
+    )
+    result = load_plan_capabilities(subs)
+    assert "marketplace.browse" in result
+
+
+def test_load_capabilities_returns_empty_when_absent(tmp_path: Path) -> None:
+    result = load_plan_capabilities(tmp_path / "nonexistent.yaml")
+    assert result == set()
+
+
+def test_load_capabilities_returns_empty_for_no_caps(tmp_path: Path) -> None:
+    subs = _write_subscriptions(tmp_path / "config", v2=True, capabilities=[])
+    result = load_plan_capabilities(subs)
+    assert "extra.cap" in result  # Pro plan still has extra.cap
+    assert "marketplace.browse" not in result
+
+
+# ---------------------------------------------------------------------------
+# check_entitlement_gate_coverage — end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_check_coverage_returns_empty_when_all_covered(tmp_path: Path) -> None:
+    """All gates covered by at least one plan → empty result."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir, "tasks", actions=[{"id": "create", "entitlement_gate": "tasks.create"}]
+    )
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=["tasks.create"])
+
+    assert check_entitlement_gate_coverage(tmp_path) == []
+
+
+def test_check_coverage_reports_uncovered_gate(tmp_path: Path) -> None:
+    """Gate referencing an undeclared capability must be reported."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir,
+        "marketplace",
+        actions=[{"id": "order_ad", "entitlement_gate": "marketplace.ad.order"}],
+    )
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=["some.other.cap"])
+
+    result = check_entitlement_gate_coverage(tmp_path)
+    assert result == [("marketplace", "order_ad", "marketplace.ad.order")]
+
+
+def test_check_coverage_reports_all_uncovered(tmp_path: Path) -> None:
+    """Every uncovered gate must be reported, not just the first."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir,
+        "marketplace",
+        actions=[
+            {"id": "browse", "entitlement_gate": "marketplace.browse"},
+            {"id": "order", "entitlement_gate": "marketplace.order"},
+        ],
+    )
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=[])
+
+    result = check_entitlement_gate_coverage(tmp_path)
+    # both uncovered; sorted
+    assert set(r[2] for r in result) == {"marketplace.browse", "marketplace.order"}
+    assert result == sorted(result)
+
+
+def test_check_coverage_returns_empty_when_no_gates(tmp_path: Path) -> None:
+    """No entitlement gates → nothing to check, result is empty."""
+    modules_dir = tmp_path / "modules"
+    _write_module(modules_dir, "tasks", actions=[{"id": "list"}, {"id": "create"}])
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=[])
+
+    assert check_entitlement_gate_coverage(tmp_path) == []
+
+
+def test_check_coverage_returns_empty_when_no_subscriptions_yaml(
+    tmp_path: Path,
+) -> None:
+    """No subscriptions.yaml means no subscription enforcement — gates are no-ops."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir,
+        "tasks",
+        actions=[{"id": "create", "entitlement_gate": "tasks.create"}],
+    )
+    # config/ directory exists but has no subscriptions.yaml
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+
+    assert check_entitlement_gate_coverage(tmp_path) == []
+
+
+def test_check_coverage_result_is_sorted(tmp_path: Path) -> None:
+    """Result must be sorted for deterministic output in CI failure messages."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir, "z_module", actions=[{"id": "act", "entitlement_gate": "z.cap"}]
+    )
+    _write_module(
+        modules_dir, "a_module", actions=[{"id": "act", "entitlement_gate": "a.cap"}]
+    )
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=[])
+
+    result = check_entitlement_gate_coverage(tmp_path)
+    assert result == sorted(result)
+
+
+def test_check_coverage_gate_in_any_plan_is_sufficient(tmp_path: Path) -> None:
+    """A gate covered by any plan (even non-default) must not be reported."""
+    modules_dir = tmp_path / "modules"
+    _write_module(
+        modules_dir,
+        "marketplace",
+        actions=[{"id": "order", "entitlement_gate": "extra.cap"}],
+    )
+    # extra.cap is only in the Pro plan injected by _write_subscriptions
+    _write_subscriptions(tmp_path / "config", v2=True, capabilities=[])
+
+    assert check_entitlement_gate_coverage(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: drift-guard pattern for a generated app
+# ---------------------------------------------------------------------------
+
+
+def test_drift_guard_pattern_used_by_generated_app_tests(tmp_path: Path) -> None:
+    """The drift-guard pattern from module_archetypes.yaml must correctly catch
+    an entitlement gate that references a capability not in any plan.
+
+    This test mimics exactly what AppGenerator scaffolds into a generated app's
+    drift-guard test suite.
+    """
+    modules_dir = tmp_path / "modules"
+    # Simulate a module where the developer added entitlement_gate but forgot
+    # to add the capability to subscriptions.yaml
+    _write_module(
+        modules_dir,
+        "billing",
+        actions=[
+            {"id": "upgrade_plan", "entitlement_gate": "billing.upgrade"},
+        ],
+    )
+    _write_subscriptions(
+        tmp_path / "config",
+        v2=True,
+        capabilities=["billing.view"],  # billing.upgrade was forgotten
+    )
+
+    # This is the exact assertion a generated drift-guard test would make:
+    uncovered = check_entitlement_gate_coverage(tmp_path)
+    assert uncovered != [], (
+        "Expected the drift-guard to catch the undeclared entitlement gate; "
+        "the entitlement_gate_coverage pattern is broken"
+    )
+    assert any(cap == "billing.upgrade" for _, _, cap in uncovered)


### PR DESCRIPTION
## Summary

- Adds `mozaiksai/core/runtime/app/entitlement_drift.py` with `scan_module_entitlement_gates`, `load_plan_capabilities`, and `check_entitlement_gate_coverage` public functions
- Adds `tests/test_entitlement_drift.py` with 16 tests covering both v1/v2 subscriptions.yaml formats, missing gates, multi-module scans, and the generated-app drift-guard pattern
- Documents `entitlement_gate_coverage` as a named pattern in `module_archetypes.yaml` `drift_guard_test_guidance` so AppGenerator scaffolds it in generated app CI tests

## Motivation

The platform startup function `_warn_undeclared_entitlement_gates` logs a soft warning when an `entitlement_gate` capability_id is not granted by any plan. An undeclared gate causes **silent always-deny** for all non-trusted callers regardless of subscription — almost always a misconfiguration, not intentional. This utility makes that soft warning a hard CI assertion.

## Test plan
- [ ] `pytest tests/test_entitlement_drift.py` — 16 tests pass
- [ ] Verify `module_archetypes.yaml` `drift_guard_test_guidance.entitlement_gate_coverage` template imports correctly in a generated app test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)