### PR TITLE
Integrate app layout validation into bundle scanning

### DIFF
--- a/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
+++ b/factory_app/workflows/AppGenerator/tools/community_component_lifecycle.py
@@ -403,6 +403,9 @@ def apply_component_upgrade(
         path.relative_to(app_root).as_posix(): path.read_text(encoding="utf-8")
         for path in app_root.rglob("*")
         if path.is_file()
+        and "__pycache__" not in path.parts
+        and ".pytest_cache" not in path.parts
+        and path.suffix not in {".pyc", ".pyo"}
     })
     provenance_errors = [error for error in scanner_errors if "pack_provenance" in error]
     if provenance_errors:

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -34,6 +34,18 @@ from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templat
     ManagedCapabilityTemplateError,
     resolve_declared_pack_output_paths,
 )
+from mozaiksai.core.runtime.app.layout_registry import (
+    ExtensionSlot,
+    LayoutExtension,
+    PathScope,
+    build_app_layout_registry,
+)
+from mozaiksai.core.runtime.app.layout_validation import (
+    filter_layout_scannable_file_map,
+    layout_extensions_from_selected_packs,
+    layout_validation_errors,
+    validate_file_map_layout,
+)
 from mozaiksai.core.runtime.app.paths import (
     APP_AUTH_CONFIG_PATH,
     APP_DATA_CONTRACT_PATH,
@@ -2067,10 +2079,83 @@ def _scan_event_reaction_closure(files_map: dict[str, str]) -> list[str]:
     return errors
 
 
+def _layout_extensions_for_selected_packs(
+    capability_packs: list[dict[str, Any]] | None,
+) -> tuple[LayoutExtension, ...]:
+    extensions = list(layout_extensions_from_selected_packs(capability_packs))
+    for pack in capability_packs or []:
+        pack_id = _pack_id_from_descriptor(pack)
+        if not pack_id:
+            continue
+        for path in sorted(resolve_declared_pack_output_paths([pack])):
+            if _path_is_already_layout_registered(path, tuple(extensions)):
+                continue
+            extensions.append(
+                LayoutExtension(
+                    slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+                    pack_id=pack_id,
+                    path=path,
+                )
+            )
+    return tuple(sorted(extensions, key=lambda item: (item.slot.value, item.pack_id, item.path or "")))
+
+
+def _path_is_already_layout_registered(path: str, extensions: tuple[LayoutExtension, ...]) -> bool:
+    registry = build_app_layout_registry(extensions)
+    scopes = (
+        PathScope.APP_BUNDLE_ROOT,
+        PathScope.DEPLOYMENT_DERIVED,
+        PathScope.WORKSPACE_ROOT,
+        PathScope.GENERATED_STAGING,
+    )
+    for scope in scopes:
+        try:
+            registry.match_path(path, scope)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def _scan_declared_pack_repo_support_outputs(
+    files_map: dict[str, str],
+    *,
+    capability_packs: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    if not capability_packs:
+        return []
+    try:
+        declared_paths = resolve_declared_pack_output_paths(capability_packs)
+    except ManagedCapabilityTemplateError as exc:
+        return [f"Selected CapabilityPack output contract is invalid: {exc}"]
+
+    repo_support = (
+        ".claude/",
+        ".github/",
+        "docs/",
+        "scripts/",
+    )
+    invalid = sorted(
+        path
+        for path in _normalized_files_map(files_map)
+        if path.startswith(repo_support)
+        and path != ".github/workflows/deploy.yml"
+        and path not in declared_paths
+    )
+    if not invalid:
+        return []
+    return [
+        "Generated app bundle contains undeclared repository-support pack outputs: "
+        f"{invalid}. Selected capability packs must declare generated docs, scripts, "
+        "and repository-support files explicitly."
+    ]
+
+
 def scan_generated_bundle(
     files_map: dict[str, str],
     *,
     capability_packs: list[dict[str, Any]] | None = None,
+    layout_extensions: tuple[LayoutExtension, ...] | None = None,
     require_deployment_artifacts: bool = False,
 ) -> list[str]:
     """Scan files_map for forbidden patterns.
@@ -2088,65 +2173,84 @@ def scan_generated_bundle(
     - modules/*/contracts/reactions.yaml: event_type closure, target.kind taxonomy,
       target-kind-specific required fields.
     """
-    errors: list[str] = []
+    try:
+        selected_layout_extensions = (
+            tuple(layout_extensions)
+            if layout_extensions is not None
+            else _layout_extensions_for_selected_packs(capability_packs)
+        )
+    except ManagedCapabilityTemplateError as exc:
+        return [f"Selected CapabilityPack output contract is invalid: {exc}"]
+    layout_report = validate_file_map_layout(
+        files_map,
+        selected_extensions=selected_layout_extensions,
+    )
+    errors: list[str] = layout_validation_errors(layout_report)
     errors.extend(
-        _scan_canonical_app_paths(
+        _scan_declared_pack_repo_support_outputs(
             files_map,
             capability_packs=capability_packs,
         )
     )
-    errors.extend(_scan_security_secret_contract(files_map))
-    errors.extend(_scan_pack_provenance_manifest(files_map))
-    errors.extend(_scan_route_manifest_consistency(files_map))
-    errors.extend(_scan_route_manifest_component_files(files_map))
-    errors.extend(_scan_page_schema_structure(files_map))
-    errors.extend(_scan_page_api_endpoint_alignment(files_map))
-    errors.extend(_scan_action_api_surface(files_map))
-    errors.extend(_scan_event_reaction_closure(files_map))
-    errors.extend(_scan_data_contract_module_alignment(files_map))
+    scannable_files_map = filter_layout_scannable_file_map(files_map, layout_report)
+    errors.extend(
+        _scan_canonical_app_paths(
+            scannable_files_map,
+            capability_packs=capability_packs,
+        )
+    )
+    errors.extend(_scan_security_secret_contract(scannable_files_map))
+    errors.extend(_scan_pack_provenance_manifest(scannable_files_map))
+    errors.extend(_scan_route_manifest_consistency(scannable_files_map))
+    errors.extend(_scan_route_manifest_component_files(scannable_files_map))
+    errors.extend(_scan_page_schema_structure(scannable_files_map))
+    errors.extend(_scan_page_api_endpoint_alignment(scannable_files_map))
+    errors.extend(_scan_action_api_surface(scannable_files_map))
+    errors.extend(_scan_event_reaction_closure(scannable_files_map))
+    errors.extend(_scan_data_contract_module_alignment(scannable_files_map))
     errors.extend(
         _scan_selected_managed_capability_boundaries(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
     errors.extend(
         _scan_managed_setup_provider_leaks(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
     errors.extend(
         _scan_token_wallets_require_mozaikspay(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
     errors.extend(
         _scan_mozaikspay_saas_contract(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
     errors.extend(
         _scan_mozaiks_cloud_connector_contract(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
     errors.extend(
         _scan_self_hosted_entitlement_dispatch_contract(
-            files_map,
+            scannable_files_map,
             capability_packs=capability_packs,
         )
     )
-    errors.extend(_scan_entitlement_gate_capability_alignment(files_map))
-    errors.extend(_scan_auth_app_contract(files_map))
+    errors.extend(_scan_entitlement_gate_capability_alignment(scannable_files_map))
+    errors.extend(_scan_auth_app_contract(scannable_files_map))
     if require_deployment_artifacts:
-        errors.extend(_scan_deployment_artifacts_contract(files_map))
-        errors.extend(_scan_auth_deployment_contract(files_map))
+        errors.extend(_scan_deployment_artifacts_contract(scannable_files_map))
+        errors.extend(_scan_auth_deployment_contract(scannable_files_map))
 
-    for path, content in files_map.items():
+    for path, content in scannable_files_map.items():
         if not isinstance(path, str) or not isinstance(content, str):
             continue
 

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -26,6 +26,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
+from pydantic import ValidationError as PydanticValidationError
 
 from factory_app.workflows._shared.generated_ui_contract import (
     VALID_PAGE_TYPES as _CANONICAL_PAGE_TYPES,
@@ -120,6 +121,9 @@ _SCANNABLE_SUFFIXES = (
     ".py", ".js", ".jsx", ".ts", ".tsx",
     ".yaml", ".yml", ".env.example", ".env.staging.example",
     ".env.production.example", ".env",
+    # Pack-declared workspace scripts ship to customers and must never carry
+    # raw credentials or provider leaks.
+    ".ps1", ".sh",
 )
 
 _RAW_SECRET_FIELD_KEYS = frozenset(
@@ -2083,25 +2087,40 @@ def _layout_extensions_for_selected_packs(
     capability_packs: list[dict[str, Any]] | None,
 ) -> tuple[LayoutExtension, ...]:
     extensions = list(layout_extensions_from_selected_packs(capability_packs))
+    claimed_paths: dict[str, str] = {}
     for pack in capability_packs or []:
         pack_id = _pack_id_from_descriptor(pack)
         if not pack_id:
             continue
         for path in sorted(resolve_declared_pack_output_paths([pack])):
-            if _path_is_already_layout_registered(path, tuple(extensions)):
-                continue
-            extensions.append(
-                LayoutExtension(
-                    slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
-                    pack_id=pack_id,
-                    path=path,
+            prior_owner = claimed_paths.get(path)
+            if prior_owner is not None and prior_owner != pack_id:
+                raise ManagedCapabilityTemplateError(
+                    f"Selected packs '{prior_owner}' and '{pack_id}' both declare "
+                    f"output path {path!r}; duplicate pack output claims fail closed"
                 )
-            )
+            claimed_paths[path] = pack_id
+            if _path_matches_core_layout(path):
+                continue
+            try:
+                extensions.append(
+                    LayoutExtension(
+                        slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+                        pack_id=pack_id,
+                        path=path,
+                    )
+                )
+            except (ValueError, PydanticValidationError) as exc:
+                raise ManagedCapabilityTemplateError(
+                    f"Pack '{pack_id}' declares output {path!r} outside the "
+                    f"permitted pack output lanes: {exc}"
+                ) from exc
     return tuple(sorted(extensions, key=lambda item: (item.slot.value, item.pack_id, item.path or "")))
 
 
-def _path_is_already_layout_registered(path: str, extensions: tuple[LayoutExtension, ...]) -> bool:
-    registry = build_app_layout_registry(extensions)
+def _path_matches_core_layout(path: str) -> bool:
+    """True when the core registry (no extensions) already classifies the path."""
+    registry = build_app_layout_registry(())
     scopes = (
         PathScope.APP_BUNDLE_ROOT,
         PathScope.DEPLOYMENT_DERIVED,
@@ -2122,10 +2141,12 @@ def _scan_declared_pack_repo_support_outputs(
     *,
     capability_packs: list[dict[str, Any]] | None = None,
 ) -> list[str]:
-    if not capability_packs:
-        return []
     try:
-        declared_paths = resolve_declared_pack_output_paths(capability_packs)
+        declared_paths = (
+            resolve_declared_pack_output_paths(capability_packs)
+            if capability_packs
+            else frozenset()
+        )
     except ManagedCapabilityTemplateError as exc:
         return [f"Selected CapabilityPack output contract is invalid: {exc}"]
 
@@ -2134,12 +2155,13 @@ def _scan_declared_pack_repo_support_outputs(
         ".github/",
         "docs/",
         "scripts/",
+        "tests/",
     )
     invalid = sorted(
         path
         for path in _normalized_files_map(files_map)
         if path.startswith(repo_support)
-        and path != ".github/workflows/deploy.yml"
+        and path not in {".github/workflows/deploy.yml", ".github/workflows/readiness.yml"}
         and path not in declared_paths
     )
     if not invalid:
@@ -2155,7 +2177,6 @@ def scan_generated_bundle(
     files_map: dict[str, str],
     *,
     capability_packs: list[dict[str, Any]] | None = None,
-    layout_extensions: tuple[LayoutExtension, ...] | None = None,
     require_deployment_artifacts: bool = False,
 ) -> list[str]:
     """Scan files_map for forbidden patterns.
@@ -2174,11 +2195,7 @@ def scan_generated_bundle(
       target-kind-specific required fields.
     """
     try:
-        selected_layout_extensions = (
-            tuple(layout_extensions)
-            if layout_extensions is not None
-            else _layout_extensions_for_selected_packs(capability_packs)
-        )
+        selected_layout_extensions = _layout_extensions_for_selected_packs(capability_packs)
     except ManagedCapabilityTemplateError as exc:
         return [f"Selected CapabilityPack output contract is invalid: {exc}"]
     layout_report = validate_file_map_layout(
@@ -2250,7 +2267,7 @@ def scan_generated_bundle(
         errors.extend(_scan_deployment_artifacts_contract(scannable_files_map))
         errors.extend(_scan_auth_deployment_contract(scannable_files_map))
 
-    for path, content in scannable_files_map.items():
+    for path, content in files_map.items():
         if not isinstance(path, str) or not isinstance(content, str):
             continue
 

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -74,6 +74,7 @@ class ArtifactKind(StrEnum):
     APP_UI_ROUTE_MANIFEST = "app_ui_route_manifest"
     APP_UI_PAGE_SCHEMA = "app_ui_page_schema"
     APP_UI_CUSTOM_ROUTE = "app_ui_custom_route"
+    APP_UI_AUTH_ADAPTER = "app_ui_auth_adapter"
     APP_UI_EXTENSION_BARREL = "app_ui_extension_barrel"
     APP_UI_MODULE_API = "app_ui_module_api"
     APP_ADMIN_REGISTRY = "app_admin_registry"
@@ -100,6 +101,7 @@ class ArtifactKind(StrEnum):
     WORKFLOW_TASK_BATCH = "workflow_task_batch"
     BUILD_CONTEXT_REGISTRY = "build_context_registry"
     BUILD_CONTEXT_ASSET = "build_context_asset"
+    CAPABILITY_PACK_OUTPUT = "capability_pack_output"
     GENERATED_APP_STAGING = "generated_app_staging"
     GENERATED_WORKFLOW_STAGING = "generated_workflow_staging"
     PROHIBITED_LEGACY = "prohibited_legacy"
@@ -216,6 +218,7 @@ class PlaceholderIdentifier(StrEnum):
 class ExtensionSlot(StrEnum):
     MANAGED_CAPABILITY_CONFIG = "managed_capability_config"
     MANAGED_CAPABILITY_CLIENT = "managed_capability_client"
+    CAPABILITY_PACK_OUTPUT = "capability_pack_output"
     SERVICE_ADAPTER = "service_adapter"
     SERVICE_ROUTE = "service_route"
     BUILD_CONTEXT_PACK = "build_context_pack"
@@ -288,6 +291,7 @@ class ArtifactMatch(LayoutModel):
 class LayoutExtension(LayoutModel):
     slot: ExtensionSlot
     pack_id: str = Field(min_length=1)
+    path: str | None = None
 
     @field_validator("pack_id")
     @classmethod
@@ -296,6 +300,22 @@ class LayoutExtension(LayoutModel):
         if not re.fullmatch(r"[a-z][a-z0-9_]{0,63}", text):
             raise ValueError("pack_id must be a lowercase registry identifier")
         return text
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _normalize_template(value)
+
+    @model_validator(mode="after")
+    def _validate_slot_path(self) -> LayoutExtension:
+        if self.slot == ExtensionSlot.CAPABILITY_PACK_OUTPUT:
+            if not self.path:
+                raise ValueError("capability_pack_output extensions require an exact path")
+        elif self.path is not None:
+            raise ValueError("path is only valid for capability_pack_output extensions")
+        return self
 
 
 class AppLayoutRegistry(LayoutModel):
@@ -442,7 +462,9 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_DASHBOARD, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "dashboard/dashboard.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_ROUTE_MANIFEST, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "ui/route_manifest.json", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_PAGE_SCHEMA, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_PAGE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,)),
+        _family(ArtifactKind.APP_UI_CUSTOM_ROUTE, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/custom/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_CUSTOM_ROUTE, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/custom/{page_id}.jsx", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, multiplicity=Multiplicity.MANY, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
+        _family(ArtifactKind.APP_UI_AUTH_ADAPTER, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/auth/authAdapter.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_AUTH_ENABLED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_EXTENSION_BARREL, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/index.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_MODULE_API, LayoutOwner.PLATFORM, Requirement.CONDITIONAL, app, "ui/lib/moduleApi.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_ADMIN_REGISTRY, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "admin/admin_registry.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST),
@@ -633,7 +655,58 @@ def _extension_families(extensions: tuple[LayoutExtension, ...]) -> tuple[Artifa
                     condition=ConditionIdentifier.WHEN_EXTENSION_SELECTED,
                 )
             )
+        elif extension.slot == ExtensionSlot.CAPABILITY_PACK_OUTPUT:
+            assert extension.path is not None
+            result.append(
+                _family(
+                    ArtifactKind.CAPABILITY_PACK_OUTPUT,
+                    LayoutOwner.CAPABILITY_PACK,
+                    Requirement.CONDITIONAL,
+                    _capability_pack_output_scope(extension.path),
+                    extension.path,
+                    ValidatorIdentifier.GENERATED_APP_VALIDATOR,
+                    _capability_pack_output_consumer(extension.path),
+                    condition=ConditionIdentifier.WHEN_EXTENSION_SELECTED,
+                    security=_capability_pack_output_security(extension.path),
+                )
+            )
     return tuple(result)
+
+
+def _capability_pack_output_scope(path: str) -> PathScope:
+    if path.startswith("generated/"):
+        return PathScope.GENERATED_STAGING
+    if path in {
+        "Dockerfile",
+        "docker-compose.yml",
+        ".env.example",
+        ".env.staging.example",
+        ".env.production.example",
+        "deployment.manifest.json",
+        ".github/workflows/deploy.yml",
+    }:
+        return PathScope.DEPLOYMENT_DERIVED
+    if path.startswith(("docs/", "scripts/", ".claude/", ".github/")):
+        return PathScope.WORKSPACE_ROOT
+    return PathScope.APP_BUNDLE_ROOT
+
+
+def _capability_pack_output_consumer(path: str) -> RuntimeConsumerIdentifier:
+    if path.startswith(("docs/", "scripts/", ".claude/", ".github/")):
+        return RuntimeConsumerIdentifier.NONE
+    if _capability_pack_output_scope(path) == PathScope.DEPLOYMENT_DERIVED:
+        return RuntimeConsumerIdentifier.DOWNLOAD_EXPORT
+    return RuntimeConsumerIdentifier.PLATFORM_HOST
+
+
+def _capability_pack_output_security(path: str) -> SecurityClass:
+    if path.lower().endswith((".py", ".js", ".jsx", ".ts", ".tsx", ".ps1", ".sh")):
+        return SecurityClass.EXECUTABLE_STUB
+    if _capability_pack_output_scope(path) == PathScope.DEPLOYMENT_DERIVED:
+        return SecurityClass.DEPLOYMENT_METADATA
+    if path.startswith("generated/"):
+        return SecurityClass.GENERATED_STAGING
+    return SecurityClass.INTERNAL_CONTRACT
 
 
 def _family(

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -313,6 +313,7 @@ class LayoutExtension(LayoutModel):
         if self.slot == ExtensionSlot.CAPABILITY_PACK_OUTPUT:
             if not self.path:
                 raise ValueError("capability_pack_output extensions require an exact path")
+            _validate_capability_pack_output_path(self.path)
         elif self.path is not None:
             raise ValueError("path is only valid for capability_pack_output extensions")
         return self
@@ -351,6 +352,12 @@ class AppLayoutRegistry(LayoutModel):
         ]
         if not matches:
             raise ValueError(f"path {path!r} is not registered for scope {resolved_scope.value!r}")
+        prohibited = [m for m in matches if m.family.requirement is Requirement.PROHIBITED]
+        if prohibited:
+            # Prohibition is absolute: no extension or literal registration may
+            # shadow a prohibited family through specificity precedence.
+            prohibited.sort(key=lambda m: (len(m.values), m.family.path_template))
+            return prohibited[0]
         if len(matches) > 1:
             # Deterministic specificity precedence: a template with fewer
             # placeholders is more literal and wins (a registered-extension
@@ -462,7 +469,6 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_DASHBOARD, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "dashboard/dashboard.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_ROUTE_MANIFEST, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "ui/route_manifest.json", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_PAGE_SCHEMA, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_PAGE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,)),
-        _family(ArtifactKind.APP_UI_CUSTOM_ROUTE, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/custom/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_CUSTOM_ROUTE, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/custom/{page_id}.jsx", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, multiplicity=Multiplicity.MANY, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_AUTH_ADAPTER, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/auth/authAdapter.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_AUTH_ENABLED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_EXTENSION_BARREL, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/index.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
@@ -508,6 +514,7 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, ".env.production.example", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
         _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, "deployment.manifest.json", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
         _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, ".github/workflows/deploy.yml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
+        _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, ".github/workflows/readiness.yml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
         _family(ArtifactKind.APP_MANIFEST, LayoutOwner.PLATFORM, Requirement.REQUIRED, workspace, "app/app.json", ValidatorIdentifier.APP_LOADER, RuntimeConsumerIdentifier.APP_LOADER),
         _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workspace, "workflows/{workflow_id}/orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, multiplicity=Multiplicity.MANY),
         _family(ArtifactKind.BUILD_CONTEXT_REGISTRY, LayoutOwner.CAPABILITY_PACK, Requirement.OPTIONAL, workspace, "build_context/{pack_id}/context.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.NONE, multiplicity=Multiplicity.MANY),
@@ -673,39 +680,80 @@ def _extension_families(extensions: tuple[LayoutExtension, ...]) -> tuple[Artifa
     return tuple(result)
 
 
-def _capability_pack_output_scope(path: str) -> PathScope:
-    if path.startswith("generated/"):
-        return PathScope.GENERATED_STAGING
-    if path in {
+# Pack contracts may declare only app-bundle interior outputs plus the two
+# authentic workspace-support lanes (docs/, scripts/) proven by shipped packs
+# such as operator_readiness.  Deployment artifacts stay renderer-owned,
+# generated/ staging stays factory-owned, and agent/CI configuration is never
+# a pack output.
+_PACK_OUTPUT_FORBIDDEN_PREFIXES = (
+    ".claude/",
+    ".github/",
+    "config/data_migrations/",
+    "control_plane/",
+    "generated/",
+    "services/data/",
+    "services/security/",
+    "tests/",
+)
+_PACK_OUTPUT_FORBIDDEN_EXACT = frozenset(
+    {
         "Dockerfile",
         "docker-compose.yml",
         ".env.example",
         ".env.staging.example",
         ".env.production.example",
         "deployment.manifest.json",
-        ".github/workflows/deploy.yml",
-    }:
-        return PathScope.DEPLOYMENT_DERIVED
-    if path.startswith(("docs/", "scripts/", ".claude/", ".github/")):
+        "config/data.json",
+        "config/llm.yaml",
+        "config/secrets.yaml",
+        "security/secrets.yaml",
+    }
+)
+_PACK_OUTPUT_SECRET_TOKEN_RE = re.compile(
+    r"(?:^|[._/-])(?:api[_-]?keys?|credentials?|passwords?|secrets?|tokens?)(?:[._/-]|$)",
+    re.IGNORECASE,
+)
+_PACK_OUTPUT_SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".crt", ".der", ".jks")
+
+
+def _validate_capability_pack_output_path(path: str) -> None:
+    if _PLACEHOLDER_RE.search(path):
+        raise ValueError(
+            f"capability_pack_output paths must be exact literals, not templates: {path!r}"
+        )
+    lower = path.lower()
+    if path in _PACK_OUTPUT_FORBIDDEN_EXACT or any(
+        lower.startswith(prefix) for prefix in _PACK_OUTPUT_FORBIDDEN_PREFIXES
+    ):
+        raise ValueError(
+            f"capability_pack_output path is not a permitted pack output lane: {path!r}"
+        )
+    basename = PurePosixPath(path).name.lower()
+    if (
+        basename.startswith(".env")
+        or lower.endswith(_PACK_OUTPUT_SECRET_SUFFIXES)
+        or _PACK_OUTPUT_SECRET_TOKEN_RE.search(path)
+    ):
+        raise ValueError(
+            f"capability_pack_output path is secret-shaped and not registrable: {path!r}"
+        )
+
+
+def _capability_pack_output_scope(path: str) -> PathScope:
+    if path.startswith(("docs/", "scripts/")):
         return PathScope.WORKSPACE_ROOT
     return PathScope.APP_BUNDLE_ROOT
 
 
 def _capability_pack_output_consumer(path: str) -> RuntimeConsumerIdentifier:
-    if path.startswith(("docs/", "scripts/", ".claude/", ".github/")):
+    if _capability_pack_output_scope(path) is PathScope.WORKSPACE_ROOT:
         return RuntimeConsumerIdentifier.NONE
-    if _capability_pack_output_scope(path) == PathScope.DEPLOYMENT_DERIVED:
-        return RuntimeConsumerIdentifier.DOWNLOAD_EXPORT
     return RuntimeConsumerIdentifier.PLATFORM_HOST
 
 
 def _capability_pack_output_security(path: str) -> SecurityClass:
     if path.lower().endswith((".py", ".js", ".jsx", ".ts", ".tsx", ".ps1", ".sh")):
         return SecurityClass.EXECUTABLE_STUB
-    if _capability_pack_output_scope(path) == PathScope.DEPLOYMENT_DERIVED:
-        return SecurityClass.DEPLOYMENT_METADATA
-    if path.startswith("generated/"):
-        return SecurityClass.GENERATED_STAGING
     return SecurityClass.INTERNAL_CONTRACT
 
 

--- a/mozaiksai/core/runtime/app/layout_validation.py
+++ b/mozaiksai/core/runtime/app/layout_validation.py
@@ -1,0 +1,441 @@
+"""Validation facade for ``mozaiks.app_layout.v1`` file-map classification.
+
+The layout registry is the typed authority. This module adds scanner-friendly
+classification and diagnostics without changing runtime discovery or
+materialization behavior.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import PurePosixPath
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    AppLayoutRegistry,
+    ArtifactMatch,
+    ExtensionSlot,
+    LayoutExtension,
+    LayoutOwner,
+    PathScope,
+    Requirement,
+    build_app_layout_registry,
+)
+
+_REPO_SUPPORT_PREFIXES = (
+    ".claude/",
+    ".github/",
+    "docs/",
+    "scripts/",
+    "tests/",
+)
+
+_REPO_SUPPORT_EXACT = frozenset({".claude", ".github", "docs", "scripts", "tests"})
+
+
+class LayoutValidationModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LayoutClassificationStatus(StrEnum):
+    REGISTERED = "registered"
+    PROHIBITED = "prohibited"
+    UNKNOWN = "unknown"
+    AMBIGUOUS = "ambiguous"
+    IGNORED_REPO_SUPPORT = "ignored_repo_support"
+
+
+class LayoutDiagnosticCode(StrEnum):
+    PROHIBITED_PATH = "prohibited_path"
+    UNKNOWN_PATH = "unknown_path"
+    AMBIGUOUS_PATH = "ambiguous_path"
+    UNSAFE_PATH = "unsafe_path"
+
+
+class LayoutFileClassification(LayoutValidationModel):
+    path: str
+    normalized_path: str
+    scope: PathScope | None
+    status: LayoutClassificationStatus
+    artifact_kind: str | None = None
+    owner: str | None = None
+    requirement: str | None = None
+    assignment_kinds: tuple[str, ...] = Field(default_factory=tuple)
+    validator: str | None = None
+    runtime_consumer: str | None = None
+    security_class: str | None = None
+    extension_selection: str | None = None
+    values: dict[str, str] = Field(default_factory=dict)
+    reason: str | None = None
+
+
+class LayoutValidationDiagnostic(LayoutValidationModel):
+    code: LayoutDiagnosticCode
+    path: str
+    normalized_path: str
+    scope: PathScope | None
+    message: str
+
+
+class LayoutValidationReport(LayoutValidationModel):
+    classifications: tuple[LayoutFileClassification, ...]
+    diagnostics: tuple[LayoutValidationDiagnostic, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not self.diagnostics
+
+    @property
+    def app_bundle_paths(self) -> tuple[str, ...]:
+        return tuple(
+            item.normalized_path
+            for item in self.classifications
+            if item.status == LayoutClassificationStatus.REGISTERED
+            and item.scope == PathScope.APP_BUNDLE_ROOT
+        )
+
+    @property
+    def deployment_paths(self) -> tuple[str, ...]:
+        return tuple(
+            item.normalized_path
+            for item in self.classifications
+            if item.status == LayoutClassificationStatus.REGISTERED
+            and item.scope == PathScope.DEPLOYMENT_DERIVED
+        )
+
+
+def validate_file_map_layout(
+    files_map: Mapping[str, Any],
+    *,
+    selected_extensions: tuple[LayoutExtension, ...] = (),
+    registry: AppLayoutRegistry | None = None,
+) -> LayoutValidationReport:
+    """Classify generated file-map paths through the app layout registry.
+
+    ``selected_extensions`` is explicit selected-extension authority. Paths do
+    not select extensions by filename.
+    """
+
+    layout_registry = registry or build_app_layout_registry(selected_extensions)
+    classifications: list[LayoutFileClassification] = []
+    diagnostics: list[LayoutValidationDiagnostic] = []
+
+    for raw_path in sorted(str(path) for path in files_map):
+        classification = classify_layout_path(
+            raw_path,
+            selected_extensions=selected_extensions,
+            registry=layout_registry,
+        )
+        classifications.append(classification)
+        diagnostic = _diagnostic_for(classification)
+        if diagnostic is not None:
+            diagnostics.append(diagnostic)
+
+    return LayoutValidationReport(
+        classifications=tuple(sorted(classifications, key=_classification_sort_key)),
+        diagnostics=tuple(sorted(diagnostics, key=_diagnostic_sort_key)),
+    )
+
+
+def classify_layout_path(
+    path: str,
+    *,
+    selected_extensions: tuple[LayoutExtension, ...] = (),
+    registry: AppLayoutRegistry | None = None,
+) -> LayoutFileClassification:
+    layout_registry = registry or build_app_layout_registry(selected_extensions)
+    try:
+        normalized = _normalize_path(path)
+    except ValueError as exc:
+        return LayoutFileClassification(
+            path=path,
+            normalized_path=str(path or ""),
+            scope=None,
+            status=LayoutClassificationStatus.UNKNOWN,
+            reason=str(exc),
+        )
+
+    for scope in _candidate_scopes(normalized, registry=layout_registry):
+        classification = _match_scope(
+            path,
+            normalized,
+            scope,
+            registry=layout_registry,
+            selected_extensions=selected_extensions,
+        )
+        if classification.status in {
+            LayoutClassificationStatus.REGISTERED,
+            LayoutClassificationStatus.PROHIBITED,
+            LayoutClassificationStatus.AMBIGUOUS,
+        }:
+            return classification
+
+    if _is_repo_support_path(normalized):
+        return LayoutFileClassification(
+            path=path,
+            normalized_path=normalized,
+            scope=None,
+            status=LayoutClassificationStatus.IGNORED_REPO_SUPPORT,
+            reason="repository support file outside generated app bundle",
+        )
+
+    return LayoutFileClassification(
+        path=path,
+        normalized_path=normalized,
+        scope=PathScope.APP_BUNDLE_ROOT,
+        status=LayoutClassificationStatus.UNKNOWN,
+        reason=f"path {normalized!r} is not registered for generated app validation",
+    )
+
+
+def filter_layout_scannable_file_map(
+    files_map: Mapping[str, str],
+    report: LayoutValidationReport,
+) -> dict[str, str]:
+    """Return files that remain part of scanner content validation."""
+
+    allowed = {
+        item.normalized_path
+        for item in report.classifications
+        if item.status
+        in {
+            LayoutClassificationStatus.REGISTERED,
+            LayoutClassificationStatus.PROHIBITED,
+            LayoutClassificationStatus.UNKNOWN,
+        }
+        and (
+            item.scope in {PathScope.APP_BUNDLE_ROOT, PathScope.DEPLOYMENT_DERIVED}
+            or item.scope is None
+        )
+    }
+    result: dict[str, str] = {}
+    for raw_path, content in files_map.items():
+        try:
+            normalized = _normalize_path(raw_path)
+        except ValueError:
+            continue
+        if normalized in allowed:
+            result[normalized] = str(content)
+    return result
+
+
+def layout_validation_errors(report: LayoutValidationReport) -> list[str]:
+    return [diagnostic.message for diagnostic in report.diagnostics]
+
+
+def layout_extensions_from_selected_packs(
+    capability_packs: list[dict[str, Any]] | None,
+) -> tuple[LayoutExtension, ...]:
+    """Project explicit selected managed-capability packs to layout extensions."""
+
+    extensions: set[LayoutExtension] = set()
+    for pack in capability_packs or []:
+        if not isinstance(pack, dict):
+            continue
+        if str(pack.get("capability_source") or "").strip() != "managed_capability":
+            continue
+        pack_id = str(pack.get("capability_pack_id") or pack.get("id") or pack.get("pack_id") or "").strip()
+        if not pack_id:
+            continue
+        for slot in (
+            ExtensionSlot.MANAGED_CAPABILITY_CLIENT,
+            ExtensionSlot.MANAGED_CAPABILITY_CONFIG,
+        ):
+            try:
+                extensions.add(LayoutExtension(slot=slot, pack_id=pack_id))
+            except ValueError:
+                continue
+    return tuple(sorted(extensions, key=lambda item: (item.slot.value, item.pack_id, item.path or "")))
+
+
+def _match_scope(
+    path: str,
+    normalized: str,
+    scope: PathScope,
+    *,
+    registry: AppLayoutRegistry,
+    selected_extensions: tuple[LayoutExtension, ...],
+) -> LayoutFileClassification:
+    try:
+        match = registry.match_path(normalized, scope)
+    except ValueError as exc:
+        status = (
+            LayoutClassificationStatus.AMBIGUOUS
+            if "ambiguous" in str(exc).lower()
+            else LayoutClassificationStatus.UNKNOWN
+        )
+        return LayoutFileClassification(
+            path=path,
+            normalized_path=normalized,
+            scope=scope,
+            status=status,
+            reason=str(exc),
+        )
+    return _classification_from_match(
+        path,
+        normalized,
+        scope,
+        match,
+        selected_extensions=selected_extensions,
+    )
+
+
+def _classification_from_match(
+    path: str,
+    normalized: str,
+    scope: PathScope,
+    match: ArtifactMatch,
+    *,
+    selected_extensions: tuple[LayoutExtension, ...],
+) -> LayoutFileClassification:
+    family = match.family
+    status = (
+        LayoutClassificationStatus.PROHIBITED
+        if family.requirement == Requirement.PROHIBITED
+        else LayoutClassificationStatus.REGISTERED
+    )
+    return LayoutFileClassification(
+        path=path,
+        normalized_path=normalized,
+        scope=scope,
+        status=status,
+        artifact_kind=family.kind.value,
+        owner=family.owner.value,
+        requirement=family.requirement.value,
+        assignment_kinds=tuple(kind.value for kind in family.assignment_kinds),
+        validator=family.validator.value,
+        runtime_consumer=family.runtime_consumer.value,
+        security_class=family.security_class.value,
+        extension_selection=_extension_selection(match, selected_extensions),
+        values={key.value: value for key, value in match.values.items()},
+        reason=None,
+    )
+
+
+def _candidate_scopes(normalized: str, *, registry: AppLayoutRegistry) -> tuple[PathScope, ...]:
+    if normalized.startswith("generated/"):
+        return (PathScope.GENERATED_STAGING,)
+    scopes: list[PathScope] = []
+    if _matches_scope(registry, normalized, PathScope.DEPLOYMENT_DERIVED):
+        scopes.append(PathScope.DEPLOYMENT_DERIVED)
+    if _is_repo_support_path(normalized) and _matches_scope(
+        registry,
+        normalized,
+        PathScope.WORKSPACE_ROOT,
+    ):
+        scopes.append(PathScope.WORKSPACE_ROOT)
+    scopes.append(PathScope.APP_BUNDLE_ROOT)
+    return tuple(scopes)
+
+
+def _matches_scope(registry: AppLayoutRegistry, path: str, scope: PathScope) -> bool:
+    try:
+        registry.match_path(path, scope)
+    except ValueError:
+        return False
+    return True
+
+
+def _diagnostic_for(classification: LayoutFileClassification) -> LayoutValidationDiagnostic | None:
+    if classification.status == LayoutClassificationStatus.PROHIBITED:
+        return LayoutValidationDiagnostic(
+            code=LayoutDiagnosticCode.PROHIBITED_PATH,
+            path=classification.path,
+            normalized_path=classification.normalized_path,
+            scope=classification.scope,
+            message=(
+                f"{classification.normalized_path}: removed app paths are explicitly "
+                "prohibited by mozaiks.app_layout.v1."
+            ),
+        )
+    if classification.status == LayoutClassificationStatus.AMBIGUOUS:
+        return LayoutValidationDiagnostic(
+            code=LayoutDiagnosticCode.AMBIGUOUS_PATH,
+            path=classification.path,
+            normalized_path=classification.normalized_path,
+            scope=classification.scope,
+            message=(
+                f"{classification.normalized_path}: outside the canonical app planes "
+                f"or registered generated/deployment scopes: {classification.reason}"
+            ),
+        )
+    if classification.status == LayoutClassificationStatus.UNKNOWN:
+        code = (
+            LayoutDiagnosticCode.UNSAFE_PATH
+            if classification.scope is None
+            else LayoutDiagnosticCode.UNKNOWN_PATH
+        )
+        return LayoutValidationDiagnostic(
+            code=code,
+            path=classification.path,
+            normalized_path=classification.normalized_path,
+            scope=classification.scope,
+            message=(
+                f"{classification.normalized_path}: outside the canonical app planes "
+                f"or registered generated/deployment scopes: {classification.reason}"
+            ),
+        )
+    return None
+
+
+def _extension_selection(
+    match: ArtifactMatch,
+    selected_extensions: tuple[LayoutExtension, ...],
+) -> str | None:
+    if match.family.owner not in {LayoutOwner.REGISTERED_EXTENSION, LayoutOwner.CAPABILITY_PACK}:
+        return None
+    for extension in selected_extensions:
+        probe_registry = build_app_layout_registry((extension,))
+        try:
+            probe = probe_registry.match_path(match.normalized_path, match.family.path_scope)
+        except ValueError:
+            continue
+        if probe.family.owner in {LayoutOwner.REGISTERED_EXTENSION, LayoutOwner.CAPABILITY_PACK}:
+            return f"{extension.slot.value}:{extension.pack_id}"
+    return match.family.owner.value
+
+
+def _normalize_path(path: object) -> str:
+    text = unicodedata.normalize("NFC", str(path or "")).replace("\\", "/").strip()
+    if not text:
+        raise ValueError("path must be non-empty")
+    if text.startswith("/") or "://" in text:
+        raise ValueError(f"absolute paths are not allowed: {path!r}")
+    pure = PurePosixPath(text)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        raise ValueError(f"unsafe path: {path!r}")
+    if pure.parts and ":" in pure.parts[0]:
+        raise ValueError(f"absolute drive paths are not allowed: {path!r}")
+    if any(char in text for char in "*?["):
+        raise ValueError(f"glob characters are not allowed in paths: {path!r}")
+    return str(pure)
+
+
+def _is_repo_support_path(path: str) -> bool:
+    return path in _REPO_SUPPORT_EXACT or any(path.startswith(prefix) for prefix in _REPO_SUPPORT_PREFIXES)
+
+
+def _classification_sort_key(item: LayoutFileClassification) -> tuple[str, str, str]:
+    return (item.normalized_path, item.status.value, item.scope.value if item.scope else "")
+
+
+def _diagnostic_sort_key(item: LayoutValidationDiagnostic) -> tuple[str, str, str]:
+    return (item.normalized_path, item.code.value, item.message)
+
+
+__all__ = [
+    "LayoutClassificationStatus",
+    "LayoutDiagnosticCode",
+    "LayoutFileClassification",
+    "LayoutValidationDiagnostic",
+    "LayoutValidationReport",
+    "classify_layout_path",
+    "filter_layout_scannable_file_map",
+    "layout_extensions_from_selected_packs",
+    "layout_validation_errors",
+    "validate_file_map_layout",
+]

--- a/mozaiksai/core/runtime/app/layout_validation.py
+++ b/mozaiksai/core/runtime/app/layout_validation.py
@@ -13,7 +13,7 @@ from enum import StrEnum
 from pathlib import PurePosixPath
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from mozaiksai.core.runtime.app.layout_registry import (
     AppLayoutRegistry,
@@ -54,6 +54,7 @@ class LayoutDiagnosticCode(StrEnum):
     UNKNOWN_PATH = "unknown_path"
     AMBIGUOUS_PATH = "ambiguous_path"
     UNSAFE_PATH = "unsafe_path"
+    INVALID_EXTENSION_REGISTRATION = "invalid_extension_registration"
 
 
 class LayoutFileClassification(LayoutValidationModel):
@@ -120,7 +121,24 @@ def validate_file_map_layout(
     not select extensions by filename.
     """
 
-    layout_registry = registry or build_app_layout_registry(selected_extensions)
+    try:
+        layout_registry = registry or build_app_layout_registry(selected_extensions)
+    except (ValueError, ValidationError) as exc:
+        return LayoutValidationReport(
+            classifications=(),
+            diagnostics=(
+                LayoutValidationDiagnostic(
+                    code=LayoutDiagnosticCode.INVALID_EXTENSION_REGISTRATION,
+                    path="",
+                    normalized_path="",
+                    scope=None,
+                    message=(
+                        "selected layout extensions could not be registered and the "
+                        f"file map fails closed: {exc}"
+                    ),
+                ),
+            ),
+        )
     classifications: list[LayoutFileClassification] = []
     diagnostics: list[LayoutValidationDiagnostic] = []
 
@@ -159,6 +177,7 @@ def classify_layout_path(
             reason=str(exc),
         )
 
+    accepted: list[LayoutFileClassification] = []
     for scope in _candidate_scopes(normalized, registry=layout_registry):
         classification = _match_scope(
             path,
@@ -167,12 +186,27 @@ def classify_layout_path(
             registry=layout_registry,
             selected_extensions=selected_extensions,
         )
-        if classification.status in {
-            LayoutClassificationStatus.REGISTERED,
-            LayoutClassificationStatus.PROHIBITED,
-            LayoutClassificationStatus.AMBIGUOUS,
-        }:
+        if classification.status is LayoutClassificationStatus.PROHIBITED:
             return classification
+        if classification.status is LayoutClassificationStatus.AMBIGUOUS:
+            return classification
+        if classification.status is LayoutClassificationStatus.REGISTERED:
+            accepted.append(classification)
+
+    if len(accepted) == 1:
+        return accepted[0]
+    if len(accepted) > 1:
+        scopes = sorted(item.scope.value for item in accepted if item.scope)
+        return LayoutFileClassification(
+            path=path,
+            normalized_path=normalized,
+            scope=None,
+            status=LayoutClassificationStatus.AMBIGUOUS,
+            reason=(
+                f"path {normalized!r} is registered in more than one scope {scopes}; "
+                "scope must be structurally unique, never selected by trial"
+            ),
+        )
 
     if _is_repo_support_path(normalized):
         return LayoutFileClassification(
@@ -317,27 +351,20 @@ def _classification_from_match(
 
 
 def _candidate_scopes(normalized: str, *, registry: AppLayoutRegistry) -> tuple[PathScope, ...]:
+    """Structural candidate scopes for a bundle-relative path.
+
+    Candidacy is derived from path structure alone — never from whether a scope
+    happens to accept the path.  Acceptance in more than one candidate scope is
+    reported as ambiguity by the caller, not resolved by ordering.
+    """
+    del registry
     if normalized.startswith("generated/"):
         return (PathScope.GENERATED_STAGING,)
-    scopes: list[PathScope] = []
-    if _matches_scope(registry, normalized, PathScope.DEPLOYMENT_DERIVED):
-        scopes.append(PathScope.DEPLOYMENT_DERIVED)
-    if _is_repo_support_path(normalized) and _matches_scope(
-        registry,
-        normalized,
-        PathScope.WORKSPACE_ROOT,
-    ):
+    scopes: list[PathScope] = [PathScope.DEPLOYMENT_DERIVED]
+    if _is_repo_support_path(normalized):
         scopes.append(PathScope.WORKSPACE_ROOT)
     scopes.append(PathScope.APP_BUNDLE_ROOT)
     return tuple(scopes)
-
-
-def _matches_scope(registry: AppLayoutRegistry, path: str, scope: PathScope) -> bool:
-    try:
-        registry.match_path(path, scope)
-    except ValueError:
-        return False
-    return True
 
 
 def _diagnostic_for(classification: LayoutFileClassification) -> LayoutValidationDiagnostic | None:

--- a/tests/test_app_layout_validation.py
+++ b/tests/test_app_layout_validation.py
@@ -1,0 +1,359 @@
+"""Tests for generated-file layout validation through mozaiks.app_layout.v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import scan_generated_bundle
+from mozaiksai.core.runtime.app.layout_registry import (
+    AppLayoutRegistry,
+    ArtifactFamily,
+    ArtifactKind,
+    ConditionIdentifier,
+    ExtensionSlot,
+    LayoutExtension,
+    LayoutOwner,
+    MaterializerIdentifier,
+    Multiplicity,
+    PathScope,
+    Requirement,
+    RuntimeConsumerIdentifier,
+    SecurityClass,
+    ValidatorIdentifier,
+    default_app_layout_registry,
+    validate_registered_path,
+)
+from mozaiksai.core.runtime.app.layout_validation import (
+    LayoutClassificationStatus,
+    LayoutDiagnosticCode,
+    classify_layout_path,
+    layout_extensions_from_selected_packs,
+    validate_file_map_layout,
+)
+from mozaiksai.core.workflow.assignment_kinds import AssignmentKind
+
+_FIXTURE_APP = Path("web_shell/playwright/fixtures/generated-app/app")
+
+
+def _fixture_files() -> dict[str, str]:
+    return {
+        path.relative_to(_FIXTURE_APP).as_posix(): path.read_text(encoding="utf-8")
+        for path in _FIXTURE_APP.rglob("*")
+        if path.is_file()
+    }
+
+
+def _family(template: str, *, kind: ArtifactKind = ArtifactKind.APP_CONFIG) -> ArtifactFamily:
+    return ArtifactFamily(
+        kind=kind,
+        owner=LayoutOwner.PLATFORM,
+        requirement=Requirement.OPTIONAL,
+        multiplicity=Multiplicity.SINGLE,
+        condition=ConditionIdentifier.WHEN_APP_DECLARED,
+        path_scope=PathScope.APP_BUNDLE_ROOT,
+        path_template=template,
+        materializer=MaterializerIdentifier.APP_GENERATOR,
+        validator=ValidatorIdentifier.APP_PATHS,
+        runtime_consumer=RuntimeConsumerIdentifier.PLATFORM_HOST,
+        security_class=SecurityClass.INTERNAL_CONTRACT,
+    )
+
+
+def _by_path(report):
+    return {item.normalized_path: item for item in report.classifications}
+
+
+def test_known_generated_fixture_paths_classify_uniquely() -> None:
+    report = validate_file_map_layout(_fixture_files())
+
+    assert report.passed
+    assert len(report.classifications) == len(_fixture_files())
+    assert all(item.status is LayoutClassificationStatus.REGISTERED for item in report.classifications)
+
+    classified = _by_path(report)
+    assert classified["app.json"].artifact_kind == ArtifactKind.APP_MANIFEST.value
+    assert classified["brand/theme_config.json"].artifact_kind == ArtifactKind.APP_BRAND_THEME.value
+    assert classified["config/shell.json"].artifact_kind == ArtifactKind.APP_SHELL_CONFIG.value
+    assert classified["ui/index.js"].artifact_kind == ArtifactKind.APP_UI_EXTENSION_BARREL.value
+    assert classified["ui/lib/moduleApi.js"].artifact_kind == ArtifactKind.APP_UI_MODULE_API.value
+    assert classified["ui/pages/tickets.yaml"].artifact_kind == ArtifactKind.APP_UI_PAGE_SCHEMA.value
+    assert classified["ui/pages/custom/GatedFeaturePage.jsx"].artifact_kind == ArtifactKind.APP_UI_CUSTOM_ROUTE.value
+
+
+def test_report_serialization_round_trip_is_strict() -> None:
+    report = validate_file_map_layout({"app.json": "{}"})
+    restored = type(report).model_validate(report.model_dump(mode="json"))
+
+    assert restored == report
+
+    payload = report.model_dump(mode="json")
+    payload["generated_at"] = "2026-08-17T00:00:00Z"
+    with pytest.raises(ValidationError, match="extra"):
+        type(report).model_validate(payload)
+
+
+def test_prohibited_control_plane_and_credential_paths_fail() -> None:
+    report = validate_file_map_layout(
+        {
+            "control_plane/refinement.yaml": "",
+            "config/secrets.yaml": "",
+            "services/security/vault.py": "",
+        }
+    )
+
+    assert not report.passed
+    assert [diagnostic.code for diagnostic in report.diagnostics] == [
+        LayoutDiagnosticCode.PROHIBITED_PATH,
+        LayoutDiagnosticCode.PROHIBITED_PATH,
+        LayoutDiagnosticCode.PROHIBITED_PATH,
+    ]
+    assert [diagnostic.normalized_path for diagnostic in report.diagnostics] == [
+        "config/secrets.yaml",
+        "control_plane/refinement.yaml",
+        "services/security/vault.py",
+    ]
+
+
+def test_unknown_runtime_affecting_app_bundle_paths_fail_closed() -> None:
+    report = validate_file_map_layout({"server.py": "print('not a registered app artifact')"})
+
+    assert not report.passed
+    assert report.diagnostics[0].code is LayoutDiagnosticCode.UNKNOWN_PATH
+    assert "outside the canonical app planes" in report.diagnostics[0].message
+
+
+def test_repo_support_files_are_ignored_not_interpreted_as_bundle_files() -> None:
+    report = validate_file_map_layout(
+        {
+            "docs/readme.md": "",
+            "tests/test_generated_app.py": "",
+            "scripts/build.ps1": "",
+            ".claude/settings.local.json": "",
+            ".github/ISSUE_TEMPLATE/bug.md": "",
+        }
+    )
+
+    assert report.passed
+    assert all(
+        item.status is LayoutClassificationStatus.IGNORED_REPO_SUPPORT
+        for item in report.classifications
+    )
+
+
+def test_deployment_workflow_is_registered_even_under_github_repo_support_prefix() -> None:
+    report = validate_file_map_layout({".github/workflows/deploy.yml": ""})
+
+    assert report.passed
+    classification = report.classifications[0]
+    assert classification.scope is PathScope.DEPLOYMENT_DERIVED
+    assert classification.artifact_kind == ArtifactKind.APP_DEPLOYMENT_ARTIFACT.value
+
+
+def test_generated_staging_and_deployment_files_use_distinct_scopes() -> None:
+    report = validate_file_map_layout(
+        {
+            "Dockerfile": "",
+            "deployment.manifest.json": "",
+            "generated/apps/customer/build-001/app/app.json": "",
+        }
+    )
+
+    classified = _by_path(report)
+    assert classified["Dockerfile"].scope is PathScope.DEPLOYMENT_DERIVED
+    assert classified["deployment.manifest.json"].scope is PathScope.DEPLOYMENT_DERIVED
+    assert classified["generated/apps/customer/build-001/app/app.json"].scope is PathScope.GENERATED_STAGING
+
+
+def test_selected_extensions_classify_only_when_passed_explicitly() -> None:
+    extension = LayoutExtension(slot=ExtensionSlot.MANAGED_CAPABILITY_CONFIG, pack_id="payments")
+
+    absent = validate_file_map_layout({"config/integrations/payments.yaml": ""})
+    present = validate_file_map_layout(
+        {"config/integrations/payments.yaml": ""},
+        selected_extensions=(extension,),
+    )
+
+    assert not absent.passed
+    assert absent.diagnostics[0].code is LayoutDiagnosticCode.UNKNOWN_PATH
+    assert present.passed
+    classification = present.classifications[0]
+    assert classification.owner == LayoutOwner.REGISTERED_EXTENSION.value
+    assert classification.extension_selection == "managed_capability_config:payments"
+
+
+def test_selected_pack_projection_preserves_zero_artifact_absence() -> None:
+    extensions = layout_extensions_from_selected_packs(
+        [{"id": "mozaikspay", "capability_source": "managed_capability"}]
+    )
+    report = validate_file_map_layout({"app.json": "{}"}, selected_extensions=extensions)
+
+    assert report.passed
+    assert len(report.classifications) == 1
+    assert report.classifications[0].artifact_kind == ArtifactKind.APP_MANIFEST.value
+
+
+def test_exact_capability_pack_outputs_classify_under_their_own_scopes() -> None:
+    extensions = (
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="operator_readiness",
+            path="config/operator_readiness.yaml",
+        ),
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="operator_readiness",
+            path="docs/operations/operator-readiness.md",
+        ),
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="operator_readiness",
+            path="scripts/check_operator_readiness_local.ps1",
+        ),
+    )
+
+    report = validate_file_map_layout(
+        {
+            "config/operator_readiness.yaml": "",
+            "docs/operations/operator-readiness.md": "",
+            "scripts/check_operator_readiness_local.ps1": "",
+        },
+        selected_extensions=extensions,
+    )
+    classified = _by_path(report)
+
+    assert report.passed
+    assert classified["config/operator_readiness.yaml"].scope is PathScope.APP_BUNDLE_ROOT
+    assert classified["docs/operations/operator-readiness.md"].scope is PathScope.WORKSPACE_ROOT
+    assert classified["scripts/check_operator_readiness_local.ps1"].scope is PathScope.WORKSPACE_ROOT
+    assert classified["scripts/check_operator_readiness_local.ps1"].security_class == (
+        SecurityClass.EXECUTABLE_STUB.value
+    )
+    assert all(
+        item.extension_selection == "capability_pack_output:operator_readiness"
+        for item in report.classifications
+    )
+
+
+def test_capability_pack_output_extension_requires_exact_safe_path() -> None:
+    with pytest.raises(ValidationError, match="exact path"):
+        LayoutExtension(slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT, pack_id="operator_readiness")
+
+    with pytest.raises(ValidationError, match="path is only valid"):
+        LayoutExtension(
+            slot=ExtensionSlot.MANAGED_CAPABILITY_CONFIG,
+            pack_id="operator_readiness",
+            path="config/operator_readiness.yaml",
+        )
+
+    with pytest.raises(ValidationError):
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="operator_readiness",
+            path="../config/operator_readiness.yaml",
+        )
+
+
+def test_assignment_ownership_cannot_broaden_path_authority() -> None:
+    with pytest.raises(ValueError, match="not owned"):
+        validate_registered_path(
+            "modules/orders/backend/service.py",
+            AssignmentKind.MODULE_CONTRACT,
+            PathScope.APP_BUNDLE_ROOT,
+        )
+
+    classification = classify_layout_path("modules/orders/backend/service.py")
+    assert AssignmentKind.MODULE_CONTRACT.value not in classification.assignment_kinds
+
+
+def test_scopes_cannot_be_swapped() -> None:
+    assert classify_layout_path("Dockerfile").scope is PathScope.DEPLOYMENT_DERIVED
+    assert classify_layout_path("app/app.json").status is LayoutClassificationStatus.UNKNOWN
+
+    with pytest.raises(ValueError, match="not registered"):
+        default_app_layout_registry().match_path("Dockerfile", PathScope.APP_BUNDLE_ROOT)
+
+
+def test_unicode_and_case_normalization_is_stable() -> None:
+    report = validate_file_map_layout(
+        {
+            "ui/pages/café.yaml": "",
+            "ui/pages/café.yaml": "",
+            "UI/pages/home.yaml": "",
+            "ui/pages/home.yaml": "",
+        }
+    )
+    classified = _by_path(report)
+
+    assert classified["ui/pages/café.yaml"].status is LayoutClassificationStatus.UNKNOWN
+    assert classified["UI/pages/home.yaml"].status is LayoutClassificationStatus.UNKNOWN
+    assert classified["ui/pages/home.yaml"].status is LayoutClassificationStatus.REGISTERED
+    assert [diagnostic.normalized_path for diagnostic in report.diagnostics] == [
+        "UI/pages/home.yaml",
+        "ui/pages/café.yaml",
+        "ui/pages/café.yaml",
+    ]
+
+
+def test_ambiguous_registry_matches_are_diagnostics_not_success() -> None:
+    left = _family("config/{pack_id}.json")
+    right = _family("config/{extension_id}.json", kind=ArtifactKind.APP_TARGETS_CONFIG)
+    registry = AppLayoutRegistry.model_construct(
+        families=(left, right),
+        registry_digest="bypassed-for-ambiguity-facade-test",
+    )
+
+    report = validate_file_map_layout({"config/example.json": "{}"}, registry=registry)
+
+    assert not report.passed
+    assert report.diagnostics[0].code is LayoutDiagnosticCode.AMBIGUOUS_PATH
+    assert "ambiguous" in report.diagnostics[0].message
+
+
+def test_scanner_ignores_repo_support_but_fails_unknown_runtime_files() -> None:
+    assert scan_generated_bundle({"docs/readme.md": "", "app.json": "{}"}) == []
+
+    errors = scan_generated_bundle({"docs/readme.md": "", "server.py": ""})
+    assert any("server.py" in error for error in errors)
+    assert any("outside the canonical app planes" in error for error in errors)
+
+
+def test_scanner_extension_selection_is_explicit_not_filename_inferred() -> None:
+    path = "config/integrations/payments.yaml"
+    extension = LayoutExtension(slot=ExtensionSlot.MANAGED_CAPABILITY_CONFIG, pack_id="payments")
+
+    assert scan_generated_bundle({path: "{}"}, layout_extensions=(extension,)) == []
+
+    errors = scan_generated_bundle({path: "{}"})
+    assert any(path in error for error in errors)
+    assert any("outside the canonical app planes" in error for error in errors)
+
+
+def test_scanner_requires_repo_support_pack_outputs_to_be_declared_when_packs_selected() -> None:
+    pack = {
+        "id": "operator_readiness",
+        "capability_source": "config_file",
+        "pack_source_path": "factory_app/build_context/operator_readiness",
+    }
+
+    assert (
+        scan_generated_bundle(
+            {
+                "app.json": "{}",
+                "docs/operations/operator-readiness.md": "",
+            },
+            capability_packs=[pack],
+        )
+        == []
+    )
+
+    errors = scan_generated_bundle(
+        {
+            "app.json": "{}",
+            "docs/operations/undeclared.md": "",
+        },
+        capability_packs=[pack],
+    )
+    assert any("undeclared repository-support pack outputs" in error for error in errors)

--- a/tests/test_app_layout_validation.py
+++ b/tests/test_app_layout_validation.py
@@ -312,8 +312,10 @@ def test_ambiguous_registry_matches_are_diagnostics_not_success() -> None:
     assert "ambiguous" in report.diagnostics[0].message
 
 
-def test_scanner_ignores_repo_support_but_fails_unknown_runtime_files() -> None:
-    assert scan_generated_bundle({"docs/readme.md": "", "app.json": "{}"}) == []
+def test_scanner_fails_undeclared_repo_support_and_unknown_runtime_files() -> None:
+    # An undeclared repository-support file never sails through, packs or not.
+    undeclared = scan_generated_bundle({"docs/readme.md": "", "app.json": "{}"})
+    assert any("undeclared repository-support pack outputs" in error for error in undeclared)
 
     errors = scan_generated_bundle({"docs/readme.md": "", "server.py": ""})
     assert any("server.py" in error for error in errors)
@@ -324,7 +326,14 @@ def test_scanner_extension_selection_is_explicit_not_filename_inferred() -> None
     path = "config/integrations/payments.yaml"
     extension = LayoutExtension(slot=ExtensionSlot.MANAGED_CAPABILITY_CONFIG, pack_id="payments")
 
-    assert scan_generated_bundle({path: "{}"}, layout_extensions=(extension,)) == []
+    # Explicit selection classifies through the validation facade; the scanner
+    # derives extension authority only from selected pack contracts and exposes
+    # no caller-supplied extension bypass.
+    import inspect
+
+    assert "layout_extensions" not in inspect.signature(scan_generated_bundle).parameters
+    explicit = validate_file_map_layout({path: "{}"}, selected_extensions=(extension,))
+    assert explicit.passed
 
     errors = scan_generated_bundle({path: "{}"})
     assert any(path in error for error in errors)
@@ -357,3 +366,156 @@ def test_scanner_requires_repo_support_pack_outputs_to_be_declared_when_packs_se
         capability_packs=[pack],
     )
     assert any("undeclared repository-support pack outputs" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# Review regressions — each defect below was reproduced before fixing.
+# ---------------------------------------------------------------------------
+
+
+def test_pack_output_cannot_shadow_prohibited_families() -> None:
+    """An extension literal must never out-rank a prohibited family."""
+    with pytest.raises(ValidationError, match="not a permitted pack output lane"):
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="evil",
+            path="services/data/schema.py",
+        )
+
+    # And prohibition wins at match time over any more-literal family.
+    report = validate_file_map_layout({"services/data/schema.py": "x"})
+    assert not report.passed
+    assert report.diagnostics[0].code is LayoutDiagnosticCode.PROHIBITED_PATH
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".claude/settings.local.json",
+        ".github/workflows/deploy.yml",
+        "generated/apps/a/b/app/app.json",
+        "Dockerfile",
+        "deployment.manifest.json",
+        "config/secrets.yaml",
+        "security/secrets.yaml",
+        "tests/test_x.py",
+        "control_plane/routing.yaml",
+        "config/api_keys.json",
+        "certs/server.pem",
+        ".env.production.example",
+        "ui/pages/{page_id}.yaml",
+    ],
+)
+def test_pack_output_forbidden_lanes_fail_closed(path: str) -> None:
+    with pytest.raises(ValidationError):
+        LayoutExtension(
+            slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+            pack_id="sneaky",
+            path=path,
+        )
+
+
+def test_extension_registration_failure_is_diagnostic_not_crash() -> None:
+    """A pack output duplicating a core literal fails closed with a diagnostic."""
+    duplicate = LayoutExtension(
+        slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+        pack_id="dup",
+        path="services/config.py",
+    )
+    report = validate_file_map_layout(
+        {"services/config.py": "x"}, selected_extensions=(duplicate,)
+    )
+    assert not report.passed
+    assert report.diagnostics[0].code is (
+        LayoutDiagnosticCode.INVALID_EXTENSION_REGISTRATION
+    )
+
+
+def test_multi_scope_acceptance_is_ambiguity_not_first_scope_wins() -> None:
+    """A path accepted by more than one candidate scope fails closed."""
+    workspace = LayoutExtension(
+        slot=ExtensionSlot.CAPABILITY_PACK_OUTPUT,
+        pack_id="readiness",
+        path="docs/operations/guide.md",
+    )
+    base = validate_file_map_layout(
+        {"docs/operations/guide.md": ""}, selected_extensions=(workspace,)
+    )
+    assert base.passed  # single-scope acceptance stays valid
+
+    from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+
+    registry = build_app_layout_registry((workspace,))
+    forged = AppLayoutRegistry.model_construct(
+        families=(*registry.families, _family("docs/operations/guide.md")),
+        registry_digest="bypassed-for-multi-scope-test",
+    )
+    report = validate_file_map_layout(
+        {"docs/operations/guide.md": ""},
+        selected_extensions=(workspace,),
+        registry=forged,
+    )
+    assert not report.passed
+    assert report.diagnostics[0].code is LayoutDiagnosticCode.AMBIGUOUS_PATH
+    assert "more than one scope" in report.diagnostics[0].message
+
+
+def test_duplicate_pack_output_claims_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from factory_app.workflows.AppGenerator.tools import generated_bundle_scanner as scanner
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        ManagedCapabilityTemplateError,
+    )
+
+    def _fake_declared(packs, **_kwargs):
+        return frozenset({"scripts/shared_output.ps1"})
+
+    monkeypatch.setattr(scanner, "resolve_declared_pack_output_paths", _fake_declared)
+
+    packs = [
+        {"id": "pack_one", "capability_source": "config_file"},
+        {"id": "pack_two", "capability_source": "config_file"},
+    ]
+    with pytest.raises(ManagedCapabilityTemplateError, match="duplicate pack output"):
+        scanner._layout_extensions_for_selected_packs(packs)
+
+    errors = scanner.scan_generated_bundle({"app.json": "{}"}, capability_packs=packs)
+    assert any("duplicate pack output claims" in error for error in errors)
+
+
+def test_declared_workspace_script_content_is_still_secret_scanned() -> None:
+    pack = {
+        "id": "operator_readiness",
+        "capability_source": "config_file",
+        "pack_source_path": "factory_app/build_context/operator_readiness",
+    }
+    leaked = "$env:PAYMENT_SECRET = 'provider_live_0123456789abcdef'\n"
+    errors = scan_generated_bundle(
+        {
+            "app.json": "{}",
+            "scripts/check_operator_readiness_local.ps1": leaked,
+        },
+        capability_packs=[pack],
+    )
+    assert any(
+        "scripts/check_operator_readiness_local.ps1" in error
+        and "raw provider secret" in error
+        for error in errors
+    )
+
+
+def test_custom_route_yaml_is_not_a_registered_family() -> None:
+    """ui/pages/custom/*.yaml has no emitter or runtime consumer — must fail."""
+    report = validate_file_map_layout({"ui/pages/custom/thing.yaml": ""})
+    assert not report.passed
+    assert report.diagnostics[0].code is LayoutDiagnosticCode.UNKNOWN_PATH
+
+
+def test_auth_adapter_family_matches_rendered_template_output() -> None:
+    """ui/auth/authAdapter.js is authentic: the webapp_builder template exists."""
+    template = Path(
+        "factory_app/build_context/webapp_builder/templates/ui/auth/authAdapter.js"
+    )
+    assert template.is_file()
+    classification = classify_layout_path("ui/auth/authAdapter.js")
+    assert classification.status is LayoutClassificationStatus.REGISTERED
+    assert classification.artifact_kind == ArtifactKind.APP_UI_AUTH_ADAPTER.value

--- a/tests/test_generated_bundle_scanner.py
+++ b/tests/test_generated_bundle_scanner.py
@@ -1091,15 +1091,23 @@ def test_scan_page_schema_structure_skips_custom_pages() -> None:
     # Custom pages under ui/pages/custom/ are React escape-hatch files — not schema-native.
     errors = scan_generated_bundle(
         {
-            "ui/pages/custom/SpecialDashboard.yaml": """
-primitive: NotCanonicalAtAll
-""",
+            "ui/pages/custom/SpecialDashboard.jsx": "export default function SpecialDashboard() { return null; }",
         }
     )
 
-    # Must NOT raise an error for the custom page.
-    assert not any("SpecialDashboard" in e for e in errors)
+    # Must NOT schema-scan the custom React page.
     assert not any("canonical section primitive" in e for e in errors)
+
+    # A YAML file under ui/pages/custom/ is not a canonical artifact: no
+    # emitter writes one and no runtime loader serves one, so layout
+    # classification fails it closed instead of silently skipping it.
+    yaml_errors = scan_generated_bundle(
+        {
+            "ui/pages/custom/SpecialDashboard.yaml": "primitive: NotCanonicalAtAll\n",
+        }
+    )
+    assert any("ui/pages/custom/SpecialDashboard.yaml" in e for e in yaml_errors)
+    assert not any("canonical section primitive" in e for e in yaml_errors)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `mozaiksai.core.runtime.app.layout_validation` as the generated-file validation facade over `mozaiks.app_layout.v1`
- integrate layout classification into `scan_generated_bundle` before existing semantic/security scanners
- extend the registry with existing canonical surfaces (`ui/auth/authAdapter.js`, custom-page YAML escape hatch) and exact selected capability-pack output extensions
- keep repo-support paths out of normal app-bundle scanning while rejecting undeclared repo-support outputs for selected packs

## Boundary
- does not replace AppLoader discovery
- does not change AppGenerator prompts or Jinja materialization
- does not modify UI event contracts or add `mozaiks.ui.v1`
- no mozaiks-app changes

## Tests
- `pytest -q --no-cov tests/test_app_layout_registry.py tests/test_app_layout_validation.py tests/test_generated_bundle_scanner.py` (twice; final: 196 passed)
- `pytest -q --no-cov tests/test_generated_bundle_scanner_scan_helpers.py tests/test_continuous_deterministic_materialization.py tests/test_materialized_bundle_production_runtime.py tests/test_offline_generated_build_acceptance.py` (37 passed)
- `pytest -q --no-cov tests/test_e2e_deterministic_acceptance_gate.py tests/test_ui_portability_contract.py tests/test_appgenerator_deployment_contract.py tests/test_managed_capability_artifact_replay.py tests/test_mozaikspay_managed_capability_contract.py tests/test_mozaiks_cloud_connector_contract.py` (191 passed)
- `ruff check .`
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped`
- `pytest -q --no-cov` (13,154 passed, 77 skipped)