### PR TITLE
docs: reflect auto-merge now enabled repo-wide

### DIFF
--- a/.claude/rules/multi-agent-coordination.md
+++ b/.claude/rules/multi-agent-coordination.md
@@ -66,8 +66,14 @@ git checkout -b cc/<short-description>    # cc/ prefix = Claude Code
 # ... do work, commit ...
 git push -u origin cc/<short-description>
 gh pr create --title "..." --body "..."
-gh pr merge <number> --squash --delete-branch   # auto-merge is disabled repo-wide; merge manually once checks pass
+gh pr merge <number> --squash --delete-branch --auto
 ```
+
+Auto-merge is enabled repo-wide. Request it right when you open the PR — do
+not wait around watching CI yourself. GitHub merges automatically once every
+required check passes, so nobody has to remember to come back and click
+merge. If a check fails, auto-merge just never fires; fix the check and the
+same `--auto` request still applies once you push again.
 
 ## Branch Naming Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ git checkout -b cc/<description>  # cc/ = Claude Code, codex/ = Codex
 # ... work, commit ...
 git push -u origin cc/<description>
 gh pr create --title "..." --body "..."
-gh pr merge <number> --squash --delete-branch   # auto-merge is disabled repo-wide; merge manually once checks pass
+gh pr merge <number> --squash --delete-branch --auto   # auto-merge is enabled repo-wide; request it right away, don't wait on CI
 ```
 
 Before opening the PR, run `ruff check .` and `pytest -q --no-cov` locally in


### PR DESCRIPTION
Repo-level auto-merge was just turned on for mozaiks (matching mozaiks-app). Updates the coordination docs so agents request --auto immediately on PR creation instead of merging manually.