### PR TITLE
docs: clarify MozaiksPay provider boundary

### DIFF
--- a/docs/architecture/modules-systems/managed-capability-packs.md
+++ b/docs/architecture/modules-systems/managed-capability-packs.md
@@ -224,6 +224,25 @@ That default is modular:
 The generated app should see MozaiksPay-branded API handles, not raw payment
 provider details.
 
+This default is intentional and compatible with OSS portability. OSS may contain
+the public app-facing MozaiksPay capability contract, generated facade
+expectations, request/response shapes, client scaffolding, provider selection
+configuration, and default recommendation behavior. OSS does not need to expose
+BlocUnited-only operational internals such as provider credential topology,
+payment processor adapters, fee or markup implementation, merchant operations,
+wallet and payout internals, settlement logic, or private operational tooling.
+
+A self-hosted developer must be able to select or implement another compatible
+payment provider where the canonical capability contract supports it. The
+generated app depends on the capability/facade boundary, not on BlocUnited's
+hosted money-movement implementation.
+
+For the concrete MozaiksPay app-facing provider shape, see
+[MozaiksPay Provider Contract](mozaikspay-provider-contract.md). That contract
+documents the generated client, facade actions, provider API paths, replacement
+semantics, and credential handles without describing hosted payment, payout,
+settlement, or merchant-operation internals.
+
 ## Provider Replacement
 
 If a user explicitly wants another provider, do not fork the runtime. Generate
@@ -282,5 +301,6 @@ For `managed_capability`, verify:
 
 - [AppGenerator Capability Planning](appgenerator-capability-planning.md)
 - [Module System](module-system.md)
+- [MozaiksPay Provider Contract](mozaikspay-provider-contract.md)
 - [Build Context Packs](../workflows/build-context-packs.md)
 - [Monetization Contract](../mozaiksai/monetization-contract.md)

--- a/docs/architecture/modules-systems/mozaikspay-provider-contract.md
+++ b/docs/architecture/modules-systems/mozaikspay-provider-contract.md
@@ -1,0 +1,139 @@
+# MozaiksPay Provider Contract
+
+MozaiksPay is the default managed monetization provider for generated SaaS
+applications. It is not mandatory. A compatible provider can replace the hosted
+MozaiksPay service when it satisfies the same app-facing contract.
+
+This contract describes the public boundary a canonical app depends on. It does
+not describe BlocUnited's hosted payment processor, wallet, payout, settlement,
+merchant operations, fee policy, credentials, or production authority internals.
+
+## Generated App Boundary
+
+When Factory selects the MozaiksPay capability pack, the generated app receives:
+
+- `app/services/integrations/mozaikspay_client.py`
+- `app/modules/billing_portal/`
+- billing, usage, and pricing pages
+- `app/config/subscriptions.yaml`
+- names-only deployment/env handles
+
+Pages call the app-owned `billing_portal` module. The module calls the generated
+`MozaiksPayClient`. The generated app must not call hosted product modules,
+payment-provider SDKs, wallet internals, payout internals, or settlement systems
+directly.
+
+```text
+generated page
+  -> billing_portal module action
+  -> services/integrations/mozaikspay_client.py
+  -> MozaiksPay-compatible provider API
+```
+
+## Default And Replacement Semantics
+
+Factory should prefer MozaiksPay for monetizable apps when the app needs SaaS
+subscriptions, billing portal redirects, token top-ups, usage status, or paid
+feature gates and the user has not explicitly selected another provider.
+
+Replacement is supported at the provider boundary. A self-hosted or alternative
+provider must preserve the generated app contract:
+
+- keep the `billing_portal` facade behavior compatible
+- serve the provider API paths used by `MozaiksPayClient`
+- return the documented response fields
+- avoid provider-internal identifiers in app-facing responses
+- verify payment/subscription facts before applying provider-neutral effects
+- preserve `app/config/subscriptions.yaml` as the app plan and entitlement input
+
+Replacing the provider does not imply compatibility with BlocUnited-private
+wallet, payout, settlement, merchant, or hosted billing operations.
+
+## Configuration
+
+The generated client resolves configuration from the `mozaikspay` connector when
+available, with environment variable fallback for self-hosted/local operation.
+
+Public/app-facing handles:
+
+- `MOZAIKSPAY_API_BASE`
+- `MOZAIKS_APP_URL`
+
+Secret handles:
+
+- `MOZAIKSPAY_API_KEY`
+- `MOZAIKSPAY_CLIENT_ID`
+- `MOZAIKSPAY_CLIENT_SECRET`
+
+Generated artifacts may declare these names. They must not contain raw API keys,
+client secrets, payment-provider credentials, private keys, connection strings,
+or hosted product credential topology.
+
+## Provider API Surface
+
+The machine-readable source of truth is:
+
+```text
+factory_app/build_context/mozaikspay/provider_api_contract.yaml
+```
+
+The current public endpoints consumed by generated apps are:
+
+- `GET /api/mozaikspay/v1/subscription/status`
+- `POST /api/mozaikspay/v1/billing-portal/session`
+- `POST /api/mozaikspay/v1/subscription/checkout-session`
+- `POST /api/mozaikspay/v1/tokens/top-up-session`
+
+The generated client authenticates with a MozaiksPay API key when configured, or
+with the compatibility client-credentials headers described in
+`provider_api_contract.yaml`.
+
+Runtime usage status is read from the app runtime through `MOZAIKS_APP_URL`; it
+is not a hosted-provider ledger API.
+
+## Facade Actions
+
+The generated `billing_portal` module exposes the app-facing actions:
+
+- `get_subscription_status`
+- `get_usage_status`
+- `get_token_status`
+- `list_plans`
+- `start_subscription_checkout`
+- `start_token_top_up`
+- `open_billing_portal`
+
+Read actions require `billing_portal.read`. Checkout, top-up, and billing portal
+actions require `billing_portal.manage`.
+
+## Entitlement And Fulfillment Boundary
+
+Generated apps express plans, limits, token allowances, token top-up products,
+and assignment storage in `app/config/subscriptions.yaml`.
+
+A compatible provider owns only the external verified fact source. After a
+provider verifies a checkout, subscription change, or top-up, effects must cross
+into the app/runtime through provider-neutral fulfillment and entitlement
+boundaries such as `BillingFulfillmentCommand`, `EntitlementPort`, subscription
+assignment records, and the OSS token wallet ledger.
+
+The generated app should not embed provider product IDs, provider customer IDs,
+payment processor IDs, wallet ledgers, payout ledgers, webhook handlers, or
+payment processor SDK calls.
+
+## Error Semantics
+
+Provider responses must follow the response and error shapes in
+`provider_api_contract.yaml`.
+
+Stable expectations:
+
+- authentication failures use HTTP `401`
+- authorization failures use HTTP `403`
+- invalid app requests use HTTP `400`
+- missing app/customer/subscription facts use HTTP `404`
+- application-level failures return `success: false` with safe error details
+
+Responses must not expose raw secrets, provider customer IDs, provider
+subscription IDs, payment provider IDs, session IDs, secret hashes, or internal
+credential fields.

