### PR TITLE
docs: harden multi-agent coordination rules

### DIFF
--- a/.claude/rules/multi-agent-coordination.md
+++ b/.claude/rules/multi-agent-coordination.md
@@ -12,8 +12,49 @@ git log origin/main --oneline -5   # see what recently landed
 gh pr list --state open            # see what other agents have in flight
 ```
 
-If an open PR touches the same files you need: wait for it to merge, or branch
-off that PR's branch if it is a hard dependency.
+**Never branch off another open PR's branch, even if it looks like a hard
+dependency.** Branching on top of unmerged, not-yet-green work means you
+inherit its bugs, and every fix it needs later has to be re-propagated into
+your branch too — this is how a single in-progress refactor turns into a
+cascading chain of broken PRs. Instead:
+- Wait for the dependency PR to merge (green CI, actually merged into `main`),
+  then branch from fresh `origin/main`.
+- If you truly cannot wait, say so explicitly in your PR description ("stacked
+  on #123, will rebase once it merges") so reviewers know why checks are red,
+  and rebase onto `main` the moment the base PR lands.
+
+**Always work in an isolated worktree, never directly in the shared main
+checkout.** Multiple agents run git commands in the same main checkout folder
+concurrently, which silently switches branches and sweeps unrelated
+uncommitted edits into your commits. Before any nontrivial edit:
+
+```bash
+git worktree add .local/worktrees/<task-name> origin/main -b cc/<short-description>
+```
+
+Do all work there, and remove it when done (`git worktree remove
+.local/worktrees/<task-name> --force`).
+
+## Before Opening a PR — Local Verification Is Mandatory
+
+Do not push and open a PR on faith that CI will catch problems. Run locally
+first, in your worktree:
+
+```bash
+ruff check .                        # catches unsorted imports / lint issues before CI does
+pytest -q --no-cov                  # full suite, not just the files you touched
+```
+
+If a check fails and the failure is **not** in a file your change touched,
+confirm it's pre-existing before ignoring it:
+
+```bash
+git show origin/main:<path/to/failing/file>   # does the same failure already exist on main?
+```
+
+If the failure already exists on `origin/main`, it is not your bug — note it
+in the PR description and move on. If it does not exist on `main`, it is a
+regression from your own change — fix it before opening/leaving the PR open.
 
 ## Branch Workflow — Always Use Feature Branches
 
@@ -25,10 +66,8 @@ git checkout -b cc/<short-description>    # cc/ prefix = Claude Code
 # ... do work, commit ...
 git push -u origin cc/<short-description>
 gh pr create --title "..." --body "..."
-gh pr merge <number> --squash --delete-branch --auto
+gh pr merge <number> --squash --delete-branch   # auto-merge is disabled repo-wide; merge manually once checks pass
 ```
-
-Auto-merge fires automatically once CI passes. No human action needed.
 
 ## Branch Naming Convention
 
@@ -63,3 +102,12 @@ git push --force-with-lease
 ```
 
 This is expected behavior — not an error. The branch workflow makes it safe.
+
+## A Repo-Wide CI Failure on `main` Blocks Everyone — Fix It First
+
+If a check fails identically across multiple unrelated PRs (same file/line in
+every failure), it is very likely already broken on `origin/main` itself and
+now silently blocks every PR branched after it landed. Treat this as the
+highest-priority fix: open a small, isolated hotfix PR against `main` for that
+issue alone before continuing other work, since every other agent is blocked
+by it too until it's fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,14 @@ gh pr list --state open           # see what other agents have in flight
 git log origin/main --oneline -5  # see what recently landed
 ```
 
+Never branch off another open PR's still-unmerged branch, even as a "hard
+dependency" — you inherit its bugs and every later fix has to be re-propagated
+into your branch too. Wait for it to merge (green CI, actually in `main`) and
+branch from fresh `origin/main` instead. Always work in an isolated worktree
+(`git worktree add .local/worktrees/<task-name> origin/main -b cc/<desc>`),
+never directly in the shared main checkout — other agents run git commands
+there concurrently and will switch branches or sweep in unrelated edits.
+
 **Branch workflow — always use feature branches:**
 ```bash
 git checkout main && git reset --hard origin/main
@@ -284,8 +292,14 @@ git checkout -b cc/<description>  # cc/ = Claude Code, codex/ = Codex
 # ... work, commit ...
 git push -u origin cc/<description>
 gh pr create --title "..." --body "..."
-gh pr merge <number> --squash --delete-branch --auto
+gh pr merge <number> --squash --delete-branch   # auto-merge is disabled repo-wide; merge manually once checks pass
 ```
+
+Before opening the PR, run `ruff check .` and `pytest -q --no-cov` locally in
+the worktree. If a check still fails, confirm via `git show origin/main:<path>`
+whether it's pre-existing on `main` before assuming it's your bug — and if a
+check fails identically across multiple unrelated PRs, it's a repo-wide `main`
+regression blocking everyone; fix it first with a small isolated hotfix PR.
 
 Primary repo ownership (avoids overlap by default):
 


### PR DESCRIPTION
## Summary
- Never branch off another open PR's unmerged branch (root cause of the #216/#221 cascading breakage)
- Always use an isolated worktree, never the shared main checkout
- Require local uff check . + pytest -q --no-cov before opening a PR
- If a check fails identically across multiple unrelated PRs, treat it as a repo-wide main regression and fix it first
- Corrected an outdated claim that auto-merge is enabled on this repo (it is disabled)