### PR TITLE
feat(appgenerator): add test_scaffold task contract and drift-guard scaffold policy

### DIFF
--- a/factory_app/build_context/AppGenerator/file_contracts.yaml
+++ b/factory_app/build_context/AppGenerator/file_contracts.yaml
@@ -416,6 +416,55 @@ task_contracts:
       - Do not emit cookie-policy.md unless the app plan explicitly uses browser
         cookies or fingerprinting beyond what the platform session requires.
 
+  test_scaffold:
+    owner_agent: ConfigMiddlewareAgent
+    summary: >
+      Per-module drift-guard test scaffold. Emitted once when a new module is
+      generated, alongside the module_contract task. Provides
+      tests/test_{module_id}_module_drift.py with lightweight CI-time checks
+      that enforce module.yaml ↔ handler.py alignment and event-emission
+      contract invariants. App-level drift-guard tests (entitlement gate
+      coverage) are scaffolded separately as a single shared test file.
+    trigger:
+      emit_when:
+        - A new module is generated with at least one action.
+        - A new module is generated that declares action.emits[] for any action.
+    required_outputs:
+      - tests/test_{module_id}_module_drift.py
+    optional_outputs:
+      - tests/test_entitlement_gate_coverage.py
+    hard_constraints:
+      - Scaffold tests/test_{module_id}_module_drift.py once at module generation
+        time. Do not overwrite on routine module refinement unless
+        --force-tests is passed.
+      - Do not emit tests/ files from module_contract or business_services tasks.
+        Test scaffolding is owned exclusively by test_scaffold tasks.
+      - Include the handler_method_alignment pattern from
+        drift_guard_test_guidance in every generated test file — it loads the
+        module via ModuleLoader so handler reflection failures surface in CI,
+        not only at app startup.
+      - Include the emits_service_alignment pattern (check_orphaned_emits) only
+        when the module declares at least one action.emits[] entry.
+      - Include the events_yaml_service_alignment pattern (check_missing_emits)
+        only when the module declares at least one action.emits[] entry.
+      - Include the user_data_scope_handler_completeness pattern only when
+        module.yaml declares module.user_data_scope=true.
+      - Scaffold tests/test_entitlement_gate_coverage.py once per app (not per
+        module) when the app declares config/subscriptions.yaml and at least one
+        module action carries entitlement_gate. Use the entitlement_gate_coverage
+        pattern from drift_guard_test_guidance. Do not duplicate it; check
+        whether the file already exists before emitting.
+      - Import check_orphaned_emits and check_missing_emits from
+        mozaiksai.core.runtime.app.emit_drift.
+      - Import check_entitlement_gate_coverage from
+        mozaiksai.core.runtime.app.entitlement_drift.
+      - Import ModuleLoader from mozaiksai.core.runtime.app.loader.
+      - Generated tests must be lightweight — no mocking of business logic,
+        no running handler methods, no database connections. Inspect module
+        YAML and source only.
+      - test_{module_id}_module_drift.py must not import from other module
+        backends. Module drift-guard tests are module-local.
+
 backend_helper_files:
   description: >
     Rules for backend/{helper_name}.py files generated under app/modules/{module_id}/backend/.

--- a/factory_app/build_context/AppGenerator/module_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/module_archetypes.yaml
@@ -90,6 +90,34 @@ drift_guard_test_guidance:
     the module or inspect source, they do not mock business logic or run handler
     methods. The file should sit in the app-bundle tests/ directory alongside
     other module tests.
+
+  scaffold_policy:
+    description: >
+      Which patterns to include when generating tests/test_{module_id}_module_drift.py.
+      AppGenerator emits the test_scaffold task immediately after module_contract
+      for every new module. Pattern selection is conditional on module.yaml content.
+    always_include:
+      - handler_method_alignment
+    include_when_emits_declared:
+      condition: module.yaml declares action.emits[] for at least one action
+      patterns:
+        - emits_service_alignment
+        - events_yaml_service_alignment
+    include_when_user_data_scope:
+      condition: module.yaml declares module.user_data_scope=true
+      patterns:
+        - user_data_scope_handler_completeness
+    app_level_once:
+      description: >
+        App-level tests are scaffolded once per app workspace, not per module.
+        Check whether the file already exists before emitting.
+      include_when_entitlement_gates:
+        condition: >
+          config/subscriptions.yaml exists AND at least one module action
+          declares entitlement_gate across any module in the app
+        output: tests/test_entitlement_gate_coverage.py
+        pattern: entitlement_gate_coverage
+
   patterns:
     handler_method_alignment:
       description: >


### PR DESCRIPTION
## Summary

- Adds `test_scaffold` to `file_contracts.yaml` — named task contract for per-module drift-guard test scaffolding, owned by `ConfigMiddlewareAgent`, emitted alongside `module_contract`
- Adds `scaffold_policy` to `drift_guard_test_guidance` in `module_archetypes.yaml` — explicit conditional inclusion rules so AppGenerator knows which patterns to include for each module

## Why

Previously the `drift_guard_test_guidance` patterns existed but there was no task contract governing when AppGenerator emits drift-guard tests, and no policy for conditional pattern selection. This closes the loop between:
1. The OSS drift utilities (`emit_drift.py`, `entitlement_drift.py`)
2. The pattern templates in `module_archetypes.yaml`
3. AppGenerator actually scaffolding the test files at generation time

## Pattern inclusion rules

| Pattern | Condition |
|---------|-----------|
| `handler_method_alignment` | always |
| `emits_service_alignment` | module declares any `action.emits[]` |
| `events_yaml_service_alignment` | module declares any `action.emits[]` |
| `user_data_scope_handler_completeness` | `module.user_data_scope=true` |
| `test_entitlement_gate_coverage.py` (app-level, once) | `subscriptions.yaml` + any `entitlement_gate` |

## Test plan
- [ ] Review `file_contracts.yaml` `test_scaffold` task contract for completeness
- [ ] Review `module_archetypes.yaml` `scaffold_policy` conditions for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)