### PR TITLE
fix(factory): type AgentGenerator payload_schema fields; add SO retry middleware

### DIFF
--- a/factory_app/workflows/AgentGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AgentGenerator/structured_outputs.yaml
@@ -517,6 +517,24 @@ models:
           is the canonical shared workflow component, `workflow_wrapper` when a workflow-local
           wrapper sits on top of a shipped component, `generated_component` for true workflow-local
           custom React, and `shell_builtin` only for planning-time `composer_reply`.
+  PayloadSchemaSpec:
+    type: model
+    fields:
+      type:
+        type: str
+        description: JSON Schema type string for the payload root (e.g. "object", "string", "array").
+      description:
+        type: union
+        variants:
+        - str
+        - 'null'
+        description: Optional human-readable description of the payload shape.
+      required:
+        type: union
+        variants:
+        - list
+        - 'null'
+        description: Optional list of required property names when type is "object".
   UIToolAction:
     type: model
     fields:
@@ -548,8 +566,8 @@ models:
         - 'null'
         description: Optional approval semantic used by approval-style shared primitives.
       payload_schema:
-        type: dict
-        description: JSON-schema-like object describing expected payload shape for this action.
+        type: PayloadSchemaSpec
+        description: Typed payload schema spec describing the expected payload shape for this action.
   UIToolContract:
     type: model
     fields:
@@ -559,8 +577,8 @@ models:
         - agent_tool
         description: UI surface family. UI_Tool entries must use agent_tool.
       payload_schema:
-        type: dict
-        description: JSON-schema-like object describing the payload pushed from backend tool to UI component.
+        type: PayloadSchemaSpec
+        description: Typed payload schema spec describing the payload pushed from backend tool to UI component.
       actions_schema:
         type: list
         items: UIToolAction

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -11,6 +11,7 @@ from functools import wraps
 from typing import Any
 
 from ag2 import Agent
