### PR TITLE
Add durable work assignment worker

### DIFF
--- a/mozaiksai/core/workflow/queue.py
+++ b/mozaiksai/core/workflow/queue.py
@@ -300,6 +300,22 @@ class WorkflowQueue(Protocol):
         """
         ...
 
+    async def dead_letter(
+        self,
+        item_id: str,
+        *,
+        claim_token: str,
+        error_category: str | None = None,
+    ) -> bool:
+        """Terminally dead-letter a claimed item.
+
+        Only succeeds for the current ``claim_token`` holder. This is for
+        deterministic permanent failures where retrying the same payload cannot
+        produce a valid execution, such as malformed contracts or unknown
+        registered executors.
+        """
+        ...
+
     async def renew_lease(
         self,
         item_id: str,
@@ -368,6 +384,15 @@ class NoOpWorkflowQueue:
         error_category: str | None = None,
     ) -> str | None:
         return None
+
+    async def dead_letter(
+        self,
+        item_id: str,
+        *,
+        claim_token: str,
+        error_category: str | None = None,
+    ) -> bool:
+        return False
 
     async def renew_lease(
         self,
@@ -687,6 +712,44 @@ class MongoWorkflowQueue:
         except Exception as exc:
             logger.error("QUEUE_FAIL_FAIL item_id=%s: %s", item_id, exc)
             return None
+
+    async def dead_letter(
+        self,
+        item_id: str,
+        *,
+        claim_token: str,
+        error_category: str | None = None,
+    ) -> bool:
+        """Terminally dead-letter a CLAIMED item using the fencing token."""
+        col = self._col()
+        if col is None:
+            return False
+
+        now = self._now()
+        now_iso = now.isoformat()
+        retain_until = (now + timedelta(seconds=_ITEM_TTL)).isoformat()
+        try:
+            result = await col.update_one(
+                {
+                    "_id": item_id,
+                    "status": QueueItemStatus.CLAIMED.value,
+                    "claim_token": claim_token,
+                },
+                {
+                    "$set": {
+                        "status": QueueItemStatus.DEAD_LETTER.value,
+                        "last_failed_at": now_iso,
+                        "next_attempt_at": None,
+                        "dead_lettered_at": now_iso,
+                        "error_category": (error_category or "permanent_failure")[:128],
+                        "expires_at": retain_until,
+                    }
+                },
+            )
+            return bool(result.modified_count == 1)
+        except Exception as exc:
+            logger.error("QUEUE_DEAD_LETTER_FAIL item_id=%s: %s", item_id, exc)
+            return False
 
     async def renew_lease(
         self,

--- a/mozaiksai/core/workflow/work_assignment_worker.py
+++ b/mozaiksai/core/workflow/work_assignment_worker.py
@@ -1,0 +1,550 @@
+"""Generic durable worker for typed WorkAssignment queue items.
+
+The worker is explicitly invoked through ``run_once()``. It does not spawn
+threads, own a polling loop, or schedule DAGs. WorkflowQueue owns durable
+at-least-once delivery, leases, queue delivery attempts, and fencing. The
+WorkAssignment contract owns assignment authority, bounded in-claim executor
+retries, owned paths, assignment identity, and result validation.
+
+External side effects performed by registered executors must be idempotent by
+assignment_id/result attempt_id because a queue item may be delivered more than
+once after crash or lease expiry.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .assignment_kinds import AssignmentKind
+from .queue import ClaimResult, QueueItem, QueueItemStatus, WorkflowQueue
+from .work_contracts import (
+    WorkAssignment,
+    WorkResult,
+    validate_work_result_for_assignment,
+)
+
+WORK_ASSIGNMENT_PAYLOAD_KEY = "work_assignment"
+
+
+class WorkAssignmentFailureCategory(StrEnum):
+    INVALID_PAYLOAD = "invalid_payload"
+    UNKNOWN_EXECUTOR = "unknown_executor"
+    EXECUTOR_TRANSIENT = "executor_transient"
+    EXECUTOR_PERMANENT = "executor_permanent"
+    EXECUTOR_RESULT_INVALID = "executor_result_invalid"
+    EXECUTOR_RESULT_FAILED = "executor_result_failed"
+    EXECUTOR_RESULT_SKIPPED = "executor_result_skipped"
+
+
+class WorkAssignmentRunStatus(StrEnum):
+    NO_ITEM = "no_item"
+    COMPLETED = "completed"
+    RETRYABLE = "retryable"
+    DEAD_LETTER = "dead_letter"
+    STALE_CLAIM = "stale_claim"
+    COMPLETED_EVENT_FAILED = "completed_event_failed"
+    RETRYABLE_EVENT_FAILED = "retryable_event_failed"
+    DEAD_LETTER_EVENT_FAILED = "dead_letter_event_failed"
+
+
+class WorkAssignmentPermanentError(Exception):
+    """Executor-raised permanent failure; retrying the same payload is invalid."""
+
+
+class WorkAssignmentTransientError(Exception):
+    """Executor-raised transient failure eligible for assignment/queue retry."""
+
+
+class WorkAssignmentWorkerOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: WorkAssignmentRunStatus
+    item_id: str | None = None
+    assignment_id: str | None = None
+    assignment_kind: AssignmentKind | None = None
+    claim_token: str | None = None
+    queue_attempt_count: int = 0
+    executor_attempt_count: int = 0
+    queue_transition: QueueItemStatus | None = None
+    error_category: WorkAssignmentFailureCategory | None = None
+    result_digest: str | None = None
+    lifecycle_event_emitted: bool = False
+
+
+class WorkAssignmentLifecycleEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event_type: str = Field(pattern=r"^work_assignment\.(completed|retryable|dead_letter)$")
+    item_id: str
+    assignment_id: str
+    assignment_kind: AssignmentKind
+    worker_id: str
+    app_id: str
+    chat_id: str
+    user_id: str | None = None
+    tenant_id: str | None = None
+    workspace_id: str | None = None
+    queue_attempt_count: int
+    executor_attempt_count: int
+    queue_transition: QueueItemStatus
+    result_digest: str | None = None
+    error_category: WorkAssignmentFailureCategory | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkAssignmentExecutionContext:
+    assignment: WorkAssignment
+    item: QueueItem
+    claim_token: str
+    queue_attempt_count: int
+    executor_attempt: int
+    worker_id: str
+    allowed_agent_ids: tuple[str, ...]
+    owned_paths: tuple[str, ...]
+    required_structured_output_id: str | None
+    workspace_id: str | None
+    renew_lease: Callable[[int | None], Awaitable[bool]]
+
+
+@runtime_checkable
+class WorkAssignmentExecutor(Protocol):
+    async def execute(self, context: WorkAssignmentExecutionContext) -> WorkResult | Mapping[str, Any]:
+        """Execute a validated assignment and return a typed result payload."""
+        ...
+
+
+class WorkAssignmentExecutorRegistry:
+    """Closed registry from assignment kind to executor implementation."""
+
+    def __init__(self) -> None:
+        self._executors: dict[AssignmentKind, WorkAssignmentExecutor] = {}
+
+    def register(self, kind: AssignmentKind | str, executor: WorkAssignmentExecutor) -> None:
+        assignment_kind = AssignmentKind(kind)
+        if assignment_kind in self._executors:
+            raise ValueError(f"executor already registered for assignment kind {assignment_kind.value!r}")
+        if not callable(getattr(executor, "execute", None)):
+            raise ValueError("work assignment executor must expose async execute(context)")
+        self._executors[assignment_kind] = executor
+
+    def resolve(self, kind: AssignmentKind | str) -> WorkAssignmentExecutor | None:
+        return self._executors.get(AssignmentKind(kind))
+
+    def registered_kinds(self) -> tuple[AssignmentKind, ...]:
+        return tuple(sorted(self._executors, key=lambda item: item.value))
+
+
+LifecycleEventSink = Callable[[WorkAssignmentLifecycleEvent], Awaitable[None] | None]
+
+
+class WorkAssignmentWorker:
+    """One-claim worker over WorkflowQueue and typed WorkAssignment contracts."""
+
+    def __init__(
+        self,
+        *,
+        queue: WorkflowQueue,
+        executor_registry: WorkAssignmentExecutorRegistry,
+        worker_id: str,
+        lease_seconds: int = 300,
+        lifecycle_event_sink: LifecycleEventSink | None = None,
+    ) -> None:
+        worker = str(worker_id or "").strip()
+        if not worker:
+            raise ValueError("worker_id must be non-empty")
+        self.queue = queue
+        self.executor_registry = executor_registry
+        self.worker_id = worker
+        self.lease_seconds = int(lease_seconds)
+        self.lifecycle_event_sink = lifecycle_event_sink
+
+    async def run_once(self) -> WorkAssignmentWorkerOutcome:
+        claim = await self.queue.claim_next(self.worker_id, lease_seconds=self.lease_seconds)
+        if not claim.claimed or claim.item is None or not claim.claim_token:
+            return WorkAssignmentWorkerOutcome(status=WorkAssignmentRunStatus.NO_ITEM)
+        return await self.process_claim(claim)
+
+    async def process_claim(self, claim: ClaimResult) -> WorkAssignmentWorkerOutcome:
+        if not claim.claimed or claim.item is None or not claim.claim_token:
+            return WorkAssignmentWorkerOutcome(status=WorkAssignmentRunStatus.NO_ITEM)
+
+        item = claim.item
+        token = claim.claim_token
+        try:
+            assignment = _assignment_from_queue_item(item)
+        except Exception:
+            return await self._dead_letter_claim(
+                item=item,
+                claim_token=token,
+                queue_attempt_count=claim.attempt_count,
+                assignment=None,
+                executor_attempt_count=0,
+                error_category=WorkAssignmentFailureCategory.INVALID_PAYLOAD,
+                result_digest=None,
+            )
+
+        executor = self.executor_registry.resolve(assignment.assignment_kind)
+        if executor is None:
+            return await self._dead_letter_claim(
+                item=item,
+                claim_token=token,
+                queue_attempt_count=claim.attempt_count,
+                assignment=assignment,
+                executor_attempt_count=0,
+                error_category=WorkAssignmentFailureCategory.UNKNOWN_EXECUTOR,
+                result_digest=None,
+            )
+
+        max_executor_attempts = assignment.assignment_retry_limit + 1
+        last_transient_category = WorkAssignmentFailureCategory.EXECUTOR_TRANSIENT
+        for executor_attempt in range(1, max_executor_attempts + 1):
+            async def _renew_lease(extend_seconds: int | None = None) -> bool:
+                return await self.queue.renew_lease(
+                    item.item_id,
+                    claim_token=token,
+                    extend_seconds=extend_seconds,
+                )
+
+            context = WorkAssignmentExecutionContext(
+                assignment=assignment,
+                item=item,
+                claim_token=token,
+                queue_attempt_count=claim.attempt_count,
+                executor_attempt=executor_attempt,
+                worker_id=self.worker_id,
+                allowed_agent_ids=assignment.allowed_agent_ids,
+                owned_paths=assignment.owned_paths,
+                required_structured_output_id=assignment.required_structured_output_id,
+                workspace_id=_workspace_id(item),
+                renew_lease=_renew_lease,
+            )
+            try:
+                raw_result = await executor.execute(context)
+                result = _coerce_work_result(raw_result)
+                validate_work_result_for_assignment(assignment=assignment, result=result)
+            except WorkAssignmentPermanentError:
+                return await self._dead_letter_claim(
+                    item=item,
+                    claim_token=token,
+                    queue_attempt_count=claim.attempt_count,
+                    assignment=assignment,
+                    executor_attempt_count=executor_attempt,
+                    error_category=WorkAssignmentFailureCategory.EXECUTOR_PERMANENT,
+                    result_digest=None,
+                )
+            except WorkAssignmentTransientError:
+                if executor_attempt < max_executor_attempts:
+                    continue
+                return await self._fail_claim(
+                    item=item,
+                    claim_token=token,
+                    queue_attempt_count=claim.attempt_count,
+                    assignment=assignment,
+                    executor_attempt_count=executor_attempt,
+                    error_category=last_transient_category,
+                    result_digest=None,
+                )
+            except Exception:
+                return await self._dead_letter_claim(
+                    item=item,
+                    claim_token=token,
+                    queue_attempt_count=claim.attempt_count,
+                    assignment=assignment,
+                    executor_attempt_count=executor_attempt,
+                    error_category=WorkAssignmentFailureCategory.EXECUTOR_RESULT_INVALID,
+                    result_digest=None,
+                )
+
+            if result.status == "completed":
+                return await self._complete_claim(
+                    item=item,
+                    claim_token=token,
+                    queue_attempt_count=claim.attempt_count,
+                    assignment=assignment,
+                    executor_attempt_count=executor_attempt,
+                    result_digest=result.result_digest,
+                )
+            if result.status == "failed":
+                return await self._fail_claim(
+                    item=item,
+                    claim_token=token,
+                    queue_attempt_count=claim.attempt_count,
+                    assignment=assignment,
+                    executor_attempt_count=executor_attempt,
+                    error_category=WorkAssignmentFailureCategory.EXECUTOR_RESULT_FAILED,
+                    result_digest=result.result_digest,
+                )
+            return await self._dead_letter_claim(
+                item=item,
+                claim_token=token,
+                queue_attempt_count=claim.attempt_count,
+                assignment=assignment,
+                executor_attempt_count=executor_attempt,
+                error_category=WorkAssignmentFailureCategory.EXECUTOR_RESULT_SKIPPED,
+                result_digest=result.result_digest,
+            )
+
+        return await self._fail_claim(
+            item=item,
+            claim_token=token,
+            queue_attempt_count=claim.attempt_count,
+            assignment=assignment,
+            executor_attempt_count=max_executor_attempts,
+            error_category=last_transient_category,
+            result_digest=None,
+        )
+
+    async def _complete_claim(
+        self,
+        *,
+        item: QueueItem,
+        claim_token: str,
+        queue_attempt_count: int,
+        assignment: WorkAssignment,
+        executor_attempt_count: int,
+        result_digest: str,
+    ) -> WorkAssignmentWorkerOutcome:
+        completed = await self.queue.complete(item.item_id, claim_token=claim_token)
+        if not completed:
+            return _stale_outcome(item, claim_token, queue_attempt_count, assignment, executor_attempt_count)
+        event_ok = await self._emit_event(
+            item=item,
+            assignment=assignment,
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=QueueItemStatus.COMPLETED,
+            result_digest=result_digest,
+            error_category=None,
+        )
+        event_sink_configured = self.lifecycle_event_sink is not None
+        return WorkAssignmentWorkerOutcome(
+            status=(
+                WorkAssignmentRunStatus.COMPLETED
+                if event_ok or not event_sink_configured
+                else WorkAssignmentRunStatus.COMPLETED_EVENT_FAILED
+            ),
+            item_id=item.item_id,
+            assignment_id=assignment.assignment_id,
+            assignment_kind=assignment.assignment_kind,
+            claim_token=claim_token,
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=QueueItemStatus.COMPLETED,
+            result_digest=result_digest,
+            lifecycle_event_emitted=event_ok and event_sink_configured,
+        )
+
+    async def _fail_claim(
+        self,
+        *,
+        item: QueueItem,
+        claim_token: str,
+        queue_attempt_count: int,
+        assignment: WorkAssignment,
+        executor_attempt_count: int,
+        error_category: WorkAssignmentFailureCategory,
+        result_digest: str | None,
+    ) -> WorkAssignmentWorkerOutcome:
+        new_status = await self.queue.fail(
+            item.item_id,
+            claim_token=claim_token,
+            error_category=error_category.value,
+        )
+        if new_status is None:
+            return _stale_outcome(item, claim_token, queue_attempt_count, assignment, executor_attempt_count)
+        queue_transition = QueueItemStatus(new_status)
+        event_ok = await self._emit_event(
+            item=item,
+            assignment=assignment,
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=queue_transition,
+            result_digest=result_digest,
+            error_category=error_category,
+        )
+        base_status = (
+            WorkAssignmentRunStatus.RETRYABLE
+            if queue_transition is QueueItemStatus.RETRYABLE
+            else WorkAssignmentRunStatus.DEAD_LETTER
+        )
+        event_sink_configured = self.lifecycle_event_sink is not None
+        if not event_ok and event_sink_configured:
+            base_status = (
+                WorkAssignmentRunStatus.RETRYABLE_EVENT_FAILED
+                if queue_transition is QueueItemStatus.RETRYABLE
+                else WorkAssignmentRunStatus.DEAD_LETTER_EVENT_FAILED
+            )
+        return WorkAssignmentWorkerOutcome(
+            status=base_status,
+            item_id=item.item_id,
+            assignment_id=assignment.assignment_id,
+            assignment_kind=assignment.assignment_kind,
+            claim_token=claim_token,
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=queue_transition,
+            error_category=error_category,
+            result_digest=result_digest,
+            lifecycle_event_emitted=event_ok and event_sink_configured,
+        )
+
+    async def _dead_letter_claim(
+        self,
+        *,
+        item: QueueItem,
+        claim_token: str,
+        queue_attempt_count: int,
+        assignment: WorkAssignment | None,
+        executor_attempt_count: int,
+        error_category: WorkAssignmentFailureCategory,
+        result_digest: str | None,
+    ) -> WorkAssignmentWorkerOutcome:
+        dead_lettered = await self.queue.dead_letter(
+            item.item_id,
+            claim_token=claim_token,
+            error_category=error_category.value,
+        )
+        if not dead_lettered:
+            return WorkAssignmentWorkerOutcome(
+                status=WorkAssignmentRunStatus.STALE_CLAIM,
+                item_id=item.item_id,
+                assignment_id=assignment.assignment_id if assignment else None,
+                assignment_kind=assignment.assignment_kind if assignment else None,
+                claim_token=claim_token,
+                queue_attempt_count=queue_attempt_count,
+                executor_attempt_count=executor_attempt_count,
+                queue_transition=None,
+                error_category=error_category,
+                result_digest=result_digest,
+                lifecycle_event_emitted=False,
+            )
+        event_ok = True
+        if assignment is not None:
+            event_ok = await self._emit_event(
+                item=item,
+                assignment=assignment,
+                queue_attempt_count=queue_attempt_count,
+                executor_attempt_count=executor_attempt_count,
+                queue_transition=QueueItemStatus.DEAD_LETTER,
+                result_digest=result_digest,
+                error_category=error_category,
+            )
+        return WorkAssignmentWorkerOutcome(
+            status=(
+                WorkAssignmentRunStatus.DEAD_LETTER
+                if event_ok or self.lifecycle_event_sink is None
+                else WorkAssignmentRunStatus.DEAD_LETTER_EVENT_FAILED
+            ),
+            item_id=item.item_id,
+            assignment_id=assignment.assignment_id if assignment else None,
+            assignment_kind=assignment.assignment_kind if assignment else None,
+            claim_token=claim_token,
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=QueueItemStatus.DEAD_LETTER,
+            error_category=error_category,
+            result_digest=result_digest,
+            lifecycle_event_emitted=event_ok and self.lifecycle_event_sink is not None and assignment is not None,
+        )
+
+    async def _emit_event(
+        self,
+        *,
+        item: QueueItem,
+        assignment: WorkAssignment,
+        queue_attempt_count: int,
+        executor_attempt_count: int,
+        queue_transition: QueueItemStatus,
+        result_digest: str | None,
+        error_category: WorkAssignmentFailureCategory | None,
+    ) -> bool:
+        if self.lifecycle_event_sink is None:
+            return True
+        event = WorkAssignmentLifecycleEvent(
+            event_type=f"work_assignment.{queue_transition.value}",
+            item_id=item.item_id,
+            assignment_id=assignment.assignment_id,
+            assignment_kind=assignment.assignment_kind,
+            worker_id=self.worker_id,
+            app_id=item.app_id,
+            chat_id=item.chat_id,
+            user_id=item.user_id,
+            tenant_id=item.tenant_id,
+            workspace_id=_workspace_id(item),
+            queue_attempt_count=queue_attempt_count,
+            executor_attempt_count=executor_attempt_count,
+            queue_transition=queue_transition,
+            result_digest=result_digest,
+            error_category=error_category,
+        )
+        try:
+            maybe_awaitable = self.lifecycle_event_sink(event)
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+            return True
+        except Exception:
+            return False
+
+
+def _assignment_from_queue_item(item: QueueItem) -> WorkAssignment:
+    payload = item.payload
+    if not isinstance(payload, Mapping):
+        raise ValueError("queue payload must be a mapping")
+    assignment_payload = payload.get(WORK_ASSIGNMENT_PAYLOAD_KEY)
+    if not isinstance(assignment_payload, Mapping):
+        raise ValueError(f"queue payload missing {WORK_ASSIGNMENT_PAYLOAD_KEY!r}")
+    return WorkAssignment.model_validate(assignment_payload)
+
+
+def _coerce_work_result(value: WorkResult | Mapping[str, Any]) -> WorkResult:
+    if isinstance(value, WorkResult):
+        return value
+    if isinstance(value, Mapping):
+        return WorkResult.model_validate(value)
+    raise ValueError("executor must return WorkResult or mapping")
+
+
+def _workspace_id(item: QueueItem) -> str | None:
+    value = item.payload.get("workspace_id") if isinstance(item.payload, Mapping) else None
+    text = str(value or "").strip()
+    return text or None
+
+
+def _stale_outcome(
+    item: QueueItem,
+    claim_token: str,
+    queue_attempt_count: int,
+    assignment: WorkAssignment,
+    executor_attempt_count: int,
+) -> WorkAssignmentWorkerOutcome:
+    return WorkAssignmentWorkerOutcome(
+        status=WorkAssignmentRunStatus.STALE_CLAIM,
+        item_id=item.item_id,
+        assignment_id=assignment.assignment_id,
+        assignment_kind=assignment.assignment_kind,
+        claim_token=claim_token,
+        queue_attempt_count=queue_attempt_count,
+        executor_attempt_count=executor_attempt_count,
+        lifecycle_event_emitted=False,
+    )
+
+
+__all__ = [
+    "WORK_ASSIGNMENT_PAYLOAD_KEY",
+    "WorkAssignmentExecutionContext",
+    "WorkAssignmentExecutor",
+    "WorkAssignmentExecutorRegistry",
+    "WorkAssignmentFailureCategory",
+    "WorkAssignmentLifecycleEvent",
+    "WorkAssignmentPermanentError",
+    "WorkAssignmentRunStatus",
+    "WorkAssignmentTransientError",
+    "WorkAssignmentWorker",
+    "WorkAssignmentWorkerOutcome",
+]

