### PR TITLE
Add generated app runtime acceptance smoke

### DIFF
--- a/docs/architecture/app/generated-app-functional-acceptance.md
+++ b/docs/architecture/app/generated-app-functional-acceptance.md
@@ -18,6 +18,20 @@ contract.
 
 ## Functional Completeness Definition
 
+Generated-app acceptance is tracked in three levels:
+
+- **Level 1 — Structural:** files, schemas, contracts, and cross-artifact
+  references are valid.
+- **Level 2 — Functional:** the app loads through the runtime, declared
+  routes/actions/workflows/facades resolve, and expected surfaces do not return
+  accidental 404, 501, missing-action, or placeholder responses.
+- **Level 3 — User Journey:** representative multi-step user journeys work
+  end to end through the UI and backend.
+
+Normal OSS CI should enforce at least Level 2 for representative deterministic
+generated archetypes. Level 3 coverage should grow through golden journeys, but
+Mozaiks should not claim universal Level 3 coverage until tests prove it.
+
 A generated app is functionally complete when:
 
 - `ui/route_manifest.json` routes resolve to a built-in page, registered custom
@@ -53,6 +67,7 @@ internally declared app route/action/facade must not be missing.
 | Workflow module-action target resolution | `scan_functional_generated_app` | Static | Added |
 | Managed capability facade completeness | `scan_functional_generated_app` | Static | Added |
 | 501/not-implemented generated surfaces | `scan_functional_generated_app` | Static | Added to public facade |
+| Generated app host boot and declared HTTP page/module surfaces | Platform `TestClient` over deterministic CRUD bundle | Runtime / HTTP | Added |
 
 ## Diagnostics
 
@@ -74,6 +89,8 @@ AppGenerator `functional_completeness` acceptance subgate.
 Current automated coverage includes:
 
 - Basic authenticated CRUD route/action/schema coherence.
+- Basic CRUD app runtime boot through the platform host plus declared
+  `/api/pages/*` and `/api/modules/*` HTTP surfaces.
 - Monetized SaaS facade expectations for the public MozaiksPay-compatible
   generated-app contract.
 - Workflow/agent module-action references through declarative workflow YAML.
@@ -105,6 +122,8 @@ P1:
 - Add a generated artifact fixture that exercises a full deterministic
   AppPlan-to-materialized-app path for monetized SaaS once that fixture can be
   run without paid LLM calls.
