### PR TITLE
feat(runtime): durable reaction idempotency ledger

### DIFF
--- a/mozaiksai/core/runtime/composition/module_event_router.py
+++ b/mozaiksai/core/runtime/composition/module_event_router.py
@@ -34,6 +34,9 @@ from mozaiksai.core.runtime.composition.module_event_provenance import (
     normalize_module_reaction_provenance,
 )
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.runtime.composition.reaction_idempotency_store import (
+    ReactionIdempotencyStore,
+)
 from mozaiksai.core.runtime.composition.schema_validation import (
     SchemaValidationDiagnostic,
     validate_json_schema,
@@ -116,10 +119,12 @@ class ModuleEventRouter:
         event_emitter: EventEmitter | None = None,
         notification_store: NotificationStore | None = None,
         capability_invoker: CapabilityInvoker | None = None,
+        idempotency_store: ReactionIdempotencyStore | None = None,
     ) -> None:
         self._event_emitter = event_emitter
         self._notification_store = notification_store
         self._capability_invoker = capability_invoker
+        self._idempotency_store = idempotency_store
         self._reactions_by_event: dict[str, list[dict]] = defaultdict(list)
         self._notifications_by_event: dict[str, list[dict]] = defaultdict(list)
         self._notifications_by_key: dict[tuple[str, str], dict] = {}
@@ -192,7 +197,11 @@ class ModuleEventRouter:
                 )
                 continue
             idempotency_key = self._idempotency_key(reaction, event_type, envelope, event_provenance)
+            # durable_key_str is set when the durable store is active and the
+            # slot was successfully claimed; used to mark complete/fail after dispatch.
+            durable_key_str: str | None = None
             if idempotency_key is not None:
+                # Fast path: in-memory check (same process, established by PR #256).
                 if idempotency_key in self._processed_reaction_keys:
                     await self._emit_reaction_audit(
                         build_module_reaction_audit(
@@ -203,6 +212,26 @@ class ModuleEventRouter:
                         )
                     )
                     continue
+                # Durable path: restart-safe check via persistent ledger.
+                if self._idempotency_store is not None:
+                    durable_key_str = "|".join(idempotency_key)
+                    claimed = await self._idempotency_store.claim(
+                        app_id=event_provenance.app_id or "",
+                        tenant_id=event_provenance.tenant_id,
+                        workspace_id=event_provenance.workspace_id,
+                        idempotency_key_str=durable_key_str,
+                    )
+                    if not claimed:
+                        durable_key_str = None  # not our claim; do not mark complete/fail
+                        await self._emit_reaction_audit(
+                            build_module_reaction_audit(
+                                event=event_provenance,
+                                reaction=reaction_provenance,
+                                outcome="skipped",
+                                reason="idempotent reaction suppressed by durable ledger",
+                            )
+                        )
+                        continue
                 self._processed_reaction_keys.add(idempotency_key)
             target = reaction.get("target") if isinstance(reaction.get("target"), dict) else {}
             target_kind = str(target.get("kind") or "").strip()
@@ -234,6 +263,7 @@ class ModuleEventRouter:
                             outcome="ok",
                         )
                     )
+                    await self._durable_complete(durable_key_str, event_provenance)
                 else:
                     await self._emit_reaction_audit(
                         build_module_reaction_audit(
@@ -260,6 +290,10 @@ class ModuleEventRouter:
                         reason=reason,
                     )
                 )
+                if outcome == "ok":
+                    await self._durable_complete(durable_key_str, event_provenance)
+                else:
+                    await self._durable_mark_failed(durable_key_str, event_provenance)
             elif target_kind == "service_adapter":
                 adapter_result = await self._dispatch_service_adapter(
                     reaction,
@@ -287,6 +321,10 @@ class ModuleEventRouter:
                         ),
                     )
                 )
+                if adapter_failed:
+                    await self._durable_mark_failed(durable_key_str, event_provenance)
+                else:
+                    await self._durable_complete(durable_key_str, event_provenance)
             elif target_kind:
                 await self._emit_platform_reaction(reaction, event_type, envelope)
                 await self._emit_reaction_audit(
@@ -296,6 +334,7 @@ class ModuleEventRouter:
                         outcome="ok",
                     )
                 )
