### PR TITLE
[codex] harden event reaction runtime

### DIFF
--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -288,6 +288,11 @@ class ModuleDefinition(ModuleContractModel):
         """Maps each action id to its entitlement_gate capability_id (or None)."""
         return {action.id: action.entitlement_gate for action in self.actions}
 
+    @property
+    def action_emits_map(self) -> dict[str, list[str]]:
+        """Maps each action id to event types declared in module.yaml actions[].emits."""
+        return {action.id: list(action.emits) for action in self.actions}
+
     @model_validator(mode="after")
     def _validate_unique_ids(self) -> ModuleDefinition:
         action_ids = [action.id for action in self.actions]
@@ -1069,6 +1074,20 @@ class LoadedModule:
     def action_entitlement_map(self) -> dict[str, str | None]:
         return self.definition.action_entitlement_map
 
+    @property
+    def action_emits_map(self) -> dict[str, list[str]]:
+        return self.definition.action_emits_map
+
+    @property
+    def event_payload_schemas_map(self) -> dict[str, dict[str, Any]]:
+        if self.manifests.events is None:
+            return {}
+        return {
+            event.type: dict(event.payload_schema)
+            for event in self.manifests.events.events
+            if event.payload_schema
+        }
+
     def __repr__(self) -> str:
         return f"<LoadedModule name={self.name!r} handler={type(self.handler).__name__}>"
 
@@ -1351,12 +1370,19 @@ class ModuleLoader:
         declared_events: set[str] = manifests.events.event_types if manifests.events is not None else set()
 
         if manifests.reactions is not None:
+            declared_permission_ids = {permission.id for permission in definition.permissions}
             for reaction in manifests.reactions.reactions:
                 event_type = str(reaction.event_type or "").strip()
                 if event_type and not self._is_known_or_canonical_event(event_type, declared_events):
                     raise ModuleLoadError(
                         f"reactions.yaml references non-canonical event {event_type!r}"
                     )
+                for permission_id in reaction.permissions:
+                    if permission_id not in declared_permission_ids:
+                        raise ModuleLoadError(
+                            f"reactions.yaml reaction {reaction.id!r} references undeclared "
+                            f"permission {permission_id!r}; add it to the module-level permissions block"
+                        )
 
         if manifests.notifications is not None:
             for notification in manifests.notifications.notifications:

--- a/mozaiksai/core/runtime/composition/module_event_router.py
+++ b/mozaiksai/core/runtime/composition/module_event_router.py
@@ -13,10 +13,13 @@ This keeps module event meaning above the runtime kernel.
 
 import importlib
 import inspect
+import json
 import re
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import replace
 from datetime import UTC, datetime
+from hashlib import sha256
 from typing import Any
 from uuid import uuid4
 
@@ -31,6 +34,10 @@ from mozaiksai.core.runtime.composition.module_event_provenance import (
     normalize_module_reaction_provenance,
 )
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.runtime.composition.schema_validation import (
+    SchemaValidationDiagnostic,
+    validate_json_schema,
+)
 
 logger = get_workflow_logger("module_event_router")
 
@@ -51,12 +58,14 @@ class _ReactionCtx:
         event_emitter: EventEmitter | None,
         event_provenance: ModuleEventProvenance | None = None,
         reaction_provenance: ModuleReactionProvenance | None = None,
+        permissions: Iterable[str] | None = None,
     ) -> None:
         self.app_id = app_id
         self.tenant_id = tenant_id
         self.user_id = user_id
         self.event_provenance = event_provenance
         self.reaction_provenance = reaction_provenance
+        self.permissions = list(permissions or [])
         self.correlation_id = event_provenance.correlation_id if event_provenance is not None else None
         self.causation_id = event_provenance.causation_id if event_provenance is not None else None
         self._event_emitter = event_emitter
@@ -64,6 +73,37 @@ class _ReactionCtx:
     async def emit(self, event_type: str, payload: dict[str, Any]) -> None:
         if self._event_emitter is not None:
             await ModuleEventRouter._maybe_await(self._event_emitter(event_type, payload))
+
+
+class ModuleEventPayloadValidationError(ValueError):
+    """Raised when a routed event violates its declared payload schema."""
+
+    def __init__(
+        self,
+        *,
+        event_type: str,
+        source_module: str | None,
+        source_action: str | None,
+        diagnostic: SchemaValidationDiagnostic,
+    ) -> None:
+        self.event_type = event_type
+        self.source_module = source_module
+        self.source_action = source_action
+        self.diagnostic = diagnostic
+        super().__init__(
+            "MODULE_EVENT_PAYLOAD_INVALID: "
+            f"event={event_type} module={source_module or ''} action={source_action or ''} "
+            f"path={diagnostic.path} error={diagnostic.message}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": "MODULE_EVENT_PAYLOAD_INVALID",
+            "event_type": self.event_type,
+            "source_module": self.source_module,
+            "source_action": self.source_action,
+            "schema_error": self.diagnostic.to_dict(),
+        }
 
 
 class ModuleEventRouter:
@@ -84,7 +124,15 @@ class ModuleEventRouter:
         self._notifications_by_event: dict[str, list[dict]] = defaultdict(list)
         self._notifications_by_key: dict[tuple[str, str], dict] = {}
         self._handlers_by_module: dict[str, Any] = {}
+        self._event_schemas_by_producer: dict[tuple[str, str], dict[str, Any]] = {}
+        self._event_schemas_by_type: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+        self._capability_ids: set[str] = set()
+        self._capability_index_available = False
+        self._handler_emits_by_module_method: dict[tuple[str, str], list[str]] = {}
+        self._processed_reaction_keys: set[tuple[str, str, str, str, str]] = set()
         self._index_modules(modules)
+        self._validate_reaction_targets()
+        self._validate_static_reaction_cycles()
 
     @property
     def event_types(self) -> list[str]:
@@ -104,9 +152,58 @@ class ModuleEventRouter:
         """Handle one canonical module event envelope."""
         emitted_notifications: set[tuple[str, str]] = set()
         event_provenance = normalize_module_event_provenance(event_type, envelope)
