### PR TITLE
fix(module-dispatch): stop action user_id param from hijacking actor identity

### DIFF
--- a/mozaiksai/hosts/routers/modules.py
+++ b/mozaiksai/hosts/routers/modules.py
@@ -31,6 +31,23 @@ _MODULE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 _PUBLIC_MODULE_API_SURFACES = {"public", "public_readonly"}
 _OBSERVED_MODULES = {"messages", "workspace_support"}
 _RESERVED_CONTEXT_KEYS = ("app_id", "user_id", "tenant_id", "workspace_id", "correlation_id", "auth_token")
+# Reserved keys that are safe to auto-promote from an action's own "params" into
+# the trusted execution "context" when the caller omits them from context. This
+# is intentional for resource-scoping identifiers such as app_id, which many
+# actions also declare as a business input for the same resource being scoped.
+#
+# "user_id" is deliberately excluded: action input schemas very commonly declare
+# their own "user_id" parameter that names a *target* subject (e.g. add_member's
+# user to add, update_member_role's user whose role changes) rather than the
+# calling actor's identity. Promoting it here would silently overwrite the
+# trusted execution context's user_id with that target's user_id, letting an
+# action's own business input hijack actor identity resolution downstream
+# (privilege confusion: authorization checks would then run as the target user
+# instead of the real caller). Context-level user_id overrides must be supplied
+# explicitly under the "context" envelope key, never inferred from "params".
+_PROMOTABLE_PARAM_CONTEXT_KEYS = tuple(
+    key for key in _RESERVED_CONTEXT_KEYS if key != "user_id"
+)
 # Actions with these surfaces are only reachable through the internal event bus
 # or direct ModuleExecutor calls.  HTTP dispatch is always rejected regardless
 # of authentication status so that event-pipeline internal handlers cannot be