+                await self._durable_complete(durable_key_str, event_provenance)
 
         for rule in self._notifications_by_event.get(event_type, []):
             key = (str(rule.get("module_id") or ""), str(rule.get("id") or ""))
@@ -523,6 +562,52 @@ class ModuleEventRouter:
                 ).encode("utf-8")
             ).hexdigest()
         return (module_id, reaction_id, event_type, declared, event_identity)
+
+    async def _durable_complete(
+        self,
+        durable_key_str: str | None,
+        event_provenance: ModuleEventProvenance,
+    ) -> None:
+        """Mark the durable ledger slot as completed if active."""
+        if durable_key_str is None or self._idempotency_store is None:
+            return
+        try:
+            await self._idempotency_store.complete(
+                app_id=event_provenance.app_id or "",
+                tenant_id=event_provenance.tenant_id,
+                workspace_id=event_provenance.workspace_id,
+                idempotency_key_str=durable_key_str,
+            )
+        except Exception:
+            logger.warning(
+                "REACTION_IDEMPOTENCY_COMPLETE_FAILED: key=%s app=%s",
+                durable_key_str,
+                event_provenance.app_id,
+                exc_info=True,
+            )
+
+    async def _durable_mark_failed(
+        self,
+        durable_key_str: str | None,
+        event_provenance: ModuleEventProvenance,
+    ) -> None:
+        """Release the durable ledger slot on failure (retry-eligible)."""
+        if durable_key_str is None or self._idempotency_store is None:
+            return
+        try:
+            await self._idempotency_store.mark_failed(
+                app_id=event_provenance.app_id or "",
+                tenant_id=event_provenance.tenant_id,
+                workspace_id=event_provenance.workspace_id,
+                idempotency_key_str=durable_key_str,
+            )
+        except Exception:
+            logger.warning(
+                "REACTION_IDEMPOTENCY_FAIL_RELEASE_FAILED: key=%s app=%s",
+                durable_key_str,
+                event_provenance.app_id,
+                exc_info=True,
+            )
 
     def _handler_for(self, event_type: str) -> Callable[[dict[str, Any]], Awaitable[None]]:
         async def handle(envelope: dict[str, Any]) -> None:

