### PR TITLE
docs: correct CONTRIBUTING.md coverage gate to match CI (70%) (#317)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,15 @@ focused test file(s) that cover what you touched:
 python -m pytest tests/test_your_file.py -q
 ```
 
-**Coverage gate note:** This repo's shared `pytest` configuration enforces a
-repository-wide minimum coverage threshold (`--cov-fail-under=30`, measured
-against `mozaiksai`). Running a narrow test file against that global
-threshold will often report a coverage failure even when every test you ran
-passes. That failure reflects the coverage math for the whole package, not a
-problem with your change.
+**Coverage gate note:** The local `pyproject.toml` configuration sets a
+repository-wide minimum coverage threshold of 30% (`--cov-fail-under=30`,
+measured against `mozaiksai`). However, **CI enforces a stricter 70% gate**
+(`--cov-fail-under=70` in `.github/workflows/ci.yml`). CI is authoritative —
+your pull request must pass the 70% threshold regardless of local results.
+
+Running a narrow test file against the global threshold will often report a
+coverage failure even when every test you ran passes. That failure reflects
+the coverage math for the whole package, not a problem with your change.
 
 To run a focused slice without tripping the repository-wide coverage gate,
 use the verified command:
@@ -79,9 +82,8 @@ python -m pytest tests/test_your_file.py -q --no-cov
 
 **CI remains authoritative.** `--no-cov` is a local convenience for fast
 iteration on a narrow slice. It does not weaken what is enforced in CI — the
-full test suite still runs in CI with the project's coverage requirements
-enforced, and your pull request must pass CI regardless of what you ran
-locally.
+full test suite runs in CI with the 70% coverage gate enforced, and your pull
+request must pass CI regardless of what you ran locally.
 
 ## Working With an AI Coding Agent (Optional)
 


### PR DESCRIPTION
## Summary
Updates CONTRIBUTING.md to accurately reflect that CI enforces a 70% coverage gate, not 30%. Explains the discrepancy between the local pyproject.toml default (30%) and the CI override (70%), and clarifies that CI is authoritative.

## Changes
- Updated coverage gate note to mention both the local 30% default and the CI 70% requirement
- Added note that CI is authoritative with the specific 70% threshold
- Updated CI note to reference the 70% gate explicitly

## Why
Contributors could pass locally at 30% and be failed by CI at 70% with no explanation. This was confusing.

Closes #317