### PR TITLE
security(runtime): require explicit ModuleDispatchAuthority for module dispatch

### DIFF
--- a/ARCHITECTURAL_INVARIANTS.md
+++ b/ARCHITECTURAL_INVARIANTS.md
@@ -56,11 +56,11 @@ Automated guardrail: workflow, prompt, refinement, and intelligence surfaces pro
 
 Protects: permission boundaries while production authority is designed separately.
 
-Current enforcement: existing `granted_permissions=None` call sites are limited and tested.
+Current enforcement: every `ModuleRequest` carries a required, explicitly constructed `ModuleDispatchAuthority`. Trusted bypass exists only for a closed set of server-owned authority kinds and is validated at construction; it can never be obtained by omitting a principal or a permission list.
 
-Incomplete enforcement: a new caller could copy the pattern and obtain trusted internal execution by omission.
+Incomplete enforcement: a new caller could still construct a trusted server-owned authority kind outside its intended code path.
 
-Automated guardrail: governance CI rejects new `granted_permissions=None` source locations outside the explicit allowlist.
+Automated guardrail: governance CI rejects any reintroduction of the removed permission-list dispatch token in `mozaiksai/` source.
 
 ## 7. Mozaiks App Dogfoods Public Framework Contracts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,17 @@ This project follows a practical pre-1.0 changelog format:
   Trusted bypass is restricted to a closed, constructor-validated set of
   server-owned kinds (`framework_internal`, `operator_internal`,
   contract-declared `event_reaction`, auth-disabled `local_development`);
-  `local_development` cannot be constructed while authentication is enabled.
-  New `workflow_user_authority()` and `event_reaction_authority()` helpers are
-  the canonical producers for workflow and event-reaction dispatch. The public
-  app-local dispatch facade field is renamed to `permissions` and always
-  dispatches enforce-mode. Downstream apps constructing `ModuleRequest`
-  directly must supply an explicit authority when they adopt this version.
+  `local_development` cannot be constructed while authentication is enabled or
+  the deployment environment is production. New `workflow_user_authority()` and
+  `event_reaction_authority()` helpers are the canonical producers for workflow
+  and event-reaction dispatch. `ModuleActionDispatchRequest.authority` is also
+  required (keyword-only) and the facade's separate permission-list field is
+  deleted: the caller's enforce-mode authority carries its permissions and is
+  passed to `ModuleExecutor` exactly as supplied. `ModuleContext` receives
+  `dispatch_authority`, `dispatch_provenance`, and `dispatch_audit` on every
+  execution path, including caller-supplied contexts. Downstream apps
+  constructing `ModuleRequest` or `ModuleActionDispatchRequest` directly must
+  supply an explicit authority when they adopt this version.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Security
+
+- **Module dispatch requires explicit authority**: `ModuleRequest.authority` is
+  now a required keyword-only `ModuleDispatchAuthority`, and the
+  `granted_permissions` field is removed along with the
+  `from_granted_permissions()` translation shim and both compatibility
+  authority kinds. Permission and entitlement enforcement key exclusively on
+  `authority.permission_mode` and `authority.permissions`; a missing principal
+  or empty permission list now denies closed instead of silently bypassing.
+  Trusted bypass is restricted to a closed, constructor-validated set of
+  server-owned kinds (`framework_internal`, `operator_internal`,
+  contract-declared `event_reaction`, auth-disabled `local_development`);
+  `local_development` cannot be constructed while authentication is enabled.
+  New `workflow_user_authority()` and `event_reaction_authority()` helpers are
+  the canonical producers for workflow and event-reaction dispatch. The public
+  app-local dispatch facade field is renamed to `permissions` and always
+  dispatches enforce-mode. Downstream apps constructing `ModuleRequest`
+  directly must supply an explicit authority when they adopt this version.
+
 ### Removed
 
 - **`AppPageSchema.extensions` / `AppPageSlotExtension`**: the page slot-override

--- a/docs/architecture/app/tenant-auth-and-scope.md
+++ b/docs/architecture/app/tenant-auth-and-scope.md
@@ -70,9 +70,10 @@ The OSS runtime now provides the foundational tenant/auth scope contract:
 - When auth is enabled, external HTTP module dispatch requires an authenticated
   principal by default. The only anonymous HTTP module actions are those whose
   `actions[].api_surface` is explicitly `public` or `public_readonly`.
-- External HTTP module dispatch never uses the trusted internal
-  `granted_permissions=None` bypass. It passes a concrete permission list,
-  including an empty list for anonymous public actions.
+- External HTTP module dispatch always constructs an enforce-mode
+  `ModuleDispatchAuthority` carrying the caller's concrete permission set —
+  an empty set for anonymous public actions. There is no trusted bypass on
+  the HTTP path.
 - Authenticated HTTP module dispatch rejects request-supplied `user_id`,
   `tenant_id`, or `workspace_id` values that conflict with token-bound claims.
 - `PlatformHookRegistry` exposes `module_scope_resolver`, a provider-neutral
@@ -101,13 +102,16 @@ The platform should resolve external requests in this order:
 4. Return a canonical identity scope plus granted module permissions.
 5. Dispatch the module action with that scope in `ModuleRequest`.
 
-For external requests, missing auth or missing permission resolution should
-result in an empty permission list or an auth error, not the internal
-`granted_permissions=None` bypass.
+For external requests, missing auth or missing permission resolution results
+in an empty permission set on an enforce-mode authority or an auth error —
+never a trusted bypass.
 
-Internal runtime calls may still use trusted dispatch when the caller is already
-inside the runtime boundary. That path must stay explicit and separate from
-HTTP user traffic.
+Internal runtime calls may use trusted dispatch only by constructing one of
+the closed server-owned `ModuleDispatchAuthority` kinds
+(`framework_internal`, `operator_internal`, contract-declared
+`event_reaction`, or auth-disabled `local_development`). That path stays
+explicit and separate from HTTP user traffic; internal location alone never
+grants bypass.
 
 ## Remaining Production Work
 

--- a/docs/guides/adding-modules/01-overview.md
+++ b/docs/guides/adding-modules/01-overview.md
@@ -132,8 +132,9 @@ the external HTTP module route** (`/api/modules/{name}/{action}`). The runtime
 rejects those requests with 404 regardless of authentication status. This
 prevents external callers from triggering event-bus reaction handlers directly.
 Use these surfaces for event reactions and trusted internal runtime calls; invoke
-them through `ModuleExecutor` with `granted_permissions=None` when needed from
-trusted code paths.
+them through `ModuleExecutor` with an explicitly constructed server-owned
+`ModuleDispatchAuthority` (for example `framework_internal`, or
+`event_reaction` built via `event_reaction_authority`) from trusted code paths.
 
 ## module.yaml Schema Rules
 

--- a/factory_app/build_context/AppGenerator/file_contracts.yaml
+++ b/factory_app/build_context/AppGenerator/file_contracts.yaml
@@ -117,7 +117,7 @@ task_contracts:
       - Omit YAML files that would serialize to empty arrays or null objects.
       - YAML declares the contract; downstream agents implement Python and JS stubs.
       - actions[].api_surface is part of the module contract. Use public or public_readonly only for anonymous-safe HTTP actions. Omit it or use internal/admin_internal for actions that require an authenticated token when AUTH_ENABLED=true.
