### PR TITLE
feat(factory): verify community pack integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,17 @@ This project follows a practical pre-1.0 changelog format:
 ### Added
 
 - **Community Component Foundation v1**: Extended capability packs to carry versioned identity and machine-readable dependency declarations without introducing a parallel component runtime.
-  - `context.yaml` pack block now accepts optional `version`, `author`, `license`, and `source` fields; existing packs without these fields remain valid.
-  - `contract.yaml` now supports a canonical `requires.packs` / `requires.capabilities` block for machine-readable dependency declarations; `PackDependencyError` (a `ManagedCapabilityTemplateError` subclass) is raised with structured diagnostics when a required pack is absent from the selected list.
-  - `resolve_managed_capability_templates()` emits a `.mozaiks/pack_provenance.json` manifest on every materialization; the manifest records `pack_id`, `pack_version`, per-file paths, and `owner` classification (`templates` vs `workspace`).
-  - Structural allowlisting of `context.yaml` pack blocks via `validate_pack_context()` in `factory_app/workflows/AppGenerator/tools/pack_context_schema.py`: unexpected root or pack-block keys raise `ManagedCapabilityTemplateError` before any pack data reaches AG2.
+  - `context.yaml` pack blocks now require `version`; `author`, `license`, and `source` remain optional metadata.
+  - `contract.yaml` supports the canonical `requires.packs` / `requires.capabilities` block for machine-readable dependency declarations; exact `requires.packs[].version` values are enforced when present.
+  - `resolve_managed_capability_templates()` verifies local packs before materialization, computes one canonical `sha256:` content digest from declared pack assets, and emits `.mozaiks/pack_provenance.json` with `pack_id`, `version`, `source`, `digest`, and `materialized_owned_files`.
+  - Structural allowlisting of `context.yaml` pack blocks via `validate_pack_context()` now rejects unexpected root, asset, and pack-block keys before any pack data reaches AG2.
   - `scan_generated_bundle()` now validates the provenance manifest schema when `.mozaiks/pack_provenance.json` is present in a generated bundle.
   - `.mozaiks` added to `CANONICAL_APP_ROOT_DIRS` so the provenance directory is a first-class part of the canonical app surface.
-  - First-party packs (`messaging`, `support`, `social`, `commerce`, `notifications`, `files`, `entitlement_dispatch`, `mozaikspay`, `operator_readiness`) updated to `version: "0.1.11"`.
+  - First-party packs (`messaging`, `support`, `social`, `commerce`, `notifications`, `files`, `entitlement_dispatch`, `mozaikspay`, `operator_readiness`, `onboarding`) updated to `version: "0.1.11"`.
   - `support/contract.yaml` migrated from informal `required_packs` to canonical `requires.packs` format.
   - Fixture community packs in `tests/fixtures/community_packs/` prove dependency validation and provenance work locally without App Zero, network, or a paid LLM.
-  - 39 tests in `tests/test_community_pack_foundation.py` cover schema validation, dependency checking, provenance emission, bundle scanner integration, and unchanged first-party pack behavior.
+  - 49 tests in `tests/test_community_pack_foundation.py` cover schema validation, digest stability, tamper rejection, provenance emission,
+    bundle scanner integration, retired-shape rejection, and first-party pack behavior.
 
 - Published `docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md` as the authoritative OSS north-star software-design document; added to mkdocs.yml navigation as the primary architecture reference. No competing document exists under `docs/architecture/foundations/`.
 

--- a/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
+++ b/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
@@ -411,9 +411,10 @@ Community Component Foundation v1 currently provides:
 
 * pack identity and version metadata;
 * dependency declarations;
+* deterministic pack-content digests over declared assets;
 * pack provenance manifest emission;
 * catalog structural validation before pack context becomes generation input;
-* dependency validation before template materialization;
+* dependency and exact declared-version validation before template materialization;
 * offline local community-pack proof.
 
 It does not yet provide:
@@ -422,6 +423,8 @@ It does not yet provide:
 * cryptographic signing;
 * trust scoring;
 * automatic remote installation;
+* remote fetching;
+* marketplace behavior;
 * upgrade planning or migration execution.
 
 Future community component work should evolve capability packs by adding distribution semantics:

--- a/docs/architecture/workflows/build-context-packs.md
+++ b/docs/architecture/workflows/build-context-packs.md
@@ -74,6 +74,7 @@ assets:
     kind: templates
 pack:
   id: mozaikspay
+  version: "0.1.11"
   status: active
   capability_source: managed_capability
   required_integrations:
@@ -114,6 +115,7 @@ Required fields:
 Optional fields:
 
 - `pack`: marks the context as a selectable build pack.
+- `pack.version`: required version string for selectable packs.
 - `pack.required_integrations`: connector requirements that selected packs add
   to AppGenerator integration readiness. Declare each requirement as a
   structured object with `service`, `provider`, `kind`, `purpose`,
@@ -215,6 +217,9 @@ Current canonical asset kinds:
 - `contract`: typed agent-facing rule contract.
 - `templates`: directory of deterministic generated app files.
 
+Unknown asset kinds fail pack validation before prompt projection or
+materialization.
+
 Catalog prompt projection is declared on the catalog asset:
 
 ```yaml
@@ -281,10 +286,27 @@ facades:
     provider_module: mozaikspay
 ```
 
-Use bounded fields such as `selection_rules`, `required_outputs`,
-`required_integrations`, `forbidden_outputs`, `runtime_boundaries`, `facades`, and
-`inactive_surfaces`. Do not use top-level narrative fields such as `purpose`,
-`description`, `generation_rules`, or `recommended_facades`.
+Use bounded fields such as `selection_rules`, `required_outputs`, `requires`,
+`provides_capabilities`, `forbidden_outputs`, `runtime_boundaries`, and
+`facades`. Do not use top-level narrative fields such as `purpose`,
+`description`, `generation_rules`, `recommended_facades`, or alternate schema
+languages.
+
+Pack dependencies use one canonical contract:
+
+```yaml
+requires:
+  packs:
+    - pack_id: messaging
+      version: "0.1.11"
+      reason: Support tickets reuse messaging threads.
+  capabilities:
+    - capability_id: messaging.threads.create
+      reason: Support needs a canonical thread creation capability.
+```
+
+`requires.packs[].version` is exact when present. Mozaiks does not solve semver
+ranges for build-context packs.
 
 ## Templates
 