--- a/mozaiksai/core/runtime/composition/reaction_idempotency_store.py
+++ b/mozaiksai/core/runtime/composition/reaction_idempotency_store.py
@@ -1,0 +1,212 @@
+"""Durable reaction idempotency ledger.
+
+Provides restart-safe duplicate suppression for module reactions that declare
+an idempotency_key.  The canonical execution path remains unchanged:
+
+    UnifiedEventDispatcher → ModuleEventRouter
+
+This store is an optional persistence seam injected into the router.  It
+complements the in-memory idempotency set added in PR #256 — that set provides
+a fast O(1) check within one process lifetime; this store provides the same
+guarantee across process restarts.
+
+Guarantee
+---------
+At-most-once execution after a reaction record reaches ``completed`` status.
+A ``claimed`` record that never reached ``completed`` (e.g. process crash
+mid-execution) is treated as retry-eligible: status is set to ``failed`` by
+the router when execution raises, allowing the next restart to re-claim.
+
+Scope
+-----
+Records are keyed by (app_id, tenant_id, workspace_id, idempotency_key_str).
+The idempotency_key_str encodes the full reaction identity tuple so that two
+different reactions with the same declared ``idempotency_key`` template never
+collide.
+
+Collection
+----------
+``_mz_reaction_idempotency`` in the app database (same
+``MOZAIKS_APP_DATABASE_NAME``-configured DB used by module persistence).  The
+leading underscore signals a system collection — generated module code must
+not access it directly.
+
+Independence from event bus
+---------------------------
+This store talks to MongoDB directly.  It does NOT go through
+MongoEventBus/RedisEventBus or through ``ctx.persistence``; those layers are
+not in scope for the router's execution path.
+"""
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+_DEFAULT_DATABASE_NAME = "mozaiks_apps"
+_COLLECTION_NAME = "_mz_reaction_idempotency"
+
+ReactionIdempotencyStatus = Literal["claimed", "completed", "failed"]
+
+
+class ReactionIdempotencyStore:
+    """Durable store for reaction execution idempotency records.
+
+    Records are keyed by a compound index over
+    (app_id, tenant_id, workspace_id, idempotency_key_str).
+
+    Status transitions::
+
+        claimed → completed   (successful execution)
+        claimed → failed      (execution raised; retry-eligible)
+
+    This class is safe to construct eagerly — MongoDB is only contacted on
+    the first operation.  Callers may pass a pre-built ``client`` for testing.
+    """
+
+    def __init__(
+        self,
+        *,
+        database_name: str | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self._database_name = (
+            (database_name or os.getenv("MOZAIKS_APP_DATABASE_NAME") or "").strip()
+            or _DEFAULT_DATABASE_NAME
+        )
+        self._client = client
+        self._collection_handle: Any = None
+
+    def _collection(self) -> Any:
+        if self._collection_handle is None:
+            if self._client is None:
+                from mozaiksai.core.core_config import get_mongo_client
+
+                self._client = get_mongo_client()
+            self._collection_handle = self._client[self._database_name][_COLLECTION_NAME]
+        return self._collection_handle
+
+    @staticmethod
+    def _key_filter(
+        *,
+        app_id: str,
+        tenant_id: str | None,
+        workspace_id: str | None,
+        idempotency_key_str: str,
+    ) -> dict[str, str]:
+        return {
+            "app_id": app_id,
+            "tenant_id": tenant_id or "",
+            "workspace_id": workspace_id or "",
+            "idempotency_key_str": idempotency_key_str,
+        }
+
+    async def claim(
+        self,
+        *,
+        app_id: str,
+        tenant_id: str | None,
+        workspace_id: str | None,
+        idempotency_key_str: str,
+    ) -> bool:
+        """Attempt to claim this reaction execution slot.
+
+        Returns ``True`` if the slot was newly claimed (this process should
+        proceed with execution).
+
+        Returns ``False`` if the slot already exists in any status, meaning:
+
+        - ``completed``: a prior run finished successfully → suppress.
+        - ``claimed``: a concurrent or crashed run holds the slot → suppress.
+        - ``failed``: a prior run failed and did not release the slot before
+          crashing; ``mark_failed`` normally frees the slot for retry, but if
+          the process died between claiming and marking failed the slot stays
+          as ``claimed``.  Suppress in that case; the operator may clear the
+          record manually or rely on a future TTL/cleanup job.
+
+        The upsert is not distributed-atomic across replicas, but it is
+        sufficient for the documented guarantee: ``at-most-once after
+        completed``.
+        """
+        key = self._key_filter(
+            app_id=app_id,
+            tenant_id=tenant_id,
+            workspace_id=workspace_id,
+            idempotency_key_str=idempotency_key_str,
+        )
+        now = datetime.now(UTC)
+        result = await self._collection().update_one(
+            key,
+            {
+                "$setOnInsert": {
+                    **key,
+                    "status": "claimed",
+                    "claimed_at": now,
+                    "completed_at": None,
+                }
+            },
+            upsert=True,
+        )
+        return result.upserted_id is not None
+
+    async def complete(
+        self,
+        *,
+        app_id: str,
+        tenant_id: str | None,
+        workspace_id: str | None,
+        idempotency_key_str: str,
+    ) -> None:
+        """Mark this reaction as successfully completed.
+
+        Future replays with the same key will be suppressed by ``claim``.
+        """
+        await self._collection().update_one(
+            self._key_filter(
+                app_id=app_id,
+                tenant_id=tenant_id,
+                workspace_id=workspace_id,
+                idempotency_key_str=idempotency_key_str,
+            ),
+            {"$set": {"status": "completed", "completed_at": datetime.now(UTC)}},
+        )
+
+    async def mark_failed(
+        self,
+        *,
+        app_id: str,
+        tenant_id: str | None,
+        workspace_id: str | None,
+        idempotency_key_str: str,
+    ) -> None:
+        """Mark this reaction as failed so a future attempt may retry.
+
+        Removes the document rather than setting status=failed so that the
+        next event with the same key can re-claim the slot.  This allows
+        at-most-once after completion while still permitting retry after
+        failure.
+        """
+        await self._collection().delete_one(
+            self._key_filter(
+                app_id=app_id,
+                tenant_id=tenant_id,
+                workspace_id=workspace_id,
+                idempotency_key_str=idempotency_key_str,
+            )
+        )
+
+    async def ensure_indexes(self) -> None:
+        """Create the unique compound index.  Safe to call on every startup."""
+        await self._collection().create_index(
+            [
+                ("app_id", 1),
+                ("tenant_id", 1),
+                ("workspace_id", 1),
+                ("idempotency_key_str", 1),
+            ],
+            unique=True,
+            name="mz_reaction_idempotency_unique",
+        )
+
+
+__all__ = ["ReactionIdempotencyStore", "ReactionIdempotencyStatus"]

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -62,6 +62,9 @@ from mozaiksai.core.runtime.composition.module_authority import (
 from mozaiksai.core.runtime.composition.module_event_router import ModuleEventRouter
 from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.runtime.composition.reaction_idempotency_store import (
+    ReactionIdempotencyStore,
+)
 from mozaiksai.core.runtime.persistence import (
     DatabaseStartupPolicyError,
     apply_data_migrations,
@@ -333,10 +336,14 @@ async def _platform_startup() -> None:
                     event_emitter=dispatcher.emit,
                 )
 
+            _reaction_idempotency_store: ReactionIdempotencyStore | None = None
+            if os.getenv("MONGO_URI") or os.getenv("MONGODB_URI"):
+                _reaction_idempotency_store = ReactionIdempotencyStore()
             module_event_router = ModuleEventRouter(
                 load_result.modules,
                 event_emitter=dispatcher.emit,
                 capability_invoker=invoke_capability,
+                idempotency_store=_reaction_idempotency_store,
             )
             module_event_router.register(dispatcher)
             app.state.module_event_router = module_event_router

--- a/tests/test_durable_reaction_idempotency.py
+++ b/tests/test_durable_reaction_idempotency.py
@@ -1,0 +1,364 @@
+"""Durable reaction idempotency contract tests.
+
+Proves the restart-safe duplicate suppression guarantee:
+
+  - same reaction replay within one process → in-memory suppression (PR #256)
+  - same reaction replay after new router instance → durable store suppression
+  - different event identity → allowed
+  - different tenant → allowed
+  - different app → allowed
+  - failed execution → mark_failed releases slot → retry allowed
+  - no raw payload stored in ledger records
+
+All tests use an in-memory mock store — no MongoDB required.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mozaiksai.core.runtime.composition.module_event_router import ModuleEventRouter
+from mozaiksai.core.runtime.composition.reaction_idempotency_store import (
+    ReactionIdempotencyStore,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory mock store — mirrors ReactionIdempotencyStore semantics without Mongo
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryIdempotencyStore(ReactionIdempotencyStore):
+    """Drop-in test double for ReactionIdempotencyStore.
+
+    Uses a plain dict; no MongoDB is needed.
+    ``claimed`` keys are stored as True (in-flight / completed) or absent (retry-eligible).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(client=object())  # prevents real client creation
+        self._records: dict[str, str] = {}  # key_str → status
+
+    def _collection(self) -> Any:  # type: ignore[override]
+        raise RuntimeError("_InMemoryIdempotencyStore must not call _collection()")
+
+    async def claim(self, *, app_id, tenant_id, workspace_id, idempotency_key_str) -> bool:
+        scope = f"{app_id}|{tenant_id or ''}|{workspace_id or ''}|{idempotency_key_str}"
+        if scope in self._records:
+            return False
+        self._records[scope] = "claimed"
+        return True
+
+    async def complete(self, *, app_id, tenant_id, workspace_id, idempotency_key_str) -> None:
+        scope = f"{app_id}|{tenant_id or ''}|{workspace_id or ''}|{idempotency_key_str}"
+        self._records[scope] = "completed"
+
+    async def mark_failed(self, *, app_id, tenant_id, workspace_id, idempotency_key_str) -> None:
+        scope = f"{app_id}|{tenant_id or ''}|{workspace_id or ''}|{idempotency_key_str}"
+        self._records.pop(scope, None)
+
+    async def ensure_indexes(self) -> None:
+        pass
+
+    def status(self, *, app_id, tenant_id, workspace_id, idempotency_key_str) -> str | None:
+        scope = f"{app_id}|{tenant_id or ''}|{workspace_id or ''}|{idempotency_key_str}"
+        return self._records.get(scope)
+
+
+# ---------------------------------------------------------------------------
+# Module / reaction fixtures
+# ---------------------------------------------------------------------------
+
+
+def _handler_reaction(
+    event_type: str,
+    *,
+    reaction_id: str = "r-1",
+    handler_method: str = "on_order",
+    idempotency_key: str = "order_id",
+    module_id: str = "orders",
+) -> MagicMock:
+    m = MagicMock()
+    m.event_type = event_type
+    m.model_dump.return_value = {
+        "id": reaction_id,
+        "module_id": module_id,
+        "idempotency_key": idempotency_key,
+        "target": {"kind": "handler", "handler_method": handler_method},
+    }
+    return m
+
+
+def _loaded_module(name: str, *, handler: Any = None, reactions=None) -> MagicMock:
+    m = MagicMock()
+    m.name = name
+    m.handler = handler or MagicMock()
+    m.definition = MagicMock(actions=[], capabilities=[])
+    if reactions is not None:
+        reactions_manifest = MagicMock()
+        reactions_manifest.reactions = reactions
+        m.manifests.reactions = reactions_manifest
+    else:
+        m.manifests.reactions = None
+    m.manifests.notifications = None
+    m.manifests.events = None
+    return m
+
+
+def _envelope(
+    event_id: str = "evt_abc123",
+    *,
+    app_id: str = "app-1",
+    tenant_id: str = "tenant-1",
+    workspace_id: str | None = None,
+    actor_id: str = "user-1",
+    order_id: str = "order-99",
+) -> dict[str, Any]:
+    return {
+        "id": event_id,
+        "type": "order.created",
+        "app_id": app_id,
+        "tenant_id": tenant_id,
+        **({"workspace_id": workspace_id} if workspace_id else {}),
+        "payload": {
+            "app_id": app_id,
+            "tenant_id": tenant_id,
+            "actor_id": actor_id,
+            "order_id": order_id,
+        },
+    }
+
+
+def _make_handler(outcomes: list[str]) -> Any:
+    """Return a handler whose on_order method produces the given outcomes in sequence."""
+    call_idx = 0
+
+    class _Handler:
+        async def on_order(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_idx
+            outcome = outcomes[min(call_idx, len(outcomes) - 1)]
+            call_idx += 1
+            if outcome == "error":
+                raise RuntimeError("handler failed")
+            return {"status": outcome}
+
+    return _Handler()
+
+
+def _router_with_store(
+    store: ReactionIdempotencyStore | None,
+    handler: Any,
+    *,
+    module_id: str = "orders",
+    event_type: str = "order.created",
+) -> ModuleEventRouter:
+    reaction = _handler_reaction(event_type, module_id=module_id)
+    module = _loaded_module(module_id, handler=handler, reactions=[reaction])
+    return ModuleEventRouter(
+        [module],
+        idempotency_store=store,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Same-process replay → in-memory suppression (no store interaction needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_process_replay_suppressed_in_memory() -> None:
+    """Replay of the same event within one router instance is suppressed by the
+    in-memory set — the store's claim is only called once."""
+    store = _InMemoryIdempotencyStore()
+    handler = _make_handler(["ok", "ok"])
+    router = _router_with_store(store, handler)
+    envelope = _envelope("evt_001")
+
+    await router.handle_event("order.created", envelope)
+    await router.handle_event("order.created", envelope)
+
+    # Only one claim, one complete; second call short-circuited by in-memory check.
+    records = list(store._records.values())
+    assert records.count("completed") == 1
+    assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. New router instance + same event → durable store suppresses replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_router_instance_replay_suppressed_by_durable_store() -> None:
+    """A completed reaction is suppressed even after the process restarts
+    (simulated by creating a fresh router that shares the same store)."""
+    store = _InMemoryIdempotencyStore()
+    handler = _make_handler(["ok", "ok"])
+    envelope = _envelope("evt_001")
+
+    # First router: claim + execute + complete.
+    router_a = _router_with_store(store, handler)
+    await router_a.handle_event("order.created", envelope)
+    assert list(store._records.values()) == ["completed"]
+
+    # Second router: fresh in-memory set, same store. Must suppress.
+    execution_count = 0
+    original = handler.on_order
+
+    async def counting_on_order(ctx: Any, **kwargs: Any) -> dict:
+        nonlocal execution_count
+        execution_count += 1
+        return await original(**kwargs)
+
+    handler.on_order = counting_on_order
+    router_b = _router_with_store(store, handler)
+    await router_b.handle_event("order.created", envelope)
+
+    assert execution_count == 0, "Durable store must suppress replay after new router instance"
+
+
+# ---------------------------------------------------------------------------
+# 3. Different event identity → NOT suppressed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_different_event_identity_allowed() -> None:
+    """Two events with different IDs trigger two distinct reaction executions."""
+    store = _InMemoryIdempotencyStore()
+    execution_count = 0
+
+    class _CountHandler:
+        async def on_order(self, ctx: Any, **kwargs: Any) -> dict:
+            nonlocal execution_count
+            execution_count += 1
+            return {"status": "ok"}
+
+    router = _router_with_store(store, _CountHandler())
+    await router.handle_event("order.created", _envelope("evt_001"))
+    await router.handle_event("order.created", _envelope("evt_002"))
+
+    assert execution_count == 2
+    assert len(store._records) == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. Different tenant → NOT suppressed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_different_tenant_not_suppressed() -> None:
+    """Reactions for different tenants with the same event identity are independent."""
+    store = _InMemoryIdempotencyStore()
+    execution_count = 0
+
+    class _TenantHandler:
+        async def on_order(self, ctx: Any, **kwargs: Any) -> dict:
+            nonlocal execution_count
+            execution_count += 1
+            return {"status": "ok"}
+
+    router = _router_with_store(store, _TenantHandler())
+    await router.handle_event("order.created", _envelope("evt_001", tenant_id="tenant-A"))
+    # Second call same event_id but different tenant; router's in-memory key includes
+    # app_id+tenant_id from provenance so it won't match (no dupe in in-memory set).
+    # Create a second router to bypass in-memory set for the second tenant.
+    router2 = _router_with_store(store, _TenantHandler())
+    await router2.handle_event("order.created", _envelope("evt_001", tenant_id="tenant-B"))
+
+    assert execution_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. Different app → NOT suppressed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_different_app_not_suppressed() -> None:
+    """Reactions for different apps are isolated by the ledger scope."""
+    store = _InMemoryIdempotencyStore()
+    execution_count = 0
+
+    class _AppHandler:
+        async def on_order(self, ctx: Any, **kwargs: Any) -> dict:
+            nonlocal execution_count
+            execution_count += 1
+            return {"status": "ok"}
+
+    router_a = _router_with_store(store, _AppHandler())
+    router_b = _router_with_store(store, _AppHandler())
+    await router_a.handle_event("order.created", _envelope("evt_001", app_id="app-A"))
+    await router_b.handle_event("order.created", _envelope("evt_001", app_id="app-B"))
+
+    assert execution_count == 2
+    assert len(store._records) == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. Failed execution → mark_failed releases slot → retry allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_execution_releases_slot_for_retry() -> None:
+    """A handler that raises causes mark_failed to delete the record.
+    The next attempt with the same event can claim and execute."""
+    store = _InMemoryIdempotencyStore()
+    execution_count = 0
+
+    class _FlappyHandler:
+        _attempt = 0
+
+        async def on_order(self, ctx: Any, **kwargs: Any) -> dict:
+            nonlocal execution_count
+            self.__class__._attempt += 1
+            execution_count += 1
+            if self.__class__._attempt == 1:
+                raise RuntimeError("transient failure")
+            return {"status": "ok"}
+
+    handler = _FlappyHandler()
+    # Router A: first attempt — handler raises, slot should be released.
+    router_a = _router_with_store(store, handler)
+    await router_a.handle_event("order.created", _envelope("evt_001"))
+    # Slot must be absent (mark_failed deletes it).
+    assert not store._records, (
+        "Failed execution must release the slot so retry is possible"
+    )
+
+    # Router B: second attempt — slot is free, handler succeeds.
+    router_b = _router_with_store(store, handler)
+    await router_b.handle_event("order.created", _envelope("evt_001"))
+    assert execution_count == 2
+    assert list(store._records.values()) == ["completed"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Ledger records do not contain raw event payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ledger_record_contains_no_raw_payload() -> None:
+    """The idempotency key string stored in the ledger must not reproduce
+    raw customer payload.  It encodes structural identity only."""
+    store = _InMemoryIdempotencyStore()
+    handler = _make_handler(["ok"])
+    router = _router_with_store(store, handler)
+    sensitive_payload = {"order_id": "order-99", "card_number": "4111-1111-1111-1111"}
+    envelope = {
+        "id": "evt_sensitive",
+        "type": "order.created",
+        "app_id": "app-1",
+        "tenant_id": "tenant-1",
+        "payload": {**sensitive_payload, "app_id": "app-1", "tenant_id": "tenant-1"},
+    }
+    await router.handle_event("order.created", envelope)
+
+    for key in store._records:
+        assert "4111-1111-1111-1111" not in key, (
+            "Durable idempotency key must not reproduce raw customer payload"
+        )


### PR DESCRIPTION
## Summary

- Adds `ReactionIdempotencyStore` — a lightweight MongoDB-backed ledger at `_mz_reaction_idempotency` that persists reaction execution claims across process restarts
- Extends `ModuleEventRouter` to layer durable claim/complete/mark_failed semantics on top of the existing in-memory suppression set (PR #256); the two-layer design keeps the happy path allocation-free
- Wires the store in `mozaiksai/hosts/platform.py` when `MONGO_URI`/`MONGODB_URI` is present; falls back to in-memory-only when no Mongo is configured

## Guarantee

**At-most-once after completed claim; restart-safe duplicate suppression.**

- Same event within one router instance → in-memory fast path (no Mongo round-trip after first claim)
- Same event after new router instance (process restart) → durable store blocks replay
- Failed handler → `mark_failed()` deletes the slot → retry-eligible on next delivery
- Crashed claimed slot → stays suppressed (conservative); operator may clear or add TTL via index

## Ledger scope

Compound unique index on `(app_id, tenant_id, workspace_id, idempotency_key_str)` — reactions are fully isolated by app, tenant, and workspace.

## Tests (7 new — `tests/test_durable_reaction_idempotency.py`)

1. Same-process replay suppressed by in-memory set (store only claimed once)
2. New router instance replay suppressed by durable store
3. Different event identity → both execute
4. Different tenant → both execute
5. Different app → both execute
6. Failed execution releases slot → retry succeeds
7. Ledger record contains no raw customer payload

## Impact

- **Layer changed:** `mozaiksai/core/runtime/composition/` (new store), `mozaiksai/hosts/platform.py` (wiring)
- **Runtime/platform impact:** `ModuleEventRouter` gains optional `idempotency_store` param; backward-compatible (default `None`)
- **App workspace impact:** None — no generated app contract changes
- **Parallel event system:** No — extends existing module event router, not a new bus
- **Tests run:** `pytest tests/test_durable_reaction_idempotency.py` (7 passed), full suite 12 389 passed / 76 skipped

Closes the P1 gap left open after #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)