### PR TITLE
Gitignore the generated quickstart workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ web_shell/.mozaiks-tailwind-sources/
 .agents/settings.local.json
 .claude/settings.local.json
 .codex/settings.local.json
+
+# Local quickstart workspace (generated output, contains copies of repo files)
+mozaiks-workspace/

--- a/tests/test_quickstart_workspace_hygiene.py
+++ b/tests/test_quickstart_workspace_hygiene.py
@@ -1,0 +1,32 @@
+"""The quickstart workspace is generated output and must stay out of the repo."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_ignored(relative_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", relative_path],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def test_quickstart_workspace_is_gitignored() -> None:
+    for relative_path in (
+        "mozaiks-workspace/CLAUDE.md",
+        "mozaiks-workspace/.claude/rules/runtime.md",
+        "mozaiks-workspace/scripts/run-frontend.ps1",
+    ):
+        assert _is_ignored(relative_path), f"{relative_path} must be gitignored"
+
+
+def test_repo_owned_files_stay_tracked() -> None:
+    for relative_path in ("CLAUDE.md", "README.md", ".claude/rules/runtime.md"):
+        assert not _is_ignored(relative_path), f"{relative_path} must stay tracked"


### PR DESCRIPTION
## Summary

The README tells users to run `python -m mozaiks quickstart --dir .\mozaiks-workspace`, which generates a workspace at that path. Nothing in `.gitignore` covers it, so anyone following the Quickstart and running `git add -A` commits their whole generated workspace.

That workspace contains copies of repo files, including `CLAUDE.md`, `AGENTS.md`, `README.md`, the `.claude/rules` and `.claude/skills` files, and the `run-*.ps1` scripts. Committing those creates a second copy of project guidance that nobody can tell is non-authoritative.

This already happened: PR #295 carried 81 such files out of 86 changed.

## Change

One rule in `.gitignore`, plus two small tests.

The rule is scoped to `mozaiks-workspace/` only. Repo-owned files at the root stay tracked and editable, and one of the tests asserts that, so the rule cannot be widened later without failing.

## Tests run

```
python -m pytest tests/test_quickstart_workspace_hygiene.py -q --no-cov  ->  2 passed
```

## OSS Change Impact

- Layer changed: repo hygiene only
- Build workflow impact: none
- Runtime/platform impact: none
- App workspace impact: none
- Tests run: see above
- Docs updated: none required
- Compatibility risk: none. Nothing under `mozaiks-workspace/` is currently tracked, so no existing file becomes ignored.

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] Ordinary change. No new public schema, workflow or prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [x] No public contract added or changed.
- [x] Not a one-way-door area from `OSS_PUBLICATION_POLICY.md`, so no ADR.
- [x] Does not touch permissions, secrets, provider execution, payments, deployment, DNS, or production operations.
