### PR TITLE
feat(runner): add KnowledgeStore injection seam to AG2NetworkRunner

### DIFF
--- a/docs/architecture/workflows/ag2-ownership-boundary.md
+++ b/docs/architecture/workflows/ag2-ownership-boundary.md
@@ -106,6 +106,44 @@ launching deterministically.
 This keeps AG2 responsible for agent execution mechanics while keeping Mozaiks
 responsible for app-specific artifact and lifecycle policy.
 
+## AG2 KnowledgeStore Injection Seam
+
+AG2's `KnowledgeStore` protocol (`ag2.knowledge.KnowledgeStore`) is the
+virtual path-based store for all agent workflow memory. AG2 owns this
+abstraction; Mozaiks must not create a parallel knowledge database layer.
+
+The `AG2NetworkRunnerRequest.knowledge_store` field is the narrow injection
+point. When `None` (the default), `AG2NetworkRunner` creates a fresh
+`MemoryKnowledgeStore()` per Hub — the safe isolated default for local
+development and test runs. An operator or hosted deployment may supply any
+AG2-compatible implementation (Memory, Sqlite, Disk, Redis, Locked, or a
+custom duck-typed store) without modifying OSS code.
+
+**Lifecycle contract:**
+- One Hub is opened per workflow run (or per live session kept alive for
+  paused runs).
+- `Hub.close()` does NOT close the store; store lifetime is owned by the
+  caller that constructs it.
+- Two runs that receive distinct store instances share no AG2 workflow
+  memory. A single shared store (e.g. Redis with a namespace prefix) may be
+  passed intentionally across runs — namespace/tenant isolation is the
+  operator's responsibility.
+
+**Security contract:**
+- An injected KnowledgeStore is trusted operator runtime configuration. It
+  can observe AG2 workflow/network memory for every run that uses it.
+- Production credentials must not flow into generated app bundles through
+  this seam.
+- This seam does not grant Mozaiks tenant or platform authority.
+
+**Threading path:**
+```
+run_workflow_orchestration(knowledge_store=...)
+  → _run_ag2_network_phase(knowledge_store=...)
+    → AG2NetworkRunnerRequest(knowledge_store=...)
+      → Hub.open(request.knowledge_store or MemoryKnowledgeStore(), ...)
+```
+
 ## Review Checklist
 
 Before adding or changing workflow runtime code, confirm:

