### PR TITLE
feat(schema-taxonomy): canonical primitive validation, reference closure, and taxonomy cleanup

### DIFF
--- a/factory_app/build_context/mozaikspay/templates/ui/pages/billing.yaml
+++ b/factory_app/build_context/mozaikspay/templates/ui/pages/billing.yaml
@@ -25,7 +25,7 @@ sections:
         - starts_at
         - expires_at
   - id: billing-catalog
-    primitive: DataPanel
+    primitive: PricingCatalog
     title: Plans and Token Packs
     config:
       api_endpoint: /api/modules/billing_portal/list_plans

--- a/factory_app/build_context/mozaikspay/templates/ui/pages/usage.yaml
+++ b/factory_app/build_context/mozaikspay/templates/ui/pages/usage.yaml
@@ -14,7 +14,7 @@ navigation:
   visible: true
 sections:
   - id: usage-status
-    primitive: DataPanel
+    primitive: SummaryStrip
     title: Usage
     config:
       api_endpoint: /api/modules/billing_portal/get_usage_status
@@ -25,7 +25,7 @@ sections:
         - runtime_ai_usage.totals.completion_tokens
         - runtime_ai_usage.totals.llm_calls
   - id: token-status
-    primitive: DataPanel
+    primitive: SummaryStrip
     title: Token Balance
     config:
       api_endpoint: /api/modules/billing_portal/get_token_status

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -321,9 +321,23 @@ models:
         type: optional_str
         description: Human-readable connector label shown in inline credential prompts and the app-scoped integrations surface.
       kind:
-        type: str
-        description: Integration type such as payments, email, analytics, agent-backend,
-          storage, or external-api.
+        type: literal
+        values:
+        - payments
+        - email
+        - analytics
+        - agent-backend
+        - storage
+        - external-api
+        - auth
+        - messaging
+        - database
+        description: >
+          Canonical integration category. payments = billing/subscription provider;
+          email = transactional or marketing email; analytics = event tracking/reporting;
+          agent-backend = LLM/AI API; storage = blob/file/object store; external-api =
+          third-party REST/GraphQL API; auth = identity/SSO provider; messaging =
+          SMS/push/real-time channel; database = external data store.
       purpose:
         type: str
         description: Why the integration exists in the product.

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -125,6 +125,53 @@ _AUTH_LOGIN_METHOD_KINDS = frozenset(
     }
 )
 
+# Shell-built-in component names registered in chat-ui/src/registry/coreComponents.js.
+# These components are always available in the Mozaiks shell without a custom JSX file.
+# Route manifest entries referencing these names do NOT require a ui/pages/custom/*.jsx file.
+_SHELL_CORE_COMPONENTS = frozenset({
+    "ChatPage",
+    "SchemaPage",
+    "LauncherScreen",
+    "ConfirmScreen",
+    "ProfilePage",
+    "WorkflowCompletion",
+    "TokenStatusTab",
+    "AdminMyUsagePanel",
+    "AdminAppUsagePanel",
+})
+
+# Canonical section primitive names — must match PrimitiveSectionHint.primitive in
+# structured_outputs.yaml and the live PrimitiveRegistry.js shipped with chat-ui.
+# Unknown values fail before promotion so they cannot become runtime 404/blank surfaces.
+_CANONICAL_SECTION_PRIMITIVES = frozenset({
+    "DataTable",
+    "Form",
+    "Grid",
+    "Button",
+    "Modal",
+    "Alert",
+    "Skeleton",
+    "Empty",
+    "PageHeader",
+    "ResourceTable",
+    "SummaryStrip",
+    "InlineEmptyState",
+    "LoadingState",
+    "ErrorState",
+    "Panel",
+    "SurfaceCard",
+    "StatusPill",
+    "Metric",
+    "SegmentedBar",
+    "Timeline",
+    "CodeBlock",
+    "ProgressTracker",
+    "AlertBanner",
+    "ActionButton",
+    "FileList",
+    "PricingCatalog",
+})
+
 
 def _is_scannable(path: str) -> bool:
     """Return True if this file path should be scanned for forbidden patterns."""