+- Add HTTP/runtime acceptance for monetized SaaS and workflow/agent archetypes
+  after deterministic no-network fixtures exist for those app shapes.
 - Add browser-level route rendering smoke for generated bundles if CI can run it
   without making ordinary unit feedback slow.
 

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
 
 from factory_app.workflows.AppGenerator.tools.app_validation import (
     run_app_bundle_acceptance_gate,
 )
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
 from mozaiksai.core.validation import (
     GeneratedAppValidationRequest,
     scan_functional_generated_app,
@@ -118,6 +121,21 @@ class OrdersService:
 
 def _diagnostic_codes(files: dict[str, str], *, capability_packs: list[dict] | None = None) -> set[str]:
     return {item.code for item in scan_functional_generated_app(files, capability_packs=capability_packs)}
+
+
+def _materialize_bundle(root: Path, files: dict[str, str]) -> None:
+    for relative_path, content in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _assert_not_missing_or_placeholder(response, *, surface: str) -> None:
+    body = response.text.lower()
+    assert response.status_code != 404, f"DECLARED_SURFACE_404 surface={surface} body={response.text}"
+    assert response.status_code != 501, f"DECLARED_SURFACE_501 surface={surface} body={response.text}"
+    assert "not implemented" not in body, f"DECLARED_SURFACE_PLACEHOLDER surface={surface} body={response.text}"
+    assert "not_implemented" not in body, f"DECLARED_SURFACE_PLACEHOLDER surface={surface} body={response.text}"
 
 
 def test_functional_scanner_accepts_basic_authenticated_crud_bundle() -> None:
@@ -257,3 +275,44 @@ async def test_app_generator_acceptance_gate_includes_functional_completeness() 
     assert result["passed"] is True
     assert result["functional_completeness"]["passed"] is True
     assert "functional_completeness" in result["validation_evidence"]["completed"]
+
+
+def test_generated_crud_bundle_boots_and_serves_declared_http_surfaces(tmp_path, monkeypatch) -> None:
+    app_root = tmp_path / "app"
+    _materialize_bundle(app_root, _basic_crud_files())
+    monkeypatch.setenv("PLATFORM_PATH", str(app_root))
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    reset_auth_adapter()
+
+    from mozaiksai.hosts import platform
+
+    with TestClient(platform.app, raise_server_exceptions=False) as client:
+        health = client.get("/health")
+        assert health.status_code == 200, health.text
+        assert health.json()["status"] == "ok"
+
+        shell_config = client.get("/api/shell-config")
+        _assert_not_missing_or_placeholder(shell_config, surface="/api/shell-config")
+        assert shell_config.status_code == 200, shell_config.text
+        pages = shell_config.json().get("pages", [])
+        assert any(page.get("path") == "/orders" for page in pages)
+
+        page_schema = client.get("/api/pages/orders")
+        _assert_not_missing_or_placeholder(page_schema, surface="/api/pages/orders")
+        assert page_schema.status_code == 200, page_schema.text
+        assert page_schema.json()["route"] == "/orders"
+
+        list_response = client.post("/api/modules/orders/list_orders", json={})
+        _assert_not_missing_or_placeholder(list_response, surface="/api/modules/orders/list_orders")
+        assert list_response.status_code == 200, list_response.text
+        assert list_response.json() == {"orders": []}
+
+        create_response = client.post(
+            "/api/modules/orders/create_order",
+            json={"params": {"customer_name": "Ada"}},
+        )
+        _assert_not_missing_or_placeholder(create_response, surface="/api/modules/orders/create_order")
+        assert create_response.status_code == 200, create_response.text
+        assert create_response.json() == {"order": {"customer_name": "Ada"}}


### PR DESCRIPTION
## Summary
- add a Level 2 runtime/HTTP acceptance smoke for the deterministic generated CRUD bundle
- boot the generated bundle through the platform host and verify declared page/module HTTP surfaces do not return 404, 501, or placeholder responses
- document Level 1/2/3 generated-app acceptance semantics

## Validation
- python -m pytest -q --no-cov tests/test_generated_app_functional_acceptance.py
- python -m pytest -q --no-cov tests/test_ui_surface_taxonomy.py::test_primitive_schema_catalog_is_generated tests/test_generated_app_functional_acceptance.py
- python -m pytest -q --no-cov tests/test_platform_module_dispatch.py tests/test_module_router_context_overrides.py
- python -m pytest -q --no-cov tests/test_studio_host_smoke.py tests/test_app_loader.py
- python -m pytest -q --no-cov tests/test_generated_bundle_scanner.py tests/test_generated_bundle_scanner_helpers.py tests/test_generated_bundle_scanner_scan_helpers.py tests/test_appgenerator_validate_wiring.py tests/test_appgenerator_capability_pack_selection.py tests/test_mozaikspay_managed_capability_contract.py tests/test_build_context_mozaikspay_pack.py
- python -m pytest -q --no-cov tests/test_factory_workflow_integration_contracts.py tests/test_workflow_declarative_contracts.py tests/test_workflow_helper_contracts.py tests/test_hook_workflow_integration_contract_pure_helpers.py
- python -m pytest -q --no-cov tests/test_appgenerator_managed_capability_smoke.py tests/test_appgenerator_generated_page_binding.py tests/test_appgenerator_ui_acceptance.py tests/test_appgenerator_canonical_generation.py
- python scripts/governance_guardrails.py --all --errors-only
- ruff check tests/test_generated_app_functional_acceptance.py
- python -m mkdocs build --strict
- python -m py_compile tests/test_generated_app_functional_acceptance.py

Full local pytest note: `python -m pytest -q --no-cov` reached 12259 passed / 77 skipped, with two local-environment failures: source hygiene assumes the repo checkout is not nested under `.local/worktrees`, and primitive_schemas needed local newline/stat normalization with no content diff.