+        validation_error = self._validate_event_payload(event_type, envelope, event_provenance)
+        if validation_error is not None:
+            logger.warning(
+                "MODULE_EVENT_PAYLOAD_INVALID: event=%s module=%s action=%s path=%s error=%s",
+                event_type,
+                validation_error.source_module,
+                validation_error.source_action,
+                validation_error.diagnostic.path,
+                validation_error.diagnostic.message,
+                extra={"module_event_payload_validation": validation_error.to_dict()},
+            )
+            for reaction in self._reactions_by_event.get(event_type, []):
+                await self._emit_reaction_audit(
+                    build_module_reaction_audit(
+                        event=event_provenance,
+                        reaction=self._reaction_provenance(reaction),
+                        outcome="failed",
+                        reason=str(validation_error),
+                    )
+                )
+            raise validation_error
 
         for reaction in self._reactions_by_event.get(event_type, []):
-            reaction_provenance = normalize_module_reaction_provenance(reaction)
+            permission_result = self._evaluate_reaction_permissions(reaction, envelope)
+            reaction_provenance = self._reaction_provenance(
+                reaction,
+                permissions_enforced=permission_result["required"],
+                idempotency_enforced=bool(reaction.get("idempotency_key")),
+            )
+            if not permission_result["allowed"]:
+                await self._emit_reaction_audit(
+                    build_module_reaction_audit(
+                        event=event_provenance,
+                        reaction=reaction_provenance,
+                        outcome="skipped",
+                        reason=permission_result["reason"],
+                    )
+                )
+                continue
+            idempotency_key = self._idempotency_key(reaction, event_type, envelope, event_provenance)
+            if idempotency_key is not None:
+                if idempotency_key in self._processed_reaction_keys:
+                    await self._emit_reaction_audit(
+                        build_module_reaction_audit(
+                            event=event_provenance,
+                            reaction=reaction_provenance,
+                            outcome="skipped",
+                            reason="idempotent reaction already processed",
+                        )
+                    )
+                    continue
+                self._processed_reaction_keys.add(idempotency_key)
             target = reaction.get("target") if isinstance(reaction.get("target"), dict) else {}
             target_kind = str(target.get("kind") or "").strip()
             if target_kind == "notification":
@@ -153,6 +250,7 @@ class ModuleEventRouter:
                     envelope,
                     event_provenance=event_provenance,
                     reaction_provenance=reaction_provenance,
