### PR TITLE
docs: close MozaiksPay boundary review phase

### DIFF
--- a/docs/reviews/pre-1-0-public-architecture-roadmap.md
+++ b/docs/reviews/pre-1-0-public-architecture-roadmap.md
@@ -14,14 +14,18 @@ Status: approved for this documentation pass.
 
 ## Phase 1 — Managed Capability Boundary Review
 
-Status: approved for future review.
+Status: completed.
 
-- Review MozaiksPay public integration guidance.
-- Preserve MozaiksPay as the recommended/default monetization provider where
+- MozaiksPay remains the recommended/default monetization provider where
   currently intended.
-- Confirm the split between app-facing capability contracts and hosted
-  implementation details.
-- Confirm self-hosted replacement paths for compatible payment providers.
+- The public MozaiksPay-compatible provider contract is documented in
+  `docs/architecture/modules-systems/mozaikspay-provider-contract.md`.
+- Self-hosted and alternative provider replacement paths are documented through
+  the generated app facade/client, provider API, entitlement, and fulfillment
+  boundaries.
+- Hosted payment processor, wallet, payout, settlement, merchant operation,
+  production authority, and provider credential topology details remain outside
+  the OSS pack contract.
 
 ## Phase 2 — Strategy Seams
 

--- a/factory_app/build_context/mozaikspay/provider_api_contract.yaml
+++ b/factory_app/build_context/mozaikspay/provider_api_contract.yaml
@@ -3,7 +3,9 @@ contract_id: mozaikspay_provider_api
 description: >
   Machine-readable interface spec for the MozaiksPay provider API.
   Consumed by generated SaaS apps via mozaikspay_client.py.
-  Served by the MozaiksPay hosted platform (proprietary, separate repo).
+  Served by the selected MozaiksPay-compatible provider. The hosted MozaiksPay
+  service is the default provider implementation, but self-hosted or alternative
+  providers may satisfy this same app-facing contract.
 
   This file defines ONLY the public interface — request shape, response shape,
   auth scheme, and which fields are forbidden from responses. No payment provider
@@ -14,7 +16,7 @@ auth:
   headers:
     - name: Authorization
       format: "Bearer {api_key}"
-      description: App-scoped MozaiksPay API key issued by the hosted platform (mzk_live_ or mzk_test_ prefix).
+      description: App-scoped MozaiksPay-compatible API key issued by the selected provider.
       required: true
       secret: true
   credential_prefixes:
@@ -25,12 +27,12 @@ auth:
     scheme: client_credentials
     headers:
       - name: X-MozaiksPay-Client-Id
-        description: App-scoped client ID issued by the hosted platform (mpc_ prefix).
+        description: App-scoped client ID issued by the selected provider.
         required: true
         secret: false
       - name: Authorization
         format: "Bearer {client_secret}"
-        description: App-scoped client secret issued by the hosted platform (mps_ prefix).
+        description: App-scoped client secret issued by the selected provider.
         required: true
         secret: true
     credential_prefixes:
@@ -123,8 +125,8 @@ endpoints:
     description: >
       Create a hosted subscription checkout redirect session for a paid plan.
       The caller redirects their end-user to checkout_url. No OSS runtime state
-      is mutated by this call; subscription fulfillment is driven by the hosted
-      billing webhook after the payment provider confirms the subscription.
+      is mutated by this call; subscription fulfillment is driven by the selected
+      provider after the payment provider confirms the subscription.
     request_body:
       plan_id: { type: string, required: true }
       success_url: { type: string, format: https_url, required: true }
@@ -214,19 +216,19 @@ error_handling:
   application_errors:
     SUBSCRIPTION_NOT_FOUND: "No subscription record for the given scope."
     BILLING_CUSTOMER_NOT_FOUND: "Subscription exists but billing provider customer not yet linked."
-    MOZAIKSPAY_BILLING_NOT_CONFIGURED: "Hosted platform billing provider is not configured."
+    MOZAIKSPAY_BILLING_NOT_CONFIGURED: "Selected MozaiksPay-compatible provider is not configured."
     MOZAIKSPAY_BILLING_API_ERROR: "Billing provider returned an error."
     INVALID_INPUT: "Required field missing or unsafe URL."
     PLAN_NOT_CHECKOUTABLE: "Free/default plan cannot be purchased through checkout."
     CUSTOM_PLAN_REQUIRES_SALES: "Plan requires operator setup before self-serve checkout."
     SUBSCRIPTION_ALREADY_EXISTS: "The requested billing scope already has an active paid subscription."
-    MOZAIKSPAY_PRICE_NOT_CONFIGURED: "Hosted platform has no provider price mapping for the plan."
+    MOZAIKSPAY_PRICE_NOT_CONFIGURED: "Selected provider has no price mapping for the plan."
     TOKEN_TOP_UP_PRODUCT_NOT_FOUND: "The requested token top-up product is not declared by the app."
 
 drift_guard:
   description: >
     Changes to this file must be reflected in:
-    - The hosted platform server implementation (proprietary repo, provider_api.py)
+    - The selected provider server implementation
     - The generated client template (templates/services/integrations/mozaikspay_client.py)
     - The generated billing_portal schemas (templates/modules/billing_portal/backend/schemas.py)
     If any of these diverge, generated SaaS apps will break silently at runtime.

--- a/tests/test_build_context_mozaikspay_pack.py
+++ b/tests/test_build_context_mozaikspay_pack.py
@@ -136,6 +136,17 @@ def test_mozaikspay_provider_api_contract_ships() -> None:
     assert content.get("contract_id") == "mozaikspay_provider_api"
 
 
+def test_mozaikspay_provider_api_contract_is_provider_compatible() -> None:
+    """The machine-readable contract must not imply only BlocUnited's hosted service can satisfy it."""
+    api_contract = MOZAIKSPAY / "provider_api_contract.yaml"
+    text = api_contract.read_text(encoding="utf-8")
+
+    assert "selected MozaiksPay-compatible provider" in text
+    assert "self-hosted or alternative" in text
+    assert "Served by the MozaiksPay hosted platform" not in text
+    assert "hosted billing webhook" not in text
+
+
 def test_mozaikspay_public_provider_contract_doc_ships() -> None:
     """The public docs must explain how a compatible provider replaces MozaiksPay."""
     doc = WORKSPACE / "docs" / "architecture" / "modules-systems" / "mozaikspay-provider-contract.md"


### PR DESCRIPTION
## Summary

- Verify and close Phase 1 of the public architecture roadmap after PR #232 merged.
- Clarify the machine-readable MozaiksPay provider API contract so it describes any selected MozaiksPay-compatible provider, not only BlocUnited's hosted implementation.
- Add a focused regression test that the provider API contract remains compatible with self-hosted/alternative providers.

## Verification

- MozaiksPay remains `recommendation_rank: 1`.
- Subscription monetization still selects `capability_pack: mozaikspay`.
- Generated app-facing facade/client/API contract remains intact.
- Hosted payment processor, wallet, payout, settlement, production authority, and credential topology remain outside the OSS pack contract.

## Tests

- `python -m pytest -q --no-cov tests/test_build_context_mozaikspay_pack.py tests/test_mozaikspay_managed_capability_contract.py tests/test_appgenerator_capability_pack_selection.py`
- `python -m mkdocs build --strict`
- `python scripts/governance_guardrails.py --all --errors-only`
