### PR TITLE
feat(settings): UserSettings persistence layer for /api/me/settings

### DIFF
--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -101,6 +101,7 @@ async def add_api_version_header(request: Request, call_next):
 _DEFAULT_PROFILE_USER_ID = os.getenv("MOZAIKS_DEFAULT_USER_ID", "demo-user").strip() or "demo-user"
 _ACCOUNT_PROFILE_COLLECTION = "UserProfiles"
 _ACCOUNT_PREFERENCES_COLLECTION = "UserPreferences"
+_USER_SETTINGS_COLLECTION = "UserSettings"
 
 
 # Module runtime_extensions.yaml routers are mounted in _platform_startup()
@@ -1552,8 +1553,8 @@ async def get_module_settings_for_user(
             ]
         }
 
-    Values are resolved in priority order: default → (future) app override → (future) user override.
-    Only settings with scope="user" are intended to be user-editable from this endpoint.
+    Values are resolved in priority order: declared default → stored user override.
+    Only settings with scope="user" are user-editable from this endpoint.
     """
     resolved_app_id, user_id = _resolve_profile_scope(principal, app_id=app_id)
     module_executor = executor_registry.module_executor
@@ -1561,7 +1562,9 @@ async def get_module_settings_for_user(
         return {"module_id": module_id, "settings": []}
 
     defs = module_executor.setting_defs(module_id)
-    resolved = module_executor.resolve_settings(module_id)
+    defaults = module_executor.resolve_settings(module_id)
+    stored = await _load_user_settings(app_id=resolved_app_id, user_id=user_id, module_id=module_id)
+    resolved = {**defaults, **stored}
 
     return {
         "module_id": module_id,
@@ -1593,9 +1596,7 @@ async def update_module_settings_for_user(
     Only fields whose declared scope is 'user' may be updated via this endpoint.
     App-scoped settings are read-only from this surface (they belong in /api/admin/settings).
     Values are validated against the declared type and enum_values before storage.
-
-    NOTE: Persistence layer (UserSettings collection) is not yet implemented.
-    This endpoint validates and acknowledges the payload but does not persist.
+    Stored values are merged on top of any previously saved overrides (partial update semantics).
     """
     resolved_app_id, user_id = _resolve_profile_scope(principal, app_id=app_id)
     module_executor = executor_registry.module_executor