@@ -309,6 +331,48 @@ Examples:
 YAML files inside `templates/` are generated app declaratives, not build-context
 contracts. A selected pack copies every file under each declared `templates`
 asset to the same relative path in the generated app bundle.
+
+## Trust And Integrity
+
+Community Components are verified local `CapabilityPack` directories. Discovery
+of a descriptor does not install it, installation does not verify it, and
+verification does not grant production authority.
+
+Before materialization, a selected local pack must pass deterministic checks for:
+
+- identity and version;
+- declared asset closure;
+- catalog and contract schema shape;
+- dependency declarations and exact dependency versions when declared;
+- canonical content digest.
+
+The digest is one `sha256:` value computed from `context.yaml` and every
+declared asset file. It excludes timestamps, absolute paths, worktree location,
+and transient generated metadata. The same pack content produces the same
+digest; material pack-content changes produce a different digest.
+
+Generated bundles retain pack metadata in the existing
+`.mozaiks/pack_provenance.json` manifest:
+
+```json
+{
+  "schema_version": "mozaiks.pack_provenance.v1",
+  "packs": [
+    {
+      "pack_id": "greetings",
+      "version": "0.1.0",
+      "source": "https://example.com/community-packs/greetings",
+      "digest": "sha256:...",
+      "materialized_owned_files": [
+        { "path": "modules/greetings/module.yaml", "owner": "templates" }
+      ]
+    }
+  ]
+}
+```
+
+Mozaiks does not perform remote downloads, registry lookup, marketplace ranking,
+trust scoring, or cryptographic signing for this v1 layer.
 
 ## Resolution
 

--- a/factory_app/build_context/onboarding/context.yaml
+++ b/factory_app/build_context/onboarding/context.yaml
@@ -6,6 +6,7 @@ assets:
     kind: contract
 pack:
   id: onboarding
+  version: "0.1.11"
   status: active
   capability_source: config_file
   description: >

--- a/factory_app/build_context/operator_readiness/context.yaml
+++ b/factory_app/build_context/operator_readiness/context.yaml
@@ -8,6 +8,7 @@ assets:
     kind: templates
 pack:
   id: operator_readiness
+  version: "0.1.11"
   status: active
   capability_source: config_file
   description: >

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -1391,7 +1391,13 @@ _PACK_PROVENANCE_PATH = ".mozaiks/pack_provenance.json"
 _PACK_PROVENANCE_SCHEMA_VERSION = "mozaiks.pack_provenance.v1"
 
 _PROVENANCE_REQUIRED_KEYS = frozenset({"schema_version", "framework_version", "generated_at", "packs"})
-_PROVENANCE_PACK_REQUIRED_KEYS = frozenset({"pack_id", "pack_version", "files"})
+_PROVENANCE_PACK_REQUIRED_KEYS = frozenset({
+    "pack_id",
+    "version",
+    "source",
+    "digest",
+    "materialized_owned_files",
+})
 
 
 def _scan_pack_provenance_manifest(files_map: dict[str, str]) -> list[str]:
@@ -1418,6 +1424,9 @@ def _scan_pack_provenance_manifest(files_map: dict[str, str]) -> list[str]:
     missing_keys = _PROVENANCE_REQUIRED_KEYS - set(manifest.keys())
     for key in sorted(missing_keys):
         errors.append(f"{_PACK_PROVENANCE_PATH}: missing required field '{key}'")
+    unknown_keys = sorted(set(manifest.keys()) - _PROVENANCE_REQUIRED_KEYS)
+    for key in unknown_keys:
+        errors.append(f"{_PACK_PROVENANCE_PATH}: unsupported field '{key}'")
 
     # Check schema_version value
     sv = manifest.get("schema_version")
@@ -1440,6 +1449,17 @@ def _scan_pack_provenance_manifest(files_map: dict[str, str]) -> list[str]:
                 missing_pack_keys = _PROVENANCE_PACK_REQUIRED_KEYS - set(entry.keys())
                 for key in sorted(missing_pack_keys):
                     errors.append(f"{_PACK_PROVENANCE_PATH}: packs[{i}] missing required field '{key}'")
+                unknown_pack_keys = sorted(set(entry.keys()) - _PROVENANCE_PACK_REQUIRED_KEYS)
+                for key in unknown_pack_keys:
+                    errors.append(f"{_PACK_PROVENANCE_PATH}: packs[{i}] unsupported field '{key}'")
+                digest = str(entry.get("digest") or "")
+                if digest and not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+                    errors.append(f"{_PACK_PROVENANCE_PATH}: packs[{i}].digest must be a canonical sha256 digest")
+                files = entry.get("materialized_owned_files")
+                if files is not None and not isinstance(files, list):
+                    errors.append(
+                        f"{_PACK_PROVENANCE_PATH}: packs[{i}].materialized_owned_files must be a JSON array"
+                    )
 
     return errors
 

--- a/factory_app/workflows/AppGenerator/tools/pack_context_schema.py
+++ b/factory_app/workflows/AppGenerator/tools/pack_context_schema.py
@@ -44,12 +44,16 @@ _ALLOWED_PACK_KEYS: frozenset[str] = frozenset({
 _VALID_STATUS: frozenset[str] = frozenset({"active", "inactive", "archived"})
 
 _VALID_CAPABILITY_SOURCES: frozenset[str] = frozenset({
+    "config_file",
     "managed_capability",
     "generated_module",
     "operator_extension",
     "external_adapter",
     "framework_pack",
 })
+
+_ALLOWED_ASSET_KEYS: frozenset[str] = frozenset({"path", "kind", "description", "projections"})
+_VALID_ASSET_KINDS: frozenset[str] = frozenset({"catalog", "contract", "templates"})
 
 
 @dataclass
@@ -107,6 +111,32 @@ def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResul
             ),
         ))
 