--- a/docs/reviews/pre-1-0-public-architecture-roadmap.md
+++ b/docs/reviews/pre-1-0-public-architecture-roadmap.md
@@ -1,0 +1,69 @@
+# Pre-1.0 Public Architecture Roadmap
+
+This checklist is repo-internal and not part of the published docs navigation.
+
+## Phase 0 — Architecture Documentation / Freeze
+
+Status: approved for this documentation pass.
+
+- Commit durable public architecture decisions.
+- Establish framework/application/operator terminology.
+- Establish Framework Intelligence versus Operator/Learned Intelligence.
+- Do not move strategy code.
+- Do not implement new strategy seams.
+
+## Phase 1 — Managed Capability Boundary Review
+
+Status: approved for future review.
+
+- Review MozaiksPay public integration guidance.
+- Preserve MozaiksPay as the recommended/default monetization provider where
+  currently intended.
+- Confirm the split between app-facing capability contracts and hosted
+  implementation details.
+- Confirm self-hosted replacement paths for compatible payment providers.
+
+## Phase 2 — Strategy Seams
+
+Status: KnowledgeStore seam implemented. Refinement routing seam deferred.
+
+### AG2 KnowledgeStore injection seam — IMPLEMENTED
+
+`AG2NetworkRunnerRequest.knowledge_store` is the injection point.
+Default behavior (`MemoryKnowledgeStore`) is unchanged for self-hosters.
+See [AG2 Ownership Boundary](../architecture/workflows/ag2-ownership-boundary.md)
+for lifecycle contract, security notes, and threading path.
+
+### Refinement harness routing seam — DEFERRED
+
+Harness overlays (`refinement_harness/config/harness.yaml`) already allow
+operators to change which workflow sequence runs per change class. Introducing
+a `RefinementRoutingPort` is premature — the primary operator customization
+axis (workflow routing) is covered; classification policy is
+framework-owned. Revisit when a concrete operator use case emerges.
+
+## Phase 3 — Versioned Strategy Artifacts
+
+Status: future.
+
+- Document versioned strategy/config artifact shapes before publishing them.
+- Keep generated canonical app outputs versioned separately from operator
+  strategy inputs.
+
+## Phase 4 — Learned/Eval-Informed Strategy
+
+Status: future and publication-review required.
+
+- Integrate approved learned strategy only after deciding what is public,
+  operator-owned, or proprietary.
+- Keep eval corpora, eval results, cross-customer correction data, and
+  production outcome correlations out of OSS unless explicitly approved through
+  the publication policy.
+
+## Explicitly Not Planned In This Roadmap
+
+- Moving current MIT-published baseline strategy code.
+- Requiring BlocUnited services for OSS generation/refinement.
+- Replacing AG2 with a Mozaiks-owned agent framework.
+- Implementing production authority, payment execution, DNS execution, or
+  hosted provider operations in OSS.

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -17,7 +17,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-from ag2.knowledge import MemoryKnowledgeStore
+from ag2.knowledge import KnowledgeStore, MemoryKnowledgeStore
 from ag2.network import (
     EV_CHANNEL_CLOSED,
     EV_CONTEXT_SET,
@@ -97,6 +97,33 @@ class AG2NetworkRunnerRequest:
     close_timeout_seconds: float = 120.0
     attach_network_plugin: bool = True
     agent_text_context_deriver: Callable[[str, str], Mapping[str, Any]] | None = None
+    # ---------------------------------------------------------------------------
+    # AG2 KnowledgeStore injection seam
+    # ---------------------------------------------------------------------------
+    # Accepts an AG2-native KnowledgeStore instance (ag2.knowledge.KnowledgeStore
+    # protocol). When None the runner creates a fresh MemoryKnowledgeStore per
+    # Hub — the safe default for local development and test isolation.
+    #
+    # Lifecycle notes:
+    #   - One Hub is created per workflow run (or per live session, kept alive for
+    #     paused runs). Hub.close() does NOT close the store; store lifetime is
+    #     owned by the caller that constructs it.
+    #   - A durable operator-owned store (e.g. SqliteKnowledgeStore or
+    #     RedisKnowledgeStore) may be intentionally shared across runs. The caller
+    #     is responsible for namespace isolation and lifecycle management.
+    #   - Two runs that receive distinct store instances will not share AG2
+    #     workflow memory between them.
+    #
+    # Security notes:
+    #   - Injected KnowledgeStore code and storage are trusted operator runtime
+    #     configuration. The store can observe AG2 workflow/network memory for
+    #     every run that uses it.
+    #   - Production credentials (keys, tokens) must not flow into generated app
+    #     bundles through this seam; configure the store outside bundle artifacts.
+    #   - This seam does not grant production mutation authority over Mozaiks
+    #     tenant or platform data; AG2 memory/knowledge controls are engine-level,
+    #     not Mozaiks-level authority.
+    knowledge_store: KnowledgeStore | None = None
 
 
 @dataclass(slots=True)
@@ -143,7 +170,7 @@ class AG2NetworkRunner:
             )
 
         hub = await Hub.open(
-            MemoryKnowledgeStore(),
+            request.knowledge_store if request.knowledge_store is not None else MemoryKnowledgeStore(),
             ttl_sweep_interval=0,
             expectation_sweep_interval=0,
         )

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -616,6 +616,7 @@ async def _run_ag2_network_phase(
     structured_registry: dict[str, Any],
     max_turns: int,
     agent_text_context_deriver: Callable[[str, str], dict[str, Any]] | None = None,
+    knowledge_store: Any = None,
 ) -> Any:
     return await AG2NetworkRunner().run(
         AG2NetworkRunnerRequest(
@@ -630,6 +631,7 @@ async def _run_ag2_network_phase(
             structured_registry=structured_registry,
             max_turns=max_turns,
             agent_text_context_deriver=agent_text_context_deriver,
+            knowledge_store=knowledge_store,
         )
     )
 
@@ -647,6 +649,7 @@ async def run_workflow_orchestration(
     initial_agent_name_override: str | None = None,
     agents_factory: Callable | None = None,
     context_factory: Callable | None = None,
+    knowledge_store: Any = None,
     **kwargs: Any,
 ) -> dict[str, Any] | None:
     start_time = perf_counter()
@@ -1027,6 +1030,7 @@ async def run_workflow_orchestration(
                 structured_registry=structured_registry,
                 max_turns=max_turns,
                 agent_text_context_deriver=agent_text_context_deriver,
+                knowledge_store=knowledge_store,
             )
             if first_phase_result.status is not RunStatus.COMPLETED:
                 runner_result = first_phase_result
@@ -1091,11 +1095,12 @@ async def run_workflow_orchestration(
                         transition_rules=transition_rules,
                         initial_agent_name=continuation_agent,
                         initial_message="Continue with the completed deterministic task batch outputs.",
-                    context_variables=ctx_dict,
-                    structured_registry=structured_registry,
-                    max_turns=max_turns,
-                    agent_text_context_deriver=agent_text_context_deriver,
-                )
+                        context_variables=ctx_dict,
+                        structured_registry=structured_registry,
+                        max_turns=max_turns,
+                        agent_text_context_deriver=agent_text_context_deriver,
+                        knowledge_store=knowledge_store,
+                    )
                 else:
                     runner_result = first_phase_result
                     project_final_runner_result = False