@@ -1624,9 +1625,16 @@ async def update_module_settings_for_user(
     if errors:
         raise HTTPException(status_code=422, detail={"errors": errors})
 
-    # TODO: persist validated values to UserSettings collection
-    # For now return the resolved state with the validated overrides applied
-    resolved = {**module_executor.resolve_settings(module_id), **validated}
+    # Merge validated overrides on top of any previously stored values, then persist.
+    stored = await _load_user_settings(
+        app_id=resolved_app_id, user_id=user_id, module_id=module_id
+    )
+    merged_stored = {**stored, **validated}
+    await _save_user_settings(
+        app_id=resolved_app_id, user_id=user_id, module_id=module_id, values=merged_stored
+    )
+
+    resolved = {**module_executor.resolve_settings(module_id), **merged_stored}
     return {
         "module_id": module_id,
         "settings": [
@@ -2486,6 +2494,52 @@ async def _account_preferences_collection():
     if client is None:
         raise RuntimeError("Mongo client not initialized")
     return client["mozaiksai"][_ACCOUNT_PREFERENCES_COLLECTION]
+
+
+async def _user_settings_collection():
+    await persistence_manager.persistence._ensure_client()
+    client = persistence_manager.persistence.client
+    if client is None:
+        raise RuntimeError("Mongo client not initialized")
+    return client["mozaiksai"][_USER_SETTINGS_COLLECTION]
+
+
+def _user_settings_doc_id(app_id: str, user_id: str, module_id: str) -> str:
+    return f"{app_id}:{user_id}:{module_id}"
+
+
+async def _load_user_settings(*, app_id: str, user_id: str, module_id: str) -> dict[str, Any]:
+    """Load stored user-scoped setting overrides for one module. Returns {} when none stored."""
+    try:
+        collection = await _user_settings_collection()
+        doc = await collection.find_one({"_id": _user_settings_doc_id(app_id, user_id, module_id)})
+        return dict(doc.get("values") or {}) if doc else {}
+    except Exception as exc:
+        logger.warning("[user-settings] Could not load settings for %s/%s/%s: %s", app_id, user_id, module_id, exc)
+        return {}
+
+
+async def _save_user_settings(
+    *, app_id: str, user_id: str, module_id: str, values: dict[str, Any]
+) -> None:
+    """Upsert user-scoped setting overrides for one module."""
+    collection = await _user_settings_collection()
+    doc_id = _user_settings_doc_id(app_id, user_id, module_id)
+    now = datetime.now(UTC)
+    await collection.update_one(
+        {"_id": doc_id},
+        {
+            "$setOnInsert": {
+                "_id": doc_id,
+                "app_id": app_id,
+                "user_id": user_id,
+                "module_id": module_id,
+                "created_at": now,
+            },
+            "$set": {"values": values, "updated_at": now},
+        },
+        upsert=True,
+    )
 
 
 def _resolve_profile_scope(

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,0 +1,291 @@
+"""Tests for /api/me/settings/{module_id} persistence.
+
+Covers:
+- GET returns defaults when nothing is stored
+- PUT persists values; subsequent GET returns the stored override
+- PUT merges on top of existing stored values (partial update)
+- PUT rejects app-scoped settings with 422
+- PUT rejects type violations with 422
+- _user_settings_doc_id format
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory collection stub (same pattern as test_profile_contract.py)
+# ---------------------------------------------------------------------------
+
+class _Collection:
+    def __init__(self) -> None:
+        self.docs: dict[str, dict] = {}
+
+    async def find_one(self, query, *_args, **_kwargs):
+        doc = self.docs.get(query["_id"])
+        return deepcopy(doc) if doc is not None else None
+
+    async def update_one(self, query, update, upsert=False):
+        doc_id = query["_id"]
+        exists = doc_id in self.docs
+        if not exists and not upsert:
+            return None
+        doc = deepcopy(self.docs.get(doc_id, {"_id": doc_id}))
+        if not exists:
+            doc.update(deepcopy(update.get("$setOnInsert", {})))
+        doc.update(deepcopy(update.get("$set", {})))
+        doc["_id"] = doc_id
+        self.docs[doc_id] = doc
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Minimal ModuleExecutor stub with typed SettingDefs
+# ---------------------------------------------------------------------------
+
+def _make_executor(defs: list[dict]):
+    """Build a minimal executor stub with the given setting definitions."""
+    from mozaiksai.core.runtime.app.module_loader import SettingDef
+    from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor
+
+    executor = ModuleExecutor()
+
+    class _Stub:
+        async def noop(self, ctx, **_):
+            return {}
+
+    typed_defs = [SettingDef.model_validate(d) for d in defs]
+    executor.register(
+        "mymodule",
+        _Stub(),
+        action_method_map={"noop": "noop"},
+        settings=typed_defs,
+    )
+    return executor
+
+
+class _FakeRegistry:
+    """Drop-in replacement for ExecutorRegistry with a real (or None) module_executor."""
+
+    def __init__(self, executor):
+        self.module_executor = executor
+
+
+def _make_principal(user_id: str = "user-1"):
+    from mozaiksai.core.auth.dependencies import UserPrincipal
+    return UserPrincipal(
+        user_id=user_id, email=None, name=None, roles=[], scopes=[], raw_claims={}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_user_settings_doc_id_format():
+    from mozaiksai.hosts.platform import _user_settings_doc_id
+    assert _user_settings_doc_id("app-1", "user-1", "commerce") == "app-1:user-1:commerce"
+
+
+# ---------------------------------------------------------------------------
+# GET — returns defaults when nothing stored
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_returns_defaults_when_nothing_stored(monkeypatch):
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "notif.digest", "type": "enum", "scope": "user",
+         "default": "daily", "label": "Digest", "enum_values": ["never", "daily", "weekly"]},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    result = await platform_app.get_module_settings_for_user(
+        module_id="mymodule",
+        app_id="app-1",
+        principal=_make_principal(),
+    )
+
+    assert result["module_id"] == "mymodule"
+    assert len(result["settings"]) == 1
+    s = result["settings"][0]
+    assert s["id"] == "notif.digest"
+    assert s["value"] == "daily"   # default, nothing stored
+    assert s["default"] == "daily"
+    assert s["enum_values"] == ["never", "daily", "weekly"]
+
+
+# ---------------------------------------------------------------------------
+# PUT → GET round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_put_persists_and_get_returns_stored_value(monkeypatch):
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "notif.digest", "type": "enum", "scope": "user",
+         "default": "daily", "label": "Digest", "enum_values": ["never", "daily", "weekly"]},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    principal = _make_principal()
+
+    # PUT overrides to "weekly"
+    put_result = await platform_app.update_module_settings_for_user(
+        module_id="mymodule",
+        body={"notif.digest": "weekly"},
+        app_id="app-1",
+        principal=principal,
+    )
+    assert put_result["settings"][0]["value"] == "weekly"
+
+    # GET should now return "weekly" from storage
+    get_result = await platform_app.get_module_settings_for_user(
+        module_id="mymodule",
+        app_id="app-1",
+        principal=principal,
+    )
+    assert get_result["settings"][0]["value"] == "weekly"
+
+
+# ---------------------------------------------------------------------------
+# PUT partial update semantics
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_put_merges_on_top_of_existing_stored_values(monkeypatch):
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "a", "type": "string", "scope": "user", "default": "x", "label": "A"},
+        {"id": "b", "type": "string", "scope": "user", "default": "y", "label": "B"},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    principal = _make_principal()
+
+    # First PUT sets a="hello"
+    await platform_app.update_module_settings_for_user(
+        module_id="mymodule", body={"a": "hello"}, app_id="app-1", principal=principal,
+    )
+    # Second PUT sets b="world" — must not wipe a
+    await platform_app.update_module_settings_for_user(
+        module_id="mymodule", body={"b": "world"}, app_id="app-1", principal=principal,
+    )
+
+    result = await platform_app.get_module_settings_for_user(
+        module_id="mymodule", app_id="app-1", principal=principal,
+    )
+    values = {s["id"]: s["value"] for s in result["settings"]}
+    assert values["a"] == "hello"
+    assert values["b"] == "world"
+
+
+# ---------------------------------------------------------------------------
+# PUT rejects app-scoped settings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_put_rejects_app_scoped_setting(monkeypatch):
+    from fastapi import HTTPException
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "currency", "type": "string", "scope": "app", "default": "USD", "label": "Currency"},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await platform_app.update_module_settings_for_user(
+            module_id="mymodule",
+            body={"currency": "EUR"},
+            app_id="app-1",
+            principal=_make_principal(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert any("currency" in str(e) for e in exc_info.value.detail["errors"])
+
+
+# ---------------------------------------------------------------------------
+# PUT rejects type violations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_put_rejects_boolean_type_violation(monkeypatch):
+    from fastapi import HTTPException
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "enabled", "type": "boolean", "scope": "user", "default": True, "label": "Enabled"},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await platform_app.update_module_settings_for_user(
+            module_id="mymodule",
+            body={"enabled": "yes"},   # string instead of bool
+            app_id="app-1",
+            principal=_make_principal(),
+        )
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_enum_value_not_in_allowed_set(monkeypatch):
+    from fastapi import HTTPException
+    from mozaiksai.hosts import platform as platform_app
+
+    col = _Collection()
+    executor = _make_executor([
+        {"id": "theme", "type": "enum", "scope": "user", "default": "light",
+         "label": "Theme", "enum_values": ["light", "dark"]},
+    ])
+
+    monkeypatch.setattr(platform_app, "_user_settings_collection", lambda: _async(col))
+    monkeypatch.setattr(platform_app, "executor_registry", _FakeRegistry(executor))
+    monkeypatch.setattr(platform_app, "_resolve_default_app_id", lambda: "app-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await platform_app.update_module_settings_for_user(
+            module_id="mymodule",
+            body={"theme": "solarized"},   # not in enum_values
+            app_id="app-1",
+            principal=_make_principal(),
+        )
+
+    assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+async def _async(value: Any) -> Any:
+    return value


### PR DESCRIPTION
## Summary

- Adds `UserSettings` MongoDB collection for per-user, per-module setting overrides
- `_user_settings_doc_id(app_id, user_id, module_id)` → `"app_id:user_id:module_id"` key format
- GET `/api/me/settings/{module_id}` now merges stored overrides on top of declared defaults
- PUT uses partial-update semantics — subsequent PUTs never wipe previously stored keys
- Type validation rejects boolean/enum mismatches; scope validation rejects app-scoped setting writes via the user endpoint
- 7 unit tests using in-memory collection stub (no Mongo dependency)

## Test plan
- [x] `tests/test_user_settings.py` — 7 tests, all passing
- [x] `tests/test_platform_shell_p0_fixes.py` — no regressions
- [x] `tests/test_module_loader_contracts.py` — no regressions
- [x] `tests/test_executor_registry.py` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)