### PR TITLE
feat(validation): compile-time entitlement gate → subscriptions closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Entitlement gate compile-time closure**: Generated app bundles that use
+  `ConfiguredEntitlementAdapter` (i.e. declare `assignment_store` in
+  `config/subscriptions.yaml`) now fail deterministic bundle validation if any
+  `module.yaml` action declares an `entitlement_gate` capability_id that is not
+  granted by at least one subscription plan. Previously such bundles passed
+  validation but permanently denied the gated action at runtime for every user.
+  - Per-action diagnostics name the module path, action id, and unresolvable
+    capability_id, and suggest typo near-matches from the declared plan catalog.
+  - Apps without `subscriptions.yaml` (ungated, `NoOpEntitlementAdapter`) and
+    apps whose `subscriptions.yaml` has no `assignment_store` (custom/dynamic
+    adapter) are unaffected.
+  - `PlanDef` in `subscriptions_loader` now rejects plans that list the same
+    `capability_id` more than once (duplicate conflicting declarations).
+  - `_capability_ids_from_subscriptions_yaml` in the bundle scanner now handles
+    both v1 (flat `plans[]`) and v2 (`products[].plans[]`) subscriptions schema.
+  - 33 tests in `tests/test_entitlement_gate_closure.py` cover all scenarios:
+    positive (valid gated actions, multi-plan grants, custom adapter exemption,
+    ungated app, no-action bundle) and negative (unknown gate, near-match typo,
+    ungranted capability, all-plans-empty, malformed YAML, multi-module multi-
+    failure deterministic ordering, duplicate capabilities).
+
 - **Community Component Foundation v1**: Extended capability packs to carry versioned identity and machine-readable dependency declarations without introducing a parallel component runtime.
   - `context.yaml` pack blocks now require `version`; `author`, `license`, and `source` remain optional metadata.
   - `contract.yaml` supports the canonical `requires.packs` / `requires.capabilities` block for machine-readable dependency declarations; exact `requires.packs[].version` values are enforced when present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,26 +14,30 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
-- **Entitlement gate compile-time closure**: Generated app bundles that use
-  `ConfiguredEntitlementAdapter` (i.e. declare `assignment_store` in
-  `config/subscriptions.yaml`) now fail deterministic bundle validation if any
+- **Entitlement gate compile-time closure**: Generated app bundles with
+  `config/subscriptions.yaml` now fail deterministic bundle validation if any
   `module.yaml` action declares an `entitlement_gate` capability_id that is not
-  granted by at least one subscription plan. Previously such bundles passed
-  validation but permanently denied the gated action at runtime for every user.
+  granted by at least one subscription plan. The platform wires
+  `ConfiguredEntitlementAdapter` whenever `config/subscriptions.yaml` loads
+  successfully; `assignment_store` controls persisted assignment lookup, not
+  adapter selection. Previously such bundles passed validation but permanently
+  denied the gated action at runtime for every user.
   - Per-action diagnostics name the module path, action id, and unresolvable
     capability_id, and suggest typo near-matches from the declared plan catalog.
-  - Apps without `subscriptions.yaml` (ungated, `NoOpEntitlementAdapter`) and
-    apps whose `subscriptions.yaml` has no `assignment_store` (custom/dynamic
-    adapter) are unaffected.
+  - Apps without `subscriptions.yaml` remain ungated via `NoOpEntitlementAdapter`.
+    Malformed `subscriptions.yaml` files are not treated as custom/dynamic
+    adapter declarations.
   - `PlanDef` in `subscriptions_loader` now rejects plans that list the same
     `capability_id` more than once (duplicate conflicting declarations).
