### PR TITLE
feat(ag2): record task batch lifecycle evidence

### DIFF
--- a/docs/architecture/mozaiksai/task-batches.md
+++ b/docs/architecture/mozaiksai/task-batches.md
@@ -127,20 +127,20 @@ phased AG2 Network execution:
 parent AG2 workflow phase
   -> decomposition/trigger agent emits structured task list
   -> Mozaiks extracts tasks and dependency graph
-  -> each ready task runs in its own AG2 workflow channel
+  -> each ready task runs as an AG2 Task lifecycle-wrapped worker turn
   -> Mozaiks validates and merges task outputs
   -> downstream AG2 workflow phase starts with result context keys populated
 ```
 
-For a matching batch, each task item is executed through AG2 Network:
+For a matching batch, each task item is executed through the task-batch runner:
 
 ```text
 task.initial_agent
   -> create/select that AG2 agent
-  -> open one-task AG2 workflow channel
-  -> pass task_context through workflow channel context_vars
-  -> AG2 default handler invokes the worker
-  -> read worker output from AG2 WAL / structured output result
+  -> create an AG2 Task with a standalone stream
+  -> pass task_context through the worker turn variables/dependencies
+  -> AG2 Agent.ask invokes the worker
+  -> record AG2 Task lifecycle events from the task stream
   -> normalize returned structured/code output
   -> validate output stays within task-owned paths
 ```
@@ -257,7 +257,7 @@ Use task batches when work is:
 
 - a typed list of similar items;
 - bounded to one workflow's context;
-- safe to execute as bounded AG2 task channels;
+- safe to execute as bounded AG2 Task lifecycle-wrapped worker turns;
 - mergeable through one declared result key;
 - short enough that independent child sessions are unnecessary.
 

--- a/docs/architecture/workflows/ag2-execution-alignment-plan.md
+++ b/docs/architecture/workflows/ag2-execution-alignment-plan.md
@@ -45,7 +45,7 @@ Important AG2 facts:
 | `mozaiksai/core/workflow/orchestration_patterns.py` | Loads workflow config, persistence, context, agents, lifecycle, transport, then invokes `AG2NetworkRunner` | Keep as Mozaiks run setup/teardown. Generic turn execution belongs to AG2 Hub/AgentClient. |
 | `mozaiksai/core/workflow/outputs/runtime_validation.py` and `runtime_events.py` | Validate AG2 reply bodies against Mozaiks structured-output contracts and emit runtime validation events | Keep. These are Mozaiks contract observers around AG2 envelopes, not an execution loop. |
 | `mozaiksai/core/workflow/execution/network_graph.py` | Compiles `transition_graph.yaml` to AG2 `TransitionGraph`; resolves next speaker through `WorkflowAdapter.fold` manually | Keep compile logic. Remove manual fold as primary runtime routing once Hub workflow channels drive progression. |
-| `mozaiksai/core/workflow/task_batches.py` | Validates batch/conveyor config, extracts typed task lists, dependency-sorts tasks, runs workers through AG2 task channels, merges outputs into context | Keep typed DAG contract, dependency scheduler, ownership validation, and result merge. Worker invocation belongs to AG2 Network channels. |
+| `mozaiksai/core/workflow/task_batches.py` | Validates batch/conveyor config, extracts typed task lists, dependency-sorts tasks, runs workers through AG2 Task lifecycle-wrapped turns, merges outputs into context | Keep typed DAG contract, dependency scheduler, ownership validation, and result merge. Current worker invocation uses standalone AG2 Task stream evidence; future Hub-backed worker channels should use real AG2 channel ids and TaskMirror. |
 | `mozaiksai/core/workflow/execution/stream_bridge.py` | Bridges AG2 stream events to Mozaiks transport | Keep, but attach to AG2 channel/task streams rather than only a local per-turn stream. |
 
 ## Target Execution Shape
@@ -290,17 +290,18 @@ runtime `Agent.ask(...)` calls.
 Current checkpoint:
 
 - `mozaiksai/core/adapters/ag2_task_batch_runner.py` executes one deterministic
-  task-batch work item through an AG2 workflow channel and reads the worker
-  output from AG2 WAL / structured output results.
+  task-batch work item as an AG2 Task lifecycle-wrapped worker turn and records
+  normalized Task stream evidence.
 - `mozaiksai/core/workflow/task_batches.py` still owns task extraction,
   dependency readiness, concurrency, failure policy, output ownership, and
   result merge, but no longer calls worker agents directly.
-- Worker task context is passed through AG2 workflow channel `context_vars`, so
-  downstream worker prompts/tools consume AG2 channel state instead of a
-  Mozaiks-only `variables` kwarg.
+- Worker task context is passed through the scoped worker turn variables and
+  dependencies; this standalone path does not create a per-task AG2 Network
+  channel or WAL.
 - `run_workflow_orchestration(...)` supports task-batch workflows through
   phased AG2 Network execution: trigger-agent phase, deterministic task
-  channels, then downstream continuation phase with batch result context.
+  lifecycle-wrapped worker turns, then downstream continuation phase with batch
+  result context.
 - `tests/test_ag2_network_execution_alignment.py` verifies planner -> task
   batch -> synthesis execution across AG2 phases.
 

--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -11,10 +11,10 @@ current replacement plan lives in
 
 ## Current Baseline
 
-Reviewed on July 28, 2026 against:
+Reviewed on August 14, 2026 against:
 
-- installed package: `ag2==1.0.0` from the `ag2` import package
-- declared dependency: `ag2[a2a,openai,tracing]==1.0.0`
+- installed package: `ag2==1.0.1` from the `ag2` import package
+- declared dependency: `ag2[a2a,openai,tracing]==1.0.1`
 - AG2 docs:
   - <https://docs.ag2.ai/latest/docs/beta/network/overview/>
   - <https://docs.ag2.ai/latest/docs/beta/network/hub_and_identity/>
@@ -50,11 +50,11 @@ Mozaiks still owns deterministic product contracts around those primitives:
 | AG2 workflow runner boundary | `mozaiksai/core/adapters/ag2_network_runner.py`, `mozaiksai/core/adapters/ag2_orchestration.py` | Mozaiks must adapt workflow YAML, app/session IDs, structured-output registry, and Mozaiks `RunResult` semantics to AG2 Hub channels. | If AG2 adds a stable high-level workflow runner over `Hub`/`AgentClient`, shrink `AG2NetworkRunner` to request/result conversion only. |
 | Turn failure result mapping | `mozaiksai/core/adapters/ag2_network_runner.py` | AG2 reports agent turn crashes through `HubListener.on_turn_failed` while leaving the channel alive. Mozaiks maps that listener event to a failed `RunResult` so runtime callers do not wait for channel timeout. | If AG2 Workflow channels gain first-class failure policy or auto-close behavior for turn crashes, replace the local listener with the native channel result. |
 | Round-end context mutation bridge | `_install_context_update_handler` in `mozaiksai/core/adapters/ag2_network_runner.py` | Mozaiks tools mutate `ContextVariablesBridge`, while AG2 workflow routing reads packet `context_updates` before `WorkflowAdapter.fold(...)` selects the next speaker. The current bridge wraps AG2's default handler to merge those updates into `EV_PACKET`. | Replace with an AG2-supported round-end packet transform hook, default-handler middleware, or native context update helper when available. This is the most fragile divergence. |
-| Source-scoped deterministic transition conditions | `mozaiksai/core/adapters/ag2_transition_conditions.py`, `mozaiksai/core/workflow/execution/network_graph.py` | Mozaiks workflow YAML declares `source_agent` per rule, while AG2 `ContextEquals` and `ToolCalled` do not include source scope by themselves. AG2 1.0.0 does not ship an upstream expression evaluator for Mozaiks `${var}` workflow contracts, so Mozaiks keeps a small deterministic evaluator at the adapter boundary. | If AG2 adds native condition composition such as `FromSpeaker AND ContextEquals`, `FromSpeaker AND ToolCalled`, or a native expression evaluator, replace the local adapters with native composition. |
+| Source-scoped deterministic transition conditions | `mozaiksai/core/adapters/ag2_transition_conditions.py`, `mozaiksai/core/workflow/execution/network_graph.py` | Mozaiks workflow YAML declares `source_agent` per rule, while AG2 `ContextEquals` and `ToolCalled` do not include source scope by themselves. AG2 1.0.1 does not ship an upstream expression evaluator for Mozaiks `${var}` workflow contracts, so Mozaiks keeps a small deterministic evaluator at the adapter boundary. | If AG2 adds native condition composition such as `FromSpeaker AND ContextEquals`, `FromSpeaker AND ToolCalled`, or a native expression evaluator, replace the local adapters with native composition. |
 | One-shot workflow bootstrap transition | `BootstrapInitialDispatch` in `mozaiksai/core/adapters/ag2_transition_conditions.py`, injected by `AG2NetworkRunner._compile_graph_with_initiator(...)` | Mozaiks opens workflow channels from a human initiator and injects a first-turn dispatch to the declared initial agent. This condition is intentionally bootstrap-only and cannot be configured as a general workflow-author transition. | Remove this adapter if AG2 exposes a native workflow-channel startup target that dispatches the initial message without adding a reusable human-speaker transition. |
 | Structured-output validation after AG2 packets | `mozaiksai/core/workflow/outputs/runtime_validation.py`, `mozaiksai/core/workflow/outputs/runtime_events.py`, `AG2NetworkRunner._validate_wal_structured_outputs(...)` | AG2 owns model execution; Mozaiks owns canonical app/workflow/module artifact schemas and hard validation. | If AG2 Network supports per-agent `response_schema` on workflow channels, use it for model pressure, but keep Mozaiks validation as the artifact contract authority. |
-| Task-batch scheduling and result merge | `mozaiksai/core/workflow/task_batches.py`, `mozaiksai/core/adapters/ag2_task_batch_runner.py` | AG2 `Task` is lifecycle/observation; it does not assign, dependency-sort, enforce owned paths, or merge generated artifact outputs. | If AG2 adds a deterministic task graph/scheduler with dependency and observation semantics, move worker execution and lifecycle there while keeping Mozaiks artifact ownership validation. |
-| Phased task-batch workflow execution | `mozaiksai/core/workflow/orchestration_patterns.py` | A planning phase runs through AG2, Mozaiks executes deterministic task channels, then a continuation phase resumes with merged context. This keeps the DAG deterministic but splits one logical workflow across channels. | Replace with AG2-native parent/child workflow channels or task lineage when AG2 can preserve parent workflow context, WAL lineage, cancellation, and observation in one execution surface. |
+| Task-batch scheduling and result merge | `mozaiksai/core/workflow/task_batches.py`, `mozaiksai/core/adapters/ag2_task_batch_runner.py` | AG2 `Task` is lifecycle/observation; it does not assign, dependency-sort, enforce owned paths, or merge generated artifact outputs. Mozaiks now wraps each already-authorized worker turn in an AG2 1.0.1 `Task`, subscribes to that task's standalone `MemoryStream`, and records normalized `TaskStarted`, `TaskCompleted`, `TaskFailed`, or `TaskExpired` evidence. `TaskMirror` is not active here because AG2 requires a `HubClient` or `Hub`; no AG2 channel id or durable channel resume is claimed for this standalone path. | If AG2 adds a deterministic task graph/scheduler with dependency and observation semantics, move worker execution and lifecycle there while keeping Mozaiks artifact ownership validation. If task batches move into real Hub/AgentClient worker channels, attach `TaskMirror` and use real channel ids from AG2. |
+| Phased task-batch workflow execution | `mozaiksai/core/workflow/orchestration_patterns.py` | A planning phase runs through AG2, Mozaiks executes deterministic task lifecycle-wrapped worker turns, then a continuation phase resumes with merged context. This keeps the DAG deterministic but splits one logical workflow across channels/task streams. | Replace with AG2-native parent/child workflow channels or task lineage when AG2 can preserve parent workflow context, WAL lineage, cancellation, and observation in one execution surface. |
 | Approved-generation smoke coordinator uses AG2 task primitive | `scripts/smoke_agentgenerator_live_pack.py` | Live AgentGenerator pack smoke found the single-agent AG2 Network coordinator/metadata path timing out before packet emission, while direct AG2 task calls completed reliably. The smoke keeps the production-critical parallel workflow generation path on the real AG2 task batch runner and keeps this one-shot approved-boundary coordinator outside Mozaiks runtime code. | If AG2 Network single-agent channels gain deterministic packet emission/close behavior for one-shot coordinator calls, move the smoke coordinator/metadata calls back through `AG2NetworkRunner` or an AG2-recommended one-shot network primitive. |
 | Refinement Engine LLM checkpoints | `mozaiksai/control_plane/implementations/*`, `mozaiksai/core/adapters/ag2_agent_runner.py` | The Refinement Engine is deterministic artifact-aware policy; AG2 should only own the LLM call used for classifier/proposer/coding-plan structured output. | If AG2 Harness gains a typed one-shot agent primitive that better fits this use, adapt `AG2StructuredAgentRunner`. Do not move artifact routing, promotion, invalidation, or scoped patch policy into AG2. |
 | Studio/platform event projection | `_project_ag2_wal_to_mozaiks_transport(...)` in `mozaiksai/core/adapters/ag2_network_runner.py` | The frontend consumes Mozaiks websocket events and app-scoped chat persistence, not raw AG2 envelopes. | Prefer AG2 Hub listeners or channel event subscriptions for live projection when they support app-scoped transport and chat persistence boundaries. |
@@ -68,8 +68,8 @@ Treat these as cleanup or upstream-collaboration triggers:
   `WorkflowAdapter`/`TransitionGraph`.
 - Any new Mozaiks wrapper around `Agent.ask(...)` for multi-agent workflow
   execution outside `mozaiksai.core.adapters`.
-- Any new custom task observation stream when `TaskMirror` can provide the
-  lifecycle signal.
+- Any new custom task observation stream when a real `HubClient` or `Hub` is
+  present and `TaskMirror` can provide the lifecycle signal.
 - Any new workflow runtime state store that duplicates AG2 channel WAL or Hub
   audit without a tenant/session persistence reason.
 - Any Refinement Engine feature that lets an AG2 agent directly promote artifacts,
@@ -117,6 +117,22 @@ changes under `mozaiksai/core/workflow`, `mozaiksai/core/adapters`, or
 6. Update this file and any affected architecture docs in the same change.
 
 ## Current Decision Log
+
+### August 14, 2026
+
+- **AG2 1.0.1 task lifecycle evidence adopted for task batches**:
+  `AG2TaskBatchRunner` creates an AG2 `Task` for each deterministic
+  task-batch work item, subscribes to the task stream, executes the
+  preselected worker `Agent.ask(...)`, and records normalized lifecycle
+  evidence. Mozaiks still owns task id selection, worker selection,
+  dependencies, concurrency, prompts, context, tool profile, owned paths,
+  timeout, retries, structured-output validation, output destination, and merge
+  behavior.
+- **TaskMirror remains deferred for standalone task-batch workers**: AG2 1.0.1
+  `TaskMirror` requires a `HubClient` or `Hub`. The current task-batch runner
+  does not restructure workers into real Hub clients in this change, so it uses
+  authentic standalone Task stream events and leaves `channel_id` unset. This
+  path does not claim AG2 channel WAL or durable AG2 task/channel resume.
 
 ### July 28, 2026
 

--- a/factory_app/workflows/AgentGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AgentGenerator/structured_outputs.yaml
@@ -940,7 +940,7 @@ models:
           name is semantic drift.
       concurrency:
         type: int
-        description: Maximum concurrent AG2 task channels for ready tasks.
+        description: Maximum concurrent AG2 task lifecycle-wrapped worker turns for ready tasks.
       failure_policy:
         type: literal
         values:

--- a/mozaiksai/core/adapters/ag2_task_batch_runner.py
+++ b/mozaiksai/core/adapters/ag2_task_batch_runner.py
@@ -6,17 +6,28 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
-logger = logging.getLogger(__name__)
-
+from ag2.context import ConversationContext
+from ag2.events.task_events import (
+    TaskCancelled,
+    TaskCompleted,
+    TaskExpired,
+    TaskFailed,
+    TaskProgress,
+    TaskStarted,
+)
 from ag2.network.policies import CHANNEL_STATE_DEP
+from ag2.stream import MemoryStream
+from ag2.task import Task, TaskSpec
 
 from mozaiksai.core.ports.orchestration import RunStatus
 from mozaiksai.core.workflow.outputs.runtime_validation import (
     reply_body_to_data,
     validate_agent_structured_output,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -38,6 +49,12 @@ class AG2TaskBatchRunnerRequest:
 class AG2TaskBatchRunnerResult:
     status: RunStatus
     output: Any = None
+    task_id: str | None = None
+    capability: str | None = None
+    lifecycle_status: str | None = None
+    lifecycle_events: list[dict[str, Any]] = field(default_factory=list)
+    started_at: str | None = None
+    completed_at: str | None = None
     channel_id: str | None = None
     close_reason: str | None = None
     wal: list[dict[str, Any]] = field(default_factory=list)
@@ -45,69 +62,281 @@ class AG2TaskBatchRunnerResult:
 
 
 class AG2TaskBatchRunner:
-    """Execute one task batch worker through AG2's Agent runtime primitive."""
+    """Execute one task batch worker with authentic AG2 Task lifecycle evidence."""
 
     async def run(self, request: AG2TaskBatchRunnerRequest) -> AG2TaskBatchRunnerResult:
-        try:
-            reply = await asyncio.wait_for(
-                request.agent.ask(
-                    request.prompt,
-                    variables=dict(request.context_variables),
-                    dependencies={
-                        CHANNEL_STATE_DEP: SimpleNamespace(
-                            context_vars=dict(request.context_variables),
-                        )
-                    },
-                ),
-                timeout=float(request.timeout_seconds or 120),
-            )
-        except TimeoutError:
-            return AG2TaskBatchRunnerResult(
-                status=RunStatus.PAUSED,
-                channel_id=f"{request.batch_id}:{request.task_id}",
-                close_reason="timeout",
-                error=f"task worker did not complete within {request.timeout_seconds or 120} seconds",
-            )
-        except Exception as exc:
-            logger.error(
-                "AG2 task batch run failed batch=%s task=%s: %s",
-                request.batch_id,
-                request.task_id,
-                exc,
-                exc_info=True,
-            )
-            return AG2TaskBatchRunnerResult(
-                status=RunStatus.FAILED,
-                channel_id=f"{request.batch_id}:{request.task_id}",
-                close_reason="worker_failed",
-                error="internal_error",
-            )
+        stream = MemoryStream(persist_all=True)
+        lifecycle_events: list[dict[str, Any]] = []
 
-        validation = validate_agent_structured_output(
-            agent_name=request.agent_name,
-            reply=reply,
-            structured_registry=request.structured_registry,
+        async def _capture_lifecycle_event(event: Any) -> None:
+            normalized = _normalize_task_lifecycle_event(event)
+            if normalized is not None:
+                lifecycle_events.append(normalized)
+
+        sub_id = stream.subscribe(_capture_lifecycle_event, sync_to_thread=False)
+        dependencies = {
+            CHANNEL_STATE_DEP: SimpleNamespace(
+                context_vars=dict(request.context_variables),
+            )
+        }
+        context = ConversationContext(
+            stream=stream,
+            variables=dict(request.context_variables),
+            dependencies=dict(dependencies),
         )
-        if validation is not None:
-            if not validation.validation_passed or validation.structured_data is None:
-                return AG2TaskBatchRunnerResult(
-                    status=RunStatus.FAILED,
-                    channel_id=f"{request.batch_id}:{request.task_id}",
-                    close_reason="structured_output_validation_failed",
-                    error=(
-                        f"structured output validation failed for {request.agent_name}: "
-                        f"{validation.error}"
-                    ),
+        capability = _task_capability(request)
+        ag2_task = _create_task(request, context=context, capability=capability)
+
+        try:
+            async with ag2_task as active_task:
+                try:
+                    reply = await asyncio.wait_for(
+                        request.agent.ask(
+                            request.prompt,
+                            stream=stream,
+                            variables=dict(request.context_variables),
+                            dependencies=dependencies,
+                        ),
+                        timeout=float(request.timeout_seconds or 120),
+                    )
+                except TimeoutError:
+                    await active_task.expire()
+                    return _result_from_task(
+                        status=RunStatus.PAUSED,
+                        task=active_task,
+                        capability=capability,
+                        lifecycle_events=lifecycle_events,
+                        close_reason="expired",
+                        error=(
+                            "task worker did not complete within "
+                            f"{request.timeout_seconds or 120} seconds"
+                        ),
+                    )
+                except asyncio.CancelledError:
+                    await active_task.cancel("cancelled")
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
+                    return _result_from_task(
+                        status=RunStatus.PAUSED,
+                        task=active_task,
+                        capability=capability,
+                        lifecycle_events=lifecycle_events,
+                        close_reason="cancelled",
+                        error="task worker was cancelled",
+                    )
+                except Exception as exc:
+                    await active_task.fail(exc)
+                    logger.error(
+                        "AG2 task batch run failed batch=%s task=%s: %s",
+                        request.batch_id,
+                        request.task_id,
+                        exc,
+                        exc_info=True,
+                    )
+                    return _result_from_task(
+                        status=RunStatus.FAILED,
+                        task=active_task,
+                        capability=capability,
+                        lifecycle_events=lifecycle_events,
+                        close_reason="worker_failed",
+                        error="internal_error",
+                    )
+
+                validation = validate_agent_structured_output(
+                    agent_name=request.agent_name,
+                    reply=reply,
+                    structured_registry=request.structured_registry,
                 )
-            output = validation.structured_data
-        else:
-            output = reply_body_to_data(reply)
-        return AG2TaskBatchRunnerResult(
-            status=RunStatus.COMPLETED,
-            output=output,
-            channel_id=f"{request.batch_id}:{request.task_id}",
-            close_reason="agent_ask_completed",
+                if validation is not None:
+                    if not validation.validation_passed or validation.structured_data is None:
+                        error = (
+                            f"structured output validation failed for {request.agent_name}: "
+                            f"{validation.error}"
+                        )
+                        await active_task.fail(error)
+                        return _result_from_task(
+                            status=RunStatus.FAILED,
+                            task=active_task,
+                            capability=capability,
+                            lifecycle_events=lifecycle_events,
+                            close_reason="structured_output_validation_failed",
+                            error=error,
+                        )
+                    output = validation.structured_data
+                else:
+                    output = reply_body_to_data(reply)
+                await active_task.complete(output)
+                return _result_from_task(
+                    status=RunStatus.COMPLETED,
+                    task=active_task,
+                    capability=capability,
+                    lifecycle_events=lifecycle_events,
+                    output=output,
+                    close_reason="agent_ask_completed",
+                )
+        finally:
+            stream.unsubscribe(sub_id)
+
+
+def _task_capability(request: AG2TaskBatchRunnerRequest) -> str:
+    return ".".join(
+        [
+            "mozaiks",
+            "task_batch",
+            str(request.workflow_name or "workflow").strip() or "workflow",
+            str(request.batch_id or "batch").strip() or "batch",
+            str(request.agent_name or "agent").strip() or "agent",
+        ]
+    )
+
+
+def _create_task(
+    request: AG2TaskBatchRunnerRequest,
+    *,
+    context: ConversationContext,
+    capability: str,
+) -> Task:
+    title = f"{request.batch_id}:{request.task_id}"
+    description = (
+        "Mozaiks task-batch worker turn. Mozaiks preselected the worker, "
+        "dependencies, prompt, context, timeout, retries, schema validation, "
+        "output destination, and merge behavior."
+    )
+    payload = {
+        "workflow_name": request.workflow_name,
+        "batch_id": request.batch_id,
+        "mozaiks_task_id": request.task_id,
+        "agent_name": request.agent_name,
+        "chat_id": request.chat_id,
+        "app_id": request.app_id,
+    }
+    task_factory = getattr(request.agent, "task", None)
+    if callable(task_factory):
+        return cast(
+            Task,
+            task_factory(
+                title,
+                description=description,
+                payload=payload,
+                capability=capability,
+                ttl_seconds=request.timeout_seconds,
+                context=context,
+            ),
         )
+    return Task(
+        owner_id=request.agent_name,
+        spec=TaskSpec(
+            title=title,
+            description=description,
+            payload=payload,
+            capability=capability,
+        ),
+        context=context,
+        ttl_seconds=request.timeout_seconds,
+    )
+
+
+def _result_from_task(
+    *,
+    status: RunStatus,
+    task: Task,
+    capability: str,
+    lifecycle_events: list[dict[str, Any]],
+    close_reason: str,
+    output: Any = None,
+    error: str | None = None,
+) -> AG2TaskBatchRunnerResult:
+    metadata = task.metadata
+    return AG2TaskBatchRunnerResult(
+        status=status,
+        output=output,
+        task_id=metadata.task_id,
+        capability=capability,
+        lifecycle_status=metadata.state.value,
+        lifecycle_events=list(lifecycle_events),
+        started_at=metadata.started_at,
+        completed_at=metadata.completed_at,
+        channel_id=None,
+        close_reason=close_reason,
+        error=error,
+    )
+
+
+def _normalize_task_lifecycle_event(event: Any) -> dict[str, Any] | None:
+    if isinstance(event, TaskStarted):
+        spec = event.spec
+        return {
+            "event": "TaskStarted",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+            "capability": getattr(spec, "capability", None),
+            "expires_at": event.expires_at,
+            "payload": _json_safe(getattr(spec, "payload", {}) if spec is not None else {}),
+        }
+    if isinstance(event, TaskProgress):
+        return {
+            "event": "TaskProgress",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+            "payload": _json_safe(event.payload),
+        }
+    if isinstance(event, TaskCompleted):
+        return {
+            "event": "TaskCompleted",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+            "result": _json_safe(event.result),
+            "task_stream_id": str(event.task_stream),
+        }
+    if isinstance(event, TaskFailed):
+        return {
+            "event": "TaskFailed",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+            "error": str(event.error),
+        }
+    if isinstance(event, TaskExpired):
+        return {
+            "event": "TaskExpired",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+        }
+    if isinstance(event, TaskCancelled):
+        return {
+            "event": "TaskCancelled",
+            "task_id": event.task_id,
+            "agent_name": event.agent_name,
+            "objective": event.objective,
+            "created_at": event.created_at,
+            "reason": event.reason,
+        }
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _json_safe(model_dump(mode="json"))
+    return str(value)
 
 
 __all__ = [

--- a/mozaiksai/core/workflow/task_batches.py
+++ b/mozaiksai/core/workflow/task_batches.py
@@ -339,9 +339,9 @@ async def execute_task_batches_for_trigger(
 ) -> dict[str, Any]:
     """Execute workflow-local task batches triggered by an agent turn.
 
-    Each task item runs through its own AG2 workflow channel. Normalized outputs
-    are written back to context, then the parent AG2 Network channel continues
-    from the next declared transition.
+    Each task item runs as a Mozaiks-scheduled worker turn wrapped in AG2 Task
+    lifecycle evidence. Normalized outputs are written back to context, then the
+    parent AG2 Network channel continues from the next declared transition.
     """
 
     if not batches_config or not batches_config.batches:
@@ -671,7 +671,7 @@ async def _run_one_task(
             last_error = runner_result.error or runner_result.status.value
         if runner_result is None or runner_result.status is not RunStatus.COMPLETED:
             raise RuntimeError(
-                f"AG2 task channel failed for task {task.get('task_id')!r}: {last_error or 'unknown error'}"
+        f"AG2 task lifecycle failed for task {task.get('task_id')!r}: {last_error or 'unknown error'}"
             )
 
     output = _normalize_agent_reply(runner_result.output)
@@ -699,8 +699,14 @@ async def _run_one_task(
     output.setdefault("_worker_agent", agent_name)
     output.setdefault("_owned_paths", list(task.get("owned_paths") or []))
     output.setdefault(
-        "_ag2_task_channel",
+        "_ag2_task_lifecycle",
         {
+            "task_id": runner_result.task_id,
+            "capability": runner_result.capability,
+            "status": runner_result.lifecycle_status,
+            "events": list(runner_result.lifecycle_events),
+            "started_at": runner_result.started_at,
+            "completed_at": runner_result.completed_at,
             "channel_id": runner_result.channel_id,
             "close_reason": runner_result.close_reason,
         },

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -1227,7 +1227,7 @@ async def test_run_workflow_orchestration_executes_task_batches_between_ag2_phas
         "WorkerAgent",
         lambda context: {
             "task_id": context["current_task_id"],
-            "summary": "Worker used AG2 task channel context.",
+            "summary": "Worker used AG2 task lifecycle context.",
             "owned_paths": context["current_task"]["owned_paths"],
             "agent_message": "Worker done.",
         },
@@ -1313,7 +1313,7 @@ async def test_run_workflow_orchestration_executes_task_batches_between_ag2_phas
     assert worker_agent.context_seen[0]["current_task_id"] == "module_contract"
     assert synthesis_agent.context_seen[0]["runtime_tasks_status"] == "completed"
     assert synthesis_agent.context_seen[0]["runtime_tasks_results"]["module_contract"]["summary"] == (
-        "Worker used AG2 task channel context."
+        "Worker used AG2 task lifecycle context."
     )
     assert [message["agent_name"] for message in persistence.assistant_messages] == [
         "PlannerAgent",

--- a/tests/test_runtime_task_batch_smoke.py
+++ b/tests/test_runtime_task_batch_smoke.py
@@ -492,13 +492,18 @@ async def test_runtime_task_batch_smoke_runs_parallel_task_chats() -> None:
         "integration_adapter",
         "analytics_page",
     }
-    channel_ids = [
-        results[task_id]["_ag2_task_channel"]["channel_id"]
+    lifecycle_records = [
+        results[task_id]["_ag2_task_lifecycle"]
         for task_id in results["_meta"]["completed_tasks"]
     ]
-    assert len(channel_ids) == 4
-    assert len(set(channel_ids)) == 4
-    assert all(channel_id.startswith("runtime_smoke_tasks:") for channel_id in channel_ids)
+    assert len(lifecycle_records) == 4
+    assert all(record["channel_id"] is None for record in lifecycle_records)
+    assert all(record["status"] == "completed" for record in lifecycle_records)
+    assert all(
+        [event["event"] for event in record["events"]] == ["TaskStarted", "TaskCompleted"]
+        for record in lifecycle_records
+    )
+    assert len({record["task_id"] for record in lifecycle_records}) == 4
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_batch_contracts.py
+++ b/tests/test_task_batch_contracts.py
@@ -6,8 +6,15 @@ from types import SimpleNamespace
 
 import pytest
 import yaml
+from ag2 import Agent
 from ag2.network.policies import CHANNEL_STATE_DEP
+from pydantic import BaseModel
 
+from mozaiksai.core.adapters.ag2_task_batch_runner import (
+    AG2TaskBatchRunner,
+    AG2TaskBatchRunnerRequest,
+)
+from mozaiksai.core.ports.orchestration import RunStatus
 from mozaiksai.core.workflow.task_batches import (
     execute_task_batches_for_trigger,
     load_task_batches_config,
@@ -50,6 +57,80 @@ def _valid_payload() -> dict:
             }
         ],
     }
+
+
+class _Reply:
+    def __init__(self, body: str) -> None:
+        self.body = body
+
+
+class _RunnerAgent(Agent):
+    def __init__(
+        self,
+        body: str,
+        *,
+        fail: bool = False,
+        cancel: bool = False,
+        delay_seconds: float = 0.0,
+    ) -> None:
+        super().__init__("WorkerAgent", prompt="deterministic test worker")
+        self.body = body
+        self.fail = fail
+        self.cancel = cancel
+        self.delay_seconds = delay_seconds
+        self.ask_calls: list[dict] = []
+
+    async def ask(self, message, **kwargs):  # type: ignore[override]
+        self.ask_calls.append({"message": message, "kwargs": kwargs})
+        if self.delay_seconds:
+            import asyncio
+
+            await asyncio.sleep(self.delay_seconds)
+        if self.cancel:
+            import asyncio
+
+            raise asyncio.CancelledError()
+        if self.fail:
+            raise RuntimeError("planned worker failure")
+        return _Reply(self.body)
+
+
+class _RequiredWorkerOutput(BaseModel):
+    ok: bool
+
+
+def _runner_request(agent: Agent, **overrides) -> AG2TaskBatchRunnerRequest:
+    payload = {
+        "workflow_name": "TaskBatchWorkflow",
+        "batch_id": "document_reviews",
+        "task_id": "review_a",
+        "chat_id": "chat-1",
+        "app_id": "app-1",
+        "agent_name": "WorkerAgent",
+        "agent": agent,
+        "prompt": "Review document A.",
+        "context_variables": {"current_task_id": "review_a"},
+        "structured_registry": {},
+        "timeout_seconds": 5,
+    }
+    payload.update(overrides)
+    return AG2TaskBatchRunnerRequest(**payload)
+
+
+def _event_names(result) -> list[str]:
+    return [event["event"] for event in result.lifecycle_events]
+
+
+def _stable_lifecycle_shape(result) -> list[dict]:
+    shape: list[dict] = []
+    for event in result.lifecycle_events:
+        stable = {
+            key: value
+            for key, value in event.items()
+            if key not in {"task_id", "created_at", "expires_at", "task_stream_id"}
+        }
+        shape.append(stable)
+    return shape
 
 
 def test_parse_task_batches_config_accepts_canonical_payload() -> None:
@@ -112,6 +193,114 @@ def test_parse_task_batches_config_rejects_duplicate_conveyor_and_batch_ids() ->
 
     with pytest.raises(ValueError, match="duplicate task batch id"):
         parse_task_batches_config(payload)
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_emits_authentic_start_and_completion_evidence() -> None:
+    agent = _RunnerAgent('{"ok": true}')
+
+    result = await AG2TaskBatchRunner().run(_runner_request(agent))
+
+    assert result.status is RunStatus.COMPLETED
+    assert result.output == {"ok": True}
+    assert result.task_id
+    assert result.capability == "mozaiks.task_batch.TaskBatchWorkflow.document_reviews.WorkerAgent"
+    assert result.lifecycle_status == "completed"
+    assert result.channel_id is None
+    assert result.close_reason == "agent_ask_completed"
+    assert _event_names(result) == ["TaskStarted", "TaskCompleted"]
+    started = result.lifecycle_events[0]
+    assert started["task_id"] == result.task_id
+    assert started["capability"] == result.capability
+    assert started["payload"]["mozaiks_task_id"] == "review_a"
+    completed = result.lifecycle_events[1]
+    assert completed["task_id"] == result.task_id
+    assert completed["result"] == {"ok": True}
+    assert result.started_at
+    assert result.completed_at
+
+    ask_kwargs = agent.ask_calls[0]["kwargs"]
+    assert "TaskConfig" not in repr(ask_kwargs)
+    assert not ask_kwargs.get("tools")
+    assert "run_subtask" not in repr(ask_kwargs)
+    assert "run_subtasks" not in repr(ask_kwargs)
+    assert "background_agent_tool" not in repr(ask_kwargs)
+    assert "dynamic_agent" not in repr(ask_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_emits_failure_evidence_for_worker_exception() -> None:
+    agent = _RunnerAgent("{}", fail=True)
+
+    result = await AG2TaskBatchRunner().run(_runner_request(agent))
+
+    assert result.status is RunStatus.FAILED
+    assert result.lifecycle_status == "failed"
+    assert result.close_reason == "worker_failed"
+    assert result.channel_id is None
+    assert _event_names(result) == ["TaskStarted", "TaskFailed"]
+    assert result.lifecycle_events[-1]["error"] == "planned worker failure"
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_represents_timeout_as_task_expiry() -> None:
+    agent = _RunnerAgent("{}", delay_seconds=2.0)
+
+    result = await AG2TaskBatchRunner().run(
+        _runner_request(agent, timeout_seconds=1)
+    )
+
+    assert result.status is RunStatus.PAUSED
+    assert result.lifecycle_status == "expired"
+    assert result.close_reason == "expired"
+    assert result.channel_id is None
+    assert _event_names(result) == ["TaskStarted", "TaskExpired"]
+    assert "did not complete within 1 seconds" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_represents_worker_cancellation_truthfully() -> None:
+    agent = _RunnerAgent("{}", cancel=True)
+
+    result = await AG2TaskBatchRunner().run(_runner_request(agent))
+
+    assert result.status is RunStatus.PAUSED
+    assert result.lifecycle_status == "cancelled"
+    assert result.close_reason == "cancelled"
+    assert result.channel_id is None
+    assert _event_names(result) == ["TaskStarted", "TaskCancelled"]
+    assert result.lifecycle_events[-1]["reason"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_fails_lifecycle_on_structured_output_validation_error() -> None:
+    agent = _RunnerAgent('{"unexpected": true}')
+
+    result = await AG2TaskBatchRunner().run(
+        _runner_request(
+            agent,
+            structured_registry={"WorkerAgent": _RequiredWorkerOutput},
+        )
+    )
+
+    assert result.status is RunStatus.FAILED
+    assert result.lifecycle_status == "failed"
+    assert result.close_reason == "structured_output_validation_failed"
+    assert result.channel_id is None
+    assert _event_names(result) == ["TaskStarted", "TaskFailed"]
+    assert "structured output validation failed" in str(result.error)
+    assert "structured output validation failed" in result.lifecycle_events[-1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_lifecycle_evidence_shape_is_repeatable_offline() -> None:
+    first = await AG2TaskBatchRunner().run(_runner_request(_RunnerAgent('{"ok": true}')))
+    second = await AG2TaskBatchRunner().run(_runner_request(_RunnerAgent('{"ok": true}')))
+
+    assert _stable_lifecycle_shape(first) == _stable_lifecycle_shape(second)
+    assert first.task_id != second.task_id
+    assert first.channel_id is None
+    assert second.channel_id is None
 
 
 def test_load_task_batches_config_resolves_workflow_local_file(tmp_path: Path) -> None:
@@ -238,6 +427,13 @@ async def test_execute_task_batches_for_trigger_collects_worker_outputs() -> Non
     assert context["app_task_batch_results"]["profiles"]["code_files"][0]["filename"] == (
         "modules/profiles/module.yaml"
     )
+    lifecycle = context["app_task_batch_results"]["profiles"]["_ag2_task_lifecycle"]
+    assert lifecycle["channel_id"] is None
+    assert lifecycle["status"] == "completed"
+    assert [event["event"] for event in lifecycle["events"]] == [
+        "TaskStarted",
+        "TaskCompleted",
+    ]
     assert seen_variables[0]["task_run_mode"] is True
     assert seen_variables[0]["current_build_task_type"] == "module_contract"
     assert seen_variables[0]["dependency_task_outputs"] == {}
@@ -383,6 +579,55 @@ async def test_conveyor_rejects_task_for_agent_outside_allowed_execution_agents(
                             "execution_agent": "ToolsAgent",
                             "task_prompt": "Create tools.",
                         }
+                    ]
+                }
+            },
+            fresh_agents_per_task=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_batches_rejects_cyclic_dependencies_before_worker_execution() -> None:
+    config = parse_task_batches_config(
+        {
+            "version": 1,
+            "conveyors": [
+                {
+                    "id": "workflow_generation",
+                    "decomposition_agent": "DecompositionAgent",
+                    "execution_agents": ["AgentRosterAgent"],
+                    "concurrency": 1,
+                }
+            ],
+        }
+    )
+
+    class _UnexpectedAgent:
+        async def ask(self, message, **kwargs):  # noqa: ARG002
+            raise AssertionError("cyclic dependencies must fail before worker execution")
+
+    with pytest.raises(ValueError, match="unresolved or cyclic dependencies"):
+        await execute_task_batches_for_trigger(
+            workflow_name="AgentGenerator",
+            trigger_agent="DecompositionAgent",
+            batches_config=config,
+            agents={"AgentRosterAgent": _UnexpectedAgent()},
+            context_variables={},
+            structured_output={
+                "DecompositionPlan": {
+                    "tasks": [
+                        {
+                            "task_id": "agent_roster",
+                            "execution_agent": "AgentRosterAgent",
+                            "task_prompt": "Create the agent roster.",
+                            "depends_on": ["transition_graph"],
+                        },
+                        {
+                            "task_id": "transition_graph",
+                            "execution_agent": "AgentRosterAgent",
+                            "task_prompt": "Create the transition graph.",
+                            "depends_on": ["agent_roster"],
+                        },
                     ]
                 }
             },


### PR DESCRIPTION
## Summary
- Replaces fabricated task-batch channel evidence with authentic AG2 1.0.1 Task lifecycle evidence around each preselected Mozaiks worker turn.
- Keeps `task_batches.yaml` and Mozaiks runtime code authoritative for task ids, workers, dependencies, concurrency, prompts, context, tool profile, owned paths, timeout, retries, structured-output validation, output destination, and result merge.
- Records normalized standalone Task stream evidence under `_ag2_task_lifecycle`; `channel_id` remains `null` because this path does not create a real AG2 Network channel.

## Baseline
- `origin/main`: `d323a0d50662cac4d90e92ecf022f66924c00f25`
- Open PR collision check: #273 touches `mozaiksai/core/adapters/ag2_agent_runner.py` and `tests/test_ag2_agent_runner.py`; this branch does not touch those files.

## AG2 1.0.1 source inspected
- `C:\Users\mbari\AppData\Roaming\Python\Python313\site-packages\ag2\agent.py`
  - `Agent.task(self, title: str, *, description: str = '', payload: dict[str, typing.Any] | None = None, capability: str | None = None, ttl_seconds: int | None = None, context: ConversationContext | None = None, checkpoint_store: CheckpointStore | None = None, resume_from: str | None = None) -> ag2.task.Task`
- `C:\Users\mbari\AppData\Roaming\Python\Python313\site-packages\ag2\task.py`
  - `Task(*, owner_id: str, spec: ag2.task.TaskSpec, context: ConversationContext | None = None, ttl_seconds: int | None = None, checkpoint_store: CheckpointStore | None = None, resume_from: str | None = None)`
  - `TaskSpec(title: str, description: str = '', payload: dict[str, typing.Any] = <factory>, capability: str | None = None)`
  - `Task.__aenter__(self) -> Task`
  - `Task.__aexit__(self, exc_type, exc, tb) -> None`
  - `Task.complete(self, result: Any = None) -> None`
  - `Task.fail(self, error: str | BaseException) -> None`
  - `Task.expire(self) -> None`
- `C:\Users\mbari\AppData\Roaming\Python\Python313\site-packages\ag2\events\task_events.py`
  - `TaskStarted`, `TaskProgress`, `TaskCompleted`, `TaskFailed`, `TaskExpired`
- `C:\Users\mbari\AppData\Roaming\Python\Python313\site-packages\ag2\stream.py`
  - `MemoryStream(storage: Storage | None = None, *, id: uuid.UUID | None = None, persist_all: bool = False)`
  - `MemoryStream.subscribe(self, func=None, *, interrupt=False, sync_to_thread=True, condition=None)`
- `C:\Users\mbari\AppData\Roaming\Python\Python313\site-packages\ag2\network\task_mirror.py`
  - `TaskMirror(*, hub_client: HubClient | None = None, hub: Hub | None = None, owner_id: str, channel_id: str | None = None)`
  - `TaskMirror.attach(self, stream: Stream) -> list[object]`

## Authentic execution flow
Before:
- `AG2TaskBatchRunner` called the selected agent with `Agent.ask(...)` and returned a synthetic `channel_id` shaped as `{batch_id}:{task_id}`.
- Task-batch outputs stored `_ag2_task_channel`, implying channel evidence that AG2 did not provide.

After:
- Mozaiks creates a deterministic capability id: `mozaiks.task_batch.<workflow>.<batch>.<agent>`.
- The runner creates an AG2 `Task` through `Agent.task(...)` when available, or direct `Task(...)` for non-Agent test doubles.
- The runner binds a `ConversationContext` and `MemoryStream`, subscribes to real Task lifecycle events, runs the already-authorized `Agent.ask(...)`, and explicitly completes, fails, or expires the Task based on Mozaiks-controlled outcomes.
- Structured-output validation remains the final authority; validation failure emits `TaskFailed` and fails the Mozaiks work item.
- Timeout is represented truthfully as Mozaiks cancelling the worker turn and calling `Task.expire()`; standalone AG2 Task TTL is not automatic without a network TTL observer.

## TaskMirror status
- `TaskMirror` is not active in this PR.
- AG2 1.0.1 requires `hub_client=` or `hub=` for `TaskMirror`; the current task-batch runner is not a real Hub/AgentClient worker channel.
- Follow-up: if task-batch workers are restructured into Hub-backed worker channels, attach `TaskMirror` and return only real AG2 channel ids.

## Lifecycle events proven
- `TaskStarted` for deterministic preselected workers.
- `TaskCompleted` for successful worker completion.
- `TaskFailed` for worker exceptions and structured-output validation failure.
- `TaskExpired` for timeout/expiry representation.
- Event ordering is deterministic by runner state transition: started then terminal event.

## Files changed
- `mozaiksai/core/adapters/ag2_task_batch_runner.py`
- `mozaiksai/core/workflow/task_batches.py`
- `tests/test_task_batch_contracts.py`
- `tests/test_runtime_task_batch_smoke.py`
- `tests/test_ag2_network_execution_alignment.py`
- `docs/architecture/workflows/ag2-update-watchpoints.md`
- `docs/architecture/workflows/ag2-execution-alignment-plan.md`
- `docs/architecture/mozaiksai/task-batches.md`
- `factory_app/workflows/AgentGenerator/structured_outputs.yaml`

## Determinism statement
Mozaiks still owns scheduling and artifact authority. AG2 executes only the already-authorized worker turn and emits lifecycle evidence. No `TaskConfig`, `run_subtask`, `run_subtasks`, `Agent.as_tool`, `background_agent_tool`, `dynamic_agent`, LLM-created tasks, LLM-selected tools, or arbitrary capability names were introduced. No fake channel identity remains in the real runner path.

## Remaining limitations
- No durable AG2 task/channel resume is claimed for standalone task-batch workers.
- `channel_id` is `null` unless a future Hub-backed path supplies a real AG2 channel id.
- `TaskMirror` is deferred until task-batch workers run as real Hub/AgentClient participants.

## Tests
- `python -m pytest tests/test_task_batch_contracts.py -q --no-cov` -> 20 passed
- `python -m pytest tests/test_runtime_task_batch_smoke.py -q --no-cov` -> 12 passed
- `python -m pytest tests/test_ag2_network_execution_alignment.py tests/test_task_batch_contracts.py tests/test_workflow_network_graph.py tests/test_ag2_agent_runner.py -q --no-cov` -> 54 passed
- `python -m ruff check .` -> passed
- `python -m pytest -q --no-cov` -> 12610 passed, 77 skipped