### PR TITLE
feat(transport): canonical MozaiksEventType StrEnum (mozaiks.ui.event.v1)

### DIFF
--- a/mozaiksai/core/events/unified_event_dispatcher.py
+++ b/mozaiksai/core/events/unified_event_dispatcher.py
@@ -34,6 +34,7 @@ from mozaiksai.core.events.runtime_events import (
 )
 from mozaiksai.core.events.usage_ingest import get_usage_ingest_client
 from mozaiksai.core.ports.orchestration import DomainEvent
+from mozaiksai.core.transport.event_contract import MozaiksEventType
 from mozaiksai.core.workflow.runtime_signals import SYSTEM_RESUME_SIGNAL
 from mozaiksai.core.workflow.startup_messages import matches_hidden_initial_message
 from mozaiksai.core.workflow.workflow_manager import workflow_manager
@@ -542,18 +543,18 @@ class UnifiedEventDispatcher:
                 event_dict['auto_tool_call'] = bool(event_dict['auto_tool_call'])
 
         ns_map = {
-            'print': 'chat.print', 'text': 'chat.text', 'input_ack': 'chat.input_ack',
-            'input_timeout': 'chat.input_timeout', 'select_speaker': 'chat.select_speaker', 'resume_boundary': 'chat.resume_boundary',
-            'usage_delta': 'chat.usage_delta', 'usage_summary': 'chat.usage_summary', 'run_complete': 'chat.run_complete', 'error': 'chat.error', 'tool_call': 'chat.tool_call', 'tool_response': 'chat.tool_response',
-            'tool_progress': 'chat.tool_progress',
-            'token_budget_alert': 'chat.token_budget_alert',
-            'agent_output_validated': 'chat.agent_output_validated', 'run_start': 'chat.run_start', 'tool_call_dismiss': 'chat.tool_call_dismiss',
-            'awaiting_reply': 'chat.awaiting_reply', 'activity': 'chat.activity',
-            'attachment_uploaded': 'chat.attachment_uploaded',
-            'stream_chunk': 'chat.stream_chunk', 'stream_end': 'chat.stream_end', 'custom_event': 'chat.custom_event',
-            'greeting_echo': 'chat.greeting_echo',
+            'print': MozaiksEventType.CHAT_PRINT, 'text': MozaiksEventType.CHAT_TEXT, 'input_ack': MozaiksEventType.CHAT_INPUT_ACK,
+            'input_timeout': MozaiksEventType.CHAT_INPUT_TIMEOUT, 'select_speaker': MozaiksEventType.CHAT_SELECT_SPEAKER, 'resume_boundary': MozaiksEventType.CHAT_RESUME_BOUNDARY,
+            'usage_delta': MozaiksEventType.CHAT_USAGE_DELTA, 'usage_summary': MozaiksEventType.CHAT_USAGE_SUMMARY, 'run_complete': MozaiksEventType.CHAT_RUN_COMPLETE, 'error': MozaiksEventType.CHAT_ERROR, 'tool_call': MozaiksEventType.CHAT_TOOL_CALL, 'tool_response': MozaiksEventType.CHAT_TOOL_RESPONSE,
+            'tool_progress': MozaiksEventType.CHAT_TOOL_PROGRESS,
+            'token_budget_alert': MozaiksEventType.CHAT_TOKEN_BUDGET_ALERT,
+            'agent_output_validated': MozaiksEventType.CHAT_AGENT_OUTPUT_VALIDATED, 'run_start': MozaiksEventType.CHAT_RUN_START, 'tool_call_dismiss': MozaiksEventType.CHAT_TOOL_CALL_DISMISS,
+            'awaiting_reply': MozaiksEventType.CHAT_AWAITING_REPLY, 'activity': MozaiksEventType.CHAT_ACTIVITY,
+            'attachment_uploaded': MozaiksEventType.CHAT_ATTACHMENT_UPLOADED,
+            'stream_chunk': MozaiksEventType.CHAT_STREAM_CHUNK, 'stream_end': MozaiksEventType.CHAT_STREAM_END, 'custom_event': MozaiksEventType.CHAT_CUSTOM_EVENT,
+            'greeting_echo': MozaiksEventType.CHAT_GREETING_ECHO,
             # ui.* namespace — typed primitive event contract (L2)
-            'ui_render': 'ui.render', 'ui_update': 'ui.update', 'ui_dismiss': 'ui.dismiss',
+            'ui_render': MozaiksEventType.UI_RENDER, 'ui_update': MozaiksEventType.UI_UPDATE, 'ui_dismiss': MozaiksEventType.UI_DISMISS,
         }
         mapped_type = kind if kind.startswith('chat.') else ns_map.get(kind, kind)
         

