### PR TITLE
[codex] close brownfield and AgentGenerator handoff acceptance gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project follows a practical pre-1.0 changelog format:
 - Added `scripts/package_content_guard.py`: artifact-level content guard that inspects built wheels and sdists before publication. Fails on learned-artifact directories (`evals/`, `corpora/`, `corrections/`, `production_outcomes/`, `learned_rankings/`, `customer_patterns/`, etc.), raw private keys, raw provider credentials (`sk_live_`, `sk_test_`, etc.), `.env` files (non-example), private-key file extensions (`.pem`, `.key`), and unapproved top-level package families or `factory_app/` sub-families. Warns on large data files and review-pattern paths.
 - Added `scripts/run_release_audit.py`: local pre-release audit script that chains governance guardrails, build, package content guard, twine check, smoke install into a clean venv, Factory resource resolution verification, and offline functional acceptance tests. Run with `python scripts/run_release_audit.py` before tagging any release.
 - Added `docs/adr/0002-appgenerator-baseline-strategy-oss.md`: records the intentional decision to publish the AppGenerator baseline strategy as OSS. Establishes that future learned or operator-derived additions require a new publication review ADR before entering this repository.
+- Added deterministic brownfield and AgentGenerator handoff acceptance coverage proving captured post-reasoning artifacts can flow through AppGenerator materialization and Level-2 generated-app runtime acceptance offline.
 
 ### Security
 

--- a/docs/adr/0003-pre-1-0-oss-proprietary-boundary-freeze.md
+++ b/docs/adr/0003-pre-1-0-oss-proprietary-boundary-freeze.md
@@ -26,7 +26,7 @@ The boundary is not about features — it is about the source of intelligence:
 
 A full pre-1.0 audit found zero candidate families ready or appropriate for
 extraction. The current repository boundary is correct. See
-[`docs/architecture/foundations/oss-boundary-families.md`](../foundations/oss-boundary-families.md)
+[`docs/architecture/foundations/oss-boundary-families.md`](../architecture/foundations/oss-boundary-families.md)
 for the DO-NOT-MOVE family registry and private-by-default category list.
 
 ## Reason

--- a/docs/architecture/app/generated-app-functional-acceptance.md
+++ b/docs/architecture/app/generated-app-functional-acceptance.md
@@ -73,6 +73,8 @@ internally declared app route/action/facade must not be missing.
 | Monetized SaaS app host boot and declared MozaiksPay-compatible billing/facade surfaces | Platform `TestClient` over deterministic SaaS bundle plus in-process compatible provider fake | Runtime / HTTP | Added |
 | Workflow/agent app catalog load, start, and module-action surfaces | Workflow manager plus platform `TestClient` over deterministic workflow bundle | Runtime / HTTP | Added |
 | Cross-archetype post-plan replay | Captured `AppBuildPlan` fixtures through the real deterministic AppGenerator task-batch/materialization path, bundle validation, functional scanner, `AppLoader`, and platform `TestClient` | Static / Runtime / HTTP | Added |
+| Brownfield post-discovery handoff | Captured `ExistingAppDiscovery` artifact plus module decomposition through deterministic AppBuildPlan projection, real AppGenerator materialization, validation, `AppLoader`, and platform `TestClient` | Static / Runtime / HTTP | Added |
+| AgentGenerator-to-AppGenerator handoff | Captured `WorkflowBundleBuilderOutput` through AgentGenerator bundle materialization/promotion, workflow integration metadata, AppGenerator AppBuildPlan consumption, workflow registry loading, and platform `TestClient` | Static / Runtime / HTTP | Added |
 
 ## Diagnostics
 
@@ -189,8 +191,62 @@ dynamic.
 The workflow/agent row intentionally keeps workflow files at the workspace
 workflow root because workflow bundles are AgentGenerator-owned artifacts, not
 files inside the generated app bundle. The matrix proves the AppGenerator app
-bundle and canonical workflow registry boundary load together. A deeper
-end-to-end AgentGenerator-to-AppGenerator replay remains a P1 extension.
+bundle and canonical workflow registry boundary load together.
+
+## Brownfield Post-Discovery Proof
+
+`tests/test_brownfield_agentgenerator_acceptance.py` covers the deterministic
+boundary after ExistingAppDiscovery reasoning:
+
+```text
+local brownfield source fixture
+-> ExistingAppDiscovery source preload evidence
+-> captured ExistingAppDiscovery structured artifact
+-> captured module_decomposition_plan
+-> canonical AppContext adoption artifacts
+-> deterministic AppBuildPlan handoff
+-> AppGenerator app_build_plan normalization
+-> AppGenerator task-batch materialization
+-> validate_generated_app_bundle
+-> scan_functional_generated_app
+-> run_app_bundle_acceptance_gate
+-> AppLoader
+-> platform TestClient
+```
+
+This proves post-discovery correctness for a representative authenticated
+FastAPI/React CRUD adoption fixture. It asserts source intent survival such as
+`/projects`, `Project`, and `update_project` reaching generated page, module,
+persistence, and handler surfaces. It also mutates the generated handler to
+prove a dropped discovery-required action fails functional acceptance.
+
+This is not a raw source plus LLM determinism claim. Source discovery and
+reasoning can still be dynamic. The deterministic proof begins at the captured
+structured discovery/adoption boundary.
+
+## AgentGenerator Handoff Proof
+
+The same acceptance file covers the deterministic boundary after AgentGenerator
+reasoning:
+
+```text
+captured WorkflowBundleBuilderOutput
+-> AgentGenerator bundle file materialization
+-> workflow promotion into workspace workflow root
+-> workflow_integration_metadata extraction
+-> AppBuildPlan workflow touchpoint/module action alignment
+-> AppGenerator app materialization
+-> validation and functional scanner
+-> AppLoader
+-> workflow manager registry load
+-> platform TestClient
+```
+
+This proves that a representative AgentGenerator workflow bundle and the
+AppGenerator-produced app harness load together without paid model calls. The
+test asserts that the declared workflow, agents, context variables, structured
+outputs, tool function, page route, and referenced generated module action all
+survive the handoff.
 
 ## Remaining Gaps
 