@@ -75,10 +92,15 @@ def _split_post_body(body: dict[str, Any]) -> tuple[dict[str, Any], dict[str, An
     """Split a module POST body into action params and execution context.
 
     The canonical module API payload is {"params": {...}, "context": {...}}.
-    Values inside "params" are action inputs, so reserved words such as app_id
-    must remain available for resource-scoped actions. Raw-body payloads
-    still treat reserved words as execution context and remove them from action
-    params to preserve the old dispatch contract.
+    Values inside "params" are action inputs, so reserved resource-scoping words
+    such as app_id must remain available for resource-scoped actions and are
+    auto-promoted into context when the caller omits them there. "user_id" is
+    never auto-promoted this way (see _PROMOTABLE_PARAM_CONTEXT_KEYS) because
+    action inputs frequently name a target subject, not the caller. Raw-body
+    payloads still treat all reserved words (including user_id) as execution
+    context and remove them from action params to preserve the old dispatch
+    contract, since that legacy shape has no "params" input namespace to
+    collide with.
     """
     params_body = body.get("params")
     context_body = body.get("context")
@@ -90,7 +112,13 @@ def _split_post_body(body: dict[str, Any]) -> tuple[dict[str, Any], dict[str, An
         params = dict(body)
     context_overrides: dict[str, Any] = dict(context_body) if isinstance(context_body, dict) else {}
 
-    for key in _RESERVED_CONTEXT_KEYS:
+    # The legacy raw-body shape has no "params" input namespace, so every
+    # top-level reserved key (including user_id) has always unambiguously meant
+    # execution context there. The canonical enveloped shape does have a
+    # "params" input namespace, where "user_id" can legitimately be an action's
+    # own target-subject input, so it is excluded from promotion in that case.
+    promotable_keys = _RESERVED_CONTEXT_KEYS if not has_params_envelope else _PROMOTABLE_PARAM_CONTEXT_KEYS
+    for key in promotable_keys:
         if key in params and key not in context_overrides:
             context_overrides[key] = params[key]
 

--- a/tests/test_module_router_context_overrides.py
+++ b/tests/test_module_router_context_overrides.py
@@ -61,3 +61,90 @@ async def test_module_context_user_id_override_reaches_executor(monkeypatch):
     assert result == {"ok": True, "user_id": "demo-user"}
     assert executor.requests[0].app_id == "mozaiks-factory"
     assert executor.requests[0].user_id == "demo-user"
+
+
+def test_split_post_body_does_not_promote_action_user_id_param():
+    """An action's own "user_id" input (e.g. add_member's target user) must
+    never be promoted into the trusted execution context. Only an explicit
+    context.user_id should be able to set the execution identity."""
+    params, context_overrides = module_router._split_post_body(
+        {
+            "params": {"community_id": "c1", "user_id": "target-user", "role": "contributor"},
+            "context": {"app_id": "demo-app"},
+        }
+    )
+
+    assert params["user_id"] == "target-user"
+    assert "user_id" not in context_overrides
+    assert context_overrides["app_id"] == "demo-app"
+
+
+def test_split_post_body_still_promotes_app_id_for_resource_scoped_actions():
+    """app_id remains intentionally promoted from params into context when the
+    caller declares it as a business input and omits it from context."""
+    params, context_overrides = module_router._split_post_body(
+        {
+            "params": {"name": "My Community", "app_id": "demo-app"},
+        }
+    )
+
+    assert params["app_id"] == "demo-app"
+    assert context_overrides["app_id"] == "demo-app"
+
+
+@pytest.mark.asyncio
+async def test_module_action_own_user_id_param_does_not_hijack_actor_identity(monkeypatch):
+    """Regression test for a real authz bug: dispatching an action whose input
+    schema declares its own "user_id" param (a target subject, e.g.
+    community_membership.add_member's user being added) must not overwrite the
+    authenticated/dev-resolved execution context's user_id with that target's
+    user_id."""
+    executor = _FakeModuleExecutor()
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                failed_module_names=[],
+                executor_registry=SimpleNamespace(module_executor=executor),
+                module_action_surfaces={},
+            )
+        ),
+        query_params={},
+        headers={},
+    )
+
+    async def _scope(**kwargs):
+        requested = kwargs["requested_scope"]
+        return {
+            "app_id": requested["app_id"],
+            "tenant_id": requested["tenant_id"],
+            "workspace_id": requested["workspace_id"],
+            "user_id": requested["user_id"],
+            "permissions": [],
+        }
+
+    monkeypatch.setattr(module_router, "is_auth_enabled", lambda: False)
+    monkeypatch.setattr(
+        module_router,
+        "get_platform_hooks",
+        lambda: SimpleNamespace(call_module_scope=_scope),
+    )
+
+    params, context_overrides = module_router._split_post_body(
+        {
+            "params": {"community_id": "c1", "user_id": "target-user", "role": "contributor"},
+            "context": {"app_id": "demo-app"},
+        }
+    )
+
+    result = await module_router._execute_module_action(
+        module_name="community_membership",
+        action_name="add_member",
+        request=request,
+        principal=SimpleNamespace(user_id="actor-owner", scopes=[], tenant_id=None, workspace_id=None),
+        params=params,
+        context_overrides=context_overrides,
+    )
+
+    assert result == {"ok": True, "user_id": "actor-owner"}
+    assert executor.requests[0].user_id == "actor-owner"
+    assert executor.requests[0].params["user_id"] == "target-user"


### PR DESCRIPTION
## Bug

'_split_post_body' in 'mozaiksai/hosts/routers/modules.py' auto-promoted any 'user_id' key present in an action's own 'params' into the trusted execution 'context' whenever the caller omitted 'context.user_id'.

Many module actions declare their own 'user_id' input naming a **target subject** rather than the caller (e.g. 'community_membership.add_member(community_id, user_id, role)' where 'user_id' is the user being added). This silently overwrote 'ctx.user_id' with the target user's id, so downstream authorization checks ran as the wrong actor.

Discovered via a real repro in 'mozaiks-app': 'add_member' returned 'access denied' for a community owner immediately after 'create_community' succeeded, on a fresh community, with valid membership data. Debug instrumentation confirmed 'ctx.user_id' resolved to the *target* user_id param instead of the authenticated dev user.

## Fix

Exclude 'user_id' from the params -> context auto-promotion set for the canonical '{params, context}' envelope shape (where the ambiguity exists). The legacy raw-body shape (no 'params' namespace) is unaffected since no business-field collision is possible there — verified via existing 'test_post_raw_body_keeps_reserved_fields_as_legacy_context_only'.

'app_id'/'tenant_id'/'workspace_id'/'correlation_id'/'auth_token' promotion is unchanged.

## Tests

Added to 'tests/test_module_router_context_overrides.py':
- 'test_split_post_body_does_not_promote_action_user_id_param'
- 'test_split_post_body_still_promotes_app_id_for_resource_scoped_actions'
- 'test_module_action_own_user_id_param_does_not_hijack_actor_identity' (full '_execute_module_action' dispatch regression)

Ran full affected suites: 'test_platform_module_dispatch.py', 'test_module_router_context_overrides.py', 'test_governance_guardrails.py' — 34 passed.