### PR TITLE
docs: update license reference in README to link directly to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ This project follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION


<!--
  Thanks for contributing to Mozaiks! Please fill out this template so
  maintainers have what they need to review efficiently. See CONTRIBUTING.md
  for the full contribution path.
-->

## Related issue

N/A

## Summary

Small documentation improvements:

- Change the LICENSE reference to a clickable Markdown link in README.md.

## Tests run

N/A

## Screenshots (if applicable)

N/A

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [ ] If this adds or changes a public contract, the contract is classified and versioned.
- [ ] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included.
- [ ] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit.