@@ -206,9 +262,6 @@ P1:
   runtime wiring without executing a model-backed websocket turn.
 - Add browser-level route rendering smoke for generated bundles if CI can run it
   without making ordinary unit feedback slow.
-- Add brownfield generated-app acceptance once ExistingAppDiscovery exposes a
-  stable deterministic post-discovery/adoption-plan to AppBuildPlan
-  materialization seam.
 
 P2:
 

--- a/docs/architecture/foundations/oss-boundary-families.md
+++ b/docs/architecture/foundations/oss-boundary-families.md
@@ -116,4 +116,4 @@ When `mozaiks-app` needs new generic framework behavior, it opens a PR against
 3. Moving any DO-NOT-MOVE family to a private repo: requires ADR review and
    would be a breaking change after 1.0 publication.
 4. Adding a new public mechanism or interface: follow the
-   [One-Way Door Standard](../../../OSS_PUBLICATION_POLICY.md).
+   One-Way Door Standard in `OSS_PUBLICATION_POLICY.md`.

--- a/factory_app/workflows/ExistingAppDiscovery/tools/app_build_plan_handoff.py
+++ b/factory_app/workflows/ExistingAppDiscovery/tools/app_build_plan_handoff.py
@@ -1,0 +1,294 @@
+"""Deterministic ExistingAppDiscovery to AppGenerator handoff helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+def build_app_build_plan_from_discovery(
+    discovery_artifact: Mapping[str, Any],
+    *,
+    module_decomposition_plan: Mapping[str, Any],
+    app_id: str | None = None,
+    app_name: str | None = None,
+) -> dict[str, Any]:
+    """Project captured brownfield discovery output into an AppBuildPlan.
+
+    This is the deterministic seam after discovery reasoning. It intentionally
+    consumes structured discovery/adoption evidence rather than source files or
+    prompt text, then hands the resulting canonical plan to AppGenerator.
+    """
+    product_spec = _mapping(discovery_artifact.get("existing_product_spec"))
+    augmentation_plan = _mapping(discovery_artifact.get("agent_augmentation_plan"))
+    modules = _module_specs(module_decomposition_plan)
+    pages = _page_specs(module_decomposition_plan, modules)
+    if not modules:
+        raise ValueError("module_decomposition_plan.proposed_modules must contain at least one module")
+    if not pages:
+        raise ValueError("module_decomposition_plan.proposed_pages must contain at least one page")
+
+    resolved_app_id = _slug(app_id or product_spec.get("app_id") or product_spec.get("app_name"), fallback="existing_app")
+    resolved_app_name = _clean(app_name or product_spec.get("app_name") or resolved_app_id.replace("_", " ").title())
+    auth_strategy = "required" if _auth_required(product_spec) else "none"
+    tasks = _build_tasks(modules, pages)
+
+    return {
+        "agent_message": "Captured brownfield discovery handoff AppBuildPlan.",
+        "app_kind": "brownfield_migration",
+        "app_id": resolved_app_id,
+        "app_name": resolved_app_name,
+        "source_discovery": {
+            "artifact_version": discovery_artifact.get("artifact_version"),
+            "app_type": discovery_artifact.get("app_type") or "brownfield_app",
+            "adoption_level": augmentation_plan.get("adoption_level"),
+        },
+        "pages": pages,
+        "entities": _entities(module_decomposition_plan, modules),
+        "roles": [{"id": "user", "label": "User"}],
+        "auth_strategy": auth_strategy,
+        "service_scope": list(modules),
+        "frontend_scope": [str(page["name"]) for page in pages],
+        "capability_packs": [_capability_pack(module_id, spec, pages) for module_id, spec in modules.items()],
+        "external_integrations": [],
+        "agent_backend_required": bool(_list(module_decomposition_plan.get("proposed_workflows"))),
+        "workflow_touchpoints": _workflow_touchpoints(module_decomposition_plan, pages),
+        "build_tasks": tasks,
+        "generation_order": [task["task_id"] for task in tasks],
+    }
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _slug(value: Any, *, fallback: str) -> str:
+    text = re.sub(r"[^a-zA-Z0-9]+", "_", _clean(value).lower()).strip("_")
+    return text or fallback
+
+
+def _title(value: str) -> str:
+    return value.replace("_", " ").replace("-", " ").title()
+
+
+def _auth_required(product_spec: Mapping[str, Any]) -> bool:
+    auth = _clean(product_spec.get("auth_model") or product_spec.get("auth"))
+    return bool(auth and auth.lower() not in {"none", "public", "anonymous", "unauthenticated"})
+
+
+def _module_specs(module_decomposition_plan: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    modules: dict[str, dict[str, Any]] = {}
+    for raw in _list(module_decomposition_plan.get("proposed_modules")):
+        spec = _mapping(raw)
+        module_id = _slug(spec.get("module_id") or spec.get("id") or spec.get("name"), fallback="")
+        if not module_id:
+            continue
+        actions = [_slug(action, fallback="") for action in _list(spec.get("proposed_actions"))]
+        modules[module_id] = {**spec, "module_id": module_id, "proposed_actions": [action for action in actions if action]}
+    return modules
+
+
+def _page_specs(
+    module_decomposition_plan: Mapping[str, Any],
+    modules: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    pages: list[dict[str, Any]] = []
+    for raw in _list(module_decomposition_plan.get("proposed_pages")):
+        spec = _mapping(raw)
+        page_name = _slug(spec.get("page_id") or spec.get("name") or spec.get("route"), fallback="")
+        if not page_name:
+            continue
+        route = _clean(spec.get("route")) or f"/{page_name}"
+        primary_module = _slug(spec.get("module_id") or spec.get("primary_module"), fallback="")
+        if not primary_module:
+            primary_module = next((module_id for module_id in modules if module_id in page_name), next(iter(modules), ""))
+        actions = list(modules.get(primary_module, {}).get("proposed_actions") or [])
+        list_action = next((action for action in actions if action.startswith("list_")), actions[0] if actions else "")
+        pages.append(
+            {
+                "name": page_name,
+                "route": route,
+                "title": _clean(spec.get("title")) or _title(page_name),
+                "page_type_hint": _clean(spec.get("page_type_hint") or spec.get("page_type")) or "record_list",
+                "primary_entities": _list(spec.get("primary_entities")) or [_title(primary_module)] if primary_module else [],
+                "primary_actions": actions,
+                "sections_hint": [
+                    {
+                        "primitive": _clean(spec.get("primitive")) or "DataTable",
+                        "section_id_hint": primary_module or page_name,
+                        "title_hint": _clean(spec.get("title")) or _title(page_name),
+                        "config_hint": (
+                            f'{{"api_endpoint": "/api/modules/{primary_module}/{list_action}"}}'
+                            if primary_module and list_action
+                            else "{}"
+                        ),
+                    }
+                ],
+            }
+        )
+    return pages
+
+
+def _entities(
+    module_decomposition_plan: Mapping[str, Any],
+    modules: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    entities: list[dict[str, Any]] = []
+    for module_id, spec in modules.items():
+        raw_entities = _list(spec.get("persistence_entities")) or [_title(module_id)]
+        for raw_entity in raw_entities:
+            name = _clean(raw_entity)
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            entities.append({"name": name})
+    for raw_entity in _list(module_decomposition_plan.get("entities")):
+        name = _clean(raw_entity.get("name") if isinstance(raw_entity, Mapping) else raw_entity)
+        if name and name not in seen:
+            seen.add(name)
+            entities.append({"name": name})
+    return entities
+
+
+def _capability_pack(module_id: str, spec: Mapping[str, Any], pages: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "capability_pack_id": module_id,
+        "surface_id": module_id,
+        "surface_kind": "module",
+        "pack_type": "brownfield_module",
+        "label": _clean(spec.get("label")) or _title(module_id),
+        "summary": _clean(spec.get("summary")) or f"Brownfield generated {module_id} surface.",
+        "implementation_mode": "deterministic",
+        "primary_entities": _list(spec.get("persistence_entities")) or [_title(module_id)],
+        "primary_pages": [
+            page["name"]
+            for page in pages
+            if module_id in _clean(page.get("name")) or any(module_id in _clean(action) for action in page.get("primary_actions") or [])
+        ],
+        "operations": list(spec.get("proposed_actions") or []),
+        "required_integrations": _list(spec.get("required_integrations")),
+        "agentic_extensions": _list(spec.get("agentic_extensions")),
+    }
+
+
+def _workflow_touchpoints(module_decomposition_plan: Mapping[str, Any], pages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    touchpoints: list[dict[str, Any]] = []
+    default_page = pages[0]["name"] if pages else None
+    for raw in _list(module_decomposition_plan.get("proposed_workflows")):
+        spec = _mapping(raw)
+        workflow_id = _clean(spec.get("workflow_id") or spec.get("name"))
+        if not workflow_id:
+            continue
+        touchpoints.append(
+            {
+                "page_name": _clean(spec.get("page_name")) or default_page,
+                "workflow_id": workflow_id,
+                "label": _clean(spec.get("label")) or _title(workflow_id),
+                "context_variables": _mapping(spec.get("context_variables")),
+            }
+        )
+    return touchpoints
+
+
+def _build_tasks(modules: Mapping[str, Mapping[str, Any]], pages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    tasks: list[dict[str, Any]] = [
+        {
+            "task_id": "task_persistence",
+            "task_type": "persistence_contract",
+            "capability_pack_id": None,
+            "surface_id": "database",
+            "surface_kind": None,
+            "execution_target": "AppGenerator",
+            "initial_agent": "DatabaseAgent",
+            "description": "Stage deterministic brownfield data contract.",
+            "initial_message": "Generate data/contract.json and data/migrations/001_indexes.json.",
+            "owned_paths": ["data/contract.json", "data/migrations/001_indexes.json"],
+            "depends_on": [],
+        }
+    ]
+    for module_id in modules:
+        tasks.extend(
+            [
+                _task(
+                    module_id,
+                    "module",
+                    "module_contract",
+                    "ConfigMiddlewareAgent",
+                    [f"modules/{module_id}/module.yaml"],
+                    ["task_persistence"],
+                ),
+                _task(
+                    module_id,
+                    "models",
+                    "data_models",
+                    "ModelAgent",
+                    [f"modules/{module_id}/backend/schemas.py"],
+                    [f"task_{module_id}_module"],
+                ),
+                _task(
+                    module_id,
+                    "services",
+                    "business_services",
+                    "ServiceAgent",
+                    [
+                        f"modules/{module_id}/backend/handler.py",
+                        f"modules/{module_id}/backend/service.py",
+                        f"modules/{module_id}/backend/repo.py",
+                        f"modules/{module_id}/backend/policy.py",
+                    ],
+                    [f"task_{module_id}_models"],
+                ),
+            ]
+        )
+    tasks.append(
+        {
+            "task_id": "task_pages",
+            "task_type": "page_bundle",
+            "capability_pack_id": None,
+            "surface_id": "pages",
+            "surface_kind": "ui_only",
+            "execution_target": "AppGenerator",
+            "initial_agent": "AppSchemaAgent",
+            "description": "Generate declarative brownfield page schemas.",
+            "initial_message": "Generate app.json and ui/pages/*.yaml files from the brownfield AppBuildPlan.",
+            "owned_paths": ["app.json", *[f"ui/pages/{str(page['name']).lower().replace(' ', '_')}.yaml" for page in pages]],
+            "depends_on": [f"task_{module_id}_services" for module_id in modules],
+        }
+    )
+    return tasks
+
+
+def _task(
+    module_id: str,
+    suffix: str,
+    task_type: str,
+    initial_agent: str,
+    owned_paths: list[str],
+    depends_on: list[str],
+) -> dict[str, Any]:
+    return {
+        "task_id": f"task_{module_id}_{suffix}",
+        "task_type": task_type,
+        "capability_pack_id": module_id,
+        "surface_id": module_id,
+        "surface_kind": "module",
+        "execution_target": "AppGenerator",
+        "initial_agent": initial_agent,
+        "description": f"Generate brownfield {module_id} {task_type}.",
+        "initial_message": f"Generate {module_id} {task_type} from captured discovery output.",
+        "owned_paths": owned_paths,
+        "depends_on": depends_on,
+    }
+
+
+__all__ = ["build_app_build_plan_from_discovery"]

--- a/scripts/export-primitive-schemas.js
+++ b/scripts/export-primitive-schemas.js
@@ -235,6 +235,10 @@ function validatePrimitiveCatalog(registryEntries, primitiveCatalog) {
   }
 }
 
+function normalizeLineEndings(value) {
+  return value.replace(/\r\n/g, '\n');
+}
+
 async function main() {
   const checkOnly = process.argv.includes('--check');
   const { PRIMITIVE_SCHEMAS } = await import(pathToFileURL(schemaModulePath).href);
@@ -259,7 +263,7 @@ async function main() {
     const current = fs.existsSync(outputPath)
       ? fs.readFileSync(outputPath, 'utf8')
       : '';
-    if (current !== serialized) {
+    if (normalizeLineEndings(current) !== serialized) {
       console.error('primitive_schemas.json is out of date. Run: node scripts/export-primitive-schemas.js');
       process.exit(1);
     }

--- a/tests/test_brownfield_agentgenerator_acceptance.py
+++ b/tests/test_brownfield_agentgenerator_acceptance.py
@@ -1,0 +1,574 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from factory_app.workflows._shared.workflow_integration import (
+    apply_workflow_integration_context,
+    extract_workflow_integration_metadata_from_bundle_entries,
+)
+from factory_app.workflows.AgentGenerator.tools.generate_and_download import _write_bundle_to_disk
+from factory_app.workflows.AgentGenerator.tools.workflow_converter import promote_generated_workflow
+from factory_app.workflows.ExistingAppDiscovery.tools.app_build_plan_handoff import (
+    build_app_build_plan_from_discovery,
+)
+from factory_app.workflows.ExistingAppDiscovery.tools.app_context_mapping import (
+    build_existing_app_context_artifacts,
+)
+from factory_app.workflows.ExistingAppDiscovery.tools.preload_discovery_context import (
+    collect_prechat_discovery_context,
+)
+from mozaiksai.core.auth.adapters import registry as auth_registry
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+from mozaiksai.core.validation import GeneratedAppValidationRequest, scan_functional_generated_app
+from mozaiksai.core.validation.generated_app import validate_generated_app_bundle
+from mozaiksai.hosts import platform
+from tests.test_generated_app_archetype_matrix import (
+    WORKFLOWS_ROOT,
+    _ArchetypeSpec,
+    _assert_not_missing_or_placeholder,
+    _configure_platform,
+    _Context,
+    _FakeMongoClient,
+    _materialize_spec,
+    _PersistenceContext,
+    _RuntimeAcceptanceCollection,
+    _RuntimeAcceptancePersistence,
+    _validation_pages,
+)
+
+
+def _write_brownfield_source(root: Path) -> None:
+    (root / "backend").mkdir(parents=True)
+    (root / "frontend" / "src").mkdir(parents=True)
+    (root / "backend" / "main.py").write_text(
+        textwrap.dedent(
+            """
+            from fastapi import FastAPI
+
+            app = FastAPI()
+
+            @app.get("/api/projects")
+            async def list_projects():
+                return []
+
+            @app.post("/api/projects")
+            async def create_project(payload: dict):
+                return payload
+
+            @app.patch("/api/projects/{project_id}")
+            async def update_project(project_id: str, payload: dict):
+                return {"id": project_id, **payload}
+
+            @app.get("/api/work-items")
+            async def list_work_items():
+                return []
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (root / "frontend" / "src" / "App.jsx").write_text(
+        textwrap.dedent(
+            """
+            export default function App() {
+              return <nav><a href="/projects">Projects</a><a href="/work-items">Work Items</a></nav>
+            }
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _brownfield_discovery_artifact() -> dict[str, Any]:
+    return {
+        "request_intent": "Adopt the existing project tracker into Mozaiks-owned canonical app surfaces.",
+        "artifact_version": "captured-brownfield-v1",
+        "app_type": "brownfield_app",
+        "app_summary": "Existing FastAPI/React project tracker with authenticated project and work item surfaces.",
+        "existing_product_spec": {
+            "app_id": "existing_project_tracker",
+            "app_name": "Existing Project Tracker",
+            "tech_stack": "FastAPI, React",
+            "auth_model": "JWT required for project and work item mutation",
+            "routes": ["/projects", "/work-items"],
+            "data_entities": ["Project", "WorkItem"],
+            "api_endpoints": [
+                "GET /api/projects",
+                "POST /api/projects",
+                "PATCH /api/projects/{project_id}",
+                "GET /api/work-items",
+                "POST /api/work-items",
+            ],
+        },
+        "capability_specs": [
+            {
+                "capability_id": "customer_projects",
+                "label": "Customer Projects",
+                "summary": "CRUD over migrated project records.",
+            },
+            {
+                "capability_id": "work_items",
+                "label": "Work Items",
+                "summary": "CRUD over migrated work item records.",
+            },
+        ],
+        "agent_augmentation_plan": {
+            "adoption_level": "gradual_modernization",
+            "adoption_rationale": "Generate Mozaiks-owned canonical modules while preserving the source app as evidence.",
+            "ecosystem_bindings": ["customer_projects", "work_items"],
+        },
+        "discovery_brief": "Projects and work items should survive adoption as canonical pages, modules, and persistence.",
+        "unresolved_questions": [],
+    }
+
+
+def _brownfield_module_decomposition() -> dict[str, Any]:
+    return {
+        "proposed_modules": [
+            {
+                "module_id": "customer_projects",
+                "source_capabilities": ["projects"],
+                "source_files": ["backend/main.py", "frontend/src/App.jsx"],
+                "proposed_actions": ["create_project", "list_projects", "update_project"],
+                "persistence_entities": ["Project"],
+            },
+            {
+                "module_id": "work_items",
+                "source_capabilities": ["work-items"],
+                "source_files": ["backend/main.py", "frontend/src/App.jsx"],
+                "proposed_actions": ["create_work_item", "list_work_items"],
+                "persistence_entities": ["WorkItem"],
+            },
+        ],
+        "proposed_pages": [
+            {
+                "page_id": "projects",
+                "route": "/projects",
+                "title": "Projects",
+                "module_id": "customer_projects",
+                "page_type_hint": "record_list",
+                "primary_entities": ["Project"],
+            },
+            {
+                "page_id": "work_items",
+                "route": "/work-items",
+                "title": "Work Items",
+                "module_id": "work_items",
+                "page_type_hint": "record_list",
+                "primary_entities": ["WorkItem"],
+            },
+        ],
+        "required_migration_tasks": ["preserve_project_routes", "preserve_project_update_action"],
+    }
+
+
+def _brownfield_checks(client: TestClient, _files: dict[str, str], _loaded: Any) -> None:
+    headers = {"Authorization": "Bearer matrix-token"}
+    for page_name, route in (("projects", "/projects"), ("work_items", "/work-items")):
+        page = client.get(f"/api/pages/{page_name}", headers=headers)
+        _assert_not_missing_or_placeholder(page, surface=f"/api/pages/{page_name}")
+        assert page.status_code == 200
+        assert page.json()["route"] == route
+
+    denied = client.post("/api/modules/customer_projects/update_project", json={"params": {"project_id": "p1"}})
+    _assert_not_missing_or_placeholder(denied, surface="/api/modules/customer_projects/update_project")
+    assert denied.status_code in {401, 403}
+
+    update = client.post(
+        "/api/modules/customer_projects/update_project",
+        json={"params": {"project_id": "p1", "name": "Migrated"}},
+        headers=headers,
+    )
+    _assert_not_missing_or_placeholder(update, surface="/api/modules/customer_projects/update_project")
+    assert update.status_code == 200
+
+    work_items = client.post("/api/modules/work_items/list_work_items", json={"params": {}}, headers=headers)
+    _assert_not_missing_or_placeholder(work_items, surface="/api/modules/work_items/list_work_items")
+    assert work_items.status_code == 200
+
+
+def _captured_agentgenerator_bundle() -> dict[str, Any]:
+    workflow_name = "ResearchReviewWorkflow"
+    return {
+        "workflow_name": workflow_name,
+        "pattern_id": "deterministic_research_review",
+        "pattern_name": "Deterministic Research Review",
+        "agent_message": "Captured AgentGenerator workflow bundle.",
+        "files": [
+            {
+                "filename": "orchestrator.yaml",
+                "content": textwrap.dedent(
+                    """
+                    workflow_name: ResearchReviewWorkflow
+                    max_turns: 4
+                    human_in_the_loop: false
+                    workflow_startup_mode: AgentDriven
+                    orchestration_pattern: ag2_network
+                    initial_message: Review local source text and summarize it.
+                    initial_agent: ResearchPlannerAgent
+                    triggers:
+                      - type: domain.research.submitted
+                        description: Start review when research source is submitted.
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "agents.yaml",
+                "content": textwrap.dedent(
+                    """
+                    agents:
+                      - name: ResearchPlannerAgent
+                        system_message: Plan deterministic source review.
+                        structured_outputs_required: true
+                      - name: ResearchSummaryAgent
+                        system_message: Produce the final structured summary.
+                        structured_outputs_required: true
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "context_variables.yaml",
+                "content": textwrap.dedent(
+                    """
+                    definitions:
+                      source_text:
+                        type: string
+                        source:
+                          type: state
+                          default: Local source
+                      review_depth:
+                        type: string
+                        source:
+                          type: state
+                          default: concise
+                    agents:
+                      ResearchPlannerAgent:
+                        variables: [source_text, review_depth]
+                      ResearchSummaryAgent:
+                        variables: [source_text]
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "structured_outputs.yaml",
+                "content": textwrap.dedent(
+                    """
+                    registry:
+                      ResearchPlannerAgent: ResearchPlan
+                      ResearchSummaryAgent: ResearchSummary
+                    models:
+                      ResearchPlan:
+                        type: model
+                        fields:
+                          sections:
+                            type: list
+                            items: str
+                            description: Planned sections.
+                      ResearchSummary:
+                        type: model
+                        fields:
+                          summary:
+                            type: str
+                            description: Source summary.
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "tools.yaml",
+                "content": textwrap.dedent(
+                    """
+                    tools:
+                      - agent: ResearchPlannerAgent
+                        file: tools/research_tools.py
+                        function: summarize_source
+                        description: Calls the generated research.summarize_source module action boundary.
+                        tool_type: Agent_Tool
+                        auto_tool_call: false
+                    lifecycle_tools: []
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "tools/__init__.py",
+                "content": "",
+            },
+            {
+                "filename": "tools/research_tools.py",
+                "content": "async def summarize_source(source_text: str):\n    return {'summary': source_text[:32]}\n",
+            },
+            {
+                "filename": "transition_graph.yaml",
+                "content": textwrap.dedent(
+                    """
+                    transition_rules:
+                      - source_agent: ResearchPlannerAgent
+                        target_agent: ResearchSummaryAgent
+                        transition_type: after_turn
+                      - source_agent: ResearchSummaryAgent
+                        target_agent: terminate
+                        transition_type: after_turn
+                    """
+                ).lstrip(),
+            },
+            {
+                "filename": "ui_config.yaml",
+                "content": "visual_agents:\n  - ResearchPlannerAgent\n  - ResearchSummaryAgent\n",
+            },
+        ],
+    }
+
+
+def _workflow_app_checks(client: TestClient, _files: dict[str, str], _loaded: Any) -> None:
+    from mozaiksai.core.workflow.workflow_manager import initialize_workflows, workflow_manager
+
+    workflow_root = Path(__import__("os").environ["MOZAIKS_WORKFLOWS_PATH"])
+    initialize_workflows(str(workflow_root))
+    assert "ResearchReviewWorkflow" in workflow_manager.get_all_workflow_names(), "WORKFLOW_GAP workflow=ResearchReviewWorkflow"
+    config = workflow_manager.get_config("ResearchReviewWorkflow")
+    assert "ResearchSummary" in config["structured_outputs"]["models"]
+    assert "source_text" in config["context_variables"]["definitions"]
+    tool = config["tools"][0]
+    assert tool["function"] == "summarize_source"
+
+    headers = {"Authorization": "Bearer matrix-token"}
+    page = client.get("/api/pages/research", headers=headers)
+    _assert_not_missing_or_placeholder(page, surface="/api/pages/research")
+    assert page.status_code == 200
+    summarize = client.post(
+        "/api/modules/research/summarize_source",
+        json={"params": {"source_text": "Deterministic agentgenerator handoff source"}},
+        headers=headers,
+    )
+    _assert_not_missing_or_placeholder(summarize, surface="/api/modules/research/summarize_source")
+    assert summarize.status_code == 200
+    workflows = client.get("/api/workflows", headers=headers)
+    _assert_not_missing_or_placeholder(workflows, surface="/api/workflows")
+    assert workflows.status_code in {200, 401, 403}
+
+
+def _workflow_plan() -> dict[str, Any]:
+    from tests.test_generated_app_archetype_matrix import _base_plan
+
+    plan = _base_plan(
+        app_kind="agentgenerator_handoff_research",
+        pages=[
+            {
+                "name": "research",
+                "route": "/research",
+                "title": "Research",
+                "page_type_hint": "workflow_board",
+                "sections_hint": [
+                    {
+                        "primitive": "ActionButton",
+                        "section_id_hint": "start-research",
+                        "title_hint": "Start Research Review",
+                        "config_hint": json.dumps({"api_endpoint": "/api/modules/research/start_research"}),
+                    }
+                ],
+            }
+        ],
+        modules={"research": ["summarize_source", "start_research"]},
+        auth_strategy="required",
+    )
+    plan["agent_backend_required"] = True
+    plan["workflow_touchpoints"] = [
+        {
+            "page_name": "research",
+            "workflow_id": "ResearchReviewWorkflow",
+            "label": "Start research review",
+            "context_variables": {"source_text": "Local deterministic source"},
+        }
+    ]
+    return plan
+
+
+async def _run_platform_acceptance(
+    *,
+    spec: _ArchetypeSpec,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, str], Path, Any]:
+    previous_state = {
+        "executor_registry": getattr(platform.app.state, "executor_registry", None),
+        "subscriptions_config": getattr(platform.app.state, "subscriptions_config", None),
+        "failed_module_names": list(getattr(platform.app.state, "failed_module_names", [])),
+        "startup_degraded": getattr(platform.app.state, "startup_degraded", False),
+        "startup_degraded_reason": getattr(platform.app.state, "startup_degraded_reason", None),
+        "module_action_surfaces": deepcopy(getattr(platform.app.state, "module_action_surfaces", {})),
+    }
+    _PersistenceContext.reset()
+    try:
+        files_one, app_root, loaded = await _materialize_spec(spec, tmp_path / "run1")
+        files_two, _, _ = await _materialize_spec(spec, tmp_path / "run2")
+        assert files_one == files_two, f"MATERIALIZATION_GAP nondeterministic file map for {spec.archetype_id}"
+
+        _configure_platform(app_root=app_root, loaded=loaded, spec=spec, monkeypatch=monkeypatch)
+        fake_persistence = _RuntimeAcceptancePersistence()
+        fake_chat_collection = _RuntimeAcceptanceCollection()
+
+        async def _fake_chat_coll() -> _RuntimeAcceptanceCollection:
+            return fake_chat_collection
+
+        monkeypatch.setattr(platform, "persistence_manager", fake_persistence)
+        monkeypatch.setattr(platform.runtime_app, "persistence_manager", fake_persistence)
+        monkeypatch.setattr(platform.runtime_app, "_chat_coll", _fake_chat_coll)
+        monkeypatch.setattr(platform.runtime_app, "simple_transport", None)
+        monkeypatch.setattr(platform.runtime_app, "mongo_client", _FakeMongoClient())
+
+        with TestClient(platform.app, raise_server_exceptions=False) as client:
+            health = client.get("/health")
+            assert health.status_code == 200, health.text
+            shell = client.get("/api/shell-config?surface=platform")
+            _assert_not_missing_or_placeholder(shell, surface="/api/shell-config")
+            assert shell.status_code == 200, shell.text
+            spec.runtime_checks(client, files_one, loaded)
+        return files_one, app_root, loaded
+    finally:
+        from mozaiksai.core.workflow.workflow_manager import initialize_workflows
+
+        initialize_workflows(str(WORKFLOWS_ROOT))
+        platform.app.state.executor_registry = previous_state["executor_registry"]
+        platform.app.state.subscriptions_config = previous_state["subscriptions_config"]
+        platform.app.state.failed_module_names = previous_state["failed_module_names"]
+        platform.app.state.startup_degraded = previous_state["startup_degraded"]
+        platform.app.state.startup_degraded_reason = previous_state["startup_degraded_reason"]
+        platform.app.state.module_action_surfaces = previous_state["module_action_surfaces"]
+        auth_registry._adapter_registry.clear()
+        reset_auth_adapter()
+
+
+@pytest.mark.asyncio
+async def test_brownfield_discovery_handoff_materializes_deterministically_and_boots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_root = tmp_path / "source"
+    _write_brownfield_source(source_root)
+    preload_context = _Context({"repo_path": str(source_root), "chat_id": "brownfield-chat", "app_id": "existing_project_tracker"})
+    preload = await collect_prechat_discovery_context(preload_context)
+    assert preload["preload_status"] in {"ready", "partial"}
+    assert preload_context.get("repo_path") == str(source_root)
+
+    discovery = _brownfield_discovery_artifact()
+    decomposition = _brownfield_module_decomposition()
+    context = _Context(
+        {
+            "app_id": "existing_project_tracker",
+            "chat_id": "brownfield-chat",
+            "module_decomposition_plan": decomposition,
+            "source_refs": [{"source_ref_id": "src_existing_project_tracker", "kind": "local_directory", "uri": str(source_root)}],
+        }
+    )
+    drafts = build_existing_app_context_artifacts(discovery, context)
+    payloads = drafts.as_artifact_payloads()
+    assert payloads["adoption_plan"]["recommended_path"] == "gradual_modernization"
+    assert "customer_projects" in json.dumps(payloads, sort_keys=True)
+
+    plan = build_app_build_plan_from_discovery(discovery, module_decomposition_plan=decomposition)
+    spec = _ArchetypeSpec(
+        archetype_id="brownfield_project_tracker",
+        app_id="existing_project_tracker",
+        app_name="Existing Project Tracker",
+        plan=plan,
+        modules=("customer_projects", "work_items"),
+        pages=("projects", "work_items"),
+        runtime_checks=_brownfield_checks,
+        auth_enabled=True,
+    )
+    files, _, _ = await _run_platform_acceptance(spec=spec, tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    assert "route: /projects" in files["ui/pages/projects.yaml"], "PLAN_LOSS source route /projects was dropped"
+    assert "modules/customer_projects/module.yaml" in files, "MODULE_GAP source Project entity module was dropped"
+    assert "update_project" in files["modules/customer_projects/module.yaml"], "MODULE_GAP source update action was dropped"
+    assert "Project" in json.loads(files["data/contract.json"])["surfaces"][0]["collections"][0]["entity_name"] or "customer_projects" in files["data/contract.json"]
+
+
+@pytest.mark.asyncio
+async def test_brownfield_acceptance_fails_when_required_action_is_dropped(tmp_path: Path) -> None:
+    plan = build_app_build_plan_from_discovery(
+        _brownfield_discovery_artifact(),
+        module_decomposition_plan=_brownfield_module_decomposition(),
+    )
+    spec = _ArchetypeSpec(
+        archetype_id="brownfield_project_tracker_negative",
+        app_id="existing_project_tracker",
+        app_name="Existing Project Tracker",
+        plan=plan,
+        modules=("customer_projects", "work_items"),
+        pages=("projects", "work_items"),
+        runtime_checks=_brownfield_checks,
+        auth_enabled=True,
+    )
+    files, _, _ = await _materialize_spec(spec, tmp_path / "run")
+    mutated = dict(files)
+    mutated["modules/customer_projects/backend/handler.py"] = mutated["modules/customer_projects/backend/handler.py"].replace(
+        "\n    async def update_project(self, ctx, **params):\n        return {\"ok\": True, \"action\": \"update_project\"}\n",
+        "\n",
+    )
+
+    validation = validate_generated_app_bundle(
+        GeneratedAppValidationRequest(
+            files=mutated,
+            pages=_validation_pages(spec.plan, mutated),
+            build_tasks=spec.plan.get("build_tasks", []),
+            capability_packs=spec.plan.get("capability_packs", []),
+        )
+    )
+    codes = {item.code for item in scan_functional_generated_app(mutated)}
+
+    assert validation.passed is False
+    assert "MISSING_MODULE_HANDLER" in codes or "MISSING_MODULE_ACTION" in codes
+
+
+@pytest.mark.asyncio
+async def test_agentgenerator_bundle_handoff_materializes_app_and_workflow_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _captured_agentgenerator_bundle()
+    generated_root = tmp_path / "generated_workflows"
+    workflow_dir, created = _write_bundle_to_disk(bundle["workflow_name"], bundle["files"], generated_root)
+    assert "orchestrator.yaml" in created
+
+    active_workflows_root = tmp_path / "workspace" / "workflows"
+    promotion = promote_generated_workflow(workflow_dir, active_workflows_root)
+    assert Path(promotion["target_dir"]).exists()
+
+    metadata = extract_workflow_integration_metadata_from_bundle_entries([bundle], bundle_name="ResearchReviewPack")
+    assert metadata is not None
+    context = _Context({})
+    apply_workflow_integration_context(context, metadata)
+    assert context.get("generated_workflow_name") == "ResearchReviewWorkflow"
+
+    workspace_files = {
+        str(path.relative_to(active_workflows_root.parent).as_posix()): path.read_text(encoding="utf-8")
+        for path in sorted(active_workflows_root.rglob("*"))
+        if path.is_file()
+    }
+    plan = _workflow_plan()
+    spec = _ArchetypeSpec(
+        archetype_id="agentgenerator_appgenerator_handoff",
+        app_id="agentgenerator-handoff",
+        app_name="AgentGenerator Handoff",
+        plan=plan,
+        modules=("research",),
+        pages=("research",),
+        runtime_checks=_workflow_app_checks,
+        workspace_files=workspace_files,
+        auth_enabled=True,
+    )
+    files, _, _ = await _run_platform_acceptance(spec=spec, tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    assert "ResearchReviewWorkflow" in workspace_files["workflows/ResearchReviewWorkflow/orchestrator.yaml"]
+    assert "summarize_source" in workspace_files["workflows/ResearchReviewWorkflow/tools.yaml"]
+    assert "summarize_source" in files["modules/research/module.yaml"], "MODULE_GAP AgentGenerator tool target action was dropped"
+    assert any(
+        touchpoint.get("workflow_id") == context.get("generated_workflow_name")
+        for touchpoint in spec.plan.get("workflow_touchpoints") or []
+    ), "PLAN_LOSS AgentGenerator workflow was not referenced by AppBuildPlan"

--- a/tests/test_generated_app_archetype_matrix.py
+++ b/tests/test_generated_app_archetype_matrix.py
@@ -266,6 +266,18 @@ def _module_contract(module_id: str, actions: list[tuple[str, str]], *, entitlem
     )
 
 
+def _plan_actions(spec: _ArchetypeSpec, module_id: str) -> list[str]:
+    for pack in spec.plan.get("capability_packs") or []:
+        if not isinstance(pack, Mapping):
+            continue
+        if str(pack.get("capability_pack_id") or pack.get("surface_id") or "") != module_id:
+            continue
+        actions = [str(action) for action in pack.get("operations") or [] if str(action).strip()]
+        if actions:
+            return actions
+    return []
+
+
 def _simple_backend(module_id: str, actions: list[str]) -> dict[str, str]:
     methods = []
     for action in actions:
@@ -543,7 +555,9 @@ def _app_task_output(spec: _ArchetypeSpec, *, task_type: str, task: Mapping[str,
             "incidents": [("create_incident", "Create incident."), ("list_incidents", "List incidents.")],
             "posts": [("create_post", "Create post."), ("list_posts", "List posts.")],
             "comments": [("create_comment", "Create comment."), ("list_comments", "List comments.")],
-        }[module_id]
+        }.get(module_id)
+        if actions is None:
+            actions = [(action, f"{action.replace('_', ' ').title()}.") for action in _plan_actions(spec, module_id)]
         files = [{"filename": f"modules/{module_id}/module.yaml", "content": _module_contract(module_id, actions)}]
         files.extend(
             {"filename": path, "content": "schema_version: mozaiks.events.v1\nevents: []\n"}
@@ -575,7 +589,9 @@ def _app_task_output(spec: _ArchetypeSpec, *, task_type: str, task: Mapping[str,
             "incidents": ["create_incident", "list_incidents"],
             "posts": ["create_post", "list_posts"],
             "comments": ["create_comment", "list_comments"],
-        }[module_id]
+        }.get(module_id)
+        if actions is None:
+            actions = _plan_actions(spec, module_id)
         backend_files = _simple_backend(module_id, actions)
         return {
             "code_files": [


### PR DESCRIPTION
## Summary
- Add deterministic ExistingAppDiscovery post-discovery -> AppBuildPlan handoff helper.
- Add offline Level-2 acceptance covering brownfield source preload, captured discovery/module decomposition, AppGenerator materialization, validation, AppLoader, and platform HTTP/module surfaces.
- Add offline AgentGenerator -> AppGenerator replay covering captured WorkflowBundleBuilderOutput materialization/promotion, workflow integration metadata, AppBuildPlan workflow touchpoint/module action alignment, workflow registry load, and platform runtime surfaces.
- Fix Windows CRLF false positive in primitive schema catalog check without committing generated catalog churn.
- Fix two mkdocs strict link issues from governance docs.

## Validation
- `python -m pytest tests/test_brownfield_agentgenerator_acceptance.py -q --no-cov`
- `python -m pytest tests/test_generated_app_archetype_matrix.py -q --no-cov`
- `python -m pytest tests/test_existing_app_discovery_contracts.py tests/test_brownfield_adoption_generation_contract.py tests/test_agentgenerator_generated_workflow_e2e.py tests/test_workflow_integration_metadata.py -q --no-cov`
- `python -m pytest tests/test_brownfield_agentgenerator_acceptance.py tests/test_existing_app_discovery_contracts.py tests/test_brownfield_adoption_generation_contract.py tests/test_agentgenerator_generated_workflow_e2e.py tests/test_agentgenerator_workflow_converter.py tests/test_workflow_integration_metadata.py -q --no-cov`
- `python -m pytest tests/test_appplan_materialization_acceptance.py tests/test_generated_app_archetype_matrix.py tests/test_generated_app_functional_acceptance.py tests/test_generated_app_validation_public_api.py tests/test_appgenerator_canonical_generation.py tests/test_appgenerator_module_contracts.py tests/test_appgenerator_persistence_alignment.py tests/test_appgenerator_managed_capability_smoke.py -q --no-cov`
- `python -m pytest tests/test_mozaikspay_managed_capability_contract.py tests/test_build_context_mozaikspay_pack.py tests/test_smoke_appgenerator_live_subscription.py tests/test_app_loader.py tests/test_platform_module_dispatch.py tests/test_platform_routing_helpers.py tests/test_platform_shell_helpers.py tests/test_governance_guardrails.py tests/test_package_content_guard.py -q --no-cov`
- `python -m pytest tests/test_workflow_declarative_contracts.py tests/test_workflow_manager_reload.py tests/test_workflow_network_graph.py tests/test_workflow_session_manager.py tests/test_workflow_ui_tool_contracts.py tests/test_factory_workflow_integration_contracts.py -q --no-cov`
- `node scripts/export-primitive-schemas.js --check`
- `python -m pytest tests/test_ui_surface_taxonomy.py::test_primitive_schema_catalog_is_generated -q --no-cov`
- `ruff check .`
- `mkdocs build --strict`
- tracked+untracked `py_compile` check
- `python -m pytest -q --no-cov` -> 12324 passed, 77 skipped

No paid APIs, hosted services, or mozaiks-app dependency.