### PR TITLE
fix(ci): scope secret-scan to HEAD, not all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,11 @@ jobs:
 
       - name: Scan for secrets
         # --redact masks found secrets in CI output.
+        # --log-opts=HEAD restricts the scan to this ref's own history; without it,
+        # gitleaks defaults to `--all` and flags unrelated open branches' commits
+        # (e.g. other PRs' intentional fake-secret test fixtures), failing every PR.
         # To ignore a historical false positive, add its fingerprint to .gitleaksignore.
-        run: gitleaks detect --source . --log-level warn --redact
+        run: gitleaks detect --source . --log-level warn --log-opts="HEAD" --redact
 
   dependency-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Root cause of the repo-wide secret-scan failures on PRs #240, #241, #242, #243:

gitleaks defaults to `--log-opts=--all` when unset, and `fetch-depth: 0` on the
checkout step fetches every remote branch's full history. So every PR's
secret-scan job scans ALL open branches, not just its own commits — meaning
PR #242's intentional fake-secret test fixtures
(`tests/test_package_content_guard.py`, testing the new package content guard)
get flagged as leaks on every unrelated PR.

Fix: pass `--log-opts="HEAD"` so gitleaks only walks the checked-out ref's own
ancestry.

Verified locally: `gitleaks detect --source . --log-opts="HEAD"` finds 0 leaks
from an unrelated branch checkout, vs 3 false-positive leaks without the flag.