-      - Public/public_readonly actions are only anonymous entrypoints; they still receive a concrete granted_permissions list and still run actions[].permissions and actions[].entitlement_gate checks.
+      - Public/public_readonly actions are only anonymous entrypoints; they still dispatch with an enforce-mode authority carrying a concrete (possibly empty) permission set and still run actions[].permissions and actions[].entitlement_gate checks.
       - External HTTP dispatch and internal runtime dispatch are separate paths. Internal event reactions may use api_surface=internal and permissions=[] because the event bus is the authorization boundary; do not mark internal reaction handlers public.
       - contracts/reactions.yaml target.kind may be handler, capability, notification, or service_adapter. service_adapter targets must declare target.adapter and target.adapter_method, point only to app-owned services/adapters/* support code, and must not be used to bypass facade modules, module state ownership, or managed-provider boundaries.
       - JS stubs are allowed only for declared customization surfaces.

--- a/mozaiksai/core/runtime/composition/__init__.py
+++ b/mozaiksai/core/runtime/composition/__init__.py
@@ -8,6 +8,7 @@ from .extensions import (
     stop_services,
 )
 from .module_authority import (
+    TRUSTED_BYPASS_KINDS,
     ModuleDispatchAudit,
     ModuleDispatchAuthority,
     ModuleDispatchProvenance,
@@ -15,6 +16,8 @@ from .module_authority import (
     ModuleExecutionPolicyDecision,
     ModuleExecutionPolicyInput,
     ModulePermissionCheck,
+    event_reaction_authority,
+    workflow_user_authority,
 )
 from .module_context import ModuleContext
 from .module_dispatch import (
@@ -60,6 +63,9 @@ __all__ = [
     "normalize_module_reaction_provenance",
     "ModuleDispatchAudit",
     "ModuleDispatchAuthority",
+    "TRUSTED_BYPASS_KINDS",
+    "event_reaction_authority",
+    "workflow_user_authority",
     "ModuleDispatchProvenance",
     "ModuleEntitlementCheck",
     "ModuleExecutionPolicyDecision",

--- a/mozaiksai/core/runtime/composition/module_authority.py
+++ b/mozaiksai/core/runtime/composition/module_authority.py
@@ -56,16 +56,22 @@ class ModuleDispatchAuthority:
         if self.kind == "local_development" and not _local_development_allowed():
             raise ValueError(
                 "local_development dispatch authority is not available when "
-                "authentication is enabled"
+                "authentication is enabled or the deployment environment is production"
             )
 
 
 def _local_development_allowed() -> bool:
-    """local_development authority exists only while runtime auth is disabled."""
+    """local_development authority exists only while runtime auth is disabled
+    and the deployment environment is not production."""
+
+    import os
 
     from mozaiksai.core.auth.adapters.registry import is_auth_enabled
 
-    return not is_auth_enabled()
+    if is_auth_enabled():
+        return False
+    env_name = os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
+    return env_name != "production"
 
 
 def workflow_user_authority(

--- a/mozaiksai/core/runtime/composition/module_authority.py
+++ b/mozaiksai/core/runtime/composition/module_authority.py
@@ -14,11 +14,21 @@ ModuleDispatchAuthorityKind = Literal[
     "event_reaction",
     "app_internal",
     "operator_internal",
-    "legacy_permissions",
-    "legacy_trusted",
 ]
 
 ModuleDispatchPermissionMode = Literal["enforce", "trusted_bypass"]
+
+# Only server-owned dispatch reasons may ever bypass permission and
+# entitlement enforcement. Bypass is a property of how the authority was
+# constructed, never of a missing principal or an empty permission list.
+TRUSTED_BYPASS_KINDS: frozenset[str] = frozenset(
+    {
+        "framework_internal",
+        "operator_internal",
+        "event_reaction",
+        "local_development",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -34,34 +44,91 @@ class ModuleDispatchAuthority:
     reason: str
     actor_id: str | None = None
     permissions: tuple[str, ...] = ()
-    legacy_granted_permissions_none: bool = False
 
-    @classmethod
-    def from_granted_permissions(
-        cls,
-        granted_permissions: list[str] | None,
-        *,
-        actor_id: str | None = None,
-    ) -> ModuleDispatchAuthority:
-        """Translate existing ModuleRequest permission semantics into metadata."""
-
-        if granted_permissions is None:
-            return cls(
-                kind="legacy_trusted",
-                permission_mode="trusted_bypass",
-                reason="compatibility trusted dispatch",
-                actor_id=actor_id,
-                permissions=(),
-                legacy_granted_permissions_none=True,
+    def __post_init__(self) -> None:
+        if self.permission_mode == "trusted_bypass" and self.kind not in TRUSTED_BYPASS_KINDS:
+            raise ValueError(
+                f"Authority kind {self.kind!r} may not use trusted_bypass; "
+                f"only {sorted(TRUSTED_BYPASS_KINDS)} qualify."
             )
-        return cls(
-            kind="legacy_permissions",
-            permission_mode="enforce",
-            reason="compatibility concrete permissions dispatch",
-            actor_id=actor_id,
-            permissions=tuple(granted_permissions),
-            legacy_granted_permissions_none=False,
+        if self.kind == "workflow" and self.permission_mode != "enforce":
+            raise ValueError("workflow dispatch authority must always enforce permissions")
+        if self.kind == "local_development" and not _local_development_allowed():
+            raise ValueError(
+                "local_development dispatch authority is not available when "
+                "authentication is enabled"
+            )
+
+
+def _local_development_allowed() -> bool:
+    """local_development authority exists only while runtime auth is disabled."""
+
+    from mozaiksai.core.auth.adapters.registry import is_auth_enabled
+
+    return not is_auth_enabled()
+
+
+def workflow_user_authority(
+    *,
+    actor_id: str | None,
+    permissions: tuple[str, ...] = (),
+    workflow_name: str | None = None,
+) -> ModuleDispatchAuthority:
+    """Authority for a user-facing workflow tool dispatching a module action.
+
+    Identity and scopes must come from the server-side session principal,
+    never from workflow context_variables or model output. Workflow dispatch
+    always enforces the action's declared permissions and entitlement gate.
+    """
+
+    return ModuleDispatchAuthority(
+        kind="workflow",
+        permission_mode="enforce",
+        reason=f"workflow tool dispatch: {workflow_name or 'unknown'}",
+        actor_id=actor_id,
+        permissions=tuple(permissions),
+    )
+
+
+def event_reaction_authority(
+    *,
+    event_id: str,
+    event_type: str,
+    event_producer: str,
+    contract_declares_trusted: bool = False,
+    actor_id: str | None = None,
+) -> tuple[ModuleDispatchAuthority, ModuleDispatchProvenance]:
+    """Authority for an event reaction dispatching a module action.
+
+    Reactions enforce by default. A reaction may run trusted only when the
+    consuming module contract explicitly declares it trusted AND full event
+    provenance is supplied. Being an internal call is never sufficient.
+    """
+
+    if not (event_id and event_type and event_producer):
+        raise ValueError(
+            "event_reaction dispatch requires event_id, event_type, and event_producer provenance"
         )
+    mode: ModuleDispatchPermissionMode = (
+        "trusted_bypass" if contract_declares_trusted else "enforce"
+    )
+    authority = ModuleDispatchAuthority(
+        kind="event_reaction",
+        permission_mode=mode,
+        reason=(
+            "contract-declared trusted event reaction"
+            if contract_declares_trusted
+            else "event reaction dispatch"
+        ),
+        actor_id=actor_id,
+    )
+    provenance = ModuleDispatchProvenance(
+        surface="event_reaction",
+        event_id=event_id,
+        event_type=event_type,
+        event_producer=event_producer,
+    )
+    return authority, provenance
 
 
 @dataclass(frozen=True)
@@ -84,7 +151,7 @@ class ModulePermissionCheck:
     """Result of framework module permission enforcement."""
 
     checked: bool
-    granted_permissions: tuple[str, ...] = ()
+    granted: tuple[str, ...] = ()
     required_permissions: tuple[str, ...] = ()
     missing_permissions: tuple[str, ...] = ()
 
@@ -171,7 +238,7 @@ class ModuleDispatchAudit:
             "permission_mode": self.permission_mode,
             "permission_check": {
                 "checked": self.permission_check.checked,
-                "granted_permissions": list(self.permission_check.granted_permissions),
+                "granted": list(self.permission_check.granted),
                 "required_permissions": list(self.permission_check.required_permissions),
                 "missing_permissions": list(self.permission_check.missing_permissions),
                 "allowed": self.permission_check.allowed,

--- a/mozaiksai/core/runtime/composition/module_dispatch.py
+++ b/mozaiksai/core/runtime/composition/module_dispatch.py
@@ -40,7 +40,9 @@ class ModuleActionDispatchRequest:
     params: dict[str, Any] = field(default_factory=dict)
     scope: ModuleDispatchScope = field(default_factory=lambda: ModuleDispatchScope(app_id="default"))
     metadata: ModuleDispatchMetadata = field(default_factory=ModuleDispatchMetadata)
-    granted_permissions: list[str] = field(default_factory=list)
+    # Concrete caller-held permission ids. Always a list; this facade has no
+    # trusted path, so an empty list simply means "no permissions held".
+    permissions: list[str] = field(default_factory=list)
     authority: ModuleDispatchAuthority | None = None
     provenance: ModuleDispatchProvenance | None = None
 
@@ -65,9 +67,9 @@ def _validate_request(request: ModuleActionDispatchRequest) -> None:
         raise ValueError("Invalid action name")
     if not request.scope.app_id:
         raise ValueError("scope.app_id is required")
-    if request.granted_permissions is None:  # type: ignore[unreachable]
+    if request.permissions is None:  # type: ignore[unreachable]
         raise ValueError(
-            "granted_permissions must be a concrete list. Trusted/internal authority "
+            "permissions must be a concrete list. Trusted/internal authority "
             "dispatch is intentionally not exposed by this public facade."
         )
     if request.authority is not None:
@@ -80,14 +82,11 @@ def _validate_public_authority(authority: ModuleDispatchAuthority) -> None:
             "Public module dispatch authority must use permission_mode='enforce'. "
             "Trusted bypass is intentionally not exposed by this facade."
         )
-    if authority.legacy_granted_permissions_none:
-        raise ValueError("legacy_trusted dispatch cannot be requested through the public facade.")
     if authority.kind in {
-        "legacy_permissions",
-        "legacy_trusted",
         "framework_internal",
         "operator_internal",
         "local_development",
+        "event_reaction",
     }:
         raise ValueError(f"Authority kind {authority.kind!r} is not valid for public module dispatch.")
 
@@ -99,28 +98,21 @@ async def dispatch_module_action(
 ) -> ModuleResult:
     """Dispatch an app-local module action without exposing executor registries.
 
-    This facade preserves current permission and entitlement behavior for
-    concrete permission lists. It intentionally does not provide a public path
-    to the current ``granted_permissions=None`` trusted bypass.
+    This facade always dispatches with an enforce-mode authority built from the
+    caller's concrete permission list. It intentionally provides no trusted
+    bypass path of any kind.
     """
 
     _validate_request(request)
     executor = _resolve_module_executor(app)
-    granted_permissions = list(request.granted_permissions)
-    authority = request.authority or ModuleDispatchAuthority(
-        kind="app_internal",
-        permission_mode="enforce",
-        reason="public app-local module dispatch facade",
-        actor_id=request.scope.user_id,
-        permissions=tuple(granted_permissions),
-    )
+    permissions = tuple(request.permissions)
+    base = request.authority
     authority = ModuleDispatchAuthority(
-        kind=authority.kind,
-        permission_mode=authority.permission_mode,
-        reason=authority.reason,
-        actor_id=authority.actor_id or request.scope.user_id,
-        permissions=tuple(granted_permissions),
-        legacy_granted_permissions_none=False,
+        kind=base.kind if base is not None else "app_internal",
+        permission_mode="enforce",
+        reason=base.reason if base is not None else "public app-local module dispatch facade",
+        actor_id=(base.actor_id if base is not None else None) or request.scope.user_id,
+        permissions=permissions,
     )
     provenance = request.provenance or ModuleDispatchProvenance(
         surface="app_local_dispatch",
@@ -148,7 +140,6 @@ async def dispatch_module_action(
         workspace_id=request.scope.workspace_id,
         auth_token=request.metadata.auth_token,
         correlation_id=request.metadata.correlation_id,
-        granted_permissions=granted_permissions,
         authority=authority,
         provenance=provenance,
     )

--- a/mozaiksai/core/runtime/composition/module_dispatch.py
+++ b/mozaiksai/core/runtime/composition/module_dispatch.py
@@ -40,10 +40,11 @@ class ModuleActionDispatchRequest:
     params: dict[str, Any] = field(default_factory=dict)
     scope: ModuleDispatchScope = field(default_factory=lambda: ModuleDispatchScope(app_id="default"))
     metadata: ModuleDispatchMetadata = field(default_factory=ModuleDispatchMetadata)
-    # Concrete caller-held permission ids. Always a list; this facade has no
-    # trusted path, so an empty list simply means "no permissions held".
-    permissions: list[str] = field(default_factory=list)
-    authority: ModuleDispatchAuthority | None = None
+    # Explicit dispatch authority. Required: the caller states who is
+    # dispatching and which concrete permissions it holds. This facade accepts
+    # only enforce-mode, public-safe authorities and passes them through to
+    # ModuleExecutor unchanged.
+    authority: ModuleDispatchAuthority = field(kw_only=True)
     provenance: ModuleDispatchProvenance | None = None
 
 
@@ -67,13 +68,7 @@ def _validate_request(request: ModuleActionDispatchRequest) -> None:
         raise ValueError("Invalid action name")
     if not request.scope.app_id:
         raise ValueError("scope.app_id is required")
-    if request.permissions is None:  # type: ignore[unreachable]
-        raise ValueError(
-            "permissions must be a concrete list. Trusted/internal authority "
-            "dispatch is intentionally not exposed by this public facade."
-        )
-    if request.authority is not None:
-        _validate_public_authority(request.authority)
+    _validate_public_authority(request.authority)
 
 
 def _validate_public_authority(authority: ModuleDispatchAuthority) -> None:
@@ -98,22 +93,14 @@ async def dispatch_module_action(
 ) -> ModuleResult:
     """Dispatch an app-local module action without exposing executor registries.
 
-    This facade always dispatches with an enforce-mode authority built from the
-    caller's concrete permission list. It intentionally provides no trusted
-    bypass path of any kind.
+    The caller's explicit enforce-mode authority is validated and passed to
+    ModuleExecutor exactly as supplied. This facade provides no trusted bypass
+    path of any kind and never rewrites the caller's permission set.
     """
 
     _validate_request(request)
     executor = _resolve_module_executor(app)
-    permissions = tuple(request.permissions)
-    base = request.authority
-    authority = ModuleDispatchAuthority(
-        kind=base.kind if base is not None else "app_internal",
-        permission_mode="enforce",
-        reason=base.reason if base is not None else "public app-local module dispatch facade",
-        actor_id=(base.actor_id if base is not None else None) or request.scope.user_id,
-        permissions=permissions,
-    )
+    authority = request.authority
     provenance = request.provenance or ModuleDispatchProvenance(
         surface="app_local_dispatch",
         correlation_id=request.metadata.correlation_id,

--- a/mozaiksai/core/runtime/composition/module_event_router.py
+++ b/mozaiksai/core/runtime/composition/module_event_router.py
@@ -526,7 +526,7 @@ class ModuleEventRouter:
         authority = envelope.get("authority") if isinstance(envelope.get("authority"), dict) else {}
         granted = [
             str(permission).strip()
-            for permission in (authority.get("granted_permissions") if isinstance(authority, dict) else []) or []
+            for permission in (authority.get("permissions") if isinstance(authority, dict) else []) or []
             if str(permission).strip()
         ]
         missing = sorted(set(required) - set(granted))

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -487,6 +487,12 @@ class ModuleExecutor:
                 dispatch_provenance=dispatch_provenance,
                 dispatch_audit=dispatch_audit,
             )
+        else:
+            # A caller-supplied context still carries this dispatch's authority
+            # facts so ctx.dispatch_authority is present on every execution path.
+            context.dispatch_authority = dispatch_authority
+            context.dispatch_provenance = dispatch_provenance
+            context.dispatch_audit = dispatch_audit
 
         timeout = _action_timeout()
         try:

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -125,11 +125,11 @@ class ModuleRequest:
     auth_token: str | None = None
     correlation_id: str | None = None
 
-    # Permission ids held by the caller. When None, enforcement is skipped
-    # (trusted internal / AI workflow call). When set (even to []), the executor
-    # checks that all action-declared permissions are present.
-    granted_permissions: list[str] | None = None
-    authority: ModuleDispatchAuthority | None = None
+    # Explicit framework dispatch authority. Required: every caller must state
+    # who is dispatching and whether the action's declared permissions and
+    # entitlement gate are enforced. Trusted bypass is a property of the
+    # authority's construction, never of a missing principal or empty list.
+    authority: ModuleDispatchAuthority = field(kw_only=True)
     provenance: ModuleDispatchProvenance | None = None
 
 
@@ -258,7 +258,8 @@ class ModuleExecutor:
             settings:            Setting definitions from settings.yaml (list of setting dicts).
                                  Injected into ModuleContext.settings on every action call.
             action_permissions:  Maps action id -> list of required permission ids.
-                                 Used to enforce ModuleRequest.granted_permissions at dispatch time.
+                                 Enforced against ModuleRequest.authority.permissions
+                                 for every enforce-mode dispatch.
             action_schemas:      Maps action id -> {input: JSON Schema, output: JSON Schema}.
                                  Input validated before dispatch; output validated after (warn only).
             action_entitlements: Maps action id -> capability_id (or None).
@@ -307,14 +308,11 @@ class ModuleExecutor:
 
         Builds a ModuleContext from the request if one is not supplied.
         """
-        dispatch_authority = request.authority or ModuleDispatchAuthority.from_granted_permissions(
-            request.granted_permissions,
-            actor_id=request.user_id,
-        )
+        dispatch_authority = request.authority
         dispatch_provenance = request.provenance or ModuleDispatchProvenance(
             correlation_id=request.correlation_id,
         )
-        permission_check = self._build_permission_check(request)
+        permission_check = self._build_permission_check(request, dispatch_authority)
         entitlement_check = ModuleEntitlementCheck(checked=False, status="skipped")
         dispatch_audit = self._build_dispatch_audit(
             request,
@@ -366,9 +364,9 @@ class ModuleExecutor:
             )
 
         # Entitlement check — only when the action declares an entitlement_gate.
-        # Trusted internal/AI-workflow calls (granted_permissions is None) bypass
-        # both permission and entitlement checks.
-        if request.granted_permissions is not None:
+        # Enforce-mode dispatch always runs it; trusted_bypass authorities
+        # (closed server-owned kinds only) skip both checks.
+        if dispatch_authority.permission_mode == "enforce":
             capability_id = self._action_entitlements.get(request.module, {}).get(request.action)
             if capability_id:
                 ent_result = await self._entitlement_checker.check(
@@ -477,8 +475,8 @@ class ModuleExecutor:
                 action_id=request.action,
                 auth_token=request.auth_token,
                 permissions=(
-                    list(request.granted_permissions)
-                    if request.granted_permissions is not None
+                    list(dispatch_authority.permissions)
+                    if dispatch_authority.permission_mode == "enforce"
                     else None
                 ),
                 correlation_id=request.correlation_id,
@@ -613,16 +611,20 @@ class ModuleExecutor:
     def can_handle(self, target: str) -> bool:
         return target in self._modules
 
-    def _build_permission_check(self, request: ModuleRequest) -> ModulePermissionCheck:
-        if request.granted_permissions is None:
+    def _build_permission_check(
+        self,
+        request: ModuleRequest,
+        authority: ModuleDispatchAuthority,
+    ) -> ModulePermissionCheck:
+        if authority.permission_mode == "trusted_bypass":
             return ModulePermissionCheck(checked=False)
         required = tuple(self._action_permissions.get(request.module, {}).get(request.action, []))
-        granted = tuple(request.granted_permissions)
+        granted = tuple(authority.permissions)
         granted_set = set(granted)
         missing = tuple(permission for permission in required if permission not in granted_set)
         return ModulePermissionCheck(
             checked=True,
-            granted_permissions=granted,
+            granted=granted,
             required_permissions=required,
             missing_permissions=missing,
         )
@@ -735,16 +737,11 @@ class ModuleExecutor:
                 "payload": payload,
                 "visibility": "internal",
             }
-            if request.granted_permissions is not None:
-                authority = request.authority or ModuleDispatchAuthority.from_granted_permissions(
-                    request.granted_permissions,
-                    actor_id=request.user_id,
-                )
-                envelope["authority"] = {
-                    "kind": authority.kind,
-                    "permission_mode": authority.permission_mode,
-                    "granted_permissions": list(request.granted_permissions),
-                }
+            envelope["authority"] = {
+                "kind": request.authority.kind,
+                "permission_mode": request.authority.permission_mode,
+                "permissions": list(request.authority.permissions),
+            }
             if request.user_id:
                 envelope["actor"] = {"type": "user", "id": request.user_id}
 

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -1829,7 +1829,6 @@ async def get_profile_panels(
                     tenant_id=str(principal.tenant_id) if principal.tenant_id else None,
                     auth_token=None,
                     correlation_id=None,
-                    granted_permissions=list(principal.scopes) if principal else None,
                     authority=ModuleDispatchAuthority(
                         kind="authenticated_user",
                         permission_mode="enforce",
@@ -1939,7 +1938,6 @@ async def get_profile_tabs(
                     tenant_id=str(principal.tenant_id) if principal.tenant_id else None,
                     auth_token=None,
                     correlation_id=None,
-                    granted_permissions=list(principal.scopes) if principal else None,
                     authority=ModuleDispatchAuthority(
                         kind="authenticated_user",
                         permission_mode="enforce",
@@ -2081,7 +2079,6 @@ async def get_profile_pages(
                     tenant_id=str(principal.tenant_id) if principal.tenant_id else None,
                     auth_token=None,
                     correlation_id=None,
-                    granted_permissions=list(principal.scopes) if principal else None,
                     authority=ModuleDispatchAuthority(
                         kind="authenticated_user",
                         permission_mode="enforce",
@@ -2238,7 +2235,6 @@ async def get_current_user_relationships(
                 tenant_id=str(principal.tenant_id) if principal.tenant_id else None,
                 auth_token=None,
                 correlation_id=None,
-                granted_permissions=list(principal.scopes) if principal else None,
                 authority=ModuleDispatchAuthority(
                     kind="authenticated_user",
                     permission_mode="enforce",

--- a/mozaiksai/hosts/routers/modules.py
+++ b/mozaiksai/hosts/routers/modules.py
@@ -209,7 +209,8 @@ async def _execute_module_action(
     # Internal-surface actions are event-bus reactions or trusted runtime calls.
     # They must never be reachable via the external HTTP module dispatch path,
     # regardless of authentication status.  Callers that need to invoke these
-    # actions directly must use ModuleExecutor with granted_permissions=None.
+    # actions directly must use ModuleExecutor with a server-owned trusted
+    # dispatch authority.
     if _is_internal_module_action(request, module_name, action_name):
         raise HTTPException(status_code=404, detail="Action not found")
 
@@ -309,18 +310,15 @@ async def _execute_module_action(
     # such module HTTP calls as trusted local dispatch so module permission
     # declarations don't block the Studio admin UI. In production
     # (AUTH_ENABLED=true), non-public HTTP callers must carry a token with
-    # explicit scopes, so granted_permissions remains a concrete list.
+    # explicit scopes that become the enforce-mode authority's permissions.
     if not is_auth_enabled():
-        granted_permissions = None
         authority = ModuleDispatchAuthority(
             kind="local_development",
             permission_mode="trusted_bypass",
             reason="auth-disabled local HTTP module dispatch",
             actor_id=str(user_id) if user_id else None,
-            legacy_granted_permissions_none=True,
         )
     else:
-        granted_permissions = list(dispatch_scope.get("permissions") or [])
         authority_kind = cast(
             ModuleDispatchAuthorityKind,
             "authenticated_user" if principal is not None else "public_http",
@@ -330,7 +328,7 @@ async def _execute_module_action(
             permission_mode="enforce",
             reason="HTTP module dispatch",
             actor_id=str(user_id) if user_id else None,
-            permissions=tuple(granted_permissions),
+            permissions=tuple(dispatch_scope.get("permissions") or []),
         )
 
     module_request = ModuleRequest(
@@ -343,12 +341,6 @@ async def _execute_module_action(
         workspace_id=str(dispatch_scope.get("workspace_id") or workspace_id) if (dispatch_scope.get("workspace_id") or workspace_id) else None,
         auth_token=str(auth_token) if auth_token else None,
         correlation_id=str(correlation_id) if correlation_id else None,
-        # HTTP module dispatch supplies a concrete permission list when auth is
-        # enabled. When auth is disabled (dev mode, no principal) granted_permissions
-        # is None so the executor bypasses enforcement as a trusted internal call.
-        # Internal trusted calls can also bypass by invoking ModuleExecutor directly
-        # with granted_permissions=None.
-        granted_permissions=granted_permissions,
         authority=authority,
         provenance=ModuleDispatchProvenance(
             surface="http_module_dispatch",

--- a/scripts/governance_guardrails.py
+++ b/scripts/governance_guardrails.py
@@ -56,23 +56,6 @@ AGENT_LOCAL_CONFIG_PATHS = {
     ".codex/settings.local.json",
 }
 
-GRANTED_PERMISSIONS_NONE_ALLOWLIST = {
-    "ARCHITECTURAL_INVARIANTS.md",
-    "CHANGELOG.md",
-    "docs/architecture/app/tenant-auth-and-scope.md",
-    "docs/guides/adding-modules/01-overview.md",
-    "mozaiksai/core/runtime/composition/module_authority.py",
-    "mozaiksai/core/runtime/composition/module_dispatch.py",
-    "mozaiksai/hosts/routers/modules.py",
-    "scripts/governance_guardrails.py",
-    "tests/test_governance_guardrails.py",
-    "tests/test_module_action_dispatch_public_api.py",
-    "tests/test_module_dispatch_authority_policy.py",
-    "tests/test_module_executor_dispatch.py",
-    "tests/test_module_executor_permission_enforcement.py",
-    "tests/test_module_loader_contracts.py",
-}
-
 # Directories that are private by default (OSS_PUBLICATION_POLICY.md §Learned-Artifact Quarantine).
 # Finding any data file under these paths in OSS source is an error; the
 # *mechanism* (e.g. an eval runner script) may be public, but BlocUnited eval
@@ -141,7 +124,7 @@ REVIEW_MARKERS = (
     "governance_review:",
 )
 
-GRANTED_PERMISSIONS_NONE_RE = re.compile(r"\bgranted_permissions\s*=\s*None\b")
+GRANTED_PERMISSIONS_TOKEN_RE = re.compile(r"\bgranted_permissions\b")
 PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
 PROVIDER_SECRET_RE = re.compile(
     r"\b(?:sk_live|rk_live|whsec|payment_provider_(?:live|test)|stripe_(?:live|test))_[A-Za-z0-9]{10,}\b"
@@ -313,18 +296,21 @@ def _scan_file(path: Path, repo_root: Path) -> tuple[list[GovernanceFinding], li
             )
         )
 
-    if GRANTED_PERMISSIONS_NONE_RE.search(text) and relative not in GRANTED_PERMISSIONS_NONE_ALLOWLIST:
-        match = GRANTED_PERMISSIONS_NONE_RE.search(text)
-        assert match is not None
-        errors.append(
-            GovernanceFinding(
-                severity="error",
-                code="authority_bypass_not_reviewed",
-                path=relative,
-                line=_line_for(text, match),
-                message="new granted_permissions=None usage requires explicit authority review",
+    if relative.startswith("mozaiksai/"):
+        match = GRANTED_PERMISSIONS_TOKEN_RE.search(text)
+        if match is not None:
+            errors.append(
+                GovernanceFinding(
+                    severity="error",
+                    code="authority_bypass_not_reviewed",
+                    path=relative,
+                    line=_line_for(text, match),
+                    message=(
+                        "granted_permissions is a removed dispatch contract; construct an "
+                        "explicit ModuleDispatchAuthority instead"
+                    ),
+                )
             )
-        )
 
     if _is_public_artifact(relative):
         for pattern, code in (

--- a/tests/module_authority_test_helpers.py
+++ b/tests/module_authority_test_helpers.py
@@ -1,0 +1,40 @@
+"""Shared explicit-dispatch-authority builders for module executor tests.
+
+Every ModuleRequest requires an explicit ModuleDispatchAuthority. These
+helpers keep test intent obvious: enforce-mode dispatch with concrete
+permissions, or a server-owned trusted authority. There is deliberately no
+permissive default that hides the enforcement decision.
+"""
+
+from __future__ import annotations
+
+from mozaiksai.core.runtime.composition.module_authority import (
+    ModuleDispatchAuthority,
+    ModuleDispatchAuthorityKind,
+)
+
+
+def enforce_authority(
+    *permissions: str,
+    kind: ModuleDispatchAuthorityKind = "authenticated_user",
+    actor_id: str | None = None,
+) -> ModuleDispatchAuthority:
+    """Enforce-mode authority carrying the given concrete permission ids."""
+
+    return ModuleDispatchAuthority(
+        kind=kind,
+        permission_mode="enforce",
+        reason="test enforce dispatch",
+        actor_id=actor_id,
+        permissions=tuple(permissions),
+    )
+
+
+def trusted_framework_authority(reason: str = "test trusted framework dispatch") -> ModuleDispatchAuthority:
+    """Server-owned trusted authority for tests exercising internal dispatch."""
+
+    return ModuleDispatchAuthority(
+        kind="framework_internal",
+        permission_mode="trusted_bypass",
+        reason=reason,
+    )

--- a/tests/test_app_metrics.py
+++ b/tests/test_app_metrics.py
@@ -8,6 +8,7 @@ import pytest
 from mozaiksai.core.metrics import AppMetrics, normalize_metric_event_name
 from mozaiksai.core.runtime.composition.module_context import ModuleContext
 from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
+from tests.module_authority_test_helpers import trusted_framework_authority
 
 
 class FakeCollection:
@@ -273,7 +274,7 @@ async def test_module_executor_injects_module_and_action_into_context() -> None:
     executor = ModuleExecutor()
     executor.register("analytics", Handler())
 
-    result = await executor.execute(ModuleRequest(module="analytics", action="run", app_id="app-1"))
+    result = await executor.execute(ModuleRequest(module="analytics", action="run", app_id="app-1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data == {"module_id": "analytics", "action_id": "run"}

--- a/tests/test_downstream_persistent_projects_generation.py
+++ b/tests/test_downstream_persistent_projects_generation.py
@@ -19,6 +19,7 @@ from mozaiksai.core.runtime.persistence import (
     apply_database_indexes,
     load_data_migrations,
 )
+from tests.module_authority_test_helpers import trusted_framework_authority
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "appplan_persistent_projects_output.json"
@@ -839,11 +840,11 @@ async def test_downstream_artifact_loads_indexes_migrations_and_executes(
             app_id="app_a",
             tenant_id="tenant_1",
             user_id="user_1",
-            params={"project_id": "project_1", "name": "Launch Plan"},
+            params={"project_id": "project_1", "name": "Launch Plan"}, authority=trusted_framework_authority(),
         )
     )
     listed_projects = await executor.execute(
-        ModuleRequest(module="projects", action="list_projects", app_id="app_a", params={})
+        ModuleRequest(module="projects", action="list_projects", app_id="app_a", params={}, authority=trusted_framework_authority())
     )
     created_task = await executor.execute(
         ModuleRequest(
@@ -851,14 +852,14 @@ async def test_downstream_artifact_loads_indexes_migrations_and_executes(
             action="create_task",
             app_id="app_a",
             user_id="user_1",
-            params={"task_id": "task_1", "title": "Draft scope", "project_id": "project_1"},
+            params={"task_id": "task_1", "title": "Draft scope", "project_id": "project_1"}, authority=trusted_framework_authority(),
         )
     )
     listed_tasks = await executor.execute(
-        ModuleRequest(module="tasks", action="list_tasks", app_id="app_a", params={"project_id": "project_1"})
+        ModuleRequest(module="tasks", action="list_tasks", app_id="app_a", params={"project_id": "project_1"}, authority=trusted_framework_authority())
     )
     app_b_projects = await executor.execute(
-        ModuleRequest(module="projects", action="list_projects", app_id="app_b", params={})
+        ModuleRequest(module="projects", action="list_projects", app_id="app_b", params={}, authority=trusted_framework_authority())
     )
 
     assert created_project.success is True

--- a/tests/test_entitlement_dispatch_docker_integration.py
+++ b/tests/test_entitlement_dispatch_docker_integration.py
@@ -35,6 +35,8 @@ from uuid import uuid4
 import pytest
 import yaml
 
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
+
 _RUN_ENV = "MOZAIKS_RUN_REAL_MONGO_TESTS"
 _LEGACY_ENV = "MOZAIKS_RUN_MONGO_INTEGRATION"
 
@@ -366,7 +368,7 @@ async def test_entitlement_dispatch_docker_integration(
                 app_id=app_id,
                 user_id="user_free",
                 params={"report_id": "r1"},
-                granted_permissions=[],  # user request — triggers entitlement check
+                authority=enforce_authority(),  # user request — triggers entitlement check
             )
         )
         assert pre_result.success is False
@@ -381,7 +383,7 @@ async def test_entitlement_dispatch_docker_integration(
                 action="activate_subscription",
                 app_id=app_id,
                 user_id="user_pro",
-                params={"user_id": "user_pro", "plan_id": "pro"},
+                params={"user_id": "user_pro", "plan_id": "pro"}, authority=trusted_framework_authority(),
             )
         )
         assert activate_result.success is True, (
@@ -404,7 +406,7 @@ async def test_entitlement_dispatch_docker_integration(
                 app_id=app_id,
                 user_id="user_pro",
                 params={"report_id": "r1"},
-                granted_permissions=[],  # user request — triggers entitlement check
+                authority=enforce_authority(),  # user request — triggers entitlement check
             )
         )
         assert export_result.success is True, (
@@ -420,7 +422,7 @@ async def test_entitlement_dispatch_docker_integration(
                 app_id=app_id,
                 user_id="user_free",
                 params={"report_id": "r1"},
-                granted_permissions=[],  # user request — triggers entitlement check
+                authority=enforce_authority(),  # user request — triggers entitlement check
             )
         )
         assert free_result.success is False
@@ -436,7 +438,7 @@ async def test_entitlement_dispatch_docker_integration(
                 app_id=app_id,
                 user_id="user_free",
                 params={},
-                granted_permissions=[],  # user request — triggers entitlement check
+                authority=enforce_authority(),  # user request — triggers entitlement check
             )
         )
         assert list_result.success is True
@@ -448,7 +450,7 @@ async def test_entitlement_dispatch_docker_integration(
                 action="deactivate_subscription",
                 app_id=app_id,
                 user_id="user_pro",
-                params={"user_id": "user_pro"},
+                params={"user_id": "user_pro"}, authority=trusted_framework_authority(),
             )
         )
         assert deactivate_result.success is True
@@ -465,7 +467,7 @@ async def test_entitlement_dispatch_docker_integration(
                 app_id=app_id,
                 user_id="user_pro",
                 params={"report_id": "r1"},
-                granted_permissions=[],  # user request — triggers entitlement check
+                authority=enforce_authority(),  # user request — triggers entitlement check
             )
         )
         assert post_deactivate_result.success is False

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -18,6 +18,7 @@ from mozaiksai.core.validation import (
     scan_functional_generated_app,
     validate_generated_app_bundle,
 )
+from tests.module_authority_test_helpers import enforce_authority
 
 
 def _basic_crud_files() -> dict[str, str]:
@@ -871,7 +872,7 @@ def test_generated_monetized_saas_bundle_boots_and_serves_mozaikspay_runtime_sur
                 params={"topic": "retention"},
                 app_id="generated-saas",
                 user_id="anonymous",
-                granted_permissions=[],
+                authority=enforce_authority(),
             ),
         )
         assert enforced_result.success is False

--- a/tests/test_generated_app_persistence_smoke.py
+++ b/tests/test_generated_app_persistence_smoke.py
@@ -17,6 +17,7 @@ from mozaiksai.core.runtime.persistence import (
     apply_database_indexes,
     load_data_migrations,
 )
+from tests.module_authority_test_helpers import trusted_framework_authority
 
 
 class FakePersistenceCollection:
@@ -647,11 +648,11 @@ async def test_module_executor_runs_generated_persistent_modules_end_to_end(
             app_id="app_a",
             tenant_id="tenant_1",
             user_id="user_1",
-            params={"name": "Launch Plan", "project_id": "project_1"},
+            params={"name": "Launch Plan", "project_id": "project_1"}, authority=trusted_framework_authority(),
         )
     )
     listed_projects = await executor.execute(
-        ModuleRequest(module="projects", action="list_projects", app_id="app_a", params={})
+        ModuleRequest(module="projects", action="list_projects", app_id="app_a", params={}, authority=trusted_framework_authority())
     )
     created_task = await executor.execute(
         ModuleRequest(
@@ -659,14 +660,14 @@ async def test_module_executor_runs_generated_persistent_modules_end_to_end(
             action="create_task",
             app_id="app_a",
             user_id="user_1",
-            params={"title": "Draft scope", "task_id": "task_1", "project_id": "project_1"},
+            params={"title": "Draft scope", "task_id": "task_1", "project_id": "project_1"}, authority=trusted_framework_authority(),
         )
     )
     listed_tasks = await executor.execute(
-        ModuleRequest(module="tasks", action="list_tasks", app_id="app_a", params={"project_id": "project_1"})
+        ModuleRequest(module="tasks", action="list_tasks", app_id="app_a", params={"project_id": "project_1"}, authority=trusted_framework_authority())
     )
     app_b_projects = await executor.execute(
-        ModuleRequest(module="projects", action="list_projects", app_id="app_b", params={})
+        ModuleRequest(module="projects", action="list_projects", app_id="app_b", params={}, authority=trusted_framework_authority())
     )
 
     assert created_project.success is True
@@ -685,5 +686,5 @@ async def test_module_executor_runs_generated_persistent_modules_end_to_end(
     assert app_b_projects.data == {"items": [], "count": 0}
 
     assert any(context.app_id == "app_a" for context in FakePersistenceContext.constructed)
-    assert not hasattr(module_executor_module.ModuleRequest(module="x", action="y"), "db")
+    assert not hasattr(module_executor_module.ModuleRequest(module="x", action="y", authority=trusted_framework_authority()), "db")
 

--- a/tests/test_generated_saas_subscription_runtime_acceptance.py
+++ b/tests/test_generated_saas_subscription_runtime_acceptance.py
@@ -25,6 +25,7 @@ from mozaiksai.core.tokens.guard import TokenUsageDenied, TokenUsageGuard
 from mozaiksai.core.tokens.wallet import TokenWalletLedger
 from mozaiksai.hosts.platform import _current_user_token_wallet_summary
 from mozaiksai.hosts.routers.billing import router as billing_router
+from tests.module_authority_test_helpers import enforce_authority
 
 
 class _Cursor:
@@ -401,7 +402,7 @@ async def test_factory_shaped_saas_app_fulfills_runs_debits_and_blocks_depleted_
             params={"topic": "retention"},
             app_id="generated-saas",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert denied.success is False
@@ -451,7 +452,7 @@ async def test_factory_shaped_saas_app_fulfills_runs_debits_and_blocks_depleted_
             params={"topic": "retention"},
             app_id="generated-saas",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert granted.success is True
@@ -533,7 +534,7 @@ async def test_factory_shaped_saas_app_fulfills_runs_debits_and_blocks_depleted_
             params={"topic": "retention"},
             app_id="generated-saas",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert cancelled.success is False
@@ -606,7 +607,7 @@ async def test_generated_saas_app_http_fulfillment_closes_entitlement_and_token_
             params={"topic": "retention"},
             app_id="generated-saas",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert denied_before_fulfillment.success is False
@@ -652,7 +653,7 @@ async def test_generated_saas_app_http_fulfillment_closes_entitlement_and_token_
             params={"topic": "retention"},
             app_id="generated-saas",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert granted_after_fulfillment.success is True

--- a/tests/test_governance_guardrails.py
+++ b/tests/test_governance_guardrails.py
@@ -34,26 +34,30 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
 
 
-def test_governance_guardrail_rejects_new_permission_bypass(tmp_path: Path) -> None:
+def test_governance_guardrail_rejects_removed_permission_list_token(tmp_path: Path) -> None:
+    """Any reintroduction of the removed permission-list dispatch contract in
+    runtime source is an error, regardless of the value assigned."""
     guardrails = _load_guardrails_module()
-    path = _write(
-        tmp_path,
+    for candidate in (
         "mozaiksai/core/runtime/composition/new_dispatch.py",
-        "request = ModuleRequest(granted_permissions=None)\n",
-    )
+        "mozaiksai/hosts/routers/modules.py",
+    ):
+        path = _write(
+            tmp_path,
+            candidate,
+            "request = ModuleRequest(granted_permissions=['x'])\n",
+        )
+        errors, notices = guardrails.scan_paths([path], repo_root=tmp_path)
+        assert notices == []
+        assert [error.code for error in errors] == ["authority_bypass_not_reviewed"], candidate
 
-    errors, notices = guardrails.scan_paths([path], repo_root=tmp_path)
 
-    assert notices == []
-    assert [error.code for error in errors] == ["authority_bypass_not_reviewed"]
-
-
-def test_governance_guardrail_keeps_current_permission_allowlist(tmp_path: Path) -> None:
+def test_governance_guardrail_ignores_token_outside_runtime_source(tmp_path: Path) -> None:
     guardrails = _load_guardrails_module()
     path = _write(
         tmp_path,
-        "mozaiksai/hosts/routers/modules.py",
-        "request.granted_permissions = None\n",
+        "CHANGELOG.md",
+        "Removed granted_permissions from ModuleRequest.\n",
     )
 
     errors, notices = guardrails.scan_paths([path], repo_root=tmp_path)

--- a/tests/test_managed_capability_artifact_replay.py
+++ b/tests/test_managed_capability_artifact_replay.py
@@ -27,6 +27,7 @@ from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, M
 from mozaiksai.core.tokens.guard import TokenUsageDenied, TokenUsageGuard
 from mozaiksai.core.tokens.wallet import TokenWalletLedger
 from mozaiksai.hosts.platform import _current_user_token_wallet_summary
+from tests.module_authority_test_helpers import enforce_authority
 from tests.test_generated_saas_subscription_runtime_acceptance import (
     _Collection,
     _Database,
@@ -782,7 +783,7 @@ async def test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance(
             params={"topic": "retention"},
             app_id="mozaikspay-replay",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert denied.success is False
@@ -795,7 +796,7 @@ async def test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance(
             params={},
             app_id="mozaikspay-replay",
             user_id="user_1",
-            granted_permissions=["billing_portal.read"],
+            authority=enforce_authority("billing_portal.read"),
         )
     )
     assert plan_catalog.success is True
@@ -832,7 +833,7 @@ async def test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance(
             params={"topic": "retention"},
             app_id="mozaikspay-replay",
             user_id="user_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert granted.success is True

--- a/tests/test_module_action_dispatch_public_api.py
+++ b/tests/test_module_action_dispatch_public_api.py
@@ -100,7 +100,7 @@ async def test_dispatch_module_action_preserves_scope_metadata_and_permissions()
                 auth_token="token-1",
                 correlation_id="corr-1",
             ),
-            granted_permissions=["orders.read"],
+            permissions=["orders.read"],
         ),
         app=_app_with_executor(),
     )
@@ -134,7 +134,7 @@ async def test_dispatch_module_action_preserves_permission_enforcement() -> None
             module="orders",
             action="restricted",
             scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-            granted_permissions=[],
+            permissions=[],
         ),
         app=_app_with_executor(),
     )
@@ -171,7 +171,7 @@ async def test_dispatch_module_action_accepts_workflow_authority_and_provenance(
                 workspace_id="workspace-1",
             ),
             metadata=ModuleDispatchMetadata(correlation_id="corr-workflow"),
-            granted_permissions=["orders.read"],
+            permissions=["orders.read"],
             authority=ModuleDispatchAuthority(
                 kind="workflow",
                 permission_mode="enforce",
@@ -219,7 +219,7 @@ async def test_dispatch_module_action_workflow_authority_still_requires_permissi
             module="orders",
             action="restricted",
             scope=ModuleDispatchScope(app_id="app-1", user_id="workflow-user"),
-            granted_permissions=[],
+            permissions=[],
             authority=ModuleDispatchAuthority(
                 kind="workflow",
                 permission_mode="enforce",
@@ -244,7 +244,7 @@ async def test_dispatch_module_action_does_not_expose_implicit_trusted_bypass() 
         module="orders",
         action="restricted",
         scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-        granted_permissions=None,  # type: ignore[arg-type]
+        permissions=None,  # type: ignore[arg-type]
     )
 
     with pytest.raises(ValueError, match="Trusted/internal authority"):
@@ -256,23 +256,17 @@ async def test_dispatch_module_action_does_not_expose_implicit_trusted_bypass() 
     "authority",
     [
         ModuleDispatchAuthority(
-            kind="workflow",
-            permission_mode="trusted_bypass",
-            reason="not allowed",
-        ),
-        ModuleDispatchAuthority(
-            kind="legacy_trusted",
-            permission_mode="trusted_bypass",
-            reason="not allowed",
-            legacy_granted_permissions_none=True,
-        ),
-        ModuleDispatchAuthority(
-            kind="legacy_permissions",
+            kind="framework_internal",
             permission_mode="enforce",
             reason="not allowed",
         ),
         ModuleDispatchAuthority(
-            kind="framework_internal",
+            kind="operator_internal",
+            permission_mode="enforce",
+            reason="not allowed",
+        ),
+        ModuleDispatchAuthority(
+            kind="event_reaction",
             permission_mode="enforce",
             reason="not allowed",
         ),
@@ -283,7 +277,7 @@ async def test_dispatch_module_action_rejects_public_unsafe_authority(authority)
         module="orders",
         action="restricted",
         scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-        granted_permissions=["orders.read"],
+        permissions=["orders.read"],
         authority=authority,
     )
 

--- a/tests/test_module_action_dispatch_public_api.py
+++ b/tests/test_module_action_dispatch_public_api.py
@@ -100,7 +100,13 @@ async def test_dispatch_module_action_preserves_scope_metadata_and_permissions()
                 auth_token="token-1",
                 correlation_id="corr-1",
             ),
-            permissions=["orders.read"],
+            authority=ModuleDispatchAuthority(
+                kind="app_internal",
+                permission_mode="enforce",
+                reason="app-local dispatch",
+                actor_id="user-1",
+                permissions=("orders.read",),
+            ),
         ),
         app=_app_with_executor(),
     )
@@ -134,7 +140,12 @@ async def test_dispatch_module_action_preserves_permission_enforcement() -> None
             module="orders",
             action="restricted",
             scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-            permissions=[],
+            authority=ModuleDispatchAuthority(
+                kind="app_internal",
+                permission_mode="enforce",
+                reason="app-local dispatch",
+                actor_id="user-1",
+            ),
         ),
         app=_app_with_executor(),
     )
@@ -171,13 +182,12 @@ async def test_dispatch_module_action_accepts_workflow_authority_and_provenance(
                 workspace_id="workspace-1",
             ),
             metadata=ModuleDispatchMetadata(correlation_id="corr-workflow"),
-            permissions=["orders.read"],
             authority=ModuleDispatchAuthority(
                 kind="workflow",
                 permission_mode="enforce",
                 reason="campaign asset workflow dispatch",
                 actor_id="workflow-user",
-                permissions=("ignored.by.facade",),
+                permissions=("orders.read",),
             ),
             provenance=ModuleDispatchProvenance(
                 surface="workflow_tool",
@@ -219,7 +229,6 @@ async def test_dispatch_module_action_workflow_authority_still_requires_permissi
             module="orders",
             action="restricted",
             scope=ModuleDispatchScope(app_id="app-1", user_id="workflow-user"),
-            permissions=[],
             authority=ModuleDispatchAuthority(
                 kind="workflow",
                 permission_mode="enforce",
@@ -239,16 +248,13 @@ async def test_dispatch_module_action_workflow_authority_still_requires_permissi
 
 
 @pytest.mark.asyncio
-async def test_dispatch_module_action_does_not_expose_implicit_trusted_bypass() -> None:
-    request = ModuleActionDispatchRequest(
-        module="orders",
-        action="restricted",
-        scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-        permissions=None,  # type: ignore[arg-type]
-    )
-
-    with pytest.raises(ValueError, match="Trusted/internal authority"):
-        await dispatch_module_action(request, app=_app_with_executor())
+async def test_dispatch_module_action_requires_explicit_authority() -> None:
+    with pytest.raises(TypeError):
+        ModuleActionDispatchRequest(  # type: ignore[call-arg]
+            module="orders",
+            action="restricted",
+            scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
+        )
 
 
 @pytest.mark.asyncio
@@ -277,9 +283,45 @@ async def test_dispatch_module_action_rejects_public_unsafe_authority(authority)
         module="orders",
         action="restricted",
         scope=ModuleDispatchScope(app_id="app-1", user_id="user-1"),
-        permissions=["orders.read"],
         authority=authority,
     )
 
     with pytest.raises(ValueError):
         await dispatch_module_action(request, app=_app_with_executor())
+
+
+@pytest.mark.asyncio
+async def test_dispatch_module_action_preserves_supplied_authority_exactly(monkeypatch) -> None:
+    policy_inputs = []
+
+    async def before_module_execution(policy_input):
+        policy_inputs.append(policy_input)
+        return True
+
+    registry = PlatformHookRegistry()
+    registry._register_bundle(
+        PlatformExtensionBundle(before_module_execution=before_module_execution)
+    )
+    monkeypatch.setattr(PlatformHookRegistry, "_instance", registry)
+
+    supplied = ModuleDispatchAuthority(
+        kind="authenticated_user",
+        permission_mode="enforce",
+        reason="caller-stated reason",
+        actor_id="user-42",
+        permissions=("orders.read", "orders.write"),
+    )
+    result = await dispatch_module_action(
+        ModuleActionDispatchRequest(
+            module="orders",
+            action="restricted",
+            scope=ModuleDispatchScope(app_id="app-1", user_id="user-42"),
+            authority=supplied,
+        ),
+        app=_app_with_executor(),
+    )
+
+    assert result.success is True
+    # The facade passes the caller's authority through unchanged — same object,
+    # no rebuilt kind/reason/actor/permissions.
+    assert policy_inputs[0].authority is supplied

--- a/tests/test_module_dispatch_authority_contract.py
+++ b/tests/test_module_dispatch_authority_contract.py
@@ -1,0 +1,220 @@
+"""Contract proofs for required explicit ModuleDispatchAuthority.
+
+Every ModuleRequest carries a constructor-validated authority. Trusted bypass
+is a closed, server-owned construction property — never an inference from a
+missing principal, an empty permission list, or caller/model-supplied state.
+ModuleExecutor remains the sole evaluator of module action permissions and
+entitlement gates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from mozaiksai.core.ports.entitlement import EntitlementPort, EntitlementResult
+from mozaiksai.core.runtime.composition.module_authority import (
+    TRUSTED_BYPASS_KINDS,
+    ModuleDispatchAuthority,
+    event_reaction_authority,
+    workflow_user_authority,
+)
+from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
+
+
+class _OrdersHandler:
+    async def run(self, ctx):
+        return {"ran": True}
+
+    async def public_ping(self, ctx):
+        return {"pong": True}
+
+
+def _executor(entitlement_checker: EntitlementPort | None = None) -> ModuleExecutor:
+    executor = ModuleExecutor(entitlement_checker=entitlement_checker)
+    executor.register(
+        "orders",
+        _OrdersHandler(),
+        action_method_map={"run": "run", "public_ping": "public_ping"},
+        action_permissions={"run": ["orders.run"], "public_ping": []},
+        action_entitlements={"run": "orders.premium", "public_ping": None},
+    )
+    return executor
+
+
+# ---------------------------------------------------------------------------
+# Construction invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_request_requires_explicit_authority() -> None:
+    with pytest.raises(TypeError):
+        ModuleRequest(module="orders", action="run", app_id="app-1")  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["authenticated_user", "public_http", "workflow", "app_internal"],
+)
+def test_trusted_bypass_rejected_for_non_server_owned_kinds(kind) -> None:
+    with pytest.raises(ValueError, match="trusted_bypass"):
+        ModuleDispatchAuthority(kind=kind, permission_mode="trusted_bypass", reason="nope")
+
+
+def test_trusted_bypass_kind_set_is_closed() -> None:
+    assert TRUSTED_BYPASS_KINDS == frozenset(
+        {"framework_internal", "operator_internal", "event_reaction", "local_development"}
+    )
+
+
+def test_workflow_authority_always_enforces() -> None:
+    authority = workflow_user_authority(
+        actor_id="user-1", permissions=("orders.run",), workflow_name="OrderFlow"
+    )
+    assert authority.kind == "workflow"
+    assert authority.permission_mode == "enforce"
+    assert authority.permissions == ("orders.run",)
+
+
+def test_local_development_rejected_when_auth_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    with pytest.raises(ValueError, match="local_development"):
+        ModuleDispatchAuthority(
+            kind="local_development",
+            permission_mode="trusted_bypass",
+            reason="dev dispatch",
+        )
+
+
+def test_local_development_available_when_auth_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.delenv("AUTH_PROVIDER", raising=False)
+    authority = ModuleDispatchAuthority(
+        kind="local_development",
+        permission_mode="trusted_bypass",
+        reason="dev dispatch",
+    )
+    assert authority.permission_mode == "trusted_bypass"
+
+
+def test_event_reaction_enforces_by_default_and_requires_provenance() -> None:
+    authority, provenance = event_reaction_authority(
+        event_id="evt-1",
+        event_type="domain.orders.created",
+        event_producer="orders",
+    )
+    assert authority.kind == "event_reaction"
+    assert authority.permission_mode == "enforce"
+    assert provenance.event_id == "evt-1"
+    assert provenance.event_type == "domain.orders.created"
+    assert provenance.event_producer == "orders"
+
+    with pytest.raises(ValueError, match="provenance"):
+        event_reaction_authority(event_id="", event_type="x", event_producer="y")
+
+
+def test_event_reaction_trust_requires_contract_declaration() -> None:
+    authority, _ = event_reaction_authority(
+        event_id="evt-1",
+        event_type="domain.orders.created",
+        event_producer="orders",
+        contract_declares_trusted=True,
+    )
+    assert authority.permission_mode == "trusted_bypass"
+    # Without the contract declaration, internal origin alone never grants trust.
+    default_authority, _ = event_reaction_authority(
+        event_id="evt-1",
+        event_type="domain.orders.created",
+        event_producer="orders",
+    )
+    assert default_authority.permission_mode == "enforce"
+
+
+# ---------------------------------------------------------------------------
+# Executor enforcement — ModuleExecutor is the only evaluator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RecordingEntitlements(EntitlementPort):
+    granted: bool = True
+    checks: int = 0
+
+    async def check(self, capability_id, *, app_id, user_id=None, tenant_id=None, workspace_id=None):
+        self.checks += 1
+        return EntitlementResult(
+            granted=self.granted,
+            reason="active_grant" if self.granted else "no_grant",
+        )
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_uses_authority_permissions_only() -> None:
+    entitlements = _RecordingEntitlements(granted=True)
+    executor = _executor(entitlements)
+
+    denied = await executor.execute(
+        ModuleRequest(module="orders", action="run", app_id="app-1", authority=enforce_authority())
+    )
+    assert denied.success is False
+    assert denied.error_code == "PERMISSION_DENIED"
+    assert entitlements.checks == 0
+
+    allowed = await executor.execute(
+        ModuleRequest(
+            module="orders",
+            action="run",
+            app_id="app-1",
+            authority=enforce_authority("orders.run"),
+        )
+    )
+    assert allowed.success is True
+    assert entitlements.checks == 1
+
+
+@pytest.mark.asyncio
+async def test_public_http_empty_permissions_only_runs_permission_free_actions() -> None:
+    executor = _executor()
+    public_authority = enforce_authority(kind="public_http")
+
+    ping = await executor.execute(
+        ModuleRequest(module="orders", action="public_ping", app_id="app-1", authority=public_authority)
+    )
+    assert ping.success is True
+
+    run = await executor.execute(
+        ModuleRequest(module="orders", action="run", app_id="app-1", authority=public_authority)
+    )
+    assert run.success is False
+    assert run.error_code == "PERMISSION_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_entitlement_gate_enforced_in_enforce_mode_and_skipped_for_trusted() -> None:
+    entitlements = _RecordingEntitlements(granted=False)
+    executor = _executor(entitlements)
+
+    denied = await executor.execute(
+        ModuleRequest(
+            module="orders",
+            action="run",
+            app_id="app-1",
+            authority=enforce_authority("orders.run"),
+        )
+    )
+    assert denied.success is False
+    assert denied.error_code == "ENTITLEMENT_REQUIRED"
+    assert entitlements.checks == 1
+
+    trusted = await executor.execute(
+        ModuleRequest(
+            module="orders",
+            action="run",
+            app_id="app-1",
+            authority=trusted_framework_authority(),
+        )
+    )
+    assert trusted.success is True
+    assert entitlements.checks == 1  # no additional check for trusted dispatch

--- a/tests/test_module_dispatch_authority_contract.py
+++ b/tests/test_module_dispatch_authority_contract.py
@@ -218,3 +218,40 @@ async def test_entitlement_gate_enforced_in_enforce_mode_and_skipped_for_trusted
     )
     assert trusted.success is True
     assert entitlements.checks == 1  # no additional check for trusted dispatch
+
+
+def test_local_development_rejected_in_production_profile(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.delenv("AUTH_PROVIDER", raising=False)
+    monkeypatch.setenv("ENV", "production")
+    with pytest.raises(ValueError, match="local_development"):
+        ModuleDispatchAuthority(
+            kind="local_development",
+            permission_mode="trusted_bypass",
+            reason="dev dispatch",
+        )
+
+
+@pytest.mark.asyncio
+async def test_supplied_context_receives_dispatch_authority() -> None:
+    from mozaiksai.core.runtime.composition.module_context import ModuleContext
+
+    executor = _executor()
+    supplied_ctx = ModuleContext(app_id="app-1", module_id="orders", action_id="public_ping")
+    assert supplied_ctx.dispatch_authority is None
+
+    result = await executor.execute(
+        ModuleRequest(
+            module="orders",
+            action="public_ping",
+            app_id="app-1",
+            authority=enforce_authority(kind="public_http"),
+        ),
+        context=supplied_ctx,
+    )
+
+    assert result.success is True
+    assert supplied_ctx.dispatch_authority is not None
+    assert supplied_ctx.dispatch_authority.kind == "public_http"
+    assert supplied_ctx.dispatch_provenance is not None
+    assert supplied_ctx.dispatch_audit is not None

--- a/tests/test_module_dispatch_authority_policy.py
+++ b/tests/test_module_dispatch_authority_policy.py
@@ -15,6 +15,7 @@ from mozaiksai.core.runtime.composition import (
     PlatformHookRegistry,
 )
 from mozaiksai.core.runtime.composition import module_executor as module_executor_mod
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
 
 
 class _Handler:
@@ -86,7 +87,7 @@ async def test_no_configured_policy_hook_preserves_dispatch_behavior(monkeypatch
             action="run",
             params={"secret": "sk_test_secret"},
             app_id="app-1",
-            granted_permissions=["orders.run"],
+            authority=enforce_authority("orders.run"),
         )
     )
     await asyncio.sleep(0)
@@ -97,7 +98,7 @@ async def test_no_configured_policy_hook_preserves_dispatch_behavior(monkeypatch
     assert result.data["entitlement_status"] == "granted"
     assert result.data["has_params_in_audit"] is False
     assert result.data["secret_in_audit"] is False
-    assert hooks.policy_inputs[0].permission_check.granted_permissions == ("orders.run",)
+    assert hooks.policy_inputs[0].permission_check.granted == ("orders.run",)
     assert hooks.policy_inputs[0].entitlement_check.status == "granted"
 
 
@@ -113,7 +114,7 @@ async def test_policy_allow_hook_permits_dispatch(monkeypatch) -> None:
             module="orders",
             action="run",
             app_id="app-1",
-            granted_permissions=["orders.run"],
+            authority=enforce_authority("orders.run"),
         )
     )
 
@@ -139,7 +140,7 @@ async def test_policy_deny_hook_blocks_before_action_execution(monkeypatch) -> N
             module="orders",
             action="run",
             app_id="app-1",
-            granted_permissions=["orders.run"],
+            authority=enforce_authority("orders.run"),
         )
     )
     await asyncio.sleep(0)
@@ -168,7 +169,7 @@ async def test_policy_hook_exception_fails_closed(monkeypatch) -> None:
             module="orders",
             action="run",
             app_id="app-1",
-            granted_permissions=["orders.run"],
+            authority=enforce_authority("orders.run"),
         )
     )
 
@@ -186,7 +187,7 @@ async def test_permission_and_entitlement_denials_expose_structured_results(monk
     handler = _Handler()
 
     permission_result = await _executor(handler).execute(
-        ModuleRequest(module="orders", action="run", app_id="app-1", granted_permissions=[])
+        ModuleRequest(module="orders", action="run", app_id="app-1", authority=enforce_authority())
     )
     await asyncio.sleep(0)
 
@@ -204,7 +205,7 @@ async def test_permission_and_entitlement_denials_expose_structured_results(monk
             module="orders",
             action="run",
             app_id="app-1",
-            granted_permissions=["orders.run"],
+            authority=enforce_authority("orders.run"),
         )
     )
     await asyncio.sleep(0)
@@ -216,18 +217,18 @@ async def test_permission_and_entitlement_denials_expose_structured_results(monk
 
 
 @pytest.mark.asyncio
-async def test_legacy_trusted_dispatch_remains_explicit_and_skips_checks(monkeypatch) -> None:
+async def test_trusted_dispatch_requires_explicit_server_owned_authority(monkeypatch) -> None:
     hooks = _Hooks()
     audit = _AuditLogger()
     _install_hooks(monkeypatch, hooks, audit)
     handler = _Handler()
 
     result = await _executor(handler).execute(
-        ModuleRequest(module="orders", action="run", app_id="app-1", granted_permissions=None)
+        ModuleRequest(module="orders", action="run", app_id="app-1", authority=trusted_framework_authority())
     )
 
     assert result.success is True
-    assert hooks.policy_inputs[0].authority.kind == "legacy_trusted"
+    assert hooks.policy_inputs[0].authority.kind == "framework_internal"
     assert hooks.policy_inputs[0].permission_check.checked is False
     assert hooks.policy_inputs[0].entitlement_check.status == "skipped"
 

--- a/tests/test_module_event_router.py
+++ b/tests/test_module_event_router.py
@@ -578,7 +578,7 @@ class TestHandleEventHandlerTarget:
                 "tenant": {"app_id": "app-99", "tenant_id": "t-99", "workspace_id": "w-99"},
                 "actor": {"type": "user", "id": "user-99"},
                 "correlation": {"correlation_id": "corr-99", "causation_id": "cause-99"},
-                "authority": {"granted_permissions": ["orders.react"]},
+                "authority": {"permissions": ["orders.react"]},
                 "payload": {},
             },
         )
@@ -643,7 +643,7 @@ class TestHandleEventHandlerTarget:
         await router.handle_event(
             "domain.orders.created",
             _envelope(payload={"order_id": "o-1"})
-            | {"authority": {"granted_permissions": ["orders.react"]}},
+            | {"authority": {"permissions": ["orders.react"]}},
         )
 
         assert len(received_ctx) == 1

--- a/tests/test_module_executor_dispatch.py
+++ b/tests/test_module_executor_dispatch.py
@@ -201,7 +201,7 @@ class TestPermissionEnforcement:
         assert result.error_code == "PERMISSION_DENIED"
 
     @pytest.mark.asyncio
-    async def test_empty_granted_permissions_denies_gated_action(self):
+    async def test_empty_authority_permissions_denies_gated_action(self):
         ex = ModuleExecutor()
         ex.register(
             "contacts",

--- a/tests/test_module_executor_dispatch.py
+++ b/tests/test_module_executor_dispatch.py
@@ -12,11 +12,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from mozaiksai.core.ports.entitlement import EntitlementResult
+from mozaiksai.core.runtime.composition.module_authority import ModuleDispatchAuthority
 from mozaiksai.core.runtime.composition.module_executor import (
     ModuleExecutor,
     ModuleRequest,
     _validate_schema,
 )
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -54,7 +56,7 @@ def _request(
     user_id: str | None = "user-1",
     tenant_id: str | None = None,
     workspace_id: str | None = None,
-    granted_permissions: list[str] | None = None,
+    authority: ModuleDispatchAuthority | None = None,
 ) -> ModuleRequest:
     return ModuleRequest(
         module=module,
@@ -64,7 +66,7 @@ def _request(
         user_id=user_id,
         tenant_id=tenant_id,
         workspace_id=workspace_id,
-        granted_permissions=granted_permissions,
+        authority=authority if authority is not None else trusted_framework_authority(),
     )
 
 
@@ -151,7 +153,7 @@ class TestActionErrorHandling:
         """PermissionError raised inside a handler maps to PERMISSION_DENIED (403), not EXECUTION_ERROR (500)."""
         ex = ModuleExecutor()
         ex.register("contacts", _ErrorHandler())
-        result = await ex.execute(_request(action="restricted", granted_permissions=["contacts.read"]))
+        result = await ex.execute(_request(action="restricted", authority=enforce_authority("contacts.read")))
         assert result.success is False
         assert result.error_code == "PERMISSION_DENIED"
         # Generic message returned — internal permission names are not leaked to callers.
@@ -171,8 +173,8 @@ class TestPermissionEnforcement:
             _EchoHandler(),
             action_permissions={"echo": ["contacts.read"]},
         )
-        # granted_permissions=None → trusted internal call, no enforcement
-        result = await ex.execute(_request(granted_permissions=None))
+        # authority=trusted_framework_authority() → trusted internal call, no enforcement
+        result = await ex.execute(_request(authority=trusted_framework_authority()))
         assert result.success is True
 
     @pytest.mark.asyncio
@@ -183,7 +185,7 @@ class TestPermissionEnforcement:
             _EchoHandler(),
             action_permissions={"echo": ["contacts.read"]},
         )
-        result = await ex.execute(_request(granted_permissions=["contacts.read", "other.perm"]))
+        result = await ex.execute(_request(authority=enforce_authority("contacts.read", "other.perm")))
         assert result.success is True
 
     @pytest.mark.asyncio
@@ -194,7 +196,7 @@ class TestPermissionEnforcement:
             _EchoHandler(),
             action_permissions={"echo": ["contacts.read"]},
         )
-        result = await ex.execute(_request(granted_permissions=["other.perm"]))
+        result = await ex.execute(_request(authority=enforce_authority("other.perm")))
         assert result.success is False
         assert result.error_code == "PERMISSION_DENIED"
 
@@ -206,7 +208,7 @@ class TestPermissionEnforcement:
             _EchoHandler(),
             action_permissions={"echo": ["contacts.read"]},
         )
-        result = await ex.execute(_request(granted_permissions=[]))
+        result = await ex.execute(_request(authority=enforce_authority()))
         assert result.success is False
         assert result.error_code == "PERMISSION_DENIED"
 
@@ -218,7 +220,7 @@ class TestPermissionEnforcement:
             _EchoHandler(),
             action_permissions={},  # no permissions required
         )
-        result = await ex.execute(_request(granted_permissions=[]))
+        result = await ex.execute(_request(authority=enforce_authority()))
         assert result.success is True
 
 
@@ -237,7 +239,7 @@ class TestEntitlementGate:
             _EchoHandler(),
             action_entitlements={"echo": "wallet.payout"},
         )
-        result = await ex.execute(_request(module="wallet", granted_permissions=["wallet.manage"]))
+        result = await ex.execute(_request(module="wallet", authority=enforce_authority("wallet.manage")))
         assert result.success is True
         granted_checker.check.assert_awaited_once_with(
             "wallet.payout",
@@ -262,7 +264,7 @@ class TestEntitlementGate:
                 module="wallet",
                 tenant_id="tenant-1",
                 workspace_id="workspace-1",
-                granted_permissions=["wallet.manage"],
+                authority=enforce_authority("wallet.manage"),
             )
         )
         assert result.success is True
@@ -286,7 +288,7 @@ class TestEntitlementGate:
             _EchoHandler(),
             action_entitlements={"echo": "wallet.payout"},
         )
-        result = await ex.execute(_request(module="wallet", granted_permissions=["wallet.manage"]))
+        result = await ex.execute(_request(module="wallet", authority=enforce_authority("wallet.manage")))
         assert result.success is False
         assert result.error_code == "ENTITLEMENT_REQUIRED"
 
@@ -301,7 +303,7 @@ class TestEntitlementGate:
             _EchoHandler(),
             action_entitlements={"echo": "wallet.payout"},
         )
-        result = await ex.execute(_request(module="wallet", granted_permissions=None))
+        result = await ex.execute(_request(module="wallet", authority=trusted_framework_authority()))
         assert result.success is True
         checked.check.assert_not_awaited()
 
@@ -315,7 +317,7 @@ class TestEntitlementGate:
             _EchoHandler(),
             action_entitlements={},  # no gate on any action
         )
-        result = await ex.execute(_request(granted_permissions=["any.perm"]))
+        result = await ex.execute(_request(authority=enforce_authority("any.perm")))
         assert result.success is True
         checked.check.assert_not_awaited()
 

--- a/tests/test_module_executor_permission_enforcement.py
+++ b/tests/test_module_executor_permission_enforcement.py
@@ -71,7 +71,7 @@ def _request(*, action: str, authority: ModuleDispatchAuthority) -> ModuleReques
 
 
 @pytest.mark.asyncio
-async def test_granted_permissions_none_bypasses_enforcement():
+async def test_trusted_authority_bypasses_enforcement():
     """authority=trusted_framework_authority() is the trusted-internal bypass; always allowed."""
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
@@ -96,7 +96,7 @@ async def test_trusted_authority_is_observable_in_module_context():
 
 
 @pytest.mark.asyncio
-async def test_granted_permissions_containing_required_scope_allows_action():
+async def test_authority_containing_required_scope_allows_action():
     """When the granted set includes the required permission, the action proceeds."""
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
@@ -122,7 +122,7 @@ async def test_enforced_authority_is_observable_in_module_context():
 
 
 @pytest.mark.asyncio
-async def test_granted_permissions_missing_required_scope_denies_action():
+async def test_authority_missing_required_scope_denies_action():
     """When the required permission is absent from the granted set, PERMISSION_DENIED."""
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
@@ -134,7 +134,7 @@ async def test_granted_permissions_missing_required_scope_denies_action():
 
 
 @pytest.mark.asyncio
-async def test_empty_action_permissions_allows_any_granted_set():
+async def test_empty_action_permissions_allows_any_authority():
     """Actions with no declared permissions are always allowed regardless of scopes."""
     executor = _executor_with_permissions({})  # no permissions declared
 
@@ -158,7 +158,7 @@ async def test_partial_scope_match_still_denies():
 
 
 @pytest.mark.asyncio
-async def test_granted_permissions_are_injected_into_module_context():
+async def test_authority_permissions_are_injected_into_module_context():
     """Module policies can inspect ctx.permissions for resource-level checks."""
     executor = _executor_with_permissions({})
 

--- a/tests/test_module_executor_permission_enforcement.py
+++ b/tests/test_module_executor_permission_enforcement.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import pytest
 
+from mozaiksai.core.runtime.composition.module_authority import ModuleDispatchAuthority
 from mozaiksai.core.runtime.composition.module_executor import (
     ModuleExecutor,
     ModuleRequest,
 )
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
 
 # ── minimal handler ────────────────────────────────────────────────────────────
 
@@ -33,9 +35,6 @@ class _Handler:
         return {
             "authority_kind": authority.kind if authority else None,
             "permission_mode": authority.permission_mode if authority else None,
-            "legacy_granted_permissions_none": (
-                authority.legacy_granted_permissions_none if authority else None
-            ),
             "authority_permissions": list(authority.permissions) if authority else None,
             "provenance_correlation_id": provenance.correlation_id if provenance else None,
         }
@@ -58,13 +57,13 @@ def _executor_with_permissions(action_permissions: dict) -> ModuleExecutor:
     return executor
 
 
-def _request(*, action: str, granted_permissions) -> ModuleRequest:
+def _request(*, action: str, authority: ModuleDispatchAuthority) -> ModuleRequest:
     return ModuleRequest(
         module="orders",
         action=action,
         params={},
         app_id="app_1",
-        granted_permissions=granted_permissions,
+        authority=authority,
     )
 
 
@@ -73,25 +72,24 @@ def _request(*, action: str, granted_permissions) -> ModuleRequest:
 
 @pytest.mark.asyncio
 async def test_granted_permissions_none_bypasses_enforcement():
-    """granted_permissions=None is the trusted-internal bypass; always allowed."""
+    """authority=trusted_framework_authority() is the trusted-internal bypass; always allowed."""
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
-    result = await executor.execute(_request(action="list", granted_permissions=None))
+    result = await executor.execute(_request(action="list", authority=trusted_framework_authority()))
 
     assert result.success is True
 
 
 @pytest.mark.asyncio
-async def test_granted_permissions_none_becomes_observable_legacy_trusted_authority():
+async def test_trusted_authority_is_observable_in_module_context():
     executor = _executor_with_permissions({"authority": ["orders:read"]})
 
-    result = await executor.execute(_request(action="authority", granted_permissions=None))
+    result = await executor.execute(_request(action="authority", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data == {
-        "authority_kind": "legacy_trusted",
+        "authority_kind": "framework_internal",
         "permission_mode": "trusted_bypass",
-        "legacy_granted_permissions_none": True,
         "authority_permissions": [],
         "provenance_correlation_id": None,
     }
@@ -103,24 +101,23 @@ async def test_granted_permissions_containing_required_scope_allows_action():
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
     result = await executor.execute(
-        _request(action="list", granted_permissions=["orders:read", "orders:write"])
+        _request(action="list", authority=enforce_authority("orders:read", "orders:write"))
     )
 
     assert result.success is True
 
 
 @pytest.mark.asyncio
-async def test_concrete_granted_permissions_become_observable_enforced_authority():
+async def test_enforced_authority_is_observable_in_module_context():
     executor = _executor_with_permissions({"authority": ["orders:read"]})
 
     result = await executor.execute(
-        _request(action="authority", granted_permissions=["orders:read"])
+        _request(action="authority", authority=enforce_authority("orders:read"))
     )
 
     assert result.success is True
-    assert result.data["authority_kind"] == "legacy_permissions"
+    assert result.data["authority_kind"] == "authenticated_user"
     assert result.data["permission_mode"] == "enforce"
-    assert result.data["legacy_granted_permissions_none"] is False
     assert result.data["authority_permissions"] == ["orders:read"]
 
 
@@ -129,7 +126,7 @@ async def test_granted_permissions_missing_required_scope_denies_action():
     """When the required permission is absent from the granted set, PERMISSION_DENIED."""
     executor = _executor_with_permissions({"list": ["orders:read"]})
 
-    result = await executor.execute(_request(action="list", granted_permissions=[]))
+    result = await executor.execute(_request(action="list", authority=enforce_authority()))
 
     assert result.success is False
     assert result.error_code == "PERMISSION_DENIED"
@@ -141,7 +138,7 @@ async def test_empty_action_permissions_allows_any_granted_set():
     """Actions with no declared permissions are always allowed regardless of scopes."""
     executor = _executor_with_permissions({})  # no permissions declared
 
-    result = await executor.execute(_request(action="list", granted_permissions=[]))
+    result = await executor.execute(_request(action="list", authority=enforce_authority()))
 
     assert result.success is True
 
@@ -152,7 +149,7 @@ async def test_partial_scope_match_still_denies():
     executor = _executor_with_permissions({"read": ["orders:read", "orders:admin"]})
 
     result = await executor.execute(
-        _request(action="read", granted_permissions=["orders:read"])  # missing orders:admin
+        _request(action="read", authority=enforce_authority("orders:read"))  # missing orders:admin
     )
 
     assert result.success is False
@@ -166,7 +163,7 @@ async def test_granted_permissions_are_injected_into_module_context():
     executor = _executor_with_permissions({})
 
     result = await executor.execute(
-        _request(action="permissions", granted_permissions=["orders:read"])
+        _request(action="permissions", authority=enforce_authority("orders:read"))
     )
 
     assert result.success is True
@@ -188,7 +185,7 @@ async def test_type_error_does_not_leak_exception_message():
         action_method_map={"act": "do_action"},
         action_permissions={},
     )
-    req = ModuleRequest(module="bad", action="act", params={}, app_id="app_1", granted_permissions=None)
+    req = ModuleRequest(module="bad", action="act", params={}, app_id="app_1", authority=trusted_framework_authority())
     result = await executor.execute(req)
 
     assert result.success is False
@@ -228,7 +225,7 @@ async def test_execution_error_does_not_leak_exception_message():
         action="risky",
         params={},
         app_id="app_test",
-        granted_permissions=None,
+        authority=trusted_framework_authority(),
     )
 
     result = await executor.execute(req)

--- a/tests/test_module_loader_contracts.py
+++ b/tests/test_module_loader_contracts.py
@@ -8,6 +8,7 @@ from mozaiksai.core.runtime.app.loader import AppLoader
 from mozaiksai.core.runtime.app.module_loader import ActionDef, ModuleLoader, ModuleLoadError
 from mozaiksai.core.runtime.composition.module_event_router import ModuleEventRouter
 from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
+from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
 
 
 def _write_canonical_module(
@@ -501,7 +502,7 @@ async def test_module_executor_dispatches_public_action_id_to_handler_method(tmp
             action="create",
             params={"title": "Draft"},
             app_id="app_1",
-            user_id="user_1",
+            user_id="user_1", authority=trusted_framework_authority(),
         )
     )
 
@@ -532,7 +533,7 @@ async def test_module_executor_wraps_handler_events_in_canonical_envelope(tmp_pa
             app_id="app_1",
             user_id="user_1",
             tenant_id="tenant_1",
-            correlation_id="corr_1",
+            correlation_id="corr_1", authority=trusted_framework_authority(),
         )
     )
 
@@ -587,7 +588,7 @@ class TasksModule:
             action="create",
             params={"title": "Draft"},
             app_id="app_1",
-            user_id="user_1",
+            user_id="user_1", authority=trusted_framework_authority(),
         )
     )
 
@@ -705,7 +706,7 @@ class TasksModule:
     )
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1")
+        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1", authority=trusted_framework_authority())
     )
 
     assert result.success is True
@@ -729,7 +730,7 @@ class TasksModule:
     executor.register(loaded.name, loaded.handler, action_method_map=loaded.action_method_map)
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1")
+        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1", authority=trusted_framework_authority())
     )
 
     assert result.success is True
@@ -754,7 +755,7 @@ async def test_module_executor_enforces_action_permissions(tmp_path: Path) -> No
             action="create",
             params={"title": "x"},
             app_id="app_1",
-            granted_permissions=["tasks.write"],
+            authority=enforce_authority("tasks.write"),
         )
     )
     assert result_ok.success is True
@@ -766,7 +767,7 @@ async def test_module_executor_enforces_action_permissions(tmp_path: Path) -> No
             action="create",
             params={"title": "x"},
             app_id="app_1",
-            granted_permissions=[],
+            authority=enforce_authority(),
         )
     )
     assert result_denied.success is False
@@ -775,7 +776,11 @@ async def test_module_executor_enforces_action_permissions(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_module_executor_bypasses_enforcement_when_granted_permissions_is_none(tmp_path: Path) -> None:
+async def test_module_executor_has_no_implicit_bypass_path(tmp_path: Path) -> None:
+    """Bypass cannot exist by omission: a request without an explicit authority
+    is unconstructible, and an enforce-mode authority with no permissions is
+    denied. Only an explicitly constructed server-owned trusted authority skips
+    enforcement."""
     loaded = ModuleLoader(str(tmp_path)).load(_write_canonical_module(tmp_path).name)
     executor = ModuleExecutor()
     executor.register(
@@ -785,11 +790,34 @@ async def test_module_executor_bypasses_enforcement_when_granted_permissions_is_
         action_permissions=loaded.action_permissions_map,
     )
 
-    # granted_permissions=None → trusted call, bypasses enforcement
-    result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1")
+    # Missing authority fails at construction — there is no default.
+    with pytest.raises(TypeError):
+        ModuleRequest(module="tasks", action="create", params={"title": "x"}, app_id="app_1")  # type: ignore[call-arg]
+
+    # An empty enforce-mode permission set is a denial, not a trusted call.
+    denied = await executor.execute(
+        ModuleRequest(
+            module="tasks",
+            action="create",
+            params={"title": "x"},
+            app_id="app_1",
+            authority=enforce_authority(),
+        )
     )
-    assert result.success is True
+    assert denied.success is False
+    assert denied.error_code == "PERMISSION_DENIED"
+
+    # Only an explicit server-owned trusted authority bypasses enforcement.
+    trusted = await executor.execute(
+        ModuleRequest(
+            module="tasks",
+            action="create",
+            params={"title": "x"},
+            app_id="app_1",
+            authority=trusted_framework_authority(),
+        )
+    )
+    assert trusted.success is True
 
 
 def test_module_definition_action_permissions_map(tmp_path: Path) -> None:
@@ -820,7 +848,7 @@ async def test_module_executor_rejects_invalid_input(tmp_path: Path) -> None:
 
     # Missing required 'title' → INVALID_PARAMS
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={}, app_id="app_1")
+        ModuleRequest(module="tasks", action="create", params={}, app_id="app_1", authority=trusted_framework_authority())
     )
     assert result.success is False
     assert result.error_code == "INVALID_PARAMS"
@@ -839,7 +867,7 @@ async def test_module_executor_accepts_valid_input(tmp_path: Path) -> None:
     )
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={"title": "My Task"}, app_id="app_1")
+        ModuleRequest(module="tasks", action="create", params={"title": "My Task"}, app_id="app_1", authority=trusted_framework_authority())
     )
     assert result.success is True
 
@@ -852,7 +880,7 @@ async def test_module_executor_skips_validation_when_no_schema(tmp_path: Path) -
     executor.register(loaded.name, loaded.handler, action_method_map=loaded.action_method_map)
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", params={}, app_id="app_1")
+        ModuleRequest(module="tasks", action="create", params={}, app_id="app_1", authority=trusted_framework_authority())
     )
     # No schema → dispatched even with missing params (handler gets TypeError → INVALID_PARAMS from existing guard)
     assert result.error_code in (None, "INVALID_PARAMS")  # either path is acceptable without schema

--- a/tests/test_platform_module_dispatch.py
+++ b/tests/test_platform_module_dispatch.py
@@ -36,9 +36,6 @@ class _OrdersHandler:
         return {
             "authority_kind": authority.kind if authority else None,
             "permission_mode": authority.permission_mode if authority else None,
-            "legacy_granted_permissions_none": (
-                authority.legacy_granted_permissions_none if authority else None
-            ),
             "actor_id": authority.actor_id if authority else None,
             "permissions": list(authority.permissions) if authority else None,
             "surface": provenance.surface if provenance else None,
@@ -254,7 +251,6 @@ def test_auth_disabled_module_dispatch_uses_local_development_authority(monkeypa
     assert resp.json() == {
         "authority_kind": "local_development",
         "permission_mode": "trusted_bypass",
-        "legacy_granted_permissions_none": True,
         "actor_id": "anonymous",
         "permissions": [],
         "surface": "http_module_dispatch",
@@ -416,7 +412,6 @@ def test_authenticated_module_dispatch_uses_authenticated_user_authority(monkeyp
     assert resp.json() == {
         "authority_kind": "authenticated_user",
         "permission_mode": "enforce",
-        "legacy_granted_permissions_none": False,
         "actor_id": "u1",
         "permissions": ["orders.read"],
         "surface": "http_module_dispatch",

--- a/tests/test_public_framework_contract_freeze.py
+++ b/tests/test_public_framework_contract_freeze.py
@@ -123,7 +123,6 @@ def test_framework_authority_and_provenance_do_not_claim_production_authority() 
         actor_id="user-1",
         permissions=("orders.read",),
     )
-    translated = ModuleDispatchAuthority.from_granted_permissions(None, actor_id="system")
     event = ModuleEventProvenance(
         event_id="evt-1",
         event_type="domain.orders.created",
@@ -132,9 +131,8 @@ def test_framework_authority_and_provenance_do_not_claim_production_authority() 
     )
 
     assert authority.permission_mode == "enforce"
-    assert translated.kind == "leg" + "acy_trusted"
-    assert translated.permission_mode == "trusted" + "_bypass"
-    assert getattr(translated, "leg" + "acy_granted_permissions_none") is True
+    # The permission-list translation shim and its compatibility kinds are gone.
+    assert not hasattr(ModuleDispatchAuthority, "from_" + "granted_permissions")
     assert "payload" not in event.to_dict()
     authority_fields = {field.name for field in fields(authority)}
     assert "production_authority" not in authority_fields

--- a/tests/test_runtime_persistence_module_injection.py
+++ b/tests/test_runtime_persistence_module_injection.py
@@ -10,6 +10,7 @@ from mozaiksai.core.runtime.app.module_loader import SettingDef
 from mozaiksai.core.runtime.composition.module_context import ModuleContext
 from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
 from mozaiksai.core.runtime.persistence import MongoPersistenceContext
+from tests.module_authority_test_helpers import trusted_framework_authority
 
 
 class FakeCursor:
@@ -122,7 +123,7 @@ async def test_module_executor_injects_persistence_when_app_id_exists() -> None:
     executor = ModuleExecutor()
     executor.register("inspect", CaptureContextHandler())
 
-    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1"))
+    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["has_persistence"] is True
@@ -142,7 +143,7 @@ async def test_module_executor_production_path_uses_real_mongo_persistence_conte
     executor = ModuleExecutor()
     executor.register("inspect", CaptureContextHandler())
 
-    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1"))
+    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["persistence_type"] == "MongoPersistenceContext"
@@ -153,7 +154,7 @@ async def test_injected_persistence_is_mongo_context_with_current_app_id() -> No
     executor = ModuleExecutor()
     executor.register("inspect", CaptureContextHandler())
 
-    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_abc"))
+    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_abc", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["app_id"] == "app_abc"
@@ -171,7 +172,7 @@ async def test_user_and_tenant_scope_are_passed_to_persistence() -> None:
             app_id="app_1",
             user_id="user_1",
             tenant_id="tenant_1",
-            workspace_id="workspace_1",
+            workspace_id="workspace_1", authority=trusted_framework_authority(),
         )
     )
 
@@ -187,7 +188,7 @@ async def test_ctx_db_attribute_does_not_exist() -> None:
     executor = ModuleExecutor()
     executor.register("inspect", CaptureContextHandler())
 
-    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1"))
+    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["has_db"] is False
@@ -198,7 +199,7 @@ async def test_handler_can_access_ctx_persistence() -> None:
     executor = ModuleExecutor()
     executor.register("inspect", CaptureContextHandler())
 
-    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1"))
+    result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["has_persistence"] is True
@@ -211,7 +212,7 @@ async def test_handler_can_call_persistence_collection(monkeypatch: pytest.Monke
     executor = ModuleExecutor()
     executor.register("projects", PersistenceUsingHandler())
 
-    result = await executor.execute(ModuleRequest(module="projects", action="read_project", app_id="app_1"))
+    result = await executor.execute(ModuleRequest(module="projects", action="read_project", app_id="app_1", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data["doc"]["query"] == {"app_id": "app_1", "_id": "project_1"}
@@ -228,7 +229,7 @@ async def test_existing_event_emit_behavior_remains_unchanged() -> None:
     executor.register("tasks", EmitHandler())
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", app_id="app_1", user_id="user_1", tenant_id="tenant_1")
+        ModuleRequest(module="tasks", action="create", app_id="app_1", user_id="user_1", tenant_id="tenant_1", authority=trusted_framework_authority())
     )
 
     assert result.success is True
@@ -254,7 +255,7 @@ async def test_event_emit_includes_workspace_when_present() -> None:
             app_id="app_1",
             user_id="user_1",
             tenant_id="tenant_1",
-            workspace_id="workspace_1",
+            workspace_id="workspace_1", authority=trusted_framework_authority(),
         )
     )
 
@@ -273,7 +274,7 @@ async def test_existing_settings_and_auth_fields_remain_unchanged() -> None:
     executor.register("tasks", EmitHandler(), settings=settings)
 
     result = await executor.execute(
-        ModuleRequest(module="tasks", action="create", app_id="app_1", auth_token="token_123")
+        ModuleRequest(module="tasks", action="create", app_id="app_1", auth_token="token_123", authority=trusted_framework_authority())
     )
 
     assert result.success is True
@@ -286,7 +287,7 @@ async def test_module_execution_still_works_without_persistence_when_app_id_miss
     executor = ModuleExecutor()
     executor.register("optional", OptionalPersistenceHandler())
 
-    result = await executor.execute(ModuleRequest(module="optional", action="run"))
+    result = await executor.execute(ModuleRequest(module="optional", action="run", authority=trusted_framework_authority()))
 
     assert result.success is True
     assert result.data == {"persistence": None}

--- a/tests/test_runtime_persistence_real_mongo.py
+++ b/tests/test_runtime_persistence_real_mongo.py
@@ -17,6 +17,7 @@ from mozaiksai.core.runtime.persistence import (
     migration_hash,
 )
 from mozaiksai.core.runtime.persistence.mongo import DEFAULT_APP_DATABASE_NAME
+from tests.module_authority_test_helpers import trusted_framework_authority
 
 RUN_ENV = "MOZAIKS_RUN_REAL_MONGO_TESTS"
 LEGACY_RUN_ENV = "MOZAIKS_RUN_MONGO_INTEGRATION"
@@ -144,7 +145,7 @@ async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pyte
                 action="create_project",
                 app_id=app_id,
                 user_id="integration_user",
-                params={"project_id": project_id, "name": "Real Mongo Smoke"},
+                params={"project_id": project_id, "name": "Real Mongo Smoke"}, authority=trusted_framework_authority(),
             )
         )
         assert create_result.success is True
@@ -158,10 +159,10 @@ async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pyte
         )
 
         list_result = await executor.execute(
-            ModuleRequest(module="projects", action="list_projects", app_id=app_id)
+            ModuleRequest(module="projects", action="list_projects", app_id=app_id, authority=trusted_framework_authority())
         )
         other_list_result = await executor.execute(
-            ModuleRequest(module="projects", action="list_projects", app_id=other_app_id)
+            ModuleRequest(module="projects", action="list_projects", app_id=other_app_id, authority=trusted_framework_authority())
         )
 
         assert list_result.success is True


### PR DESCRIPTION
## Summary

First bounded prerequisite for the deterministic tool/module compiler track: explicit `ModuleDispatchAuthority` becomes the sole dispatch authority input, and the permission-list sentinel contract is deleted completely.

- `ModuleRequest.authority` is a required keyword-only `ModuleDispatchAuthority` (no default); the `granted_permissions` field is deleted.
- `ModuleDispatchAuthority.from_granted_permissions()`, the `legacy_granted_permissions_none` field, and both compatibility authority kinds are deleted. Only authentic dispatch kinds remain.
- `ModuleExecutor` permission evaluation keys exclusively on `authority.permission_mode` and `authority.permissions`; entitlement gates run for every enforce-mode dispatch that declares one. `ModuleExecutor` remains the sole evaluator — no permission or entitlement logic was added anywhere else (nothing in AG2 Depends).
- Trusted bypass is a closed, constructor-validated property: only `framework_internal`, `operator_internal`, contract-declared `event_reaction`, and auth-disabled `local_development` may carry `trusted_bypass`. `workflow` always enforces. `local_development` cannot be constructed while authentication is enabled. Missing principal, empty permissions, caller fields, or internal location never produce trust.
- New server-side constructors: `workflow_user_authority()` (enforce-only; identity/scopes from the server-side session principal, never workflow context_variables) and `event_reaction_authority()` (enforce by default; trusted only with an explicit contract declaration plus full event provenance `event_id`/`event_type`/`event_producer`).
- Production construction sites updated: `hosts/routers/modules.py` (authenticated/public/local-dev branches), the four `hosts/platform.py` hydration sites (the `if principal else None` ternaries are gone — principal-absent dispatch on authenticated paths now denies closed), the `module_dispatch.py` public facade (`authority` is required keyword-only; the separate permission-list field is deleted; the caller's enforce-mode authority is validated and passed to ModuleExecutor exactly as supplied), and the executor's event envelope (now always carries `authority.kind/permission_mode/permissions`; `module_event_router` reaction permission evaluation reads the new key).
- Governance: the old allowlist is deleted; any `granted_permissions` token in `mozaiksai/` source is now a CI error. `ModulePermissionCheck.granted_permissions` renamed to `granted` (audit `to_dict` key too) so the runtime carries no trace of the removed contract.
- Docs updated: `ARCHITECTURAL_INVARIANTS.md` §6, `docs/architecture/app/tenant-auth-and-scope.md`, `docs/guides/adding-modules/01-overview.md`, `factory_app/build_context/AppGenerator/file_contracts.yaml` prose.
- Tests: shared helpers in `tests/module_authority_test_helpers.py` (no permissive defaults — every construction states enforce-with-permissions or server-owned trusted); the old None-bypass test is replaced by `test_module_executor_has_no_implicit_bypass_path` proving the bypass cannot exist; new `tests/test_module_dispatch_authority_contract.py` covers all authority invariants (14 tests).

## Proof checklist

- Missing authority fails at `ModuleRequest` construction (kw-only, no default) — `test_module_request_requires_explicit_authority`.
- Invalid kind/mode pairs rejected at construction — `test_trusted_bypass_rejected_for_non_server_owned_kinds`, closed-set equality test.
- Principal-absent authenticated dispatch denies closed — platform ternaries removed; empty enforce-mode permissions deny (`PERMISSION_DENIED`).
- `public_http` with empty permissions executes only permission-free actions — `test_public_http_empty_permissions_only_runs_permission_free_actions`.
- `workflow` authority always enforces — constructor validation + `test_workflow_authority_always_enforces`.
- Trusted bypass only for closed server-owned cases — `TRUSTED_BYPASS_KINDS` + `__post_init__`.
- Event-reaction trust requires declared binding + provenance — `event_reaction_authority` validation tests.
- `local_development` rejected while auth is enabled or the deployment environment is production — constructor guard + tests.
- Permissions/entitlements evaluated only by `ModuleExecutor` — entitlement recorder tests show exactly one check per enforce dispatch, zero for trusted; no gate code added elsewhere.
- No `granted_permissions` token remains anywhere under `mozaiksai/` (governance rule now enforces this permanently).

## Downstream (mozaiks-app) pin migration requirements

When mozaiks-app bumps its OSS pin to include this change, its 12 direct `ModuleRequest` constructions must supply explicit authorities:

- `app/modules/community_governance/backend/participation_policy_input_dispatcher.py` and `app/modules/community_revenue_participation/backend/participation_policy_input_dispatcher.py` — build an enforce-mode authority from their trusted-input permission lists.
- `app/modules/remediation_registry/backend/module_action_dispatcher.py` — currently reads `getattr(ctx, "permissions", None)`; the None tolerance must become a declared authority (enforce with concrete permissions, or an explicit server-owned trusted kind). This aligns with #223's rule that trust is never derived from missing permissions.
- Any facade callers using `ModuleActionDispatchRequest` must construct an explicit enforce-mode `ModuleDispatchAuthority` (the request's `authority` field is required keyword-only; the old permission-list field is gone — permissions ride on the authority).
- `ModulePermissionCheck.granted_permissions` consumers (audit records) must read `granted`.

## Validation

- Focused suites (20 module/dispatch/persistence/acceptance test files) twice: 361 passed, 2 skipped each run (`test_generated_app_functional_acceptance.py` passes in isolation; its 3 failures inside one specific multi-file ordering are pre-existing — reproduced byte-identically at the pinned base `638fd85c` in a clean worktree).
- New contract tests: 14 passed.
- Governance + packaging + hygiene gates: `test_governance_guardrails.py`, `test_package_content_guard.py`, `test_oss_prompt_hygiene.py`, `test_production_readiness_gate.py` — 96 passed.
- Full offline suite twice on the branch: 13,284 passed / 0 failed / 77 skipped both runs. Clean full-suite baseline at the pinned base `638fd85c` in a separate worktree: 13,271 passed / 0 failed / 77 skipped — the +13 net tests are the new authority contract module and reshaped proofs.
- `ruff check .` clean; `mypy mozaiksai/ factory_app/` clean (557 files).

## Independent review corrections (`485ac97e`)

- `ModuleActionDispatchRequest.authority` made required keyword-only; the facade's separate permission-list field deleted (no dual request shape); the supplied authority now reaches `ModuleExecutor` exactly as constructed (identity-proven in tests).
- `local_development` additionally unconstructible when `ENV`/`ENVIRONMENT` is `production`.
- Caller-supplied `ModuleContext` now receives `dispatch_authority`/`dispatch_provenance`/`dispatch_audit` on every execution path.
- Stale test names referencing the removed permission-list shape renamed.
- Post-correction: full offline suite 13,287 passed / 0 failed; focused authority/facade suites 244 passed twice; mypy clean (557 files).
- Open obligation for the future event-reaction dispatcher: `event_reaction_authority(contract_declares_trusted=...)` must be fed from the consuming module's reactions contract declaration, never a caller-chosen literal — no OSS dispatcher constructs it yet.

Draft PR for independent review — auto-merge intentionally NOT enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