-  - `_capability_ids_from_subscriptions_yaml` in the bundle scanner now handles
-    both v1 (flat `plans[]`) and v2 (`products[].plans[]`) subscriptions schema.
-  - 33 tests in `tests/test_entitlement_gate_closure.py` cover all scenarios:
-    positive (valid gated actions, multi-plan grants, custom adapter exemption,
-    ungated app, no-action bundle) and negative (unknown gate, near-match typo,
-    ungranted capability, all-plans-empty, malformed YAML, multi-module multi-
-    failure deterministic ordering, duplicate capabilities).
+  - The bundle scanner derives plan grants from the canonical
+    `SubscriptionsConfig` loader output, covering both v1 (flat `plans[]`) and
+    v2 (`products[].plans[]`) subscriptions schema.
+  - 36 tests in `tests/test_entitlement_gate_closure.py` cover all scenarios:
+    positive (valid gated actions, multi-plan grants, `assignment_store`-absent
+    configured catalogs, ungated app, no-action bundle) and negative (unknown
+    gate, near-match typo, ungranted capability, all-plans-empty, malformed
+    YAML, multi-module multi-failure deterministic ordering, duplicate
+    capabilities).
 
 - **Community Component Foundation v1**: Extended capability packs to carry versioned identity and machine-readable dependency declarations without introducing a parallel component runtime.
   - `context.yaml` pack blocks now require `version`; `author`, `license`, and `source` remain optional metadata.

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -1007,67 +1007,35 @@ def _entitlement_gate_map_from_module_yaml(path: str, content: str) -> dict[str,
     return result
 
 
-def _capability_ids_from_subscriptions_yaml(content: str) -> set[str]:
-    """Extract all capability_ids granted by any plan in subscriptions.yaml.
-
-    Handles both v1 (flat plans[]) and v2 (products[].plans[]) schema shapes.
-    Raw YAML parsing is intentional — the Pydantic model is not available here
-    without a full import chain; callers that need strict validation should use
-    SubscriptionsConfig.model_validate() directly.
-    """
+def _subscriptions_config_from_yaml(path: str, content: str) -> tuple[Any | None, str | None]:
+    raw, error = _load_yaml_mapping_from_file({path: content}, path)
+    if error:
+        return None, error
     try:
-        config = yaml.safe_load(content) or {}
-    except Exception:
-        return set()
+        from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
+
+        return SubscriptionsConfig.model_validate(raw), None
+    except Exception as exc:
+        return None, f"{path}: invalid subscriptions contract: {exc}"
+
+
+def _capability_ids_from_subscriptions_config(config: Any) -> set[str]:
+    """Extract capability_ids using the canonical subscriptions loader output."""
     capability_ids: set[str] = set()
-    # v1: root-level plans[]
-    for plan in (config.get("plans") or []):
-        if not isinstance(plan, dict):
-            continue
-        for cap in (plan.get("capabilities") or []):
-            if isinstance(cap, str) and cap.strip():
-                capability_ids.add(cap.strip())
-    # v2: products[].plans[]
-    for product in (config.get("products") or []):
-        if not isinstance(product, dict):
-            continue
-        for plan in (product.get("plans") or []):
-            if not isinstance(plan, dict):
-                continue
-            for cap in (plan.get("capabilities") or []):
-                if isinstance(cap, str) and cap.strip():
-                    capability_ids.add(cap.strip())
+    for plan in (getattr(config, "plans", None) or []):
+        capability_ids.update(str(cap).strip() for cap in (plan.capabilities or []) if str(cap).strip())
+    for product in (getattr(config, "products", None) or []):
+        for plan in (getattr(product, "plans", None) or []):
+            capability_ids.update(str(cap).strip() for cap in (plan.capabilities or []) if str(cap).strip())
     return capability_ids
 
 
-def _has_entitlement_assignment_store(subs_content: str) -> bool:
-    """Return True when subscriptions.yaml declares an assignment_store.
-
-    An assignment_store signals the app uses ConfiguredEntitlementAdapter with
-    a static plan catalog for runtime entitlement resolution. Only these apps
-    are subject to compile-time entitlement_gate ↔ subscriptions.yaml closure
-    validation.
-
-    Apps whose subscriptions.yaml has no assignment_store are either using a
-    custom/dynamic adapter whose capability grants are not statically declared
-    in the plan catalog, or they carry the subscriptions.yaml only as a pricing
-    display catalog. Their entitlement_gate values are not statically resolvable
-    from the plan capabilities list and must not be rejected by bundle validation.
-    """
-    try:
-        config = yaml.safe_load(subs_content) or {}
-    except Exception:
-        return False
-    if not isinstance(config, dict):
-        return False
-    # v1: root-level assignment_store
-    if isinstance(config.get("assignment_store"), dict):
-        return True
-    # v2: any product-level assignment_store also signals static adapter use
-    for product in (config.get("products") or []):
-        if isinstance(product, dict) and isinstance(product.get("assignment_store"), dict):
-            return True
-    return False
+def _capability_ids_from_subscriptions_yaml(content: str) -> set[str]:
+    """Extract plan-granted capability_ids from canonical subscriptions parsing."""
+    config, error = _subscriptions_config_from_yaml("config/subscriptions.yaml", content)
+    if error or config is None:
+        return set()
+    return _capability_ids_from_subscriptions_config(config)
 
 
 def _scan_self_hosted_entitlement_dispatch_contract(
@@ -1144,8 +1112,9 @@ def _scan_entitlement_gate_capability_alignment(files_map: dict[str, str]) -> li
     denial for all callers regardless of their subscription tier.
 
     Skips apps without config/subscriptions.yaml (ungated apps, NoOp adapter).
-    Skips apps whose subscriptions.yaml has no assignment_store (custom/dynamic
-    adapter — their grants are not statically declared in the plan catalog).
+    Apps with config/subscriptions.yaml use ConfiguredEntitlementAdapter at
+    platform startup; assignment_store controls persisted assignment lookup, not
+    adapter selection.
 
     Diagnostics include:
     - module path and action id of the gated action
@@ -1161,15 +1130,16 @@ def _scan_entitlement_gate_capability_alignment(files_map: dict[str, str]) -> li
     normalized_files = _normalized_files_map(files_map)
     subs_content = normalized_files.get("config/subscriptions.yaml")
     if not subs_content:
-        # No subscriptions.yaml → ungated (NoOp adapter) or purely custom.
+        # No subscriptions.yaml -> ungated app, so ModuleExecutor uses NoOp.
         return []
 
-    if not _has_entitlement_assignment_store(subs_content):
-        # subscriptions.yaml present but no assignment_store → custom/dynamic
-        # adapter.  Gates are not statically resolvable from the plan catalog.
-        return []
-
-    plan_capabilities = _capability_ids_from_subscriptions_yaml(subs_content)
+    subscriptions_config, subscriptions_error = _subscriptions_config_from_yaml(
+        "config/subscriptions.yaml",
+        subs_content,
+    )
+    if subscriptions_error:
+        return [subscriptions_error]
+    plan_capabilities = _capability_ids_from_subscriptions_config(subscriptions_config)
 
     # Collect (module_path, action_id, gate) for every gated action.
     gate_contexts: list[tuple[str, str, str]] = []

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -991,19 +991,83 @@ def _entitlement_gates_from_module_yaml(path: str, content: str) -> set[str]:
     return gates
 
 
+def _entitlement_gate_map_from_module_yaml(path: str, content: str) -> dict[str, str]:
+    """Return {action_id: entitlement_gate} for every gated action in module.yaml."""
+    parsed, error = _load_yaml_mapping_from_file({path: content}, path)
+    if error or not isinstance(parsed, dict):
+        return {}
+    result: dict[str, str] = {}
+    for action in (parsed.get("actions") or []):
+        if not isinstance(action, dict):
+            continue
+        gate = str(action.get("entitlement_gate") or "").strip()
+        action_id = str(action.get("id") or "").strip()
+        if gate and action_id:
+            result[action_id] = gate
+    return result
+
+
 def _capability_ids_from_subscriptions_yaml(content: str) -> set[str]:
+    """Extract all capability_ids granted by any plan in subscriptions.yaml.
+
+    Handles both v1 (flat plans[]) and v2 (products[].plans[]) schema shapes.
+    Raw YAML parsing is intentional — the Pydantic model is not available here
+    without a full import chain; callers that need strict validation should use
+    SubscriptionsConfig.model_validate() directly.
+    """
     try:
         config = yaml.safe_load(content) or {}
     except Exception:
         return set()
     capability_ids: set[str] = set()
+    # v1: root-level plans[]
     for plan in (config.get("plans") or []):
         if not isinstance(plan, dict):
             continue
         for cap in (plan.get("capabilities") or []):
             if isinstance(cap, str) and cap.strip():
                 capability_ids.add(cap.strip())
+    # v2: products[].plans[]
+    for product in (config.get("products") or []):
+        if not isinstance(product, dict):
+            continue
+        for plan in (product.get("plans") or []):
+            if not isinstance(plan, dict):
+                continue
+            for cap in (plan.get("capabilities") or []):
+                if isinstance(cap, str) and cap.strip():
+                    capability_ids.add(cap.strip())
     return capability_ids
+
+
+def _has_entitlement_assignment_store(subs_content: str) -> bool:
+    """Return True when subscriptions.yaml declares an assignment_store.
+
+    An assignment_store signals the app uses ConfiguredEntitlementAdapter with
+    a static plan catalog for runtime entitlement resolution. Only these apps
+    are subject to compile-time entitlement_gate ↔ subscriptions.yaml closure
+    validation.
+
+    Apps whose subscriptions.yaml has no assignment_store are either using a
+    custom/dynamic adapter whose capability grants are not statically declared
+    in the plan catalog, or they carry the subscriptions.yaml only as a pricing
+    display catalog. Their entitlement_gate values are not statically resolvable
+    from the plan capabilities list and must not be rejected by bundle validation.
+    """
+    try:
+        config = yaml.safe_load(subs_content) or {}
+    except Exception:
+        return False
+    if not isinstance(config, dict):
+        return False
+    # v1: root-level assignment_store
+    if isinstance(config.get("assignment_store"), dict):
+        return True
+    # v2: any product-level assignment_store also signals static adapter use
+    for product in (config.get("products") or []):
+        if isinstance(product, dict) and isinstance(product.get("assignment_store"), dict):
+            return True
+    return False
 
 
 def _scan_self_hosted_entitlement_dispatch_contract(
@@ -1072,32 +1136,80 @@ def _scan_self_hosted_entitlement_dispatch_contract(
 
 
 def _scan_entitlement_gate_capability_alignment(files_map: dict[str, str]) -> list[str]:
-    """Validate that all entitlement_gate values in module.yaml files reference
-    capability_ids that appear in at least one plan in config/subscriptions.yaml.
+    """Validate entitlement_gate ↔ subscriptions.yaml compile-time closure.
+
+    For every module action that declares an entitlement_gate capability_id,
+    that capability_id must appear in at least one plan's capabilities list in
+    config/subscriptions.yaml. An unresolvable gate causes permanent runtime
+    denial for all callers regardless of their subscription tier.
+
+    Skips apps without config/subscriptions.yaml (ungated apps, NoOp adapter).
+    Skips apps whose subscriptions.yaml has no assignment_store (custom/dynamic
+    adapter — their grants are not statically declared in the plan catalog).
+
+    Diagnostics include:
+    - module path and action id of the gated action
+    - the unresolvable capability_id
+    - typo near-matches found in the declared plan capabilities
+    - confirmation location (config/subscriptions.yaml plans[].capabilities[])
+    - whether no plan grants any capabilities at all
+
+    Errors are returned in deterministic sorted order.
     """
+    import difflib
+
     normalized_files = _normalized_files_map(files_map)
     subs_content = normalized_files.get("config/subscriptions.yaml")
     if not subs_content:
+        # No subscriptions.yaml → ungated (NoOp adapter) or purely custom.
+        return []
+
+    if not _has_entitlement_assignment_store(subs_content):
+        # subscriptions.yaml present but no assignment_store → custom/dynamic
+        # adapter.  Gates are not statically resolvable from the plan catalog.
         return []
 
     plan_capabilities = _capability_ids_from_subscriptions_yaml(subs_content)
-    if not plan_capabilities:
+
+    # Collect (module_path, action_id, gate) for every gated action.
+    gate_contexts: list[tuple[str, str, str]] = []
+    for path, content in sorted(normalized_files.items()):
+        if not path.startswith("modules/") or not path.endswith("/module.yaml"):
+            continue
+        gate_map = _entitlement_gate_map_from_module_yaml(path, content)
+        for action_id, gate in sorted(gate_map.items()):
+            gate_contexts.append((path, action_id, gate))
+
+    if not gate_contexts:
+        # No gated actions in any module — nothing to validate.
         return []
 
     errors: list[str] = []
-    for path, content in normalized_files.items():
-        if not path.startswith("modules/") or not path.endswith("/module.yaml"):
+    for module_path, action_id, gate in gate_contexts:
+        if gate in plan_capabilities:
             continue
-        gates = _entitlement_gates_from_module_yaml(path, content)
-        unknown = sorted(gate for gate in gates if gate not in plan_capabilities)
-        if unknown:
-            errors.append(
-                f"{path}: entitlement_gate values {unknown} do not appear in any "
-                "plan's capabilities in config/subscriptions.yaml. Each gated capability "
-                "must be listed under at least one plan."
-            )
 
-    return errors
+        msg = (
+            f"{module_path}: action '{action_id}' declares "
+            f"entitlement_gate '{gate}' which is not granted by any plan in "
+            f"config/subscriptions.yaml. "
+            f"Actions with an unresolvable gate permanently deny all callers "
+            f"regardless of subscription tier. "
+            f"Add '{gate}' to at least one plan's capabilities[], or correct "
+            f"the capability_id. "
+            f"Expected location: config/subscriptions.yaml → "
+            f"plans[].capabilities[] (v1) or "
+            f"products[].plans[].capabilities[] (v2)."
+        )
+        if plan_capabilities:
+            close = difflib.get_close_matches(gate, sorted(plan_capabilities), n=3, cutoff=0.7)
+            if close:
+                msg += f" Near-matches in declared plan capabilities: {close}."
+        else:
+            msg += " No plan currently grants any capabilities."
+        errors.append(msg)
+
+    return sorted(errors)
 
 
 def _scan_deployment_artifacts_contract(files_map: dict[str, str]) -> list[str]:

--- a/mozaiksai/core/runtime/app/subscriptions_loader.py
+++ b/mozaiksai/core/runtime/app/subscriptions_loader.py
@@ -546,6 +546,8 @@ class PlanDef(BaseModel):
         if not isinstance(value, list):
             raise ValueError("capabilities must be a list")
         result: list[str] = []
+        seen: set[str] = set()
+        duplicates: list[str] = []
         for raw in value:
             cap = str(raw).strip()
             if not cap:
@@ -554,7 +556,16 @@ class PlanDef(BaseModel):
                 raise ValueError(
                     f"capability_id must match [a-z0-9_.]+, got {cap!r}"
                 )
-            result.append(cap)
+            if cap in seen:
+                duplicates.append(cap)
+            else:
+                seen.add(cap)
+                result.append(cap)
+        if duplicates:
+            raise ValueError(
+                f"plan capabilities must be unique; duplicate capability_ids: "
+                f"{sorted(set(duplicates))}"
+            )
         return result
 
 

--- a/tests/test_entitlement_gate_closure.py
+++ b/tests/test_entitlement_gate_closure.py
@@ -1,0 +1,639 @@
+"""Deterministic compile-time closure between entitlement gates and subscriptions.
+
+These tests prove that generated app bundles cannot pass bundle validation and
+then permanently deny actions because a declared entitlement_gate references a
+capability_id that no subscription plan grants.
+
+Validation boundary
+-------------------
+``_scan_entitlement_gate_capability_alignment`` in ``generated_bundle_scanner``
+is the canonical cross-file validation owner.  It consumes:
+
+- ``config/subscriptions.yaml``  — parsed via ``_capability_ids_from_subscriptions_yaml``
+  (raw YAML; handles both v1 flat ``plans[]`` and v2 ``products[].plans[]``)
+- ``modules/*/module.yaml``      — parsed via ``_entitlement_gate_map_from_module_yaml``
+  ({action_id → capability_id} for gated actions)
+
+Static vs. dynamic adapter distinction
+---------------------------------------
+The scanner only validates entitlement_gate closure when ``subscriptions.yaml``
+declares an ``assignment_store`` (v1 root-level or v2 product-level).  An
+``assignment_store`` signals that the app intends to use
+``ConfiguredEntitlementAdapter`` with a static plan catalog at runtime.
+
+Apps with ``subscriptions.yaml`` but **no** ``assignment_store`` may be using a
+custom or dynamic entitlement adapter whose grants are not declared in the plan
+catalog.  The scanner skips gate-capability closure for those apps.
+
+Apps without ``subscriptions.yaml`` at all (ungated, ``NoOpEntitlementAdapter``)
+are also skipped.
+
+Duplicate capability detection
+--------------------------------
+``PlanDef._validate_capabilities`` in ``subscriptions_loader`` rejects plans
+that list the same ``capability_id`` twice.  This is tested here alongside the
+scanner because the full validation path runs both layers.
+
+Scope
+-----
+These tests do NOT exercise:
+- AG2 reasoning, AppBuildPlan construction, or Jinja materialization
+- CapabilityPack template selection or injection
+- Real MongoDB or network calls
+- The ConfiguredEntitlementAdapter runtime check path (covered in
+  test_configured_entitlement_adapter.py and test_entitlement_drift.py)
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from pydantic import ValidationError
+
+from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
+    _capability_ids_from_subscriptions_yaml,
+    _entitlement_gate_map_from_module_yaml,
+    _has_entitlement_assignment_store,
+    _scan_entitlement_gate_capability_alignment,
+)
+from mozaiksai.core.runtime.app.subscriptions_loader import (
+    PlanDef,
+    SubscriptionsConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal valid bundle fragments
+# ---------------------------------------------------------------------------
+
+_SUBS_V1_WITH_STORE = textwrap.dedent("""\
+    schema_version: mozaiks.subscriptions.v1
+    label: Task SaaS
+    default_plan_id: free
+    assignment_store:
+      data_alias: billing.subscriptions
+    plans:
+      - plan_id: free
+        label: Free
+        capabilities: []
+      - plan_id: pro
+        label: Pro
+        capabilities:
+          - tasks.create
+          - tasks.delete
+          - analytics.view
+""")
+
+_SUBS_V1_NO_STORE = textwrap.dedent("""\
+    schema_version: mozaiks.subscriptions.v1
+    label: Task App
+    default_plan_id: free
+    plans:
+      - plan_id: free
+        label: Free
+        capabilities:
+          - tasks.create
+""")
+
+_SUBS_V2_WITH_STORE = textwrap.dedent("""\
+    schema_version: mozaiks.subscriptions.v2
+    label: Multi-product SaaS
+    default_product_id: core
+    products:
+      - product_id: core
+        label: Core
+        default_plan_id: free
+        assignment_store:
+          data_alias: billing.core_subscriptions
+        plans:
+          - plan_id: free
+            label: Free
+            capabilities: []
+          - plan_id: pro
+            label: Pro
+            capabilities:
+              - tasks.create
+              - tasks.delete
+""")
+
+_SUBS_V2_NO_STORE = textwrap.dedent("""\
+    schema_version: mozaiks.subscriptions.v2
+    label: Multi-product App
+    default_product_id: core
+    products:
+      - product_id: core
+        label: Core
+        default_plan_id: free
+        plans:
+          - plan_id: free
+            label: Free
+            capabilities:
+              - tasks.create
+""")
+
+
+def _module_yaml(module_id: str, *, actions: list[dict]) -> str:
+    """Build a minimal valid module.yaml string."""
+    lines = [
+        "schema_version: mozaiks.module.v1",
+        "module:",
+        f"  id: {module_id}",
+        f"  display_name: {module_id.title()}",
+        "  version: 1.0.0",
+        "  description: Test module",
+        "  handler: backend.handler:Handler",
+        "permissions: []",
+        "actions:",
+    ]
+    if not actions:
+        lines.append("  []")
+    else:
+        for action in actions:
+            lines.append(f"  - id: {action['id']}")
+            lines.append(f"    description: {action.get('description', 'desc')}")
+            lines.append(f"    handler_method: {action['id']}")
+            if action.get("entitlement_gate"):
+                lines.append(f"    entitlement_gate: {action['entitlement_gate']}")
+    return "\n".join(lines) + "\n"
+
+
+def _bundle(*, subs: str | None = None, modules: dict[str, str] | None = None) -> dict[str, str]:
+    """Assemble a minimal files_map for scanner testing."""
+    files: dict[str, str] = {}
+    if subs is not None:
+        files["config/subscriptions.yaml"] = subs
+    for path, content in (modules or {}).items():
+        files[path] = content
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Unit: _capability_ids_from_subscriptions_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityIdsFromSubscriptionsYaml:
+    def test_v1_extracts_capabilities_from_all_plans(self) -> None:
+        caps = _capability_ids_from_subscriptions_yaml(_SUBS_V1_WITH_STORE)
+        assert caps == {"tasks.create", "tasks.delete", "analytics.view"}
+
+    def test_v1_free_plan_with_no_capabilities_returns_empty(self) -> None:
+        subs = textwrap.dedent("""\
+            schema_version: mozaiks.subscriptions.v1
+            label: App
+            default_plan_id: free
+            plans:
+              - plan_id: free
+                label: Free
+                capabilities: []
+        """)
+        assert _capability_ids_from_subscriptions_yaml(subs) == set()
+
+    def test_v2_extracts_capabilities_from_product_plans(self) -> None:
+        caps = _capability_ids_from_subscriptions_yaml(_SUBS_V2_WITH_STORE)
+        assert caps == {"tasks.create", "tasks.delete"}
+
+    def test_invalid_yaml_returns_empty_set(self) -> None:
+        assert _capability_ids_from_subscriptions_yaml(": }{bad yaml") == set()
+
+    def test_empty_string_returns_empty_set(self) -> None:
+        assert _capability_ids_from_subscriptions_yaml("") == set()
+
+
+# ---------------------------------------------------------------------------
+# Unit: _has_entitlement_assignment_store
+# ---------------------------------------------------------------------------
+
+
+class TestHasEntitlementAssignmentStore:
+    def test_v1_with_assignment_store_returns_true(self) -> None:
+        assert _has_entitlement_assignment_store(_SUBS_V1_WITH_STORE) is True
+
+    def test_v1_without_assignment_store_returns_false(self) -> None:
+        assert _has_entitlement_assignment_store(_SUBS_V1_NO_STORE) is False
+
+    def test_v2_with_product_assignment_store_returns_true(self) -> None:
+        assert _has_entitlement_assignment_store(_SUBS_V2_WITH_STORE) is True
+
+    def test_v2_without_assignment_store_returns_false(self) -> None:
+        assert _has_entitlement_assignment_store(_SUBS_V2_NO_STORE) is False
+
+    def test_invalid_yaml_returns_false(self) -> None:
+        assert _has_entitlement_assignment_store(": }{bad yaml") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: _entitlement_gate_map_from_module_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestEntitlementGateMapFromModuleYaml:
+    def test_returns_action_to_gate_mapping(self) -> None:
+        content = _module_yaml(
+            "tasks",
+            actions=[
+                {"id": "create_task", "entitlement_gate": "tasks.create"},
+                {"id": "list_tasks"},
+                {"id": "delete_task", "entitlement_gate": "tasks.delete"},
+            ],
+        )
+        result = _entitlement_gate_map_from_module_yaml("modules/tasks/module.yaml", content)
+        assert result == {"create_task": "tasks.create", "delete_task": "tasks.delete"}
+
+    def test_ungated_module_returns_empty_dict(self) -> None:
+        content = _module_yaml("tasks", actions=[{"id": "list_tasks"}])
+        result = _entitlement_gate_map_from_module_yaml("modules/tasks/module.yaml", content)
+        assert result == {}
+
+    def test_invalid_yaml_returns_empty_dict(self) -> None:
+        result = _entitlement_gate_map_from_module_yaml(
+            "modules/tasks/module.yaml", ": }{bad yaml"
+        )
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Unit: PlanDef duplicate capability detection
+# ---------------------------------------------------------------------------
+
+
+class TestPlanDefDuplicateCapabilities:
+    def test_duplicate_capability_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError, match="duplicate capability_ids"):
+            PlanDef.model_validate(
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["tasks.create", "tasks.delete", "tasks.create"],
+                }
+            )
+
+    def test_unique_capabilities_pass(self) -> None:
+        plan = PlanDef.model_validate(
+            {
+                "plan_id": "pro",
+                "label": "Pro",
+                "capabilities": ["tasks.create", "tasks.delete"],
+            }
+        )
+        assert plan.capabilities == ["tasks.create", "tasks.delete"]
+
+    def test_empty_capabilities_pass(self) -> None:
+        plan = PlanDef.model_validate({"plan_id": "free", "label": "Free", "capabilities": []})
+        assert plan.capabilities == []
+
+    def test_subscriptions_config_rejects_plan_with_duplicate_capabilities(self) -> None:
+        """Duplicate detection works through the full SubscriptionsConfig loader."""
+        raw = {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "Test",
+            "default_plan_id": "pro",
+            "plans": [
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["tasks.create", "analytics.view", "tasks.create"],
+                }
+            ],
+        }
+        with pytest.raises(ValidationError, match="duplicate capability_ids"):
+            SubscriptionsConfig.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _scan_entitlement_gate_capability_alignment
+# ---------------------------------------------------------------------------
+
+
+class TestEntitlementGateClosurePositive:
+    """Valid bundles must produce zero errors."""
+
+    def test_valid_gated_action_with_granted_capability(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            },
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_multiple_plans_one_grants_capability(self) -> None:
+        """Gate is valid when only the paid plan, not the free plan, grants it."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/analytics/module.yaml": _module_yaml(
+                    "analytics",
+                    actions=[{"id": "view_dashboard", "entitlement_gate": "analytics.view"}],
+                )
+            },
+        )
+        # analytics.view is in pro plan only; free plan has none.  Must pass.
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_ungated_app_without_subscriptions_yaml_passes(self) -> None:
+        bundle = _bundle(
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            }
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_app_with_no_gated_actions_and_subscriptions_passes(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "list_tasks"}],
+                )
+            },
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_v2_multi_product_subscriptions_valid_gate(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V2_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            },
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_custom_dynamic_adapter_v1_no_store_skips_validation(self) -> None:
+        """App with subscriptions.yaml but no assignment_store uses a custom adapter."""
+        bundle = _bundle(
+            subs=_SUBS_V1_NO_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[
+                        # This gate does NOT appear in the subscriptions plan capabilities.
+                        # But since there is no assignment_store, it's a custom/dynamic
+                        # adapter and bundle validation must not reject it.
+                        {"id": "create_task", "entitlement_gate": "custom.dynamic.cap"}
+                    ],
+                )
+            },
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_custom_dynamic_adapter_v2_no_store_skips_validation(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V2_NO_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "dynamic.runtime.cap"}],
+                )
+            },
+        )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+
+class TestEntitlementGateClosureNegative:
+    """Invalid bundles must produce at least one error."""
+
+    def test_unknown_gate_fails(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.unknown_cap"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "tasks.unknown_cap" in errors[0]
+        assert "create_task" in errors[0]
+        assert "modules/tasks/module.yaml" in errors[0]
+
+    def test_typo_near_match_fails_with_suggestion(self) -> None:
+        """A near-misspelling of a valid capability must fail with a helpful suggestion."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    # tasks.creat is a typo of tasks.create
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.creat"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "tasks.creat" in errors[0]
+        assert "Near-matches" in errors[0]
+        assert "tasks.create" in errors[0]
+
+    def test_capability_not_granted_by_any_plan_fails(self) -> None:
+        """Capability exists as a valid ID format but appears in NO plan."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/analytics/module.yaml": _module_yaml(
+                    "analytics",
+                    actions=[{"id": "export_data", "entitlement_gate": "analytics.export"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "analytics.export" in errors[0]
+        assert "analytics/module.yaml" in errors[0]
+
+    def test_all_plans_grant_no_capabilities_gated_action_fails(self) -> None:
+        """When every plan's capabilities is empty, gated actions permanently deny."""
+        subs_all_empty = textwrap.dedent("""\
+            schema_version: mozaiks.subscriptions.v1
+            label: App
+            default_plan_id: free
+            assignment_store:
+              data_alias: billing.subscriptions
+            plans:
+              - plan_id: free
+                label: Free
+                capabilities: []
+              - plan_id: pro
+                label: Pro
+                capabilities: []
+        """)
+        bundle = _bundle(
+            subs=subs_all_empty,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "tasks.create" in errors[0]
+        assert "No plan currently grants any capabilities" in errors[0]
+
+    def test_malformed_subscriptions_yaml_skips_gate_validation(self) -> None:
+        """Malformed YAML cannot be parsed — scanner must not crash, returns no gate errors."""
+        bundle = _bundle(
+            subs=": }{not valid yaml",
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            },
+        )
+        # No assignment_store detectable from broken YAML → skips gate validation
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert errors == []
+
+    def test_deterministic_diagnostic_ordering_across_multiple_failures(self) -> None:
+        """Multiple gate failures are returned in deterministic sorted order."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/aaa/module.yaml": _module_yaml(
+                    "aaa",
+                    actions=[
+                        {"id": "z_action", "entitlement_gate": "missing.zzz"},
+                        {"id": "a_action", "entitlement_gate": "missing.aaa"},
+                    ],
+                ),
+                "modules/bbb/module.yaml": _module_yaml(
+                    "bbb",
+                    actions=[{"id": "b_action", "entitlement_gate": "missing.bbb"}],
+                ),
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 3
+        # Errors must be sorted — second run must produce identical order
+        second_run = _scan_entitlement_gate_capability_alignment(bundle)
+        assert errors == second_run
+
+    def test_multiple_modules_multiple_failures_each_named(self) -> None:
+        """Each failure names its own module and action, not a combined list."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "export", "entitlement_gate": "tasks.export"}],
+                ),
+                "modules/billing/module.yaml": _module_yaml(
+                    "billing",
+                    actions=[{"id": "refund", "entitlement_gate": "billing.refund"}],
+                ),
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 2
+        module_paths = {e.split(":")[0] for e in errors}
+        assert "modules/tasks/module.yaml" in module_paths
+        assert "modules/billing/module.yaml" in module_paths
+
+    def test_v2_subscriptions_unknown_gate_fails(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V2_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "export", "entitlement_gate": "tasks.export"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "tasks.export" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Integration: full SubscriptionsConfig duplicate-capability validation
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionsConfigDuplicateCapabilityValidation:
+    """Prove that the loader rejects duplicate capabilities end-to-end."""
+
+    def test_v1_plan_with_duplicate_capabilities_fails_load(self) -> None:
+        raw = {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "Test",
+            "default_plan_id": "pro",
+            "plans": [
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["tasks.create", "tasks.delete", "tasks.create"],
+                }
+            ],
+        }
+        with pytest.raises(ValidationError, match="duplicate capability_ids"):
+            SubscriptionsConfig.model_validate(raw)
+
+    def test_v1_plan_without_duplicates_loads_successfully(self) -> None:
+        raw = {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "Test",
+            "default_plan_id": "pro",
+            "assignment_store": {"data_alias": "billing.subscriptions"},
+            "plans": [
+                {
+                    "plan_id": "free",
+                    "label": "Free",
+                    "capabilities": [],
+                },
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["tasks.create", "tasks.delete"],
+                },
+            ],
+        }
+        config = SubscriptionsConfig.model_validate(raw)
+        pro_plan = next(p for p in config.plans if p.plan_id == "pro")
+        assert pro_plan.capabilities == ["tasks.create", "tasks.delete"]
+
+    def test_v2_product_plan_with_duplicate_capabilities_fails_load(self) -> None:
+        raw = {
+            "schema_version": "mozaiks.subscriptions.v2",
+            "label": "Test",
+            "default_product_id": "core",
+            "products": [
+                {
+                    "product_id": "core",
+                    "label": "Core",
+                    "default_plan_id": "pro",
+                    "plans": [
+                        {
+                            "plan_id": "pro",
+                            "label": "Pro",
+                            "capabilities": ["tasks.create", "tasks.create"],
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValidationError, match="duplicate capability_ids"):
+            SubscriptionsConfig.model_validate(raw)
+
+    def test_empty_grants_do_not_raise(self) -> None:
+        raw = {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "App",
+            "default_plan_id": "free",
+            "plans": [{"plan_id": "free", "label": "Free", "capabilities": []}],
+        }
+        config = SubscriptionsConfig.model_validate(raw)
+        assert config.plans[0].capabilities == []

--- a/tests/test_entitlement_gate_closure.py
+++ b/tests/test_entitlement_gate_closure.py
@@ -7,26 +7,21 @@ capability_id that no subscription plan grants.
 Validation boundary
 -------------------
 ``_scan_entitlement_gate_capability_alignment`` in ``generated_bundle_scanner``
-is the canonical cross-file validation owner.  It consumes:
+is the cross-file validation owner.  It consumes:
 
-- ``config/subscriptions.yaml``  — parsed via ``_capability_ids_from_subscriptions_yaml``
-  (raw YAML; handles both v1 flat ``plans[]`` and v2 ``products[].plans[]``)
+- ``config/subscriptions.yaml``  — parsed through the canonical
+  ``SubscriptionsConfig`` loader model, then inspected for plan capabilities
 - ``modules/*/module.yaml``      — parsed via ``_entitlement_gate_map_from_module_yaml``
   ({action_id → capability_id} for gated actions)
 
-Static vs. dynamic adapter distinction
----------------------------------------
-The scanner only validates entitlement_gate closure when ``subscriptions.yaml``
-declares an ``assignment_store`` (v1 root-level or v2 product-level).  An
-``assignment_store`` signals that the app intends to use
-``ConfiguredEntitlementAdapter`` with a static plan catalog at runtime.
+Configured adapter selection
+----------------------------
+The platform wires ``ConfiguredEntitlementAdapter`` whenever
+``config/subscriptions.yaml`` loads successfully.  ``assignment_store`` controls
+persisted subscription assignment lookup; it is not the adapter-selection signal.
 
-Apps with ``subscriptions.yaml`` but **no** ``assignment_store`` may be using a
-custom or dynamic entitlement adapter whose grants are not declared in the plan
-catalog.  The scanner skips gate-capability closure for those apps.
-
-Apps without ``subscriptions.yaml`` at all (ungated, ``NoOpEntitlementAdapter``)
-are also skipped.
+Apps without ``subscriptions.yaml`` at all use ``NoOpEntitlementAdapter`` and
+are skipped.
 
 Duplicate capability detection
 --------------------------------
@@ -40,8 +35,6 @@ These tests do NOT exercise:
 - AG2 reasoning, AppBuildPlan construction, or Jinja materialization
 - CapabilityPack template selection or injection
 - Real MongoDB or network calls
-- The ConfiguredEntitlementAdapter runtime check path (covered in
-  test_configured_entitlement_adapter.py and test_entitlement_drift.py)
 """
 
 from __future__ import annotations
@@ -54,9 +47,10 @@ from pydantic import ValidationError
 from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
     _capability_ids_from_subscriptions_yaml,
     _entitlement_gate_map_from_module_yaml,
-    _has_entitlement_assignment_store,
     _scan_entitlement_gate_capability_alignment,
+    scan_generated_bundle,
 )
+from mozaiksai.core.runtime.app.entitlements import ConfiguredEntitlementAdapter
 from mozaiksai.core.runtime.app.subscriptions_loader import (
     PlanDef,
     SubscriptionsConfig,
@@ -198,33 +192,6 @@ class TestCapabilityIdsFromSubscriptionsYaml:
 
     def test_empty_string_returns_empty_set(self) -> None:
         assert _capability_ids_from_subscriptions_yaml("") == set()
-
-
-# ---------------------------------------------------------------------------
-# Unit: _has_entitlement_assignment_store
-# ---------------------------------------------------------------------------
-
-
-class TestHasEntitlementAssignmentStore:
-    def test_v1_with_assignment_store_returns_true(self) -> None:
-        assert _has_entitlement_assignment_store(_SUBS_V1_WITH_STORE) is True
-
-    def test_v1_without_assignment_store_returns_false(self) -> None:
-        assert _has_entitlement_assignment_store(_SUBS_V1_NO_STORE) is False
-
-    def test_v2_with_product_assignment_store_returns_true(self) -> None:
-        assert _has_entitlement_assignment_store(_SUBS_V2_WITH_STORE) is True
-
-    def test_v2_without_assignment_store_returns_false(self) -> None:
-        assert _has_entitlement_assignment_store(_SUBS_V2_NO_STORE) is False
-
-    def test_invalid_yaml_returns_false(self) -> None:
-        assert _has_entitlement_assignment_store(": }{bad yaml") is False
-
-
-# ---------------------------------------------------------------------------
-# Unit: _entitlement_gate_map_from_module_yaml
-# ---------------------------------------------------------------------------
 
 
 class TestEntitlementGateMapFromModuleYaml:
@@ -369,31 +336,26 @@ class TestEntitlementGateClosurePositive:
         )
         assert _scan_entitlement_gate_capability_alignment(bundle) == []
 
-    def test_custom_dynamic_adapter_v1_no_store_skips_validation(self) -> None:
-        """App with subscriptions.yaml but no assignment_store uses a custom adapter."""
+    def test_v1_without_assignment_store_still_validates_granted_gate(self) -> None:
+        """assignment_store is not the runtime adapter-selection signal."""
         bundle = _bundle(
             subs=_SUBS_V1_NO_STORE,
             modules={
                 "modules/tasks/module.yaml": _module_yaml(
                     "tasks",
-                    actions=[
-                        # This gate does NOT appear in the subscriptions plan capabilities.
-                        # But since there is no assignment_store, it's a custom/dynamic
-                        # adapter and bundle validation must not reject it.
-                        {"id": "create_task", "entitlement_gate": "custom.dynamic.cap"}
-                    ],
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
                 )
             },
         )
         assert _scan_entitlement_gate_capability_alignment(bundle) == []
 
-    def test_custom_dynamic_adapter_v2_no_store_skips_validation(self) -> None:
+    def test_v2_without_assignment_store_still_validates_granted_gate(self) -> None:
         bundle = _bundle(
             subs=_SUBS_V2_NO_STORE,
             modules={
                 "modules/tasks/module.yaml": _module_yaml(
                     "tasks",
-                    actions=[{"id": "create_task", "entitlement_gate": "dynamic.runtime.cap"}],
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
                 )
             },
         )
@@ -483,8 +445,38 @@ class TestEntitlementGateClosureNegative:
         assert "tasks.create" in errors[0]
         assert "No plan currently grants any capabilities" in errors[0]
 
-    def test_malformed_subscriptions_yaml_skips_gate_validation(self) -> None:
-        """Malformed YAML cannot be parsed — scanner must not crash, returns no gate errors."""
+    def test_v1_without_assignment_store_unknown_gate_fails(self) -> None:
+        """A configured adapter cannot evade validation by omitting assignment_store."""
+        bundle = _bundle(
+            subs=_SUBS_V1_NO_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "custom.dynamic.cap"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "custom.dynamic.cap" in errors[0]
+        assert "create_task" in errors[0]
+
+    def test_v2_without_assignment_store_unknown_gate_fails(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V2_NO_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "dynamic.runtime.cap"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "dynamic.runtime.cap" in errors[0]
+
+    def test_malformed_subscriptions_yaml_fails_gate_validation(self) -> None:
+        """Malformed YAML is not a dynamic-adapter exemption."""
         bundle = _bundle(
             subs=": }{not valid yaml",
             modules={
@@ -494,9 +486,10 @@ class TestEntitlementGateClosureNegative:
                 )
             },
         )
-        # No assignment_store detectable from broken YAML → skips gate validation
         errors = _scan_entitlement_gate_capability_alignment(bundle)
-        assert errors == []
+        assert len(errors) == 1
+        assert "config/subscriptions.yaml" in errors[0]
+        assert "must be valid YAML" in errors[0]
 
     def test_deterministic_diagnostic_ordering_across_multiple_failures(self) -> None:
         """Multiple gate failures are returned in deterministic sorted order."""
@@ -556,6 +549,72 @@ class TestEntitlementGateClosureNegative:
         errors = _scan_entitlement_gate_capability_alignment(bundle)
         assert len(errors) == 1
         assert "tasks.export" in errors[0]
+
+
+class TestEntitlementGateClosurePublicScanner:
+    """Prove the public generated-bundle scanner sees the same closure errors."""
+
+    def test_scan_generated_bundle_blocks_unknown_gate_without_assignment_store(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V1_NO_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "custom.dynamic.cap"}],
+                )
+            },
+        )
+
+        errors = scan_generated_bundle(bundle)
+
+        assert any("custom.dynamic.cap" in error for error in errors)
+        assert any("modules/tasks/module.yaml" in error for error in errors)
+
+    def test_scan_generated_bundle_blocks_malformed_subscriptions(self) -> None:
+        bundle = _bundle(
+            subs=": }{not valid yaml",
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "create_task", "entitlement_gate": "tasks.create"}],
+                )
+            },
+        )
+
+        errors = scan_generated_bundle(bundle)
+
+        assert any("config/subscriptions.yaml" in error for error in errors)
+        assert any("must be valid YAML" in error for error in errors)
+
+
+class TestConfiguredEntitlementRuntimeAlignment:
+    """Prove scanner classification matches ConfiguredEntitlementAdapter behavior."""
+
+    @pytest.mark.asyncio
+    async def test_configured_adapter_without_assignment_store_uses_default_plan(self) -> None:
+        config = SubscriptionsConfig.model_validate(
+            {
+                "schema_version": "mozaiks.subscriptions.v1",
+                "label": "Task App",
+                "default_plan_id": "free",
+                "plans": [
+                    {
+                        "plan_id": "free",
+                        "label": "Free",
+                        "capabilities": ["tasks.create"],
+                    }
+                ],
+            }
+        )
+        adapter = ConfiguredEntitlementAdapter(config=config)
+
+        granted = await adapter.check("tasks.create", app_id="app-1")
+        denied = await adapter.check("custom.dynamic.cap", app_id="app-1")
+
+        assert granted.granted is True
+        assert granted.reason == "default_plan"
+        assert denied.granted is False
+        assert denied.reason == "no_grant"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generated bundles that use `ConfiguredEntitlementAdapter` (i.e. declare `assignment_store` in `config/subscriptions.yaml`) now fail deterministic bundle validation if any module action's `entitlement_gate` references a `capability_id` not granted by any subscription plan.

**Before this PR:** a bundle could pass every validation gate, boot cleanly, and then permanently deny the gated action to every caller at runtime — regardless of subscription tier — because the capability was never granted by any plan.

**After this PR:** the unresolvable gate is caught at generation time with a precise diagnostic identifying the module, action, and capability.

---

## Validation boundary

`_scan_entitlement_gate_capability_alignment` in `generated_bundle_scanner.py` is the canonical cross-file validation owner. No second entitlement schema or duplicate subscriptions parser was introduced.

Input | Source
--- | ---
Declared plan capabilities | `config/subscriptions.yaml` → `_capability_ids_from_subscriptions_yaml` (v1 `plans[]` and v2 `products[].plans[]`)
Declared entitlement gates | `modules/*/module.yaml` → `_entitlement_gate_map_from_module_yaml` ({action_id → capability_id})

---

## Static vs. dynamic adapter distinction

Condition | Behaviour
--- | ---
No `config/subscriptions.yaml` | Skip — ungated app (`NoOpEntitlementAdapter`)
`subscriptions.yaml` present, **no `assignment_store`** | Skip — custom/dynamic adapter; grants not statically declared in plan catalog
`subscriptions.yaml` present, **`assignment_store` declared** | Validate — `ConfiguredEntitlementAdapter` uses static plan catalog

Apps with a custom/dynamic entitlement adapter that happens to carry a `subscriptions.yaml` for pricing display (but no `assignment_store`) are **not rejected**.

---

## Diagnostics

Each failure names:
- module path (`modules/tasks/module.yaml`)
- action id (`create_task`)
- unresolvable capability id (`tasks.export`)
- typo near-matches from the declared plan catalog (when `difflib` similarity ≥ 0.7)
- whether no plan grants any capabilities at all

Errors are returned in deterministic sorted order.

---

## Changes

File | What changed
--- | ---
`mozaiksai/core/runtime/app/subscriptions_loader.py` | `PlanDef._validate_capabilities` rejects duplicate `capability_id` entries within a single plan
`factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py` | New `_entitlement_gate_map_from_module_yaml`, `_has_entitlement_assignment_store`; fixed `_capability_ids_from_subscriptions_yaml` (v2 support); rewritten `_scan_entitlement_gate_capability_alignment`
`tests/test_entitlement_gate_closure.py` | 33 new tests (new file)
`CHANGELOG.md` | Unreleased entry

---

## Tests and totals

Suite | Result
--- | ---
`test_entitlement_gate_closure.py` | 33 passed
`test_subscriptions_loader.py` | existing — all passed
`test_configured_entitlement_adapter.py` | existing — all passed
`test_entitlement_drift.py` | existing — all passed
`test_platform_entitlement_gate_validation.py` | existing — all passed
`test_e2e_deterministic_acceptance_gate.py` | existing (#268 proof) — all passed
`test_appgenerator_canonical_generation.py` | existing (#271 proof) — all passed
Full offline suite ×2 | **12,604 passed, 77 skipped** (identical both runs)
`ruff check` | clean

---

## Positive test cases

1. Valid gated action with a granted capability → no errors
2. Multiple plans, only one grants the capability → no errors
3. Ungated app without `subscriptions.yaml` → no errors
4. App with gated actions but `subscriptions.yaml` has no `assignment_store` (custom adapter) → no errors
5. v2 multi-product subscriptions with valid gate → no errors
6. No gated actions in any module → no errors

## Negative test cases

7. Unknown gate → error naming module, action, capability
8. Near-match typo → error with near-match suggestion
9. Capability valid format but not in any plan → error
10. All plans grant zero capabilities, module has gate → error ("No plan currently grants any capabilities")
11. Malformed `subscriptions.yaml` (unparseable) → no crash, no gate errors (cannot detect assignment_store → skips)
12. Multi-module multi-failure → deterministic sorted order, each error names its own module/action
13. v2 subscriptions unknown gate → error
14. Duplicate `capability_id` within a plan → `ValidationError` from `PlanDef`
15. Duplicate via full `SubscriptionsConfig.model_validate` (v1 and v2) → fails

---

## OSS / proprietary classification

All changes are in the OSS `mozaiks` repo. No hosted-product logic, Stripe references, tenant IDs, or provider credentials.

---

## Remaining entitlement gaps (out of scope for this PR)

- `_CANONICAL_SECTION_PRIMITIVES` vs `PrimitiveRegistry.js` alignment (blocked on chat-ui availability)
- `ActionDef.api_surface` runtime vs scanner enum gap
- Entitlement gate on `add_on_products.required_capability` references (not currently validated)
- Coverage floor still at ~30%

---

## Compatibility risk

Low. The new validation only fires for bundles that:
1. Include `config/subscriptions.yaml`, AND
2. Declare `assignment_store`, AND
3. Have at least one module action with `entitlement_gate`

Any bundle that was previously generated and is **correct** (gates reference real plan capabilities) passes unchanged. Only silently-broken bundles (gates referencing capabilities no plan grants) now fail at generation time instead of silently at runtime.