@@ -1381,6 +1428,14 @@ def _scan_page_schema_structure(files_map: dict[str, str]) -> list[str]:
                     errors.append(f"{path}: sections[{i}] missing 'id'")
                 if "primitive" not in section:
                     errors.append(f"{path}: sections[{i}] missing 'primitive'")
+                else:
+                    primitive = str(section.get("primitive") or "").strip()
+                    if primitive and primitive not in _CANONICAL_SECTION_PRIMITIVES:
+                        errors.append(
+                            f"{path}: sections[{i}] primitive '{primitive}' is not a "
+                            f"canonical section primitive. Must be one of: "
+                            f"{', '.join(sorted(_CANONICAL_SECTION_PRIMITIVES))}."
+                        )
         elif sections is not None:
             errors.append(f"{path}: 'sections' must be a list")
 
@@ -1444,6 +1499,131 @@ def _scan_pack_provenance_manifest(files_map: dict[str, str]) -> list[str]:
     return errors
 
 
+def _scan_page_api_endpoint_alignment(files_map: dict[str, str]) -> list[str]:
+    """Validate that api_endpoint values in schema-native page sections reference
+    modules and actions declared in the same bundle.
+
+    Only fires when module.yaml files are present — bundles without modules are
+    either page-only bundles or capability-only bundles, both of which may
+    legitimately call external modules.
+
+    Endpoints that do not match /api/modules/{module_id}/{action_id} exactly are
+    already flagged by the ui_quality gate; this check only verifies that
+    well-formed endpoints resolve to declared bundle artifacts.
+    """
+    normalized_files = _normalized_files_map(files_map)
+
+    # Build module_id → set[action_id] from all module.yaml files in the bundle.
+    module_actions: dict[str, set[str]] = {}
+    for path, content in normalized_files.items():
+        if not (path.startswith("modules/") and path.endswith("/module.yaml")):
+            continue
+        parts = PurePosixPath(path).parts
+        if len(parts) != 3:
+            continue
+        module_id = parts[1]
+        actions = _module_actions_from_yaml(path, content)
+        module_actions[module_id] = actions
+
+    if not module_actions:
+        return []  # No modules in bundle — skip reference closure.
+
+    errors: list[str] = []
+    for path, content in sorted(normalized_files.items()):
+        if not path.startswith("ui/pages/") or not path.endswith(".yaml") or "/custom/" in path:
+            continue
+        try:
+            schema = yaml.safe_load(content) or {}
+        except Exception:
+            continue
+        if not isinstance(schema, dict):
+            continue
+        sections = schema.get("sections")
+        if not isinstance(sections, list):
+            continue
+        for i, section in enumerate(sections):
+            if not isinstance(section, dict):
+                continue
+            for ep in (
+                section.get("api_endpoint"),
+                (section.get("config") or {}).get("api_endpoint"),
+            ):
+                if not isinstance(ep, str):
+                    continue
+                ep = ep.strip()
+                if not ep.startswith("/api/modules/"):
+                    continue
+                ep_parts = ep.split("/")
+                # Expected: ['', 'api', 'modules', module_id, action_id]
+                if len(ep_parts) != 5:
+                    continue
+                ref_module, ref_action = ep_parts[3], ep_parts[4]
+                if not ref_module or not ref_action:
+                    continue
+                if ref_module not in module_actions:
+                    errors.append(
+                        f"{path}: sections[{i}] api_endpoint '{ep}' references "
+                        f"module '{ref_module}' which is not declared in this bundle."
+                    )
+                elif ref_action not in module_actions[ref_module]:
+                    errors.append(
+                        f"{path}: sections[{i}] api_endpoint '{ep}' references "
+                        f"action '{ref_action}' which is not declared in "
+                        f"modules/{ref_module}/module.yaml."
+                    )
+    return errors
+
+
+def _scan_route_manifest_component_files(files_map: dict[str, str]) -> list[str]:
+    """Validate that every component declared in ui/route_manifest.json has a
+    matching custom page file under ui/pages/custom/.
+
+    This catches the common generation failure where route_manifest.json is
+    written correctly but the corresponding JSX file is missing, which produces
+    a runtime 404 for every missing component.
+    """
+    errors: list[str] = []
+    normalized = _normalized_files_map(files_map)
+    manifest_raw = normalized.get("ui/route_manifest.json")
+    if not manifest_raw:
+        return errors
+
+    try:
+        manifest = json.loads(manifest_raw)
+    except Exception:
+        return errors  # Already caught by _scan_route_manifest_consistency.
+
+    pages = manifest.get("pages") if isinstance(manifest, dict) else None
+    if not isinstance(pages, list):
+        return errors
+
+    # Collect custom page file stems that are actually present.
+    custom_page_stems: set[str] = set()
+    for path in normalized:
+        if path.startswith("ui/pages/custom/") and path.endswith(".jsx"):
+            stem = PurePosixPath(path).stem
+            if stem:
+                custom_page_stems.add(stem)
+
+    for i, page in enumerate(pages):
+        if not isinstance(page, dict):
+            continue
+        component = str(page.get("component") or "").strip()
+        if not component:
+            continue
+        # Shell-built-in components are always available — no custom JSX file required.
+        if component in _SHELL_CORE_COMPONENTS:
+            continue
+        if component not in custom_page_stems:
+            route_path = str(page.get("path") or "<unknown>").strip()
+            errors.append(
+                f"ui/route_manifest.json: pages[{i}] route '{route_path}' declares "
+                f"component '{component}' but ui/pages/custom/{component}.jsx is missing. "
+                f"The route will 404 at runtime."
+            )
+    return errors
+
+
 def scan_generated_bundle(
     files_map: dict[str, str],
     *,
@@ -1458,15 +1638,17 @@ def scan_generated_bundle(
     Checks applied per file type:
     - All scannable files: raw provider secret key literals.
     - .mozaiks/pack_provenance.json: schema validation when present.
-    - ui/route_manifest.json: required path/component fields when present.
-    - ui/pages/*.yaml (schema-native): required name/route/sections fields when present.
+    - ui/route_manifest.json: required path/component fields; component file existence.
+    - ui/pages/*.yaml (schema-native): required fields, canonical primitives, api_endpoint closure.
     """
     errors: list[str] = []
     errors.extend(_scan_canonical_app_paths(files_map))
     errors.extend(_scan_security_secret_contract(files_map))
     errors.extend(_scan_pack_provenance_manifest(files_map))
     errors.extend(_scan_route_manifest_consistency(files_map))
+    errors.extend(_scan_route_manifest_component_files(files_map))
     errors.extend(_scan_page_schema_structure(files_map))
+    errors.extend(_scan_page_api_endpoint_alignment(files_map))
     errors.extend(_scan_data_contract_module_alignment(files_map))
     errors.extend(
         _scan_selected_managed_capability_boundaries(

--- a/mozaiksai/core/workflow/generator_support/page_plan_utils.py
+++ b/mozaiksai/core/workflow/generator_support/page_plan_utils.py
@@ -90,7 +90,7 @@ def _page_from_plan(page: dict[str, Any], stem: str) -> dict[str, Any]:
         "name": str(page.get("name") or title).strip(),
         "route": route,
         "title": title,
-        "page_type": str(page.get("page_type") or page.get("page_type_hint") or page.get("ui_layout") or "standard").strip(),
+        "page_type": str(page.get("page_type_hint") or page.get("page_type") or "record_list").strip(),
         "layout": str(page.get("layout") or "stack").strip(),
         "shell_mode": str(page.get("shell_mode") or page.get("shell_mode_hint") or "workspace").strip(),
         "roles": page.get("roles"),

--- a/tests/test_generated_app_archetype_matrix.py
+++ b/tests/test_generated_app_archetype_matrix.py
@@ -1096,7 +1096,7 @@ def _matrix_specs() -> list[_ArchetypeSpec]:
                 "page_type_hint": "activity_feed",
                 "sections_hint": [
                     {
-                        "primitive": "ResourceList",
+                        "primitive": "ResourceTable",
                         "section_id_hint": "posts",
                         "title_hint": "Posts",
                         "config_hint": json.dumps({"api_endpoint": "/api/modules/posts/list_posts"}),

--- a/tests/test_generated_bundle_scanner.py
+++ b/tests/test_generated_bundle_scanner.py
@@ -1027,3 +1027,266 @@ def test_scan_generated_bundle_does_not_skip_entitlement_dispatch_for_non_manage
 
     assert any("entitlement_dispatch" in error for error in errors)
     assert any("assignment_store" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# Schema-native page structure validation (_scan_page_schema_structure)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_page_schema_structure_rejects_unknown_primitive() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/orders.yaml": """
+name: Orders
+route: /orders
+sections:
+  - id: orders-table
+    primitive: LegacyGridWidget
+""",
+        }
+    )
+
+    assert any("primitive 'LegacyGridWidget' is not a canonical section primitive" in e for e in errors)
+
+
+def test_scan_page_schema_structure_accepts_canonical_primitives() -> None:
+    # Spot-check a representative subset — DataTable, Form, PageHeader, SummaryStrip.
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/dashboard.yaml": """
+name: Dashboard
+route: /dashboard
+sections:
+  - id: header
+    primitive: PageHeader
+  - id: summary
+    primitive: SummaryStrip
+  - id: table
+    primitive: DataTable
+  - id: form
+    primitive: Form
+""",
+        }
+    )
+
+    assert not any("canonical section primitive" in e for e in errors)
+
+
+def test_scan_page_schema_structure_rejects_missing_required_fields() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/broken.yaml": """
+title: Missing name and route
+sections: []
+""",
+        }
+    )
+
+    assert any("missing required field 'name'" in e for e in errors)
+    assert any("missing required field 'route'" in e for e in errors)
+
+
+def test_scan_page_schema_structure_skips_custom_pages() -> None:
+    # Custom pages under ui/pages/custom/ are React escape-hatch files — not schema-native.
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/custom/SpecialDashboard.yaml": """
+primitive: NotCanonicalAtAll
+""",
+        }
+    )
+
+    # Must NOT raise an error for the custom page.
+    assert not any("SpecialDashboard" in e for e in errors)
+    assert not any("canonical section primitive" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# API endpoint → module/action reference closure (_scan_page_api_endpoint_alignment)
+# ---------------------------------------------------------------------------
+
+
+def _simple_module_yaml(module_id: str, *action_ids: str) -> str:
+    actions_yaml = "\n".join(
+        f"  - id: {action_id}\n    handler_method: {action_id}" for action_id in action_ids
+    )
+    return f"""schema_version: mozaiks.module.v1
+module:
+  id: {module_id}
+  handler: backend.handler:Handler
+actions:
+{actions_yaml if actions_yaml else "  []"}
+"""
+
+
+def test_scan_page_api_endpoint_alignment_skips_when_no_modules() -> None:
+    # Bundle with no module.yaml files — api_endpoint closure check must not fire.
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/landing.yaml": """
+name: Landing
+route: /landing
+sections:
+  - id: cta
+    primitive: Button
+    api_endpoint: /api/modules/some_module/some_action
+""",
+        }
+    )
+
+    # The missing-module check fires on a different path; this check must stay silent.
+    assert not any("not declared in this bundle" in e for e in errors)
+
+
+def test_scan_page_api_endpoint_alignment_accepts_valid_endpoint() -> None:
+    errors = scan_generated_bundle(
+        {
+            "modules/orders/module.yaml": _simple_module_yaml("orders", "list_orders", "create_order"),
+            "modules/orders/backend/handler.py": "class Handler: pass\n",
+            "ui/pages/orders.yaml": """
+name: Orders
+route: /orders
+sections:
+  - id: orders-table
+    primitive: DataTable
+    config:
+      api_endpoint: /api/modules/orders/list_orders
+""",
+        }
+    )
+
+    assert not any("api_endpoint" in e and "not declared" in e for e in errors)
+
+
+def test_scan_page_api_endpoint_alignment_rejects_undeclared_module() -> None:
+    errors = scan_generated_bundle(
+        {
+            "modules/orders/module.yaml": _simple_module_yaml("orders", "list_orders"),
+            "modules/orders/backend/handler.py": "class Handler: pass\n",
+            "ui/pages/invoices.yaml": """
+name: Invoices
+route: /invoices
+sections:
+  - id: invoices-table
+    primitive: DataTable
+    config:
+      api_endpoint: /api/modules/invoices/list_invoices
+""",
+        }
+    )
+
+    assert any(
+        "module 'invoices' which is not declared in this bundle" in e for e in errors
+    )
+
+
+def test_scan_page_api_endpoint_alignment_rejects_undeclared_action() -> None:
+    errors = scan_generated_bundle(
+        {
+            "modules/orders/module.yaml": _simple_module_yaml("orders", "list_orders"),
+            "modules/orders/backend/handler.py": "class Handler: pass\n",
+            "ui/pages/orders.yaml": """
+name: Orders
+route: /orders
+sections:
+  - id: orders-table
+    primitive: DataTable
+    api_endpoint: /api/modules/orders/delete_order
+""",
+        }
+    )
+
+    assert any(
+        "action 'delete_order' which is not declared in modules/orders/module.yaml" in e
+        for e in errors
+    )
+
+
+def test_scan_page_api_endpoint_alignment_checks_both_section_and_config_endpoints() -> None:
+    # The scanner checks both section.api_endpoint and section.config.api_endpoint.
+    errors = scan_generated_bundle(
+        {
+            "modules/users/module.yaml": _simple_module_yaml("users", "list_users"),
+            "modules/users/backend/handler.py": "class Handler: pass\n",
+            "ui/pages/admin.yaml": """
+name: Admin
+route: /admin
+sections:
+  - id: direct-ep
+    primitive: DataTable
+    api_endpoint: /api/modules/users/ghost_action
+  - id: config-ep
+    primitive: Form
+    config:
+      api_endpoint: /api/modules/users/another_ghost
+""",
+        }
+    )
+
+    assert any("ghost_action" in e for e in errors)
+    assert any("another_ghost" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Route manifest → custom page file closure (_scan_route_manifest_component_files)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_route_manifest_component_files_passes_when_no_manifest() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/pages/dashboard.yaml": """
+name: Dashboard
+route: /dashboard
+sections:
+  - id: header
+    primitive: PageHeader
+""",
+        }
+    )
+
+    assert not any("route_manifest" in e and "404" in e for e in errors)
+
+
+def test_scan_route_manifest_component_files_accepts_present_jsx() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/route_manifest.json": '{"pages": [{"path": "/custom", "component": "CustomDashboard"}]}',
+            "ui/pages/custom/CustomDashboard.jsx": "export default function CustomDashboard() { return null; }\n",
+        }
+    )
+
+    assert not any("CustomDashboard" in e and "404" in e for e in errors)
+
+
+def test_scan_route_manifest_component_files_rejects_missing_jsx() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/route_manifest.json": '{"pages": [{"path": "/dashboard", "component": "MissingPage"}]}',
+        }
+    )
+
+    assert any("MissingPage" in e and "404 at runtime" in e for e in errors)
+    assert any("ui/pages/custom/MissingPage.jsx is missing" in e for e in errors)
+
+
+def test_scan_route_manifest_component_files_rejects_multiple_missing_jsx() -> None:
+    errors = scan_generated_bundle(
+        {
+            "ui/route_manifest.json": """
+{
+  "pages": [
+    {"path": "/alpha", "component": "AlphaPage"},
+    {"path": "/beta", "component": "BetaPage"}
+  ]
+}
+""",
+            "ui/pages/custom/AlphaPage.jsx": "export default function AlphaPage() { return null; }\n",
+        }
+    )
+
+    # AlphaPage present → no error for it.
+    assert not any("AlphaPage" in e and "404" in e for e in errors)
+    # BetaPage missing → error.
+    assert any("BetaPage" in e and "404 at runtime" in e for e in errors)

--- a/tests/test_managed_capability_artifact_replay.py
+++ b/tests/test_managed_capability_artifact_replay.py
@@ -354,7 +354,7 @@ def _mozaikspay_replay_plan() -> dict[str, Any]:
                 "sections_hint": [
                     {
                         "section_id_hint": "usage-status",
-                        "primitive": "DataPanel",
+                        "primitive": "SummaryStrip",
                         "config_hint": {
                             "api_endpoint": "/api/modules/mozaikspay/get_usage_status",
                             "method": "POST",


### PR DESCRIPTION
## Final Report

**CURRENT MAIN:** `a48dec12` (docs: enforce deterministic schema generation guardrails #258)

**SCHEMA FAMILIES CHANGED:**
- `factory_app/workflows/AppGenerator/structured_outputs.yaml` — `AppBuildIntegration.kind`
- `factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py` — primitive taxonomy, reference closure
- `mozaiksai/core/workflow/generator_support/page_plan_utils.py` — page_type fallback chain

**CANONICAL TAXONOMIES:**
- Section primitives: `_CANONICAL_SECTION_PRIMITIVES` frozenset (26 values) — exact match to `PrimitiveRegistry.js` and `structured_outputs.yaml` literal enum
- Shell core components: `_SHELL_CORE_COMPONENTS` (9 values) — exact match to `chat-ui/src/registry/coreComponents.js` CORE_COMPONENTS

**LEGACY VALUES REMOVED:**
- `DataPanel` — not in PrimitiveRegistry.js, removed from mozaikspay billing.yaml and usage.yaml templates
- `ResourceList` — component primitive only (not in PrimitiveRegistry page renderer), removed from community_content archetype test fixture

**COMPATIBILITY LOGIC REMOVED:**
- Silent page_type fallback via `page.get("ui_layout")` (wrong domain — layout values are not page archetypes)
- Silent fallback to `"standard"` (not in VALID_PAGE_TYPES)

**FREE-FORM FIELDS MADE FINITE:**
- `AppBuildIntegration.kind`: `type: str` → `type: literal` with 9 canonical values (payments, email, analytics, agent-backend, storage, external-api, auth, messaging, database)

**REFERENCE CLOSURE:** PASS
- api_endpoint → module/action declared in same bundle ✓
- route_manifest component → custom JSX file present (non-shell) ✓

**FACTORY UPDATED:** YES
- mozaikspay templates: `DataPanel` → `PricingCatalog` (billing) / `SummaryStrip` (usage)

**FACTORY DOGFOOD:** PASS — full suite 12,459 passed, 0 failures

**REPRESENTATIVE ROUTE 404 PROOF:** PASS
- `_scan_route_manifest_component_files` catches missing JSX (non-shell components)
- `_scan_page_api_endpoint_alignment` catches api_endpoint pointing to undeclared module or action

**CUSTOM PY/JS ESCAPE HATCH:** PRESERVED
- `ui/pages/custom/*.jsx` excluded from schema-native page validation
- Custom components in route_manifest that are shell built-ins exempted

**NEW PARALLEL SCHEMA SYSTEM:** NO — extends existing scanner, no new schema layer

**TESTS:**
- 12 new tests in `test_generated_bundle_scanner.py`
- `_scan_page_schema_structure`: unknown primitive rejected, canonical accepted, missing fields rejected, custom pages skipped
- `_scan_page_api_endpoint_alignment`: no modules = skip, valid endpoint accepted, undeclared module rejected, undeclared action rejected, both section.api_endpoint and config.api_endpoint checked
- `_scan_route_manifest_component_files`: no manifest = pass, JSX present accepted, missing JSX rejected, partial presence correct
- Pre-existing: 12,459 passed → 12,459 passed (0 regressions)

**REMAINING TAXONOMY P1:**
- `ResourceList` not registered in PrimitiveRegistry — should be added if `activity_feed` pages need a non-table list primitive (tracked separately)
- `UsageTrendPanel`, `AnalyticsSummaryStrip`, `PerformanceTileGrid`, `ContentRail` exported but not in page renderer — candidates for future registration

**PR:** (this PR)