### PR TITLE
fix(studio): authenticate Studio API fetches

### DIFF
--- a/factory_app/app/admin/pages/AppOverviewPage.jsx
+++ b/factory_app/app/admin/pages/AppOverviewPage.jsx
@@ -26,7 +26,7 @@ import {
   getPlanStateLabel,
   normalizeAppStatus,
 } from './appStudioModel.js'
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 import { useAppStudioData } from './useAppStudioData.js'
 
 
@@ -427,7 +427,7 @@ function AppIntelligencePanel({ context, appId }) {
     setValidationRunning(true)
     setValidationError(null)
     try {
-      const response = await fetch(`${API_BASE}/api/studio/apps/${encodeURIComponent(appId)}/context/validation/run`, {
+      const response = await studioFetch(`/api/studio/apps/${encodeURIComponent(appId)}/context/validation/run`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ confirm_execution: true }),

--- a/factory_app/app/admin/pages/WorkspaceUsersPage.jsx
+++ b/factory_app/app/admin/pages/WorkspaceUsersPage.jsx
@@ -24,7 +24,7 @@ import {
 } from '../../ui/components/StudioShared.jsx'
 import { WorkspaceStudioHero, formatCompactNumber } from './AppStudioChrome.jsx'
 import { getAppDisplayName } from './appStudioModel.js'
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 import { useWorkspaceApps } from './useWorkspaceApps.js'
 
 function useWorkspaceUserSummary() {
@@ -33,7 +33,7 @@ function useWorkspaceUserSummary() {
 
   useEffect(() => {
     const controller = new AbortController()
-    fetch(`${API_BASE}/api/admin/users`, { signal: controller.signal })
+    studioFetch('/api/admin/users', { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : null))
       .then((payload) => {
         if (!controller.signal.aborted) setData(payload)

--- a/factory_app/app/admin/pages/dashboardRoutes.js
+++ b/factory_app/app/admin/pages/dashboardRoutes.js
@@ -1,4 +1,4 @@
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 
 export function getDashboardSurface(payload, scope = 'app') {
   if (payload?.surface?.scope === scope) return payload.surface
@@ -35,7 +35,7 @@ export async function fetchDashboardConfig({ scope = null, appId = null, signal 
   if (scope) params.set('scope', scope)
   if (appId) params.set('app_id', appId)
   const suffix = params.toString() ? `?${params.toString()}` : ''
-  const response = await fetch(`${API_BASE}/api/studio/dashboard${suffix}`, {
+  const response = await studioFetch(`/api/studio/dashboard${suffix}`, {
     headers: {
       Accept: 'application/json',
     },

--- a/factory_app/app/admin/pages/studioApi.js
+++ b/factory_app/app/admin/pages/studioApi.js
@@ -1,2 +1,66 @@
 export const API_BASE =
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_URL) || '';
+
+export function getStudioAccessToken() {
+  try {
+    if (typeof window !== 'undefined' && window.mozaiksAuth?.getAccessToken) {
+      return window.mozaiksAuth.getAccessToken();
+    }
+    if (typeof window !== 'undefined' && window.mozaiksAuth?.token) {
+      return window.mozaiksAuth.token;
+    }
+  } catch {
+    // Fall through to storage-backed lookup.
+  }
+
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      const token = sessionStorage.getItem('mozaiks_access_token');
+      if (token) return token;
+    }
+  } catch {
+    // Ignore unavailable storage.
+  }
+
+  try {
+    if (typeof localStorage !== 'undefined') {
+      return (
+        localStorage.getItem('mozaiks_access_token') ||
+        localStorage.getItem('chatui_token') ||
+        localStorage.getItem('access_token')
+      );
+    }
+  } catch {
+    // Ignore unavailable storage.
+  }
+
+  return null;
+}
+
+export function studioAuthHeaders(headers = {}) {
+  const token = getStudioAccessToken();
+  return {
+    ...headers,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export function studioFetch(path, options = {}) {
+  const headers = studioAuthHeaders(options.headers || {});
+  return fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers,
+  });
+}
+
+export async function studioModuleAction(moduleName, actionName, input = {}) {
+  const response = await studioFetch(`/api/modules/${moduleName}/${actionName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(input || {}),
+  });
+  if (!response.ok) {
+    throw new Error(`${moduleName}.${actionName} ${response.status}`);
+  }
+  return response.json();
+}

--- a/factory_app/app/admin/pages/useAppStudioData.js
+++ b/factory_app/app/admin/pages/useAppStudioData.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 import {
   buildStudioDemoAppSummary,
   getStudioDemoActivity,
@@ -143,16 +143,16 @@ export function useAppStudioData(appId) {
           contextRes,
           runtimeMetricsRes,
         ] = await Promise.allSettled([
-          fetch(`${API_BASE}/api/studio/overview?app_id=${encodeURIComponent(appId)}`),
-          fetch(`${API_BASE}/api/admin/stats?app_id=${encodeURIComponent(appId)}`),
-          fetch(`${API_BASE}/api/admin/runs?app_id=${encodeURIComponent(appId)}&limit=12`),
-          fetch(`${API_BASE}/api/admin/sessions?app_id=${encodeURIComponent(appId)}&limit=12`),
-          fetch(`${API_BASE}/api/admin/usage?app_id=${encodeURIComponent(appId)}&limit=500`),
-          fetch(`${API_BASE}/api/studio/build?app_id=${encodeURIComponent(appId)}`),
-          fetch(`${API_BASE}/api/studio/build/history?app_id=${encodeURIComponent(appId)}&limit=8`),
-          fetch(`${API_BASE}/api/studio/integrations?app_id=${encodeURIComponent(appId)}`),
-          fetch(`${API_BASE}/api/studio/apps/${encodeURIComponent(appId)}/context`),
-          fetch(`${API_BASE}/api/admin/metrics/runtime`),
+          studioFetch(`/api/studio/overview?app_id=${encodeURIComponent(appId)}`),
+          studioFetch(`/api/admin/stats?app_id=${encodeURIComponent(appId)}`),
+          studioFetch(`/api/admin/runs?app_id=${encodeURIComponent(appId)}&limit=12`),
+          studioFetch(`/api/admin/sessions?app_id=${encodeURIComponent(appId)}&limit=12`),
+          studioFetch(`/api/admin/usage?app_id=${encodeURIComponent(appId)}&limit=500`),
+          studioFetch(`/api/studio/build?app_id=${encodeURIComponent(appId)}`),
+          studioFetch(`/api/studio/build/history?app_id=${encodeURIComponent(appId)}&limit=8`),
+          studioFetch(`/api/studio/integrations?app_id=${encodeURIComponent(appId)}`),
+          studioFetch(`/api/studio/apps/${encodeURIComponent(appId)}/context`),
+          studioFetch('/api/admin/metrics/runtime'),
         ])
 
         const overview = overviewRes.status === 'fulfilled' && overviewRes.value.ok ? await overviewRes.value.json() : null

--- a/factory_app/app/admin/pages/useWorkspaceApps.js
+++ b/factory_app/app/admin/pages/useWorkspaceApps.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 
 export function useWorkspaceApps(errorFallback = 'Workspace apps could not be loaded.') {
   const [apps, setApps] = useState([])
@@ -14,7 +14,7 @@ export function useWorkspaceApps(errorFallback = 'Workspace apps could not be lo
 
     async function load() {
       try {
-        const res = await fetch(`${API_BASE}/api/studio/apps`)
+        const res = await studioFetch('/api/studio/apps')
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
         const payload = await res.json()
         if (!cancelled) {
@@ -39,7 +39,7 @@ export function useWorkspaceApps(errorFallback = 'Workspace apps could not be lo
 
   const deleteApp = useCallback(async (buildRegistryId) => {
     try {
-      const res = await fetch(`${API_BASE}/api/studio/apps/${encodeURIComponent(buildRegistryId)}`, {
+      const res = await studioFetch(`/api/studio/apps/${encodeURIComponent(buildRegistryId)}`, {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)

--- a/factory_app/app/admin/pages/useWorkspaceStudioData.js
+++ b/factory_app/app/admin/pages/useWorkspaceStudioData.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 import {
   buildStudioDemoApps,
   getStudioDemoWorkspaceUsage,
@@ -28,10 +28,10 @@ export function useWorkspaceStudioData(errorFallback = 'Workspace Studio data co
     async function load() {
       try {
         const [appsRes, statsRes, runsRes, usageRes] = await Promise.allSettled([
-          fetch(`${API_BASE}/api/studio/apps`),
-          fetch(`${API_BASE}/api/admin/stats`),
-          fetch(`${API_BASE}/api/admin/runs?limit=48`),
-          fetch(`${API_BASE}/api/admin/usage?limit=1000`),
+          studioFetch('/api/studio/apps'),
+          studioFetch('/api/admin/stats'),
+          studioFetch('/api/admin/runs?limit=48'),
+          studioFetch('/api/admin/usage?limit=1000'),
         ])
 
         const appsPayload = appsRes.status === 'fulfilled' && appsRes.value.ok ? await appsRes.value.json() : null

--- a/factory_app/app/ui/installOnboardingTour.jsx
+++ b/factory_app/app/ui/installOnboardingTour.jsx
@@ -1,27 +1,12 @@
 import { createRoot } from 'react-dom/client'
 import onboardingConfigSource from '../config/onboarding.yaml?raw'
+import { studioModuleAction } from '../admin/pages/studioApi.js'
 import { OnboardingTour, parseOnboardingConfigSource } from '@mozaiks/chat-ui/ui'
 
 let installed = false
 
 async function moduleAction(moduleName, actionName, input = {}) {
-  const token =
-    window.mozaiksAuth?.getAccessToken?.() ||
-    sessionStorage.getItem('mozaiks_access_token') ||
-    localStorage.getItem('mozaiks_access_token') ||
-    localStorage.getItem('chatui_token') ||
-    localStorage.getItem('access_token')
-
-  const headers = { 'Content-Type': 'application/json' }
-  if (token) headers['Authorization'] = `Bearer ${token}`
-
-  const res = await fetch(`/api/modules/${moduleName}/${actionName}`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(input),
-  })
-  if (!res.ok) throw new Error(`${moduleName}.${actionName} ${res.status}`)
-  return res.json()
+  return studioModuleAction(moduleName, actionName, input)
 }
 
 export function installOnboardingTour() {

--- a/tests/test_factory_studio_auth_fetch.py
+++ b/tests/test_factory_studio_auth_fetch.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from mozaiksai.core.auth.adapters import AuthError, UserClaims, get_auth_adapter, register_adapter
+from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = ROOT / "factory_app" / "app" / "admin" / "pages"
+ONBOARDING_INSTALLER = ROOT / "factory_app" / "app" / "ui" / "installOnboardingTour.jsx"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_studio_api_exports_canonical_authenticated_fetch_helpers() -> None:
+    source = _read(PAGES / "studioApi.js")
+
+    assert "export function getStudioAccessToken()" in source
+    assert "window.mozaiksAuth?.getAccessToken" in source
+    assert "sessionStorage.getItem('mozaiks_access_token')" in source
+    assert "export function studioAuthHeaders" in source
+    assert "Authorization: `Bearer ${token}`" in source
+    assert "export function studioFetch" in source
+    assert "export async function studioModuleAction" in source
+
+
+def test_workspace_apps_uses_authenticated_studio_fetch_for_studio_routes() -> None:
+    source = _read(PAGES / "useWorkspaceApps.js")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch('/api/studio/apps')" in source
+    assert "studioFetch(`/api/studio/apps/${encodeURIComponent(buildRegistryId)}`" in source
+    assert "fetch(`${API_BASE}/api/studio/apps`)" not in source
+
+
+def test_workspace_dashboard_uses_authenticated_studio_fetch() -> None:
+    source = _read(PAGES / "dashboardRoutes.js")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch(`/api/studio/dashboard${suffix}`" in source
+    assert "fetch(`${API_BASE}/api/studio/dashboard${suffix}`" not in source
+
+
+def test_workspace_studio_data_uses_authenticated_fetch_for_apps_endpoint() -> None:
+    source = _read(PAGES / "useWorkspaceStudioData.js")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch('/api/studio/apps')" in source
+    assert "studioFetch('/api/admin/stats')" in source
+    assert "studioFetch('/api/admin/runs?limit=48')" in source
+    assert "studioFetch('/api/admin/usage?limit=1000')" in source
+    assert "fetch(`${API_BASE}/api/studio/apps`)" not in source
+
+
+def test_app_studio_data_uses_authenticated_fetch_for_studio_and_admin_routes() -> None:
+    source = _read(PAGES / "useAppStudioData.js")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch(`/api/studio/overview?app_id=${encodeURIComponent(appId)}`)" in source
+    assert "studioFetch(`/api/admin/stats?app_id=${encodeURIComponent(appId)}`)" in source
+    assert "studioFetch(`/api/studio/apps/${encodeURIComponent(appId)}/context`)" in source
+    assert "fetch(`${API_BASE}/api/studio/" not in source
+    assert "fetch(`${API_BASE}/api/admin/" not in source
+
+
+def test_workspace_users_uses_authenticated_fetch_for_admin_users() -> None:
+    source = _read(PAGES / "WorkspaceUsersPage.jsx")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch('/api/admin/users', { signal: controller.signal })" in source
+    assert "fetch(`${API_BASE}/api/admin/users`" not in source
+
+
+def test_factory_onboarding_uses_canonical_studio_module_action() -> None:
+    source = _read(ONBOARDING_INSTALLER)
+
+    assert "import { studioModuleAction } from '../admin/pages/studioApi.js'" in source
+    assert "return studioModuleAction(moduleName, actionName, input)" in source
+    assert "sessionStorage.getItem('mozaiks_access_token')" not in source
+    assert "localStorage.getItem('chatui_token')" not in source
+
+
+def test_studio_apps_endpoint_rejects_missing_bearer_and_accepts_authenticated_user(monkeypatch) -> None:
+    class _TestStudioAuthAdapter(BaseAuthAdapter):
+        name = "studio-test"
+
+        async def validate_token(self, token: str) -> UserClaims:
+            if token != "valid-studio-token":
+                raise AuthError("Invalid test token", status_code=401, provider=self.name)
+            return UserClaims(
+                user_id="studio-user",
+                email="studio@example.test",
+                roles=["admin"],
+                scopes=["access_as_user"],
+                raw_claims={"sub": "studio-user"},
+                provider=self.name,
+            )
+
+        def is_enabled(self) -> bool:
+            return True
+
+    class _AppRegistryService:
+        async def list_apps(self, **kwargs):
+            assert kwargs["owner_user_id"] == "studio-user"
+            return {"apps": []}
+
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_PROVIDER", "studio-test")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    reset_auth_adapter()
+    get_auth_adapter(force_provider="none")
+    register_adapter("studio-test", _TestStudioAuthAdapter)
+
+    from mozaiksai.hosts import studio as studio_app
+
+    monkeypatch.setattr(studio_app, "_get_app_registry_service", lambda: _AppRegistryService())
+
+    client = TestClient(studio_app.app)
+    try:
+        missing_bearer = client.get("/api/studio/apps")
+        assert missing_bearer.status_code == 401
+        assert missing_bearer.json()["detail"] == "Missing authorization token"
+
+        authenticated = client.get(
+            "/api/studio/apps",
+            headers={"Authorization": "Bearer valid-studio-token"},
+        )
+        assert authenticated.status_code == 200
+        assert authenticated.json()["apps"] == []
+    finally:
+        reset_auth_adapter()


### PR DESCRIPTION
## Summary
- centralize bearer propagation in the existing Studio API helper
- route authenticated Studio/Admin loaders through the canonical helper
- reuse the helper for onboarding module actions instead of duplicating token lookup
- add regression coverage for bearer propagation, missing-bearer rejection, and raw authenticated Studio fetch drift

## Tests
- ruff check .
- pytest -q --no-cov
- npm ci (web_shell)
- npm run build (web_shell)