### PR TITLE
fix(windows): handle UnicodeEncodeError on legacy consoles

### DIFF
--- a/mozaiks_cli/commands/info.py
+++ b/mozaiks_cli/commands/info.py
@@ -2,10 +2,21 @@
 mozaiks info - Show current configuration.
 """
 
+import sys
 import json
 from pathlib import Path
 
 from mozaiks_cli.workspace import resolve_active_app_root
+
+
+def _supports_unicode() -> bool:
+    """Check if stdout supports Unicode characters."""
+    enc = getattr(sys.stdout, "encoding", None) or "ascii"
+    try:
+        "✓✗".encode(enc)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
 
 # Tier definitions
 TIER_PRESETS = {
@@ -104,8 +115,12 @@ def _show_current_config():
     print(f"  Preset:        {preset}")
     print(f"  Auth Required: {auth_required}")
     print("\nEnabled Features:")
+    use_unicode = _supports_unicode()
     for feature, enabled in sorted(features.items()):
-        status = "✓" if enabled else "✗"
+        if use_unicode:
+            status = "✓" if enabled else "✗"
+        else:
+            status = "[x]" if enabled else "[ ]"
         print(f"    {status} {feature}")
 
     # Show upgrade path if not full

--- a/mozaiks_cli/commands/info.py
+++ b/mozaiks_cli/commands/info.py
@@ -2,8 +2,8 @@
 mozaiks info - Show current configuration.
 """
 
-import sys
 import json
+import sys
 from pathlib import Path
 
 from mozaiks_cli.workspace import resolve_active_app_root


### PR DESCRIPTION
## Summary

Fixed `mozaiks info` crashing with `UnicodeEncodeError` on Windows consoles using legacy code pages (cp1252/cp437).

## Changes

- Added `_supports_unicode()` helper to check if stdout can encode Unicode characters
- Fall back to `[x]`/`[ ]` on legacy Windows consoles

## Testing

```bash
PYTHONIOENCODING=cp1252 python -m mozaiks info
```

Fixes #307
