### PR TITLE
Add generated app functional acceptance gate

### DIFF
--- a/docs/architecture/app/generated-app-functional-acceptance.md
+++ b/docs/architecture/app/generated-app-functional-acceptance.md
@@ -1,0 +1,116 @@
+# Generated-App Functional Acceptance
+
+Mozaiks generated apps must be functionally coherent, not only schema-valid.
+The acceptance boundary is:
+
+```text
+deterministic canonical plan
+-> generated app bundle
+-> static cross-artifact validation
+-> runtime load smoke
+-> representative routes/actions/facades resolve
+```
+
+This gate is intentionally independent of App Zero and BlocUnited hosted
+services. Proprietary strategy may produce better app plans, but OSS baseline
+output and proprietary-enhanced output must pass the same canonical acceptance
+contract.
+
+## Functional Completeness Definition
+
+A generated app is functionally complete when:
+
+- `ui/route_manifest.json` routes resolve to a built-in page, registered custom
+  component, intentional redirect, or explicitly external route.
+- `SchemaPage` routes point to a matching `ui/pages/*.yaml` or `*.yml` schema.
+- Declared module actions in `modules/*/module.yaml` have an implemented module
+  handler method.
+- Page and custom UI module calls target declared `/api/modules/{module}/{action}`
+  actions.
+- Workflow YAML/JSON module-action references target declared module actions.
+- Selected managed capabilities include the generated app-facing facade files
+  and actions required by their public contract.
+- Expected generated app surfaces do not contain accidental 501,
+  `NotImplementedError`, or `*_NOT_IMPLEMENTED` placeholders.
+- The app bundle loads through `AppLoader` without startup import errors.
+
+The gate does not require real Stripe, Azure, GitHub, DNS, or BlocUnited hosted
+credentials. External provider configuration may fail clearly at runtime, but an
+internally declared app route/action/facade must not be missing.
+
+## Existing Validation Matrix
+
+| Invariant | Existing Validator | Static / Runtime | Coverage |
+| --- | --- | --- | --- |
+| Canonical path and secret boundaries | `generated_bundle_scanner.scan_generated_bundle` | Static | Existing, reused |
+| Page schema shape and module endpoint syntax | `audit_page_schemas` | Static | Existing, reused |
+| Page endpoint to module action wiring | `validate_wiring` | Static | Existing, reused in AppGenerator gate |
+| Module action handler implementation | `validate_module_implementation_contract` | Static AST | Existing, reused in AppGenerator gate |
+| Placeholder backend runtime data | `audit_module_runtime_quality` | Static AST/text | Existing, reused in AppGenerator gate |
+| Workflow event/capability integration | `validate_workflow_integration_contract` | Static | Existing, reused when AgentGenerator metadata exists |
+| App startup import/load | `AppLoader.load` via acceptance gate | Runtime smoke | Existing, reused |
+| Route component/schema resolution | `scan_functional_generated_app` | Static | Added |
+| Workflow module-action target resolution | `scan_functional_generated_app` | Static | Added |
+| Managed capability facade completeness | `scan_functional_generated_app` | Static | Added |
+| 501/not-implemented generated surfaces | `scan_functional_generated_app` | Static | Added to public facade |
+
+## Diagnostics
+
+Functional failures are structured diagnostics. Examples:
+
+- `MISSING_ROUTE_COMPONENT`
+- `MISSING_SCHEMA_PAGE`
+- `MISSING_MODULE_ACTION`
+- `MISSING_MODULE_HANDLER`
+- `CAPABILITY_FACADE_MISSING`
+- `PLACEHOLDER_IMPLEMENTATION`
+
+These diagnostics are exposed through
+`mozaiksai.core.validation.validate_generated_app_bundle(...)` and through the
+AppGenerator `functional_completeness` acceptance subgate.
+
+## Representative Archetypes
+
+Current automated coverage includes:
+
+- Basic authenticated CRUD route/action/schema coherence.
+- Monetized SaaS facade expectations for the public MozaiksPay-compatible
+  generated-app contract.
+- Workflow/agent module-action references through declarative workflow YAML.
+
+The first gate uses deterministic fixtures rather than live LLM calls. This
+tests the deterministic boundary after reasoning:
+
+```text
+captured/generated artifacts -> functional acceptance
+```
+
+## CI Meaning
+
+The functional scanner is part of normal pytest coverage through
+`tests/test_generated_app_functional_acceptance.py` and is invoked by the public
+generated-app validation facade. A failure means the Factory can produce or
+accept an app bundle whose declared app surfaces do not resolve internally.
+
+The gate is deliberately not a broad static analyzer for arbitrary Python or
+JavaScript. It validates canonical contracts and generated references where the
+framework has deterministic knowledge.
+
+## Remaining Gaps
+
+P0: none identified by this pass in the covered deterministic fixtures.
+
+P1:
+
+- Add a generated artifact fixture that exercises a full deterministic
+  AppPlan-to-materialized-app path for monetized SaaS once that fixture can be
+  run without paid LLM calls.
+- Add browser-level route rendering smoke for generated bundles if CI can run it
+  without making ordinary unit feedback slow.
+
+P2:
+
+- Expand workflow reference checks as workflow packs add more declarative target
+  shapes.
+- Add optional brownfield generated-app acceptance once existing-app discovery
+  has a stable deterministic adoption-plan fixture.

--- a/docs/architecture/app/index.md
+++ b/docs/architecture/app/index.md
@@ -10,6 +10,7 @@ app manifests, app lifecycle, or app-owned service surfaces.
 | Doc | Scope |
 | --- | --- |
 | [Generated App Lifecycle](generated-app-lifecycle-model.md) | App lifecycle states and promotion model |