+    assets = context.get("assets")
+    if assets is not None:
+        if not isinstance(assets, list):
+            diagnostics.append(PackContextDiagnostic("assets", "assets must be a list"))
+        else:
+            for index, asset in enumerate(assets):
+                field = f"assets[{index}]"
+                if not isinstance(asset, dict):
+                    diagnostics.append(PackContextDiagnostic(field, "asset must be a mapping"))
+                    continue
+                unknown_asset_keys = sorted(set(asset) - _ALLOWED_ASSET_KEYS)
+                if unknown_asset_keys:
+                    diagnostics.append(PackContextDiagnostic(
+                        field,
+                        f"asset has unsupported fields: {unknown_asset_keys}",
+                    ))
+                asset_path = str(asset.get("path") or "").strip()
+                asset_kind = str(asset.get("kind") or "").strip()
+                if not asset_path:
+                    diagnostics.append(PackContextDiagnostic(f"{field}.path", "asset.path is required"))
+                if asset_kind not in _VALID_ASSET_KINDS:
+                    diagnostics.append(PackContextDiagnostic(
+                        f"{field}.kind",
+                        f"asset.kind must be one of: {sorted(_VALID_ASSET_KINDS)}",
+                    ))
+
     # --- pack: block ---
     pack = context.get("pack")
     if pack is None:
@@ -145,7 +175,11 @@ def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResul
             f"pack.status '{status}' must be one of: {sorted(_VALID_STATUS)}",
         ))
 
-    # --- pack.capability_source (warn, not error, for forward compatibility) ---
+    version = pack.get("version")
+    if version is None or not isinstance(version, str) or not version.strip():
+        diagnostics.append(PackContextDiagnostic("pack.version", "pack.version is required and must be a string"))
+
+    # --- pack.capability_source ---
     cap_source = pack.get("capability_source")
     if cap_source is not None:
         cap_source_str = str(cap_source).strip()
@@ -154,11 +188,10 @@ def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResul
                 "pack.capability_source",
                 f"pack.capability_source '{cap_source_str}' is not a known value; "
                 f"expected one of: {sorted(_VALID_CAPABILITY_SOURCES)}",
-                severity="warning",
             ))
 
     # --- Optional string identity fields ---