+                    permissions=permission_result["granted"],
                 )
                 await self._emit_reaction_audit(
                     build_module_reaction_audit(
@@ -208,8 +306,36 @@ class ModuleEventRouter:
         for module in modules:
             module_id = module.name
             self._handlers_by_module[module_id] = module.handler
-            if module.manifests.reactions is not None:
-                for reaction_model in module.manifests.reactions.reactions:
+            manifests = getattr(module, "manifests", None)
+            definition = getattr(module, "definition", None)
+            if definition is not None:
+                capabilities = getattr(definition, "capabilities", None)
+                actions = getattr(definition, "actions", None)
+                if isinstance(capabilities, list):
+                    self._capability_index_available = True
+                for capability in capabilities or []:
+                    capability_id = str(getattr(capability, "capability_id", "") or "").strip()
+                    if capability_id:
+                        self._capability_ids.add(capability_id)
+                for action in actions or []:
+                    handler_method = str(getattr(action, "handler_method", "") or "").strip()
+                    emits = [str(event).strip() for event in getattr(action, "emits", []) or [] if str(event).strip()]
+                    if handler_method:
+                        self._handler_emits_by_module_method[(module_id, handler_method)] = emits
+            events_manifest = getattr(manifests, "events", None)
+            if events_manifest is not None:
+                events = getattr(events_manifest, "events", None)
+                if not isinstance(events, list):
+                    events = []
+                for event in events:
+                    event_type = str(getattr(event, "type", "") or "").strip()
+                    payload_schema = getattr(event, "payload_schema", None)
+                    if event_type and isinstance(payload_schema, dict) and payload_schema:
+                        self._event_schemas_by_producer[(module_id, event_type)] = dict(payload_schema)
+                        self._event_schemas_by_type[event_type].append((module_id, dict(payload_schema)))
+            reactions_manifest = getattr(manifests, "reactions", None)
+            if reactions_manifest is not None:
+                for reaction_model in reactions_manifest.reactions:
                     event_type = str(reaction_model.event_type or "").strip()
                     if not event_type:
                         continue
@@ -217,8 +343,9 @@ class ModuleEventRouter:
                     reaction["module_id"] = module_id
                     self._reactions_by_event[event_type].append(reaction)
 
-            if module.manifests.notifications is not None:
-                for raw_rule in module.manifests.notifications.notifications:
+            notifications_manifest = getattr(manifests, "notifications", None)
+            if notifications_manifest is not None:
+                for raw_rule in notifications_manifest.notifications:
                     if hasattr(raw_rule, "as_rule") and callable(raw_rule.as_rule):
                         raw_rule = raw_rule.as_rule()
                     elif hasattr(raw_rule, "model_dump") and callable(raw_rule.model_dump):
@@ -233,6 +360,169 @@ class ModuleEventRouter:
                     rule["module_id"] = module_id
                     self._notifications_by_event[event_type].append(rule)
                     self._notifications_by_key[(module_id, rule_id)] = rule
+
+    def _validate_reaction_targets(self) -> None:
+        for reactions in self._reactions_by_event.values():
+            for reaction in reactions:
+                module_id = str(reaction.get("module_id") or "").strip()
+                target = reaction.get("target") if isinstance(reaction.get("target"), dict) else {}
+                target_kind = str(target.get("kind") or "").strip()
+                if target_kind == "handler":
+                    handler_method = str(target.get("handler_method") or "").strip()
+                    handler = self._handlers_by_module.get(module_id)
+                    if handler is not None and handler_method and not callable(getattr(handler, handler_method, None)):
+                        raise ValueError(
+                            "MODULE_REACTION_TARGET_INVALID: "
+                            f"module={module_id} reaction={reaction.get('id')} "
+                            f"handler_method={handler_method} not found"
+                        )
+                elif target_kind == "capability":
+                    capability_id = str(target.get("capability_id") or "").strip()
+                    if self._capability_index_available and capability_id not in self._capability_ids:
+                        raise ValueError(
+                            "MODULE_REACTION_TARGET_INVALID: "
+                            f"module={module_id} reaction={reaction.get('id')} "
+                            f"capability_id={capability_id} not declared"
+                        )
+
+    def _validate_static_reaction_cycles(self) -> None:
+        edges: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+        for event_type, reactions in self._reactions_by_event.items():
+            for reaction in reactions:
+                target = reaction.get("target") if isinstance(reaction.get("target"), dict) else {}
+                if target.get("kind") != "handler":
+                    continue
+                module_id = str(reaction.get("module_id") or "").strip()
+                handler_method = str(target.get("handler_method") or "").strip()
+                for emitted_event in self._handler_emits_by_module_method.get((module_id, handler_method), []):
+                    edges[event_type].append((emitted_event, reaction))
+
+        visiting: list[str] = []
+        visited: set[str] = set()
+
+        def visit(event_type: str) -> None:
+            if event_type in visiting:
+                cycle = [*visiting[visiting.index(event_type):], event_type]
+                raise ValueError(
+                    "MODULE_REACTION_CYCLE: "
+                    + " -> ".join(cycle)
+                )
+            if event_type in visited:
+                return
+            visiting.append(event_type)
+            for next_event, _reaction in edges.get(event_type, []):
+                visit(next_event)
+            visiting.pop()
+            visited.add(event_type)
+
+        for event_type in list(edges):
+            visit(event_type)
+
+    def _validate_event_payload(
+        self,
+        event_type: str,
+        envelope: dict[str, Any],
+        event_provenance: ModuleEventProvenance,
+    ) -> ModuleEventPayloadValidationError | None:
+        schema = self._payload_schema_for_event(event_type, event_provenance)
+        if not schema:
+            return None
+        payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
+        diagnostic = validate_json_schema(payload, schema)
+        if diagnostic is None:
+            return None
+        return ModuleEventPayloadValidationError(
+            event_type=event_type,
+            source_module=event_provenance.producer_module_id,
+            source_action=event_provenance.producer_action_id,
+            diagnostic=diagnostic,
+        )
+
+    def _payload_schema_for_event(
+        self,
+        event_type: str,
+        event_provenance: ModuleEventProvenance,
+    ) -> dict[str, Any] | None:
+        producer_module = str(event_provenance.producer_module_id or "").strip()
+        if producer_module:
+            schema = self._event_schemas_by_producer.get((producer_module, event_type))
+            if schema:
+                return schema
+        schemas = self._event_schemas_by_type.get(event_type) or []
+        if len(schemas) == 1:
+            return schemas[0][1]
+        return None
+
+    def _reaction_provenance(
+        self,
+        reaction: dict[str, Any],
+        *,
+        permissions_enforced: bool = False,
+        idempotency_enforced: bool = False,
+    ) -> ModuleReactionProvenance:
+        provenance = normalize_module_reaction_provenance(reaction)
+        return replace(
+            provenance,
+            permissions_enforced=permissions_enforced,
+            idempotency_enforced=idempotency_enforced,
+        )
+
+    def _evaluate_reaction_permissions(
+        self,
+        reaction: dict[str, Any],
+        envelope: dict[str, Any],
+    ) -> dict[str, Any]:
+        required = [
+            str(permission).strip()
+            for permission in (reaction.get("permissions") or [])
+            if str(permission).strip()
+        ]
+        if not required:
+            return {"allowed": True, "required": False, "granted": [], "reason": None}
+        authority = envelope.get("authority") if isinstance(envelope.get("authority"), dict) else {}
+        granted = [
+            str(permission).strip()
+            for permission in (authority.get("granted_permissions") if isinstance(authority, dict) else []) or []
+            if str(permission).strip()
+        ]
+        missing = sorted(set(required) - set(granted))
+        if missing:
+            return {
+                "allowed": False,
+                "required": True,
+                "granted": granted,
+                "reason": f"reaction permission denied: missing {missing}",
+            }
+        return {"allowed": True, "required": True, "granted": granted, "reason": None}
+
+    def _idempotency_key(
+        self,
+        reaction: dict[str, Any],
+        event_type: str,
+        envelope: dict[str, Any],
+        event_provenance: ModuleEventProvenance,
+    ) -> tuple[str, str, str, str, str] | None:
+        declared = str(reaction.get("idempotency_key") or "").strip()
+        if not declared:
+            return None
+        reaction_id = str(reaction.get("id") or "").strip()
+        module_id = str(reaction.get("module_id") or "").strip()
+        event_identity = str(event_provenance.event_id or "").strip()
+        if not event_identity:
+            event_identity = sha256(
+                json.dumps(
+                    {
+                        "event_type": event_type,
+                        "tenant_id": event_provenance.tenant_id,
+                        "app_id": event_provenance.app_id,
+                        "actor_id": event_provenance.actor_id,
+                        "payload": envelope.get("payload", envelope),
+                    },
+                    sort_keys=True,
+                    default=str,
+                ).encode("utf-8")
+            ).hexdigest()
+        return (module_id, reaction_id, event_type, declared, event_identity)
 
     def _handler_for(self, event_type: str) -> Callable[[dict[str, Any]], Awaitable[None]]:
         async def handle(envelope: dict[str, Any]) -> None:
@@ -370,6 +660,7 @@ class ModuleEventRouter:
         *,
         event_provenance: ModuleEventProvenance,
         reaction_provenance: ModuleReactionProvenance,
+        permissions: Iterable[str] | None = None,
     ) -> tuple[str, str | None]:
         module_id = str(reaction.get("module_id") or "").strip()
         target = reaction.get("target") if isinstance(reaction.get("target"), dict) else {}
@@ -405,6 +696,7 @@ class ModuleEventRouter:
             event_emitter=self._event_emitter,
             event_provenance=event_provenance,
             reaction_provenance=reaction_provenance,
+            permissions=permissions,
         )
         payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else {}
         try:

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -35,8 +35,6 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-import jsonschema
-
 from logs.logging_config import get_workflow_logger
 from mozaiksai.core.audit.audit_logger import get_audit_logger
 from mozaiksai.core.ports.entitlement import EntitlementPort, NoOpEntitlementAdapter