--- a/mozaiksai/core/workflow/work_assignment_worker.py
+++ b/mozaiksai/core/workflow/work_assignment_worker.py
@@ -203,14 +203,15 @@ class WorkAssignmentWorker:
 
         max_executor_attempts = assignment.assignment_retry_limit + 1
         last_transient_category = WorkAssignmentFailureCategory.EXECUTOR_TRANSIENT
-        for executor_attempt in range(1, max_executor_attempts + 1):
-            async def _renew_lease(extend_seconds: int | None = None) -> bool:
-                return await self.queue.renew_lease(
-                    item.item_id,
-                    claim_token=token,
-                    extend_seconds=extend_seconds,
-                )
 
+        async def _renew_lease(extend_seconds: int | None = None) -> bool:
+            return await self.queue.renew_lease(
+                item.item_id,
+                claim_token=token,
+                extend_seconds=extend_seconds,
+            )
+
+        for executor_attempt in range(1, max_executor_attempts + 1):
             context = WorkAssignmentExecutionContext(
                 assignment=assignment,
                 item=item,

--- a/mozaiksai/core/workflow/work_contracts.py
+++ b/mozaiksai/core/workflow/work_contracts.py
@@ -296,6 +296,36 @@ def make_work_result(
     )
 
 
+def validate_work_result_for_assignment(
+    *,
+    assignment: WorkAssignment,
+    result: WorkResult,
+) -> WorkResult:
+    """Validate an executor-supplied result against assignment authority."""
+    result = WorkResult.model_validate(result.model_dump(mode="json"))
+    if result.assignment_id != assignment.assignment_id:
+        raise ValueError(f"WorkResult assignment_id {result.assignment_id!r} does not match assignment")
+    if result.assignment_digest != assignment.assignment_digest:
+        raise ValueError(f"WorkResult for {assignment.assignment_id!r} has mismatched assignment_digest")
+    if result.baseline_sha != assignment.baseline_sha:
+        raise ValueError(f"WorkResult for {assignment.assignment_id!r} has mismatched baseline_sha")
+
+    owned = set(assignment.owned_paths)
+    seen_paths: set[str] = set()
+    for artifact in result.changed_artifacts:
+        if artifact.path in seen_paths:
+            raise ValueError(f"duplicate changed artifact path: {artifact.path!r}")
+        seen_paths.add(artifact.path)
+        if not path_is_within_owned(artifact.path, owned):
+            raise ValueError(f"WorkResult changed artifact {artifact.path!r} is outside assignment owned_paths")
+
+    if result.status == "completed":
+        _validate_required_artifacts(assignment, result.changed_artifacts)
+        evidence_payload = [item.model_dump(mode="json") for item in result.validation_evidence]
+        _validate_required_validators(assignment, evidence_payload)
+    return result
+
+
 def validate_assignment_dag(assignments: list[WorkAssignment]) -> None:
     _topological_sort(assignments)
 
@@ -700,5 +730,6 @@ __all__ = [
     "make_work_assignment",
     "make_work_result",
     "stable_digest",
+    "validate_work_result_for_assignment",
     "validate_assignment_dag",
 ]

--- a/tests/test_work_assignment_worker.py
+++ b/tests/test_work_assignment_worker.py
@@ -1,0 +1,563 @@
+"""Tests for the generic durable WorkAssignment worker."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from mozaiksai.core.workflow.queue import (
+    _DEFAULT_MAX_ATTEMPTS,
+    ClaimResult,
+    QueueItem,
+    _validated_max_attempts,
+)
+from mozaiksai.core.workflow.work_assignment_worker import (
+    WORK_ASSIGNMENT_PAYLOAD_KEY,
+    WorkAssignmentExecutionContext,
+    WorkAssignmentExecutorRegistry,
+    WorkAssignmentFailureCategory,
+    WorkAssignmentLifecycleEvent,
+    WorkAssignmentPermanentError,
+    WorkAssignmentRunStatus,
+    WorkAssignmentTransientError,
+    WorkAssignmentWorker,
+)
+from mozaiksai.core.workflow.work_contracts import (
+    ArtifactIdentity,
+    WorkAssignment,
+    WorkResult,
+    make_work_assignment,
+    make_work_result,
+    stable_digest,
+)
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.current = datetime(2026, 1, 1, tzinfo=UTC)
+
+    def now(self) -> datetime:
+        return self.current
+
+    def advance(self, seconds: int) -> None:
+        self.current += timedelta(seconds=seconds)
+
+
+class InMemoryWorkQueue:
+    def __init__(self, *, now_fn: Any) -> None:
+        self._records: dict[str, dict[str, Any]] = {}
+        self._now_fn = now_fn
+
+    async def enqueue(
+        self,
+        item: QueueItem,
+        *,
+        max_attempts: int | None = None,
+        retry_delay_seconds: int = 0,
+    ) -> str:
+        item.max_attempts = _validated_max_attempts(max_attempts)
+        item.retry_delay_seconds = max(0, int(retry_delay_seconds))
+        self._records[item.item_id] = item.to_document()
+        return item.item_id
+
+    async def claim_next(self, worker_id: str, *, lease_seconds: int = 300) -> ClaimResult:
+        now = self._now_fn()
+        now_iso = now.isoformat()
+        lease_seconds = max(10, min(3600, int(lease_seconds)))
+        candidates: list[dict[str, Any]] = []
+        for doc in self._records.values():
+            if doc["status"] == "pending":
+                candidates.append(doc)
+            elif doc["status"] == "retryable" and (doc.get("next_attempt_at") or "") <= now_iso:
+                candidates.append(doc)
+            elif doc["status"] == "claimed" and (doc.get("lease_expires_at") or "") <= now_iso:
+                candidates.append(doc)
+        if not candidates:
+            return ClaimResult(claimed=False)
+        candidates.sort(key=lambda doc: (-int(doc.get("priority") or 0), str(doc.get("enqueued_at") or "")))
+        doc = candidates[0]
+        token = str(uuid4())
+        doc["status"] = "claimed"
+        doc["claimed_by"] = worker_id
+        doc["claim_token"] = token
+        doc["claimed_at"] = now_iso
+        doc["lease_expires_at"] = (now + timedelta(seconds=lease_seconds)).isoformat()
+        doc["attempt_count"] = int(doc.get("attempt_count") or 0) + 1
+        item = QueueItem.from_document(doc)
+        return ClaimResult(claimed=True, item=item, claim_token=token, attempt_count=item.attempt_count)
+
+    async def complete(self, item_id: str, *, claim_token: str) -> bool:
+        doc = self._records.get(item_id)
+        if not doc or doc.get("status") != "claimed" or doc.get("claim_token") != claim_token:
+            return False
+        now = self._now_fn()
+        doc["status"] = "completed"
+        doc["completed_at"] = now.isoformat()
+        doc["expires_at"] = (now + timedelta(seconds=3600)).isoformat()
+        return True
+
+    async def fail(self, item_id: str, *, claim_token: str, error_category: str | None = None) -> str | None:
+        doc = self._records.get(item_id)
+        if not doc or doc.get("status") != "claimed" or doc.get("claim_token") != claim_token:
+            return None
+        now = self._now_fn()
+        attempt_count = int(doc.get("attempt_count") or 0)
+        max_attempts = int(doc.get("max_attempts") or _DEFAULT_MAX_ATTEMPTS)
+        if attempt_count >= max_attempts:
+            status = "dead_letter"
+            doc["dead_lettered_at"] = now.isoformat()
+            doc["next_attempt_at"] = None
+            doc["expires_at"] = (now + timedelta(seconds=3600)).isoformat()
+        else:
+            status = "retryable"
+            doc["next_attempt_at"] = (now + timedelta(seconds=int(doc.get("retry_delay_seconds") or 0))).isoformat()
+            doc["dead_lettered_at"] = None
+            doc["expires_at"] = None
+        doc["status"] = status
+        doc["last_failed_at"] = now.isoformat()
+        doc["error_category"] = (error_category or "execution_error")[:128]
+        return status
+
+    async def dead_letter(self, item_id: str, *, claim_token: str, error_category: str | None = None) -> bool:
+        doc = self._records.get(item_id)
+        if not doc or doc.get("status") != "claimed" or doc.get("claim_token") != claim_token:
+            return False
+        now = self._now_fn()
+        doc["status"] = "dead_letter"
+        doc["last_failed_at"] = now.isoformat()
+        doc["dead_lettered_at"] = now.isoformat()
+        doc["next_attempt_at"] = None
+        doc["error_category"] = (error_category or "permanent_failure")[:128]
+        doc["expires_at"] = (now + timedelta(seconds=3600)).isoformat()
+        return True
+
+    async def renew_lease(self, item_id: str, *, claim_token: str, extend_seconds: int | None = None) -> bool:
+        doc = self._records.get(item_id)
+        now = self._now_fn()
+        if not doc or doc.get("status") != "claimed" or doc.get("claim_token") != claim_token:
+            return False
+        if not doc.get("lease_expires_at") or doc["lease_expires_at"] <= now.isoformat():
+            return False
+        doc["lease_expires_at"] = (now + timedelta(seconds=int(extend_seconds or 300))).isoformat()
+        return True
+
+    async def active_count(self) -> int:
+        return len([doc for doc in self._records.values() if doc.get("status") == "claimed"])
+
+    async def queue_depth(self) -> int:
+        return len([doc for doc in self._records.values() if doc.get("status") == "pending"])
+
+    def status(self, item_id: str) -> str:
+        return str(self._records[item_id]["status"])
+
+    def document(self, item_id: str) -> dict[str, Any]:
+        return dict(self._records[item_id])
+
+
+class RecordingExecutor:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.contexts: list[WorkAssignmentExecutionContext] = []
+
+    async def execute(self, context: WorkAssignmentExecutionContext) -> WorkResult | dict[str, Any]:
+        self.contexts.append(context)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if callable(outcome):
+            maybe = outcome(context)
+            return await maybe if hasattr(maybe, "__await__") else maybe
+        return outcome
+
+
+class CrashDuringExecution(BaseException):
+    pass
+
+
+def _assignment(**overrides: Any) -> WorkAssignment:
+    payload = {
+        "assignment_id": "work-1",
+        "plan_id": "plan-1",
+        "plan_digest": "a" * 64,
+        "baseline_sha": "b" * 40,
+        "assignment_kind": "module_contract",
+        "owned_paths": ["modules/inventory/module.yaml"],
+    }
+    payload.update(overrides)
+    return make_work_assignment(**payload)
+
+
+def _result(assignment: WorkAssignment, *, status: str = "completed") -> WorkResult:
+    return make_work_result(
+        assignment=assignment,
+        status=status,
+        attempt_id=f"{assignment.assignment_id}:attempt",
+        changed_artifacts=[
+            {
+                "path": assignment.owned_paths[0],
+                "operation": "create",
+                "content_digest": stable_digest(f"{assignment.assignment_id}:content"),
+            }
+        ],
+    )
+
+
+def _outside_result(assignment: WorkAssignment) -> WorkResult:
+    artifact = ArtifactIdentity(
+        path="modules/other/module.yaml",
+        operation="create",
+        content_digest=stable_digest("outside"),
+    )
+    payload = {
+        "assignment_id": assignment.assignment_id,
+        "assignment_digest": assignment.assignment_digest,
+        "baseline_sha": assignment.baseline_sha,
+        "status": "completed",
+        "changed_artifacts": [artifact.model_dump(mode="json")],
+        "validation_evidence": [],
+        "output_digest": stable_digest({}),
+        "attempt_id": "outside-attempt",
+    }
+    return WorkResult(
+        **payload,
+        result_digest=stable_digest(payload),
+    )
+
+
+def _item(assignment: WorkAssignment, **payload_overrides: Any) -> QueueItem:
+    payload = {
+        WORK_ASSIGNMENT_PAYLOAD_KEY: assignment.model_dump(mode="json"),
+        "workspace_id": "workspace-1",
+    }
+    payload.update(payload_overrides)
+    return QueueItem(
+        workflow_name="WorkAssignmentWorker",
+        chat_id="chat-1",
+        app_id="app-1",
+        user_id="user-1",
+        tenant_id="tenant-1",
+        payload=payload,
+    )
+
+
+def _registry(executor: RecordingExecutor | None = None, *, kind: str = "module_contract") -> WorkAssignmentExecutorRegistry:
+    registry = WorkAssignmentExecutorRegistry()
+    if executor is not None:
+        registry.register(kind, executor)
+    return registry
+
+
+async def _enqueue_worker(
+    *,
+    queue: InMemoryWorkQueue,
+    assignment: WorkAssignment,
+    executor: RecordingExecutor | None,
+    max_attempts: int | None = None,
+    events: list[WorkAssignmentLifecycleEvent] | None = None,
+) -> tuple[str, WorkAssignmentWorker]:
+    item = _item(assignment)
+    item_id = await queue.enqueue(item, max_attempts=max_attempts)
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(executor),
+        worker_id="worker-1",
+        lease_seconds=30,
+        lifecycle_event_sink=(events.append if events is not None else None),
+    )
+    return item_id, worker
+
+
+@pytest.mark.asyncio
+async def test_run_once_claims_validates_executes_and_completes_with_fencing() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    events: list[WorkAssignmentLifecycleEvent] = []
+    executor = RecordingExecutor([_result(assignment)])
+    item_id, worker = await _enqueue_worker(queue=queue, assignment=assignment, executor=executor, events=events)
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED
+    assert queue.status(item_id) == "completed"
+    assert len(executor.contexts) == 1
+    context = executor.contexts[0]
+    assert context.assignment == assignment
+    assert context.claim_token == outcome.claim_token
+    assert context.owned_paths == assignment.owned_paths
+    assert context.workspace_id == "workspace-1"
+    assert events[0].event_type == "work_assignment.completed"
+    assert events[0].tenant_id == "tenant-1"
+
+
+@pytest.mark.asyncio
+async def test_crash_before_executor_invocation_is_reclaimed_after_lease_expiry() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+    first = await queue.claim_next("crashed-worker", lease_seconds=30)
+    assert first.claimed
+    executor = RecordingExecutor([_result(assignment)])
+    worker = WorkAssignmentWorker(queue=queue, executor_registry=_registry(executor), worker_id="replacement", lease_seconds=30)
+
+    clock.advance(31)
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED
+    assert outcome.claim_token != first.claim_token
+    assert queue.document(item_id)["attempt_count"] == 2
+    assert len(executor.contexts) == 1
+
+
+@pytest.mark.asyncio
+async def test_crash_during_execution_leaves_claim_for_replacement_worker() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id, worker = await _enqueue_worker(
+        queue=queue,
+        assignment=assignment,
+        executor=RecordingExecutor([CrashDuringExecution("process died")]),
+    )
+
+    with pytest.raises(CrashDuringExecution):
+        await worker.run_once()
+
+    assert queue.status(item_id) == "claimed"
+    clock.advance(31)
+    replacement = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([_result(assignment)])),
+        worker_id="replacement",
+        lease_seconds=30,
+    )
+    outcome = await replacement.run_once()
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED
+    assert queue.document(item_id)["attempt_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_worker_result_rejected_after_replacement_claim() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+    old_claim = await queue.claim_next("old", lease_seconds=30)
+    clock.advance(31)
+    new_claim = await queue.claim_next("new", lease_seconds=30)
+    assert old_claim.claim_token != new_claim.claim_token
+    stale_worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([_result(assignment)])),
+        worker_id="old",
+        lease_seconds=30,
+    )
+
+    outcome = await stale_worker.process_claim(old_claim)
+
+    assert outcome.status is WorkAssignmentRunStatus.STALE_CLAIM
+    assert queue.status(item_id) == "claimed"
+    assert await queue.complete(item_id, claim_token=old_claim.claim_token or "") is False
+    assert await queue.fail(item_id, claim_token=old_claim.claim_token or "") is None
+    assert await queue.renew_lease(item_id, claim_token=old_claim.claim_token or "") is False
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_dead_letters_without_executor_invocation() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    item_id = await queue.enqueue(QueueItem(workflow_name="WorkAssignmentWorker", chat_id="chat", app_id="app", payload={}))
+    executor = RecordingExecutor([RuntimeError("should not run")])
+    worker = WorkAssignmentWorker(queue=queue, executor_registry=_registry(executor), worker_id="worker")
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert outcome.error_category is WorkAssignmentFailureCategory.INVALID_PAYLOAD
+    assert queue.status(item_id) == "dead_letter"
+    assert executor.contexts == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_executor_dead_letters_registered_kind_without_arbitrary_resolution() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment(assignment_kind="page_bundle", owned_paths=["ui/pages/home.yaml"])
+    item_id, worker = await _enqueue_worker(queue=queue, assignment=assignment, executor=None)
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert outcome.error_category is WorkAssignmentFailureCategory.UNKNOWN_EXECUTOR
+    assert queue.document(item_id)["error_category"] == "unknown_executor"
+
+
+@pytest.mark.asyncio
+async def test_transient_executor_retries_inside_assignment_budget_before_queue_retry() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment(assignment_retry_limit=1)
+    executor = RecordingExecutor([WorkAssignmentTransientError("temporary"), _result(assignment)])
+    item_id, worker = await _enqueue_worker(queue=queue, assignment=assignment, executor=executor)
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED
+    assert outcome.executor_attempt_count == 2
+    assert queue.document(item_id)["attempt_count"] == 1
+    assert len(executor.contexts) == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_exhaustion_uses_queue_delivery_budget() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment(assignment_retry_limit=0)
+    executor = RecordingExecutor([WorkAssignmentTransientError("temporary")])
+    item_id, worker = await _enqueue_worker(queue=queue, assignment=assignment, executor=executor, max_attempts=2)
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.RETRYABLE
+    assert queue.status(item_id) == "retryable"
+    assert queue.document(item_id)["error_category"] == "executor_transient"
+
+
+@pytest.mark.asyncio
+async def test_permanent_executor_error_dead_letters_immediately() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id, worker = await _enqueue_worker(
+        queue=queue,
+        assignment=assignment,
+        executor=RecordingExecutor([WorkAssignmentPermanentError("bad contract")]),
+        max_attempts=5,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert queue.status(item_id) == "dead_letter"
+    assert queue.document(item_id)["attempt_count"] == 1
+    assert queue.document(item_id)["error_category"] == "executor_permanent"
+
+
+@pytest.mark.asyncio
+async def test_queue_max_attempts_dead_letters_after_delivery_budget() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id, worker = await _enqueue_worker(
+        queue=queue,
+        assignment=assignment,
+        executor=RecordingExecutor([WorkAssignmentTransientError("one")]),
+        max_attempts=1,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert queue.status(item_id) == "dead_letter"
+
+
+@pytest.mark.asyncio
+async def test_executor_malformed_result_dead_letters() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id, worker = await _enqueue_worker(queue=queue, assignment=assignment, executor=RecordingExecutor([{"not": "result"}]))
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert outcome.error_category is WorkAssignmentFailureCategory.EXECUTOR_RESULT_INVALID
+    assert queue.status(item_id) == "dead_letter"
+
+
+@pytest.mark.asyncio
+async def test_executor_result_outside_owned_paths_dead_letters() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id, worker = await _enqueue_worker(
+        queue=queue,
+        assignment=assignment,
+        executor=RecordingExecutor([_outside_result(assignment)]),
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert outcome.error_category is WorkAssignmentFailureCategory.EXECUTOR_RESULT_INVALID
+    assert queue.status(item_id) == "dead_letter"
+
+
+@pytest.mark.asyncio
+async def test_executor_can_explicitly_renew_current_lease() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+
+    async def _renew_then_result(context: WorkAssignmentExecutionContext) -> WorkResult:
+        assert await context.renew_lease(120) is True
+        return _result(assignment)
+
+    item_id, worker = await _enqueue_worker(
+        queue=queue,
+        assignment=assignment,
+        executor=RecordingExecutor([_renew_then_result]),
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED
+    assert queue.status(item_id) == "completed"
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_after_durable_completion_does_not_reopen_work() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+
+    async def _bad_sink(event: WorkAssignmentLifecycleEvent) -> None:
+        raise RuntimeError("event sink down")
+
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([_result(assignment)])),
+        worker_id="worker",
+        lifecycle_event_sink=_bad_sink,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.COMPLETED_EVENT_FAILED
+    assert queue.status(item_id) == "completed"
+
+
+@pytest.mark.asyncio
+async def test_identical_delivery_cannot_bypass_fencing() -> None:
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+    claim = await queue.claim_next("worker", lease_seconds=30)
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([_result(assignment), _result(assignment)])),
+        worker_id="worker",
+    )
+
+    first = await worker.process_claim(claim)
+    second = await worker.process_claim(claim)
+
+    assert first.status is WorkAssignmentRunStatus.COMPLETED
+    assert second.status is WorkAssignmentRunStatus.STALE_CLAIM
+    assert queue.status(item_id) == "completed"

--- a/tests/test_work_assignment_worker.py
+++ b/tests/test_work_assignment_worker.py
@@ -561,3 +561,204 @@ async def test_identical_delivery_cannot_bypass_fencing() -> None:
     assert first.status is WorkAssignmentRunStatus.COMPLETED
     assert second.status is WorkAssignmentRunStatus.STALE_CLAIM
     assert queue.status(item_id) == "completed"
+
+
+@pytest.mark.asyncio
+async def test_executor_result_failed_uses_queue_retry_budget() -> None:
+    """result.status=='failed' routes through _fail_claim, not dead_letter."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    executor = RecordingExecutor([_result(assignment, status="failed")])
+    item_id, worker = await _enqueue_worker(
+        queue=queue, assignment=assignment, executor=executor, max_attempts=2,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.RETRYABLE
+    assert outcome.error_category is WorkAssignmentFailureCategory.EXECUTOR_RESULT_FAILED
+    assert queue.status(item_id) == "retryable"
+
+
+@pytest.mark.asyncio
+async def test_executor_result_skipped_dead_letters() -> None:
+    """result.status=='skipped' is a deterministic permanent failure."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    executor = RecordingExecutor([_result(assignment, status="skipped")])
+    item_id, worker = await _enqueue_worker(
+        queue=queue, assignment=assignment, executor=executor, max_attempts=5,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert outcome.error_category is WorkAssignmentFailureCategory.EXECUTOR_RESULT_SKIPPED
+    assert queue.status(item_id) == "dead_letter"
+
+
+def test_registry_rejects_duplicate_registration() -> None:
+    registry = WorkAssignmentExecutorRegistry()
+    executor = RecordingExecutor([])
+    registry.register("module_contract", executor)
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("module_contract", executor)
+
+
+def test_registry_rejects_missing_execute_method() -> None:
+    registry = WorkAssignmentExecutorRegistry()
+    with pytest.raises(ValueError, match="must expose"):
+        registry.register("module_contract", object())  # type: ignore[arg-type]
+
+
+def test_worker_rejects_empty_worker_id() -> None:
+    from mozaiksai.core.workflow.queue import NoOpWorkflowQueue
+
+    with pytest.raises(ValueError, match="worker_id must be non-empty"):
+        WorkAssignmentWorker(
+            queue=NoOpWorkflowQueue(),
+            executor_registry=WorkAssignmentExecutorRegistry(),
+            worker_id="",
+        )
+
+
+def test_worker_rejects_whitespace_only_worker_id() -> None:
+    from mozaiksai.core.workflow.queue import NoOpWorkflowQueue
+
+    with pytest.raises(ValueError, match="worker_id must be non-empty"):
+        WorkAssignmentWorker(
+            queue=NoOpWorkflowQueue(),
+            executor_registry=WorkAssignmentExecutorRegistry(),
+            worker_id="   ",
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_dead_letter_rejected_after_replacement_claim() -> None:
+    """Dead-letter by a stale worker must be rejected by fencing."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+    old_claim = await queue.claim_next("old", lease_seconds=30)
+    clock.advance(31)
+    new_claim = await queue.claim_next("new", lease_seconds=30)
+    assert old_claim.claim_token != new_claim.claim_token
+
+    # Old worker tries to dead_letter with stale token
+    assert await queue.dead_letter(item_id, claim_token=old_claim.claim_token or "") is False
+    assert queue.status(item_id) == "claimed"
+    assert queue.document(item_id)["claim_token"] == new_claim.claim_token
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_after_retryable_fail_does_not_revert_transition() -> None:
+    """Event sink failure after fail() must not revert the queue transition."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment(assignment_retry_limit=0)
+    item_id = await queue.enqueue(_item(assignment), max_attempts=2)
+
+    async def _bad_sink(event: WorkAssignmentLifecycleEvent) -> None:
+        raise RuntimeError("event sink down")
+
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([WorkAssignmentTransientError("temp")])),
+        worker_id="worker",
+        lifecycle_event_sink=_bad_sink,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.RETRYABLE_EVENT_FAILED
+    assert queue.status(item_id) == "retryable"
+    assert outcome.lifecycle_event_emitted is False
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_after_dead_letter_does_not_revert_transition() -> None:
+    """Event sink failure after dead_letter() must not revert the queue transition."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    assignment = _assignment()
+    item_id = await queue.enqueue(_item(assignment))
+
+    async def _bad_sink(event: WorkAssignmentLifecycleEvent) -> None:
+        raise RuntimeError("event sink down")
+
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([WorkAssignmentPermanentError("bad")])),
+        worker_id="worker",
+        lifecycle_event_sink=_bad_sink,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER_EVENT_FAILED
+    assert queue.status(item_id) == "dead_letter"
+    assert outcome.lifecycle_event_emitted is False
+
+
+@pytest.mark.asyncio
+async def test_no_lifecycle_event_when_assignment_is_none_on_dead_letter() -> None:
+    """Malformed payload (assignment=None) dead-letters without emitting lifecycle event."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    events: list[WorkAssignmentLifecycleEvent] = []
+    item_id = await queue.enqueue(QueueItem(
+        workflow_name="WorkAssignmentWorker", chat_id="chat", app_id="app",
+        payload={"work_assignment": "not_a_dict"},
+    ))
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=_registry(RecordingExecutor([])),
+        worker_id="worker",
+        lifecycle_event_sink=events.append,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.DEAD_LETTER
+    assert queue.status(item_id) == "dead_letter"
+    assert events == []
+    assert outcome.lifecycle_event_emitted is False
+
+
+@pytest.mark.asyncio
+async def test_run_once_no_item_returns_no_item() -> None:
+    """run_once on empty queue returns NO_ITEM without side effects."""
+    clock = ManualClock()
+    queue = InMemoryWorkQueue(now_fn=clock.now)
+    worker = WorkAssignmentWorker(
+        queue=queue,
+        executor_registry=WorkAssignmentExecutorRegistry(),
+        worker_id="worker",
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.status is WorkAssignmentRunStatus.NO_ITEM
+    assert outcome.item_id is None
+    assert outcome.assignment_id is None
+
+
+@pytest.mark.asyncio
+async def test_registry_resolve_unknown_kind_returns_none() -> None:
+    """Resolving an unregistered kind returns None, not an error."""
+    registry = WorkAssignmentExecutorRegistry()
+    assert registry.resolve("module_contract") is None
+
+
+def test_registered_kinds_returns_sorted_tuple() -> None:
+    registry = WorkAssignmentExecutorRegistry()
+    e1 = RecordingExecutor([])
+    e2 = RecordingExecutor([])
+    registry.register("page_bundle", e1)
+    registry.register("module_contract", e2)
+    kinds = registry.registered_kinds()
+    assert isinstance(kinds, tuple)
+    assert list(kinds) == sorted(kinds, key=lambda k: k.value)

--- a/tests/test_workflow_queue_leases.py
+++ b/tests/test_workflow_queue_leases.py
@@ -196,6 +196,29 @@ class InMemoryWorkflowQueue:
         rec.doc["error_category"] = (error_category or "execution_error")[:128]
         return new_status
 
+    async def dead_letter(
+        self,
+        item_id: str,
+        *,
+        claim_token: str,
+        error_category: str | None = None,
+    ) -> bool:
+        rec = self._records.get(item_id)
+        if rec is None:
+            return False
+        if rec.doc.get("status") != "claimed" or rec.doc.get("claim_token") != claim_token:
+            return False
+
+        now = self._now()
+        now_iso = now.isoformat()
+        rec.doc["status"] = "dead_letter"
+        rec.doc["last_failed_at"] = now_iso
+        rec.doc["dead_lettered_at"] = now_iso
+        rec.doc["next_attempt_at"] = None
+        rec.doc["error_category"] = (error_category or "permanent_failure")[:128]
+        rec.doc["expires_at"] = (now + timedelta(seconds=3600)).isoformat()
+        return True
+
     async def renew_lease(
         self,
         item_id: str,
@@ -1378,7 +1401,54 @@ async def test_replacement_worker_completes_after_reclaim() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 54. Enqueue with max_attempts=None uses default
+# 54. Fenced immediate dead-letter for deterministic permanent failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_uses_current_fencing_token() -> None:
+    q = InMemoryWorkflowQueue()
+    item = _item()
+    await q.enqueue(item, max_attempts=3)
+    claim = await q.claim_next("worker")
+    assert claim.claimed
+
+    assert await q.dead_letter(item.item_id, claim_token="stale-token") is False
+    assert q.item_status(item.item_id) == "claimed"
+
+    assert await q.dead_letter(
+        item.item_id,
+        claim_token=claim.claim_token,
+        error_category="invalid_payload",
+    ) is True
+    assert q.item_status(item.item_id) == "dead_letter"
+    assert q.item_expires_at(item.item_id) is not None
+    doc = q._records[item.item_id].doc
+    assert doc["error_category"] == "invalid_payload"
+    assert doc["next_attempt_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_stale_dead_letter_rejected_after_reclaim() -> None:
+    clock = _Clock()
+    q = InMemoryWorkflowQueue(now_fn=clock)
+    item = _item()
+    await q.enqueue(item, max_attempts=3)
+    old = await q.claim_next("w-old", lease_seconds=30)
+    assert old.claimed
+    clock.advance(31)
+    new = await q.claim_next("w-new", lease_seconds=30)
+    assert new.claimed
+
+    assert await q.dead_letter(item.item_id, claim_token=old.claim_token) is False
+    assert q.item_status(item.item_id) == "claimed"
+
+    assert await q.dead_letter(item.item_id, claim_token=new.claim_token) is True
+    assert q.item_status(item.item_id) == "dead_letter"
+
+
+# ---------------------------------------------------------------------------
+# 55. Enqueue with max_attempts=None uses default
 # ---------------------------------------------------------------------------
 
 
@@ -1393,7 +1463,7 @@ async def test_enqueue_max_attempts_none_uses_default() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 55. QueueItem dataclass default max_attempts
+# 56. QueueItem dataclass default max_attempts
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds the first generic explicitly invoked WorkAssignment worker over the durable WorkflowQueue.

The worker lifecycle is bounded and explicit:

```text
claim queue item
-> validate canonical WorkAssignment payload
-> resolve a registered assignment-kind executor
-> execute with assignment-scoped context and lease renewal capability
-> validate WorkResult against assignment identity and owned paths
-> fenced complete / fail / immediate dead-letter
-> emit safe lifecycle event only after durable state change
```

## Architecture

- Reuses `WorkflowQueue` as the durable delivery, lease, retry, and fencing owner.
- Reuses PR #280 `WorkAssignment` / `WorkResult` as the typed authority boundary.
- Adds `WorkAssignmentExecutorRegistry` keyed by canonical `AssignmentKind`; no import-path execution or arbitrary class/tool resolution.
- Adds `WorkAssignmentExecutionContext` so executors receive only scoped assignment facts: owned paths, allowed agents, structured-output id, queue scope, claim token, and explicit lease renewal.
- Adds `WorkflowQueue.dead_letter()` for fenced immediate terminal transition on deterministic permanent failures.
- Documents at-least-once delivery in the worker module: external side effects must be idempotent by assignment/result identity.

## Validation

- Executor results are revalidated from JSON and checked against assignment identity, baseline, assignment digest, owned paths, required artifacts, and required validators.
- Transient executor failures use assignment retry budget inside a single queue claim, then queue delivery budget via `WorkflowQueue.fail()`.
- Permanent contract failures use fenced `WorkflowQueue.dead_letter()`.
- Lifecycle events are emitted only after durable queue transition and failure to emit does not reopen completed work.

## Tests run

- `python -m pytest tests/test_work_assignment_worker.py -q --no-cov` twice
- `python -m pytest tests/test_work_assignment_worker.py tests/test_workflow_queue_leases.py tests/test_work_integration_contracts.py -q --no-cov`
- `python -m pytest tests/test_task_batch_contracts.py tests/test_task_batches_helpers.py tests/test_task_batches_extended_helpers.py tests/test_runtime_task_batch_smoke.py tests/test_runtime_context_expression_task_batch_smoke.py tests/test_refinement_task_batch_smoke.py tests/test_appgenerator_task_batch_contracts.py tests/test_ag2_agent_runner.py tests/test_ag2_network_execution_alignment.py -q --no-cov`
- `ruff check .`
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped`
- `python -m pytest -q --no-cov` (`12936 passed, 77 skipped`)

## Scope notes

- No AppContextGraph or PR #279-owned files touched.
- No unmanaged loops, startup background tasks, GitHub execution, autonomous agents, arbitrary import-path execution, or new queue/scheduler/AG2 runner.