--- a/factory_app/build_context/mozaikspay/contract.yaml
+++ b/factory_app/build_context/mozaikspay/contract.yaml
@@ -156,9 +156,10 @@ facades:
 provider_api_response_contract:
   spec_file: provider_api_contract.yaml
   description: >
-    The MozaiksPay hosted platform serves provider API endpoints consumed by generated apps.
-    Response shapes are pinned in provider_api_contract.yaml. Any change to field
-    names or types on either side is a breaking change requiring coordinated release.
+    A MozaiksPay-compatible provider serves the provider API endpoints consumed
+    by generated apps. Response shapes are pinned in provider_api_contract.yaml.
+    Any change to field names or types on either side is a breaking change
+    requiring coordinated release.
   subscription_status_required_fields:
     - success
     - found
@@ -202,39 +203,27 @@ inactive_surfaces:
   - wallet_connection
 
 # ---------------------------------------------------------------------------
-# Platform hooks — lifecycle responsibilities owned by the hosted platform,
-# not by the generated app.  Generated apps never implement these; the
-# platform reacts to well-known events and performs the corresponding work.
+# Provider lifecycle boundary — responsibilities owned by the selected
+# MozaiksPay-compatible provider, not by the generated app. Generated apps never
+# implement payment-provider provisioning, hosted billing modules, wallet
+# engines, payout engines, settlement logic, or provider credential handling.
 # ---------------------------------------------------------------------------
-platform_hooks:
-  # When a hosted app is deployed the platform reads the app bundle's
-  # app/config/subscriptions.yaml catalog, and the hosted billing module
-  # provisions Stripe products and prices for each paid plan (amount > 0).
-  # The resulting price_ids are persisted in hosted_billing.app_billing_plans
-  # keyed by app_id and the checkout flow looks them up at runtime.
-  # Plans without a price.amount field are treated as contact-sales and
-  # skipped — no Stripe price is created.
-  - id: billing_plan_provisioning
-    trigger_event: hosted.hosting.app.deployed
-    responsible_module: hosted_billing
-    responsible_action: provision_app_billing_plans
+provider_lifecycle_boundary:
+  - id: plan_catalog_mapping
+    provider_role: mozaikspay_compatible_provider
     description: >
-      On deployment the platform reads the app bundle's app/config/subscriptions.yaml
-      catalog and provisions Stripe billing products and prices for paid plans.
-      This is idempotent — existing Stripe prices are reused via lookup_key.
-      Emits hosted.billing.app_billing_plans.provisioned on success.
-      Skips silently when MozaiksPay billing is not configured or when the
-      app bundle contains no paid plans.
+      The selected provider may read the app bundle's app/config/subscriptions.yaml
+      catalog to map paid plans and top-up products to provider-owned billing
+      objects. Mapping, provisioning, idempotency, provider IDs, payment
+      processor objects, and hosted operational records remain provider-owned and
+      are not generated into the canonical app bundle.
     app_requirements:
