### PR TITLE
fix(factory): preserve component upgrade ownership provenance

### DIFF
--- a/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
+++ b/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
@@ -240,6 +240,17 @@ def _provenance_pack_entries(app_root: Path) -> list[dict[str, Any]]:
     return [item for item in packs or [] if isinstance(item, dict)]
 
 
+def _pack_owned_paths(app_root: Path, pack_id: str) -> set[str]:
+    paths: set[str] = set()
+    for pack in _provenance_pack_entries(app_root):
+        if str(pack.get("pack_id") or "").strip() != pack_id:
+            continue
+        for file_entry in pack.get("materialized_owned_files") or []:
+            if isinstance(file_entry, dict) and file_entry.get("path"):
+                paths.add(str(file_entry["path"]))
+    return paths
+
+
 def _current_owner_by_path(app_root: Path) -> dict[str, str]:
     owner_by_path: dict[str, str] = {}
     for pack in _provenance_pack_entries(app_root):
@@ -294,9 +305,13 @@ def plan_component_upgrade(
             target = app_root / path
             if target.exists() and not owner:
                 potential_conflicts.append({"path": path, "kind": "workspace_owned_file"})
+        owned_by_candidate = _pack_owned_paths(app_root, pack_id)
         for path in sorted(changed + removed):
             target = app_root / path
             if not target.exists():
+                continue
+            if owned_by_candidate and path not in owned_by_candidate:
+                potential_conflicts.append({"path": path, "kind": "not_owned_by_installed_pack"})
                 continue
             current_content = target.read_text(encoding="utf-8")
             if current_content != old_files[path]:
@@ -366,9 +381,15 @@ def apply_component_upgrade(
         if target.exists():
             target.unlink()
 
-    provenance = _files_by_name(resolve_managed_capability_templates(descriptors))[_PROVENANCE_PATH]
+    provenance = json.loads(_files_by_name(resolve_managed_capability_templates(descriptors))[_PROVENANCE_PATH])
+    existing_entries = [
+        pack
+        for pack in _provenance_pack_entries(app_root)
+        if str(pack.get("pack_id") or "").strip() != pack_id
+    ]
+    provenance["packs"] = existing_entries + list(provenance.get("packs") or [])
     (app_root / _PROVENANCE_PATH).parent.mkdir(parents=True, exist_ok=True)
-    (app_root / _PROVENANCE_PATH).write_text(provenance, encoding="utf-8")
+    (app_root / _PROVENANCE_PATH).write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     state = load_installed_components(root)
     installed = component_by_id(state)

--- a/factory_app/workflows/AppGenerator/tools/community_component_state.py
+++ b/factory_app/workflows/AppGenerator/tools/community_component_state.py
@@ -163,7 +163,10 @@ def load_installed_components(build_context_root: Path) -> dict[str, Any]:
     components = raw.get("components")
     if not isinstance(components, list):
         raise InstalledComponentStateError(f"{path} components must be an array")
-    return canonical_installed_state([item for item in components if isinstance(item, dict)])
+    for index, item in enumerate(components):
+        if not isinstance(item, dict):
+            raise InstalledComponentStateError(f"{path} components[{index}] must be an object")
+    return canonical_installed_state(components)
 
 
 def write_installed_components(build_context_root: Path, state: dict[str, Any]) -> Path:

--- a/tests/test_community_component_lifecycle.py
+++ b/tests/test_community_component_lifecycle.py
@@ -116,6 +116,26 @@ def test_same_exact_pack_reinstall_is_idempotent(tmp_path: Path) -> None:
     assert before == after
 
 
+def test_malformed_installed_state_fails_instead_of_dropping_entry(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_state import (
+        InstalledComponentStateError,
+        load_installed_components,
+    )
+
+    state_path = tmp_path / "build_context" / ".mozaiks" / "installed_components.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps({
+            "schema_version": "mozaiks.installed_components.v1",
+            "components": ["not-an-object"],
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InstalledComponentStateError, match="components\\[0\\] must be an object"):
+        load_installed_components(tmp_path / "build_context")
+
+
 def test_two_compatible_packs_install_when_dependency_is_present(tmp_path: Path) -> None:
     build_context_root = tmp_path / "build_context"
 
@@ -247,6 +267,33 @@ def test_upgrade_plan_detects_local_modification_conflict(tmp_path: Path) -> Non
     assert any(conflict["kind"] == "locally_modified_owned_file" for conflict in plan.potential_conflicts)
 
 
+def test_upgrade_plan_blocks_removed_file_when_provenance_does_not_own_it(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        plan_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    _write_app_root_from_pack(app_root, GREETINGS, "greetings")
+    provenance_path = app_root / ".mozaiks" / "pack_provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["packs"][0]["materialized_owned_files"] = [
+        file_entry
+        for file_entry in provenance["packs"][0]["materialized_owned_files"]
+        if file_entry["path"] != "modules/greetings/backend/__init__.py"
+    ]
+    provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+
+    plan = plan_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=_greetings_v2(tmp_path, remove_init=True),
+        workspace_app_root=app_root,
+    )
+
+    assert {"path": "modules/greetings/backend/__init__.py", "kind": "not_owned_by_installed_pack"} in plan.potential_conflicts
+
+
 def test_safe_upgrade_apply_updates_state_and_provenance(tmp_path: Path) -> None:
     from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
         apply_component_upgrade,
@@ -270,3 +317,36 @@ def test_safe_upgrade_apply_updates_state_and_provenance(tmp_path: Path) -> None
     assert state["components"][0]["version"] == "0.2.0"
     provenance = json.loads((app_root / ".mozaiks" / "pack_provenance.json").read_text(encoding="utf-8"))
     assert provenance["packs"][0]["version"] == "0.2.0"
+
+
+def test_safe_upgrade_apply_preserves_other_pack_provenance(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.community_component_lifecycle import (
+        apply_component_upgrade,
+    )
+
+    build_context_root = tmp_path / "build_context"
+    app_root = tmp_path / "app"
+    _install(GREETINGS, build_context_root)
+    _write_app_root_from_pack(app_root, GREETINGS, "greetings")
+    provenance_path = app_root / ".mozaiks" / "pack_provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["packs"].append({
+        "pack_id": "other_pack",
+        "version": "1.0.0",
+        "source": "local",
+        "digest": "sha256:" + "a" * 64,
+        "materialized_owned_files": [
+            {"path": "modules/other/module.yaml", "owner": "templates"}
+        ],
+    })
+    provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+
+    apply_component_upgrade(
+        build_context_root=build_context_root,
+        candidate_pack_source_path=_greetings_v2(tmp_path),
+        workspace_app_root=app_root,
+    )
+
+    updated = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert {pack["pack_id"] for pack in updated["packs"]} == {"greetings", "other_pack"}
+    assert next(pack for pack in updated["packs"] if pack["pack_id"] == "greetings")["version"] == "0.2.0"


