### PR TITLE
Add local community component install lifecycle

### DIFF
--- a/docs/architecture/workflows/build-context-packs.md
+++ b/docs/architecture/workflows/build-context-packs.md
@@ -371,8 +371,64 @@ Generated bundles retain pack metadata in the existing
 }
 ```
 
+Local installation pins a verified Community Component in workspace
+build-context metadata:
+
+```text
+build_context/
+└── .mozaiks/
+    ├── installed_components.json
+    └── installed_component_sources.json
+```
+
+`installed_components.json` is the canonical deterministic state:
+
+```json
+{
+  "schema_version": "mozaiks.installed_components.v1",
+  "components": [
+    {
+      "pack_id": "greetings",
+      "version": "0.1.0",
+      "digest": "sha256:...",
+      "source": "https://example.com/community-packs/greetings",
+      "dependencies": {
+        "packs": [],
+        "capabilities": []
+      },
+      "capabilities": [
+        { "capability_id": "greetings.say_hello" }
+      ]
+    }
+  ]
+}
+```
+
+It does not store absolute developer-machine paths. The non-portable
+`installed_component_sources.json` sidecar maps installed `pack_id` values to
+local source paths so deterministic verification and materialization can be
+re-run in that workspace checkout.
+
+Installation verifies the local pack, validates dependencies against already
+installed components, and writes pinned version/digest state. It does not
+materialize files and does not select the pack for a build.
+
+Upgrade planning is a dry run:
+
+```text
+installed A@v1 + verified local candidate A@v2 -> UpgradePlan
+```
+
+The plan reports exact version/digest movement, dependency changes, added,
+removed, and changed owned files, and potential conflicts. Applying an upgrade
+is allowed only when the operation can compare the workspace files against the
+old pack's rendered content. It refuses to overwrite locally modified owned
+files, files owned by another installed pack, or workspace-owned/custom files.
+It does not execute migration scripts.
+
 Mozaiks does not perform remote downloads, registry lookup, marketplace ranking,
-trust scoring, or cryptographic signing for this v1 layer.
+trust scoring, cryptographic signing, or automatic semver range upgrades for
+this local lifecycle layer.
 
 ## Resolution
 
@@ -392,6 +448,13 @@ For each context that applies to the target workflow:
 6. `templates` assets are materialized only for selected packs.
 
 Explicit launch context values take precedence over projected values.
+
+Installed Community Components are consumed only through explicit selection.
+An `AppBuildPlan` may select an installed `capability_pack_id`; the existing
+materializer then resolves the pinned local source through
+`build_context/.mozaiks` when launch context includes `build_context_root`.
+Installed state alone is not a selected pack list, and selected pack
+materialization still grants no provider or production authority.
 
 ## Build Context vs. Context Variables
 

--- a/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
+++ b/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
@@ -1,0 +1,401 @@
+"""Local Community Component install and upgrade lifecycle operations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .community_component_state import (
+    InstalledComponentStateError,
+    canonical_component_entry,
+    component_by_id,
+    load_installed_component_sources,
+    load_installed_components,
+    write_installed_component_sources,
+    write_installed_components,
+)
+from .generated_bundle_scanner import scan_generated_bundle
+from .resolve_managed_capability_templates import (
+    PackDependencyError,
+    PackIntegrityError,
+    _capabilities_from_context,
+    _extract_requires,
+    _read_pack_context,
+    _read_pack_contract,
+    resolve_managed_capability_templates,
+    resolve_templates_for_pack,
+    verify_pack_integrity,
+)
+
+_PROVENANCE_PATH = ".mozaiks/pack_provenance.json"
+
+
+class CommunityComponentLifecycleError(ValueError):
+    """Raised when local component lifecycle validation fails."""
+
+
+class CommunityComponentConflictError(CommunityComponentLifecycleError):
+    """Raised when install or upgrade would overwrite non-owned changes."""
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    status: str
+    pack_id: str
+    version: str
+    digest: str
+    installed_state_path: str
+    source_state_path: str
+
+
+@dataclass(frozen=True)
+class UpgradePlan:
+    status: str
+    identity_match: bool
+    pack_id: str
+    from_version: str
+    to_version: str
+    from_digest: str
+    to_digest: str
+    dependency_changes: dict[str, list[dict[str, str]]]
+    owned_file_changes: dict[str, list[str]]
+    added_files: list[str] = field(default_factory=list)
+    removed_files: list[str] = field(default_factory=list)
+    changed_files: list[str] = field(default_factory=list)
+    potential_conflicts: list[dict[str, str]] = field(default_factory=list)
+
+
+def _pack_id_from_context(pack_source_path: Path) -> str:
+    context = yaml.safe_load((pack_source_path / "context.yaml").read_text(encoding="utf-8")) or {}
+    if not isinstance(context, dict):
+        raise CommunityComponentLifecycleError(f"Pack context must be a mapping: {pack_source_path / 'context.yaml'}")
+    raw_pack = context.get("pack")
+    pack: dict[str, Any] = raw_pack if isinstance(raw_pack, dict) else {}
+    pack_id = str(pack.get("id") or context.get("context_id") or "").strip()
+    if not pack_id:
+        raise CommunityComponentLifecycleError(f"Pack context does not declare a pack id: {pack_source_path}")
+    return pack_id
+
+
+def _dependency_block(contract: dict[str, Any]) -> dict[str, list[dict[str, str]]]:
+    packs, capabilities = _extract_requires(contract)
+    return {
+        "packs": sorted(packs, key=lambda item: item["pack_id"]),
+        "capabilities": [{"capability_id": cap} for cap in sorted(capabilities)],
+    }
+
+
+def _component_entry_from_verified_pack(pack_source_path: Path, pack_id: str) -> dict[str, Any]:
+    metadata = verify_pack_integrity(pack_source_path, pack_id)
+    context = _read_pack_context(pack_source_path.resolve(), pack_id)
+    contract = _read_pack_contract(pack_source_path.resolve())
+    return canonical_component_entry({
+        "pack_id": metadata["pack_id"],
+        "version": metadata["version"],
+        "digest": metadata["digest"],
+        "source": metadata["source"],
+        "dependencies": _dependency_block(contract),
+        "capabilities": [
+            {"capability_id": cap_id}
+            for cap_id in sorted(_capabilities_from_context(context))
+        ],
+    })
+
+
+def _ensure_dependencies_satisfied(candidate: dict[str, Any], installed: dict[str, dict[str, Any]]) -> None:
+    missing_packs: list[str] = []
+    missing_capabilities: list[str] = []
+    version_mismatches: list[str] = []
+
+    for dependency in candidate["dependencies"]["packs"]:
+        dep_id = dependency["pack_id"]
+        installed_dep = installed.get(dep_id)
+        if not installed_dep:
+            missing_packs.append(dep_id)
+            continue
+        required_version = dependency.get("version")
+        if required_version and installed_dep["version"] != required_version:
+            version_mismatches.append(f"{dep_id} expected {required_version}, installed {installed_dep['version']}")
+
+    provided_capabilities = {
+        cap["capability_id"]
+        for component in installed.values()
+        for cap in component.get("capabilities") or []
+        if isinstance(cap, dict)
+    }
+    provided_capabilities.update(
+        cap["capability_id"]
+        for cap in candidate.get("capabilities") or []
+        if isinstance(cap, dict)
+    )
+    for dependency in candidate["dependencies"]["capabilities"]:
+        cap_id = dependency["capability_id"]
+        if cap_id not in provided_capabilities:
+            missing_capabilities.append(cap_id)
+
+    if missing_packs or missing_capabilities or version_mismatches:
+        raise PackDependencyError(
+            candidate["pack_id"],
+            missing_packs=missing_packs,
+            missing_capabilities=missing_capabilities,
+            version_mismatches=version_mismatches,
+        )
+
+
+def install_verified_local_pack(
+    *,
+    pack_source_path: str | Path,
+    build_context_root: str | Path,
+) -> InstallResult:
+    """Verify a local pack and pin it in workspace build-context state."""
+
+    root = Path(build_context_root).resolve()
+    source_path = Path(pack_source_path).resolve()
+    pack_id = _pack_id_from_context(source_path)
+    candidate = _component_entry_from_verified_pack(source_path, pack_id)
+    state = load_installed_components(root)
+    installed = component_by_id(state)
+    existing = installed.get(pack_id)
+    if existing and existing != candidate:
+        raise CommunityComponentLifecycleError(
+            f"Pack '{pack_id}' is already installed at {existing['version']} {existing['digest']}; "
+            "use the deterministic upgrade plan instead."
+        )
+
+    _ensure_dependencies_satisfied(candidate, {k: v for k, v in installed.items() if k != pack_id})
+    installed[pack_id] = candidate
+    state_path = write_installed_components(root, {"components": list(installed.values())})
+    sources = load_installed_component_sources(root)
+    sources[pack_id] = str(source_path)
+    source_state_path = write_installed_component_sources(root, sources)
+    return InstallResult(
+        status="installed" if existing is None else "unchanged",
+        pack_id=pack_id,
+        version=candidate["version"],
+        digest=candidate["digest"],
+        installed_state_path=str(state_path),
+        source_state_path=str(source_state_path),
+    )
+
+
+def resolve_installed_component_descriptors(
+    *,
+    build_context_root: str | Path,
+    selected_pack_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Resolve explicitly selected installed components to materializer descriptors."""
+
+    root = Path(build_context_root).resolve()
+    state = load_installed_components(root)
+    installed = component_by_id(state)
+    sources = load_installed_component_sources(root)
+    descriptors: list[dict[str, Any]] = []
+    for pack_id in selected_pack_ids:
+        installed_component = installed.get(pack_id)
+        if not installed_component:
+            raise InstalledComponentStateError(f"Selected pack is not installed: {pack_id}")
+        source = sources.get(pack_id)
+        if not source:
+            raise InstalledComponentStateError(f"Installed pack has no non-portable local source sidecar: {pack_id}")
+        metadata = verify_pack_integrity(Path(source), pack_id)
+        if metadata["version"] != installed_component["version"] or metadata["digest"] != installed_component["digest"]:
+            raise PackIntegrityError(f"Installed pack source no longer matches pinned state: {pack_id}")
+        descriptor = {
+            "id": pack_id,
+            "pack_id": pack_id,
+            "capability_pack_id": pack_id,
+            "version": installed_component["version"],
+            "digest": installed_component["digest"],
+            "source": installed_component["source"],
+            "capabilities": installed_component.get("capabilities") or [],
+            "dependencies": installed_component.get("dependencies") or {"packs": [], "capabilities": []},
+            "pack_source_path": source,
+            "capability_source": "generated_module",
+        }
+        descriptors.append(descriptor)
+    return descriptors
+
+
+def _files_by_name(files: list[dict[str, str]]) -> dict[str, str]:
+    return {str(file["filename"]): str(file["content"]) for file in files if file.get("filename")}
+
+
+def _render_owned_files(pack_source_path: Path, pack_id: str) -> dict[str, str]:
+    return _files_by_name(resolve_templates_for_pack(pack_source_path, pack_id))
+
+
+def _provenance_pack_entries(app_root: Path) -> list[dict[str, Any]]:
+    path = app_root.resolve() / _PROVENANCE_PATH
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise CommunityComponentLifecycleError(f"Invalid pack provenance at {path}: {exc}") from exc
+    packs = data.get("packs") if isinstance(data, dict) else None
+    return [item for item in packs or [] if isinstance(item, dict)]
+
+
+def _current_owner_by_path(app_root: Path) -> dict[str, str]:
+    owner_by_path: dict[str, str] = {}
+    for pack in _provenance_pack_entries(app_root):
+        pack_id = str(pack.get("pack_id") or "").strip()
+        for file_entry in pack.get("materialized_owned_files") or []:
+            if isinstance(file_entry, dict) and file_entry.get("path"):
+                owner_by_path[str(file_entry["path"])] = pack_id
+    return owner_by_path
+
+
+def plan_component_upgrade(
+    *,
+    build_context_root: str | Path,
+    candidate_pack_source_path: str | Path,
+    workspace_app_root: str | Path | None = None,
+) -> UpgradePlan:
+    """Dry-run a deterministic upgrade from installed pack state to a local candidate."""
+
+    root = Path(build_context_root).resolve()
+    candidate_source = Path(candidate_pack_source_path).resolve()
+    pack_id = _pack_id_from_context(candidate_source)
+    state = load_installed_components(root)
+    installed = component_by_id(state)
+    current = installed.get(pack_id)
+    if not current:
+        raise CommunityComponentLifecycleError(f"Candidate pack is not installed yet: {pack_id}")
+    candidate = _component_entry_from_verified_pack(candidate_source, pack_id)
+    _ensure_dependencies_satisfied(candidate, {k: v for k, v in installed.items() if k != pack_id})
+
+    sources = load_installed_component_sources(root)
+    old_source_raw = sources.get(pack_id)
+    if not old_source_raw:
+        raise CommunityComponentLifecycleError(f"Installed pack has no old local source sidecar: {pack_id}")
+    old_source = Path(old_source_raw).resolve()
+    old_files = _render_owned_files(old_source, pack_id)
+    new_files = _render_owned_files(candidate_source, pack_id)
+
+    old_paths = set(old_files)
+    new_paths = set(new_files)
+    added = sorted(new_paths - old_paths)
+    removed = sorted(old_paths - new_paths)
+    changed = sorted(path for path in old_paths & new_paths if old_files[path] != new_files[path])
+    potential_conflicts: list[dict[str, str]] = []
+
+    app_root = Path(workspace_app_root).resolve() if workspace_app_root else None
+    if app_root:
+        owner_by_path = _current_owner_by_path(app_root)
+        for path in sorted(added + changed):
+            owner = owner_by_path.get(path)
+            if owner and owner != pack_id:
+                potential_conflicts.append({"path": path, "kind": "owned_by_other_pack", "owner": owner})
+            target = app_root / path
+            if target.exists() and not owner:
+                potential_conflicts.append({"path": path, "kind": "workspace_owned_file"})
+        for path in sorted(changed + removed):
+            target = app_root / path
+            if not target.exists():
+                continue
+            current_content = target.read_text(encoding="utf-8")
+            if current_content != old_files[path]:
+                potential_conflicts.append({"path": path, "kind": "locally_modified_owned_file"})
+
+    dependency_changes = {
+        "added_packs": [item for item in candidate["dependencies"]["packs"] if item not in current["dependencies"]["packs"]],
+        "removed_packs": [item for item in current["dependencies"]["packs"] if item not in candidate["dependencies"]["packs"]],
+        "added_capabilities": [
+            item for item in candidate["dependencies"]["capabilities"] if item not in current["dependencies"]["capabilities"]
+        ],
+        "removed_capabilities": [
+            item for item in current["dependencies"]["capabilities"] if item not in candidate["dependencies"]["capabilities"]
+        ],
+    }
+    return UpgradePlan(
+        status="blocked" if potential_conflicts else "ready",
+        identity_match=current["pack_id"] == candidate["pack_id"],
+        pack_id=pack_id,
+        from_version=current["version"],
+        to_version=candidate["version"],
+        from_digest=current["digest"],
+        to_digest=candidate["digest"],
+        dependency_changes=dependency_changes,
+        owned_file_changes={
+            "added": added,
+            "removed": removed,
+            "changed": changed,
+        },
+        added_files=added,
+        removed_files=removed,
+        changed_files=changed,
+        potential_conflicts=potential_conflicts,
+    )
+
+
+def apply_component_upgrade(
+    *,
+    build_context_root: str | Path,
+    candidate_pack_source_path: str | Path,
+    workspace_app_root: str | Path,
+) -> UpgradePlan:
+    """Apply a safe local component upgrade and update installed state/provenance."""
+
+    root = Path(build_context_root).resolve()
+    app_root = Path(workspace_app_root).resolve()
+    candidate_source = Path(candidate_pack_source_path).resolve()
+    pack_id = _pack_id_from_context(candidate_source)
+    plan = plan_component_upgrade(
+        build_context_root=root,
+        candidate_pack_source_path=candidate_source,
+        workspace_app_root=app_root,
+    )
+    if plan.potential_conflicts:
+        raise CommunityComponentConflictError(f"Upgrade for '{pack_id}' has conflicts: {plan.potential_conflicts}")
+
+    candidate = _component_entry_from_verified_pack(candidate_source, pack_id)
+    descriptors = [{"id": pack_id, "pack_id": pack_id, "pack_source_path": str(candidate_source)}]
+    rendered = _files_by_name(resolve_managed_capability_templates(descriptors))
+    rendered.pop(_PROVENANCE_PATH, None)
+    for path in sorted(plan.added_files + plan.changed_files):
+        target = app_root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(rendered[path], encoding="utf-8")
+    for path in plan.removed_files:
+        target = app_root / path
+        if target.exists():
+            target.unlink()
+
+    provenance = _files_by_name(resolve_managed_capability_templates(descriptors))[_PROVENANCE_PATH]
+    (app_root / _PROVENANCE_PATH).parent.mkdir(parents=True, exist_ok=True)
+    (app_root / _PROVENANCE_PATH).write_text(provenance, encoding="utf-8")
+
+    state = load_installed_components(root)
+    installed = component_by_id(state)
+    installed[pack_id] = candidate
+    write_installed_components(root, {"components": list(installed.values())})
+    sources = load_installed_component_sources(root)
+    sources[pack_id] = str(candidate_source)
+    write_installed_component_sources(root, sources)
+
+    scanner_errors = scan_generated_bundle({
+        path.relative_to(app_root).as_posix(): path.read_text(encoding="utf-8")
+        for path in app_root.rglob("*")
+        if path.is_file()
+    })
+    provenance_errors = [error for error in scanner_errors if "pack_provenance" in error]
+    if provenance_errors:
+        raise CommunityComponentLifecycleError(f"Updated component provenance failed validation: {provenance_errors}")
+    return plan
+
+
+__all__ = [
+    "CommunityComponentConflictError",
+    "CommunityComponentLifecycleError",
+    "InstallResult",
+    "UpgradePlan",
+    "apply_component_upgrade",
+    "install_verified_local_pack",
+    "plan_component_upgrade",
+    "resolve_installed_component_descriptors",
+]

--- a/factory_app/workflows/AppGenerator/tools/community_component_state.py
+++ b/factory_app/workflows/AppGenerator/tools/community_component_state.py
@@ -1,0 +1,238 @@
+"""Deterministic installed-state helpers for local Community Components.
+
+Installed Community Components are workspace build-context facts. The
+canonical installed state is path-free and reproducible; the local source path
+needed to verify and materialize a developer checkout lives in a separate
+non-portable sidecar.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_STATE_SCHEMA_VERSION = "mozaiks.installed_components.v1"
+_SOURCES_SCHEMA_VERSION = "mozaiks.installed_component_sources.v1"
+_STATE_PATH = ".mozaiks/installed_components.json"
+_SOURCES_PATH = ".mozaiks/installed_component_sources.json"
+_SAFE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$")
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class InstalledComponentStateError(ValueError):
+    """Raised when installed component state is invalid."""
+
+
+def installed_components_path(build_context_root: Path) -> Path:
+    return build_context_root.resolve() / _STATE_PATH
+
+
+def installed_component_sources_path(build_context_root: Path) -> Path:
+    return build_context_root.resolve() / _SOURCES_PATH
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise InstalledComponentStateError(f"Invalid JSON at {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise InstalledComponentStateError(f"Installed component file must be a JSON object: {path}")
+    return data
+
+
+def _validate_dependency_block(raw: Any, *, field: str) -> dict[str, list[dict[str, str]]]:
+    if raw is None:
+        return {"packs": [], "capabilities": []}
+    if not isinstance(raw, dict):
+        raise InstalledComponentStateError(f"{field} must be an object")
+    unknown = sorted(set(raw) - {"packs", "capabilities"})
+    if unknown:
+        raise InstalledComponentStateError(f"{field} has unsupported fields: {unknown}")
+
+    packs: list[dict[str, str]] = []
+    raw_packs = raw.get("packs") or []
+    if not isinstance(raw_packs, list):
+        raise InstalledComponentStateError(f"{field}.packs must be an array")
+    for index, item in enumerate(raw_packs):
+        if not isinstance(item, dict):
+            raise InstalledComponentStateError(f"{field}.packs[{index}] must be an object")
+        unknown_pack = sorted(set(item) - {"pack_id", "version"})
+        if unknown_pack:
+            raise InstalledComponentStateError(f"{field}.packs[{index}] has unsupported fields: {unknown_pack}")
+        pack_id = str(item.get("pack_id") or "").strip()
+        version = str(item.get("version") or "").strip()
+        if not _SAFE_ID_RE.fullmatch(pack_id):
+            raise InstalledComponentStateError(f"{field}.packs[{index}].pack_id is invalid")
+        entry = {"pack_id": pack_id}
+        if version:
+            entry["version"] = version
+        packs.append(entry)
+
+    capabilities: list[dict[str, str]] = []
+    raw_caps = raw.get("capabilities") or []
+    if not isinstance(raw_caps, list):
+        raise InstalledComponentStateError(f"{field}.capabilities must be an array")
+    for index, item in enumerate(raw_caps):
+        if not isinstance(item, dict):
+            raise InstalledComponentStateError(f"{field}.capabilities[{index}] must be an object")
+        unknown_cap = sorted(set(item) - {"capability_id"})
+        if unknown_cap:
+            raise InstalledComponentStateError(
+                f"{field}.capabilities[{index}] has unsupported fields: {unknown_cap}"
+            )
+        capability_id = str(item.get("capability_id") or "").strip()
+        if not capability_id:
+            raise InstalledComponentStateError(f"{field}.capabilities[{index}].capability_id is required")
+        capabilities.append({"capability_id": capability_id})
+    return {
+        "packs": sorted(packs, key=lambda item: item["pack_id"]),
+        "capabilities": sorted(capabilities, key=lambda item: item["capability_id"]),
+    }
+
+
+def canonical_component_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    pack_id = str(entry.get("pack_id") or "").strip()
+    version = str(entry.get("version") or "").strip()
+    digest = str(entry.get("digest") or "").strip()
+    source = str(entry.get("source") or "local").strip()
+    if not _SAFE_ID_RE.fullmatch(pack_id):
+        raise InstalledComponentStateError(f"Installed component pack_id is invalid: {pack_id!r}")
+    if not version:
+        raise InstalledComponentStateError(f"Installed component {pack_id} version is required")
+    if not _DIGEST_RE.fullmatch(digest):
+        raise InstalledComponentStateError(f"Installed component {pack_id} digest must be a canonical sha256 digest")
+    dependencies = _validate_dependency_block(entry.get("dependencies"), field=f"components[{pack_id}].dependencies")
+
+    capabilities: list[dict[str, str]] = []
+    raw_caps = entry.get("capabilities") or []
+    if not isinstance(raw_caps, list):
+        raise InstalledComponentStateError(f"components[{pack_id}].capabilities must be an array")
+    for index, item in enumerate(raw_caps):
+        if not isinstance(item, dict):
+            raise InstalledComponentStateError(f"components[{pack_id}].capabilities[{index}] must be an object")
+        unknown = sorted(set(item) - {"capability_id"})
+        if unknown:
+            raise InstalledComponentStateError(
+                f"components[{pack_id}].capabilities[{index}] has unsupported fields: {unknown}"
+            )
+        capability_id = str(item.get("capability_id") or "").strip()
+        if capability_id:
+            capabilities.append({"capability_id": capability_id})
+
+    return {
+        "pack_id": pack_id,
+        "version": version,
+        "digest": digest,
+        "source": source,
+        "dependencies": dependencies,
+        "capabilities": sorted(capabilities, key=lambda item: item["capability_id"]),
+    }
+
+
+def canonical_installed_state(components: list[dict[str, Any]]) -> dict[str, Any]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for component in components:
+        entry = canonical_component_entry(component)
+        existing = by_id.get(entry["pack_id"])
+        if existing and existing != entry:
+            raise InstalledComponentStateError(f"Duplicate installed component with different state: {entry['pack_id']}")
+        by_id[entry["pack_id"]] = entry
+    return {
+        "schema_version": _STATE_SCHEMA_VERSION,
+        "components": [by_id[key] for key in sorted(by_id)],
+    }
+
+
+def load_installed_components(build_context_root: Path) -> dict[str, Any]:
+    path = installed_components_path(build_context_root)
+    raw = _read_json(path)
+    if raw is None:
+        return canonical_installed_state([])
+    unknown = sorted(set(raw) - {"schema_version", "components"})
+    if unknown:
+        raise InstalledComponentStateError(f"{path} has unsupported fields: {unknown}")
+    if raw.get("schema_version") != _STATE_SCHEMA_VERSION:
+        raise InstalledComponentStateError(
+            f"{path} schema_version must be {_STATE_SCHEMA_VERSION!r}"
+        )
+    components = raw.get("components")
+    if not isinstance(components, list):
+        raise InstalledComponentStateError(f"{path} components must be an array")
+    return canonical_installed_state([item for item in components if isinstance(item, dict)])
+
+
+def write_installed_components(build_context_root: Path, state: dict[str, Any]) -> Path:
+    canonical = canonical_installed_state(list(state.get("components") or []))
+    path = installed_components_path(build_context_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(canonical, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def load_installed_component_sources(build_context_root: Path) -> dict[str, str]:
+    path = installed_component_sources_path(build_context_root)
+    raw = _read_json(path)
+    if raw is None:
+        return {}
+    unknown = sorted(set(raw) - {"schema_version", "sources"})
+    if unknown:
+        raise InstalledComponentStateError(f"{path} has unsupported fields: {unknown}")
+    if raw.get("schema_version") != _SOURCES_SCHEMA_VERSION:
+        raise InstalledComponentStateError(
+            f"{path} schema_version must be {_SOURCES_SCHEMA_VERSION!r}"
+        )
+    sources = raw.get("sources")
+    if not isinstance(sources, list):
+        raise InstalledComponentStateError(f"{path} sources must be an array")
+    result: dict[str, str] = {}
+    for index, source in enumerate(sources):
+        if not isinstance(source, dict):
+            raise InstalledComponentStateError(f"{path} sources[{index}] must be an object")
+        unknown_source = sorted(set(source) - {"pack_id", "local_source_path"})
+        if unknown_source:
+            raise InstalledComponentStateError(f"{path} sources[{index}] has unsupported fields: {unknown_source}")
+        pack_id = str(source.get("pack_id") or "").strip()
+        local_source_path = str(source.get("local_source_path") or "").strip()
+        if not _SAFE_ID_RE.fullmatch(pack_id):
+            raise InstalledComponentStateError(f"{path} sources[{index}].pack_id is invalid")
+        if not local_source_path:
+            raise InstalledComponentStateError(f"{path} sources[{index}].local_source_path is required")
+        result[pack_id] = local_source_path
+    return result
+
+
+def write_installed_component_sources(build_context_root: Path, sources: dict[str, str]) -> Path:
+    path = installed_component_sources_path(build_context_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": _SOURCES_SCHEMA_VERSION,
+        "sources": [
+            {"pack_id": pack_id, "local_source_path": sources[pack_id]}
+            for pack_id in sorted(sources)
+        ],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def component_by_id(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(item["pack_id"]): item for item in state.get("components") or [] if isinstance(item, dict)}
+
+
+__all__ = [
+    "InstalledComponentStateError",
+    "canonical_component_entry",
+    "canonical_installed_state",
+    "component_by_id",
+    "installed_component_sources_path",
+    "installed_components_path",
+    "load_installed_component_sources",
+    "load_installed_components",
+    "write_installed_component_sources",
+    "write_installed_components",
+]

--- a/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
@@ -187,6 +187,8 @@ def _capabilities_from_context(context: dict[str, Any]) -> list[str]:
 
 def _validate_pack_dependencies(
     capability_packs: list[dict[str, Any]],
+    *,
+    context_variables: Any | None = None,
 ) -> None:
     """Check that every pack's declared ``requires`` is satisfied by the selection.
 
@@ -223,7 +225,7 @@ def _validate_pack_dependencies(
         # Capabilities from context.yaml (fallback when descriptor lacks them).
         # Only attempt when pack_id is safe — unsafe IDs will be caught later
         # by resolve_templates_for_pack's _is_safe_identifier check.
-        raw_path = pack.get("pack_source_path")
+        raw_path = _resolve_pack_source_from_installed_state(pack, context_variables=context_variables)
         if raw_path and pid and _is_safe_identifier(pid):
             try:
                 context_data = _read_pack_context(Path(raw_path).resolve(), pid)
@@ -240,8 +242,8 @@ def _validate_pack_dependencies(
     for pack in capability_packs:
         if not isinstance(pack, dict):
             continue
-        raw_path = pack.get("pack_source_path")
         pack_id = str(pack.get("id") or pack.get("pack_id") or pack.get("capability_pack_id") or "").strip()
+        raw_path = _resolve_pack_source_from_installed_state(pack, context_variables=context_variables)
         if not raw_path or not pack_id:
             continue
 
@@ -571,6 +573,7 @@ def _context_to_dict(context_variables: Any | None) -> dict[str, Any]:
     if hasattr(context_variables, "get"):
         try:
             keys = [
+                "build_context_root",
                 "readiness_profile",
                 "evidence_mode",
                 "evidence_ledger_path",
@@ -587,6 +590,44 @@ def _context_to_dict(context_variables: Any | None) -> dict[str, Any]:
         except Exception:
             return {}
     return {}
+
+
+def _context_build_context_root(context_variables: Any | None) -> Path | None:
+    context = _context_to_dict(context_variables)
+    raw = context.get("build_context_root")
+    if raw:
+        return Path(str(raw)).expanduser().resolve()
+    return None
+
+
+def _resolve_pack_source_from_installed_state(
+    pack: dict[str, Any],
+    *,
+    context_variables: Any | None,
+) -> str | None:
+    """Resolve an explicitly selected installed pack without copying local paths into AppBuildPlan."""
+
+    raw_path = pack.get("pack_source_path")
+    if raw_path:
+        return str(raw_path)
+    pack_id = str(pack.get("id") or pack.get("pack_id") or pack.get("capability_pack_id") or "").strip()
+    build_context_root = _context_build_context_root(context_variables)
+    if not pack_id or build_context_root is None:
+        return None
+    try:
+        from .community_component_lifecycle import resolve_installed_component_descriptors
+
+        descriptors = resolve_installed_component_descriptors(
+            build_context_root=build_context_root,
+            selected_pack_ids=[pack_id],
+        )
+    except Exception as exc:
+        raise ManagedCapabilityTemplateError(
+            f"Selected installed pack '{pack_id}' could not be resolved from workspace state: {exc}"
+        ) from exc
+    if not descriptors:
+        return None
+    return str(descriptors[0].get("pack_source_path") or "")
 
 
 def resolve_templates_for_pack(
@@ -664,7 +705,7 @@ def resolve_managed_capability_templates(
         return []
 
     # --- Step 1: dependency validation (fast fail before rendering) ---
-    _validate_pack_dependencies(capability_packs)
+    _validate_pack_dependencies(capability_packs, context_variables=context_variables)
 
     # --- Step 2: render templates, tracking per-pack output for provenance ---
     results_by_filename: dict[str, str] = {}
@@ -674,8 +715,8 @@ def resolve_managed_capability_templates(
     for pack in capability_packs:
         if not isinstance(pack, dict):
             continue
-        raw_path = pack.get("pack_source_path")
         pack_id = str(pack.get("id") or pack.get("pack_id") or pack.get("capability_pack_id") or "").strip()
+        raw_path = _resolve_pack_source_from_installed_state(pack, context_variables=context_variables)
         if not raw_path or not pack_id:
             continue
 

--- a/tests/test_community_component_lifecycle.py
+++ b/tests/test_community_component_lifecycle.py
@@ -1,0 +1,272 @@
+"""Community Component local install and upgrade lifecycle tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from shutil import copytree
+
+import pytest
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "community_packs"
+GREETINGS = FIXTURES / "greetings"
+FAREWELL = FIXTURES / "farewell"
+
+
+def _install(pack: Path, build_context_root: Path):
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        install_verified_local_pack,
+    )
+
+    return install_verified_local_pack(pack_source_path=pack, build_context_root=build_context_root)
+
+
+def _materialized_files(pack: Path, pack_id: str) -> dict[str, str]:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        resolve_managed_capability_templates,
+    )
+
+    return {
+        item["filename"]: item["content"]
+        for item in resolve_managed_capability_templates(
+            [{"id": pack_id, "pack_id": pack_id, "pack_source_path": str(pack)}]
+        )
+    }
+
+
+def _write_app_root_from_pack(app_root: Path, pack: Path, pack_id: str) -> None:
+    for filename, content in _materialized_files(pack, pack_id).items():
+        target = app_root / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+
+def _greetings_v2(tmp_path: Path, *, add_extra: bool = False, remove_init: bool = False) -> Path:
+    v2 = tmp_path / "greetings_v2"
+    copytree(GREETINGS, v2)
+    context = v2 / "context.yaml"
+    context.write_text(
+        context.read_text(encoding="utf-8").replace('version: "0.1.0"', 'version: "0.2.0"'),
+        encoding="utf-8",
+    )
+    service = v2 / "templates" / "modules" / "greetings" / "backend" / "service.py"
+    service.write_text(
+        service.read_text(encoding="utf-8").replace("fixture community pack", "fixture community pack v2"),
+        encoding="utf-8",
+    )
+    if add_extra:
+        (service.parent / "extra.py").write_text('"""v2 extra file."""\n', encoding="utf-8")
+    if remove_init:
+        (service.parent / "__init__.py").unlink()
+    return v2
+
+
+def test_install_verified_local_pack_writes_path_free_canonical_state(tmp_path: Path) -> None:
+    build_context_root = tmp_path / "build_context"
+
+    result = _install(GREETINGS, build_context_root)
+
+    assert result.status == "installed"
+    state_raw = Path(result.installed_state_path).read_text(encoding="utf-8")
+    state = json.loads(state_raw)
+    assert state["schema_version"] == "mozaiks.installed_components.v1"
+    assert state["components"][0]["pack_id"] == "greetings"
+    assert state["components"][0]["version"] == "0.1.0"
+    assert state["components"][0]["digest"].startswith("sha256:")
+    assert str(GREETINGS) not in state_raw
+    sources = json.loads(Path(result.source_state_path).read_text(encoding="utf-8"))
+    assert sources["schema_version"] == "mozaiks.installed_component_sources.v1"
+    assert sources["sources"][0]["local_source_path"] == str(GREETINGS.resolve())
+
+
+def test_tampered_local_pack_install_fails_before_state_is_written(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        ManagedCapabilityTemplateError,
+    )
+
+    bad_pack = tmp_path / "bad_greetings"
+    copytree(GREETINGS, bad_pack)
+    context = bad_pack / "context.yaml"
+    context.write_text(context.read_text(encoding="utf-8") + "\ninjected_prompt: bad\n", encoding="utf-8")
+
+    with pytest.raises(ManagedCapabilityTemplateError):
+        _install(bad_pack, tmp_path / "build_context")
+
+    assert not (tmp_path / "build_context" / ".mozaiks" / "installed_components.json").exists()
+
+
+def test_dependency_missing_install_fails(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        PackDependencyError,
+    )
+
+    with pytest.raises(PackDependencyError):
+        _install(FAREWELL, tmp_path / "build_context")
+
+
+def test_same_exact_pack_reinstall_is_idempotent(tmp_path: Path) -> None:
+    build_context_root = tmp_path / "build_context"
+    first = _install(GREETINGS, build_context_root)
+    before = Path(first.installed_state_path).read_text(encoding="utf-8")
+
+    second = _install(GREETINGS, build_context_root)
+    after = Path(second.installed_state_path).read_text(encoding="utf-8")
+
+    assert second.status == "unchanged"
+    assert before == after
+
+
+def test_two_compatible_packs_install_when_dependency_is_present(tmp_path: Path) -> None:
+    build_context_root = tmp_path / "build_context"
+
+    _install(GREETINGS, build_context_root)
+    result = _install(FAREWELL, build_context_root)
+
+    assert result.status == "installed"
+    state = json.loads((build_context_root / ".mozaiks" / "installed_components.json").read_text(encoding="utf-8"))
+    assert [component["pack_id"] for component in state["components"]] == ["farewell", "greetings"]
+
+
+def test_installed_pack_is_not_materialized_until_explicitly_selected(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        resolve_managed_capability_templates,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    _install(GREETINGS, build_context_root)
+
+    assert resolve_managed_capability_templates([], context_variables={"build_context_root": str(build_context_root)}) == []
+    files = resolve_managed_capability_templates(
+        [{"capability_pack_id": "greetings"}],
+        context_variables={"build_context_root": str(build_context_root)},
+    )
+
+    assert any(item["filename"] == "modules/greetings/module.yaml" for item in files)
+
+
+def test_upgrade_plan_reports_deterministic_file_changes(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        plan_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    _install(GREETINGS, build_context_root)
+    candidate = _greetings_v2(tmp_path, remove_init=True)
+
+    plan = plan_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=candidate,
+    )
+
+    assert plan.status == "ready"
+    assert plan.identity_match is True
+    assert plan.from_version == "0.1.0"
+    assert plan.to_version == "0.2.0"
+    assert "modules/greetings/backend/service.py" in plan.changed_files
+    assert "modules/greetings/backend/__init__.py" in plan.removed_files
+
+
+def test_upgrade_plan_detects_workspace_owned_file_collision(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        plan_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    candidate = _greetings_v2(tmp_path, add_extra=True)
+    target = app_root / "modules" / "greetings" / "backend" / "extra.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("custom\n", encoding="utf-8")
+
+    plan = plan_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=candidate,
+        workspace_app_root=app_root,
+    )
+
+    assert {"path": "modules/greetings/backend/extra.py", "kind": "workspace_owned_file"} in plan.potential_conflicts
+
+
+def test_upgrade_plan_detects_other_pack_ownership_collision(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        plan_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    candidate = _greetings_v2(tmp_path)
+    provenance = {
+        "schema_version": "mozaiks.pack_provenance.v1",
+        "framework_version": "test",
+        "generated_at": "2026-08-13T00:00:00+00:00",
+        "packs": [
+            {
+                "pack_id": "other_pack",
+                "version": "1.0.0",
+                "source": "local",
+                "digest": "sha256:" + "a" * 64,
+                "materialized_owned_files": [
+                    {"path": "modules/greetings/backend/service.py", "owner": "templates"}
+                ],
+            }
+        ],
+    }
+    target = app_root / ".mozaiks" / "pack_provenance.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps(provenance), encoding="utf-8")
+
+    plan = plan_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=candidate,
+        workspace_app_root=app_root,
+    )
+
+    assert any(conflict["kind"] == "owned_by_other_pack" for conflict in plan.potential_conflicts)
+
+
+def test_upgrade_plan_detects_local_modification_conflict(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        plan_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    _write_app_root_from_pack(app_root, GREETINGS, "greetings")
+    service = app_root / "modules" / "greetings" / "backend" / "service.py"
+    service.write_text(service.read_text(encoding="utf-8") + "\n# local edit\n", encoding="utf-8")
+
+    plan = plan_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=_greetings_v2(tmp_path),
+        workspace_app_root=app_root,
+    )
+
+    assert any(conflict["kind"] == "locally_modified_owned_file" for conflict in plan.potential_conflicts)
+
+
+def test_safe_upgrade_apply_updates_state_and_provenance(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        apply_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    _write_app_root_from_pack(app_root, GREETINGS, "greetings")
+    candidate = _greetings_v2(tmp_path, remove_init=True)
+
+    plan = apply_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=candidate,
+        workspace_app_root=app_root,
+    )
+
+    assert plan.status == "ready"
+    assert not (app_root / "modules" / "greetings" / "backend" / "__init__.py").exists()
+    state = json.loads((build_context_root / ".mozaiks" / "installed_components.json").read_text(encoding="utf-8"))
+    assert state["components"][0]["version"] == "0.2.0"
+    provenance = json.loads((app_root / ".mozaiks" / "pack_provenance.json").read_text(encoding="utf-8"))
+    assert provenance["packs"][0]["version"] == "0.2.0"


### PR DESCRIPTION
## Summary
- add canonical path-free installed Community Component state under workspace build_context/.mozaiks
- add deterministic local install, selected installed-pack resolution, upgrade planning, conflict detection, and safe apply helpers
- document the local lifecycle boundary: no remote fetch, marketplace, semver ranges, provider authority, or parallel component runtime

## Validation
- python -m pytest tests/test_community_component_lifecycle.py tests/test_community_pack_foundation.py tests/test_generated_bundle_scanner.py --no-cov
- python -m pytest tests/test_app_build_plan_pack_facade_helpers.py tests/test_managed_capability_template_expansion.py tests/test_appgenerator_managed_capability_smoke.py tests/test_appplan_materialization_acceptance.py --no-cov
- python -m pytest tests/test_generated_bundle_scanner.py tests/test_generated_bundle_scanner_helpers.py tests/test_generated_bundle_scanner_scan_helpers.py tests/test_generated_app_functional_acceptance.py tests/test_offline_generated_build_acceptance.py --no-cov
- python -m pytest tests/test_context_schema.py tests/test_appgenerator_schema_migration_contract.py tests/test_no_legacy_workflow_schema_terms.py tests/test_ui_surface_taxonomy.py tests/test_monetization_taxonomy.py tests/test_ui_portability_contract.py tests/test_build_context_events_yaml_alignment.py tests/test_build_context_emits_reactions_alignment.py tests/test_generator_event_system_contracts.py tests/test_event_dispatcher_domain_event.py tests/test_event_serialization_and_app_ids.py tests/test_module_event_router.py tests/test_module_reactions_docs_contract.py tests/test_durable_reaction_idempotency.py tests/test_governance_guardrails.py tests/test_package_content_guard.py --no-cov
- ruff check .
- python -m mypy factory_app/workflows/AppGenerator/tools/community_component_state.py factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
- python -m py_compile factory_app/workflows/AppGenerator/tools/community_component_state.py factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py tests/test_community_component_lifecycle.py
- python scripts/governance_guardrails.py --all --errors-only
- python -m pytest -q --no-cov
- mkdocs build --strict