-      # The app bundle's subscriptions.yaml plan entries may carry an optional
-      # price block.  When present, the platform provisions Stripe billing for
-      # that plan automatically.  When absent, the plan is free or requires
-      # manual pricing configuration through the platform admin UI.
       subscriptions_yaml_price_block:
         description: >
           Optional price metadata on each plan entry in app/config/subscriptions.yaml.
-          When present on a plan, the platform will provision a Stripe product
-          and price for that plan on app deployment.
+          When present on a plan, a compatible provider may use this metadata to
+          map or provision provider-owned billing objects. When absent, the plan
+          is free or requires provider/operator-side pricing configuration.
         example: |
           plans:
             - plan_id: pro
@@ -244,6 +233,6 @@ platform_hooks:
                 currency: usd
                 interval: month   # month | year
               billing:
-                lookup_key: my_app_pro_monthly   # optional; defaults to {app_id}_{plan_id}_{interval}
+                lookup_key: my_app_pro_monthly   # optional stable provider mapping key
                 allow_promotion_codes: true
               capabilities: [...]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
               - Internal Messaging: architecture/modules-systems/internal-messaging.md
               - AppGenerator Capability Planning: architecture/modules-systems/appgenerator-capability-planning.md
               - Managed Capability Packs: architecture/modules-systems/managed-capability-packs.md
+              - MozaiksPay Provider Contract: architecture/modules-systems/mozaikspay-provider-contract.md
               - Framework Capability Classification: architecture/modules-systems/framework-capability-classification.md
 
       # ── 3. AI Workflows ──────────────────────────────────────────────────────

--- a/tests/test_build_context_mozaikspay_pack.py
+++ b/tests/test_build_context_mozaikspay_pack.py
@@ -136,6 +136,44 @@ def test_mozaikspay_provider_api_contract_ships() -> None:
     assert content.get("contract_id") == "mozaikspay_provider_api"
 
 
+def test_mozaikspay_public_provider_contract_doc_ships() -> None:
+    """The public docs must explain how a compatible provider replaces MozaiksPay."""
+    doc = WORKSPACE / "docs" / "architecture" / "modules-systems" / "mozaikspay-provider-contract.md"
+    assert doc.exists(), "MozaiksPay provider replacement contract doc must ship"
+
+    text = doc.read_text(encoding="utf-8")
+    assert "MozaiksPay is the default managed monetization provider" in text
+    assert "compatible provider can replace the hosted" in text
+    assert "provider_api_contract.yaml" in text
+    assert "GET /api/mozaikspay/v1/subscription/status" in text
+    assert "POST /api/mozaikspay/v1/billing-portal/session" in text
+    assert "POST /api/mozaikspay/v1/subscription/checkout-session" in text
+    assert "POST /api/mozaikspay/v1/tokens/top-up-session" in text
+    assert "wallet, payout, settlement" in text
+
+
+def test_mozaikspay_pack_contract_avoids_hosted_implementation_topology() -> None:
+    """The OSS pack can describe provider lifecycle needs without naming App Zero internals."""
+    text = (MOZAIKSPAY / "contract.yaml").read_text(encoding="utf-8")
+
+    forbidden_hosted_details = (
+        "hosted.hosting.app.deployed",
+        "hosted_billing",
+        "provision_app_billing_plans",
+        "Stripe products",
+        "Stripe prices",
+        "price_ids",
+        "hosted.billing.app_billing_plans",
+    )
+    for detail in forbidden_hosted_details:
+        assert detail not in text
+
+    contract = _read_yaml(MOZAIKSPAY / "contract.yaml")
+    boundary = contract.get("provider_lifecycle_boundary") or []
+    assert boundary
+    assert boundary[0]["provider_role"] == "mozaikspay_compatible_provider"
+
+
 def test_mozaikspay_provider_api_contract_declares_required_response_fields() -> None:
     contract = _read_yaml(MOZAIKSPAY / "contract.yaml")
     api = _read_yaml(MOZAIKSPAY / "provider_api_contract.yaml")


### PR DESCRIPTION
## Summary

- Document the public MozaiksPay-compatible provider contract for generated apps.
- Preserve MozaiksPay as the default/recommended managed monetization provider while documenting self-host/alternate-provider replacement semantics.
- Remove App Zero hosted implementation topology from the OSS MozaiksPay pack wording and replace it with provider-compatible lifecycle language.
- Add focused contract tests for the public provider doc and hosted-topology boundary.

## Validation

- `python -m pytest -q --no-cov tests/test_build_context_mozaikspay_pack.py tests/test_mozaikspay_managed_capability_contract.py tests/test_appgenerator_capability_pack_selection.py`
- `python scripts/governance_guardrails.py --all --errors-only`
- `python -m mkdocs build --strict`
- `python -m pytest -q --no-cov tests/test_governance_guardrails.py`

## Notes

This PR does not change MozaiksPay default recommendation behavior, generated app templates, production authority, payment execution, or App Zero code.
