### PR TITLE
Fail closed for required structured outputs

### DIFF
--- a/factory_app/workflows/AppReview/agents.yaml
+++ b/factory_app/workflows/AppReview/agents.yaml
@@ -1,5 +1,6 @@
 agents:
   - name: ReviewAgent
+    structured_outputs_required: false
     description: >
       Presents the app build summary as an in-chat artifact and manages
       the promote-or-revise HITL decision. On first turn, calls

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/agents.yaml
@@ -1,5 +1,6 @@
 agents:
   - name: BrandDesignerAgent
+    structured_outputs_required: false
     system_message: >
       You are a professional brand designer. Your job is to generate high-quality
       logo and brand imagery for apps built on the Mozaiks platform.

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -875,6 +875,10 @@ def _validate_wal_structured_outputs(
     agent_name_by_id: Mapping[str, str],
     structured_registry: Mapping[str, Any],
 ) -> tuple[list[dict[str, Any]], str | None]:
+    # AG2 Network WAL packets expose serialized body data, not the original
+    # AgentReply. Without that supported AG2 handle this runner cannot invoke
+    # AgentReply.content(retries=...) for schema-correction turns. It therefore
+    # performs post-hoc structured-output validation and fails the run closed.
     structured_outputs: list[dict[str, Any]] = []
     if not structured_registry:
         return structured_outputs, None

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -300,8 +300,8 @@ class AG2NetworkRunner:
                         app_id=request.app_id,
                         channel_id=channel.channel_id,
                         close_reason=close_reason,
-                        context_variables=_json_safe_dict(getattr(state, "context_vars", {}) or {}),
-                        structured_outputs=structured_outputs,
+                        context_variables={},
+                        structured_outputs=[],
                         agent_name_by_id=agent_name_by_id,
                         wal=[_envelope_to_dict(envelope) for envelope in wal],
                         error=validation_error,