--- a/mozaiksai/core/transport/event_contract.py
+++ b/mozaiksai/core/transport/event_contract.py
@@ -1,0 +1,103 @@
+"""
+mozaiks.ui.event.v1 — Canonical event type contract.
+
+All WebSocket event type strings are defined here. The unified event dispatcher
+and UI layer import from this module. Wire-format strings are stable.
+"""
+from __future__ import annotations
+
+import uuid
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+# Deterministic event ID namespace
+NAMESPACE_MOZAIKS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # uuid.NAMESPACE_URL
+
+
+class MozaiksEventType(StrEnum):
+    # ── Outbound: AG2 chat stream events ──────────────────────────────────────
+    CHAT_TEXT = "chat.text"
+    CHAT_PRINT = "chat.print"
+    CHAT_TOOL_CALL = "chat.tool_call"
+    CHAT_TOOL_RESPONSE = "chat.tool_response"
+    CHAT_TOOL_PROGRESS = "chat.tool_progress"
+    CHAT_TOOL_CALL_DISMISS = "chat.tool_call_dismiss"
+    CHAT_RUN_START = "chat.run_start"
+    CHAT_RUN_COMPLETE = "chat.run_complete"
+    CHAT_ERROR = "chat.error"
+    CHAT_STREAM_CHUNK = "chat.stream_chunk"
+    CHAT_STREAM_END = "chat.stream_end"
+    CHAT_AGENT_OUTPUT_VALIDATED = "chat.agent_output_validated"
+    CHAT_GREETING_ECHO = "chat.greeting_echo"
+    # ── Outbound: Session / flow events ───────────────────────────────────────
+    CHAT_INPUT_ACK = "chat.input_ack"
+    CHAT_INPUT_TIMEOUT = "chat.input_timeout"
+    CHAT_SELECT_SPEAKER = "chat.select_speaker"
+    CHAT_RESUME_BOUNDARY = "chat.resume_boundary"
+    CHAT_AWAITING_REPLY = "chat.awaiting_reply"
+    CHAT_ACTIVITY = "chat.activity"
+    CHAT_ATTACHMENT_UPLOADED = "chat.attachment_uploaded"
+    CHAT_CUSTOM_EVENT = "chat.custom_event"
+    # ── Outbound: Usage / token budget events ─────────────────────────────────
+    CHAT_USAGE_DELTA = "chat.usage_delta"
+    CHAT_USAGE_SUMMARY = "chat.usage_summary"
+    CHAT_TOKEN_BUDGET_ALERT = "chat.token_budget_alert"
+    # ── Outbound: Workflow state events ───────────────────────────────────────
+    CHAT_WORKFLOW_STARTED = "chat.workflow_started"
+    CHAT_WORKFLOW_REROUTED = "chat.workflow_rerouted"
+    CHAT_WORKFLOW_BATCH_STARTED = "chat.workflow_batch_started"
+    CHAT_CONTEXT_SWITCHED = "chat.context_switched"
+    CHAT_MODE_CHANGED = "chat.mode_changed"
+    CHAT_GENERAL_SESSION_CREATED = "chat.general_session_created"
+    CHAT_NAVIGATE = "chat.navigate"
+    # ── Inbound: Client-initiated actions ─────────────────────────────────────
+    CHAT_ARTIFACT_ACTION = "chat.artifact_action"
+    CHAT_SWITCH_WORKFLOW = "chat.switch_workflow"
+    CHAT_ENTER_GENERAL_MODE = "chat.enter_general_mode"
+    CHAT_START_GENERAL_CHAT = "chat.start_general_chat"
+    CHAT_START_WORKFLOW = "chat.start_workflow"
+    CHAT_START_WORKFLOW_BATCH = "chat.start_workflow_batch"
+    # ── Outbound: UI component events (L2 primitive contract) ─────────────────
+    UI_RENDER = "ui.render"
+    UI_UPDATE = "ui.update"
+    UI_DISMISS = "ui.dismiss"
+
+
+def compute_event_id(
+    tenant_id: str,
+    run_id: str | None,
+    session_id: str | None,
+    sequence_number: int,
+    event_type: MozaiksEventType,
+) -> str:
+    """Deterministic event ID for replay and deduplication."""
+    scope = run_id or session_id or "global"
+    return uuid.uuid5(
+        NAMESPACE_MOZAIKS,
+        f"{tenant_id}:{scope}:{sequence_number}:{event_type}",
+    ).hex
+
+
+class MozaiksEventEnvelope(BaseModel):
+    """Outbound WebSocket event envelope.
+
+    Carries a canonical ``type`` string (a ``MozaiksEventType`` member) plus
+    optional correlation metadata. Additional transport fields such as ``data``,
+    ``chat_id``, and ``timestamp`` are allowed via ``extra = "allow"`` so this
+    model can wrap arbitrary event payloads without stripping them.
+    """
+
+    model_config = {"extra": "allow"}
+
+    type: MozaiksEventType
+    event_id: str | None = None
+    corr: str | None = None  # correlation / trace ID
+
+
+__all__ = [
+    "NAMESPACE_MOZAIKS",
+    "MozaiksEventType",
+    "MozaiksEventEnvelope",
+    "compute_event_id",
+]