@@ -52,6 +50,11 @@ from mozaiksai.core.runtime.composition.module_authority import (
 )
 from mozaiksai.core.runtime.composition.module_context import ModuleContext
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.runtime.composition.schema_validation import (
+    SchemaValidationDiagnostic,
+    normalize_nullable_schema,
+    validate_json_schema,
+)
 from mozaiksai.core.runtime.persistence import MongoPersistenceContext
 
 logger = get_workflow_logger("module_executor")
@@ -145,24 +148,7 @@ class ModuleResult:
 
 def _normalize_nullable_schema(schema: Any) -> Any:
     """Translate OpenAPI-style nullable fields into JSON Schema."""
-    if isinstance(schema, list):
-        return [_normalize_nullable_schema(item) for item in schema]
-    if not isinstance(schema, dict):
-        return schema
-
-    normalized = {key: _normalize_nullable_schema(value) for key, value in schema.items()}
-    if normalized.get("nullable") is True:
-        schema_type = normalized.get("type")
-        if isinstance(schema_type, str):
-            normalized["type"] = [schema_type, "null"] if schema_type != "null" else schema_type
-        elif isinstance(schema_type, list) and "null" not in schema_type:
-            normalized["type"] = [*schema_type, "null"]
-
-        enum_values = normalized.get("enum")
-        if isinstance(enum_values, list) and None not in enum_values:
-            normalized["enum"] = [*enum_values, None]
-
-    return normalized
+    return normalize_nullable_schema(schema)
 
 
 def _validate_schema(value: Any, schema: dict[str, Any]) -> str | None:
@@ -173,14 +159,39 @@ def _validate_schema(value: Any, schema: dict[str, Any]) -> str | None:
     """
     if not schema or not isinstance(schema, dict):
         return None
-    try:
-        jsonschema.validate(instance=value, schema=_normalize_nullable_schema(schema))
-        return None
-    except jsonschema.ValidationError as exc:
-        return exc.message  # type: ignore[no-any-return]
-    except Exception as exc:  # malformed schema — don't crash the executor
-        logger.warning("MODULE_SCHEMA_ERROR: could not validate schema: %s", exc)
-        return None
+    diagnostic = validate_json_schema(value, schema)
+    return diagnostic.message if diagnostic is not None else None
+
+
+class ModuleEventPayloadValidationError(ValueError):
+    """Raised when a module emits an event payload that violates its contract."""
+
+    def __init__(
+        self,
+        *,
+        event_type: str,
+        source_module: str | None,
+        source_action: str | None,
+        diagnostic: SchemaValidationDiagnostic,
+    ) -> None:
+        self.event_type = event_type
+        self.source_module = source_module
+        self.source_action = source_action
+        self.diagnostic = diagnostic
+        super().__init__(
+            "MODULE_EVENT_PAYLOAD_INVALID: "
+            f"event={event_type} module={source_module or ''} action={source_action or ''} "
+            f"path={diagnostic.path} error={diagnostic.message}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": "MODULE_EVENT_PAYLOAD_INVALID",
+            "event_type": self.event_type,
+            "source_module": self.source_module,
+            "source_action": self.source_action,
+            "schema_error": self.diagnostic.to_dict(),
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +226,8 @@ class ModuleExecutor:
         self._action_permissions: dict[str, dict[str, list[str]]] = {}
         self._action_schemas: dict[str, dict[str, dict[str, Any]]] = {}
         self._action_entitlements: dict[str, dict[str, str | None]] = {}
+        self._action_emits: dict[str, dict[str, list[str]]] = {}
+        self._event_payload_schemas: dict[str, dict[str, dict[str, Any]]] = {}
         self._event_emitter = event_emitter
         # When None, use the no-op adapter — grants everything without a DB check.
         self._entitlement_checker: EntitlementPort = entitlement_checker or NoOpEntitlementAdapter()
@@ -233,6 +246,8 @@ class ModuleExecutor:
         action_permissions: dict[str, list[str]] | None = None,
         action_schemas: dict[str, dict[str, Any]] | None = None,
         action_entitlements: dict[str, str | None] | None = None,
+        action_emits: dict[str, list[str]] | None = None,
+        event_payload_schemas: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         """Register a module handler instance under a name.
 
@@ -250,6 +265,8 @@ class ModuleExecutor:
                                  When a capability_id is set, the executor calls
                                  EntitlementPort.check() before dispatch and returns
                                  ENTITLEMENT_REQUIRED on denial.
