### PR TITLE
docs: require architecture-first agent review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,25 @@ Never read from or write to OneDrive paths (`C:\Users\...\OneDrive\...`). Those 
 
 Read [ARCHITECTURE.md](ARCHITECTURE.md) and [CLAUDE.md](CLAUDE.md) first.
 
+## Required Pre-Edit Architecture Check
+
+Before editing Mozaiks OSS:
+
+- read [docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md](docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md)
+- if the task changes, extends, replaces, or challenges architecture, also read
+  [docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md](docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md)
+- current source remains final authority
+- if current source contradicts the frozen north star, stop and report the
+  contradiction before editing
+- before introducing a subsystem, identify the current canonical owner,
+  determine whether AG2 already owns the primitive, determine whether Mozaiks
+  already has the canonical implementation, and prefer extending or connecting
+  the existing owner
+- do not introduce a parallel subsystem without proving the canonical owner
+  cannot satisfy the requirement
+- architectural changes that contradict the frozen north star require an ADR or
+  explicit architecture decision
+
 This repo uses layered FastAPI hosts as the canonical OSS server composition:
 - `mozaiksai.hosts.runtime`
 - `mozaiksai.hosts.platform`

--- a/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
+++ b/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
@@ -34,6 +34,15 @@ The authoritative OSS software-design document is
 | One-app App Intelligence and brownfield adoption | Mozaiks OSS |
 | Cross-app Build Intelligence, learned routing, operator evidence | Operator/private by default |
 
+## Required Pre-Edit Architecture Check
+
+Before editing Mozaiks OSS:
+
+1. read this quick reference;
+2. if the task changes, extends, replaces, or challenges architecture, read [Mozaiks OSS Software Design](MOZAIKS_OSS_SOFTWARE_DESIGN.md);
+3. treat current source as final authority;
+4. if current source contradicts the frozen north star, stop and report the contradiction.
+
 ## Agent Development Rule
 
 Before introducing a subsystem:
@@ -42,4 +51,4 @@ Before introducing a subsystem:
 2. inspect whether AG2 already owns the primitive;
 3. inspect whether Mozaiks already has the canonical implementation;
 4. extend or connect existing architecture first;
-5. do not introduce a parallel implementation without an ADR.
+5. do not introduce a parallel subsystem without an ADR.

--- a/tests/test_contributor_guidance_framing.py
+++ b/tests/test_contributor_guidance_framing.py
@@ -55,6 +55,21 @@ def test_top_level_guidance_documents_shared_workflow_ui_lane() -> None:
     assert "Do not import UI from a sibling workflow folder" in agents
 
 
+def test_agent_guidance_requires_architecture_first_review() -> None:
+    agents = _read("AGENTS.md")
+    quick_reference = _read("docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md")
+
+    for text in (agents, quick_reference):
+        assert "Required Pre-Edit Architecture Check" in text
+        assert "ARCHITECTURE_QUICK_REFERENCE.md" in text or "read this quick reference" in text
+        assert "MOZAIKS_OSS_SOFTWARE_DESIGN.md" in text
+        assert "current source" in text.lower()
+        assert "final authority" in text.lower()
+        assert "parallel subsystem" in text
+
+    assert "architectural changes that contradict the frozen north star require an ADR" in agents
+
+
 def test_refinement_guidance_states_checkpoint_reentry_truth() -> None:
     architecture = _read("ARCHITECTURE.md")
     refinement_harness = _read("docs/architecture/workflows/refinement-harness-architecture.md")


### PR DESCRIPTION
## Summary
- add a repository-wide required pre-edit architecture check to AGENTS.md
- add the same concise pre-edit check to the Architecture Quick Reference
- extend existing contributor guidance tests so the rule cannot silently disappear

## Validation
- python -m pytest -q --no-cov tests/test_contributor_guidance_framing.py tests/test_governance_guardrails.py
- python -m pytest -q --no-cov tests/test_contributor_guidance_readiness_doc.py tests/test_getting_started_docs.py
- git diff --check
