### PR TITLE
docs: add AI policy, DCO sign-off, canned replies, and Discord links

### DIFF
--- a/.github/AI_POLICY.md
+++ b/.github/AI_POLICY.md
@@ -1,0 +1,153 @@
+# AI Policy
+
+Mozaiks is a framework for building AI-native software, and much of it is
+itself built with AI assistance. Contributors who use coding agents are
+welcome here. What we ask in return is simple and applies to everyone:
+
+**You are responsible for everything you publish** — code, issue descriptions,
+pull request bodies, comments, and reviews. A human has to stand behind the
+submission and be able to discuss it.
+
+This standard does not change based on how a contribution was produced. It
+applies to a first-time contributor using Copilot, to a maintainer running
+Claude Code, and to the automated agents that open PRs on this repository.
+
+## This applies to maintainers too
+
+A large share of the commits on `main` are agent-authored. Maintainer agents
+push branches under `cc/` (Claude Code) and `codex/` (Codex) and open pull
+requests the same way anyone else does.
+
+Those PRs are held to this policy, not exempted from it. A named human
+maintainer is accountable for every agent-authored PR merged here: they are
+responsible for the diff, they answer questions about it, and "the agent wrote
+it" is not an explanation. If we could not accept that answer from you, we
+should not accept it from ourselves.
+
+We say this explicitly because a policy that governs only outside contributors
+is not a standard, it is a toll gate.
+
+## Code: ownership and licensing
+
+If you used AI to generate code, understand what it does and test it before
+submitting. If your tests were also AI-generated, check that they actually
+exercise the behavior. Tests written alongside the code they test have a habit
+of asserting whatever the code happens to do, including the bug.
+
+Mozaiks is [MIT licensed](https://github.com/BlocUnited-LLC/mozaiks/blob/main/LICENSE).
+There is no CLA and no rights assignment; contributions are certified under the
+[Developer Certificate of Origin](https://github.com/BlocUnited-LLC/mozaiks/blob/main/DCO.md),
+which you sign per commit with `git commit -s`.
+
+That certification is a statement about provenance, and AI-assisted work is
+where provenance is easiest to lose track of. A model can reproduce training
+data closely enough to matter, so before signing off on generated code, satisfy
+yourself that you are not carrying in third-party material you have no right to
+contribute. If a generated block looks like it came from somewhere specific, it
+may have.
+
+## Know which repository your change belongs in
+
+This is the failure mode most specific to Mozaiks, and coding agents walk into
+it constantly.
+
+`mozaiks` is the open framework: runtime, contracts, ports, capability packs,
+module archetypes, CLI, and Studio. BlocUnited's hosted product is a separate,
+private codebase that implements those contracts — the concrete payment
+provider integration, hosted billing, plan tiers, and production operations.
+
+The seam is `mozaiksai/core/ports/`. The framework defines the Protocol and
+ships a default or no-op adapter; a product implements the real one. The
+`EntitlementPort` is the clearest example: this repository owns the contract,
+the `EntitlementResult` shape, the fail-closed convention, and the
+`NoOpEntitlementAdapter`. It deliberately does not own anything that resolves a
+real customer's paid subscription.
+
+Given an issue that mentions billing or entitlement, an agent will cheerfully
+propose a full grant store, a payout ledger, or a provider webhook handler, and
+none of that belongs here. If your change adds provider-specific commercial
+logic to this repository, it is in the wrong repository, however good the code
+is.
+
+Read [OSS_PUBLICATION_POLICY.md](https://github.com/BlocUnited-LLC/mozaiks/blob/main/OSS_PUBLICATION_POLICY.md)
+before starting anything that touches payments, entitlement, provider
+execution, deployment, DNS, credentials, or production operations. MIT
+publication is a one-way door, and the pull request template's boundary
+checkbox is a prompt to think, not a box for an agent to tick.
+
+When you are unsure which side of the line a change falls on, ask in the issue
+before writing the code. That question is always welcome and never a bother.
+
+## Issues, pull requests, and discussion
+
+If you open an issue, understand the problem well enough to describe it
+clearly. If AI helped you draft the description, edit it so it reflects your own
+understanding before posting.
+
+If you open a pull request, be able to explain the change — in the body, and in
+response to review questions. Verify specific claims against the actual diff:
+file paths, function names, error messages, and especially "I ran the tests."
+A PR body that describes behavior the diff does not have is worse than a PR
+body with no description at all, because it costs a reviewer the time to
+discover the mismatch.
+
+**Be prepared to discuss and revise in your own words.** Pasting an agent's
+reply back at a reviewer does not move the conversation forward, and it is
+usually obvious.
+
+Mentioning significant AI assistance in the PR body is appreciated. It is not
+held against you; it helps a reviewer calibrate where to look.
+
+If you want to share raw AI output in a comment, put it in a quote block, say
+what it is, and add your own commentary on why it is relevant. Keep it short.
+
+### A note on our issues
+
+Many issues in this repository — particularly those labeled
+`good first issue` — are written in unusual detail, with file and line
+references and a suggested approach. That is deliberate: it lowers the barrier
+for a genuine first contribution.
+
+It also makes those issues easy to hand to an agent without ever reading the
+surrounding code. Please read the code. The suggested approach in an issue is a
+starting point written by someone who may have been wrong, and noticing that it
+is wrong is a more valuable contribution than implementing it faithfully.
+
+## Reviews
+
+Reviews from anyone in the community are welcome, not just maintainers. AI
+tools can help you read a large diff or spot patterns worth a closer look, but
+**a review has to reflect that a person engaged with the code**.
+
+A review reads as unverified AI output when it:
+
+- restates the PR description back as findings instead of responding to the diff,
+- praises choices in generic terms without pointing at specific lines,
+- asks questions the diff answers directly, such as whether something is tested
+  when the test file is right there,
+- approves while leaving its own open question unresolved,
+- reuses the same template across unrelated PRs.
+
+Maintainers may hide a review showing clear signs of unverified AI content, and
+will leave a comment explaining why. Reviews do not gate a PR — only a
+maintainer's approval does — but a low-effort review can mislead a less
+experienced contributor into believing a change was vetted when it was not.
+
+## Non-native English speakers
+
+AI is genuinely useful for writing in a second language, and we would rather
+have your contribution in imperfect English than not at all. If you use AI to
+polish your comments, make sure the result still says what you meant. If you
+use it to translate, consider writing in your own language and including the
+translation.
+
+## Maintainer discretion
+
+Maintainers may close or deprioritize contributions where the author cannot
+explain the change, has not tested it, or cannot engage with review questions.
+
+The bar is the same regardless of how the work was produced. We only need to be
+able to trust that a person stands behind it.
+
+Questions about any of this are welcome in
+[Discord](https://discord.gg/Qnsywad9kp) or on the issue itself.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Ask a question on Discord
+    url: https://discord.gg/Qnsywad9kp
+    about: Usage questions, design discussion, and help getting set up. Faster than an issue for anything that is not a bug or a concrete proposal.
+  - name: Read the docs
+    url: https://docs.mozaiks.ai
+    about: Architecture, contracts, CLI reference, and contributor guides.
   - name: Report a security vulnerability
     url: https://github.com/BlocUnited-LLC/mozaiks/security
     about: Please use GitHub's private vulnerability reporting instead of a public issue. See SECURITY.md.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,9 @@
   Using an AI coding agent? That is welcome — see .github/AI_POLICY.md. The
   short version: make sure this description matches what the diff actually
   does, and that you can explain the change in review.
+
+  Mozaiks does not run a bounty program; issues carry no payment. See
+  CONTRIBUTING.md.
 -->
 
 ## Related issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
   Thanks for contributing to Mozaiks! Please fill out this template so
   maintainers have what they need to review efficiently. See CONTRIBUTING.md
   for the full contribution path.
+
+  Using an AI coding agent? That is welcome — see .github/AI_POLICY.md. The
+  short version: make sure this description matches what the diff actually
+  does, and that you can explain the change in review.
 -->
 
 ## Related issue
@@ -18,6 +22,14 @@
   List the commands you ran and their result, e.g.:
   `pytest tests/test_foo.py -v` -> 12 passed
   For docs-only changes: `python -m mkdocs build --strict` -> succeeded
+-->
+
+## AI assistance (optional)
+
+<!--
+  If an AI tool did significant work here, a one-line mention helps reviewers
+  calibrate where to look. It is not held against you — a good chunk of this
+  repo is agent-authored. Delete this section if it does not apply.
 -->
 
 ## Screenshots (if applicable)

--- a/.github/review/replies/README.md
+++ b/.github/review/replies/README.md
@@ -1,0 +1,36 @@
+# Canned replies
+
+Template responses for common triage situations. Maintainers use them as
+copy-paste starting points — personalize whenever it helps. Nothing here is
+meant to be sent as-is if a real sentence would serve the contributor better.
+
+Placeholders use `{{name}}` syntax. Common ones: `{{author}}` (GitHub login
+without the `@`), `{{observations}}`, `{{reason}}`.
+
+The HTML comment at the top of each file documents when to use it. It is not
+part of the reply — delete it when you paste.
+
+| File | Situation |
+|---|---|
+| `welcome-first-pr.md` | A first-time contributor opened a PR |
+| `ai-slop.md` | A PR or issue shows signs of unverified AI-generated content |
+| `needs-reproduction.md` | A bug report cannot be reproduced as written |
+
+## Why this is deliberately short
+
+Larger projects run a dozen or more of these, backed by a label taxonomy and
+triage automation. Mozaiks does not have that volume yet, and a template
+library nobody maintains is worse than no library. Add a new reply when you
+have written roughly the same comment three times, not in anticipation.
+
+## Tone
+
+These are the first words a stranger reads from this project. Two rules:
+
+1. **Say what happens next.** A contributor who knows their PR is queued
+   behind a CI approval is waiting. One who does not is being ignored.
+2. **Criticize the submission, never the person.** `ai-slop.md` in particular
+   is about verification, not about whether someone used AI. The
+   [AI policy](../../AI_POLICY.md) welcomes AI assistance and holds maintainer
+   agents to the same standard — the reply should not read as if it forgot
+   that.

--- a/.github/review/replies/ai-slop.md
+++ b/.github/review/replies/ai-slop.md
@@ -1,0 +1,37 @@
+<!--
+Use when: a PR or issue shows signs of unverified AI-generated content — the description
+does not match the diff, invented APIs or file paths, claims of testing with no evidence,
+boilerplate reasoning that could apply to any change.
+
+Do NOT use when: the work is simply wrong, or the author is inexperienced. Those get a
+normal review comment. This reply is specifically about content that was not verified
+before being published.
+
+Fill in {{observations}} with the actual specifics. A generic version of this message is
+itself the thing it is complaining about.
+-->
+
+Hi @{{author}}, thanks for the submission.
+
+AI-assisted contributions are welcome here — our
+[AI policy](https://github.com/BlocUnited-LLC/mozaiks/blob/main/.github/AI_POLICY.md)
+says so explicitly, and a good share of this repository is agent-authored. The
+standard it sets is that a person verified the result before publishing it, and
+this submission has some signs that did not happen:
+
+{{observations}}
+
+To move this forward:
+
+1. Explain in your own words what problem this solves and how the change works.
+2. Make the description match the actual diff — remove anything it claims that
+   the code does not do.
+3. Say how you validated it: the commands you ran and what you saw.
+
+We ask this of every submission flagged this way, including our own. An
+unverified description costs a reviewer more time than it saved the author,
+because the reviewer has to discover the mismatch before they can start
+reviewing.
+
+Happy to help if you are stuck on any part of it — reply here or ask in
+[Discord](https://discord.gg/Qnsywad9kp).

--- a/.github/review/replies/needs-reproduction.md
+++ b/.github/review/replies/needs-reproduction.md
@@ -1,0 +1,26 @@
+<!--
+Use when: a bug report cannot be reproduced from what is written, or is missing the
+information needed to try.
+Action: label `question`, or close as *not planned* if there is no response after a
+reasonable wait. Say the wait out loud rather than letting it go quiet.
+-->
+
+Thanks for the report @{{author}}. I tried to reproduce this and could not, so
+I am probably missing a piece of your setup.
+
+Could you add:
+
+- the exact command you ran and the full output or traceback,
+- what you expected instead,
+- `python --version`, your OS, and whether you installed with
+  `pip install -e ".[dev]"` from a checkout,
+- the commit you are on (`git rev-parse --short HEAD`),
+- for anything involving Studio or the frontend: your Node version, and whether
+  MongoDB is local, Atlas, or Docker.
+
+If you can reduce it to a minimal case that fails — a few lines, or a single
+failing test — that usually turns a hard bug into an obvious one.
+
+I will leave this open for now. If we do not hear back in a couple of weeks I
+will close it to keep the queue honest, but a comment at any point reopens the
+conversation and nothing is lost.

--- a/.github/review/replies/welcome-first-pr.md
+++ b/.github/review/replies/welcome-first-pr.md
@@ -1,0 +1,29 @@
+<!--
+Use when: a first-time contributor opens their first PR.
+Action: none — informational. Combine with other replies if something is also blocking.
+Note: post this promptly. It is also the moment to click "Approve and run workflows",
+since a first-time contributor's CI will not start without it.
+-->
+
+Welcome @{{author}}, and thanks for your first contribution to Mozaiks! 🎉
+
+What happens next:
+
+- **CI needs a maintainer to start it.** GitHub holds workflow runs from
+  first-time contributors until someone approves them, so if the checks look
+  like they are not running, that is on our side and not on yours. We have
+  approved them now.
+- A maintainer will review the diff and either merge it or leave specific
+  comments. If we ask for changes, push to the same branch — the PR updates
+  automatically, no need to open a new one.
+- If CI fails, the log usually says why. `python -m pytest <your test file> -q --no-cov`
+  reproduces most failures locally; the `--no-cov` flag avoids tripping the
+  repository-wide coverage gate on a narrow test run.
+
+Useful links: [Contributing guide](https://github.com/BlocUnited-LLC/mozaiks/blob/main/CONTRIBUTING.md) ·
+[AI policy](https://github.com/BlocUnited-LLC/mozaiks/blob/main/.github/AI_POLICY.md) ·
+[Docs](https://docs.mozaiks.ai) ·
+[Discord](https://discord.gg/Qnsywad9kp)
+
+If anything about the process is unclear or slower than you expected, say so
+here or in Discord. That feedback is useful to us.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,101 @@
+name: DCO
+
+# Verifies every commit in a pull request carries a Developer Certificate of
+# Origin sign-off. See DCO.md for the certificate text and how to sign off.
+#
+# Implemented inline rather than with a third-party action, matching how the
+# other repo-specific gates in ci.yml are written, and so this workflow pulls
+# in no supply-chain dependency of its own.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    # Bot-authored PRs (Dependabot and friends) do not sign off and are trusted
+    # by virtue of being repo automation, not third-party contributions.
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check sign-off on every commit
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script body, so PR-controlled values can never be executed.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import subprocess
+          import sys
+
+          base = os.environ["BASE_SHA"]
+          head = os.environ["HEAD_SHA"]
+
+          # \x1e separates records, \x1f separates fields - neither can appear
+          # in a commit message, unlike any printable delimiter.
+          fmt = "%H\x1f%an\x1f%ae\x1f%B\x1e"
+          out = subprocess.run(
+              ["git", "log", "--no-merges", f"--format={fmt}", f"{base}..{head}"],
+              capture_output=True, text=True, check=True,
+          ).stdout
+
+          # Presence and shape are enforced; an exact match against the commit
+          # author is not. Sign-off identities legitimately differ from author
+          # identities (shared machines, GitHub noreply addresses, patches
+          # relayed under DCO clause (c)), and failing those costs contributors
+          # more than it protects the project.
+          trailer = re.compile(r"^Signed-off-by: .+ <[^<>@\s]+@[^<>\s]+>\s*$", re.M)
+
+          unsigned = []
+          checked = 0
+          for record in out.split("\x1e"):
+              record = record.strip("\n")
+              if not record:
+                  continue
+              sha, name, email, message = record.split("\x1f", 3)
+              checked += 1
+              if not trailer.search(message):
+                  subject = message.strip().splitlines()[0] if message.strip() else "(no message)"
+                  unsigned.append((sha, name, email, subject))
+
+          if not checked:
+              print("No non-merge commits to check.")
+              sys.exit(0)
+
+          if unsigned:
+              print("Missing Developer Certificate of Origin sign-off:\n", file=sys.stderr)
+              for sha, name, email, subject in unsigned:
+                  print(f"  {sha[:12]}  {subject}", file=sys.stderr)
+                  print(f"                {name} <{email}>\n", file=sys.stderr)
+              print(
+                  "Every commit needs a 'Signed-off-by' line certifying you have the\n"
+                  "right to contribute it. There is no CLA and no rights assignment;\n"
+                  "see DCO.md.\n\n"
+                  "To fix the most recent commit:\n"
+                  "    git commit --amend -s --no-edit\n"
+                  "    git push --force-with-lease\n\n"
+                  f"To fix every commit on this branch:\n"
+                  f"    git rebase --signoff {base[:12]}\n"
+                  "    git push --force-with-lease\n\n"
+                  "Sign off future commits automatically with 'git commit -s'.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print(f"All {checked} commit(s) signed off.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,16 @@ when it fails.
 - **The issue itself** — if an issue is unclear or its suggested approach looks
   wrong, say so there. That is useful feedback, not an interruption.
 
+## Bounties
+
+Mozaiks does not run a bounty program. Issues here carry no payment, including
+those labeled `good first issue`, and we cannot act on requests for payment
+attached to a pull request.
+
+Contributions are voluntary. We think that is worth stating plainly rather than
+leaving people to guess, since some ecosystems do attach bounties to issues and
+the absence of a policy reads as ambiguity rather than as an answer.
+
 ## Security
 
 Do not commit secrets, production tokens, or private keys. To report a security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,20 @@ change, a new test, or a small feature:
    ```
 
 4. **Make a focused change.** Keep the diff scoped to one thing and avoid unrelated refactors.
-5. **Run the relevant tests** for what you changed. Use the narrowest test slice that covers your change (see [Running Tests Locally](#running-tests-locally) below), or run the full suite with `pytest`.
-6. **Open a pull request** against `main` using the pull request template. Describe what changed, why, and what you tested.
+5. **Sign off your commits** with `git commit -s`. This certifies you have the
+   right to contribute the change under the
+   [Developer Certificate of Origin](DCO.md) - there is no CLA and no rights
+   assignment. CI checks for it, and forgetting is easy to fix after the fact.
+6. **Run the relevant tests** for what you changed. Use the narrowest test slice that covers your change (see [Running Tests Locally](#running-tests-locally) below), or run the full suite with `pytest`.
+7. **Open a pull request** against `main` using the pull request template. Describe what changed, why, and what you tested.
 
-Using an AI coding agent (Claude Code, Cursor, Copilot, or similar)? See
+Using an AI coding agent (Claude Code, Cursor, Copilot, or similar)? Read the
+[AI Policy](.github/AI_POLICY.md) first — it is short, it applies to
+maintainers and their agents too, and it explains what we ask of any
+contribution regardless of how it was written. Then see
 [Working With an AI Coding Agent](#working-with-an-ai-coding-agent-optional)
-below — it is optional tooling this repo supports, not a prerequisite for
-contributing.
+below for the repo's optional agent routing system, which is tooling this repo
+supports rather than a prerequisite for contributing.
 
 ## What You Can Contribute Without Extra Setup
 
@@ -84,6 +91,14 @@ enforced, and your pull request must pass CI regardless of what you ran
 locally.
 
 ## Working With an AI Coding Agent (Optional)
+
+> **Before anything below:** the [AI Policy](.github/AI_POLICY.md) covers what
+> we ask of AI-assisted contributions — you understand and have tested the
+> change, the description matches the diff, and you can discuss it in review.
+> It applies to maintainer agents on `cc/` and `codex/` branches on exactly the
+> same terms. It also explains the boundary question agents get wrong most
+> often here: which changes belong in this repository and which belong in the
+> hosted product.
 
 This repo also maintains a skill/rule routing system that AI coding agents
 (Claude Code, Cursor, Copilot, and similar tools) use to find the right
@@ -183,6 +198,44 @@ introduced. In addition:
 - Keep commits focused.
 - Avoid unrelated refactors in the same PR.
 - Do not include generated noise unless required.
+
+## Developer Certificate of Origin
+
+Mozaiks has **no CLA**. You keep the copyright to your work and assign us
+nothing. Instead, every commit carries a one-line certification that you have
+the right to contribute it, which is what the
+[Developer Certificate of Origin](DCO.md) says.
+
+`git commit -s` adds it for you:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Set `git config user.name` and `git config user.email` first, since the line is
+generated from them.
+
+Forgot? Nothing is lost:
+
+```bash
+# most recent commit
+git commit --amend -s --no-edit && git push --force-with-lease
+
+# every commit on your branch
+git rebase --signoff origin/main && git push --force-with-lease
+```
+
+The `DCO` check on your pull request prints the exact command for your branch
+when it fails.
+
+## Getting Help
+
+- **[Discord](https://discord.gg/Qnsywad9kp)** — questions, design discussion,
+  and a good place to ask before writing code if you are unsure whether an
+  approach fits.
+- **[Docs](https://docs.mozaiks.ai)** — architecture, contracts, and guides.
+- **The issue itself** — if an issue is unclear or its suggested approach looks
+  wrong, say so there. That is useful feedback, not an interruption.
 
 ## Security
 

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,64 @@
+# Developer Certificate of Origin
+
+Contributions to Mozaiks are certified under the Developer Certificate of
+Origin (DCO) 1.1, reproduced verbatim below.
+
+You certify it by adding a `Signed-off-by` line to each commit, which
+`git commit -s` does for you:
+
+```bash
+git commit -s -m "fix: correct the thing"
+```
+
+That appends a line matching your git author identity:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Forgot to sign off? Amend the last commit with `git commit --amend -s --no-edit`
+and force-push, or for several commits use
+`git rebase --signoff origin/main` before pushing.
+
+There is **no CLA** and no rights assignment. Mozaiks is
+[MIT licensed](LICENSE); the DCO only records that you have the right to
+contribute what you submitted. Your contribution stays yours.
+
+---
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/BlocUnited-LLC/mozaiks/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue?logo=python)](https://www.python.org/)
 [![AG2](https://img.shields.io/badge/AG2-1.0_beta-green)](https://github.com/ag2ai/ag2)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/Qnsywad9kp)
 
 </div>
 
@@ -135,6 +136,14 @@ Fork, branch, install development dependencies with `pip install -e ".[dev]"`,
 make a focused change, run the relevant tests, and open a pull request.
 Documentation, most tests, and many CLI changes don't need MongoDB, Node.js,
 or an LLM API key. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full path.
+
+Using an AI coding agent? Welcome — read the
+[AI Policy](.github/AI_POLICY.md) first. It is short, and it applies to
+maintainers and their agents on the same terms.
+
+Questions, or want to talk through an approach before writing code? Join us on
+[Discord](https://discord.gg/Qnsywad9kp).
+
 This project follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License

--- a/docs/contributing/ai-policy.md
+++ b/docs/contributing/ai-policy.md
@@ -1,0 +1,10 @@
+<!--
+  This page is a snippet include. The canonical source is .github/AI_POLICY.md
+  at the repository root, so that GitHub's contributor-facing surfaces and
+  docs.mozaiks.ai never drift apart.
+
+  Edit .github/AI_POLICY.md, not this file. Links inside that file are absolute
+  GitHub URLs precisely so they resolve correctly here as well.
+-->
+
+--8<-- ".github/AI_POLICY.md"

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -21,8 +21,15 @@ Start there.
 
 - **[Local Setup](../local-setup.md)** — source checkout, editable install, and how to run the builder stack from repo
 - **[Architecture](../architecture/index.md)** — how the runtime, app bundle contract, module system, workflows, and frontend fit together
+- **[AI Policy](ai-policy.md)** — what we ask of AI-assisted contributions, and the repository-boundary mistake coding agents make most often here
 - **[Agent Bootstrap Prompt](../agent-bootstrap-prompt.md)** — hand a task to Claude Code, Cursor, or Copilot with the repo-aware bootstrap prompt
 - **[Contributor Guidance Readiness](contributor-guidance-readiness.md)** — current skill coverage, routing map, deferrals, and guidance validation tests
+
+## Getting Help
+
+Ask in [Discord](https://discord.gg/Qnsywad9kp) — questions about an approach
+are welcome before you write the code, and usually save everyone a review
+cycle.
 
 ## Preview the Docs Locally
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,11 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      # Allows docs pages to include canonical files kept outside docs/,
+      # e.g. .github/AI_POLICY.md, so GitHub and the docs site cannot drift.
+      base_path: ["."]
+      check_paths: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
@@ -281,6 +285,7 @@ nav:
           - Refinement Classifier: manual-smoke-tests/refinement-classifier.md
           - Refinement Dry Run: manual-smoke-tests/refinement-dry-run.md
       - AI Coding Agents:
+          - AI Policy: contributing/ai-policy.md
           - Agent Bootstrap Prompt: agent-bootstrap-prompt.md
       - Release:
           - Releasing: releasing.md


### PR DESCRIPTION
## Related issue

N/A — follows from the contribution-workflow discussion after the recent `good first issue` push and the first external PRs (#314, #315, #336).

## Summary

Adds an explicit standard for AI-assisted contributions, a DCO instead of a CLA, three canned triage replies, and the Discord links that were previously nowhere in the repo.

### AI policy

`.github/AI_POLICY.md`, modeled on [ag2ai/ag2's](https://github.com/ag2ai/ag2/blob/main/.github/AI_POLICY.md) and adapted in three ways that matter here:

1. **No CLA** — theirs leans on cla-assistant; ours points at the DCO below.
2. **It binds maintainer agents.** A large share of `main` is agent-authored via `cc/` and `codex/`. The policy says those PRs are held to the same standard and a named human is accountable for each. A policy governing only outside contributors is a toll gate, not a standard — and the asymmetry would be obvious the first time we invoked it against a stranger.
3. **A repository-boundary section.** Handed an issue mentioning entitlement or billing, an agent will propose a grant store, a payout ledger, or a provider webhook handler — none of which belong here. The section names `mozaiksai/core/ports/` as the seam, uses `EntitlementPort` as the worked example, and routes to `OSS_PUBLICATION_POLICY.md` before anyone touches payments, provider execution, deployment, DNS, or credentials.

It also owns something about our own issues: the `good first issue` bodies are written in near-spec detail, which is good for a real first-timer and also makes them easy to hand to an agent without reading the code. The policy asks people to read it anyway, and says noticing that a suggested approach is wrong beats implementing it faithfully.

### DCO instead of a CLA

`DCO.md` plus `.github/workflows/dco.yml`. Contributors sign off per commit with `git commit -s`; there is no rights assignment and no signing gate before a first PR can be opened.

The reasoning for DCO over CLA: MIT already permits the hosted product to use anything contributed here, so a CLA buys essentially one thing — the option to relicense mozaiks away from MIT later. `OSS_PUBLICATION_POLICY.md` already treats MIT publication as a deliberate one-way door, so that option appears to be one we have chosen not to hold. **If that reading is wrong, this is the cheap moment to say so** — a CLA is far easier to adopt at three external contributors than at fifty.

Implementation notes:
- Written inline rather than pulling in a third-party action, matching the Keycloak-realm and source-hygiene gates already in `ci.yml`. No new supply-chain dependency.
- Bot PRs are skipped, so Dependabot (#290, #291) is unaffected.
- Sign-off **presence and shape** are enforced; an exact match against the commit author is not. Legitimate mismatches (GitHub noreply addresses, shared machines, patches relayed under DCO clause (c)) would fail contributors more often than they would protect the project.
- On failure it prints the exact remediation command for that branch, including the right base SHA for `git rebase --signoff`.

### Canned replies and Discord

Three replies, not nineteen. `welcome-first-pr.md` tells a first-time contributor that CI does not start until a maintainer approves the workflow run — currently invisible, and it reads as being ignored. `ai-slop.md` requires the maintainer to fill in specific observations, since a generic version of that message is itself the thing it complains about.

The AI policy publishes to docs.mozaiks.ai through a `pymdownx.snippets` include of the canonical `.github/` file so the two cannot drift (this needed `base_path` on the snippets extension). Discord now appears in the README badges, CONTRIBUTING's Getting Help section, the docs contributing index, and the issue-template chooser.

## Tests run

```
ruff check .                                                  -> All checks passed
python -m pytest tests/test_contributor_guidance_framing.py \
  tests/test_contributor_quickstart.py \
  tests/test_contributor_skill_routing_map.py \
  tests/test_claude_guidance_operating_system.py -q --no-cov   -> 30 passed
python -m mkdocs build --strict                                -> built, no warnings
grep -c "8<--" site/contributing/ai-policy/index.html          -> 0 (snippet resolved)
python scripts/governance_guardrails.py --all --errors-only    -> passed
source hygiene scan (as CI runs it)                            -> 0 violations in changed files
python -c "import yaml; yaml.safe_load(open('.github/workflows/dco.yml'))"  -> parses
```

The DCO check was exercised against four cases before committing, by extracting the inline script and running it over real commit ranges:

| Case | Result |
|---|---|
| Unsigned commit | fails, lists the commit, prints correct `git rebase --signoff <base>` |
| Signed commit | passes |
| Empty range | passes ("No non-merge commits to check") |
| Multi-commit unsigned range | fails, lists each commit separately |

The hygiene scan reports 24 violations repo-wide, all in untracked local scratch directories (`web_shell/.mozaiks-tailwind-sources/`, `.codex-worktrees/`) that CI will not see on a clean checkout. None are from this change.

## Screenshots (if applicable)

N/A — no UI change.

## AI assistance (optional)

Written by Claude Code end to end, including this description. Flagging it because the policy asks for exactly that, and a PR introducing an AI policy should be the first thing held to it.

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [x] If this adds or changes a public contract, the contract is classified and versioned. — N/A, documentation and CI only.
- [x] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included. — N/A. The policy *describes* the existing boundary for contributors; it does not move it. The DCO choice is called out above so it can be overridden deliberately rather than by default.
- [x] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit. — N/A.

---

## ⚠️ Merge this **after** #314, #315, and #336

The DCO check applies to every new PR once it lands, and none of the three open contributor PRs are signed off — no existing commit in this repo is. Merging this first would turn all three red and require their authors to rebase, immediately after we apologized to two of them for a delay that was already our fault.

They are small and close to ready. Land them, then this.

**Also deliberately not auto-merged**, contrary to the usual repo workflow. This is governance text that outside contributors will be held to, so it should have a human read it rather than landing unattended. Please look at the tone of `ai-slop.md` in particular — it has to correct without being hostile, and that is a judgment call I should not make alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