@@ -1112,6 +1117,7 @@ async def run_workflow_orchestration(
                 structured_registry=structured_registry,
                 max_turns=max_turns,
                 agent_text_context_deriver=agent_text_context_deriver,
+                knowledge_store=knowledge_store,
             )
 
         await _emit_structured_once(runner_result, projected_sequence)

--- a/tests/test_ag2_knowledge_store_seam.py
+++ b/tests/test_ag2_knowledge_store_seam.py
@@ -1,0 +1,318 @@
+"""Tests for the AG2 KnowledgeStore injection seam.
+
+Verifies:
+1. No knowledge_store supplied → MemoryKnowledgeStore is used (current behavior).
+2. A custom AG2-compatible KnowledgeStore can be supplied.
+3. The supplied store reaches Hub.open() — not a different store.
+4. Two runs with distinct store instances do not share AG2 workflow memory.
+5. A single store instance CAN be shared across runs when the caller supplies it.
+6. AG2NetworkRunnerRequest public contract is backward-compatible (no new required args).
+7. run_workflow_orchestration accepts knowledge_store kwarg without error.
+8. The knowledge_store field is None by default on the request.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mozaiksai.core.adapters.ag2_network_runner import (
+    AG2NetworkRunner,
+    AG2NetworkRunnerRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal AG2-compatible fake KnowledgeStore
+# ---------------------------------------------------------------------------
+
+class FakeKnowledgeStore:
+    """Duck-typed KnowledgeStore (satisfies ag2.knowledge.KnowledgeStore Protocol)."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+        self._data: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    async def read(self, path: str) -> str | None:
+        self.calls.append(f"read:{path}")
+        return self._data.get(path)
+
+    async def write(self, path: str, content: str) -> None:
+        self.calls.append(f"write:{path}")
+        self._data[path] = content
+
+    async def list(self, path: str = "/") -> list[str]:
+        self.calls.append(f"list:{path}")
+        return []
+
+    async def delete(self, path: str) -> None:
+        self.calls.append(f"delete:{path}")
+        self._data.pop(path, None)
+
+    async def exists(self, path: str) -> bool:
+        return path in self._data
+
+    async def append(self, path: str, content: str) -> int:
+        existing = self._data.get(path, "")
+        offset = len(existing.encode())
+        self._data[path] = existing + content
+        return offset
+
+    async def read_range(self, path: str, start: int, end: int | None = None) -> str:
+        content = self._data.get(path, "")
+        data = content.encode()[start:end]
+        return data.decode()
+
+    async def on_change(self, path: str, callback: Any) -> Any:
+        return SimpleNamespace(close=AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(**overrides: Any) -> AG2NetworkRunnerRequest:
+    """Return a minimal AG2NetworkRunnerRequest with sensible defaults."""
+    defaults: dict[str, Any] = dict(
+        workflow_name="TestWorkflow",
+        chat_id="chat-1",
+        app_id="app-1",
+        agents={"AgentA": MagicMock()},
+        transition_rules=[],
+        initial_agent_name="AgentA",
+        initial_message="hello",
+    )
+    defaults.update(overrides)
+    return AG2NetworkRunnerRequest(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Default: knowledge_store is None → MemoryKnowledgeStore used
+# ---------------------------------------------------------------------------
+
+class TestDefaultBehavior:
+    def test_knowledge_store_defaults_to_none(self) -> None:
+        req = _make_request()
+        assert req.knowledge_store is None
+
+    def test_existing_required_fields_unchanged(self) -> None:
+        req = _make_request()
+        assert req.workflow_name == "TestWorkflow"
+        assert req.chat_id == "chat-1"
+        assert req.app_id == "app-1"
+        assert req.initial_agent_name == "AgentA"
+        assert req.initial_message == "hello"
+
+    def test_request_constructable_without_knowledge_store(self) -> None:
+        # Proves backward compatibility — no new required arguments
+        req = AG2NetworkRunnerRequest(
+            workflow_name="W",
+            chat_id="c",
+            app_id="a",
+            agents={"A": MagicMock()},
+            transition_rules=[],
+            initial_agent_name="A",
+            initial_message="hi",
+        )
+        assert req.knowledge_store is None
+
+    @pytest.mark.asyncio
+    async def test_no_store_uses_memory_store(self) -> None:
+        """When knowledge_store is None, Hub.open receives a fresh MemoryKnowledgeStore."""
+        from ag2.knowledge import MemoryKnowledgeStore
+
+        req = _make_request()
+
+        captured_store: list[Any] = []
+
+        async def fake_hub_open(store: Any, **kwargs: Any) -> Any:
+            captured_store.append(store)
+            # Return a minimal fake hub that won't try to run agents
+            hub = MagicMock()
+            hub.close = AsyncMock()
+            hub.register_listener = MagicMock()
+            hub.read_wal = AsyncMock(return_value=[])
+            hub.adapter_state = MagicMock(return_value=SimpleNamespace(context_vars={}))
+            return hub
+
+        with patch("mozaiksai.core.adapters.ag2_network_runner.Hub.open", fake_hub_open):
+            runner = AG2NetworkRunner()
+            # The run will fail after Hub.open because agents aren't real AG2 agents,
+            # but we only need to confirm Hub.open was called with a MemoryKnowledgeStore.
+            await runner.run(req)
+
+        assert len(captured_store) == 1
+        assert isinstance(captured_store[0], MemoryKnowledgeStore)
+
+
+# ---------------------------------------------------------------------------
+# 2. Custom store is supplied → reaches Hub.open
+# ---------------------------------------------------------------------------
+
+class TestCustomStoreReachesHub:
+    @pytest.mark.asyncio
+    async def test_supplied_store_passed_to_hub_open(self) -> None:
+        custom_store = FakeKnowledgeStore(name="custom")
+        req = _make_request(knowledge_store=custom_store)
+
+        captured_store: list[Any] = []
+
+        async def fake_hub_open(store: Any, **kwargs: Any) -> Any:
+            captured_store.append(store)
+            hub = MagicMock()
+            hub.close = AsyncMock()
+            hub.register_listener = MagicMock()
+            hub.read_wal = AsyncMock(return_value=[])
+            hub.adapter_state = MagicMock(return_value=SimpleNamespace(context_vars={}))
+            return hub
+
+        with patch("mozaiksai.core.adapters.ag2_network_runner.Hub.open", fake_hub_open):
+            await AG2NetworkRunner().run(req)
+
+        assert len(captured_store) == 1
+        assert captured_store[0] is custom_store, (
+            "The exact supplied store instance must be forwarded to Hub.open, not a copy."
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_memory_store_created_when_custom_store_supplied(self) -> None:
+        """When a custom store is supplied, MemoryKnowledgeStore() must not be constructed."""
+        custom_store = FakeKnowledgeStore(name="custom")
+        req = _make_request(knowledge_store=custom_store)
+
+        memory_store_calls: list[Any] = []
+        OriginalMemory = __import__(
+            "ag2.knowledge", fromlist=["MemoryKnowledgeStore"]
+        ).MemoryKnowledgeStore
+
+        class TrackingMemoryStore(OriginalMemory):
+            def __init__(self) -> None:
+                memory_store_calls.append(True)
+                super().__init__()
+
+        async def fake_hub_open(store: Any, **kwargs: Any) -> Any:
+            hub = MagicMock()
+            hub.close = AsyncMock()
+            hub.register_listener = MagicMock()
+            hub.read_wal = AsyncMock(return_value=[])
+            hub.adapter_state = MagicMock(return_value=SimpleNamespace(context_vars={}))
+            return hub
+
+        with (
+            patch("mozaiksai.core.adapters.ag2_network_runner.Hub.open", fake_hub_open),
+            patch(
+                "mozaiksai.core.adapters.ag2_network_runner.MemoryKnowledgeStore",
+                TrackingMemoryStore,
+            ),
+        ):
+            await AG2NetworkRunner().run(req)
+
+        assert memory_store_calls == [], (
+            "MemoryKnowledgeStore() must not be constructed when a custom store is supplied."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Isolation: two runs with distinct stores do not share memory
+# ---------------------------------------------------------------------------
+
+class TestRunIsolation:
+    def test_two_distinct_requests_have_independent_stores(self) -> None:
+        store_a = FakeKnowledgeStore(name="a")
+        store_b = FakeKnowledgeStore(name="b")
+        req_a = _make_request(knowledge_store=store_a, chat_id="chat-A")
+        req_b = _make_request(knowledge_store=store_b, chat_id="chat-B")
+
+        # Each request references its own store.
+        assert req_a.knowledge_store is store_a
+        assert req_b.knowledge_store is store_b
+        assert req_a.knowledge_store is not req_b.knowledge_store
+
+    def test_two_requests_without_store_are_independent(self) -> None:
+        """Two default requests each get their own None; MemoryKnowledgeStore is
+        created fresh inside the runner, so no shared state."""
+        req_a = _make_request()
+        req_b = _make_request()
+        assert req_a.knowledge_store is None
+        assert req_b.knowledge_store is None
+        # Neither request carries a shared pre-built store.
+
+    @pytest.mark.asyncio
+    async def test_shared_store_instance_reaches_both_runs(self) -> None:
+        """An operator may intentionally share a single durable store across runs.
+
+        This is a legitimate use case (e.g. a SQLite store shared across
+        sessions for persistent cross-run memory). The seam must support it.
+        """
+        shared_store = FakeKnowledgeStore(name="shared")
+        req_a = _make_request(knowledge_store=shared_store, chat_id="chat-A")
+        req_b = _make_request(knowledge_store=shared_store, chat_id="chat-B")
+
+        captured: list[Any] = []
+
+        async def fake_hub_open(store: Any, **kwargs: Any) -> Any:
+            captured.append(store)
+            hub = MagicMock()
+            hub.close = AsyncMock()
+            hub.register_listener = MagicMock()
+            hub.read_wal = AsyncMock(return_value=[])
+            hub.adapter_state = MagicMock(return_value=SimpleNamespace(context_vars={}))
+            return hub
+
+        with patch("mozaiksai.core.adapters.ag2_network_runner.Hub.open", fake_hub_open):
+            runner = AG2NetworkRunner()
+            await runner.run(req_a)
+            await runner.run(req_b)
+
+        assert len(captured) == 2
+        assert captured[0] is shared_store
+        assert captured[1] is shared_store
+
+
+# ---------------------------------------------------------------------------
+# 4. AG2 KnowledgeStore protocol satisfied by FakeKnowledgeStore
+# ---------------------------------------------------------------------------
+
+class TestFakeKnowledgeStoreProtocol:
+    def test_fake_store_satisfies_ag2_protocol(self) -> None:
+        """Prove FakeKnowledgeStore satisfies the AG2 KnowledgeStore Protocol
+        so tests above use a legitimate duck-typed implementation."""
+        from ag2.knowledge import KnowledgeStore
+
+        store = FakeKnowledgeStore()
+        assert isinstance(store, KnowledgeStore), (
+            "FakeKnowledgeStore must satisfy the AG2 KnowledgeStore @runtime_checkable Protocol."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. run_workflow_orchestration accepts knowledge_store kwarg
+# ---------------------------------------------------------------------------
+
+class TestOrchestrationPatternsSignature:
+    def test_run_workflow_orchestration_accepts_knowledge_store(self) -> None:
+        """Verifies the public orchestration entry point declares knowledge_store."""
+        import inspect
+
+        from mozaiksai.core.workflow.orchestration_patterns import run_workflow_orchestration
+
+        sig = inspect.signature(run_workflow_orchestration)
+        assert "knowledge_store" in sig.parameters, (
+            "run_workflow_orchestration must accept a knowledge_store parameter."
+        )
+        param = sig.parameters["knowledge_store"]
+        assert param.default is None, (
+            "knowledge_store must default to None for backward compatibility."
+        )
+
+    def test_run_ag2_network_phase_accepts_knowledge_store(self) -> None:
+        """Verifies the internal phase function accepts knowledge_store."""
+        import inspect
+
+        from mozaiksai.core.workflow.orchestration_patterns import _run_ag2_network_phase
+
+        sig = inspect.signature(_run_ag2_network_phase)
+        assert "knowledge_store" in sig.parameters
+        assert sig.parameters["knowledge_store"].default is None

--- a/tests/test_ag2_knowledge_store_seam.py
+++ b/tests/test_ag2_knowledge_store_seam.py
@@ -6,7 +6,7 @@ Verifies:
 3. The supplied store reaches Hub.open() — not a different store.
 4. Two runs with distinct store instances do not share AG2 workflow memory.
 5. A single store instance CAN be shared across runs when the caller supplies it.
-6. AG2NetworkRunnerRequest public contract is backward-compatible (no new required args).
+6. AG2NetworkRunnerRequest public contract stays compatible with existing callers (no new required args).
 7. run_workflow_orchestration accepts knowledge_store kwarg without error.
 8. The knowledge_store field is None by default on the request.
 """
@@ -106,7 +106,7 @@ class TestDefaultBehavior:
         assert req.initial_message == "hello"
 
     def test_request_constructable_without_knowledge_store(self) -> None:
-        # Proves backward compatibility — no new required arguments
+        # Proves existing callers keep working — no new required arguments
         req = AG2NetworkRunnerRequest(
             workflow_name="W",
             chat_id="c",
@@ -304,7 +304,7 @@ class TestOrchestrationPatternsSignature:
         )
         param = sig.parameters["knowledge_store"]
         assert param.default is None, (
-            "knowledge_store must default to None for backward compatibility."
+            "knowledge_store must default to None so existing callers are unaffected."
         )
 
     def test_run_ag2_network_phase_accepts_knowledge_store(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `knowledge_store: KnowledgeStore | None = None` to `AG2NetworkRunnerRequest` — the narrow, AG2-native injection point for operator-supplied stores.
- `AG2NetworkRunner.run()` uses the supplied store in `Hub.open()`; falls back to a fresh `MemoryKnowledgeStore()` when `None` (current behavior, unchanged for self-hosters and factory_app).
- Threads `knowledge_store` through `run_workflow_orchestration()` → `_run_ag2_network_phase()` so the `OrchestrationPort.extra` dict and the orchestration adapter can pass it without internal knowledge.

## Background

Two independent architecture reviews identified this as the highest fork-pressure point: any operator needing cross-session or durable AG2 workflow memory must currently fork `ag2_network_runner.py` to change the store. AG2 1.0.x already owns the `KnowledgeStore` protocol and `Hub.open(store=...)` injection point — this PR exposes it without inventing a Mozaiks-owned abstraction.

## Design: Instance, not factory

`Hub.close()` does **not** close the store — store lifecycle is caller-owned. A durable shared store (e.g. Redis with a namespace prefix) is a legitimate operator use case. Accepting an instance is the thinnest AG2-native pass-through; a factory callable would invent a Mozaiks abstraction AG2 does not need.

## Lifecycle / security contract

- One Hub per run; Hub does not own the store lifecycle.
- Two runs with distinct instances share no AG2 workflow memory.
- A shared store may be intentionally supplied across runs; namespace isolation is operator responsibility.
- Injected store has full AG2 network memory access for runs that use it — treat as trusted operator config, not generated-app artifact.

## Tests

12 new tests (`tests/test_ag2_knowledge_store_seam.py`): default MemoryKnowledgeStore behavior, supplied store reaches Hub.open, MemoryKnowledgeStore is NOT constructed when a custom store is supplied, two-run isolation, intentional shared-store case, AG2 protocol conformance, and public API signature checks.

All 74 pre-existing runner/orchestration tests remain green.

## Docs

- `docs/architecture/workflows/ag2-ownership-boundary.md`: adds AG2 KnowledgeStore Injection Seam section with lifecycle contract, security contract, and threading path.
- `docs/reviews/pre-1-0-public-architecture-roadmap.md`: created; marks Phase 2 KnowledgeStore seam as implemented, refinement routing seam as deferred.

## Test plan

- [x] `pytest tests/test_ag2_knowledge_store_seam.py` — 12/12 pass
- [x] `pytest tests/test_ag2_runner_helpers.py tests/test_ag2_network_patternbook.py tests/test_orchestration_port.py tests/test_orchestration_patterns_helpers.py tests/test_ag2_network_execution_alignment.py` — 74/74 pass
- [x] `ruff check` — clean on all touched files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)