+| [Generated App Functional Acceptance](generated-app-functional-acceptance.md) | Deterministic checks that generated routes, actions, workflows, facades, and runtime load are coherent |
 | [Canonical App Structure](canonical-app-structure.md) | App workspace shape for config, backend, modules, pages, root workflows, and brand |
 | [App Manifest and Platform Targets](app-manifest-and-platform-targets.md) | App manifest fields and platform target semantics |
 | [App Bundle Declaratives](app-bundle-declaratives.md) | Declarative app artifact families |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -42,6 +42,7 @@ Use this section as the web navigation layer for that architecture.
 ## App Contracts
 
 - [Generated App Lifecycle Model](app/generated-app-lifecycle-model.md)
+- [Generated App Functional Acceptance](app/generated-app-functional-acceptance.md)
 - [Canonical App Structure](app/canonical-app-structure.md)
 - [App Manifest and Platform Targets](app/app-manifest-and-platform-targets.md)
 - [App Bundle Declaratives](app/app-bundle-declaratives.md)

--- a/factory_app/workflows/AppGenerator/tools/app_validation.py
+++ b/factory_app/workflows/AppGenerator/tools/app_validation.py
@@ -2116,6 +2116,10 @@ async def run_app_bundle_acceptance_gate(
     if generated_files:
         _context_set(context_variables, "generated_files", generated_files)
 
+    from mozaiksai.core.validation.functional_generated_app import (
+        scan_functional_generated_app,
+    )
+
     from .generated_bundle_scanner import scan_generated_bundle
     from .validate_wiring import validate_wiring
 
@@ -2159,6 +2163,64 @@ async def run_app_bundle_acceptance_gate(
     wiring_result = await validate_wiring(context_variables=context_variables)
     module_implementation_result = validate_module_implementation_contract(generated_files)
     runtime_quality_result = _runtime_quality_result(generated_files)
+    functional_diagnostics = scan_functional_generated_app(
+        generated_files,
+        capability_packs=selected_capability_packs,
+    )
+    functional_errors = [item for item in functional_diagnostics if item.severity == "error"]
+    functional_result = {
+        "contract_version": "1.0",
+        "passed": not functional_errors,
+        "checks": [
+            _check_result(
+                check_id="generated_app_functional_completeness",
+                passed=not functional_errors,
+                message=(
+                    "Generated app routes, module references, capability facades, and expected handlers are functionally coherent."
+                    if not functional_errors
+                    else f"{len(functional_errors)} generated app functional completeness issue(s) found."
+                ),
+                details={
+                    "diagnostic_count": len(functional_diagnostics),
+                    "error_count": len(functional_errors),
+                    "diagnostics": [
+                        {
+                            "code": item.code,
+                            "message": item.message,
+                            "path": item.path,
+                            "severity": item.severity,
+                        }
+                        for item in functional_diagnostics
+                    ],
+                },
+            )
+        ],
+        "failed_tests": [
+            {
+                "test": item.code,
+                "path": item.path,
+                "error": item.message,
+                "fix_suggestion": (
+                    "Regenerate or repair the canonical app artifact so declared "
+                    "routes, module actions, workflow/tool references, capability "
+                    "facades, and implementation files resolve before export."
+                ),
+            }
+            for item in functional_errors
+        ],
+        "warnings": [
+            item.message for item in functional_diagnostics if item.severity == "warning"
+        ],
+        "diagnostics": [
+            {
+                "code": item.code,
+                "message": item.message,
+                "path": item.path,
+                "severity": item.severity,
+            }
+            for item in functional_diagnostics
+        ],
+    }
     workflow_integration_result = validate_workflow_integration_contract(
         generated_files,
         context_variables,
@@ -2171,6 +2233,7 @@ async def run_app_bundle_acceptance_gate(
         "module_wiring": wiring_result,
         "module_implementation": module_implementation_result,
         "module_runtime_quality": runtime_quality_result,
+        "functional_completeness": functional_result,
         "workflow_integration": workflow_integration_result,
         "app_runtime_load": app_runtime_load_result,
     }
@@ -2214,6 +2277,7 @@ async def run_app_bundle_acceptance_gate(
             _result_check(wiring_result, default_id="module_wiring", default_message="Module wiring check completed."),
             _result_check(module_implementation_result, default_id="module_implementation", default_message="Module implementation check completed."),
             _result_check(runtime_quality_result, default_id="module_runtime_quality", default_message="Module runtime quality check completed."),
+            _result_check(functional_result, default_id="functional_completeness", default_message="Functional completeness check completed."),
             _result_check(workflow_integration_result, default_id="workflow_integration", default_message="Workflow integration check completed."),
             _result_check(app_runtime_load_result, default_id="app_runtime_load", default_message="App runtime load check completed."),
         ],
@@ -2245,6 +2309,8 @@ async def run_app_bundle_acceptance_gate(
     _context_set(context_variables, "module_runtime_quality_status", "passed" if runtime_quality_result["passed"] else "blocked")
     _context_set(context_variables, "module_runtime_quality_warnings", runtime_quality_result.get("warnings") or [])
     _context_set(context_variables, "module_runtime_quality_result", runtime_quality_result)
+    _context_set(context_variables, "generated_app_functional_completeness_passed", functional_result.get("passed"))
+    _context_set(context_variables, "generated_app_functional_completeness_result", functional_result)
     _context_set(context_variables, "workflow_integration_validation_passed", workflow_integration_result.get("passed"))
     _context_set(context_variables, "workflow_integration_validation_result", workflow_integration_result)
     _context_set(context_variables, "app_runtime_load_passed", app_runtime_load_result.get("passed"))
@@ -2410,6 +2476,7 @@ async def validate_app_bundle_from_request(
     wiring_result = acceptance_result["module_wiring"]
     module_implementation_result = acceptance_result["module_implementation"]
     runtime_quality_result = acceptance_result["module_runtime_quality"]
+    functional_result = acceptance_result["functional_completeness"]
     workflow_integration_result = acceptance_result["workflow_integration"]
     app_runtime_load_result = acceptance_result["app_runtime_load"]
     workflow_integration_repair = acceptance_result.get("workflow_integration_repair")
@@ -2423,6 +2490,7 @@ async def validate_app_bundle_from_request(
         "module_wiring": wiring_result,
         "module_implementation": module_implementation_result,
         "module_runtime_quality": runtime_quality_result,
+        "functional_completeness": functional_result,
         "workflow_integration": workflow_integration_result,
         "app_runtime_load": app_runtime_load_result,
         "workflow_integration_repair": workflow_integration_repair,
@@ -2441,6 +2509,7 @@ async def validate_app_bundle_from_request(
         "wiring_validation_result": wiring_result,
         "module_implementation_validation_result": module_implementation_result,
         "module_runtime_quality_result": runtime_quality_result,
+        "generated_app_functional_completeness_result": functional_result,
         "workflow_integration_validation_result": workflow_integration_result,
         "app_runtime_load_result": app_runtime_load_result,
         "workflow_integration_repair": workflow_integration_repair,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
           - App Architecture:
               - architecture/app/index.md
               - Generated App Lifecycle: architecture/app/generated-app-lifecycle-model.md
+              - Generated App Functional Acceptance: architecture/app/generated-app-functional-acceptance.md
               - Canonical App Structure: architecture/app/canonical-app-structure.md
               - App Manifest & Platform Targets: architecture/app/app-manifest-and-platform-targets.md
               - App Bundle Declaratives: architecture/app/app-bundle-declaratives.md

--- a/mozaiksai/core/validation/__init__.py
+++ b/mozaiksai/core/validation/__init__.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from .functional_generated_app import (
+    FunctionalGeneratedAppDiagnostic,
+    scan_functional_generated_app,
+)
 from .generated_app import (
     GeneratedAppValidationDiagnostic,
     GeneratedAppValidationRequest,
@@ -8,8 +12,10 @@ from .generated_app import (
 )
 
 __all__ = [
+    "FunctionalGeneratedAppDiagnostic",
     "GeneratedAppValidationDiagnostic",
     "GeneratedAppValidationRequest",
     "GeneratedAppValidationResult",
+    "scan_functional_generated_app",
     "validate_generated_app_bundle",
 ]

--- a/mozaiksai/core/validation/functional_generated_app.py
+++ b/mozaiksai/core/validation/functional_generated_app.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+import yaml
+
+
+@dataclass(frozen=True)
+class FunctionalGeneratedAppDiagnostic:
+    code: str
+    message: str
+    path: str | None = None
+    severity: Literal["error", "warning"] = "error"
+
+
+_MODULE_ENDPOINT_RE = re.compile(r"^/api/modules/([^/?#]+)/([^/?#]+)$")
+_MODULE_ENDPOINT_ANYWHERE_RE = re.compile(r"/api/modules/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)")
+_MODULE_ACTION_CALL_RE = re.compile(
+    r"\bmoduleAction\s*\(\s*['\"](?P<module>[A-Za-z0-9_.-]+)['\"]\s*,\s*['\"](?P<action>[A-Za-z0-9_.-]+)['\"]"
+)
+_REGISTER_COMPONENT_RE = re.compile(
+    r"\bregisterComponent\s*\(\s*['\"](?P<name>[A-Za-z_$][\w$.-]*)['\"]"
+)
+_PLACEHOLDER_RE = re.compile(
+    r"\bNotImplementedError\b|\b[A-Z0-9_]*NOT_IMPLEMENTED[A-Z0-9_]*\b|\bstatus_code\s*=\s*501\b|\bHTTP_501_",
+    re.IGNORECASE,
+)
+
+_BUILT_IN_ROUTE_COMPONENTS = {
+    "SchemaPage",
+    "DashboardPortalPage",
+    "AdminPortal",
+    "ProfilePage",
+}
+
+
+def _safe_path(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return ""
+    normalized = raw.replace("\\", "/").strip()
+    try:
+        path = PurePosixPath(normalized)
+    except Exception:
+        return ""
+    if path.is_absolute() or any(part == ".." for part in path.parts):
+        return ""
+    return str(path)
+
+
+def _safe_files(files: dict[str, str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw_path, content in (files or {}).items():
+        path = _safe_path(raw_path)
+        if path:
+            out[path] = str(content)
+    return out
+
+
+def _diag(
+    code: str,
+    message: str,
+    *,
+    path: str | None = None,
+    severity: Literal["error", "warning"] = "error",
+) -> FunctionalGeneratedAppDiagnostic:
+    return FunctionalGeneratedAppDiagnostic(code=code, message=message, path=path, severity=severity)
+
+
+def _load_json(path: str, content: str, diagnostics: list[FunctionalGeneratedAppDiagnostic]) -> Any:
+    try:
+        return json.loads(content)
+    except Exception as exc:
+        diagnostics.append(_diag("INVALID_JSON", f"{path} must be valid JSON: {exc}", path=path))
+        return None
+
+
+def _load_yaml(path: str, content: str, diagnostics: list[FunctionalGeneratedAppDiagnostic]) -> Any:
+    try:
+        return yaml.safe_load(content) or {}
+    except Exception as exc:
+        diagnostics.append(_diag("INVALID_YAML", f"{path} must be valid YAML: {exc}", path=path))
+        return None
+
+
+def _module_action_registry(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> dict[str, dict[str, Any]]:
+    actions: dict[str, dict[str, Any]] = {}
+    for path, content in sorted(files.items()):
+        parts = PurePosixPath(path).parts
+        if len(parts) != 3 or parts[0] != "modules" or parts[2] != "module.yaml":
+            continue
+        parsed = _load_yaml(path, content, diagnostics)
+        if not isinstance(parsed, dict):
+            continue
+        module_block = parsed.get("module") if isinstance(parsed.get("module"), dict) else parsed
+        module_id = str(module_block.get("id") if isinstance(module_block, dict) else "").strip() or parts[1]
+        handler = str(module_block.get("handler") if isinstance(module_block, dict) else "").strip()
+        if not module_id:
+            diagnostics.append(_diag("MISSING_MODULE_ID", f"{path} must declare module.id.", path=path))
+            continue
+        for index, action in enumerate(parsed.get("actions") or []):
+            if not isinstance(action, dict):
+                diagnostics.append(
+                    _diag("INVALID_MODULE_ACTION", f"{path} actions[{index}] must be an object.", path=path)
+                )
+                continue
+            action_id = str(action.get("id") or "").strip()
+            if not action_id:
+                diagnostics.append(
+                    _diag("MISSING_MODULE_ACTION_ID", f"{path} actions[{index}] must declare id.", path=path)
+                )
+                continue
+            actions[f"{module_id}/{action_id}"] = {
+                "module_id": module_id,
+                "action_id": action_id,
+                "handler": handler,
+                "handler_method": str(action.get("handler_method") or "").strip(),
+                "module_yaml": path,
+            }
+    return actions
+
+
+def _validate_action_handlers(
+    files: dict[str, str],
+    actions: dict[str, dict[str, Any]],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> None:
+    parsed_handlers: dict[str, ast.Module] = {}
+
+    def parse_backend(path: str) -> ast.Module | None:
+        tree = parsed_handlers.get(path)
+        if tree is not None:
+            return tree
+        if path not in files:
+            return None
+        try:
+            tree = ast.parse(files[path])
+            parsed_handlers[path] = tree
+            return tree
+        except SyntaxError as exc:
+            diagnostics.append(_diag("INVALID_PYTHON", f"{path} must parse as Python: {exc}", path=path))
+            return None
+
+    def class_methods(module_id: str, class_name: str, *, seen: set[str] | None = None) -> set[str] | None:
+        seen = seen or set()
+        if class_name in seen:
+            return set()
+        seen.add(class_name)
+        methods: set[str] = set()
+        class_node: ast.ClassDef | None = None
+        for path in sorted(files):
+            if not path.startswith(f"modules/{module_id}/backend/") or not path.endswith(".py"):
+                continue
+            tree = parse_backend(path)
+            if tree is None:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef) and node.name == class_name:
+                    class_node = node
+                    break
+            if class_node is not None:
+                break
+        if class_node is None:
+            return None
+        methods.update(
+            node.name
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+        for base in class_node.bases:
+            base_name = ""
+            if isinstance(base, ast.Name):
+                base_name = base.id
+            elif isinstance(base, ast.Attribute):
+                base_name = base.attr
+            if not base_name:
+                continue
+            inherited = class_methods(module_id, base_name, seen=seen)
+            if inherited:
+                methods.update(inherited)
+        return methods
+
+    for action in actions.values():
+        handler = action["handler"]
+        module_id = action["module_id"]
+        action_id = action["action_id"]
+        handler_method = action["handler_method"]
+        module_yaml = action["module_yaml"]
+        if not handler or ":" not in handler:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_HANDLER",
+                    f"{module_yaml} action {action_id!r} cannot resolve because module.handler is missing or invalid.",
+                    path=module_yaml,
+                )
+            )
+            continue
+        if not handler_method:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_HANDLER_METHOD",
+                    f"{module_yaml} action {action_id!r} must declare handler_method.",
+                    path=module_yaml,
+                )
+            )
+            continue
+        handler_module, class_name = [part.strip() for part in handler.split(":", 1)]
+        handler_path = f"modules/{module_id}/{handler_module.replace('.', '/')}.py"
+        if handler_path not in files:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_HANDLER",
+                    f"{module_yaml} action {action_id!r} declares handler {handler!r}, but {handler_path} is missing.",
+                    path=handler_path,
+                )
+            )
+            continue
+        methods = class_methods(module_id, class_name)
+        if methods is None:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_HANDLER",
+                    f"{handler_path} does not define handler class {class_name!r}.",
+                    path=handler_path,
+                )
+            )
+            continue
+        if handler_method not in methods:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_ACTION",
+                    (
+                        f"{module_yaml} action {action_id!r} declares handler_method "
+                        f"{handler_method!r}, but {handler_path} class {class_name!r} does not implement it."
+                    ),
+                    path=handler_path,
+                )
+            )
+
+
+def _route_manifest_pages(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> list[dict[str, Any]]:
+    content = files.get("ui/route_manifest.json")
+    if content is None:
+        return []
+    parsed = _load_json("ui/route_manifest.json", content, diagnostics)
+    if not isinstance(parsed, dict):
+        return []
+    pages = parsed.get("pages")
+    if not isinstance(pages, list):
+        diagnostics.append(
+            _diag("INVALID_ROUTE_MANIFEST", "ui/route_manifest.json pages must be a list.", path="ui/route_manifest.json")
+        )
+        return []
+    return [page for page in pages if isinstance(page, dict)]
+
+
+def _page_schema_index(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> set[str]:
+    schemas: set[str] = set()
+    for path, content in sorted(files.items()):
+        pure = PurePosixPath(path)
+        if len(pure.parts) < 3 or pure.parts[:2] != ("ui", "pages"):
+            continue
+        if pure.suffix.lower() not in {".yaml", ".yml", ".json"}:
+            continue
+        if "custom" in pure.parts:
+            continue
+        schemas.add(pure.stem)
+        parsed = _load_yaml(path, content, diagnostics) if pure.suffix.lower() in {".yaml", ".yml"} else _load_json(path, content, diagnostics)
+        if isinstance(parsed, dict):
+            for key in ("id", "name", "page_id", "pageId"):
+                value = str(parsed.get(key) or "").strip()
+                if value:
+                    schemas.add(value)
+                    schemas.add(value.lower().replace(" ", "_").replace("-", "_"))
+    return schemas
+
+
+def _registered_components(files: dict[str, str]) -> set[str]:
+    registered: set[str] = set()
+    for path, content in files.items():
+        if path == "ui/index.js" or path.endswith("/index.js") or path.endswith("/index.jsx"):
+            registered.update(match.group("name") for match in _REGISTER_COMPONENT_RE.finditer(content))
+    return registered
+
+
+def _validate_routes(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> None:
+    pages = _route_manifest_pages(files, diagnostics)
+    if not pages:
+        return
+    schemas = _page_schema_index(files, diagnostics)
+    registered = _registered_components(files)
+    custom_files = {
+        PurePosixPath(path).stem
+        for path in files
+        if path.startswith("ui/pages/custom/") and PurePosixPath(path).suffix.lower() in {".js", ".jsx", ".ts", ".tsx"}
+    }
+    for index, page in enumerate(pages):
+        path = str(page.get("path") or page.get("route") or "").strip()
+        component = str(page.get("component") or "").strip()
+        route_label = f"ui/route_manifest.json pages[{index}]"
+        if not path or not path.startswith("/"):
+            diagnostics.append(
+                _diag("INVALID_ROUTE", f"{route_label} must declare an app-relative path.", path="ui/route_manifest.json")
+            )
+        if not component:
+            diagnostics.append(
+                _diag("MISSING_ROUTE_COMPONENT", f"{route_label} path {path!r} must declare component.", path="ui/route_manifest.json")
+            )
+            continue
+        if component == "SchemaPage":
+            schema = str(page.get("schema") or page.get("page") or page.get("name") or "").strip()
+            if not schema:
+                diagnostics.append(
+                    _diag(
+                        "MISSING_SCHEMA_PAGE",
+                        f"{route_label} path {path!r} uses SchemaPage but does not declare schema.",
+                        path="ui/route_manifest.json",
+                    )
+                )
+                continue
+            normalized = schema.lower().replace(" ", "_").replace("-", "_")
+            if schema not in schemas and normalized not in schemas:
+                diagnostics.append(
+                    _diag(
+                        "MISSING_SCHEMA_PAGE",
+                        f"{route_label} path {path!r} uses SchemaPage schema {schema!r}, but no matching ui/pages schema file exists.",
+                        path="ui/route_manifest.json",
+                    )
+                )
+            continue
+        if component in _BUILT_IN_ROUTE_COMPONENTS:
+            continue
+        if component not in registered:
+            diagnostics.append(
+                _diag(
+                    "MISSING_ROUTE_COMPONENT",
+                    f"{route_label} path {path!r} references component {component!r}, but ui/index.js does not register it.",
+                    path="ui/route_manifest.json",
+                )
+            )
+        elif component not in custom_files and not any(
+            re.search(rf"\b{re.escape(component)}\b", content)
+            for route_path, content in files.items()
+            if route_path == "ui/index.js" or route_path.endswith("/index.js") or route_path.endswith("/index.jsx")
+        ):
+            diagnostics.append(
+                _diag(
+                    "MISSING_ROUTE_COMPONENT",
+                    f"{route_label} path {path!r} registers component {component!r}, but no generated component source is evident.",
+                    path="ui/route_manifest.json",
+                )
+            )
+
+
+def _walk_values(value: Any) -> list[Any]:
+    out: list[Any] = []
+    if isinstance(value, dict):
+        for child in value.values():
+            out.extend(_walk_values(child))
+    elif isinstance(value, list):
+        for child in value:
+            out.extend(_walk_values(child))
+    else:
+        out.append(value)
+    return out
+
+
+def _walk_dicts(value: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        out.append(value)
+        for child in value.values():
+            out.extend(_walk_dicts(child))
+    elif isinstance(value, list):
+        for child in value:
+            out.extend(_walk_dicts(child))
+    return out
+
+
+def _collect_module_refs(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> list[tuple[str, str, str, str]]:
+    refs: list[tuple[str, str, str, str]] = []
+    for path, content in sorted(files.items()):
+        pure = PurePosixPath(path)
+        if pure.suffix.lower() in {".yaml", ".yml", ".json"}:
+            if path.endswith("module.yaml"):
+                continue
+            parsed = _load_yaml(path, content, diagnostics) if pure.suffix.lower() in {".yaml", ".yml"} else _load_json(path, content, diagnostics)
+            if parsed is None:
+                continue
+            for item in _walk_dicts(parsed):
+                module_id = str(item.get("module_id") or item.get("module") or "").strip()
+                action_id = str(item.get("action_id") or item.get("action") or "").strip()
+                if module_id and action_id:
+                    refs.append((path, module_id, action_id, "module/action reference"))
+            for value in _walk_values(parsed):
+                if not isinstance(value, str):
+                    continue
+                parsed_url = urlsplit(value.strip())
+                if parsed_url.query or parsed_url.fragment:
+                    if value.strip().startswith("/api/modules/"):
+                        diagnostics.append(
+                            _diag(
+                                "INVALID_MODULE_ENDPOINT",
+                                f"{path} references module endpoint {value!r} with query string or fragment.",
+                                path=path,
+                            )
+                        )
+                    continue
+                match = _MODULE_ENDPOINT_RE.match(parsed_url.path)
+                if match:
+                    refs.append((path, match.group(1), match.group(2), value.strip()))
+            continue
+        if pure.suffix.lower() in {".js", ".jsx", ".ts", ".tsx"}:
+            for match in _MODULE_ACTION_CALL_RE.finditer(content):
+                refs.append((path, match.group("module"), match.group("action"), "moduleAction(...)"))
+            for match in _MODULE_ENDPOINT_ANYWHERE_RE.finditer(content):
+                refs.append((path, match.group(1), match.group(2), match.group(0)))
+    return refs
+
+
+def _validate_module_refs(
+    actions: dict[str, dict[str, Any]],
+    refs: list[tuple[str, str, str, str]],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> None:
+    for path, module_id, action_id, source in refs:
+        key = f"{module_id}/{action_id}"
+        if key not in actions:
+            diagnostics.append(
+                _diag(
+                    "MISSING_MODULE_ACTION",
+                    f"{path} references {source!r}, but module action {key!r} is not declared.",
+                    path=path,
+                )
+            )
+
+
+def _selected_capability_ids(capability_packs: list[dict[str, Any]]) -> set[str]:
+    ids: set[str] = set()
+    for pack in capability_packs or []:
+        if not isinstance(pack, dict):
+            continue
+        for key in ("id", "capability_pack_id", "pack_id", "capability_id", "module_id"):
+            value = str(pack.get(key) or "").strip()
+            if value:
+                ids.add(value)
+    return ids
+
+
+def _validate_mozaikspay_facade(
+    files: dict[str, str],
+    actions: dict[str, dict[str, Any]],
+    capability_packs: list[dict[str, Any]],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> None:
+    selected = _selected_capability_ids(capability_packs)
+    if "mozaikspay" not in selected:
+        return
+    required_files = {
+        "services/integrations/mozaikspay_client.py": "generated MozaiksPay-compatible client",
+        "modules/billing_portal/module.yaml": "app-owned billing_portal facade module",
+    }
+    for path, label in required_files.items():
+        if path not in files:
+            diagnostics.append(
+                _diag(
+                    "CAPABILITY_FACADE_MISSING",
+                    f"mozaikspay capability requires {label} at {path}.",
+                    path=path,
+                )
+            )
+    for action_id in ("list_plans", "get_subscription_status", "open_billing_portal"):
+        if f"billing_portal/{action_id}" not in actions:
+            diagnostics.append(
+                _diag(
+                    "CAPABILITY_FACADE_MISSING",
+                    f"mozaikspay capability requires billing_portal action {action_id!r}.",
+                    path="modules/billing_portal/module.yaml",
+                )
+            )
+
+
+def _validate_placeholders(
+    files: dict[str, str],
+    diagnostics: list[FunctionalGeneratedAppDiagnostic],
+) -> None:
+    for path, content in sorted(files.items()):
+        pure = PurePosixPath(path)
+        if pure.suffix.lower() not in {".py", ".js", ".jsx", ".ts", ".tsx", ".yaml", ".yml"}:
+            continue
+        if not (
+            path.startswith("modules/")
+            or path.startswith("services/")
+            or path.startswith("ui/pages/")
+            or path.startswith("workflows/")
+        ):
+            continue
+        match = _PLACEHOLDER_RE.search(content)
+        if match:
+            diagnostics.append(
+                _diag(
+                    "PLACEHOLDER_IMPLEMENTATION",
+                    f"{path} contains placeholder/not-implemented marker {match.group(0)!r}.",
+                    path=path,
+                )
+            )
+
+
+def scan_functional_generated_app(
+    files: dict[str, str],
+    *,
+    capability_packs: list[dict[str, Any]] | None = None,
+) -> list[FunctionalGeneratedAppDiagnostic]:
+    """Validate cross-artifact functional coherence for a canonical app bundle.
+
+    This intentionally stays deterministic and contract-driven. It checks
+    canonical manifests and generated source references, but does not attempt to
+    understand arbitrary Python or JavaScript control flow.
+    """
+
+    safe_files = _safe_files(files)
+    diagnostics: list[FunctionalGeneratedAppDiagnostic] = []
+    actions = _module_action_registry(safe_files, diagnostics)
+    _validate_action_handlers(safe_files, actions, diagnostics)
+    _validate_routes(safe_files, diagnostics)
+    refs = _collect_module_refs(safe_files, diagnostics)
+    _validate_module_refs(actions, refs, diagnostics)
+    _validate_mozaikspay_facade(safe_files, actions, capability_packs or [], diagnostics)
+    _validate_placeholders(safe_files, diagnostics)
+    return diagnostics
+
+
+__all__ = [
+    "FunctionalGeneratedAppDiagnostic",
+    "scan_functional_generated_app",
+]

--- a/mozaiksai/core/validation/generated_app.py
+++ b/mozaiksai/core/validation/generated_app.py
@@ -112,6 +112,9 @@ def validate_generated_app_bundle(
     from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
         scan_generated_bundle,
     )
+    from mozaiksai.core.validation.functional_generated_app import (
+        scan_functional_generated_app,
+    )
 
     scanner_errors = scan_generated_bundle(
         request.files,
@@ -138,6 +141,19 @@ def validate_generated_app_bundle(
     )
 
     diagnostics.extend(_validate_build_task_dependencies(list(request.build_tasks)))
+
+    diagnostics.extend(
+        GeneratedAppValidationDiagnostic(
+            code=diagnostic.code,
+            message=diagnostic.message,
+            path=diagnostic.path,
+            severity=diagnostic.severity,
+        )
+        for diagnostic in scan_functional_generated_app(
+            request.files,
+            capability_packs=list(request.capability_packs),
+        )
+    )
 
     return GeneratedAppValidationResult(
         passed=not any(item.severity == "error" for item in diagnostics),

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from factory_app.workflows.AppGenerator.tools.app_validation import (
+    run_app_bundle_acceptance_gate,
+)
+from mozaiksai.core.validation import (
+    GeneratedAppValidationRequest,
+    scan_functional_generated_app,
+    validate_generated_app_bundle,
+)
+
+
+def _basic_crud_files() -> dict[str, str]:
+    return {
+        "app.json": json.dumps(
+            {
+                "appId": "support-operations",
+                "appName": "Support Operations",
+                "version": "1.0.0",
+                "startup": {"landing_spot": "/orders"},
+            }
+        ),
+        "config/ai.json": json.dumps({"chat": {"chat_startup_mode": "ask"}}),
+        "config/shell.json": json.dumps({"navigation": {"autoFromPages": True}}),
+        "ui/route_manifest.json": json.dumps(
+            {
+                "pages": [
+                    {
+                        "path": "/orders",
+                        "component": "SchemaPage",
+                        "label": "Orders",
+                        "schema": "orders",
+                    }
+                ]
+            }
+        ),
+        "ui/pages/orders.yaml": """
+name: orders
+route: /orders
+title: Orders
+sections:
+  - id: orders-list
+    type: record_list
+    config:
+      api_endpoint: /api/modules/orders/list_orders
+  - id: create-order
+    type: form
+    config:
+      submit_action:
+        api_endpoint: /api/modules/orders/create_order
+""",
+        "data/contract.json": json.dumps(
+            {
+                "version": "1",
+                "app_id": "support-operations",
+                "surfaces": [
+                    {
+                        "surface_id": "orders",
+                        "surface_kind": "module",
+                        "collections": [{"name": "orders"}],
+                    }
+                ],
+            }
+        ),
+        "security/secrets.yaml": "version: 1\nsecrets: []\n",
+        "modules/orders/module.yaml": """
+schema_version: mozaiks.module.v1
+module:
+  id: orders
+  display_name: Orders
+  version: 1.0.0
+  handler: backend.handler:OrdersModule
+actions:
+  - id: list_orders
+    description: List orders.
+    handler_method: list_orders
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+  - id: create_order
+    description: Create an order.
+    handler_method: create_order
+    input_schema:
+      type: object
+      required: [customer_name]
+      properties:
+        customer_name: {type: string}
+    output_schema: {type: object}
+""",
+        "modules/orders/backend/__init__.py": "",
+        "modules/orders/backend/handler.py": """
+from .service import OrdersService
+
+
+class OrdersModule:
+    def __init__(self):
+        self.service = OrdersService()
+
+    async def list_orders(self, ctx, **params):
+        return await self.service.list_orders(ctx, **params)
+
+    async def create_order(self, ctx, **params):
+        return await self.service.create_order(ctx, **params)
+""",
+        "modules/orders/backend/service.py": """
+class OrdersService:
+    async def list_orders(self, ctx, **params):
+        return {"orders": []}
+
+    async def create_order(self, ctx, **params):
+        return {"order": {"customer_name": params.get("customer_name")}}
+""",
+    }
+
+
+def _diagnostic_codes(files: dict[str, str], *, capability_packs: list[dict] | None = None) -> set[str]:
+    return {item.code for item in scan_functional_generated_app(files, capability_packs=capability_packs)}
+
+
+def test_functional_scanner_accepts_basic_authenticated_crud_bundle() -> None:
+    assert scan_functional_generated_app(_basic_crud_files()) == []
+
+
+def test_public_generated_app_validation_runs_functional_completeness() -> None:
+    files = _basic_crud_files()
+    files["ui/route_manifest.json"] = json.dumps(
+        {"pages": [{"path": "/missing", "component": "MissingPage"}]}
+    )
+
+    result = validate_generated_app_bundle(GeneratedAppValidationRequest(files=files))
+
+    assert result.passed is False
+    assert any(item.code == "MISSING_ROUTE_COMPONENT" for item in result.diagnostics)
+
+
+def test_schema_route_requires_matching_declarative_page_schema() -> None:
+    files = _basic_crud_files()
+    files["ui/route_manifest.json"] = json.dumps(
+        {"pages": [{"path": "/orders", "component": "SchemaPage", "schema": "missing"}]}
+    )
+
+    assert "MISSING_SCHEMA_PAGE" in _diagnostic_codes(files)
+
+
+def test_page_module_endpoint_must_resolve_to_declared_action() -> None:
+    files = _basic_crud_files()
+    files["ui/pages/orders.yaml"] = files["ui/pages/orders.yaml"].replace(
+        "/api/modules/orders/create_order",
+        "/api/modules/orders/archive_order",
+    )
+
+    assert "MISSING_MODULE_ACTION" in _diagnostic_codes(files)
+
+
+def test_declared_module_action_requires_implemented_handler_method() -> None:
+    files = _basic_crud_files()
+    files["modules/orders/module.yaml"] = files["modules/orders/module.yaml"].replace(
+        "handler_method: create_order",
+        "handler_method: archive_order",
+    )
+
+    assert "MISSING_MODULE_ACTION" in _diagnostic_codes(files)
+
+
+def test_workflow_module_action_reference_must_resolve() -> None:
+    files = _basic_crud_files()
+    files["workflows/OrderWorkflow/tools.yaml"] = """
+tools:
+  - id: archive
+    module_id: orders
+    action_id: archive_order
+"""
+
+    assert "MISSING_MODULE_ACTION" in _diagnostic_codes(files)
+
+
+def test_placeholder_implementation_is_blocking() -> None:
+    files = _basic_crud_files()
+    files["modules/orders/backend/service.py"] += """
+
+async def legacy_placeholder():
+    raise NotImplementedError("not ready")
+"""
+
+    assert "PLACEHOLDER_IMPLEMENTATION" in _diagnostic_codes(files)
+
+
+def test_mozaikspay_selected_capability_requires_public_facade_files() -> None:
+    files = _basic_crud_files()
+
+    codes = _diagnostic_codes(files, capability_packs=[{"id": "mozaikspay"}])
+
+    assert "CAPABILITY_FACADE_MISSING" in codes
+
+
+def test_mozaikspay_facade_supports_inherited_base_handler_methods() -> None:
+    files = _basic_crud_files()
+    files.update(
+        {
+            "services/integrations/mozaikspay_client.py": "class MozaiksPayClient: pass\n",
+            "modules/billing_portal/module.yaml": """
+schema_version: mozaiks.module.v1
+module:
+  id: billing_portal
+  display_name: Billing Portal
+  version: 1.0.0
+  handler: backend.handler:BillingPortalHandler
+actions:
+  - id: list_plans
+    description: List plans.
+    handler_method: list_plans
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+  - id: get_subscription_status
+    description: Get subscription status.
+    handler_method: get_subscription_status
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+  - id: open_billing_portal
+    description: Open billing portal.
+    handler_method: open_billing_portal
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+""",
+            "modules/billing_portal/backend/__init__.py": "",
+            "modules/billing_portal/backend/base_handler.py": """
+class BillingPortalBaseHandler:
+    async def list_plans(self, ctx, **params):
+        return {"plans": []}
+
+    async def get_subscription_status(self, ctx, **params):
+        return {"found": False}
+
+    async def open_billing_portal(self, ctx, **params):
+        return {"portal_url": None}
+""",
+            "modules/billing_portal/backend/handler.py": """
+from .base_handler import BillingPortalBaseHandler
+
+
+class BillingPortalHandler(BillingPortalBaseHandler):
+    pass
+""",
+        }
+    )
+
+    assert scan_functional_generated_app(files, capability_packs=[{"id": "mozaikspay"}]) == []
+
+
+@pytest.mark.asyncio
+async def test_app_generator_acceptance_gate_includes_functional_completeness() -> None:
+    result = await run_app_bundle_acceptance_gate(files=_basic_crud_files())
+
+    assert result["passed"] is True
+    assert result["functional_completeness"]["passed"] is True
+    assert "functional_completeness" in result["validation_evidence"]["completed"]


### PR DESCRIPTION
## Summary
- add a public deterministic functional generated-app scanner
- wire functional completeness into validate_generated_app_bundle and AppGenerator acceptance
- add regression tests for route/component/schema, module action, workflow action, MozaiksPay facade, and placeholder failures
- document the functional completeness definition, coverage matrix, diagnostics, CI meaning, and remaining gaps

## Validation
- python -m ruff check mozaiksai\\core\\validation\\functional_generated_app.py mozaiksai\\core\\validation\\generated_app.py mozaiksai\\core\\validation\\__init__.py factory_app\\workflows\\AppGenerator\\tools\\app_validation.py tests\\test_generated_app_functional_acceptance.py
- python -m py_compile mozaiksai\\core\\validation\\functional_generated_app.py mozaiksai\\core\\validation\\generated_app.py factory_app\\workflows\\AppGenerator\\tools\\app_validation.py tests\\test_generated_app_functional_acceptance.py
- python -m pytest -q --no-cov tests\\test_generated_app_functional_acceptance.py tests\\test_generated_app_validation_public_api.py
- python -m pytest -q --no-cov tests\\test_generated_app_functional_acceptance.py tests\\test_generated_app_validation_public_api.py tests\\test_offline_generated_build_acceptance.py tests\\test_generated_saas_subscription_runtime_acceptance.py tests\\test_generated_bundle_scanner.py tests\\test_generated_bundle_scanner_helpers.py tests\\test_generated_bundle_scanner_scan_helpers.py tests\\test_appgenerator_validate_wiring.py tests\\test_appgenerator_component_drift_guard.py tests\\test_appgenerator_managed_capability_smoke.py tests\\test_build_context_mozaikspay_pack.py tests\\test_workflow_declarative_contracts.py tests\\test_factory_workflow_integration_contracts.py tests\\test_factory_workflow_context_contracts.py

## Full-suite note
- python -m pytest -q --no-cov tests: 12259 passed, 77 skipped, 1 failed
- Remaining failure: tests/test_ui_surface_taxonomy.py::test_primitive_schema_catalog_is_generated reports primitive_schemas.json is out of date. This appears unrelated to this acceptance-gate change; no working tree files were modified by the failed check.