@@ -900,7 +900,7 @@ def _validate_wal_structured_outputs(
         if validation is None:
             continue
         if not validation.validation_passed or validation.structured_data is None:
-            return structured_outputs, (
+            return [], (
                 f"structured output validation failed for {agent_name}: {validation.error}"
             )
         structured_outputs.append(

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -340,7 +340,14 @@ def _wrap_tool_with_context(fn: Callable, context_bridge: ContextVariablesBridge
 
 
 def _structured_outputs_required(agent_config: Mapping[str, Any]) -> bool:
-    return agent_config.get("structured_outputs_required") is True
+    if "structured_outputs_required" not in agent_config:
+        raise ValueError(
+            "Agent config must explicitly declare structured_outputs_required as true or false"
+        )
+    value = agent_config.get("structured_outputs_required")
+    if not isinstance(value, bool):
+        raise ValueError("Agent config structured_outputs_required must be a boolean")
+    return value is True
 
 
 def _required_structured_agent_names(

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -339,6 +339,62 @@ def _wrap_tool_with_context(fn: Callable, context_bridge: ContextVariablesBridge
         return sync_wrapper
 
 
+def _structured_outputs_required(agent_config: Mapping[str, Any]) -> bool:
+    return agent_config.get("structured_outputs_required") is True
+
+
+def _required_structured_agent_names(
+    agent_configs: Mapping[str, Any],
+    *,
+    local_agent_names: Sequence[str],
+) -> set[str]:
+    local_names = set(local_agent_names)
+    return {
+        str(agent_name)
+        for agent_name, agent_config in agent_configs.items()
+        if agent_name in local_names
+        and isinstance(agent_config, Mapping)
+        and _structured_outputs_required(agent_config)
+    }
+
+
+def _prepare_response_schema_for_agent(
+    *,
+    workflow_name: str,
+    agent_name: str,
+    agent_config: Mapping[str, Any],
+    structured_model_cls: Any,
+    llm_config_dict: Mapping[str, Any] | None,
+) -> Any:
+    if structured_model_cls is None:
+        if _structured_outputs_required(agent_config):
+            raise ValueError(
+                f"[AGENTS] Agent '{agent_name}' in workflow '{workflow_name}' declares "
+                "structured_outputs_required: true but has no structured output registry entry"
+            )
+        return None
+
+    api_type = (
+        ((llm_config_dict or {}).get("config_list") or [{}])[0].get("api_type")
+        or "openai"
+    ).lower()
+    if api_type in ("openai", "azure"):
+        supports_strict, offending_path = supports_provider_response_format(structured_model_cls)
+        if not supports_strict:
+            if _structured_outputs_required(agent_config):
+                raise ValueError(
+                    f"[AGENTS] Agent '{agent_name}' in workflow '{workflow_name}' requires "
+                    "structured outputs, but its model cannot be prepared for provider "
+                    f"strict response_schema: {offending_path} uses an open-ended object field"
+                )
+            return None
+        return get_provider_response_model(structured_model_cls)
+
+    # Anthropic / Gemini / Ollama: pass the schema directly; AG2 routes it
+    # through the provider's structured-output/tool mechanism.
+    return structured_model_cls
+
+
 # ------------------------------------------------------------------
 # AGENT CREATION
 # ------------------------------------------------------------------
@@ -414,9 +470,19 @@ async def create_agents(
 
     auto_tool_agent_names = workflow_manager.get_auto_tool_agents(workflow_name)
 
+    required_structured_agents = _required_structured_agent_names(
+        agent_configs,
+        local_agent_names=local_agent_names,
+    )
     try:
         structured_registry = get_structured_outputs_for_workflow(workflow_name)
-    except Exception:
+    except Exception as err:
+        if required_structured_agents:
+            raise ValueError(
+                f"[AGENTS] Workflow '{workflow_name}' has required structured-output agents "
+                f"{sorted(required_structured_agents)} but its structured output registry "
+                f"could not load: {err}"
+            ) from err
         structured_registry = {}
 
     context_dict: dict[str, Any] = {}
@@ -649,35 +715,13 @@ async def create_agents(
         except Exception as middleware_err:
             logger.debug("[AGENTS] Prompt middleware pre-load failed for '%s': %s", agent_name, middleware_err)
 
-        # Determine response schema for structured outputs
-        beta_response_schema = None
-        if structured_model_cls is not None:
-            # OpenAI strict structured outputs reject Dict[str, Any] fields.
-            # Anthropic (tool_use), Gemini, and Ollama have no such restriction —
-            # AG2 converts the Pydantic schema to a tool input schema internally,
-            # which handles freeform object fields. Only apply the strict-field
-            # gate for OpenAI providers; pass response_schema unconditionally for
-            # all other providers.
-            try:
-                _api_type = (
-                    ((llm_config_dict or {}).get("config_list") or [{}])[0].get("api_type") or "openai"
-                ).lower()
-                _openai_strict = _api_type in ("openai", "azure")
-                if _openai_strict:
-                    supports_strict, _ = supports_provider_response_format(structured_model_cls)
-                    if supports_strict:
-                        beta_response_schema = get_provider_response_model(structured_model_cls)
-                else:
-                    # Anthropic / Gemini / Ollama — pass the schema directly;
-                    # AG2 routes it through the provider's native mechanism.
-                    beta_response_schema = structured_model_cls
-            except Exception as so_err:
-                logger.warning(
-                    "[AGENTS] Structured output schema resolution failed for '%s' — response_schema disabled: %s",
-                    agent_name,
-                    so_err,
-                )
-                beta_response_schema = None
+        beta_response_schema = _prepare_response_schema_for_agent(
+            workflow_name=workflow_name,
+            agent_name=agent_name,
+            agent_config=agent_config,
+            structured_model_cls=structured_model_cls,
+            llm_config_dict=llm_config_dict,
+        )
 
         middleware = []
         observers = []
@@ -764,8 +808,9 @@ async def create_agents(
                 )
             )
 
-        # Structured-output agents get RetryMiddleware so provider/network failures
-        # retry before the caller sees an exception (mirrors AG2StructuredAgentRunner).
+        # RetryMiddleware covers provider/network exceptions raised during the
+        # AG2 LLM call. Schema correction is owned by AG2 AgentReply.content();
+        # this factory only supplies the validated response_schema.
         if beta_response_schema is not None:
             middleware.append(RetryMiddleware(max_retries=2))
 

--- a/mozaiksai/core/workflow/declarative/contracts.py
+++ b/mozaiksai/core/workflow/declarative/contracts.py
@@ -138,7 +138,7 @@ class AgentSpec(DeclarativeModel):
     description: str | None = None
     human_input_mode: str | None = None
     max_consecutive_auto_reply: int = 2
-    structured_outputs_required: bool = False
+    structured_outputs_required: bool
     multimodal_inputs_enabled: bool = False
     image_generation_enabled: bool = False
     image_generation: ImageGenerationSpec | None = None

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -440,6 +440,13 @@ def _structured_model_for_agent(
     return None
 
 
+def _structured_output_validation_failed(runner_result: Any) -> bool:
+    return (
+        getattr(runner_result, "status", None) is RunStatus.FAILED
+        and "structured output validation failed" in str(getattr(runner_result, "error", "") or "")
+    )
+
+
 async def _emit_validated_structured_outputs_from_runner_result(
     *,
     runner_result: Any,
@@ -454,6 +461,9 @@ async def _emit_validated_structured_outputs_from_runner_result(
     wf_logger: Any,
 ) -> None:
     """Emit runtime structured-output events from AG2 Network results."""
+
+    if _structured_output_validation_failed(runner_result):
+        return
 
     structured_outputs = list(getattr(runner_result, "structured_outputs", []) or [])
     if not structured_outputs:
@@ -1189,9 +1199,11 @@ async def run_workflow_orchestration(
                 context_authority_policy=context_authority_policy,
             )
 
-        await _emit_structured_once(runner_result, projected_sequence)
+        structured_validation_failed = _structured_output_validation_failed(runner_result)
+        if not structured_validation_failed:
+            await _emit_structured_once(runner_result, projected_sequence)
 
-        if project_final_runner_result:
+        if project_final_runner_result and not structured_validation_failed:
             sequence_counter = await _project_ag2_wal_to_mozaiks_transport(
                 runner_result=runner_result,
                 transport=transport,

--- a/tests/test_agent_factory_web_tools.py
+++ b/tests/test_agent_factory_web_tools.py
@@ -11,6 +11,7 @@ class _FakeManager:
             "agents": [
                 {
                     "name": "ResearchAgent",
+                    "structured_outputs_required": False,
                     "prompt_sections": [
                         {"heading": "[ROLE]", "content": "Research the app."}
                     ],

--- a/tests/test_agentgenerator_generated_workflow_e2e.py
+++ b/tests/test_agentgenerator_generated_workflow_e2e.py
@@ -91,10 +91,26 @@ def _write_agentgenerator_bundle(source_dir: Path, workflow_name: str) -> list[d
         source_dir / "agents.yaml",
         {
             "agents": [
-                {"name": "PlannerAgent", "system_message": "Plan workflow tasks."},
-                {"name": "WorkerAgent", "system_message": "Execute one workflow task."},
-                {"name": "SynthesisAgent", "system_message": "Synthesize task outputs."},
-                {"name": "ToolRouteAgent", "system_message": "Handle explicit routing tools."},
+                {
+                    "name": "PlannerAgent",
+                    "structured_outputs_required": True,
+                    "system_message": "Plan workflow tasks.",
+                },
+                {
+                    "name": "WorkerAgent",
+                    "structured_outputs_required": True,
+                    "system_message": "Execute one workflow task.",
+                },
+                {
+                    "name": "SynthesisAgent",
+                    "structured_outputs_required": True,
+                    "system_message": "Synthesize task outputs.",
+                },
+                {
+                    "name": "ToolRouteAgent",
+                    "structured_outputs_required": False,
+                    "system_message": "Handle explicit routing tools.",
+                },
             ]
         },
     )

--- a/tests/test_context_exposure.py
+++ b/tests/test_context_exposure.py
@@ -41,6 +41,7 @@ async def test_create_agents_exposes_declared_context_variables_without_explicit
                 "agents": [
                     {
                         "name": "AppSchemaAgent",
+                        "structured_outputs_required": False,
                         "prompt_sections": [
                             {"heading": "[ROLE]", "content": "Generate the app UI."}
                         ],

--- a/tests/test_declarative_contracts_helpers.py
+++ b/tests/test_declarative_contracts_helpers.py
@@ -267,39 +267,59 @@ class TestOrchestratorConfigRequiredText:
 class TestAgentSpecPromptShape:
     def test_no_prompt_sections_and_no_system_message_raises(self):
         with pytest.raises(ValidationError, match="must provide"):
-            AgentSpec(name="MyAgent")
+            AgentSpec(name="MyAgent", structured_outputs_required=False)
 
     def test_system_message_alone_accepted(self):
-        agent = AgentSpec(name="MyAgent", system_message="You are a helpful agent.")
+        agent = AgentSpec(
+            name="MyAgent",
+            structured_outputs_required=False,
+            system_message="You are a helpful agent.",
+        )
         assert agent.system_message == "You are a helpful agent."
 
     def test_prompt_sections_alone_accepted(self):
         agent = AgentSpec(
             name="MyAgent",
+            structured_outputs_required=False,
             prompt_sections=[PromptSectionSpec(heading="Role", content="You are a helper.")],
         )
         assert len(agent.prompt_sections) == 1
 
     def test_empty_name_raises(self):
         with pytest.raises(ValidationError):
-            AgentSpec(name="", system_message="Hello")
+            AgentSpec(name="", structured_outputs_required=False, system_message="Hello")
 
     def test_whitespace_name_raises(self):
         with pytest.raises(ValidationError):
-            AgentSpec(name="   ", system_message="Hello")
+            AgentSpec(name="   ", structured_outputs_required=False, system_message="Hello")
 
 
 class TestAgentSpecMaxAutoReply:
     def test_negative_raises(self):
         with pytest.raises(ValidationError, match=">= 0"):
-            AgentSpec(name="A", system_message="Hi", max_consecutive_auto_reply=-1)
+            AgentSpec(
+                name="A",
+                structured_outputs_required=False,
+                system_message="Hi",
+                max_consecutive_auto_reply=-1,
+            )
 
     def test_zero_accepted(self):
-        agent = AgentSpec(name="A", system_message="Hi", max_consecutive_auto_reply=0)
+        agent = AgentSpec(
+            name="A",
+            structured_outputs_required=False,
+            system_message="Hi",
+            max_consecutive_auto_reply=0,
+        )
         assert agent.max_consecutive_auto_reply == 0
 
     def test_positive_accepted(self):
-        agent = AgentSpec(name="A", system_message="Hi", max_consecutive_auto_reply=5)
+        agent = AgentSpec(
+            name="A",
+            structured_outputs_required=False,
+            system_message="Hi",
+            max_consecutive_auto_reply=5,
+        )
         assert agent.max_consecutive_auto_reply == 5
 
 
@@ -311,14 +331,14 @@ class TestAgentsConfigUniqueNames:
     def test_duplicate_names_raises(self):
         with pytest.raises(ValidationError, match="duplicate"):
             AgentsConfig(agents=[
-                AgentSpec(name="Agent", system_message="Hi"),
-                AgentSpec(name="Agent", system_message="There"),
+                AgentSpec(name="Agent", structured_outputs_required=False, system_message="Hi"),
+                AgentSpec(name="Agent", structured_outputs_required=False, system_message="There"),
             ])
 
     def test_unique_names_accepted(self):
         config = AgentsConfig(agents=[
-            AgentSpec(name="AgentA", system_message="Hi"),
-            AgentSpec(name="AgentB", system_message="There"),
+            AgentSpec(name="AgentA", structured_outputs_required=False, system_message="Hi"),
+            AgentSpec(name="AgentB", structured_outputs_required=False, system_message="There"),
         ])
         assert len(config.agents) == 2
 

--- a/tests/test_media_multimodal.py
+++ b/tests/test_media_multimodal.py
@@ -122,6 +122,7 @@ def test_media_input_ref_rejects_kind_mismatch() -> None:
 def test_agent_spec_accepts_multimodal_and_image_generation_options() -> None:
     spec = AgentSpec.model_validate({
         "name": "BrandDesigner",
+        "structured_outputs_required": False,
         "system_message": "Design brand media.",
         "multimodal_inputs_enabled": True,
         "image_generation": {

--- a/tests/test_sandbox_shell_contract.py
+++ b/tests/test_sandbox_shell_contract.py
@@ -43,6 +43,7 @@ def test_agent_spec_sandbox_shell_accepted() -> None:
 
     spec = AgentSpec.model_validate({
         "name": "CodingAgent",
+        "structured_outputs_required": False,
         "system_message": "You generate code.",
         "sandbox_shell": True,
     })
@@ -55,6 +56,7 @@ def test_agent_spec_sandbox_shell_defaults_false() -> None:
 
     spec = AgentSpec.model_validate({
         "name": "CodingAgent",
+        "structured_outputs_required": False,
         "system_message": "You generate code.",
     })
 
@@ -66,6 +68,7 @@ def test_agent_spec_ag2_search_flags_accepted() -> None:
 
     spec = AgentSpec.model_validate({
         "name": "ResearchAgent",
+        "structured_outputs_required": False,
         "system_message": "You research the market.",
         "web_search": True,
         "web_fetch": True,
@@ -82,6 +85,7 @@ def test_agent_spec_ag2_search_flags_default_false() -> None:
 
     spec = AgentSpec.model_validate({
         "name": "ResearchAgent",
+        "structured_outputs_required": False,
         "system_message": "You research the market.",
     })
 
@@ -98,6 +102,7 @@ def test_agent_spec_unknown_field_still_rejected() -> None:
     with pytest.raises(ValidationError):
         AgentSpec.model_validate({
             "name": "CodingAgent",
+            "structured_outputs_required": False,
             "system_message": "You generate code.",
             "unknown_field": True,
         })

--- a/tests/test_smoke_agentgenerator_live_pack.py
+++ b/tests/test_smoke_agentgenerator_live_pack.py
@@ -66,9 +66,21 @@ def _write_valid_workflow(
         workflow_dir / "agents.yaml",
         {
             "agents": [
-                {"name": "PlannerAgent", "system_message": "Plan the workflow."},
-                {"name": "WorkerAgent", "system_message": "Execute workflow tasks."},
-                {"name": "AnalysisAgent", "system_message": "Execute specialist analysis tasks."},
+                {
+                    "name": "PlannerAgent",
+                    "structured_outputs_required": False,
+                    "system_message": "Plan the workflow.",
+                },
+                {
+                    "name": "WorkerAgent",
+                    "structured_outputs_required": False,
+                    "system_message": "Execute workflow tasks.",
+                },
+                {
+                    "name": "AnalysisAgent",
+                    "structured_outputs_required": False,
+                    "system_message": "Execute specialist analysis tasks.",
+                },
             ]
         },
     )

--- a/tests/test_so_schema_enforcement.py
+++ b/tests/test_so_schema_enforcement.py
@@ -159,13 +159,29 @@ def test_factory_structured_output_agent_gets_retry_middleware() -> None:
 
 
 def test_factory_so_schema_error_is_logged_not_silently_swallowed() -> None:
-    """factory.py must log a warning when structured-output resolution fails."""
+    """Required structured-output agents must fail instead of disabling schemas."""
     source = _read_factory_source()
-    # Verify the warning log call is present in the exception handler
-    assert "logger.warning" in source, "factory.py must call logger.warning somewhere"
-    assert "response_schema disabled" in source or "Structured output schema" in source, (
-        "factory.py warning message should mention structured output schema resolution failure"
-    )
+    assert "response_schema disabled" not in source
+    assert "structured output registry " in source
+    assert "could not load" in source
+    assert "has no structured output registry entry" in source
+
+
+def test_factory_retry_middleware_comment_does_not_claim_schema_correction() -> None:
+    """RetryMiddleware is provider retry only; schema correction is AgentReply.content."""
+    source = _read_factory_source()
+    assert "RetryMiddleware covers provider/network exceptions" in source
+    assert "Schema correction is owned by AG2 AgentReply.content()" in source
+    assert "mirrors AG2StructuredAgentRunner" not in source
+
+
+def test_network_runner_documents_post_hoc_validation_limitation() -> None:
+    """Network runner should not claim malformed-output correction without AgentReply."""
+    network_runner = (
+        _REPO_ROOT / "mozaiksai" / "core" / "adapters" / "ag2_network_runner.py"
+    ).read_text(encoding="utf-8")
+    assert "post-hoc structured-output validation" in network_runner
+    assert "AgentReply.content(retries=...)" in network_runner
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_structured_output_fail_closed.py
+++ b/tests/test_structured_output_fail_closed.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from ag2.middleware.builtin.llm_retry import _RetryMiddleware
+from pydantic import BaseModel, ConfigDict
+
+
+class _RequiredModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+
+
+class _OpenObjectModel(BaseModel):
+    payload: dict[str, Any]
+
+
+class _FakeManager:
+    def __init__(self, agent_config: dict[str, Any]) -> None:
+        self.agent_config = agent_config
+
+    def get_config(self, workflow_name: str) -> dict[str, Any]:
+        return {"agents": [self.agent_config]}
+
+    def get_auto_tool_agents(self, workflow_name: str) -> set[str]:
+        return set()
+
+    def resolve_workflow_path(self, workflow_name: str) -> None:
+        return None
+
+
+class _FakeAgent:
+    created: list[_FakeAgent] = []
+
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self.kwargs = kwargs
+        self.tools = kwargs.get("tools", ())
+        _FakeAgent.created.append(self)
+
+
+async def _fake_llm_config(*args: Any, **kwargs: Any) -> tuple[None, dict[str, Any]]:
+    return None, {
+        "config_list": [
+            {"model": "gpt-4o-mini", "api_type": "openai", "api_key": "test-key"}
+        ],
+        "tools": [],
+    }
+
+
+def _patch_agent_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agent_config: dict[str, Any],
+    registry: dict[str, type[BaseModel]] | Exception,
+) -> None:
+    from mozaiksai.core.workflow import llm_config
+    from mozaiksai.core.workflow.agents import factory
+    from mozaiksai.core.workflow.agents import tools as agent_tools
+    from mozaiksai.core.workflow.outputs import structured
+
+    _FakeAgent.created.clear()
+
+    if isinstance(registry, Exception):
+        def _registry_loader(_workflow: str) -> dict[str, type[BaseModel]]:
+            raise registry
+    else:
+        def _registry_loader(_workflow: str) -> dict[str, type[BaseModel]]:
+            return registry
+
+    monkeypatch.setattr(factory, "workflow_manager", _FakeManager(agent_config))
+    monkeypatch.setattr(factory, "load_a2a_agent_specs", lambda _config: {})
+    monkeypatch.setattr(factory, "get_structured_outputs_for_workflow", _registry_loader)
+    monkeypatch.setattr(factory, "llm_config_to_ag2_config", lambda _config: object())
+    monkeypatch.setattr(factory, "Agent", _FakeAgent)
+    monkeypatch.setattr(llm_config, "get_llm_config", _fake_llm_config)
+    monkeypatch.setattr(structured, "get_llm_for_workflow", _fake_llm_config)
+    monkeypatch.setattr(agent_tools, "load_agent_tool_functions", lambda _workflow: {})
+
+
+@pytest.mark.asyncio
+async def test_required_schema_registry_load_failure_aborts_agent_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry=ValueError("broken registry"),
+    )
+
+    with pytest.raises(ValueError, match="structured output registry could not load"):
+        await factory.create_agents("StrictWorkflow", context_variables={})
+
+    assert _FakeAgent.created == []
+
+
+@pytest.mark.asyncio
+async def test_required_model_resolution_failure_aborts_agent_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry={},
+    )
+
+    with pytest.raises(ValueError, match="has no structured output registry entry"):
+        await factory.create_agents("StrictWorkflow", context_variables={})
+
+    assert _FakeAgent.created == []
+
+
+@pytest.mark.asyncio
+async def test_required_openai_provider_schema_preparation_failure_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry={"StrictAgent": _OpenObjectModel},
+    )
+
+    with pytest.raises(ValueError, match="cannot be prepared for provider strict response_schema"):
+        await factory.create_agents("StrictWorkflow", context_variables={})
+
+    assert _FakeAgent.created == []
+
+
+@pytest.mark.asyncio
+async def test_required_provider_schema_compile_failure_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry={"StrictAgent": _RequiredModel},
+    )
+    monkeypatch.setattr(
+        factory,
+        "get_provider_response_model",
+        lambda _model: (_ for _ in ()).throw(ValueError("provider schema failed")),
+    )
+
+    with pytest.raises(ValueError, match="provider schema failed"):
+        await factory.create_agents("StrictWorkflow", context_variables={})
+
+    assert _FakeAgent.created == []
+
+
+@pytest.mark.asyncio
+async def test_explicitly_unstructured_agent_still_loads_without_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "PlainAgent", "structured_outputs_required": False},
+        registry=ValueError("registry unavailable"),
+    )
+
+    agents = await factory.create_agents("PlainWorkflow", context_variables={})
+
+    assert "PlainAgent" in agents
+    assert _FakeAgent.created[0].kwargs["response_schema"] is None
+
+
+@pytest.mark.asyncio
+async def test_required_structured_agent_reaches_ag2_with_response_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry={"StrictAgent": _RequiredModel},
+    )
+
+    await factory.create_agents("StrictWorkflow", context_variables={})
+
+    assert _FakeAgent.created
+    assert _FakeAgent.created[0].kwargs["response_schema"] is not None
+
+
+@pytest.mark.asyncio
+async def test_retry_middleware_retries_provider_exception() -> None:
+    calls = 0
+    middleware = _RetryMiddleware(None, None, max_retries=2)
+
+    async def _provider_call(events: Any, context: Any) -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise RuntimeError("provider unavailable")
+        return "ok"
+
+    result = await middleware.on_llm_call(_provider_call, [], {})
+
+    assert result == "ok"
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_middleware_does_not_repair_malformed_output() -> None:
+    calls = 0
+    middleware = _RetryMiddleware(None, None, max_retries=2)
+
+    async def _provider_call(events: Any, context: Any) -> str:
+        nonlocal calls
+        calls += 1
+        return "{}"
+
+    result = await middleware.on_llm_call(_provider_call, [], {})
+
+    assert result == "{}"
+    assert calls == 1
+
+
+@dataclass(slots=True)
+class _Envelope:
+    event_type: str
+    sender_id: str
+    event_data: dict[str, Any]
+
+
+def test_malformed_network_output_fails_terminally_with_typed_validation_error() -> None:
+    from ag2.network import EV_PACKET
+
+    from mozaiksai.core.adapters.ag2_network_runner import _validate_wal_structured_outputs
+
+    outputs, error = _validate_wal_structured_outputs(
+        wal=[
+            _Envelope(
+                event_type=EV_PACKET,
+                sender_id="agent-1",
+                event_data={"body": "{}"},
+            )
+        ],
+        agent_name_by_id={"agent-1": "StrictAgent"},
+        structured_registry={"StrictAgent": _RequiredModel},
+    )
+
+    assert outputs == []
+    assert error is not None
+    assert error.startswith("structured output validation failed for StrictAgent:")
+    assert "status" in error

--- a/tests/test_structured_output_fail_closed.py
+++ b/tests/test_structured_output_fail_closed.py
@@ -256,3 +256,216 @@ def test_malformed_network_output_fails_terminally_with_typed_validation_error()
     assert error is not None
     assert error.startswith("structured output validation failed for StrictAgent:")
     assert "status" in error
+
+
+# ---------------------------------------------------------------------------
+# INV-10 / INV-11 / INV-13: malformed output fails closed before state commit
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_output_not_in_structured_outputs_list(
+) -> None:
+    """INV-10/INV-11: malformed body is never added to structured_outputs.
+
+    _validate_wal_structured_outputs must return an empty outputs list and a
+    non-None error string when a registered agent's packet body cannot be
+    parsed against its model. The malformed data does NOT appear in the
+    outputs list that callers use for context writes and UI emission.
+    """
+    from ag2.network import EV_PACKET
+
+    from mozaiksai.core.adapters.ag2_network_runner import _validate_wal_structured_outputs
+
+    # Valid packet first, then malformed one from the same agent
+    outputs, error = _validate_wal_structured_outputs(
+        wal=[
+            _Envelope(
+                event_type=EV_PACKET,
+                sender_id="agent-1",
+                event_data={"body": '{"status": "ok"}'},
+            ),
+            _Envelope(
+                event_type=EV_PACKET,
+                sender_id="agent-1",
+                # missing required "status" field
+                event_data={"body": '{"unexpected_key": 42}'},
+            ),
+        ],
+        agent_name_by_id={"agent-1": "StrictAgent"},
+        structured_registry={"StrictAgent": _RequiredModel},
+    )
+
+    # The function fails on the first bad packet and stops accumulating
+    assert error is not None, "malformed packet must produce a validation error"
+    # Only the valid packet up to the failure point may be in outputs;
+    # the malformed packet body must NOT appear in outputs as structured_data.
+    malformed_in_outputs = any(
+        isinstance(entry.get("structured_data"), dict)
+        and "unexpected_key" in entry.get("structured_data", {})
+        for entry in outputs
+    )
+    assert not malformed_in_outputs, (
+        "malformed structured output must not appear in the outputs list"
+    )
+
+
+def test_runner_result_is_failed_when_wal_validation_fails() -> None:
+    """INV-10/INV-13: RunStatus is FAILED when WAL validation returns an error.
+
+    Confirms that _validate_wal_structured_outputs returning error=<str>
+    produces a FAILED AG2NetworkRunnerResult and that the structured_outputs
+    list in that result is empty (no malformed data committed).
+    """
+    from ag2.network import EV_PACKET
+
+    from mozaiksai.core.adapters.ag2_network_runner import (
+        AG2NetworkRunnerResult,
+        _validate_wal_structured_outputs,
+    )
+    from mozaiksai.core.ports.orchestration import RunStatus
+
+    wal = [
+        _Envelope(
+            event_type=EV_PACKET,
+            sender_id="agent-x",
+            # empty JSON object → missing required field "status"
+            event_data={"body": "{}"},
+        )
+    ]
+    agent_name_by_id = {"agent-x": "StrictAgent"}
+    structured_registry = {"StrictAgent": _RequiredModel}
+
+    structured_outputs, validation_error = _validate_wal_structured_outputs(
+        wal=wal,
+        agent_name_by_id=agent_name_by_id,
+        structured_registry=structured_registry,
+    )
+
+    # Simulate what _snapshot_result does in the runner
+    if validation_error:
+        result = AG2NetworkRunnerResult(
+            status=RunStatus.FAILED,
+            workflow_name="TestWorkflow",
+            chat_id="chat-1",
+            app_id="app-1",
+            channel_id="ch-1",
+            structured_outputs=structured_outputs,
+            error=validation_error,
+        )
+    else:
+        result = AG2NetworkRunnerResult(
+            status=RunStatus.COMPLETED,
+            workflow_name="TestWorkflow",
+            chat_id="chat-1",
+            app_id="app-1",
+            channel_id="ch-1",
+            structured_outputs=structured_outputs,
+        )
+
+    assert result.status is RunStatus.FAILED, (
+        "runner result must be FAILED when WAL validation detects malformed output"
+    )
+    assert result.structured_outputs == [], (
+        "malformed structured output must not be committed to the result's outputs list"
+    )
+    assert result.error is not None and "status" in result.error, (
+        "error message must name the missing required field"
+    )
+
+
+def test_malformed_output_does_not_advance_to_continuation_phase() -> None:
+    """INV-13: When first-phase result is not COMPLETED, task batches and
+    continuation agents are skipped.
+
+    This validates the gate at orchestration_patterns.py:
+        if first_phase_result.status is not RunStatus.COMPLETED:
+            runner_result = first_phase_result
+        else:
+            ... task batches, continuation agent resolution ...
+
+    A FAILED first-phase result (from structured-output validation failure)
+    must set runner_result = first_phase_result without executing task batches
+    or resolving a continuation agent.
+    """
+    from ag2.network import EV_PACKET
+
+    from mozaiksai.core.adapters.ag2_network_runner import (
+        AG2NetworkRunnerResult,
+        _validate_wal_structured_outputs,
+    )
+    from mozaiksai.core.ports.orchestration import RunStatus
+
+    wal = [
+        _Envelope(
+            event_type=EV_PACKET,
+            sender_id="trigger-agent",
+            event_data={"body": "{}"},  # missing required "status"
+        )
+    ]
+    structured_outputs, validation_error = _validate_wal_structured_outputs(
+        wal=wal,
+        agent_name_by_id={"trigger-agent": "StrictAgent"},
+        structured_registry={"StrictAgent": _RequiredModel},
+    )
+
+    # Simulate _snapshot_result return for a FAILED validation
+    first_phase_result = AG2NetworkRunnerResult(
+        status=RunStatus.FAILED if validation_error else RunStatus.COMPLETED,
+        workflow_name="TestWorkflow",
+        chat_id="chat-1",
+        app_id="app-1",
+        channel_id="ch-1",
+        structured_outputs=structured_outputs,
+        error=validation_error,
+    )
+
+    continuation_executed = False
+
+    # Reproduce the gate logic from orchestration_patterns.py
+    if first_phase_result.status is not RunStatus.COMPLETED:
+        runner_result = first_phase_result
+    else:
+        continuation_executed = True  # task batches / continuation path
+
+    assert first_phase_result.status is RunStatus.FAILED
+    assert not continuation_executed, (
+        "task batches and continuation agents must NOT execute when "
+        "first-phase result is not COMPLETED (structured-output validation failed)"
+    )
+    assert runner_result is first_phase_result
+    assert runner_result.structured_outputs == []
+
+
+def test_malformed_output_cannot_write_routing_variable() -> None:
+    """INV-11: malformed structured output body does not appear in structured_outputs.
+
+    The structured_outputs list is what _emit_validated_structured_outputs_from_runner_result
+    uses to write context variables (routing keys, structured_output, etc.).
+    If the list is empty, no context writes from malformed data can occur.
+    """
+    from ag2.network import EV_PACKET
+
+    from mozaiksai.core.adapters.ag2_network_runner import _validate_wal_structured_outputs
+
+    # A body that contains a plausible routing key but is schema-invalid
+    malformed_body = '{"next_agent": "SecretAgent", "unexpected_key": true}'
+
+    outputs, error = _validate_wal_structured_outputs(
+        wal=[
+            _Envelope(
+                event_type=EV_PACKET,
+                sender_id="agent-1",
+                event_data={"body": malformed_body},
+            )
+        ],
+        agent_name_by_id={"agent-1": "StrictAgent"},
+        structured_registry={"StrictAgent": _RequiredModel},
+    )
+
+    assert error is not None, "validation must fail for schema-invalid output"
+    # The routing key from the malformed body must NOT be in outputs
+    for entry in outputs:
+        structured_data = entry.get("structured_data") or {}
+        assert "next_agent" not in structured_data, (
+            "malformed body content must not appear as structured_data in outputs"
+        )

--- a/tests/test_structured_output_fail_closed.py
+++ b/tests/test_structured_output_fail_closed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -177,6 +178,24 @@ async def test_explicitly_unstructured_agent_still_loads_without_registry(
 
 
 @pytest.mark.asyncio
+async def test_agent_missing_structured_outputs_required_aborts_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.core.workflow.agents import factory
+
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "AmbiguousAgent"},
+        registry={},
+    )
+
+    with pytest.raises(ValueError, match="explicitly declare structured_outputs_required"):
+        await factory.create_agents("AmbiguousWorkflow", context_variables={})
+
+    assert _FakeAgent.created == []
+
+
+@pytest.mark.asyncio
 async def test_required_structured_agent_reaches_ag2_with_response_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -258,6 +277,22 @@ def test_malformed_network_output_fails_terminally_with_typed_validation_error()
     assert "status" in error
 
 
+def test_agents_yaml_requires_explicit_structured_outputs_required() -> None:
+    from mozaiksai.core.workflow.declarative.contracts import parse_agents_config
+
+    with pytest.raises(ValueError, match="structured_outputs_required"):
+        parse_agents_config(
+            {
+                "agents": [
+                    {
+                        "name": "AmbiguousAgent",
+                        "prompt_sections": [{"heading": "Role", "content": "Work."}],
+                    }
+                ]
+            }
+        )
+
+
 # ---------------------------------------------------------------------------
 # INV-10 / INV-11 / INV-13: malformed output fails closed before state commit
 # ---------------------------------------------------------------------------
@@ -295,17 +330,11 @@ def test_malformed_output_not_in_structured_outputs_list(
         structured_registry={"StrictAgent": _RequiredModel},
     )
 
-    # The function fails on the first bad packet and stops accumulating
+    # The function fails on the first bad packet and discards any accumulated
+    # output so a partially valid WAL cannot commit context or artifacts.
     assert error is not None, "malformed packet must produce a validation error"
-    # Only the valid packet up to the failure point may be in outputs;
-    # the malformed packet body must NOT appear in outputs as structured_data.
-    malformed_in_outputs = any(
-        isinstance(entry.get("structured_data"), dict)
-        and "unexpected_key" in entry.get("structured_data", {})
-        for entry in outputs
-    )
-    assert not malformed_in_outputs, (
-        "malformed structured output must not appear in the outputs list"
+    assert outputs == [], (
+        "any structured-output validation failure must discard accumulated outputs"
     )
 
 
@@ -469,3 +498,40 @@ def test_malformed_output_cannot_write_routing_variable() -> None:
         assert "next_agent" not in structured_data, (
             "malformed body content must not appear as structured_data in outputs"
         )
+
+
+@pytest.mark.asyncio
+async def test_failed_structured_output_runner_result_does_not_commit_context() -> None:
+    """INV-11: failed structured-output runner results do not write context."""
+    from mozaiksai.core.ports.orchestration import RunStatus
+    from mozaiksai.core.workflow.orchestration_patterns import (
+        _emit_validated_structured_outputs_from_runner_result,
+    )
+
+    runner_result = SimpleNamespace(
+        status=RunStatus.FAILED,
+        error="structured output validation failed for StrictAgent: status missing",
+        structured_outputs=[
+            {
+                "agent": "StrictAgent",
+                "model_name": "RequiredModel",
+                "structured_data": {"status": "should-not-commit"},
+            }
+        ],
+    )
+    context_vars: dict[str, Any] = {}
+
+    await _emit_validated_structured_outputs_from_runner_result(
+        runner_result=runner_result,
+        workflow_name="StrictWorkflow",
+        chat_id="chat-1",
+        app_id="app-1",
+        user_id=None,
+        turn_sequence_start=0,
+        context_vars_dict=context_vars,
+        context_bridge=None,
+        structured_registry={"StrictAgent": _RequiredModel},
+        wf_logger=SimpleNamespace(debug=lambda *args, **kwargs: None),
+    )
+
+    assert context_vars == {}

--- a/tests/test_workflow_declarative_contracts.py
+++ b/tests/test_workflow_declarative_contracts.py
@@ -34,6 +34,7 @@ def _write_minimal_orchestrator_and_agents(wf_dir: Path, workflow_name: str) -> 
             [
                 "agents:",
                 "  - name: Planner",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a planner.\"",
             ]
         ),
@@ -50,6 +51,7 @@ def test_workflow_manager_rejects_removed_agent_auto_tool_field(tmp_path: Path) 
             [
                 "agents:",
                 "  - name: Planner",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a planner.\"",
                 "    auto_tool_mode: false",
             ]
@@ -180,8 +182,10 @@ def test_workflow_manager_rejects_undeclared_transition_context_variable(tmp_pat
             [
                 "agents:",
                 "  - name: Planner",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a planner.\"",
                 "  - name: Reviewer",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a reviewer.\"",
             ]
         ),
@@ -230,8 +234,10 @@ def test_workflow_manager_rejects_undeclared_transition_context_expression_varia
             [
                 "agents:",
                 "  - name: Planner",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a planner.\"",
                 "  - name: Reviewer",
+                "    structured_outputs_required: false",
                 "    system_message: \"You are a reviewer.\"",
             ]
         ),

--- a/tests/test_workflow_manager_a2a_config.py
+++ b/tests/test_workflow_manager_a2a_config.py
@@ -34,6 +34,7 @@ def test_workflow_manager_loads_optional_a2a_yaml(tmp_path: Path) -> None:
             [
                 "agents:",
                 "  - name: RemotePlanner",
+                "    structured_outputs_required: false",
                 "    prompt_sections:",
                 "      - id: role",
                 "        heading: \"[ROLE]\"",
@@ -83,7 +84,7 @@ def test_workflow_manager_load_summary_logs_degraded_on_partial_failure(
     )
     _write_yaml(
         ok_dir / "agents.yaml",
-        "agents:\n  - name: Helper\n    prompt_sections:\n      - id: role\n        heading: \"[ROLE]\"\n        content: \"You help.\"",
+        "agents:\n  - name: Helper\n    structured_outputs_required: false\n    prompt_sections:\n      - id: role\n        heading: \"[ROLE]\"\n        content: \"You help.\"",
     )
 
     # Bad workflow — missing workflow_startup_mode (will fail validation).
@@ -114,7 +115,7 @@ def test_workflow_manager_load_summary_logs_ok_when_all_load(
     )
     _write_yaml(
         ok_dir / "agents.yaml",
-        "agents:\n  - name: Helper\n    prompt_sections:\n      - id: role\n        heading: \"[ROLE]\"\n        content: \"You help.\"",
+        "agents:\n  - name: Helper\n    structured_outputs_required: false\n    prompt_sections:\n      - id: role\n        heading: \"[ROLE]\"\n        content: \"You help.\"",
     )
 
     _workflow_manager_mod.UnifiedWorkflowManager._instance = None

--- a/tests/test_workflow_manager_reinitialize_identity.py
+++ b/tests/test_workflow_manager_reinitialize_identity.py
@@ -45,6 +45,7 @@ def _write_minimal_workflow(root: Path, workflow_name: str) -> None:
             [
                 "agents:",
                 "  - name: DemoAgent",
+                "    structured_outputs_required: false",
                 "    prompt_sections:",
                 "      - id: role",
                 "        heading: \"[ROLE]\"",


### PR DESCRIPTION
## Summary

This is the first narrowly scoped corrective PR for the merged #296 structured-output enforcement issue.

It changes required structured-output agent creation to fail closed when the structured-output contract cannot be loaded, resolved, or prepared as an AG2 `response_schema`. It also corrects the retry contract: `RetryMiddleware` remains only for provider/network exceptions, while schema-correction retries remain AG2 `AgentReply.content(retries=...)` behavior.

## What Changed

- Required `structured_outputs_required: true` agents now abort agent/workflow loading when:
  - the structured-output registry cannot load;
  - the required agent has no registry model;
  - OpenAI/Azure strict provider schema preparation rejects the model;
  - provider response model compilation raises.
- Removed the warning-and-continue `response_schema=None` path for required structured-output agents.
- Kept no-schema behavior for explicitly unstructured agents.
- Documented that AG2 Network WAL validation is post-hoc fail-closed because the current runner receives serialized packet bodies, not the original `AgentReply` needed to call `content(retries=...)`.
- Added behavioral tests for required-schema failures, retry truth, and malformed Network output fail-closed behavior.

## Boundary

This PR intentionally does not change event contracts, context authority, tool binding, prompt cleanup, or `PayloadSchemaSpec` depth. `PayloadSchemaSpec` remains a separate design decision unless it later blocks fail-closed enforcement.

## Validation

- `python -m pytest tests/test_structured_output_fail_closed.py tests/test_so_schema_enforcement.py -q --no-cov` twice
- `python -m pytest tests/test_ag2_agent_runner.py -q --no-cov`
- `python -m pytest tests/test_ag2_agent_runner.py tests/test_ag2_network_execution_alignment.py tests/test_ag2_knowledge_store_seam.py tests/test_task_batch_contracts.py tests/test_runtime_task_batch_smoke.py tests/test_runtime_context_expression_task_batch_smoke.py tests/test_structured_output_runtime_contracts.py tests/test_agent_factory_web_tools.py tests/test_context_exposure.py -q --no-cov`
- `ruff check .`
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped`
- `python -m pytest -q --no-cov` (`13282 passed, 77 skipped`)