--- a/mozaiksai/core/transport/ui_events.py
+++ b/mozaiksai/core/transport/ui_events.py
@@ -5,10 +5,10 @@
 # Defines canonical shapes for UI component rendering events sent from the
 # Python runtime to the frontend over WebSocket.
 #
-# Outbound event types (Python → frontend):
-#   ui.render  — render a named UI component (inline or artifact)
-#   ui.update  — patch an already-rendered component's payload in place
-#   ui.dismiss — tear down a rendered component
+# Outbound event types (Python → frontend) — canonical type strings:
+#   MozaiksEventType.UI_RENDER  ("ui.render")  — render a named UI component (inline or artifact)
+#   MozaiksEventType.UI_UPDATE  ("ui.update")  — patch an already-rendered component's payload in place
+#   MozaiksEventType.UI_DISMISS ("ui.dismiss") — tear down a rendered component
 #
 # Inbound event types (frontend → backend) are unchanged:
 #   tool_call_response — user interaction response correlated by tool_call_id
@@ -19,6 +19,10 @@ from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from mozaiksai.core.transport.event_contract import (
+    MozaiksEventType as MozaiksEventType,  # re-exported for ui.* consumers
+)
 
 
 class UIDisplayMode(StrEnum):
@@ -74,6 +78,7 @@ class UIDismissData(BaseModel):
 
 
 __all__ = [
+    "MozaiksEventType",
     "UIDisplayMode",
     "UIRenderData",
     "UIUpdateData",

--- a/tests/test_event_contract.py
+++ b/tests/test_event_contract.py
@@ -1,0 +1,97 @@
+"""Tests for the mozaiks.ui.event.v1 canonical event contract."""
+from mozaiksai.core.transport.event_contract import (
+    MozaiksEventEnvelope,
+    MozaiksEventType,
+    compute_event_id,
+)
+
+
+def test_event_type_strings_are_namespaced():
+    """All event types must have a dot-namespaced format."""
+    for et in MozaiksEventType:
+        assert "." in et, f"{et} is not namespaced"
+
+
+def test_ui_event_types_present():
+    assert MozaiksEventType.UI_RENDER == "ui.render"
+    assert MozaiksEventType.UI_UPDATE == "ui.update"
+    assert MozaiksEventType.UI_DISMISS == "ui.dismiss"
+
+
+def test_chat_event_types_present():
+    assert MozaiksEventType.CHAT_TEXT == "chat.text"
+    assert MozaiksEventType.CHAT_TOOL_CALL == "chat.tool_call"
+    assert MozaiksEventType.CHAT_RUN_COMPLETE == "chat.run_complete"
+
+
+def test_all_ns_map_kinds_covered():
+    """Every chat.* and ui.* kind emitted by the ns_map must be a MozaiksEventType member."""
+    expected_outbound = {
+        "chat.print", "chat.text", "chat.input_ack", "chat.input_timeout",
+        "chat.select_speaker", "chat.resume_boundary", "chat.usage_delta",
+        "chat.usage_summary", "chat.run_complete", "chat.error", "chat.tool_call",
+        "chat.tool_response", "chat.tool_progress", "chat.token_budget_alert",
+        "chat.agent_output_validated", "chat.run_start", "chat.tool_call_dismiss",
+        "chat.awaiting_reply", "chat.activity", "chat.attachment_uploaded",
+        "chat.stream_chunk", "chat.stream_end", "chat.custom_event",
+        "chat.greeting_echo", "ui.render", "ui.update", "ui.dismiss",
+    }
+    valid = set(MozaiksEventType)
+    for type_str in expected_outbound:
+        assert type_str in valid, f"{type_str!r} from ns_map is not in MozaiksEventType"
+
+
+def test_compute_event_id_is_deterministic():
+    id1 = compute_event_id("tenant_a", "run_1", None, 0, MozaiksEventType.CHAT_TEXT)
+    id2 = compute_event_id("tenant_a", "run_1", None, 0, MozaiksEventType.CHAT_TEXT)
+    assert id1 == id2
+    assert isinstance(id1, str)
+
+
+def test_compute_event_id_changes_with_sequence():
+    id1 = compute_event_id("t", "r", None, 0, MozaiksEventType.CHAT_TEXT)
+    id2 = compute_event_id("t", "r", None, 1, MozaiksEventType.CHAT_TEXT)
+    assert id1 != id2
+
+
+def test_compute_event_id_changes_with_event_type():
+    id1 = compute_event_id("t", "r", None, 0, MozaiksEventType.CHAT_TEXT)
+    id2 = compute_event_id("t", "r", None, 0, MozaiksEventType.CHAT_TOOL_CALL)
+    assert id1 != id2
+
+
+def test_compute_event_id_uses_session_when_no_run():
+    id1 = compute_event_id("t", None, "sess_1", 0, MozaiksEventType.CHAT_TEXT)
+    id2 = compute_event_id("t", None, "sess_1", 0, MozaiksEventType.CHAT_TEXT)
+    assert id1 == id2
+
+
+def test_envelope_accepts_extra_fields():
+    env = MozaiksEventEnvelope(type=MozaiksEventType.CHAT_TEXT, text="hello", seq=5)
+    assert env.type == "chat.text"
+
+
+def test_envelope_type_compares_as_string():
+    """MozaiksEventType is a StrEnum — it must compare equal to its string value."""
+    env = MozaiksEventEnvelope(type=MozaiksEventType.UI_RENDER)
+    assert env.type == "ui.render"
+    assert env.type == MozaiksEventType.UI_RENDER
+
+
+def test_ns_map_uses_canonical_types():
+    """ns_map values in the dispatcher must all be MozaiksEventType members."""
+    # The ns_map is built inline inside build_outbound_event_envelope.
+    # Inspect the source to find all MozaiksEventType.XYZ references and
+    # verify each one resolves to a defined enum member.
+    import inspect
+    import re
+
+    from mozaiksai.core.events.unified_event_dispatcher import UnifiedEventDispatcher
+
+    src = inspect.getsource(UnifiedEventDispatcher.build_outbound_event_envelope)
+    # Extract string values that look like event type strings from the ns_map block.
+    # We match 'MozaiksEventType.XYZ' patterns and verify they resolve correctly.
+    enum_refs = re.findall(r"MozaiksEventType\.(\w+)", src)
+    assert len(enum_refs) > 0, "No MozaiksEventType references found in build_outbound_event_envelope"
+    for ref in enum_refs:
+        assert hasattr(MozaiksEventType, ref), f"MozaiksEventType.{ref} referenced in ns_map but not defined"


### PR DESCRIPTION
## Summary

- Creates `mozaiksai/core/transport/event_contract.py` with `MozaiksEventType` StrEnum, `MozaiksEventEnvelope` Pydantic model, and `compute_event_id()` deterministic ID helper
- Updates `unified_event_dispatcher.py` ns_map to reference `MozaiksEventType.*` enum values instead of bare strings
- Updates `ui_events.py` to import and re-export `MozaiksEventType` so UI layer consumers have a single import point
- No wire-format changes — StrEnum compares equal to its string value; all existing string comparisons continue to work
- Frontend `chat-ui/src/core/ui/uiEventTypes.js` unchanged (already correct)

## Layer changed
- Framework capability: `mozaiksai/core/transport/` and `mozaiksai/core/events/`
- No runtime substrate changes, no app workspace changes, no hosted product changes

## Tests
- `tests/test_event_contract.py` — 11 tests covering type string format, deterministic IDs, envelope model, ns_map alignment
- Full suite: 13213 passed, 77 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)