+            action_emits:        Maps action id -> event types declared in module.yaml.
+            event_payload_schemas: Maps event type -> payload_schema from contracts/events.yaml.
         """
         self._modules[name] = handler
         self._action_methods[name] = dict(action_method_map or {})
@@ -257,6 +274,8 @@ class ModuleExecutor:
         self._action_permissions[name] = dict(action_permissions or {})
         self._action_schemas[name] = dict(action_schemas or {})
         self._action_entitlements[name] = dict(action_entitlements or {})
+        self._action_emits[name] = {k: list(v) for k, v in (action_emits or {}).items()}
+        self._event_payload_schemas[name] = dict(event_payload_schemas or {})
         logger.info("MODULE_REGISTERED: %s (%s)", name, type(handler).__name__)
 
     def registered_modules(self) -> list[str]:
@@ -510,6 +529,27 @@ class ModuleExecutor:
                 error="Permission denied.",
                 error_code="PERMISSION_DENIED",
             )
+        except ModuleEventPayloadValidationError as exc:
+            logger.warning(
+                "MODULE_EVENT_PAYLOAD_INVALID: module=%s action=%s event=%s path=%s error=%s",
+                request.module,
+                request.action,
+                exc.event_type,
+                exc.diagnostic.path,
+                exc.diagnostic.message,
+                extra={"module_event_payload_validation": exc.to_dict()},
+            )
+            asyncio.create_task(
+                self._emit_dispatch_audit(
+                    replace(dispatch_audit, outcome="failed", reason="MODULE_EVENT_PAYLOAD_INVALID"),
+                    error="MODULE_EVENT_PAYLOAD_INVALID",
+                )
+            )
+            return ModuleResult(
+                success=False,
+                error=str(exc),
+                error_code="INVALID_EVENT_PAYLOAD",
+            )
         except Exception as exc:
             logger.error(
                 "MODULE_ACTION_ERROR: module=%s action=%s error=%s", request.module, request.action, exc,
@@ -643,6 +683,32 @@ class ModuleExecutor:
             return None
 
         async def emit_module_event(event_type: str, payload: dict[str, Any]) -> None:
+            event_type_text = str(event_type or "").strip()
+            declared_emits = self._action_emits.get(request.module, {}).get(request.action)
+            if declared_emits is not None and event_type_text not in declared_emits:
+                diagnostic = SchemaValidationDiagnostic(
+                    message=f"action {request.module}.{request.action} did not declare emitted event",
+                    path="$",
+                    schema_path="$",
+                    validator="emits",
+                )
+                raise ModuleEventPayloadValidationError(
+                    event_type=event_type_text,
+                    source_module=request.module,
+                    source_action=request.action,
+                    diagnostic=diagnostic,
+                )
+            payload_schema = self._event_payload_schemas.get(request.module, {}).get(event_type_text)
+            if payload_schema:
+                validation_diagnostic = validate_json_schema(payload, payload_schema)
+                if validation_diagnostic is not None:
+                    raise ModuleEventPayloadValidationError(
+                        event_type=event_type_text,
+                        source_module=request.module,
+                        source_action=request.action,
+                        diagnostic=validation_diagnostic,
+                    )
+
             tenant_scope = {
                 "app_id": request.app_id,
                 "tenant_id": request.tenant_id,
@@ -652,13 +718,14 @@ class ModuleExecutor:
 
             envelope: dict[str, Any] = {
                 "id": f"evt_{uuid4().hex}",
-                "type": event_type,
+                "type": event_type_text,
                 "version": 1,
                 "occurred_at": datetime.now(UTC).isoformat(),
                 "source": {
                     "layer": "module",
                     "app_id": request.app_id,
                     "module_id": request.module,
+                    "action_id": request.action,
                     "capability_id": f"{request.module}.{request.action}",
                 },
                 "tenant": tenant_scope,
@@ -668,10 +735,20 @@ class ModuleExecutor:
                 "payload": payload,
                 "visibility": "internal",
             }
+            if request.granted_permissions is not None:
+                authority = request.authority or ModuleDispatchAuthority.from_granted_permissions(
+                    request.granted_permissions,
+                    actor_id=request.user_id,
+                )
+                envelope["authority"] = {
+                    "kind": authority.kind,
+                    "permission_mode": authority.permission_mode,
+                    "granted_permissions": list(request.granted_permissions),
+                }
             if request.user_id:
                 envelope["actor"] = {"type": "user", "id": request.user_id}
 
-            result = self._event_emitter(event_type, envelope)  # type: ignore[misc]
+            result = self._event_emitter(event_type_text, envelope)  # type: ignore[misc]
             if inspect.isawaitable(result):
                 await result
 

--- a/mozaiksai/core/runtime/composition/schema_validation.py
+++ b/mozaiksai/core/runtime/composition/schema_validation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Shared JSON Schema helpers for runtime contract validation."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import jsonschema
+
+from logs.logging_config import get_workflow_logger
+
+logger = get_workflow_logger("runtime_schema_validation")
+
+
+@dataclass(frozen=True)
+class SchemaValidationDiagnostic:
+    """Structured validation failure details for runtime diagnostics."""
+
+    message: str
+    path: str
+    schema_path: str
+    validator: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "path": self.path,
+            "schema_path": self.schema_path,
+            "validator": self.validator,
+        }
+
+
+def normalize_nullable_schema(schema: Any) -> Any:
+    """Translate OpenAPI-style nullable fields into JSON Schema."""
+
+    if isinstance(schema, list):
+        return [normalize_nullable_schema(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    normalized = {key: normalize_nullable_schema(value) for key, value in schema.items()}
+    if normalized.get("nullable") is True:
+        schema_type = normalized.get("type")
+        if isinstance(schema_type, str):
+            normalized["type"] = [schema_type, "null"] if schema_type != "null" else schema_type
+        elif isinstance(schema_type, list) and "null" not in schema_type:
+            normalized["type"] = [*schema_type, "null"]
+
+        enum_values = normalized.get("enum")
+        if isinstance(enum_values, list) and None not in enum_values:
+            normalized["enum"] = [*enum_values, None]
+
+    return normalized
+
+
+def validate_json_schema(value: Any, schema: dict[str, Any]) -> SchemaValidationDiagnostic | None:
+    """Validate *value* against a JSON Schema dict and return structured errors."""
+
+    if not schema or not isinstance(schema, dict):
+        return None
+    try:
+        validator = jsonschema.Draft7Validator(normalize_nullable_schema(schema))
+        errors = sorted(
+            validator.iter_errors(value),
+            key=lambda err: (list(err.path), list(err.schema_path), err.message),
+        )
+        if not errors:
+            return None
+        exc = errors[0]
+        return SchemaValidationDiagnostic(
+            message=exc.message,
+            path=_json_path(exc.path),
+            schema_path=_json_path(exc.schema_path),
+            validator=str(exc.validator) if exc.validator else None,
+        )
+    except Exception as exc:  # malformed schema - preserve existing non-crashing behavior
+        logger.warning("MODULE_SCHEMA_ERROR: could not validate schema: %s", exc)
+        return None
+
+
+def _json_path(parts: Any) -> str:
+    path = "$"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+        elif isinstance(part, str) and part.isidentifier():
+            path += f".{part}"
+        else:
+            path += f"[{part!r}]"
+    return path

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -366,6 +366,8 @@ async def _platform_startup() -> None:
                     action_permissions=loaded_module.action_permissions_map,
                     action_schemas=loaded_module.action_schemas_map,
                     action_entitlements=loaded_module.action_entitlement_map,
+                    action_emits=loaded_module.action_emits_map,
+                    event_payload_schemas=loaded_module.event_payload_schemas_map,
                 )
             executor_registry.register(module_executor)
             app.state.module_action_surfaces = module_action_surfaces

--- a/tests/test_module_event_router.py
+++ b/tests/test_module_event_router.py
@@ -22,6 +22,7 @@ Covers:
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -32,6 +33,7 @@ from mozaiksai.core.runtime.composition.module_event_provenance import (
     normalize_module_reaction_provenance,
 )
 from mozaiksai.core.runtime.composition.module_event_router import (
+    ModuleEventPayloadValidationError,
     ModuleEventRouter,
     _is_secret_context_key,
     _render_template,
@@ -80,6 +82,22 @@ def _loaded_module(
         m.manifests.notifications = None
 
     return m
+
+
+def _with_event_schema(module: MagicMock, *, event_type: str, payload_schema: dict) -> MagicMock:
+    event = SimpleNamespace(type=event_type, payload_schema=payload_schema)
+    module.manifests.events = SimpleNamespace(events=[event])
+    return module
+
+
+def _with_definition(
+    module: MagicMock,
+    *,
+    actions: list[SimpleNamespace] | None = None,
+    capabilities: list[SimpleNamespace] | None = None,
+) -> MagicMock:
+    module.definition = SimpleNamespace(actions=actions or [], capabilities=capabilities or [])
+    return module
 
 
 def _router(
@@ -374,6 +392,82 @@ class TestRegister:
         assert inspect.iscoroutinefunction(registered_handler)
 
 
+class TestStaticReactionValidation:
+    def test_handler_target_must_resolve_when_handler_is_registered(self):
+        class Handler:
+            pass
+
+        mod = _loaded_module(
+            "orders",
+            reactions=[_handler_target_reaction("domain.orders.created", handler_method="missing")],
+            handler=Handler(),
+        )
+
+        with pytest.raises(ValueError, match="MODULE_REACTION_TARGET_INVALID"):
+            _router([mod])
+
+    def test_capability_target_must_resolve_when_capabilities_are_declared(self):
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.react",
+            target={"kind": "capability", "capability_id": "orders.missing"},
+        )
+        mod = _with_definition(
+            _loaded_module("orders", reactions=[reaction]),
+            capabilities=[
+                SimpleNamespace(capability_id="orders.review"),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="MODULE_REACTION_TARGET_INVALID"):
+            _router([mod])
+
+    def test_statically_detectable_reaction_cycle_fails_load(self):
+        class HandlerA:
+            async def on_b(self, ctx, **kwargs):
+                return None
+
+        class HandlerB:
+            async def on_a(self, ctx, **kwargs):
+                return None
+
+        mod_a = _with_definition(
+            _loaded_module(
+                "component_a",
+                reactions=[
+                    _handler_target_reaction(
+                        "domain.component_b.y",
+                        handler_method="on_b",
+                        reaction_id="component_a.react_y",
+                    )
+                ],
+                handler=HandlerA(),
+            ),
+            actions=[
+                SimpleNamespace(handler_method="on_b", emits=["domain.component_a.x"]),
+            ],
+        )
+        mod_b = _with_definition(
+            _loaded_module(
+                "component_b",
+                reactions=[
+                    _handler_target_reaction(
+                        "domain.component_a.x",
+                        handler_method="on_a",
+                        reaction_id="component_b.react_x",
+                    )
+                ],
+                handler=HandlerB(),
+            ),
+            actions=[
+                SimpleNamespace(handler_method="on_a", emits=["domain.component_b.y"]),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="MODULE_REACTION_CYCLE"):
+            _router([mod_a, mod_b])
+
+
 # ---------------------------------------------------------------------------
 # 5. handle_event — handler target
 # ---------------------------------------------------------------------------
@@ -484,6 +578,7 @@ class TestHandleEventHandlerTarget:
                 "tenant": {"app_id": "app-99", "tenant_id": "t-99", "workspace_id": "w-99"},
                 "actor": {"type": "user", "id": "user-99"},
                 "correlation": {"correlation_id": "corr-99", "causation_id": "cause-99"},
+                "authority": {"granted_permissions": ["orders.react"]},
                 "payload": {},
             },
         )
@@ -500,8 +595,189 @@ class TestHandleEventHandlerTarget:
         assert ctx.reaction_provenance.reaction_id == "orders.react"
         assert ctx.reaction_provenance.idempotency_key == "order_id"
         assert ctx.reaction_provenance.declared_permissions == ("orders.react",)
-        assert ctx.reaction_provenance.permissions_enforced is False
-        assert ctx.reaction_provenance.idempotency_enforced is False
+        assert ctx.reaction_provenance.permissions_enforced is True
+        assert ctx.reaction_provenance.idempotency_enforced is True
+        assert ctx.permissions == ["orders.react"]
+
+    @pytest.mark.asyncio
+    async def test_payload_permission_claim_does_not_authorize_reaction(self):
+        called = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                called.append((ctx, kwargs))
+
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.react",
+            target={"kind": "handler", "handler_method": "on_event"},
+            permissions=["orders.react"],
+        )
+        mod = _loaded_module("orders", reactions=[reaction], handler=Handler())
+        router = _router([mod])
+
+        await router.handle_event(
+            "domain.orders.created",
+            _envelope(payload={"order_id": "o-1", "permissions": ["orders.react"]}),
+        )
+
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_runtime_authority_authorizes_declared_reaction_permission(self):
+        received_ctx = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                received_ctx.append(ctx)
+
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.react",
+            target={"kind": "handler", "handler_method": "on_event"},
+            permissions=["orders.react"],
+        )
+        mod = _loaded_module("orders", reactions=[reaction], handler=Handler())
+        router = _router([mod])
+
+        await router.handle_event(
+            "domain.orders.created",
+            _envelope(payload={"order_id": "o-1"})
+            | {"authority": {"granted_permissions": ["orders.react"]}},
+        )
+
+        assert len(received_ctx) == 1
+        assert received_ctx[0].permissions == ["orders.react"]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_executes_same_event_reaction_once(self):
+        called = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                called.append(kwargs)
+
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.react",
+            target={"kind": "handler", "handler_method": "on_event"},
+            idempotency_key="order_id",
+        )
+        mod = _loaded_module("orders", reactions=[reaction], handler=Handler())
+        router = _router([mod])
+        envelope = _envelope(payload={"order_id": "o-1"})
+
+        await router.handle_event("domain.orders.created", envelope)
+        await router.handle_event("domain.orders.created", envelope)
+
+        assert called == [{"order_id": "o-1"}]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_keeps_distinct_events_separate(self):
+        called = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                called.append(kwargs)
+
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.react",
+            target={"kind": "handler", "handler_method": "on_event"},
+            idempotency_key="order_id",
+        )
+        mod = _loaded_module("orders", reactions=[reaction], handler=Handler())
+        router = _router([mod])
+
+        await router.handle_event("domain.orders.created", _envelope(payload={"order_id": "o-1"}))
+        await router.handle_event(
+            "domain.orders.created",
+            _envelope(payload={"order_id": "o-2"}) | {"id": "evt-2"},
+        )
+
+        assert called == [{"order_id": "o-1"}, {"order_id": "o-2"}]
+
+    @pytest.mark.asyncio
+    async def test_declared_event_payload_schema_rejects_invalid_payload_before_reaction(self):
+        called = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                called.append(kwargs)
+
+        event_type = "domain.component_a.item_created"
+        producer = _with_event_schema(
+            _loaded_module("component_a"),
+            event_type=event_type,
+            payload_schema={
+                "type": "object",
+                "required": ["item_id"],
+                "properties": {"item_id": {"type": "string"}},
+                "additionalProperties": False,
+            },
+        )
+        consumer = _loaded_module(
+            "component_b",
+            reactions=[_handler_target_reaction(event_type, handler_method="on_event")],
+            handler=Handler(),
+        )
+        router = _router([producer, consumer])
+        envelope = {
+            "id": "evt-invalid",
+            "type": event_type,
+            "source": {"layer": "module", "module_id": "component_a", "action_id": "create"},
+            "tenant": {"app_id": "app-1", "tenant_id": "tenant-1"},
+            "payload": {"bad": "payload"},
+        }
+
+        with pytest.raises(ModuleEventPayloadValidationError) as exc_info:
+            await router.handle_event(event_type, envelope)
+
+        assert called == []
+        diagnostic = exc_info.value.to_dict()
+        assert diagnostic["event_type"] == event_type
+        assert diagnostic["source_module"] == "component_a"
+        assert diagnostic["source_action"] == "create"
+        assert diagnostic["schema_error"]["path"] == "$"
+
+    @pytest.mark.asyncio
+    async def test_community_component_event_composition_valid_payload_dispatches(self):
+        called = []
+
+        class Handler:
+            async def on_event(self, ctx, **kwargs):
+                called.append((ctx.event_provenance.producer_module_id, kwargs))
+
+        event_type = "domain.component_a.item_created"
+        producer = _with_event_schema(
+            _loaded_module("component_a"),
+            event_type=event_type,
+            payload_schema={
+                "type": "object",
+                "required": ["item_id"],
+                "properties": {"item_id": {"type": "string"}},
+                "additionalProperties": False,
+            },
+        )
+        consumer = _loaded_module(
+            "component_b",
+            reactions=[_handler_target_reaction(event_type, handler_method="on_event")],
+            handler=Handler(),
+        )
+        router = _router([producer, consumer])
+
+        await router.handle_event(
+            event_type,
+            {
+                "id": "evt-valid",
+                "type": event_type,
+                "source": {"layer": "module", "module_id": "component_a", "action_id": "create"},
+                "tenant": {"app_id": "app-1", "tenant_id": "tenant-1"},
+                "payload": {"item_id": "item-1"},
+            },
+        )
+
+        assert called == [("component_a", {"item_id": "item-1"})]
 
 
 # ---------------------------------------------------------------------------
@@ -806,6 +1082,40 @@ class TestEmitPlatformReaction:
         router = _router([mod], event_emitter=event_emitter, capability_invoker=capability_invoker)
         await router.handle_event("ev.cap", _envelope())
         assert "my_capability" in invoker_calls
+
+    @pytest.mark.asyncio
+    async def test_declared_workflow_capability_reaction_uses_capability_id(self):
+        invoker_calls = []
+
+        async def event_emitter(event_type, payload):
+            pass
+
+        async def capability_invoker(capability_id, envelope, reaction):
+            invoker_calls.append((capability_id, reaction["target"]))
+            return {"workflow_id": "OrderReviewWorkflow"}
+
+        reaction = _reaction_model(
+            "domain.orders.created",
+            id="orders.workflow",
+            target={"kind": "capability", "capability_id": "orders-review-workflow"},
+        )
+        mod = _with_definition(
+            _loaded_module("orders", reactions=[reaction]),
+            capabilities=[
+                SimpleNamespace(
+                    capability_id="orders-review-workflow",
+                    kind="workflow",
+                    target="OrderReviewWorkflow",
+                )
+            ],
+        )
+        router = _router([mod], event_emitter=event_emitter, capability_invoker=capability_invoker)
+
+        await router.handle_event("domain.orders.created", _envelope(payload={"order_id": "o-1"}))
+
+        assert invoker_calls == [
+            ("orders-review-workflow", {"kind": "capability", "capability_id": "orders-review-workflow"})
+        ]
 
     @pytest.mark.asyncio
     async def test_service_adapter_target_invokes_adapter_and_emits_result(self):

--- a/tests/test_module_loader_contracts.py
+++ b/tests/test_module_loader_contracts.py
@@ -59,6 +59,11 @@ capabilities:
     permissions: [tasks.write]
     input_schema:
       type: object
+  - capability_id: tasks.review
+    kind: workflow
+    target: ReviewWorkflow
+    title: Review Task
+    permissions: [tasks.write]
 """.lstrip(),
         encoding="utf-8",
     )
