### PR TITLE
fix(studio): authenticate artifact review calls

### DIFF
--- a/factory_app/app/admin/pages/AppBuildReviewPage.jsx
+++ b/factory_app/app/admin/pages/AppBuildReviewPage.jsx
@@ -19,7 +19,7 @@ import {
 import CarryForwardReportSummary from './CarryForwardReportSummary.jsx'
 import AppStudioHero, { formatDateTimeLabel } from './AppStudioChrome.jsx'
 import { getAppStudioSnapshot } from './appStudioDataHelpers.js'
-import { API_BASE } from './studioApi.js'
+import { studioFetch } from './studioApi.js'
 import { useAppStudioData } from './useAppStudioData.js'
 
 
@@ -69,8 +69,8 @@ async function postReviewAction({ appId, artifactVersionId, actionId }) {
   }
   const endpoint = endpointByAction[actionId]
   if (!endpoint) throw new Error(`${actionId} is not available yet.`)
-  const response = await fetch(
-    `${API_BASE}/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${endpoint}?app_id=${encodeURIComponent(appId)}`,
+  const response = await studioFetch(
+    `/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${endpoint}?app_id=${encodeURIComponent(appId)}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -103,8 +103,8 @@ function ReviewPackagePanel({ appId, artifactVersionId, dataMode, onRefresh }) {
       setLoading(true)
       setError(null)
       try {
-        const response = await fetch(
-          `${API_BASE}/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review?app_id=${encodeURIComponent(appId)}`,
+        const response = await studioFetch(
+          `/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review?app_id=${encodeURIComponent(appId)}`,
         )
         if (!response.ok) {
           const body = await response.json().catch(() => null)

--- a/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
+++ b/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
@@ -16,6 +16,7 @@ import E2BPreviewArtifact from './E2BPreviewArtifact';
 import ExportActions from './ExportActions';
 import FileTreeArtifact from './FileTreeArtifact';
 import HarnessDecisionCard from '../../../app/ui/components/HarnessDecisionCard.jsx';
+import { studioFetch } from '../../../app/admin/pages/studioApi.js';
 
 // Known locations where AppGenerator may write the theme config file.
 const _THEME_FILE_CANDIDATES = [
@@ -160,7 +161,7 @@ const AppWorkbench = ({
       setArtifactReviewBusy(true);
       setArtifactReviewError(null);
       try {
-        const response = await fetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review`);
+        const response = await studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review`);
         const body = await response.json().catch(() => ({ detail: response.statusText }));
         if (!response.ok) {
           throw new Error(body.detail || 'Artifact review could not be loaded.');
@@ -314,7 +315,7 @@ const AppWorkbench = ({
     setArtifactReviewBusy(true);
     setArtifactReviewError(null);
     try {
-      const response = await fetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${action}`, {
+      const response = await studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${action}`, {
         method: 'POST',
       });
       const body = await response.json().catch(() => ({ detail: response.statusText }));

--- a/factory_app/workflows/AppReview/ui/AppReview/AppReviewSummary.jsx
+++ b/factory_app/workflows/AppReview/ui/AppReview/AppReviewSummary.jsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback } from 'react';
 import { Panel, StatusPill, Button, Metric } from '@mozaiks/chat-ui/ui';
+import { studioFetch } from '../../../../app/admin/pages/studioApi.js';
 
 const STATUS_TONE = {
   passed: 'success',
@@ -48,16 +49,10 @@ export default function AppReviewSummary({ payload = {} }) {
     setPromoting(true);
     setError(null);
     try {
-      const apiBase =
-        typeof window !== 'undefined' ? window.__MOZAIKS_API_BASE__ || '' : '';
-      const token =
-        typeof window !== 'undefined' ? window.__MOZAIKS_ACCESS_TOKEN__ || '' : '';
-      const headers = { 'Content-Type': 'application/json' };
-      if (token) headers['Authorization'] = `Bearer ${token}`;
       const appIdQuery = payload?.app_id ? `?app_id=${encodeURIComponent(payload.app_id)}` : '';
-      const res = await fetch(`${apiBase}/api/studio/build/artifacts/${encodeURIComponent(payload.artifact_version_id)}/promote${appIdQuery}`, {
+      const res = await studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(payload.artifact_version_id)}/promote${appIdQuery}`, {
         method: 'POST',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ build_registry_id: payload.build_registry_id || null }),
       });
       if (!res.ok) {

--- a/tests/test_factory_studio_auth_fetch.py
+++ b/tests/test_factory_studio_auth_fetch.py
@@ -76,6 +76,34 @@ def test_workspace_users_uses_authenticated_fetch_for_admin_users() -> None:
     assert "fetch(`${API_BASE}/api/admin/users`" not in source
 
 
+def test_app_build_review_uses_authenticated_fetch_for_artifact_routes() -> None:
+    source = _read(PAGES / "AppBuildReviewPage.jsx")
+
+    assert "import { studioFetch } from './studioApi.js'" in source
+    assert "studioFetch(\n    `/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${endpoint}?app_id=${encodeURIComponent(appId)}`" in source
+    assert "studioFetch(\n          `/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review?app_id=${encodeURIComponent(appId)}`" in source
+    assert "fetch(\n    `${API_BASE}/api/studio/build/artifacts/" not in source
+    assert "fetch(\n          `${API_BASE}/api/studio/build/artifacts/" not in source
+
+
+def test_workflow_review_summary_uses_authenticated_fetch_for_promote() -> None:
+    source = _read(ROOT / "factory_app" / "workflows" / "AppReview" / "ui" / "AppReview" / "AppReviewSummary.jsx")
+
+    assert "import { studioFetch } from '../../../../app/admin/pages/studioApi.js';" in source
+    assert "studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(payload.artifact_version_id)}/promote${appIdQuery}`" in source
+    assert "window.__MOZAIKS_ACCESS_TOKEN__" not in source
+
+
+def test_app_workbench_uses_authenticated_fetch_for_artifact_review_actions() -> None:
+    source = _read(ROOT / "factory_app" / "workflows" / "AppGenerator" / "ui" / "AppWorkbench.js")
+
+    assert "import { studioFetch } from '../../../app/admin/pages/studioApi.js';" in source
+    assert "studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review`)" in source
+    assert "studioFetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${action}`" in source
+    assert "fetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/review`)" not in source
+    assert "fetch(`/api/studio/build/artifacts/${encodeURIComponent(artifactVersionId)}/${action}`" not in source
+
+
 def test_factory_onboarding_uses_canonical_studio_module_action() -> None:
     source = _read(ONBOARDING_INSTALLER)
 


### PR DESCRIPTION
## Summary
- route App Build Review artifact review/action calls through the canonical Studio authenticated fetch helper
- route AppGenerator workbench artifact review/action calls through the same helper
- route AppReview summary promotion through the same helper instead of a separate token lookup
- extend Studio auth regression coverage for these artifact routes

## Tests
- python -m pytest tests/test_factory_studio_auth_fetch.py --no-cov
- ruff check .
- python -m pytest -q --no-cov
- npm run build (web_shell)

## Notes
- python -m pytest tests/test_factory_studio_auth_fetch.py passes all tests but exits nonzero under the repo-wide coverage threshold when run alone; rerun with --no-cov passes.
- 
pm ci in chat-ui hit Windows/cache permission plus registry fetch errors; web_shell installed and the production Vite build passed.