### PR TITLE
docs: clarify release hold and local install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This project follows a practical pre-1.0 changelog format:
 
 - OSS framework telemetry now emits only structural build outcome payloads. Build satisfaction and other customer/operator feedback belongs to app/operator-owned endpoints rather than the generic `MOZAIKS_TELEMETRY_ENDPOINT` channel.
 - Tree-sitter parser packages are now installed with the core Mozaiks package so source-backed Context Graph indexing is part of the default code-context setup.
+- Public docs now describe Mozaiks as not yet published to PyPI or GitHub releases, and direct users to install from a local checkout with editable install instructions instead of a public package URL.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Main repo layout:
 - [Architecture Overview](https://github.com/BlocUnited-LLC/mozaiks/blob/main/ARCHITECTURE.md) — System design and component model
 - [Getting Started](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/getting-started.md) — Full setup guide
 - [Releasing](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/releasing.md) — Release hold and future publish workflow
-- [Mid-Flight Journeys](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/architecture/mozaiksai/mid-flight-journeys.md) — Flagship orchestration capability and runtime semantics
+- [Workflow Routing Transitions](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/architecture/workflows/workflow-routing-transitions.md) — Flagship orchestration capability and runtime semantics
 - [Workflow Authoring Contracts](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/architecture/workflows/workflow-authoring-contracts.md) — Canonical strict YAML contract
 - [Contributing](https://github.com/BlocUnited-LLC/mozaiks/blob/main/CONTRIBUTING.md) — Development workflow
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   <img src="https://raw.githubusercontent.com/BlocUnited-LLC/mozaiks/main/docs/assets/logo-light.png" alt="Mozaiks" width="260"/>
 </picture>
 
-[![Release](https://img.shields.io/github/v/release/BlocUnited-LLC/mozaiks)](https://github.com/BlocUnited-LLC/mozaiks/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/BlocUnited-LLC/mozaiks/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue?logo=python)](https://www.python.org/)
 [![AG2](https://img.shields.io/badge/AG2-1.0_beta-green)](https://github.com/ag2ai/ag2)
@@ -31,16 +30,19 @@ The goal is not to generate a throwaway demo. Mozaiks stages production-shaped
 artifacts, validates them against strict contracts, and keeps runtime concerns
 separate from builder workflows.
 
+Mozaiks is not published as a public PyPI package yet. Install it from a local
+checkout in editable mode.
+
 ## Quickstart
 
 Install Python 3.11+ and Node.js 18+. Studio also needs a reachable MongoDB
 database for workspace state. Docker Desktop is not required; use MongoDB Atlas,
 a local MongoDB install, or Docker only if that is how you prefer to run MongoDB.
 
-Install Mozaiks:
+Install from a local checkout:
 
 ```powershell
-pip install mozaiks
+python -m pip install -e ".[dev]"
 ```
 
 Configure MongoDB before opening Studio:
@@ -118,7 +120,7 @@ Main repo layout:
 
 - [Architecture Overview](https://github.com/BlocUnited-LLC/mozaiks/blob/main/ARCHITECTURE.md) — System design and component model
 - [Getting Started](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/getting-started.md) — Full setup guide
-- [Releasing](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/releasing.md) — Tag-driven release and PyPI publish flow
+- [Releasing](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/releasing.md) — Release hold and future publish workflow
 - [Mid-Flight Journeys](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/architecture/mozaiksai/mid-flight-journeys.md) — Flagship orchestration capability and runtime semantics
 - [Workflow Authoring Contracts](https://github.com/BlocUnited-LLC/mozaiks/blob/main/docs/architecture/workflows/workflow-authoring-contracts.md) — Canonical strict YAML contract
 - [Contributing](https://github.com/BlocUnited-LLC/mozaiks/blob/main/CONTRIBUTING.md) — Development workflow

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -42,7 +42,7 @@ Open **http://127.0.0.1:8000** — the site rebuilds automatically when you save
 
 ## Release and Maintenance
 
-- **[Releasing](../releasing.md)** — tag-driven PyPI publish flow
+- **[Releasing](../releasing.md)** — release hold and future publish workflow
 - **[Verified Setup Guide](../architecture/verified/setup-guide.md)** — maintainer-verified local environment
 - **[Auth Setup](../architecture/verified/auth-setup.md)** — Keycloak and auth configuration
 - **[Trigger Mechanisms](../architecture/verified/trigger-mechanisms.md)** — workflow trigger reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,9 +6,10 @@
 - Node.js 18+
 - Docker Desktop — [download here](https://www.docker.com/products/docker-desktop/) (used to run MongoDB)
 
-Mozaiks installs Tree-sitter parser packages with the core Python package so
-Studio can build source-backed App Intelligence for generated and existing
-apps.
+Mozaiks installs Tree-sitter parser packages with the core framework checkout
+so Studio can build source-backed App Intelligence for generated and existing
+apps. Mozaiks is not published on PyPI yet, so install it from this repo
+instead of `pip install mozaiks`.
 No separate parser setup is required.
 
 ## 1. Install
@@ -16,13 +17,13 @@ No separate parser setup is required.
 === "Windows"
 
     ```powershell
-    pip install mozaiks
+    python -m pip install -e ".[dev]"
     ```
 
 === "macOS / Linux"
 
     ```bash
-    pip install mozaiks
+    python -m pip install -e ".[dev]"
     ```
 
 ## 2. Start MongoDB

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@
 
 <img src="assets/mozaik_logo.svg" alt="Mozaiks Logo" width="180"/>
 
-[![Release](https://img.shields.io/github/v/release/BlocUnited-LLC/mozaiks)](https://github.com/BlocUnited-LLC/mozaiks/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/BlocUnited-LLC/mozaiks/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue?logo=python)](https://www.python.org/)
 [![AG2](https://img.shields.io/badge/AG2-1.0_beta-green)](https://github.com/ag2ai/ag2)
@@ -14,6 +13,9 @@
 > **Mozaiks is open source.** BlocUnited offers the managed product at
 > [mozaiks.ai](https://mozaiks.ai), but you can self-host the framework and run
 > the builder locally.
+
+> Public PyPI and GitHub releases are not published yet. Install from a local
+> checkout instead.
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -132,7 +132,7 @@ git tag v<version>
 git push origin main --tags
 ```
 
-## What The Release Workflow Does
+## What The Future Release Workflow Does
 
 The GitHub Actions workflow at `.github/workflows/release.yml` runs when a tag
 matching `v*` is pushed.
@@ -145,25 +145,27 @@ It:
 4. runs `twine check`
 5. installs the built wheel into a clean virtualenv
 6. smoke-tests the installed CLI and packaged resources
-7. creates a GitHub release with attached artifacts
-8. publishes the distributions to PyPI
+7. creates a GitHub release with attached artifacts when releases are enabled
+8. publishes the distributions to PyPI when the public package is released
 
-## PyPI Setup Requirement
+## Future PyPI Setup Requirement
 
-The workflow is configured for GitHub-to-PyPI trusted publishing.
+The workflow is configured for GitHub-to-PyPI trusted publishing when public
+release publishing is enabled.
 
 The `mozaiks` PyPI project must trust this GitHub repository and the
-`release.yml` workflow.
+`release.yml` workflow before public publishing can turn on.
 
-Until that is configured on the PyPI side, the `publish-pypi` job will fail
-even if the build and GitHub release steps succeed.
+Until that is configured on the PyPI side, the `publish-pypi` job should stay
+disabled even if the build and GitHub release steps succeed.
 
 ## Documentation Impact
 
-Public install docs should present `pip install mozaiks` followed by
-`python -m mozaiks ...` so PATH mechanics stay out of the main onboarding flow.
-The `mozaiks` command can be mentioned as an optional shortcut only.
-Keep source-checkout setup separate as the framework/developer mode.
+Public install docs should present a local source checkout with
+`python -m pip install -e ".[dev]"` followed by `python -m mozaiks ...` so
+PATH mechanics stay out of the main onboarding flow. The `mozaiks` command can
+be mentioned as an optional shortcut only. Keep source-checkout setup separate
+as the framework/developer mode until public packaging is actually released.
 
 ## Notes
 

--- a/mozaiks_cli/commands/init.py
+++ b/mozaiks_cli/commands/init.py
@@ -352,7 +352,7 @@ def _create_standard_consumer_files(
     app_name: str,
     preset: str,
 ) -> None:
-    """Create root-level files that make a generated app runnable on the PyPI package."""
+    """Create root-level files that make a generated app runnable from a Mozaiks checkout."""
     scripts_dir.mkdir(parents=True, exist_ok=True)
 
     _write_text(target_dir / "requirements.txt", _requirements_txt())
@@ -378,7 +378,7 @@ def _create_agent_guidance_scaffold(*, target_dir: Path, app_name: str, preset: 
 def _requirements_txt() -> str:
     return f"""\
 # Mozaiks framework — version pin for standalone installs and deploys.
-# If you already have mozaiks installed, pip will skip this line.
+# If you already have a compatible Mozaiks install available, pip will skip this line.
 mozaiks=={_current_mozaiks_version()}
 
 # App-specific dependencies — add packages your modules and integrations need.

--- a/tests/test_user_facing_docs_language.py
+++ b/tests/test_user_facing_docs_language.py
@@ -17,6 +17,8 @@ def test_readme_uses_plain_tool_framing() -> None:
     assert 'python -m pip install -e ".[dev]"' in readme
     assert "python -m mozaiks quickstart --dir .\\mozaiks-workspace" in readme
     assert "Docker Desktop is not required" in readme
+    assert "workflow-routing-transitions.md" in readme
+    assert "mid-flight-journeys.md" not in readme
     assert "pipx" not in readme
     assert "python -m venv .venv" not in readme
     assert "python -m pip install mozaiks" not in readme

--- a/tests/test_user_facing_docs_language.py
+++ b/tests/test_user_facing_docs_language.py
@@ -13,7 +13,8 @@ def test_readme_uses_plain_tool_framing() -> None:
     readme = _read("README.md")
 
     assert "### Which Tool To Use" in readme
-    assert "pip install mozaiks" in readme
+    assert "Mozaiks is not published as a public PyPI package yet." in readme
+    assert 'python -m pip install -e ".[dev]"' in readme
     assert "python -m mozaiks quickstart --dir .\\mozaiks-workspace" in readme
     assert "Docker Desktop is not required" in readme
     assert "pipx" not in readme


### PR DESCRIPTION
Clarify that Mozaiks is not published publicly on PyPI or GitHub releases yet, remove the release badge/link from the public docs, and point install instructions at a local editable checkout. Also add a changelog note and soften the generated-app scaffold wording.