### PR TITLE
test(factory): prove deterministic production materialization

### DIFF
--- a/factory_app/workflows/AppGenerator/context_variables.yaml
+++ b/factory_app/workflows/AppGenerator/context_variables.yaml
@@ -1,4 +1,13 @@
 definitions:
+  build_timestamp:
+    type: string
+    description: >
+      Canonical timezone-aware ISO-8601 timestamp shared by every provenance
+      artifact in one deterministic app materialization. The launcher may seed
+      it for replay; otherwise provenance producers resolve current UTC.
+    source:
+      type: state
+      default: null
   platform_user_email:
     type: string
     description: >

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -1117,7 +1117,10 @@ models:
         description: Short planning summary for the build plan.
       app_kind:
         type: str
-        description: Canonical application kind used by deterministic AppBuildPlan validation and materialization.
+        description: >
+          Product/domain classification used by planning and readiness inference,
+          such as saas, marketplace, or a brownfield build-path kind. This is
+          intentionally open-ended and is not the closed AppProvenanceKind taxonomy.
       pages:
         type: optional_list
         items: AppBuildPage

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -1115,6 +1115,9 @@ models:
       agent_message:
         type: str
         description: Short planning summary for the build plan.
+      app_kind:
+        type: str
+        description: Canonical application kind used by deterministic AppBuildPlan validation and materialization.
       pages:
         type: optional_list
         items: AppBuildPage