-    for str_field in ("version", "author", "license", "source", "description", "display_name"):
+    for str_field in ("author", "license", "source", "description", "display_name"):
         val = pack.get(str_field)
         if val is not None and not isinstance(val, str):
             diagnostics.append(PackContextDiagnostic(

--- a/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
@@ -68,7 +68,8 @@ class PackIntegrityError(ManagedCapabilityTemplateError):
 
 
 def _normalized_source(pack: dict[str, Any], context: dict[str, Any]) -> str:
-    pack_block = context.get("pack") if isinstance(context.get("pack"), dict) else {}
+    pack_value = context.get("pack")
+    pack_block = pack_value if isinstance(pack_value, dict) else {}
     return str(pack.get("source") or pack_block.get("source") or "local").strip()
 
 
@@ -226,7 +227,8 @@ def _validate_pack_dependencies(
         if raw_path and pid and _is_safe_identifier(pid):
             try:
                 context_data = _read_pack_context(Path(raw_path).resolve(), pid)
-                pack_block = context_data.get("pack") if isinstance(context_data.get("pack"), dict) else {}
+                pack_value = context_data.get("pack")
+                pack_block = pack_value if isinstance(pack_value, dict) else {}
                 available_pack_versions[pid] = str(pack_block.get("version") or "").strip()
                 for cid in _capabilities_from_context(context_data):
                     available_capability_ids.add(cid)

--- a/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from datetime import UTC, datetime
@@ -43,19 +44,32 @@ class PackDependencyError(ManagedCapabilityTemplateError):
         *,
         missing_packs: list[str] | None = None,
         missing_capabilities: list[str] | None = None,
+        version_mismatches: list[str] | None = None,
     ) -> None:
         self.pack_id = pack_id
         self.missing_packs: list[str] = missing_packs or []
         self.missing_capabilities: list[str] = missing_capabilities or []
+        self.version_mismatches: list[str] = version_mismatches or []
         parts: list[str] = []
         if self.missing_packs:
             parts.append(f"missing required packs: {self.missing_packs}")
         if self.missing_capabilities:
             parts.append(f"missing required capabilities: {self.missing_capabilities}")
+        if self.version_mismatches:
+            parts.append(f"dependency version mismatches: {self.version_mismatches}")
         super().__init__(
             f"Pack '{pack_id}' dependency check failed — {'; '.join(parts)}. "
             "Ensure all required packs are included in the selected capability_packs list."
         )
+
+
+class PackIntegrityError(ManagedCapabilityTemplateError):
+    """Raised when a local pack fails deterministic trust/integrity verification."""
+
+
+def _normalized_source(pack: dict[str, Any], context: dict[str, Any]) -> str:
+    pack_block = context.get("pack") if isinstance(context.get("pack"), dict) else {}
+    return str(pack.get("source") or pack_block.get("source") or "local").strip()
 
 
 def _is_safe_identifier(name: str) -> bool:
@@ -103,21 +117,41 @@ def _read_pack_contract(pack_source_path: Path) -> dict[str, Any]:
     try:
         data = yaml.safe_load(contract_path.read_text(encoding="utf-8")) or {}
     except Exception as exc:
-        logger.warning("Cannot read pack contract at %s: %s", contract_path, exc)
-        return {}
-    return data if isinstance(data, dict) else {}
+        raise ManagedCapabilityTemplateError(f"Cannot read pack contract at {contract_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ManagedCapabilityTemplateError(f"Pack contract at {contract_path} is not a YAML mapping")
+    return data
 
 
-def _extract_requires(contract: dict[str, Any]) -> tuple[list[str], list[str]]:
-    """Return (required_pack_ids, required_capability_ids) from a contract dict.
+def _extract_requires(contract: dict[str, Any]) -> tuple[list[dict[str, str]], list[str]]:
+    """Return (required_packs, required_capability_ids) from a contract dict.
 
     Supports two declaration forms:
       packs: [pack_id, ...]                      # simple list of strings
-      packs: [{pack_id: name, reason: ...}, ...] # list of dicts with pack_id key
+      packs: [{pack_id: name, version: ..., reason: ...}]
     """
     requires = contract.get("requires")
     if not isinstance(requires, dict):
         return [], []
+
+    def _extract_pack_entries(entries: Any) -> list[dict[str, str]]:
+        if not isinstance(entries, list):
+            return []
+        packs: list[dict[str, str]] = []
+        for entry in entries:
+            if isinstance(entry, str):
+                pack_id = entry.strip()
+                if pack_id:
+                    packs.append({"pack_id": pack_id})
+            elif isinstance(entry, dict):
+                pack_id = str(entry.get("pack_id") or "").strip()
+                version = str(entry.get("version") or "").strip()
+                if pack_id:
+                    item = {"pack_id": pack_id}
+                    if version:
+                        item["version"] = version
+                    packs.append(item)
+        return packs
 
     def _extract_ids(entries: Any, id_key: str) -> list[str]:
         if not isinstance(entries, list):
@@ -132,7 +166,7 @@ def _extract_requires(contract: dict[str, Any]) -> tuple[list[str], list[str]]:
                     ids.append(val)
         return ids
 
-    pack_ids = _extract_ids(requires.get("packs"), "pack_id")
+    pack_ids = _extract_pack_entries(requires.get("packs"))
     cap_ids = _extract_ids(requires.get("capabilities"), "capability_id")
     return pack_ids, cap_ids
 
@@ -166,6 +200,7 @@ def _validate_pack_dependencies(
     # to reading context.yaml — the descriptor may not carry the capabilities list
     # when built programmatically (e.g. in tests or lightweight integrations).
     available_pack_ids: set[str] = set()
+    available_pack_versions: dict[str, str] = {}
     available_capability_ids: set[str] = set()
 
     for pack in capability_packs:
@@ -188,13 +223,16 @@ def _validate_pack_dependencies(
         # Only attempt when pack_id is safe — unsafe IDs will be caught later
         # by resolve_templates_for_pack's _is_safe_identifier check.
         raw_path = pack.get("pack_source_path")
-        if raw_path and not pack.get("capabilities") and pid and _is_safe_identifier(pid):
+        if raw_path and pid and _is_safe_identifier(pid):
             try:
                 context_data = _read_pack_context(Path(raw_path).resolve(), pid)
+                pack_block = context_data.get("pack") if isinstance(context_data.get("pack"), dict) else {}
+                available_pack_versions[pid] = str(pack_block.get("version") or "").strip()
                 for cid in _capabilities_from_context(context_data):
                     available_capability_ids.add(cid)
             except Exception:
-                pass
+                if not pack.get("capabilities"):
+                    pass
 
     # Validate each pack's declared requires
     for pack in capability_packs:
@@ -208,15 +246,215 @@ def _validate_pack_dependencies(
         contract = _read_pack_contract(Path(raw_path))
         required_packs, required_caps = _extract_requires(contract)
 
-        missing_packs = [p for p in required_packs if p not in available_pack_ids]
+        missing_packs = [p["pack_id"] for p in required_packs if p["pack_id"] not in available_pack_ids]
         missing_caps = [c for c in required_caps if c not in available_capability_ids]
+        version_mismatches: list[str] = []
+        for required in required_packs:
+            required_version = required.get("version")
+            if not required_version or required["pack_id"] not in available_pack_ids:
+                continue
+            installed_version = available_pack_versions.get(required["pack_id"], "")
+            if installed_version != required_version:
+                version_mismatches.append(
+                    f"{required['pack_id']} expected {required_version}, installed {installed_version or '<missing>'}"
+                )
 
-        if missing_packs or missing_caps:
+        if missing_packs or missing_caps or version_mismatches:
             raise PackDependencyError(
                 pack_id,
                 missing_packs=missing_packs,
                 missing_capabilities=missing_caps,
+                version_mismatches=version_mismatches,
             )
+
+
+def _safe_asset_files(context_root: Path, context: dict[str, Any]) -> list[Path]:
+    files: list[Path] = [context_root / "context.yaml"]
+    seen: set[Path] = {files[0].resolve()}
+    for asset in iter_context_assets(context):
+        try:
+            asset_path = resolve_context_asset_path(context_root, asset)
+        except BuildContextError as exc:
+            raise PackIntegrityError(str(exc)) from exc
+        if not asset_path.exists():
+            raise PackIntegrityError(f"Declared pack asset not found: {asset_path}")
+        if asset_path.is_file():
+            resolved = asset_path.resolve()
+            if resolved not in seen:
+                files.append(asset_path)
+                seen.add(resolved)
+            continue
+        if not asset_path.is_dir():
+            raise PackIntegrityError(f"Declared pack asset must be a file or directory: {asset_path}")
+        for path in sorted(item for item in asset_path.rglob("*") if item.is_file()):
+            relative = path.relative_to(asset_path)
+            if any(part == "__pycache__" or part.startswith(".") for part in relative.parts):
+                continue
+            if path.suffix in {".pyc", ".pyo"}:
+                continue
+            resolved = path.resolve()
+            if resolved not in seen:
+                files.append(path)
+                seen.add(resolved)
+    return files
+
+
+def compute_pack_digest(pack_source_path: Path, pack_id: str) -> str:
+    """Return the canonical SHA-256 digest for declared pack-owned content."""
+
+    context_root = pack_source_path.resolve()
+    context = _read_pack_context(context_root, pack_id)
+    entries: list[dict[str, str]] = []
+    for path in _safe_asset_files(context_root, context):
+        try:
+            relative = path.resolve().relative_to(context_root).as_posix()
+        except ValueError as exc:
+            raise PackIntegrityError(f"Pack digest path escapes context root: {path}") from exc
+        entries.append({
+            "path": relative,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        })
+    payload = {
+        "schema_version": "mozaiks.pack_digest.v1",
+        "pack_id": pack_id,
+        "files": sorted(entries, key=lambda item: item["path"]),
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def _validate_pack_contract_schema(pack_source_path: Path, contract: dict[str, Any]) -> None:
+    schema_version = str(contract.get("schema_version") or "").strip()
+    contract_type = str(contract.get("contract_type") or "").strip()
+    if schema_version == "mozaiks.provider_api_contract.v1":
+        allowed_provider_root = {
+            "schema_version",
+            "contract_id",
+            "description",
+            "auth",
+            "endpoints",
+            "error_handling",
+            "drift_guard",
+        }
+        unknown_provider = sorted(set(contract) - allowed_provider_root)
+        if unknown_provider:
+            raise PackIntegrityError(
+                f"{pack_source_path / 'provider_api_contract.yaml'} has unsupported fields: {unknown_provider}"
+            )
+        if not isinstance(contract.get("endpoints"), list):
+            raise PackIntegrityError("provider_api_contract.yaml endpoints must be a list")
+        return
+
+    if contract_type != "build_pack_instructions":
+        raise PackIntegrityError(
+            f"{pack_source_path / 'contract.yaml'} contract_type must be build_pack_instructions"
+        )
+
+    allowed_root = {
+        "contract_id",
+        "contract_type",
+        "requires",
+        "cross_pack_integrations",
+        "selection_rules",
+        "recommended_domains",
+        "required_integrations",
+        "required_outputs",
+        "forbidden_outputs",
+        "runtime_boundaries",
+        "facades",
+        "provides_capabilities",
+        "inactive_surfaces",
+        "managed_assignment_writer_contract",
+        "provider_api_response_contract",
+        "provider_lifecycle_boundary",
+    }
+    unknown = sorted(set(contract) - allowed_root)
+    if unknown:
+        raise PackIntegrityError(f"{pack_source_path / 'contract.yaml'} has unsupported fields: {unknown}")
+
+    requires = contract.get("requires")
+    if requires is not None:
+        if not isinstance(requires, dict):
+            raise PackIntegrityError("contract.yaml requires must be a mapping")
+        unknown_requires = sorted(set(requires) - {"packs", "capabilities"})
+        if unknown_requires:
+            raise PackIntegrityError(f"contract.yaml requires has unsupported fields: {unknown_requires}")
+        packs = requires.get("packs")
+        if packs is not None:
+            if not isinstance(packs, list):
+                raise PackIntegrityError("contract.yaml requires.packs must be a list")
+            for index, item in enumerate(packs):
+                if isinstance(item, str):
+                    continue
+                if not isinstance(item, dict):
+                    raise PackIntegrityError(f"contract.yaml requires.packs[{index}] must be a string or mapping")
+                unknown = sorted(set(item) - {"pack_id", "version", "reason"})
+                if unknown:
+                    raise PackIntegrityError(
+                        f"contract.yaml requires.packs[{index}] has unsupported fields: {unknown}"
+                    )
+                if not str(item.get("pack_id") or "").strip():
+                    raise PackIntegrityError(f"contract.yaml requires.packs[{index}].pack_id is required")
+        capabilities = requires.get("capabilities")
+        if capabilities is not None:
+            if not isinstance(capabilities, list):
+                raise PackIntegrityError("contract.yaml requires.capabilities must be a list")
+            for index, item in enumerate(capabilities):
+                if isinstance(item, str):
+                    continue
+                if not isinstance(item, dict):
+                    raise PackIntegrityError(
+                        f"contract.yaml requires.capabilities[{index}] must be a string or mapping"
+                    )
+                unknown = sorted(set(item) - {"capability_id", "reason"})
+                if unknown:
+                    raise PackIntegrityError(
+                        f"contract.yaml requires.capabilities[{index}] has unsupported fields: {unknown}"
+                    )
+                if not str(item.get("capability_id") or "").strip():
+                    raise PackIntegrityError(
+                        f"contract.yaml requires.capabilities[{index}].capability_id is required"
+                    )
+
+    for field in ("selection_rules", "recommended_domains", "required_outputs", "forbidden_outputs", "runtime_boundaries", "facades", "provides_capabilities"):
+        value = contract.get(field)
+        if value is not None and not isinstance(value, list):
+            raise PackIntegrityError(f"contract.yaml {field} must be a list")
+
+
+def verify_pack_integrity(pack_source_path: Path, pack_id: str) -> dict[str, Any]:
+    """Verify a local pack before materialization and return canonical metadata."""
+
+    if not _is_safe_identifier(pack_id):
+        raise PackIntegrityError(
+            f"Unsafe pack_id '{pack_id}': must be a simple identifier without path separators or traversal sequences"
+        )
+    context_root = pack_source_path.resolve()
+    context = _read_pack_context(context_root, pack_id)
+    pack_block = context.get("pack") if isinstance(context.get("pack"), dict) else {}
+    if not isinstance(pack_block, dict):
+        raise PackIntegrityError(f"Pack '{pack_id}' must declare a pack block before materialization")
+    version = str(pack_block.get("version") or "").strip()
+    if not version:
+        raise PackIntegrityError(f"Pack '{pack_id}' must declare pack.version before materialization")
+    _safe_asset_files(context_root, context)
+    for asset in iter_context_assets(context, kind="catalog"):
+        path = resolve_context_asset_path(context_root, asset)
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            raise PackIntegrityError(f"Catalog asset must be a YAML mapping: {path}")
+    for asset in iter_context_assets(context, kind="contract"):
+        path = resolve_context_asset_path(context_root, asset)
+        contract_data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(contract_data, dict):
+            raise PackIntegrityError(f"Contract asset must be a YAML mapping: {path}")
+        _validate_pack_contract_schema(context_root, contract_data)
+    return {
+        "pack_id": pack_id,
+        "version": version,
+        "source": _normalized_source(pack_block, context),
+        "digest": compute_pack_digest(context_root, pack_id),
+    }
 
 
 def _file_owner_map(pack_source_path: Path) -> dict[str, str]:
@@ -233,12 +471,12 @@ def _file_owner_map(pack_source_path: Path) -> dict[str, str]:
 
 
 def _build_provenance_manifest(
-    pack_file_map: list[tuple[str, str, list[dict[str, str]]]],
+    pack_file_map: list[tuple[dict[str, Any], list[dict[str, str]]]],
 ) -> str:
     """Build a provenance manifest JSON string.
 
     Args:
-        pack_file_map: List of (pack_id, pack_version, [file_entries]) tuples.
+        pack_file_map: List of (pack_metadata, [file_entries]) tuples.
 
     Returns:
         JSON string for ``.mozaiks/pack_provenance.json``.
@@ -249,11 +487,13 @@ def _build_provenance_manifest(
         framework_version = "unknown"
 
     packs_list = []
-    for pack_id, pack_version, file_entries in pack_file_map:
+    for metadata, file_entries in pack_file_map:
         packs_list.append({
-            "pack_id": pack_id,
-            "pack_version": pack_version or "",
-            "files": file_entries,
+            "pack_id": metadata["pack_id"],
+            "version": metadata["version"],
+            "source": metadata["source"],
+            "digest": metadata["digest"],
+            "materialized_owned_files": file_entries,
         })
 
     manifest = {
@@ -426,8 +666,8 @@ def resolve_managed_capability_templates(
 
     # --- Step 2: render templates, tracking per-pack output for provenance ---
     results_by_filename: dict[str, str] = {}
-    # (pack_id, pack_version, owner_map, [produced filenames])
-    provenance_entries: list[tuple[str, str, dict[str, str], list[str]]] = []
+    # (metadata, owner_map, [produced filenames])
+    provenance_entries: list[tuple[dict[str, Any], dict[str, str], list[str]]] = []
 
     for pack in capability_packs:
         if not isinstance(pack, dict):
@@ -442,10 +682,7 @@ def resolve_managed_capability_templates(
                 f"Unsafe pack_id '{pack_id}': must be a simple identifier without path separators or traversal sequences"
             )
         pack_source_path = Path(raw_path)
-        # Read pack version from context.yaml pack block (optional field)
-        context_data = _read_pack_context(pack_source_path.resolve(), pack_id)
-        pack_block = context_data.get("pack") or {}
-        pack_version = str(pack_block.get("version") or "").strip()
+        metadata = verify_pack_integrity(pack_source_path, pack_id)
 
         # Ownership map: output_path → owner (from contract.yaml required_outputs)
         owner_map = _file_owner_map(pack_source_path)
@@ -467,20 +704,19 @@ def resolve_managed_capability_templates(
             pack_files.append(filename)
 
         if pack_files:
-            provenance_entries.append((pack_id, pack_version, owner_map, pack_files))
+            provenance_entries.append((metadata, owner_map, pack_files))
 
     # --- Step 3: emit provenance manifest ---
     if provenance_entries:
         pack_file_map = [
             (
-                pid,
-                pver,
+                metadata,
                 [
                     {"path": f, "owner": omap.get(f, "templates")}
                     for f in sorted(files)
                 ],
             )
-            for pid, pver, omap, files in provenance_entries
+            for metadata, omap, files in provenance_entries
         ]
         provenance_json = _build_provenance_manifest(pack_file_map)
         existing_prov = results_by_filename.get(_PROVENANCE_PATH)
@@ -494,8 +730,11 @@ def resolve_managed_capability_templates(
 
 
 __all__ = [
+    "compute_pack_digest",
     "ManagedCapabilityTemplateError",
     "PackDependencyError",
+    "PackIntegrityError",
     "resolve_managed_capability_templates",
     "resolve_templates_for_pack",
+    "verify_pack_integrity",
 ]

--- a/tests/fixtures/community_packs/farewell/contract.yaml
+++ b/tests/fixtures/community_packs/farewell/contract.yaml
@@ -5,6 +5,7 @@ contract_type: build_pack_instructions
 requires:
   packs:
     - pack_id: greetings
+      version: "0.1.0"
       reason: "farewell module uses the greetings session context when saying goodbye"
   capabilities:
     - capability_id: greetings.say_hello

--- a/tests/test_appgenerator_managed_capability_smoke.py
+++ b/tests/test_appgenerator_managed_capability_smoke.py
@@ -597,6 +597,7 @@ def wallet_pack_root(tmp_path: Path) -> Path:
         ],
         "pack": {
             "id": "wallet",
+            "version": "0.1.0",
             "status": "active",
             "capability_source": "managed_capability",
         },

--- a/tests/test_community_pack_foundation.py
+++ b/tests/test_community_pack_foundation.py
@@ -8,7 +8,7 @@ without creating a parallel runtime.  Covers:
   - Dependency validation: satisfied/missing requirements
   - Catalog schema validation: structural allowlisting before AG2 injection
   - Deterministic materialization: fixture community pack renders expected files
-  - Provenance manifest: emitted with correct pack metadata and file ownership
+  - Provenance manifest: emitted with correct pack metadata, digest, source, and file ownership
   - Two-pack no-collision: greetings + farewell materialise without file conflicts
   - Existing first-party packs remain compatible: social, messaging, mozaikspay contexts
   - Bundle scanner validates provenance manifest schema when present
@@ -90,7 +90,7 @@ def test_valid_pack_identity_passes_schema() -> None:
     assert result.pack_id == "greetings"
 
 
-def test_pack_version_is_optional_and_still_valid() -> None:
+def test_pack_version_is_required_for_pack_blocks() -> None:
     from factory_app.workflows.AppGenerator.tools.pack_context_schema import validate_pack_context
 
     context: dict[str, Any] = {
@@ -104,7 +104,8 @@ def test_pack_version_is_optional_and_still_valid() -> None:
         },
     }
     result = validate_pack_context(context)
-    assert result.valid, [d.message for d in result.errors]
+    assert not result.valid
+    assert any(d.field == "pack.version" for d in result.errors)
 
 
 def test_pack_without_pack_block_is_valid() -> None:
@@ -209,6 +210,25 @@ def test_version_must_be_string() -> None:
     assert not result.valid
 
 
+def test_unknown_capability_source_rejected() -> None:
+    from factory_app.workflows.AppGenerator.tools.pack_context_schema import validate_pack_context
+
+    context: dict[str, Any] = {
+        "context_id": "typed_wrong",
+        "applies_to_workflows": ["AppGenerator"],
+        "assets": [],
+        "pack": {
+            "id": "typed_wrong",
+            "status": "active",
+            "version": "0.1.0",
+            "capability_source": "invented_source",
+        },
+    }
+    result = validate_pack_context(context)
+    assert not result.valid
+    assert any(d.field == "pack.capability_source" for d in result.errors)
+
+
 # ---------------------------------------------------------------------------
 # 3. Dependency validation: satisfied requirement passes
 # ---------------------------------------------------------------------------
@@ -245,6 +265,28 @@ def test_dependency_missing_raises_pack_dependency_error() -> None:
     assert "greetings" in err.missing_packs
     # The capability from greetings is also declared as required
     assert any("greetings" in c for c in err.missing_capabilities)
+
+
+def test_dependency_version_mismatch_rejected(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        PackDependencyError,
+    )
+
+    wrong_greetings = tmp_path / "greetings"
+    wrong_greetings.mkdir()
+    (wrong_greetings / "context.yaml").write_text(
+        (GREETINGS_PACK / "context.yaml").read_text(encoding="utf-8").replace('"0.1.0"', '"9.9.9"'),
+        encoding="utf-8",
+    )
+    (wrong_greetings / "contract.yaml").write_text((GREETINGS_PACK / "contract.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+    templates = wrong_greetings / "templates"
+    templates.mkdir()
+    (templates / "stub.txt").write_text("stub\n", encoding="utf-8")
+
+    with pytest.raises(PackDependencyError) as exc_info:
+        _materialize(_pack_descriptor(wrong_greetings, "greetings"), _pack_descriptor(FAREWELL_PACK, "farewell"))
+
+    assert "greetings expected 0.1.0, installed 9.9.9" in exc_info.value.version_mismatches
 
 
 def test_dependency_error_message_is_human_readable() -> None:
@@ -291,6 +333,46 @@ def test_catalog_schema_validation_rejects_untrusted_keys_at_materialization(
     desc = _pack_descriptor(pack_dir, "adversarial")
     with pytest.raises(ManagedCapabilityTemplateError, match="schema validation"):
         _materialize(desc)
+
+
+def test_missing_declared_asset_rejected_before_materialization(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        PackIntegrityError,
+    )
+
+    pack_dir = tmp_path / "missing_asset"
+    pack_dir.mkdir()
+    (pack_dir / "context.yaml").write_text(
+        "context_id: missing_asset\n"
+        "applies_to_workflows:\n  - AppGenerator\n"
+        "assets:\n  - path: missing_contract.yaml\n    kind: contract\n"
+        "pack:\n  id: missing_asset\n  version: '0.1.0'\n  status: active\n  capability_source: generated_module\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(PackIntegrityError, match="Declared pack asset not found"):
+        _materialize(_pack_descriptor(pack_dir, "missing_asset"))
+
+
+def test_contract_unknown_runtime_affecting_field_rejected(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        PackIntegrityError,
+    )
+
+    pack_dir = tmp_path / "bad_contract"
+    pack_dir.mkdir()
+    (pack_dir / "context.yaml").write_text(
+        "context_id: bad_contract\n"
+        "applies_to_workflows:\n  - AppGenerator\n"
+        "assets:\n  - path: contract.yaml\n    kind: contract\n"
+        "pack:\n  id: bad_contract\n  version: '0.1.0'\n  status: active\n  capability_source: generated_module\n",
+        encoding="utf-8",
+    )
+    (pack_dir / "contract.yaml").write_text(
+        "contract_id: bad_contract\ncontract_type: build_pack_instructions\nalternate_runtime_schema: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(PackIntegrityError, match="unsupported fields"):
+        _materialize(_pack_descriptor(pack_dir, "bad_contract"))
 
 
 # ---------------------------------------------------------------------------
@@ -372,7 +454,19 @@ def test_provenance_contains_pack_version_from_context_yaml() -> None:
 
     manifest = json.loads(files[".mozaiks/pack_provenance.json"])
     greetings_entry = next(p for p in manifest["packs"] if p["pack_id"] == "greetings")
-    assert greetings_entry["pack_version"] == "0.1.0"
+    assert greetings_entry["version"] == "0.1.0"
+
+
+def test_provenance_contains_source_and_digest() -> None:
+    greetings = _pack_descriptor(GREETINGS_PACK, "greetings")
+    files = _files_map(greetings)
+
+    manifest = json.loads(files[".mozaiks/pack_provenance.json"])
+    greetings_entry = next(p for p in manifest["packs"] if p["pack_id"] == "greetings")
+    assert greetings_entry["source"] == "https://example.com/community-packs/greetings"
+    assert isinstance(greetings_entry["digest"], str)
+    assert greetings_entry["digest"].startswith("sha256:")
+    assert len(greetings_entry["digest"]) == len("sha256:") + 64
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +480,7 @@ def test_provenance_maps_files_to_greetings_pack() -> None:
 
     manifest = json.loads(files[".mozaiks/pack_provenance.json"])
     greetings_entry = next(p for p in manifest["packs"] if p["pack_id"] == "greetings")
-    provenance_paths = {f["path"] for f in greetings_entry["files"]}
+    provenance_paths = {f["path"] for f in greetings_entry["materialized_owned_files"]}
 
     assert "modules/greetings/module.yaml" in provenance_paths
     assert "modules/greetings/backend/service.py" in provenance_paths
@@ -398,7 +492,7 @@ def test_provenance_records_owner_from_contract_required_outputs() -> None:
 
     manifest = json.loads(files[".mozaiks/pack_provenance.json"])
     greetings_entry = next(p for p in manifest["packs"] if p["pack_id"] == "greetings")
-    file_by_path = {f["path"]: f for f in greetings_entry["files"]}
+    file_by_path = {f["path"]: f for f in greetings_entry["materialized_owned_files"]}
 
     # handler.py is declared as owner=workspace in contract.yaml
     handler = file_by_path.get("modules/greetings/backend/handler.py")
@@ -445,7 +539,7 @@ def test_greetings_files_not_present_in_farewell_provenance() -> None:
 
     manifest = json.loads(files[".mozaiks/pack_provenance.json"])
     farewell_entry = next(p for p in manifest["packs"] if p["pack_id"] == "farewell")
-    farewell_paths = {f["path"] for f in farewell_entry["files"]}
+    farewell_paths = {f["path"] for f in farewell_entry["materialized_owned_files"]}
     # greetings files must not appear in farewell's provenance entry
     assert "modules/greetings/module.yaml" not in farewell_paths
 
@@ -551,6 +645,55 @@ def test_bundle_scanner_rejects_invalid_provenance_schema(tmp_path: Path) -> Non
     assert prov_errors, "Expected provenance schema error but got none"
 
 
+def test_bundle_scanner_rejects_invalid_provenance_digest() -> None:
+    from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
+        scan_generated_bundle,
+    )
+
+    files = {
+        ".mozaiks/pack_provenance.json": json.dumps({
+            "schema_version": "mozaiks.pack_provenance.v1",
+            "framework_version": "test",
+            "generated_at": "2026-08-12T00:00:00+00:00",
+            "packs": [
+                {
+                    "pack_id": "greetings",
+                    "version": "0.1.0",
+                    "source": "local",
+                    "digest": "md5:not-canonical",
+                    "materialized_owned_files": [],
+                }
+            ],
+        }),
+    }
+    errors = scan_generated_bundle(files)
+    assert any("digest must be a canonical sha256 digest" in e for e in errors)
+
+
+def test_bundle_scanner_rejects_legacy_provenance_fields() -> None:
+    from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
+        scan_generated_bundle,
+    )
+
+    files = {
+        ".mozaiks/pack_provenance.json": json.dumps({
+            "schema_version": "mozaiks.pack_provenance.v1",
+            "framework_version": "test",
+            "generated_at": "2026-08-12T00:00:00+00:00",
+            "packs": [
+                {
+                    "pack_id": "greetings",
+                    "pack_version": "0.1.0",
+                    "files": [],
+                }
+            ],
+        }),
+    }
+    errors = scan_generated_bundle(files)
+    assert any("unsupported field 'pack_version'" in e for e in errors)
+    assert any("unsupported field 'files'" in e for e in errors)
+
+
 def test_bundle_scanner_skips_provenance_check_when_absent() -> None:
     from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
         scan_generated_bundle,
@@ -591,6 +734,41 @@ def test_fixture_pack_selected_deterministically_via_descriptor() -> None:
     files2 = {k: v for k, v in _files_map(greetings).items() if k != _PROV}
 
     assert files == files2
+
+
+def test_same_pack_contents_produce_same_digest() -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        compute_pack_digest,
+    )
+
+    assert compute_pack_digest(GREETINGS_PACK, "greetings") == compute_pack_digest(GREETINGS_PACK, "greetings")
+
+
+def test_different_pack_contents_produce_different_digest(tmp_path: Path) -> None:
+    from shutil import copytree
+
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        compute_pack_digest,
+    )
+
+    pack_copy = tmp_path / "greetings"
+    copytree(GREETINGS_PACK, pack_copy)
+    before = compute_pack_digest(pack_copy, "greetings")
+    service = pack_copy / "templates" / "modules" / "greetings" / "backend" / "service.py"
+    service.write_text(service.read_text(encoding="utf-8") + "\n# material mutation\n", encoding="utf-8")
+
+    assert compute_pack_digest(pack_copy, "greetings") != before
+
+
+def test_valid_local_pack_verifies_before_materialization() -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        verify_pack_integrity,
+    )
+
+    metadata = verify_pack_integrity(GREETINGS_PACK, "greetings")
+    assert metadata["pack_id"] == "greetings"
+    assert metadata["version"] == "0.1.0"
+    assert metadata["digest"].startswith("sha256:")
 
 
 def test_fixture_pack_passes_generated_bundle_validation() -> None:

--- a/tests/test_managed_capability_artifact_replay.py
+++ b/tests/test_managed_capability_artifact_replay.py
@@ -74,7 +74,12 @@ def _write_wallet_pack(root: Path) -> dict[str, Any]:
             {
                 "context_id": "wallet",
                 "assets": [{"path": "templates/", "kind": "templates"}],
-                "pack": {"id": "wallet", "status": "active", "capability_source": "managed_capability"},
+                "pack": {
+                    "id": "wallet",
+                    "version": "0.1.0",
+                    "status": "active",
+                    "capability_source": "managed_capability",
+                },
             },
             sort_keys=False,
         ),

--- a/tests/test_managed_capability_template_expansion.py
+++ b/tests/test_managed_capability_template_expansion.py
@@ -53,6 +53,7 @@ def _write_pack(root: Path, pack_id: str, files: dict[str, str], *, status: str 
                 ],
                 "pack": {
                     "id": pack_id,
+                    "version": "0.1.0",
                     "status": status,
                     "capability_source": "managed_capability",
                 },

--- a/tests/test_ui_portability_contract.py
+++ b/tests/test_ui_portability_contract.py
@@ -144,7 +144,7 @@ def test_greetings_pack_ui_files_appear_in_provenance() -> None:
     )
     assert pack_entry is not None
 
-    pack_file_paths = {f["path"] for f in pack_entry.get("files", [])}
+    pack_file_paths = {f["path"] for f in pack_entry.get("materialized_owned_files", [])}
     assert "ui/pages/greetings.yaml" in pack_file_paths, (
         "provenance does not record ui/pages/greetings.yaml"
     )
@@ -169,7 +169,7 @@ def test_greetings_pack_ui_files_have_templates_owner_in_provenance() -> None:
     )
     assert pack_entry is not None
 
-    owner_by_path = {f["path"]: f.get("owner") for f in pack_entry.get("files", [])}
+    owner_by_path = {f["path"]: f.get("owner") for f in pack_entry.get("materialized_owned_files", [])}
     assert owner_by_path.get("ui/pages/greetings.yaml") == "templates"
     assert owner_by_path.get("ui/route_manifest.json") == "templates"
 


### PR DESCRIPTION
## Summary
- add deterministic sha256 pack-content digests for declared pack assets before materialization
- verify local pack identity, version, asset closure, contract/catalog schemas, dependencies, and exact dependency versions when declared
- extend .mozaiks/pack_provenance.json with pack_id, version, source, digest, and materialized_owned_files
- tighten generated bundle provenance validation and update Community Component docs/tests

## Non-goals
- no remote fetch
- no marketplace
- no parallel component framework

## Tests
- ruff check .
- python -m py_compile factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py factory_app/workflows/AppGenerator/tools/pack_context_schema.py factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py tests/test_community_pack_foundation.py tests/test_managed_capability_artifact_replay.py tests/test_appgenerator_managed_capability_smoke.py tests/test_managed_capability_template_expansion.py
- python -m pytest --no-cov tests/test_community_pack_foundation.py tests/test_managed_capability_template_expansion.py tests/test_ui_portability_contract.py tests/test_generated_bundle_scanner.py tests/test_generated_bundle_scanner_helpers.py
- python -m pytest --no-cov tests/test_governance_guardrails.py tests/test_no_stale_repo_artifacts.py tests/test_package_content_guard.py
- python -m pytest --no-cov tests/test_community_pack_foundation.py tests/test_managed_capability_template_expansion.py tests/test_appgenerator_managed_capability_smoke.py tests/test_appplan_materialization_acceptance.py tests/test_offline_factory_build_sequence_smoke.py tests/test_operator_readiness_assembly_smoke.py
- python -m pytest --no-cov tests/test_generated_bundle_scanner.py tests/test_generated_bundle_scanner_helpers.py tests/test_generated_bundle_scanner_scan_helpers.py tests/test_generated_app_functional_acceptance.py tests/test_offline_generated_build_acceptance.py
- python -m pytest --no-cov tests/test_ui_portability_contract.py tests/test_ui_theme_round_trip.py tests/test_brand_theme_contract.py tests/test_appgenerator_ui_acceptance.py
- python -m pytest --no-cov tests/test_module_event_router.py tests/test_durable_reaction_idempotency.py tests/test_generator_event_system_contracts.py tests/test_build_context_emits_reactions_alignment.py tests/test_module_reactions_docs_contract.py
- python -m pytest -q --no-cov (12456 passed, 77 skipped)