### PR TITLE
docs(reviews): add CLA decision brief for legal review

### DIFF
--- a/docs/reviews/cla-decision-brief.md
+++ b/docs/reviews/cla-decision-brief.md
@@ -1,0 +1,160 @@
+# CLA Decision Brief
+
+**Status:** open decision, prepared for legal review
+**Prepared:** 2026-08-19
+**Audience:** BlocUnited leadership, and outside counsel engaged to review or draft the agreement
+
+> This document was prepared by a coding agent to make a legal engagement short
+> and cheap. It is **not** legal advice, and nothing in it should be treated as
+> a drafted agreement. Its purpose is to state the facts and the decision
+> clearly enough that counsel can answer in one pass.
+
+---
+
+## 1. The decision
+
+Should contributions to the open-source `mozaiks` repository require a
+Contributor License Agreement, and if so, of what kind?
+
+Today there is none. A Developer Certificate of Origin (DCO) is in flight
+(PR #337) and is a different instrument: it records a contributor's
+representation that they had the right to submit their work, but it transfers
+no rights and does not enable relicensing.
+
+## 2. Why this is being asked now
+
+The value of a CLA is almost entirely **optionality**: it is what makes it
+possible to relicense the project later without needing agreement from every
+past contributor. That option narrows as contributions accumulate and cannot be
+reconstructed after the fact.
+
+The repository is early enough that outside contribution is still a small
+fraction of the codebase. That is what makes this worth deciding now rather
+than later. The cost is not about work already merged; it is that adopting a
+CLA gets more expensive with every contribution accepted without one.
+
+## 3. Current legal posture
+
+- **License:** MIT (`LICENSE`), applied to the whole repository.
+- **Contributions:** accepted with no CLA and no DCO to date. Contributors
+  retain their copyright; the project relies on the implicit inbound=outbound
+  convention that a contribution to an MIT project is offered under MIT.
+- **Publication policy:** `OSS_PUBLICATION_POLICY.md` treats MIT publication as
+  a deliberate one-way door and governs what may be published at all.
+- **Commercial position:** BlocUnited operates a separate, private hosted
+  product built on this framework. MIT already permits that use; **no CLA is
+  needed for the hosted product to build on contributed code.** This is worth
+  stating plainly because it is the most common reason companies believe they
+  need a CLA, and it does not apply here.
+
+## 4. What the CLA would actually be for
+
+The single question that determines whether this is worth doing:
+
+> **Does BlocUnited want to preserve the ability to relicense `mozaiks` away
+> from MIT in the future?**
+
+Scenarios where that option has value:
+
+- Moving to a source-available or reciprocal license (BSL, SSPL, AGPL) to
+  prevent a cloud provider or competitor from reselling the framework as a
+  hosted service.
+- Dual licensing — offering a commercial license alongside the open one.
+- An acquisition or funding process where a buyer's diligence asks who holds
+  rights to the codebase.
+
+Scenarios where it does not:
+
+- Using contributed code in the hosted product. **Already permitted by MIT.**
+- Protecting the proprietary adapters, MozaiksPay, hosting, or operations.
+  Those live in a separate private repository and are unaffected.
+
+## 5. Options
+
+| Option | What it does | Cost |
+|---|---|---|
+| **DCO only** (current direction) | Per-commit certification of provenance. No rights transfer. | Effectively zero. One flag: `git commit -s`. |
+| **Individual CLA (ICLA)** | Contributor grants BlocUnited a broad license, typically including the right to sublicense/relicense. Contributor retains copyright. | Signing gate before any PR merges. Some contributors decline on principle. |
+| **ICLA + Corporate CLA (CCLA)** | Adds a company-level agreement for contributors submitting on an employer's behalf. | As above, plus corporate signatories are slower. |
+| **Copyright assignment** | Contributor transfers copyright outright. | Strongest for the project, most objectionable to contributors. Not recommended. |
+| **DCO + CLA** | Both. Several large projects do this. | Redundant friction; probably unnecessary here. |
+
+The common starting point for options 2 and 3 is the Apache Software
+Foundation's ICLA/CCLA, which many companies adapt. **Adapting a template is
+exactly where counsel is needed** — the entity, jurisdiction, governing law,
+patent grant scope, and the interaction with MIT all have to be right, and a
+CLA copied from another project (for example AG2's, which is drafted for a
+different entity and for Apache-2.0) should not be used.
+
+## 6. Questions for counsel
+
+1. Given MIT outbound and the intent to preserve relicensing optionality, is an
+   ICLA sufficient, or is a CCLA also needed given that contributors may submit
+   from employer-owned time?
+2. Should the grant include an explicit patent license and defensive
+   termination clause?
+3. What governing law and venue are appropriate for BlocUnited LLC?
+4. Does accepting contributions under DCO in the interim create any obstacle to
+   introducing a CLA afterward?
+5. Is any disclosure required regarding AI-assisted contributions, given that a
+   substantial share of the codebase is agent-authored with human sign-off?
+   See `.github/AI_POLICY.md`.
+6. Should the agreement apply only to contributions merged after adoption, and
+   is anything needed to make that boundary explicit?
+
+## 7. Recommended sequencing
+
+1. **Ship the DCO now** (PR #337). It costs nothing, provides immediate
+   provenance value, and does not foreclose a CLA. Question 4 above confirms
+   this assumption before relying on it.
+2. **Engage counsel** with this brief. The ask is narrow: review or adapt an
+   ICLA (and CCLA if advised) for BlocUnited LLC against an MIT-licensed
+   project.
+3. **Enable the gate** once text exists, applying to contributions from that
+   point forward — see the implementation appendix.
+4. **Decide whether the DCO stays** alongside the CLA or is retired.
+
+## 8. What it will cost
+
+Honest accounting, so this is not adopted on optimism:
+
+- **Contributor friction.** Every contributor signs before their first merge.
+  This lands hardest during the current phase, where the project is actively
+  trying to attract its first outside contributors.
+- **Attrition.** A minority of open-source contributors decline CLAs on
+  principle, particularly ones permitting relicensing. Some contributions will
+  be lost. This is a real cost, not a hypothetical one.
+- **Any pull request open when the gate goes live** needs a signature before
+  merging, from a contributor who has already been waiting on review. Clear the
+  queue before switching it on.
+- **Ongoing.** Someone must maintain the signature record and respond when the
+  bot blocks a PR.
+
+None of these are reasons not to do it. They are reasons to decide
+deliberately rather than by default, and to merge the open PRs before the gate
+goes live.
+
+---
+
+## Appendix: implementation
+
+The standard tool is [cla-assistant.io](https://cla-assistant.io) — free for
+open-source projects, stores signatures against a gist, and posts a status
+check on each PR. Setup, once signed text exists:
+
+1. Sign in to cla-assistant.io with the GitHub account that administers
+   `BlocUnited-LLC/mozaiks` and authorize the app. **This step requires a human
+   with org admin rights; it cannot be scripted.**
+2. Create a public gist containing the agreed CLA text.
+3. In cla-assistant, link the gist to the repository and configure the check.
+4. Add the resulting `license/cla` check to the branch protection rules for
+   `main` as a required check.
+5. Update `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` to reference
+   the CLA, and reconcile the DCO wording in `.github/AI_POLICY.md` and
+   `DCO.md`.
+6. Add a `welcome-first-pr` note and a `needs-cla` canned reply under
+   `.github/review/replies/`, matching the existing set.
+
+Steps 5 and 6 are ordinary repository work and can be prepared in advance of
+the legal text. Steps 1 through 4 are gated on a human decision and a signed
+document, and should not be started before then.

--- a/docs/reviews/cla/corporate-cla-draft.md
+++ b/docs/reviews/cla/corporate-cla-draft.md
@@ -87,6 +87,10 @@ License. Nothing in this Agreement obligates BlocUnited to continue
 distributing the Work under the MIT License, and nothing in this Agreement
 revokes or limits any license previously granted to any recipient of the Work.
 
+BlocUnited will continue to make the source code of the Work publicly
+available. This commitment does not restrict the license terms BlocUnited may
+select under this Section.
+
 ### 5. Representation of Authority
 
 You represent that You are legally entitled to grant the above licenses. You

--- a/docs/reviews/cla/corporate-cla-draft.md
+++ b/docs/reviews/cla/corporate-cla-draft.md
@@ -134,10 +134,11 @@ authorized to submit Contributions on Your behalf.
 
 ### 10. Governing Law
 
-**[REVIEW]** — *Must match the Individual CLA. Counsel to set.*
+This Agreement is governed by the laws of the Commonwealth of Pennsylvania,
+United States of America, without regard to its conflict of law provisions.
 
-This Agreement is governed by the laws of [STATE], [COUNTRY], without regard to
-its conflict of law provisions.
+**[REVIEW]** — *Must match the Individual CLA, including any venue clause added
+there.*
 
 ---
 

--- a/docs/reviews/cla/corporate-cla-draft.md
+++ b/docs/reviews/cla/corporate-cla-draft.md
@@ -1,0 +1,180 @@
+# Mozaiks Corporate Contributor License Agreement
+
+**DRAFT — NOT IN FORCE — REQUIRES LEGAL REVIEW BEFORE USE**
+
+Companion to the Individual CLA draft. Adapted from the Apache Software
+Foundation Corporate Contributor License Agreement v2.0. Written by an AI
+assistant, not a lawyer, and not legal advice.
+
+Use this when a contributor is submitting work their employer owns. The
+Individual CLA alone does not solve that case: an employee generally cannot
+grant rights their employer holds, so a signature from someone authorized to
+bind the company is required.
+
+---
+
+## Mozaiks Corporate Contributor License Agreement ("Agreement")
+
+Thank you for your interest in Mozaiks, a project of BlocUnited LLC
+("BlocUnited", "We", or "Us").
+
+This Agreement is between BlocUnited and the entity identified in the signature
+block below ("Corporation"), and clarifies the intellectual property license
+granted with Contributions from the Corporation. It covers Contributions
+submitted by the employees or agents designated by the Corporation.
+
+### 1. Definitions
+
+**"You"** (or **"Your"**) means the Corporation identified below, and all other
+entities that control, are controlled by, or are under common control with that
+entity. For the purposes of this definition, "control" means (i) the power,
+direct or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or
+more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to BlocUnited for inclusion in, or documentation of, any of the products
+owned or managed by BlocUnited (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to BlocUnited or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of,
+BlocUnited for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+BlocUnited and to recipients of software distributed by BlocUnited a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+BlocUnited and to recipients of software distributed by BlocUnited a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+### 4. Outbound Licensing
+
+**[REVIEW]** — *Substantive addition to the standard ASF text; must match
+Section 4 of the Individual CLA exactly.*
+
+You acknowledge and agree that BlocUnited may license the Work, including Your
+Contributions, to third parties under any license terms BlocUnited selects,
+including open-source licenses, source-available licenses, and proprietary or
+commercial licenses, and may change such terms for future distributions of the
+Work.
+
+As of the date of this Agreement, the Work is distributed under the MIT
+License. Nothing in this Agreement obligates BlocUnited to continue
+distributing the Work under the MIT License, and nothing in this Agreement
+revokes or limits any license previously granted to any recipient of the Work.
+
+### 5. Representation of Authority
+
+You represent that You are legally entitled to grant the above licenses. You
+represent further that each employee or agent of the Corporation designated on
+Schedule A below (or in a subsequent written notice to BlocUnited) is
+authorized to submit Contributions on behalf of the Corporation.
+
+### 6. Original Creation
+
+You represent that each Contribution is an original work of the Corporation or
+of a designated employee or agent acting within the scope of their employment
+or engagement. You represent that each Contribution submission includes
+complete details of any third-party license or other restriction (including,
+but not limited to, related patents and trademarks) of which You are aware and
+which is associated with any part of the Contribution.
+
+Where an artificial intelligence tool was used to author or assist in authoring
+any part of a Contribution, You represent that the material has been reviewed
+and You are not aware of any reason it would infringe the rights of a third
+party.
+
+### 7. No Obligation of Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 8. Third-Party Work
+
+Should You wish to submit work that is not an original work of the Corporation,
+You may submit it separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction of which You are
+aware, and conspicuously marking the work as "Submitted on behalf of a
+third-party: [named here]".
+
+### 9. Notification
+
+You agree to notify BlocUnited of any facts or circumstances of which You become
+aware that would make these representations inaccurate in any respect. You
+agree to notify BlocUnited when any designated employee or agent is no longer
+authorized to submit Contributions on Your behalf.
+
+### 10. Governing Law
+
+**[REVIEW]** — *Must match the Individual CLA. Counsel to set.*
+
+This Agreement is governed by the laws of [STATE], [COUNTRY], without regard to
+its conflict of law provisions.
+
+---
+
+## Signature
+
+```
+Corporation name:   ______________________________________________
+
+Corporate address:  ______________________________________________
+                    ______________________________________________
+
+Country:            ______________________________________________
+
+Signed by:          ______________________________________________
+
+Printed name:       ______________________________________________
+
+Title:              ______________________________________________
+
+Email:              ______________________________________________
+
+Date:               ______________________________________________
+```
+
+## Schedule A — Designated Contributors
+
+Employees or agents authorized to submit Contributions on behalf of the
+Corporation. Update by written notice to BlocUnited.
+
+| Full name | GitHub username | Email |
+|---|---|---|
+|  |  |  |
+|  |  |  |
+|  |  |  |
+
+**[REVIEW]** — *An alternative to Schedule A is a clause covering all employees
+by default, which is lower maintenance but grants more broadly. Counsel should
+advise which fits BlocUnited's risk posture. cla-assistant.io does not manage
+Schedule A automatically; corporate signatures are typically handled out of
+band and recorded manually.*

--- a/docs/reviews/cla/corporate-cla-draft.md
+++ b/docs/reviews/cla/corporate-cla-draft.md
@@ -139,10 +139,13 @@ authorized to submit Contributions on Your behalf.
 ### 10. Governing Law
 
 This Agreement is governed by the laws of the Commonwealth of Pennsylvania,
-United States of America, without regard to its conflict of law provisions.
+United States of America, without regard to its conflict of law provisions. The
+state and federal courts located in Bucks County, Pennsylvania shall have
+exclusive jurisdiction over any dispute arising out of or relating to this
+Agreement.
 
-**[REVIEW]** — *Must match the Individual CLA, including any venue clause added
-there.*
+**[REVIEW]** — *Must match the Individual CLA, including whether the venue
+sentence is kept, narrowed to non-exclusive, or dropped.*
 
 ---
 

--- a/docs/reviews/cla/individual-cla-draft.md
+++ b/docs/reviews/cla/individual-cla-draft.md
@@ -86,9 +86,10 @@ the date such litigation is filed.
 ### 4. Outbound Licensing
 
 **[REVIEW]** — *This section is the substantive addition to the standard ASF
-text and is the reason BlocUnited is adopting a CLA at all. Counsel should
-confirm it achieves the intended effect and is enforceable in the governing
-jurisdiction.*
+text and is the confirmed reason BlocUnited is adopting a CLA: preserving the
+option to change the outbound license of the framework in the future. If this
+section does not achieve that, the Agreement has no purpose. Counsel should
+confirm it achieves the intended effect and is enforceable in Pennsylvania.*
 
 You acknowledge and agree that BlocUnited may license the Work, including Your
 Contributions, to third parties under any license terms BlocUnited selects,
@@ -103,12 +104,35 @@ revokes or limits any license previously granted to any recipient of the Work.
 Any version of the Work already distributed under the MIT License remains
 available to its recipients under that license.
 
-**[REVIEW]** — *Consider whether to add a commitment that the Work will remain
-available under an OSI-approved license, or that a relicensing decision
-requires some notice period. Such a commitment is not legally necessary, but
-its absence is the single most common reason contributors refuse to sign a CLA,
-and adding it materially reduces that friction. This is a business decision
-about how much optionality to trade for goodwill.*
+BlocUnited will continue to make the source code of the Work publicly
+available. This commitment does not restrict the license terms BlocUnited may
+select under this Section.
+
+**[REVIEW]** — *The paragraph immediately above is a deliberate business
+choice, not boilerplate, and it can be removed or strengthened. Context:*
+
+*The absence of any commitment is the most common reason contributors decline
+to sign a CLA — what they are actually afraid of is the project going closed.
+But the obvious-looking commitment is a trap. Three graduated options:*
+
+| Option | Contributor comfort | What it forecloses |
+|---|---|---|
+| No commitment | Lowest | Nothing |
+| **Source stays public** (drafted) | Moderate | Going fully closed-source |
+| OSI-approved license guaranteed | Highest | **BSL, SSPL, and every source-available license** |
+
+*The third option is the one to be careful about. BSL and SSPL are not
+OSI-approved, so guaranteeing an OSI-approved license would rule out precisely
+the relicensing move a company with a hosted product is most likely to want —
+the one Elastic, MongoDB, and HashiCorp each made to stop cloud providers
+reselling their software. AGPL is OSI-approved and would remain available, but
+it is a poor substitute for that specific purpose.*
+
+*The middle option is drafted because it preserves BSL, SSPL, dual licensing,
+and commercial terms, while ruling out only the scenario contributors actually
+fear. Counsel should confirm the wording creates the intended obligation and
+no more — in particular that "publicly available" is not read as a commitment
+to a particular license, delivery method, or timeframe.*
 
 ### 5. Representation of Entitlement
 

--- a/docs/reviews/cla/individual-cla-draft.md
+++ b/docs/reviews/cla/individual-cla-draft.md
@@ -192,20 +192,24 @@ aware that would make these representations inaccurate in any respect.
 ### 10. Governing Law
 
 This Agreement is governed by the laws of the Commonwealth of Pennsylvania,
-United States of America, without regard to its conflict of law provisions.
+United States of America, without regard to its conflict of law provisions. The
+state and federal courts located in Bucks County, Pennsylvania shall have
+exclusive jurisdiction over any dispute arising out of or relating to this
+Agreement.
 
 **[REVIEW]** — *Pennsylvania is formally a Commonwealth, and the phrasing above
-reflects that; "State of Pennsylvania" is a common drafting slip. Counsel should
-confirm the wording matches BlocUnited LLC's other agreements.*
+reflects that; "State of Pennsylvania" is a common drafting slip.*
 
-**[REVIEW: venue.]** — *No venue or dispute-resolution clause is included,
-because it depends on the county in which BlocUnited LLC maintains its principal
-place of business, which was not available when this was drafted. Counsel should
-add an exclusive-venue provision naming the appropriate Pennsylvania county, or
-advise that none is wanted. Note that a venue clause requiring an overseas
-contributor to litigate in Pennsylvania is, in practice, another reason people
-decline to sign; consider whether it is worth including at all for an agreement
-of this kind.*
+**[REVIEW: whether to keep the venue sentence at all.]** — *An exclusive-venue
+clause protects BlocUnited from being sued in a distant forum, which is its
+normal purpose. The tradeoff for a CLA specifically is that it asks a
+contributor in, say, Berlin or Bangalore to accept that any dispute is heard in
+Bucks County, and that is a recognized reason people decline to sign an
+agreement they are getting nothing for. Options, in descending order of
+protection: exclusive venue as drafted; non-exclusive (consent to jurisdiction
+without excluding other forums); or governing law only, with no venue clause.
+Disputes under a CLA are rare enough that counsel may reasonably advise the
+lighter options.*
 
 ### 11. Entire Agreement
 

--- a/docs/reviews/cla/individual-cla-draft.md
+++ b/docs/reviews/cla/individual-cla-draft.md
@@ -1,0 +1,240 @@
+# Mozaiks Individual Contributor License Agreement
+
+**DRAFT — NOT IN FORCE — REQUIRES LEGAL REVIEW BEFORE USE**
+
+Prepared 2026-08-19 for BlocUnited LLC. Adapted from the Apache Software
+Foundation Individual Contributor License Agreement v2.0, which is published by
+the ASF for adaptation by other projects. Written by an AI assistant, not a
+lawyer, and not legal advice. Every bracketed placeholder must be filled and
+the whole document reviewed by counsel licensed in the governing jurisdiction
+before it is presented to any contributor.
+
+Items flagged **[REVIEW]** are the ones most likely to need a lawyer's
+judgment rather than a fill-in-the-blank.
+
+---
+
+## Mozaiks Individual Contributor License Agreement ("Agreement")
+
+Thank you for your interest in Mozaiks, a project of BlocUnited LLC
+("BlocUnited", "We", or "Us").
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, BlocUnited must have on file a signed
+Agreement from each Contributor, indicating agreement to the license terms
+below. This license is for Your protection as a Contributor as well as the
+protection of BlocUnited and its users; it does not change Your rights to use
+Your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to BlocUnited. Except for the license
+granted herein to BlocUnited and recipients of software distributed by
+BlocUnited, You reserve all right, title, and interest in and to Your
+Contributions.
+
+### 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with BlocUnited. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+to be a single Contributor. For the purposes of this definition, "control"
+means (i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial ownership
+of such entity.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to BlocUnited for inclusion in, or documentation of, any of the products
+owned or managed by BlocUnited (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to BlocUnited or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of,
+BlocUnited for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+BlocUnited and to recipients of software distributed by BlocUnited a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+BlocUnited and to recipients of software distributed by BlocUnited a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+### 4. Outbound Licensing
+
+**[REVIEW]** — *This section is the substantive addition to the standard ASF
+text and is the reason BlocUnited is adopting a CLA at all. Counsel should
+confirm it achieves the intended effect and is enforceable in the governing
+jurisdiction.*
+
+You acknowledge and agree that BlocUnited may license the Work, including Your
+Contributions, to third parties under any license terms BlocUnited selects,
+including open-source licenses, source-available licenses, and proprietary or
+commercial licenses, and may change such terms for future distributions of the
+Work.
+
+As of the date of this Agreement, the Work is distributed under the MIT
+License. Nothing in this Agreement obligates BlocUnited to continue
+distributing the Work under the MIT License, and nothing in this Agreement
+revokes or limits any license previously granted to any recipient of the Work.
+Any version of the Work already distributed under the MIT License remains
+available to its recipients under that license.
+
+**[REVIEW]** — *Consider whether to add a commitment that the Work will remain
+available under an OSI-approved license, or that a relicensing decision
+requires some notice period. Such a commitment is not legally necessary, but
+its absence is the single most common reason contributors refuse to sign a CLA,
+and adding it materially reduces that friction. This is a business decision
+about how much optionality to trade for goodwill.*
+
+### 5. Representation of Entitlement
+
+You represent that You are legally entitled to grant the above licenses. If
+Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission to
+make Contributions on behalf of that employer, that Your employer has waived
+such rights for Your Contributions to BlocUnited, or that Your employer has
+executed a separate Corporate Contributor License Agreement with BlocUnited.
+
+### 6. Original Creation
+
+You represent that each of Your Contributions is Your original creation (see
+Section 8 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
+
+**[REVIEW]** — *The following paragraph is a non-standard addition addressing
+AI-assisted contributions. It reflects the project's published AI policy, under
+which AI assistance is welcome but the human contributor remains responsible.
+Counsel should confirm the wording does not inadvertently create a warranty
+BlocUnited does not want, or a burden contributors cannot reasonably meet.*
+
+Where You used an artificial intelligence tool to author or assist in authoring
+any part of a Contribution, You represent that You have reviewed the resulting
+material and are not aware of any reason it would infringe the rights of a
+third party. A Contribution is not excluded from this Agreement, nor from the
+representation in this Section, because an artificial intelligence tool was
+used to produce it.
+
+### 7. No Obligation of Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 8. Third-Party Work
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to BlocUnited separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+### 9. Notification
+
+You agree to notify BlocUnited of any facts or circumstances of which You become
+aware that would make these representations inaccurate in any respect.
+
+### 10. Governing Law
+
+**[REVIEW]** — *Counsel must set this. It should match BlocUnited LLC's state
+of formation and any venue provisions used in the company's other agreements.
+Do not guess.*
+
+This Agreement is governed by the laws of [STATE], [COUNTRY], without regard to
+its conflict of law provisions. **[REVIEW: venue / dispute resolution clause,
+if desired.]**
+
+### 11. Entire Agreement
+
+**[REVIEW]** — *Counsel should confirm whether an integration clause is
+appropriate here, and how this Agreement interacts with the project's Developer
+Certificate of Origin sign-off requirement if both remain in effect.*
+
+---
+
+## Acceptance
+
+**[REVIEW]** — *Electronic acceptance via cla-assistant.io records a signature
+as a comment on a pull request from an authenticated GitHub account. Counsel
+should confirm this satisfies signature requirements in the governing
+jurisdiction, and whether the fields below are needed given that GitHub supplies
+identity.*
+
+By signing electronically, or by signing and returning this Agreement, You
+accept and agree to its terms for Your present and future Contributions to
+BlocUnited.
+
+```
+Full name:        ______________________________________________
+
+GitHub username:  ______________________________________________
+
+Email:            ______________________________________________
+
+Postal address:   ______________________________________________
+                  ______________________________________________
+
+Country:          ______________________________________________
+
+Date:             ______________________________________________
+
+Signature:        ______________________________________________
+```
+
+---
+
+## Notes for counsel
+
+1. **Purpose.** BlocUnited operates a private hosted product built on this
+   MIT-licensed framework. MIT already permits that use; no CLA is required for
+   it. The sole purpose of this Agreement is to preserve the ability to change
+   the outbound license of the framework in the future. Section 4 is therefore
+   the operative clause, and the rest is standard ASF text retained for
+   familiarity.
+
+2. **Scope.** The intent is that this Agreement applies to Contributions
+   submitted after its adoption. Please advise whether anything is needed to
+   make that boundary explicit.
+
+3. **Interaction with the DCO.** The project is separately adopting a Developer
+   Certificate of Origin sign-off. Please advise whether both should remain in
+   effect or whether the CLA should supersede it.
+
+4. **Corporate contributors.** A companion Corporate CLA draft accompanies this
+   one. Please advise whether it is needed at the project's current stage.
+
+5. **Deviation from the ASF template.** Sections 4, the AI paragraph in Section
+   6, and Sections 10–11 are additions or changes. Sections 1–3 and 5–9
+   otherwise track ASF ICLA v2.0 closely so that contributors familiar with it
+   can recognize the terms.

--- a/docs/reviews/cla/individual-cla-draft.md
+++ b/docs/reviews/cla/individual-cla-draft.md
@@ -167,13 +167,21 @@ aware that would make these representations inaccurate in any respect.
 
 ### 10. Governing Law
 
-**[REVIEW]** — *Counsel must set this. It should match BlocUnited LLC's state
-of formation and any venue provisions used in the company's other agreements.
-Do not guess.*
+This Agreement is governed by the laws of the Commonwealth of Pennsylvania,
+United States of America, without regard to its conflict of law provisions.
 
-This Agreement is governed by the laws of [STATE], [COUNTRY], without regard to
-its conflict of law provisions. **[REVIEW: venue / dispute resolution clause,
-if desired.]**
+**[REVIEW]** — *Pennsylvania is formally a Commonwealth, and the phrasing above
+reflects that; "State of Pennsylvania" is a common drafting slip. Counsel should
+confirm the wording matches BlocUnited LLC's other agreements.*
+
+**[REVIEW: venue.]** — *No venue or dispute-resolution clause is included,
+because it depends on the county in which BlocUnited LLC maintains its principal
+place of business, which was not available when this was drafted. Counsel should
+add an exclusive-venue provision naming the appropriate Pennsylvania county, or
+advise that none is wanted. Note that a venue clause requiring an overseas
+contributor to litigate in Pennsylvania is, in practice, another reason people
+decline to sign; consider whether it is worth including at all for an agreement
+of this kind.*
 
 ### 11. Entire Agreement
 
@@ -186,10 +194,13 @@ Certificate of Origin sign-off requirement if both remain in effect.*
 ## Acceptance
 
 **[REVIEW]** — *Electronic acceptance via cla-assistant.io records a signature
-as a comment on a pull request from an authenticated GitHub account. Counsel
-should confirm this satisfies signature requirements in the governing
-jurisdiction, and whether the fields below are needed given that GitHub supplies
-identity.*
+as a comment on a pull request from an authenticated GitHub account. The federal
+E-SIGN Act and Pennsylvania's electronic-transactions statute both generally
+give electronic records and signatures the same effect as written ones, so this
+method is likely sufficient, but counsel should confirm rather than rely on this
+note. Counsel should also advise whether the postal address and country fields
+below are needed at all, given that GitHub supplies verified identity and that
+collecting contributors' home addresses carries its own privacy obligations.*
 
 By signing electronically, or by signing and returning this Agreement, You
 accept and agree to its terms for Your present and future Contributions to


### PR DESCRIPTION
## Related issue

N/A — follows from the licensing discussion after PR #337 introduced a DCO.

## Summary

Adds `docs/reviews/cla-decision-brief.md`, a prepared brief for engaging outside counsel on whether `mozaiks` should require a Contributor License Agreement.

**This is a decision document, not an agreement.** It deliberately does not draft CLA text. Adapting an ICLA template is exactly where a lawyer is required — entity, jurisdiction, governing law, patent grant scope, and the interaction with MIT all have to be right, and a CLA copied from another project is drafted for a different entity and a different outbound license.

### What the brief covers

- Current posture: MIT, no CLA, DCO in flight via #337.
- **Separates what a CLA would buy from what MIT already permits.** The hosted product can already build on contributed code under MIT; no CLA is needed for that. This is the most common reason companies believe they need one, and it does not apply here. What a CLA actually buys is the option to relicense later — moving to BSL/SSPL/AGPL, dual licensing, or satisfying acquisition diligence.
- Five instrument options with costs (DCO only, ICLA, ICLA+CCLA, copyright assignment, both).
- Six specific questions for counsel, including whether accepting contributions under DCO in the interim creates any obstacle to introducing a CLA afterward, and whether anything is needed to make "applies to contributions merged after adoption" explicit.
- An implementation appendix for cla-assistant.io, with the steps requiring org-admin action marked as human-gated.

### Why now

A CLA's value is the option to relicense without needing agreement from every past contributor, and that option narrows as contributions accumulate. The point is not anything about work already merged — it is that adoption gets more expensive with every contribution accepted without one. Deciding early is cheaper than deciding late.

### Costs, stated plainly

The brief does not advocate. It records that a CLA means a signing gate on every first contribution, some contributor attrition on principle, and signatures required for whatever sits in the review queue when the gate goes live. Those are reasons to decide deliberately and to clear the queue first, not reasons to skip it.

## Tests run

```
python -m mkdocs build --strict   -> built, no warnings
```

Filed under `docs/reviews/`, which `mkdocs.yml` excludes from publication, matching the other internal planning notes there (`pre-1-0-public-architecture-roadmap.md`, `doc-gap-analysis-2026-07.md`). It does not appear on docs.mozaiks.ai.

## Screenshots (if applicable)

N/A.

## AI assistance (optional)

Written by Claude Code, including this description. The brief says so on its face and disclaims being legal advice, because a document heading to a lawyer should be honest about its provenance.

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [x] If this adds or changes a public contract, the contract is classified and versioned. — N/A, internal document.
- [x] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included. — N/A. It documents an open licensing decision; it does not make one. Adopting a CLA later would be the decision worth recording.
- [x] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit. — N/A.

---

Independent of #337 — no overlapping files. Not auto-merged, since it exists to prompt a decision rather than to land silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