--- a/factory_app/workflows/AppGenerator/tools/assemble_app_tasks.py
+++ b/factory_app/workflows/AppGenerator/tools/assemble_app_tasks.py
@@ -364,6 +364,11 @@ async def assemble_app_tasks(
     result = await assemble_features(
         app_id=str(app_id),
         feature_outputs=feature_outputs,
+        build_timestamp=(
+            context_variables.get("build_timestamp")
+            if context_variables and hasattr(context_variables, "get")
+            else None
+        ),
     )
 
     # Merge module_interface.yaml files generated from agent_backend_integration tasks.

--- a/factory_app/workflows/AppGenerator/tools/assembly_phase.py
+++ b/factory_app/workflows/AppGenerator/tools/assembly_phase.py
@@ -22,11 +22,18 @@ from factory_app.workflows.AppGenerator.tools.code_file_utils import (
 logger = logging.getLogger(__name__)
 
 
-def _merge_code_files(feature_outputs: list[dict[str, Any]]) -> list[dict[str, str]]:
+def _merge_code_files(
+    feature_outputs: list[dict[str, Any]],
+    *,
+    build_timestamp: str | None = None,
+) -> list[dict[str, str]]:
     """Merge code_files from feature outputs, deduping by filename."""
     file_map: dict[str, str] = {}
     for output in feature_outputs:
-        for item in extract_code_file_entries_from_payload(output):
+        for item in extract_code_file_entries_from_payload(
+            output,
+            build_timestamp=build_timestamp,
+        ):
             filename = item.get("filename")
             content = item.get("content")
             if not filename or content is None:
@@ -38,6 +45,8 @@ def _merge_code_files(feature_outputs: list[dict[str, Any]]) -> list[dict[str, s
 async def assemble_features(
     app_id: str,
     feature_outputs: list[dict[str, Any]],
+    *,
+    build_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """
     Merge feature outputs into a single workflow bundle.
@@ -54,7 +63,10 @@ async def assemble_features(
         }
     """
     try:
-        merged_files = _merge_code_files(feature_outputs or [])
+        merged_files = _merge_code_files(
+            feature_outputs or [],
+            build_timestamp=build_timestamp,
+        )
         logger.info(
             "Assembled %d feature outputs into %d files",
             len(feature_outputs or []),

--- a/factory_app/workflows/AppGenerator/tools/code_file_utils.py
+++ b/factory_app/workflows/AppGenerator/tools/code_file_utils.py
@@ -27,14 +27,18 @@ from mozaiksai.core.workflow.generator_support.code_files import (
 )
 
 
-def extract_code_file_map_from_payload(payload: Any) -> dict[str, str]:
+def extract_code_file_map_from_payload(
+    payload: Any,
+    *,
+    build_timestamp: str | None = None,
+) -> dict[str, str]:
     """Materialize all code files from an AppGenerator structured output payload.
 
     Calls the runtime's generic extraction, then layers in AppGenerator-specific
     typed surfaces. Typed configs win over conflicting raw code_files entries
     for their canonical paths.
     """
-    file_map = _base_extract(payload)
+    file_map = _base_extract(payload, build_timestamp=build_timestamp)
 
     if not isinstance(payload, dict):
         return file_map
@@ -60,8 +64,15 @@ def extract_code_file_map_from_payload(payload: Any) -> dict[str, str]:
     return file_map
 
 
-def extract_code_file_entries_from_payload(payload: Any) -> list[dict[str, str]]:
-    file_map = extract_code_file_map_from_payload(payload)
+def extract_code_file_entries_from_payload(
+    payload: Any,
+    *,
+    build_timestamp: str | None = None,
+) -> list[dict[str, str]]:
+    file_map = extract_code_file_map_from_payload(
+        payload,
+        build_timestamp=build_timestamp,
+    )
     return [{"filename": name, "content": content} for name, content in sorted(file_map.items())]
 
 

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -27,6 +27,10 @@ from typing import Any
 
 import yaml
 
+from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+    ManagedCapabilityTemplateError,
+    resolve_declared_pack_output_paths,
+)
 from mozaiksai.core.runtime.app.paths import (
     APP_AUTH_CONFIG_PATH,
     APP_DATA_CONTRACT_PATH,
@@ -34,6 +38,7 @@ from mozaiksai.core.runtime.app.paths import (
     disallowed_legacy_app_paths,
     noncanonical_app_config_paths,
     noncanonical_app_root_paths,
+    unsafe_app_paths,
 )
 
 # ---------------------------------------------------------------------------
@@ -352,9 +357,23 @@ def _scan_data_contract_module_alignment(files_map: dict[str, str]) -> list[str]
     return errors
 
 
-def _scan_canonical_app_paths(files_map: dict[str, str]) -> list[str]:
+def _scan_canonical_app_paths(
+    files_map: dict[str, str],
+    *,
+    capability_packs: list[dict[str, Any]] | None = None,
+) -> list[str]:
     errors: list[str] = []
+    unsafe_paths = unsafe_app_paths(files_map)
+    if unsafe_paths:
+        errors.append(
+            "Generated app bundle contains absolute or traversal paths outside the app root: "
+            f"{unsafe_paths}. Every generated path must be app-root-relative."
+        )
     normalized_paths = sorted(_normalized_files_map(files_map))
+    try:
+        declared_pack_paths = resolve_declared_pack_output_paths(capability_packs)
+    except ManagedCapabilityTemplateError as exc:
+        return [f"Selected CapabilityPack output contract is invalid: {exc}"]
     legacy_paths = disallowed_legacy_app_paths(normalized_paths)
     if legacy_paths:
         errors.append(
@@ -363,7 +382,9 @@ def _scan_canonical_app_paths(files_map: dict[str, str]) -> list[str]:
             f"and {APP_SECURITY_SECRETS_PATH}."
         )
 
-    invalid_config_paths = noncanonical_app_config_paths(normalized_paths)
+    invalid_config_paths = sorted(
+        set(noncanonical_app_config_paths(normalized_paths)) - declared_pack_paths
+    )
     if invalid_config_paths:
         errors.append(
             "Generated app bundle contains noncanonical app config files: "
@@ -374,7 +395,9 @@ def _scan_canonical_app_paths(files_map: dict[str, str]) -> list[str]:
             "not belong under app/config/."
         )
 
-    invalid_root_paths = noncanonical_app_root_paths(normalized_paths)
+    invalid_root_paths = sorted(
+        set(noncanonical_app_root_paths(normalized_paths)) - declared_pack_paths
+    )
     if invalid_root_paths:
         errors.append(
             "Generated app bundle contains files outside the canonical app planes: "
@@ -1875,7 +1898,12 @@ def scan_generated_bundle(
       target-kind-specific required fields.
     """
     errors: list[str] = []
-    errors.extend(_scan_canonical_app_paths(files_map))
+    errors.extend(
+        _scan_canonical_app_paths(
+            files_map,
+            capability_packs=capability_packs,
+        )
+    )
     errors.extend(_scan_security_secret_contract(files_map))
     errors.extend(_scan_pack_provenance_manifest(files_map))
     errors.extend(_scan_route_manifest_consistency(files_map))

--- a/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
@@ -15,6 +14,7 @@ from jinja2 import Template
 from factory_app.workflows.AppGenerator.tools.pack_context_schema import (
     validate_pack_context,
 )
+from mozaiksai.core.runtime.app.provenance import resolve_build_timestamp
 from mozaiksai.core.session.build_context import (
     BuildContextError,
     iter_context_assets,
@@ -476,6 +476,8 @@ def _file_owner_map(pack_source_path: Path) -> dict[str, str]:
 
 def _build_provenance_manifest(
     pack_file_map: list[tuple[dict[str, Any], list[dict[str, str]]]],
+    *,
+    build_timestamp: str | None = None,
 ) -> str:
     """Build a provenance manifest JSON string.
 
@@ -503,7 +505,7 @@ def _build_provenance_manifest(
     manifest = {
         "schema_version": _PROVENANCE_SCHEMA_VERSION,
         "framework_version": framework_version,
-        "generated_at": datetime.now(tz=UTC).isoformat(),
+        "generated_at": resolve_build_timestamp(build_timestamp),
         "packs": packs_list,
     }
     return json.dumps(manifest, indent=2)
@@ -580,6 +582,7 @@ def _context_to_dict(context_variables: Any | None) -> dict[str, Any]:
                 "launch_check_command",
                 "monetization_check_command",
                 "pack_source_path",
+                "build_timestamp",
             ]
             result: dict[str, Any] = {}
             for key in keys:
@@ -628,6 +631,54 @@ def _resolve_pack_source_from_installed_state(
     if not descriptors:
         return None
     return str(descriptors[0].get("pack_source_path") or "")
+
+
+def _safe_declared_output_path(raw_path: Any, *, pack_id: str) -> str:
+    if not isinstance(raw_path, str):
+        raise PackIntegrityError(f"Pack '{pack_id}' required_outputs path must be a string")
+    path = raw_path.replace("\\", "/").strip()
+    pure = PurePosixPath(path)
+    if (
+        not path
+        or path.startswith("/")
+        or pure.is_absolute()
+        or any(part == ".." for part in pure.parts)
+        or (pure.parts and ":" in pure.parts[0])
+    ):
+        raise PackIntegrityError(
+            f"Pack '{pack_id}' required_outputs path must stay inside the app bundle: {raw_path!r}"
+        )
+    return str(pure)
+
+
+def resolve_declared_pack_output_paths(
+    capability_packs: list[dict[str, Any]] | None,
+    *,
+    context_variables: Any | None = None,
+) -> frozenset[str]:
+    """Return exact safe required_outputs paths from selected verified packs."""
+
+    paths: set[str] = set()
+    for pack in capability_packs or []:
+        if not isinstance(pack, dict):
+            continue
+        pack_id = str(pack.get("id") or pack.get("pack_id") or pack.get("capability_pack_id") or "").strip()
+        raw_path = _resolve_pack_source_from_installed_state(
+            pack,
+            context_variables=context_variables,
+        )
+        if not pack_id or not raw_path:
+            continue
+        pack_source_path = Path(raw_path)
+        verify_pack_integrity(pack_source_path, pack_id)
+        contract = _read_pack_contract(pack_source_path)
+        for index, output in enumerate(contract.get("required_outputs") or []):
+            if not isinstance(output, dict) or not str(output.get("path") or "").strip():
+                raise PackIntegrityError(
+                    f"Pack '{pack_id}' contract required_outputs[{index}].path is required"
+                )
+            paths.add(_safe_declared_output_path(output["path"], pack_id=pack_id))
+    return frozenset(paths)
 
 
 def resolve_templates_for_pack(
@@ -761,7 +812,10 @@ def resolve_managed_capability_templates(
             )
             for metadata, omap, files in provenance_entries
         ]
-        provenance_json = _build_provenance_manifest(pack_file_map)
+        provenance_json = _build_provenance_manifest(
+            pack_file_map,
+            build_timestamp=_context_to_dict(context_variables).get("build_timestamp"),
+        )
         existing_prov = results_by_filename.get(_PROVENANCE_PATH)
         if existing_prov is None:
             results_by_filename[_PROVENANCE_PATH] = provenance_json
@@ -778,6 +832,7 @@ __all__ = [
     "PackDependencyError",
     "PackIntegrityError",
     "resolve_managed_capability_templates",
+    "resolve_declared_pack_output_paths",
     "resolve_templates_for_pack",
     "verify_pack_integrity",
 ]

--- a/mozaiksai/core/runtime/app/paths.py
+++ b/mozaiksai/core/runtime/app/paths.py
@@ -13,6 +13,9 @@ APP_SECURITY_SECRETS_PATH = "security/secrets.yaml"
 APP_AUTH_CONFIG_PATH = "config/auth.yaml"
 APP_REFINEMENT_POLICY_CONFIG_PATH = "config/refinement_policy.yaml"
 APP_PROVENANCE_PATH = "provenance.yaml"
+APP_OPERATOR_READINESS_CONFIG_PATH = "config/operator_readiness.yaml"
+APP_OPERATOR_READINESS_GUIDE_PATH = "docs/operations/operator-readiness.md"
+APP_OPERATOR_READINESS_SCRIPT_PATH = "scripts/check_operator_readiness_local.ps1"
 
 CANONICAL_APP_CONFIG_FILES = frozenset(
     {
@@ -22,6 +25,7 @@ CANONICAL_APP_CONFIG_FILES = frozenset(
         "config/integrations.json",
         "config/integrations.yaml",
         "config/integrations.yml",
+        APP_OPERATOR_READINESS_CONFIG_PATH,
         APP_REFINEMENT_POLICY_CONFIG_PATH,
         "config/shell.json",
         "config/subscriptions.yaml",
@@ -37,6 +41,8 @@ CANONICAL_APP_ROOT_FILES = frozenset(
         "__init__.py",
         "app.json",
         APP_PROVENANCE_PATH,
+        APP_OPERATOR_READINESS_GUIDE_PATH,
+        APP_OPERATOR_READINESS_SCRIPT_PATH,
         "deployment.manifest.json",
         "docker-compose.yml",
         "index.html",
@@ -173,6 +179,9 @@ __all__ = [
     "APP_DATA_MIGRATIONS_DIR",
     "APP_DATA_MIGRATIONS_GLOB",
     "APP_AUTH_CONFIG_PATH",
+    "APP_OPERATOR_READINESS_CONFIG_PATH",
+    "APP_OPERATOR_READINESS_GUIDE_PATH",
+    "APP_OPERATOR_READINESS_SCRIPT_PATH",
     "APP_PROVENANCE_PATH",
     "APP_REFINEMENT_POLICY_CONFIG_PATH",
     "APP_SECURITY_SECRETS_PATH",

--- a/mozaiksai/core/runtime/app/paths.py
+++ b/mozaiksai/core/runtime/app/paths.py
@@ -13,9 +13,6 @@ APP_SECURITY_SECRETS_PATH = "security/secrets.yaml"
 APP_AUTH_CONFIG_PATH = "config/auth.yaml"
 APP_REFINEMENT_POLICY_CONFIG_PATH = "config/refinement_policy.yaml"
 APP_PROVENANCE_PATH = "provenance.yaml"
-APP_OPERATOR_READINESS_CONFIG_PATH = "config/operator_readiness.yaml"
-APP_OPERATOR_READINESS_GUIDE_PATH = "docs/operations/operator-readiness.md"
-APP_OPERATOR_READINESS_SCRIPT_PATH = "scripts/check_operator_readiness_local.ps1"
 
 CANONICAL_APP_CONFIG_FILES = frozenset(
     {
@@ -25,7 +22,6 @@ CANONICAL_APP_CONFIG_FILES = frozenset(
         "config/integrations.json",
         "config/integrations.yaml",
         "config/integrations.yml",
-        APP_OPERATOR_READINESS_CONFIG_PATH,
         APP_REFINEMENT_POLICY_CONFIG_PATH,
         "config/shell.json",
         "config/subscriptions.yaml",
@@ -41,8 +37,6 @@ CANONICAL_APP_ROOT_FILES = frozenset(
         "__init__.py",
         "app.json",
         APP_PROVENANCE_PATH,
-        APP_OPERATOR_READINESS_GUIDE_PATH,
-        APP_OPERATOR_READINESS_SCRIPT_PATH,
         "deployment.manifest.json",
         "docker-compose.yml",
         "index.html",
@@ -103,6 +97,22 @@ def normalize_app_path(raw_path: object) -> str:
     while s.startswith("./") or s.startswith("../"):
         s = s[3:] if s.startswith("../") else s[2:]
     return s
+
+
+def is_safe_app_path(raw_path: object) -> bool:
+    """Return whether a raw path is relative and contained by the app root."""
+
+    path = str(raw_path or "").replace("\\", "/").strip()
+    if not path or path.startswith("/") or "://" in path:
+        return False
+    pure = PurePosixPath(path)
+    if pure.is_absolute() or any(part == ".." for part in pure.parts):
+        return False
+    return not (pure.parts and ":" in pure.parts[0])
+
+
+def unsafe_app_paths(paths: Iterable[object]) -> list[str]:
+    return sorted({str(path) for path in paths if not is_safe_app_path(path)})
 
 
 def is_data_migration_path(path: str) -> bool:
@@ -179,9 +189,6 @@ __all__ = [
     "APP_DATA_MIGRATIONS_DIR",
     "APP_DATA_MIGRATIONS_GLOB",
     "APP_AUTH_CONFIG_PATH",
-    "APP_OPERATOR_READINESS_CONFIG_PATH",
-    "APP_OPERATOR_READINESS_GUIDE_PATH",
-    "APP_OPERATOR_READINESS_SCRIPT_PATH",
     "APP_PROVENANCE_PATH",
     "APP_REFINEMENT_POLICY_CONFIG_PATH",
     "APP_SECURITY_SECRETS_PATH",
@@ -194,8 +201,10 @@ __all__ = [
     "is_canonical_app_config_path",
     "is_data_migration_path",
     "is_disallowed_legacy_app_path",
+    "is_safe_app_path",
     "is_sensitive_app_config_path",
     "noncanonical_app_config_paths",
     "noncanonical_app_root_paths",
     "normalize_app_path",
+    "unsafe_app_paths",
 ]

--- a/mozaiksai/core/runtime/app/provenance.py
+++ b/mozaiksai/core/runtime/app/provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, cast
 
@@ -217,6 +218,28 @@ def current_mozaiks_package_ref() -> str:
     return f"package:{__version__}"
 
 
+def resolve_build_timestamp(value: str | datetime | None = None) -> str:
+    """Return one canonical UTC timestamp for generated build provenance."""
+
+    if value is None:
+        resolved = datetime.now(tz=UTC)
+    elif isinstance(value, datetime):
+        resolved = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("build_timestamp must be a non-empty ISO-8601 timestamp")
+        try:
+            resolved = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("build_timestamp must be a valid ISO-8601 timestamp") from exc
+    else:
+        raise ValueError("build_timestamp must be an ISO-8601 string or datetime")
+    if resolved.tzinfo is None or resolved.utcoffset() is None:
+        raise ValueError("build_timestamp must include a timezone offset")
+    return resolved.astimezone(UTC).isoformat()
+
+
 def build_default_app_provenance(
     *,
     app_kind: AppProvenanceKind = "hand_authored",
@@ -227,6 +250,7 @@ def build_default_app_provenance(
     build_id: str | None = None,
     artifact_version_id: str | None = None,
     app_context_version_id: str | None = None,
+    timestamp: str | datetime | None = None,
     contracts: Mapping[str, str] | None = None,
     overlays: Mapping[str, str] | None = None,
     artifact_refs: Mapping[str, Any] | None = None,
@@ -252,6 +276,7 @@ def build_default_app_provenance(
                     "build_id": build_id,
                     "artifact_version_id": artifact_version_id,
                     "app_context_version_id": app_context_version_id,
+                    "timestamp": resolve_build_timestamp(timestamp),
                 },
                 "contracts": merged_contracts,
                 "overlays": dict(overlays or {}),

--- a/mozaiksai/core/workflow/generator_support/code_files.py
+++ b/mozaiksai/core/workflow/generator_support/code_files.py
@@ -69,7 +69,11 @@ def _page_file_stem(page: dict[str, Any]) -> str:
     return normalized or "page"
 
 
-def _materialize_app_schema_file_map(payload: dict[str, Any]) -> dict[str, str]:
+def _materialize_app_schema_file_map(
+    payload: dict[str, Any],
+    *,
+    build_timestamp: str | None = None,
+) -> dict[str, str]:
     manifest = payload.get("manifest")
     pages = payload.get("pages")
     if not isinstance(manifest, dict) or not isinstance(pages, list):
@@ -91,6 +95,7 @@ def _materialize_app_schema_file_map(payload: dict[str, Any]) -> dict[str, str]:
             app_kind="generated",
             created_mode="factory",
             workflow="AppGenerator",
+            timestamp=build_timestamp,
         )
     )
 
@@ -210,7 +215,11 @@ def _normalize_code_file_entries(raw_entries: Any) -> dict[str, str]:
     return file_map
 
 
-def extract_code_file_map_from_payload(payload: Any) -> dict[str, str]:
+def extract_code_file_map_from_payload(
+    payload: Any,
+    *,
+    build_timestamp: str | None = None,
+) -> dict[str, str]:
     """Resolve deterministic code files from a structured agent payload.
 
     Handles the generic file lanes used across all generator workflows.
@@ -223,7 +232,12 @@ def extract_code_file_map_from_payload(payload: Any) -> dict[str, str]:
         return {}
 
     file_map = _normalize_code_file_entries(payload.get("code_files"))
-    file_map.update(_materialize_app_schema_file_map(payload))
+    file_map.update(
+        _materialize_app_schema_file_map(
+            payload,
+            build_timestamp=build_timestamp,
+        )
+    )
     file_map.update(_materialize_module_contract_file_map(payload))
 
     raw_python_files = payload.get("python_files")
@@ -292,8 +306,15 @@ def extract_code_file_map_from_payload(payload: Any) -> dict[str, str]:
     return file_map
 
 
-def extract_code_file_entries_from_payload(payload: Any) -> list[dict[str, str]]:
-    file_map = extract_code_file_map_from_payload(payload)
+def extract_code_file_entries_from_payload(
+    payload: Any,
+    *,
+    build_timestamp: str | None = None,
+) -> list[dict[str, str]]:
+    file_map = extract_code_file_map_from_payload(
+        payload,
+        build_timestamp=build_timestamp,
+    )
     return [{"filename": name, "content": content} for name, content in sorted(file_map.items())]
 
 

--- a/tests/test_continuous_deterministic_materialization.py
+++ b/tests/test_continuous_deterministic_materialization.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from factory_app.workflows.AppGenerator.tools.app_build_plan import app_build_plan
+from factory_app.workflows.AppGenerator.tools.app_validation import run_app_bundle_acceptance_gate
+from factory_app.workflows.AppGenerator.tools.assemble_app_tasks import assemble_app_tasks
+from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import scan_generated_bundle
+from mozaiksai.core.validation import GeneratedAppValidationRequest, validate_generated_app_bundle
+from tests.import_utils import import_module_directly
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+WORKFLOWS_ROOT = WORKSPACE / "factory_app" / "workflows"
+PACK_ROOT = WORKSPACE / "factory_app" / "build_context" / "operator_readiness"
+NONDETERMINISTIC_METADATA = frozenset({"provenance.yaml", ".mozaiks/pack_provenance.json"})
+
+
+class _Context:
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self.data = dict(initial or {})
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+
+def _load_models() -> dict[str, type]:
+    workflow_manager = import_module_directly("mozaiksai.core.workflow.workflow_manager")
+    structured = import_module_directly("mozaiksai.core.workflow.outputs.structured")
+    workflow_manager.UnifiedWorkflowManager._instance = None
+    workflow_manager.initialize_workflows(base_path=str(WORKFLOWS_ROOT))
+    structured._workflow_models.clear()
+    structured._workflow_registries.clear()
+    models, _ = structured.load_workflow_structured_outputs("AppGenerator")
+    return models
+
+
+def _plan_payload() -> dict[str, Any]:
+    return {
+        "AppBuildPlan": {
+            "agent_message": "Materialize the deterministic reports application.",
+            "app_kind": "operations_dashboard",
+            "pages": [
+                {
+                    "name": "Reports",
+                    "route": "/reports",
+                    "purpose": "Review generated operational reports.",
+                    "primary_entities": ["Report"],
+                    "primary_actions": ["list_reports"],
+                    "ui_layout": "full-width",
+                    "ui_surface": "declarative_page",
+                    "page_type_hint": "record_list",
+                    "sections_hint": [
+                        {
+                            "primitive": "DataTable",
+                            "config_hint": json.dumps(
+                                {
+                                    "columns": ["id", "title", "status"],
+                                    "api_endpoint": "/api/modules/reports/list_reports",
+                                    "search": True,
+                                },
+                                sort_keys=True,
+                            ),
+                            "section_id_hint": "reports-table",
+                            "title_hint": "Reports",
+                        }
+                    ],
+                }
+            ],
+            "entities": [{"name": "Report", "operations": ["read"], "notes": None}],
+            "roles": ["operator"],
+            "auth_strategy": "public",
+            "service_scope": ["reports"],
+            "frontend_scope": ["reports"],
+            "theme_preferences": "high-contrast operations workspace",
+            "brand_intent": None,
+            "capability_packs": [
+                {
+                    "capability_pack_id": "operator_readiness",
+                    "surface_id": "operator_readiness",
+                    "surface_kind": "app_policy",
+                    "pack_type": "custom_domain",
+                    "label": "Operator Readiness",
+                    "summary": "Deterministic local readiness evidence.",
+                    "implementation_mode": "hybrid",
+                    "capability_source": "config_file",
+                }
+            ],
+            "readiness_profile": "host_operator_platform",
+            "revenue_model": "free",
+            "external_integrations": [],
+            "agent_backend_required": False,
+            "build_tasks": [
+                {
+                    "task_id": "reports.contract",
+                    "task_type": "module_contract",
+                    "capability_pack_id": "reports",
+                    "surface_id": "reports",
+                    "surface_kind": "module",
+                    "execution_target": "AppGenerator",
+                    "initial_agent": "ConfigMiddlewareAgent",
+                    "description": "Materialize the reports module contract.",
+                    "initial_message": "Emit the canonical reports module and event contracts.",
+                    "owned_paths": [
+                        "modules/reports/module.yaml",
+                        "modules/reports/contracts/events.yaml",
+                        "modules/reports/contracts/reactions.yaml",
+                    ],
+                    "depends_on": [],
+                    "acceptance_criteria": ["Action and event references close."],
+                },
+                {
+                    "task_id": "reports.models",
+                    "task_type": "data_models",
+                    "capability_pack_id": "reports",
+                    "surface_id": "reports",
+                    "surface_kind": "module",
+                    "execution_target": "AppGenerator",
+                    "initial_agent": "ModelAgent",
+                    "description": "Materialize typed report schemas.",
+                    "initial_message": "Emit the report schema implementation.",
+                    "owned_paths": ["modules/reports/backend/schemas.py"],
+                    "depends_on": ["reports.contract"],
+                    "acceptance_criteria": ["Report schema is typed."],
+                },
+                {
+                    "task_id": "reports.services",
+                    "task_type": "business_services",
+                    "capability_pack_id": "reports",
+                    "surface_id": "reports",
+                    "surface_kind": "module",
+                    "execution_target": "AppGenerator",
+                    "initial_agent": "ServiceAgent",
+                    "description": "Materialize report handler and service code.",
+                    "initial_message": "Emit contract-bound Python implementations.",
+                    "owned_paths": [
+                        "modules/reports/backend/handler.py",
+                        "modules/reports/backend/service.py",
+                    ],
+                    "depends_on": ["reports.models"],
+                    "acceptance_criteria": ["Handler implements every declared action and reaction."],
+                },
+                {
+                    "task_id": "reports.page",
+                    "task_type": "page_bundle",
+                    "capability_pack_id": None,
+                    "surface_id": "reports_page",
+                    "surface_kind": "ui_only",
+                    "execution_target": "AppGenerator",
+                    "initial_agent": "AppSchemaAgent",
+                    "description": "Materialize the schema-native reports route.",
+                    "initial_message": "Emit app.json, semantic theme tokens, and the reports page.",
+                    "owned_paths": ["app.json", "brand/theme_config.json", "ui/pages/reports.yaml"],
+                    "depends_on": ["reports.services"],
+                    "acceptance_criteria": ["Page action resolves to reports.list_reports."],
+                },
+            ],
+            "data_contract": None,
+            "pending_schema_migration": None,
+            "generation_order": [
+                "reports.contract",
+                "reports.models",
+                "reports.services",
+                "reports.page",
+            ],
+            "carry_forward_decisions": [],
+        }
+    }
+
+
+def _typed_task_outputs(models: dict[str, type]) -> dict[str, dict[str, Any]]:
+    config_output = models["ConfigMiddlewareOutput"].model_validate(
+        {
+            "mode": "module_contract_bundle",
+            "module_contract": None,
+            "service_foundation_bundle": None,
+            "subscription_config_bundle": None,
+            "code_files": [
+                {
+                    "filename": "modules/reports/module.yaml",
+                    "content": (
+                        "schema_version: mozaiks.module.v1\n"
+                        "module:\n"
+                        "  id: reports\n"
+                        "  display_name: Reports\n"
+                        "  version: 1.0.0\n"
+                        "  handler: backend.handler:ReportsModule\n"
+                        "actions:\n"
+                        "  - id: list_reports\n"
+                        "    description: List operational reports.\n"
+                        "    handler_method: list_reports\n"
+                        "    emits: [domain.reports.report_viewed]\n"
+                        "    input_schema: {type: object, properties: {}}\n"
+                        "    output_schema: {type: object}\n"
+                        "capabilities:\n"
+                        "  - capability_id: reports.view\n"
+                        "    kind: action\n"
+                        "    target: list_reports\n"
+                        "    title: View reports\n"
+                    ),
+                },
+                {
+                    "filename": "modules/reports/contracts/events.yaml",
+                    "content": (
+                        "schema_version: mozaiks.events.v1\n"
+                        "events:\n"
+                        "  - type: domain.reports.report_viewed\n"
+                        "    version: 1\n"
+                        "    description: A report list was viewed.\n"
+                        "    producer: reports\n"
+                        "    payload_schema: {type: object, properties: {}}\n"
+                    ),
+                },
+                {
+                    "filename": "modules/reports/contracts/reactions.yaml",
+                    "content": (
+                        "schema_version: mozaiks.reactions.v1\n"
+                        "reactions:\n"
+                        "  - id: record_report_view\n"
+                        "    event_type: domain.reports.report_viewed\n"
+                        "    target:\n"
+                        "      kind: handler\n"
+                        "      handler_method: record_report_view\n"
+                    ),
+                },
+            ],
+            "deleted_files": None,
+            "agent_message": "Materialized reports contracts.",
+        }
+    )
+    model_output = models["ModelOutput"].model_validate(
+        {
+            "model_files": [
+                {
+                    "path": "modules/reports/backend/schemas.py",
+                    "entity_name": "Report",
+                    "purpose": "Typed report response.",
+                    "content": "from typing import TypedDict\n\nclass Report(TypedDict):\n    id: str\n    title: str\n    status: str\n",
+                }
+            ],
+            "code_files": [],
+            "agent_message": "Materialized report schemas.",
+        }
+    )
+    service_output = models["ServiceOutput"].model_validate(
+        {
+            "python_files": [
+                {
+                    "path": "modules/reports/backend/handler.py",
+                    "kind": "handler",
+                    "purpose": "Contract-bound reports dispatch.",
+                    "contract_refs": ["module_yaml.actions[list_reports]"],
+                    "content": (
+                        "from .service import ReportsService\n\n"
+                        "class ReportsModule:\n"
+                        "    async def list_reports(self, ctx, **params):\n"
+                        "        return await ReportsService().list_reports(ctx, **params)\n\n"
+                        "    async def record_report_view(self, ctx, **params):\n"
+                        "        return {\"recorded\": True}\n"
+                    ),
+                },
+                {
+                    "path": "modules/reports/backend/service.py",
+                    "kind": "service",
+                    "purpose": "Bounded report behavior behind the module contract.",
+                    "contract_refs": ["module_yaml.actions[list_reports]"],
+                    "content": (
+                        "class ReportsService:\n"
+                        "    async def list_reports(self, ctx, **params):\n"
+                        "        return {\"reports\": [{\"id\": \"report-1\", \"title\": \"Readiness\", \"status\": \"ready\"}]}\n"
+                    ),
+                },
+            ],
+            "code_files": [],
+            "deleted_files": None,
+            "agent_message": "Materialized report runtime code.",
+        }
+    )
+    schema_output = models["AppSchemaOutput"].model_validate(
+        {
+            "agent_message": "Materialized the reports application shell.",
+            "manifest": {
+                "app_name": "Deterministic Reports",
+                "description": "Offline deterministic materialization proof.",
+                "tagline": None,
+                "value_proposition": None,
+                "version": "1.0.0",
+                "auth_strategy": "public",
+                "roles": ["operator"],
+                "default_route": "/reports",
+                "pages": ["reports"],
+                "custom_routes": [],
+            },
+            "pages": [
+                {
+                    "name": "Reports",
+                    "route": "/reports",
+                    "title": "Reports",
+                    "page_type": "record_list",
+                    "layout": "grid",
+                    "shell_mode": "standard",
+                    "roles": None,
+                    "navigation": None,
+                    "meta": None,
+                    "sections": [],
+                    "extensions": None,
+                }
+            ],
+            "custom_route_bundle": None,
+            "theme_config_patch": {
+                "theme": {
+                    "primary": "#0f766e",
+                    "variant": "professional",
+                    "radius": "6px",
+                    "font": "IBM Plex Sans",
+                    "font_heading": "IBM Plex Serif",
+                    "appearance": "light",
+                    "density": "compact",
+                    "branding": None,
+                },
+                "identity": {
+                    "name": "Deterministic Reports",
+                    "tagline": "Operational clarity",
+                    "app_name": "Deterministic Reports",
+                },
+                "fonts": None,
+            },
+            "shell_config": None,
+            "asset_manifest": None,
+            "data_contract": None,
+        }
+    )
+    return {
+        "reports.contract": config_output.model_dump(mode="json"),
+        "reports.models": model_output.model_dump(mode="json"),
+        "reports.services": service_output.model_dump(mode="json"),
+        "reports.page": schema_output.model_dump(mode="json"),
+    }
+
+
+async def _materialize(models: dict[str, type]) -> tuple[dict[str, str], _Context]:
+    typed_plan = models["AppBuildPlanOutput"].model_validate(_plan_payload())
+    context = _Context(
+        {
+            "app_id": "deterministic-reports",
+            "app_name": "Deterministic Reports",
+            "app_slug": "deterministic-reports",
+            "readiness_profile": "host_operator_platform",
+            "evidence_mode": "local_no_spend",
+            "capability_packs": [
+                {
+                    "id": "operator_readiness",
+                    "capability_source": "config_file",
+                    "pack_source_path": str(PACK_ROOT),
+                }
+            ],
+        }
+    )
+    plan = typed_plan.AppBuildPlan.model_dump(mode="json")
+    app_build_plan(AppBuildPlan=plan, context_variables=context)
+    context.set("app_task_batch_results", _typed_task_outputs(models))
+    assembled = await assemble_app_tasks(context_variables=context)
+    files = {str(item["filename"]): str(item["content"]) for item in assembled["code_files"]}
+    return files, context
+
+
+def _deterministic_files(files: dict[str, str]) -> dict[str, bytes]:
+    return {
+        path: content.encode("utf-8")
+        for path, content in files.items()
+        if path not in NONDETERMINISTIC_METADATA
+    }
+
+
+def test_typed_plan_rejects_unknown_taxonomy() -> None:
+    models = _load_models()
+    invalid = deepcopy(_plan_payload())
+    invalid["AppBuildPlan"]["pages"][0]["page_type_hint"] = "invented_dashboard"
+
+    with pytest.raises(ValidationError, match="page_type_hint"):
+        models["AppBuildPlanOutput"].model_validate(invalid)
+
+
+def test_plan_rejects_unresolved_task_reference() -> None:
+    models = _load_models()
+    typed_plan = models["AppBuildPlanOutput"].model_validate(_plan_payload())
+    plan = typed_plan.AppBuildPlan.model_dump(mode="json")
+    plan["build_tasks"][1]["depends_on"] = ["missing.contract"]
+
+    with pytest.raises(ValueError, match="unknown task ids"):
+        app_build_plan(AppBuildPlan=plan, context_variables=_Context())
+
+
+@pytest.mark.asyncio
+async def test_materializer_rejects_path_traversal() -> None:
+    models = _load_models()
+    files, context = await _materialize(models)
+    context.set(
+        "code_files",
+        [
+            {"filename": "../../outside.txt", "content": "escape"},
+            {"filename": "config/safe.txt", "content": "inside"},
+        ],
+    )
+    assembled = await assemble_app_tasks(context_variables=context)
+    paths = [str(item["filename"]) for item in assembled["code_files"]]
+
+    assert "../../outside.txt" not in paths
+    assert "config/safe.txt" in paths
+    assert all(not Path(path).is_absolute() and ".." not in Path(path).parts for path in paths)
+    assert files
+
+
+@pytest.mark.asyncio
+async def test_typed_plan_materializes_through_jinja_and_passes_production_validation() -> None:
+    models = _load_models()
+    files_one, context_one = await _materialize(models)
+    files_two, _ = await _materialize(models)
+
+    required = {
+        "app.json",
+        "brand/theme_config.json",
+        "ui/pages/reports.yaml",
+        "modules/reports/module.yaml",
+        "modules/reports/contracts/events.yaml",
+        "modules/reports/contracts/reactions.yaml",
+        "modules/reports/backend/handler.py",
+        "modules/reports/backend/service.py",
+        "modules/reports/backend/schemas.py",
+        "config/operator_readiness.yaml",
+        "scripts/check_operator_readiness_local.ps1",
+        "docs/operations/operator-readiness.md",
+    }
+    assert required <= files_one.keys()
+    assert list(files_one) == sorted(files_one)
+    assert "readiness_profile: host_operator_platform" in files_one["config/operator_readiness.yaml"]
+    assert "{{ readiness_profile }}" not in files_one["config/operator_readiness.yaml"]
+    assert _deterministic_files(files_one) == _deterministic_files(files_two)
+    assert set(files_one) - set(_deterministic_files(files_one)) == NONDETERMINISTIC_METADATA
+
+    plan = context_one.get("app_build_plan")
+    validation = validate_generated_app_bundle(
+        GeneratedAppValidationRequest(
+            files=files_one,
+            build_tasks=plan["build_tasks"],
+            capability_packs=plan["capability_packs"],
+        )
+    )
+    assert scan_generated_bundle(files_one) == []
+    assert validation.passed is True, validation.diagnostics
+
+    acceptance = await run_app_bundle_acceptance_gate(
+        files=files_one,
+        context_variables=context_one,
+        capability_packs=plan["capability_packs"],
+    )
+    assert acceptance["passed"] is True, acceptance
+    assert context_one.get("generated_files") == files_one

--- a/tests/test_continuous_deterministic_materialization.py
+++ b/tests/test_continuous_deterministic_materialization.py
@@ -6,19 +6,34 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from factory_app.workflows.AppGenerator.tools.app_build_plan import app_build_plan
 from factory_app.workflows.AppGenerator.tools.app_validation import run_app_bundle_acceptance_gate
 from factory_app.workflows.AppGenerator.tools.assemble_app_tasks import assemble_app_tasks
 from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import scan_generated_bundle
+from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+    resolve_declared_pack_output_paths,
+)
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+from mozaiksai.core.runtime.app.loader import AppLoader
 from mozaiksai.core.validation import GeneratedAppValidationRequest, validate_generated_app_bundle
 from tests.import_utils import import_module_directly
 
 WORKSPACE = Path(__file__).resolve().parents[1]
 WORKFLOWS_ROOT = WORKSPACE / "factory_app" / "workflows"
 PACK_ROOT = WORKSPACE / "factory_app" / "build_context" / "operator_readiness"
-NONDETERMINISTIC_METADATA = frozenset({"provenance.yaml", ".mozaiks/pack_provenance.json"})
+BUILD_TIMESTAMP = "2026-08-13T20:00:00+00:00"
+LATER_BUILD_TIMESTAMP = "2026-08-13T21:00:00+00:00"
+PACK_OUTPUT_PATHS = frozenset(
+    {
+        "config/operator_readiness.yaml",
+        "docs/operations/operator-readiness.md",
+        "scripts/check_operator_readiness_local.ps1",
+    }
+)
 
 
 class _Context:
@@ -30,6 +45,38 @@ class _Context:
 
     def set(self, key: str, value: Any) -> None:
         self.data[key] = value
+
+
+class _FakeMongoAdmin:
+    async def command(self, *_args: Any, **_kwargs: Any) -> dict[str, int]:
+        return {"ok": 1}
+
+
+class _FakeMongoClient:
+    def __init__(self) -> None:
+        self.admin = _FakeMongoAdmin()
+
+    def __getitem__(self, _name: str) -> _FakeMongoClient:
+        return self
+
+    def __getattr__(self, _name: str) -> _FakeMongoClient:
+        return self
+
+    async def command(self, *_args: Any, **_kwargs: Any) -> dict[str, int]:
+        return {"ok": 1}
+
+    def close(self) -> None:
+        return None
+
+
+def _selected_packs() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "operator_readiness",
+            "capability_source": "config_file",
+            "pack_source_path": str(PACK_ROOT),
+        }
+    ]
 
 
 def _load_models() -> dict[str, type]:
@@ -346,22 +393,21 @@ def _typed_task_outputs(models: dict[str, type]) -> dict[str, dict[str, Any]]:
     }
 
 
-async def _materialize(models: dict[str, type]) -> tuple[dict[str, str], _Context]:
+async def _materialize(
+    models: dict[str, type],
+    *,
+    build_timestamp: str = BUILD_TIMESTAMP,
+) -> tuple[dict[str, str], _Context]:
     typed_plan = models["AppBuildPlanOutput"].model_validate(_plan_payload())
     context = _Context(
         {
             "app_id": "deterministic-reports",
             "app_name": "Deterministic Reports",
             "app_slug": "deterministic-reports",
+            "build_timestamp": build_timestamp,
             "readiness_profile": "host_operator_platform",
             "evidence_mode": "local_no_spend",
-            "capability_packs": [
-                {
-                    "id": "operator_readiness",
-                    "capability_source": "config_file",
-                    "pack_source_path": str(PACK_ROOT),
-                }
-            ],
+            "capability_packs": _selected_packs(),
         }
     )
     plan = typed_plan.AppBuildPlan.model_dump(mode="json")
@@ -372,12 +418,11 @@ async def _materialize(models: dict[str, type]) -> tuple[dict[str, str], _Contex
     return files, context
 
 
-def _deterministic_files(files: dict[str, str]) -> dict[str, bytes]:
-    return {
-        path: content.encode("utf-8")
-        for path, content in files.items()
-        if path not in NONDETERMINISTIC_METADATA
-    }
+def _write_bundle(root: Path, files: dict[str, str]) -> None:
+    for relative_path, content in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
 
 
 def test_typed_plan_rejects_unknown_taxonomy() -> None:
@@ -419,11 +464,32 @@ async def test_materializer_rejects_path_traversal() -> None:
     assert files
 
 
+def test_operator_readiness_registers_only_declared_safe_pack_outputs() -> None:
+    assert resolve_declared_pack_output_paths(_selected_packs()) == PACK_OUTPUT_PATHS
+
+    base_files = {"app.json": "{}"}
+    for unsafe_path in (
+        "docs/operations/undeclared.md",
+        "config/operator_readiness.yml",
+        "/config/operator_readiness.yaml",
+        "../config/operator_readiness.yaml",
+    ):
+        errors = scan_generated_bundle(
+            {**base_files, unsafe_path: "unexpected"},
+            capability_packs=_selected_packs(),
+        )
+        assert errors, f"Pack path guard accepted undeclared or unsafe path: {unsafe_path}"
+
+
 @pytest.mark.asyncio
-async def test_typed_plan_materializes_through_jinja_and_passes_production_validation() -> None:
+async def test_typed_plan_materializes_validates_loads_and_serves_same_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     models = _load_models()
-    files_one, context_one = await _materialize(models)
-    files_two, _ = await _materialize(models)
+    files_one, context_one = await _materialize(models, build_timestamp=BUILD_TIMESTAMP)
+    files_two, _ = await _materialize(models, build_timestamp=BUILD_TIMESTAMP)
+    files_later, _ = await _materialize(models, build_timestamp=LATER_BUILD_TIMESTAMP)
 
     required = {
         "app.json",
@@ -443,24 +509,85 @@ async def test_typed_plan_materializes_through_jinja_and_passes_production_valid
     assert list(files_one) == sorted(files_one)
     assert "readiness_profile: host_operator_platform" in files_one["config/operator_readiness.yaml"]
     assert "{{ readiness_profile }}" not in files_one["config/operator_readiness.yaml"]
-    assert _deterministic_files(files_one) == _deterministic_files(files_two)
-    assert set(files_one) - set(_deterministic_files(files_one)) == NONDETERMINISTIC_METADATA
+    page = yaml.safe_load(files_one["ui/pages/reports.yaml"])
+    assert page["sections"][0]["primitive"] == "DataTable"
+    assert page["sections"][0]["config"]["api_endpoint"] == "/api/modules/reports/list_reports"
+    assert files_one == files_two
+
+    changed_paths = {
+        path
+        for path in files_one
+        if files_one[path] != files_later[path]
+    }
+    assert changed_paths == {"provenance.yaml", ".mozaiks/pack_provenance.json"}
+    app_provenance = yaml.safe_load(files_one["provenance.yaml"])
+    later_app_provenance = yaml.safe_load(files_later["provenance.yaml"])
+    assert app_provenance["created_with"].pop("timestamp") == BUILD_TIMESTAMP
+    assert later_app_provenance["created_with"].pop("timestamp") == LATER_BUILD_TIMESTAMP
+    assert app_provenance == later_app_provenance
+    pack_provenance = json.loads(files_one[".mozaiks/pack_provenance.json"])
+    later_pack_provenance = json.loads(files_later[".mozaiks/pack_provenance.json"])
+    assert pack_provenance.pop("generated_at") == BUILD_TIMESTAMP
+    assert later_pack_provenance.pop("generated_at") == LATER_BUILD_TIMESTAMP
+    assert pack_provenance == later_pack_provenance
 
     plan = context_one.get("app_build_plan")
     validation = validate_generated_app_bundle(
         GeneratedAppValidationRequest(
             files=files_one,
             build_tasks=plan["build_tasks"],
-            capability_packs=plan["capability_packs"],
+            capability_packs=_selected_packs(),
         )
     )
-    assert scan_generated_bundle(files_one) == []
+    assert scan_generated_bundle(files_one, capability_packs=_selected_packs()) == []
     assert validation.passed is True, validation.diagnostics
 
     acceptance = await run_app_bundle_acceptance_gate(
         files=files_one,
         context_variables=context_one,
-        capability_packs=plan["capability_packs"],
+        capability_packs=_selected_packs(),
     )
     assert acceptance["passed"] is True, acceptance
     assert context_one.get("generated_files") == files_one
+
+    app_root = tmp_path / "app"
+    _write_bundle(app_root, files_one)
+
+    loaded = await AppLoader.load(str(app_root))
+    assert loaded.definition.name == "Deterministic Reports"
+    assert [module.name for module in loaded.modules] == ["reports"]
+    assert [page.name for page in loaded.definition.pages] == ["reports"]
+
+    fake_mongo_client = _FakeMongoClient()
+    monkeypatch.setenv("PLATFORM_PATH", str(app_root))
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    monkeypatch.setattr("mozaiksai.hosts.runtime.get_mongo_client", lambda: fake_mongo_client)
+    monkeypatch.setattr("mozaiksai.core.startup.validation.get_mongo_client", lambda: fake_mongo_client)
+    reset_auth_adapter()
+
+    from mozaiksai.hosts import platform
+
+    monkeypatch.setattr(platform.runtime_app, "mongo_client", fake_mongo_client)
+    with TestClient(platform.app, raise_server_exceptions=False) as client:
+        health = client.get("/health")
+        assert health.status_code == 200, health.text
+        assert health.json()["status"] == "ok"
+
+        page_response = client.get("/api/pages/reports")
+        assert page_response.status_code == 200, page_response.text
+        assert page_response.json()["sections"][0]["config"]["api_endpoint"] == (
+            "/api/modules/reports/list_reports"
+        )
+
+        action_response = client.post(
+            "/api/modules/reports/list_reports",
+            json={"params": {}},
+        )
+        assert action_response.status_code == 200, action_response.text
+        assert action_response.json() == {
+            "reports": [
+                {"id": "report-1", "title": "Readiness", "status": "ready"}
+            ]
+        }


### PR DESCRIPTION
## Exact proof boundary

Starts at a fixed payload parsed by the production `AppBuildPlanOutput` Pydantic model and ends at representative HTTP responses served by the production platform host from the exact assembled file map:

`typed AppBuildPlanOutput`
-> `app_build_plan()`
-> captured typed `ConfigMiddlewareOutput` / `ModelOutput` / `ServiceOutput` / `AppSchemaOutput`
-> `assemble_app_tasks()`
-> production code-file serializers
-> selected `operator_readiness` CapabilityPack
-> production Jinja rendering
-> complete canonical file map
-> `scan_generated_bundle()`
-> `validate_generated_app_bundle()`
-> `run_app_bundle_acceptance_gate()`
-> `AppLoader.load()`
-> platform lifespan / executor registration
-> `GET /health`
-> `GET /api/pages/reports`
-> `POST /api/modules/reports/list_reports`

The same `files_one` mapping is written once and consumed by every downstream validation, load, boot, and HTTP stage. No hand-authored runtime fixture or custom translation is used.

PR #268 remains the broader hand-authored generated-bundle acceptance backstop with extensive negative mutations. This PR does not rewrite it; it adds the missing upstream production materialization proof.

## Production components exercised

- AppGenerator dynamic structured-output model loader
- `app_build_plan()` normalization, task dependency validation, and planning context
- typed-output code-file serialization and deterministic assembly
- verified CapabilityPack contract/integrity loading
- real `.j2` execution from `operator_readiness`
- exact CapabilityPack `required_outputs` registration
- canonical raw-path and traversal guards
- app and pack provenance serializers
- generated-bundle structural and functional scanners
- public generated-app validation facade
- production acceptance gate
- `AppLoader`, `ModuleExecutor`, `ExecutorRegistry`, and platform host routes

## Timestamp determinism

`build_timestamp` is the canonical timezone-aware ISO-8601 timestamp injected at the AppGenerator context boundary and passed unchanged to both timestamp owners:

- `provenance.yaml` -> `created_with.timestamp`
- `.mozaiks/pack_provenance.json` -> `generated_at`

Two independent builds with identical inputs and the same timestamp produce byte-identical complete file maps, including both provenance files. Supplying a different timestamp changes only those two timestamp-owned fields; the proof parses both documents, removes only the timestamp fields for comparison, and requires every remaining value to match.

No provenance is deleted, no permanent date is hardcoded in production, and the test performs no generated-file normalization or post-processing.

## Production contracts changed

- Added missing `AppBuildPlan.app_kind` to the existing structured-output model. It remains an open product/domain planning classification because production emits domain-specific and brownfield values. It is explicitly documented as distinct from the closed runtime `AppProvenanceKind` taxonomy.
- Added AppGenerator `build_timestamp` state context and threaded it through production serializers and pack provenance.
- Replaced three operator-readiness global path exceptions with the canonical selected-pack mechanism: exact safe paths from verified `contract.yaml required_outputs`.
- Added raw app-path safety so absolute, drive-qualified, URL-like, and traversal paths fail before normalization.

The active `operator_readiness` pack owns exactly:

- `config/operator_readiness.yaml`
- `docs/operations/operator-readiness.md`
- `scripts/check_operator_readiness_local.ps1`

Undeclared near matches, absolute paths, and traversal paths remain rejected.

## Materialized application

The typed fixture produces a meaningful canonical reports application with:

- app manifest and semantic theme contract
- schema-native reports page with a `DataTable`
- page binding to `/api/modules/reports/list_reports`
- reports module/action, handler, service, typed schema
- declared event and handler reaction
- real operator-readiness Jinja outputs and pack provenance

Runtime HTTP execution proves the generated handler/service returns the expected report payload.

## Tests

- Continuous proof run 1: `5 passed`
- Continuous proof run 2: `5 passed`
- Structured-output and AppBuildPlan suites: `307 passed`
- Jinja/materializer/CapabilityPack suites: `218 passed, 8 skipped`
- Validation/AppLoader/runtime-host suites: `273 passed, 1 skipped`
- Direct scanner-loader regression slice: `109 passed`
- `ruff check .`: passed
- Full offline suite: `12553 passed, 77 skipped`

## Limitations

- AG2/LLM reasoning itself remains intentionally outside this deterministic proof.
- Captured typed task outputs represent the post-reasoning boundary; the test does not claim prompt-to-identical-source determinism.
- MongoDB is replaced with a minimal external-infrastructure fake; production loaders, validators, executors, adapters, and hosts remain real.
- Deployment and paid/provider infrastructure are not invoked.

## Merge policy

Merge only after all required GitHub checks pass and no unresolved architecture review remains.