@@ -486,6 +491,8 @@ async def test_module_executor_dispatches_public_action_id_to_handler_method(tmp
         loaded.name,
         loaded.handler,
         action_method_map=loaded.action_method_map,
+        action_emits=loaded.action_emits_map,
+        event_payload_schemas=loaded.event_payload_schemas_map,
     )
 
     result = await executor.execute(
@@ -538,12 +545,58 @@ async def test_module_executor_wraps_handler_events_in_canonical_envelope(tmp_pa
         "layer": "module",
         "app_id": "app_1",
         "module_id": "tasks",
+        "action_id": "create",
         "capability_id": "tasks.create",
     }
     assert envelope["tenant"] == {"app_id": "app_1", "tenant_id": "tenant_1"}
     assert envelope["actor"] == {"type": "user", "id": "user_1"}
     assert envelope["correlation"] == {"correlation_id": "corr_1"}
     assert envelope["payload"] == {"task_id": "task_1", "title": "Draft"}
+
+
+@pytest.mark.asyncio
+async def test_module_executor_rejects_invalid_emitted_event_payload(tmp_path: Path) -> None:
+    module_dir = _write_canonical_module(tmp_path)
+    module_dir.joinpath("backend", "handler.py").write_text(
+        """
+class TasksModule:
+    async def create_task(self, ctx, *, title):
+        await ctx.emit("domain.tasks.task_created", {"task_id": "task_1"})
+        return {"task_id": "task_1", "title": title}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    loaded = ModuleLoader(str(tmp_path)).load("tasks")
+    emitted: list[tuple[str, dict]] = []
+
+    async def capture(event_type: str, payload: dict) -> None:
+        emitted.append((event_type, payload))
+
+    executor = ModuleExecutor(event_emitter=capture)
+    executor.register(
+        loaded.name,
+        loaded.handler,
+        action_method_map=loaded.action_method_map,
+        action_emits=loaded.action_emits_map,
+        event_payload_schemas=loaded.event_payload_schemas_map,
+    )
+
+    result = await executor.execute(
+        ModuleRequest(
+            module="tasks",
+            action="create",
+            params={"title": "Draft"},
+            app_id="app_1",
+            user_id="user_1",
+        )
+    )
+
+    assert result.success is False
+    assert result.error_code == "INVALID_EVENT_PAYLOAD"
+    assert "domain.tasks.task_created" in (result.error or "")
+    assert "module=tasks" in (result.error or "")
+    assert "action=create" in (result.error or "")
+    assert emitted == []
 
 
 @pytest.mark.asyncio
@@ -572,6 +625,26 @@ def test_module_loader_rejects_undeclared_emitted_event(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ModuleLoadError, match="emits undeclared event"):
+        ModuleLoader(str(tmp_path)).load("tasks")
+
+
+def test_module_loader_rejects_reaction_undeclared_permission(tmp_path: Path) -> None:
+    module_dir = _write_canonical_module(tmp_path)
+    module_dir.joinpath("contracts", "reactions.yaml").write_text(
+        """
+schema_version: mozaiks.reactions.v1
+reactions:
+  - id: task_created_notify
+    event_type: domain.tasks.task_created
+    permissions: [tasks.missing]
+    target:
+      kind: notification
+      notification_id: task_created
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModuleLoadError, match="references undeclared permission"):
         ModuleLoader(str(tmp_path)).load("tasks")
 
 


### PR DESCRIPTION
## Summary
- enforce declared module event payload schemas at ctx.emit and router boundaries
- add in-process reaction idempotency, runtime-authority permission gating, and static reaction target/cycle checks
- preserve capability-id workflow reactions and add community component-style event composition coverage

## Validation
- python -m pytest tests/test_module_event_router.py tests/test_module_loader_contracts.py -q --no-cov
- python -m pytest tests/test_module_executor_dispatch.py tests/test_module_action_dispatch_public_api.py tests/test_platform_module_dispatch.py -q --no-cov
- python -m pytest tests/test_studio_host_smoke.py::test_platform_host_indexes_workflow_capability_routes tests/test_studio_host_smoke.py::test_platform_host_invokes_capability_route_into_workflow_session tests/test_generator_event_system_contracts.py -q --no-cov
- python -m pytest tests/test_community_pack_foundation.py -q --no-cov
- python -m pytest tests/test_generated_app_functional_acceptance.py tests/test_generated_app_archetype_matrix.py tests/test_appplan_materialization_acceptance.py -q --no-cov
- python -m pytest tests/test_generated_saas_subscription_runtime_acceptance.py tests/test_mozaikspay_managed_capability_contract.py tests/test_app_loader.py -q --no-cov
- python -m pytest tests/test_workflow_declarative_contracts.py tests/test_agentgenerator_generated_workflow_e2e.py tests/test_workflow_manager_a2a_config.py -q --no-cov
- python -m pytest tests/test_governance_guardrails.py tests/test_package_content_guard.py -q --no-cov
- ruff check .
- python -m py_compile touched runtime files
- mkdocs build --strict
- python -m pytest -q --no-cov (from C:\Repos\BlocUnitedRepo\mozaiks-event-reaction-hardening-v1): 12399 passed, 77 skipped

Note: recursive compileall over the full repo hits existing Jinja template placeholders in factory_app/build_context/infra/templates/scripts/cron_tick.py; touched runtime files compile cleanly.