### PR DESCRIPTION
## Summary
- fail malformed installed component entries instead of silently dropping them
- block upgrade removals/changes when provenance does not prove the installed pack owns the file
- preserve other pack provenance entries when applying a safe local component upgrade

## Validation
- python -m pytest tests/test_community_component_lifecycle.py --no-cov
- python -m pytest tests/test_community_pack_foundation.py tests/test_managed_capability_template_expansion.py tests/test_appgenerator_managed_capability_smoke.py --no-cov
- python -m pytest tests/test_generated_bundle_scanner.py tests/test_generated_bundle_scanner_helpers.py tests/test_generated_bundle_scanner_scan_helpers.py tests/test_appplan_materialization_acceptance.py tests/test_offline_generated_build_acceptance.py --no-cov
- python -m pytest tests/test_ui_portability_contract.py tests/test_ui_surface_taxonomy.py tests/test_workflow_ui_tool_contracts.py --no-cov
- python -m pytest tests/test_build_context_emits_reactions_alignment.py tests/test_build_context_events_yaml_alignment.py tests/test_generator_event_system_contracts.py tests/test_module_event_router.py tests/test_durable_reaction_idempotency.py tests/test_event_dispatcher_domain_event.py tests/test_event_serialization_and_app_ids.py --no-cov
- python -m pytest tests/test_greenfield_app_context_graph_edges.py tests/test_brownfield_app_context_graph_edges.py tests/test_graph_authority_contract.py tests/test_workflow_network_graph.py --no-cov
- python -m pytest tests/test_pack_schema_models.py tests/test_pack_schema_helpers.py tests/test_context_schema.py tests/test_structured_output_runtime_contracts.py tests/test_no_legacy_workflow_schema_terms.py --no-cov
- python -m pytest tests/test_governance_guardrails.py tests/test_oss_boundary_policy.py tests/test_package_content_guard.py tests/test_runtime_package_exports.py tests/test_release_packaging_contract.py --no-cov
- python scripts/governance_guardrails.py --all --errors-only
- python -m mypy factory_app/workflows/AppGenerator/tools/community_component_state.py factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
- ruff check .
- mkdocs build --strict
- git diff --check
- python -m pytest