+from ag2.middleware.builtin import RetryMiddleware
 
 from mozaiksai.core.adapters.llm_fallback import llm_config_to_ag2_config
 from mozaiksai.core.media.ag2 import (
@@ -616,7 +617,12 @@ async def create_agents(
                     # Anthropic / Gemini / Ollama — pass the schema directly;
                     # AG2 routes it through the provider's native mechanism.
                     beta_response_schema = structured_model_cls
-            except Exception:
+            except Exception as so_err:
+                logger.warning(
+                    "[AGENTS] Structured output schema resolution failed for '%s' — response_schema disabled: %s",
+                    agent_name,
+                    so_err,
+                )
                 beta_response_schema = None
 
         middleware = []
@@ -703,6 +709,11 @@ async def create_agents(
                     context_bridge=context_bridge,
                 )
             )
+
+        # Structured-output agents get RetryMiddleware so provider/network failures
+        # retry before the caller sees an exception (mirrors AG2StructuredAgentRunner).
+        if beta_response_schema is not None:
+            middleware.append(RetryMiddleware(max_retries=2))
 
         # Create beta Agent
         agent = Agent(

--- a/mozaiksai/core/workflow/llm_config.py
+++ b/mozaiksai/core/workflow/llm_config.py
@@ -307,14 +307,17 @@ async def get_llm_config(
             extra={"seed": selected_seed, "cache_key_fragment": cache_key[:60]},
         )
 
+    # NOTE: response_format is accepted as a parameter for cache-key differentiation
+    # only. It is NOT stored in the returned dict because llm_config_to_ag2_config()
+    # never reads it — actual structured-output enforcement is done via
+    # Agent(response_schema=...) in factory.py, which resolves the schema
+    # independently through get_structured_outputs_for_workflow().
     llm_config: dict[str, Any] = {
         "timeout": extra_config.get("timeout") if extra_config and "timeout" in extra_config else 600,
         "cache_seed": selected_seed,
         "config_list": config_list,
         "tools": [],  # Required by AG2 for tool registration
     }
-    if response_format is not None:
-        llm_config["response_format"] = response_format
     if extra_config:
         # Merge remaining extras without overwriting core entries already set unless user explicitly wants it
         for k, v in extra_config.items():

--- a/tests/test_so_schema_enforcement.py
+++ b/tests/test_so_schema_enforcement.py
@@ -1,0 +1,188 @@
+# ==============================================================================
+# FILE: tests/test_so_schema_enforcement.py
+# DESCRIPTION: Structured-output schema enforcement tests.
+#   1. AgentGenerator payload_schema fields are typed (no bare `dict` allowed).
+#   2. PayloadSchemaSpec model exists in AgentGenerator structured_outputs.yaml.
+#   3. factory.py adds RetryMiddleware for SO agents.
+# ==============================================================================
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AG_SO_YAML = (
+    _REPO_ROOT
+    / "factory_app"
+    / "workflows"
+    / "AgentGenerator"
+    / "structured_outputs.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Change 1 tests — payload_schema fields must not be bare `dict`
+# ---------------------------------------------------------------------------
+
+
+def _load_ag_so() -> dict:
+    with open(_AG_SO_YAML, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def test_agentgenerator_payload_schema_spec_is_strict_compatible() -> None:
+    """UIToolAction and UIToolContract must not declare payload_schema: type: dict.
+
+    A bare `dict` field causes supports_provider_response_format() to return
+    False, silently disabling strict structured outputs for PackBuildCoordinator
+    and WorkflowBundleBuilderAgent.
+    """
+    data = _load_ag_so()
+    models = data.get("models", {})
+
+    for model_name in ("UIToolAction", "UIToolContract"):
+        assert model_name in models, f"Model {model_name!r} missing from AgentGenerator structured_outputs.yaml"
+        fields = models[model_name].get("fields", {})
+        ps_field = fields.get("payload_schema", {})
+        field_type = ps_field.get("type")
+        assert field_type != "dict", (
+            f"{model_name}.payload_schema must not use type: dict — "
+            "bare dict blocks OpenAI strict mode. Use a typed model instead."
+        )
+
+
+def test_agentgenerator_payload_schema_spec_model_exists() -> None:
+    """PayloadSchemaSpec model must be declared in AgentGenerator structured_outputs.yaml."""
+    data = _load_ag_so()
+    models = data.get("models", {})
+    assert "PayloadSchemaSpec" in models, (
+        "PayloadSchemaSpec model is missing from AgentGenerator structured_outputs.yaml. "
+        "It is required to replace the bare dict fields on UIToolAction and UIToolContract."
+    )
+    spec = models["PayloadSchemaSpec"]
+    fields = spec.get("fields", {})
+    assert "type" in fields, "PayloadSchemaSpec must have a 'type' field (JSON schema type string)"
+
+
+def test_agentgenerator_uitoolaction_payload_schema_references_spec() -> None:
+    """UIToolAction.payload_schema must reference PayloadSchemaSpec (not dict)."""
+    data = _load_ag_so()
+    models = data.get("models", {})
+    ps_field = models["UIToolAction"]["fields"]["payload_schema"]
+    assert ps_field.get("type") == "PayloadSchemaSpec", (
+        "UIToolAction.payload_schema must be type: PayloadSchemaSpec"
+    )
+
+
+def test_agentgenerator_uitoolcontract_payload_schema_references_spec() -> None:
+    """UIToolContract.payload_schema must reference PayloadSchemaSpec (not dict)."""
+    data = _load_ag_so()
+    models = data.get("models", {})
+    ps_field = models["UIToolContract"]["fields"]["payload_schema"]
+    assert ps_field.get("type") == "PayloadSchemaSpec", (
+        "UIToolContract.payload_schema must be type: PayloadSchemaSpec"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Change 2 tests — RetryMiddleware in factory.py for SO agents
+# ---------------------------------------------------------------------------
+
+
+def _read_factory_source() -> str:
+    factory_path = _REPO_ROOT / "mozaiksai" / "core" / "workflow" / "agents" / "factory.py"
+    return factory_path.read_text(encoding="utf-8")
+
+
+def test_factory_retry_middleware_imported() -> None:
+    """factory.py must import RetryMiddleware from ag2.middleware.builtin."""
+    source = _read_factory_source()
+    assert "from ag2.middleware.builtin import RetryMiddleware" in source, (
+        "factory.py must import RetryMiddleware from ag2.middleware.builtin"
+    )
+
+
+def test_factory_structured_output_agent_gets_retry_middleware() -> None:
+    """factory.py must append RetryMiddleware when beta_response_schema is not None.
+
+    We verify this by inspecting the AST for the conditional append that mirrors
+    the AG2StructuredAgentRunner pattern.
+    """
+    source = _read_factory_source()
+    tree = ast.parse(source)
+
+    retry_conditional_found = False
+    for node in ast.walk(tree):
+        # Look for: if beta_response_schema is not None: middleware.append(RetryMiddleware(...))
+        if not isinstance(node, ast.If):
+            continue
+        # Check condition: beta_response_schema is not None
+        test = node.test
+        if not (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "beta_response_schema"
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.IsNot)
+            and len(test.comparators) == 1
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value is None
+        ):
+            continue
+        # Check body contains middleware.append(RetryMiddleware(...))
+        for stmt in ast.walk(node):
+            if not isinstance(stmt, ast.Expr):
+                continue
+            call = stmt.value
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "append"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "middleware"
+            ):
+                # Check arg is RetryMiddleware(...)
+                if call.args and isinstance(call.args[0], ast.Call):
+                    inner = call.args[0].func
+                    if isinstance(inner, ast.Name) and inner.id == "RetryMiddleware":
+                        retry_conditional_found = True
+                        break
+
+    assert retry_conditional_found, (
+        "factory.py must add RetryMiddleware to middleware when beta_response_schema is not None. "
+        "Pattern: `if beta_response_schema is not None: middleware.append(RetryMiddleware(...))`"
+    )
+
+
+def test_factory_so_schema_error_is_logged_not_silently_swallowed() -> None:
+    """factory.py must log a warning when structured-output resolution fails."""
+    source = _read_factory_source()
+    # Verify the warning log call is present in the exception handler
+    assert "logger.warning" in source, "factory.py must call logger.warning somewhere"
+    assert "response_schema disabled" in source or "Structured output schema" in source, (
+        "factory.py warning message should mention structured output schema resolution failure"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Change 3 tests — response_format is NOT stored in the llm_config dict
+# ---------------------------------------------------------------------------
+
+
+def test_llm_config_response_format_not_stored_in_dict() -> None:
+    """get_llm_config() must not store response_format in the returned dict.
+
+    llm_config_to_ag2_config() never reads response_format; it's dead weight.
+    Enforcement is via Agent(response_schema=...) in factory.py.
+    """
+    llm_config_path = _REPO_ROOT / "mozaiksai" / "core" / "workflow" / "llm_config.py"
+    source = llm_config_path.read_text(encoding="utf-8")
+    # The removed line was: llm_config["response_format"] = response_format
+    assert 'llm_config["response_format"] = response_format' not in source, (
+        "get_llm_config() must not store response_format in the returned dict — "
+        "llm_config_to_ag2_config() never reads it. Use Agent(response_schema=...) instead."
+    )

--- a/tests/test_structured_output_runtime_contracts.py
+++ b/tests/test_structured_output_runtime_contracts.py
@@ -262,7 +262,9 @@ def test_get_llm_for_workflow_keeps_response_format_for_strict_safe_models() -> 
 
     async def _fake_get_llm_config(*, response_format=None, extra_config=None, cache=True):
         seen["response_format"] = response_format
-        return None, {"config_list": [], "tools": [], "response_format": response_format}
+        # response_format is NOT stored in the returned dict; enforcement is via
+        # Agent(response_schema=...) in factory.py.
+        return None, {"config_list": [], "tools": []}
 
     original = _structured_mod.get_llm_config
     _structured_mod.get_llm_config = _fake_get_llm_config
@@ -276,8 +278,10 @@ def test_get_llm_for_workflow_keeps_response_format_for_strict_safe_models() -> 
     finally:
         _structured_mod.get_llm_config = original
 
+    # get_llm_for_workflow must forward the correct strict model to get_llm_config.
     assert seen["response_format"] is expected_model
-    assert cfg["response_format"] is expected_model
+    # response_format is NOT stored in the returned dict (it's dead in llm_config_to_ag2_config).
+    assert "response_format" not in cfg
 
 
 def test_designdocs_agent_output_supports_provider_strict_response_format() -> None:


### PR DESCRIPTION
## What broke

`UIToolAction.payload_schema` and `UIToolContract.payload_schema` were declared as `type: dict` in `factory_app/workflows/AgentGenerator/structured_outputs.yaml`. This caused `supports_provider_response_format()` to return `False` for any model transitively referencing these fields (including `PackBuildCoordinatorOutput` and `WorkflowBundleBuilderOutput`), so `PackBuildCoordinator` and `WorkflowBundleBuilderAgent` silently received `response_schema=None` on OpenAI/Azure — effectively disabling strict structured outputs for the core factory build agents.

## Changes

### 1 — PayloadSchemaSpec typed model (AgentGenerator structured_outputs.yaml)
Added a new `PayloadSchemaSpec` model with typed fields (`type: str`, `description`, `required`) using only field types already present in the file. Replaced `type: dict` on both `UIToolAction.payload_schema` and `UIToolContract.payload_schema` with `type: PayloadSchemaSpec`. No prompt or generator logic changed.

### 2 — RetryMiddleware for SO agents in factory.py
When an agent receives a non-None `beta_response_schema`, `RetryMiddleware(max_retries=2)` is now appended to its middleware list. This mirrors the existing `AG2StructuredAgentRunner` pattern and closes the gap where the network agent path got no retry coverage on provider/network failures for SO agents. Import added at module level.

Also fixed the silent exception swallow in the `beta_response_schema` resolution block: changed bare `except Exception: beta_response_schema = None` to log a `logger.warning(...)` before suppressing, so resolution failures are visible in logs.

### 3 — Dead response_format key removed from get_llm_config() dict
`get_llm_config()` was storing `llm_config["response_format"] = response_format` in the returned dict, but `llm_config_to_ag2_config()` never reads that key — it only reads `temperature`, `streaming`, `timeout`, etc. The actual enforcement is via `Agent(response_schema=...)` in `factory.py`. Removed the dead dict write; added a comment explaining the design. The `response_format` parameter on `get_llm_config()` is retained because it is used as a cache-key discriminator.

`test_structured_output_runtime_contracts.py` updated: the test that asserted `cfg["response_format"] is expected_model` now asserts `"response_format" not in cfg` (the key is gone) while still asserting the model was forwarded to `get_llm_config()` as a parameter.

## Tests added

`tests/test_so_schema_enforcement.py` (8 tests):
- `test_agentgenerator_payload_schema_spec_is_strict_compatible` — neither UIToolAction nor UIToolContract has `type: dict` on payload_schema
- `test_agentgenerator_payload_schema_spec_model_exists` — PayloadSchemaSpec exists and has a `type` field
- `test_agentgenerator_uitoolaction_payload_schema_references_spec` — UIToolAction.payload_schema is `type: PayloadSchemaSpec`
- `test_agentgenerator_uitoolcontract_payload_schema_references_spec` — UIToolContract.payload_schema is `type: PayloadSchemaSpec`
- `test_factory_retry_middleware_imported` — RetryMiddleware import present in factory.py
- `test_factory_structured_output_agent_gets_retry_middleware` — AST check that the conditional append exists
- `test_factory_so_schema_error_is_logged_not_silently_swallowed` — warning log present in source
- `test_llm_config_response_format_not_stored_in_dict` — the removed dict write is gone

## Pre-production cleanup policy

Replaced dead/wrong behavior. No shims, no aliases, no fallback layers.

## Test results

```
13210 passed, 77 skipped in 195s
```