### PR TITLE
docs(readme): describe what the framework actually provides

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,68 @@ separate from builder workflows.
 Mozaiks is not published as a public PyPI package yet. Install it from a local
 checkout in editable mode.
 
+## What The Framework Gives You
+
+Generation is the visible part. What makes the generated output worth keeping is
+the runtime underneath it, which is the same runtime whether an app was
+generated or hand-written.
+
+### Subscription to entitlement to feature gate
+
+The pattern almost every SaaS rebuilds by hand. In Mozaiks it is a runtime
+primitive: a module action names a capability, and the executor checks it before
+dispatch.
+
+```yaml
+# modules/reports/module.yaml
+actions:
+  - id: export_report
+    description: Export the current report as CSV
+    handler_method: export_report
+    entitlement_gate: reports.export    # checked before the handler runs
+```
+
+`app/config/subscriptions.yaml` declares which plans grant `reports.export`.
+Apps with no subscriptions get `NoOpEntitlementAdapter` and are entirely
+unaffected. Enforcement fails closed: an adapter that errors denies rather than
+grants.
+
+### Ports and adapters, not a framework you are stuck inside
+
+Infrastructure sits behind protocols the runtime declares and never implements
+for you:
+
+| Port | Contract | Ships with |
+|---|---|---|
+| `EntitlementPort` | is this capability granted for this scope? | no-op + config-driven adapters |
+| `ArtifactStore` | read/write named artifact blobs | local filesystem + S3 |
+| `AppBackendPort` | runtime to backend request/emit/health | generic HTTP adapter |
+| `SandboxPort` | isolated execution sessions | Docker adapter |
+| `SslProviderPort` | certificate provisioning | protocol only |
+
+Swap any of them for your own without forking the runtime.
+
+### Contracts that are validated, not conventions that are hoped for
+
+Every canonical YAML shape - modules, actions, events, reactions, pages,
+workflows, data contracts - is backed by a strict typed model and validated
+before it becomes active. A contract that cannot be generated repeatably and
+validated deterministically is not treated as a contract.
+
+### Execution that survives a crash
+
+The workflow queue uses leases with fencing tokens, bounded retry, and
+dead-lettering, so a worker dying mid-run does not strand or duplicate work.
+Module dispatch requires an explicit authority object rather than trusting the
+caller. Tenant isolation goes through one canonical scope filter instead of each
+query hand-rolling its own.
+
+### Apps you can leave with
+
+Generated apps are provider-neutral and self-hostable: a Dockerfile, a compose
+file, an env manifest, and staged data-contract migrations. Nothing requires
+BlocUnited's hosted platform to run.
+
 ## Quickstart
 
 Install Python 3.11+ and Node.js 18+. Studio also needs a reachable MongoDB


### PR DESCRIPTION
## Related issue

N/A — follows from the observation that the issue list and README were underselling what the OSS actually provides.

## Summary

The README led with generation and demos. A technical evaluator reading it had no way to learn that there is an entitlement primitive, a ports seam, contract validation, or crash-safe queue semantics underneath — the parts most likely to make an experienced engineer stop scrolling.

Adds a **What The Framework Gives You** section between "What is Mozaiks?" and the Quickstart, covering:

- **Subscription → entitlement → feature gate** as a runtime primitive, with a real `module.yaml` example showing `entitlement_gate`, and the fail-closed convention.
- **The ports table** — `EntitlementPort`, `ArtifactStore`, `AppBackendPort`, `SandboxPort`, `SslProviderPort` — and what ships for each.
- **Structured-output-first contract validation.**
- **Crash-safe execution** — queue leases with fencing, bounded retry, dead-lettering, explicit dispatch authority.
- **Provider-neutral, self-hostable generated apps.**

## Deliberately untouched

**The demo section stays exactly as it is.** This is purely additive: 62 insertions, 0 deletions.

The quickstart commands, the docs-build recipe, and the Node version line are also untouched, because they are the subject of open contributor issues #322 (PowerShell-only commands), #323 (conflicting docs-build recipes), and #324 (Node 18 vs Vite 8's Node 20 requirement). Editing them here would pull the rug out from under anyone already working on those.

## Two corrections worth flagging

The first draft of this section made two claims that turned out to be false when checked against the source. Both were corrected before committing:

1. `SandboxPort` was listed as "protocol only." It ships an OSS adapter — `mozaiksai/core/adapters/docker_sandbox.py`.
2. Tenancy was described as "enforced at the persistence layer rather than left to each query." That is backwards: scoping is applied at query sites through `build_app_scope_filter`. The line now says what is actually true, which is still good — one canonical filter rather than hand-rolled scoping — just not what I first wrote.

Flagging these because a README that overstates the architecture is worse than one that undersells it, and because the AI policy in #337 asks for exactly this kind of verification against the diff.

## Tests run

```
ruff check .                                                     -> All checks passed
python -m pytest tests/test_contributor_guidance_framing.py \
  tests/test_contributor_quickstart.py -q --no-cov                -> 20 passed
python -m mkdocs build --strict                                   -> built, no warnings
```

Plus a direct contract check — the `module.yaml` example in the README is extracted, parsed with `yaml.safe_load`, and validated against the real `ActionDef` model:

```
VALID  id='export_report'  handler='export_report'  gate='reports.export'
```

So the field names on the front page cannot silently drift from the contract.

That check also surfaced a genuine documentation bug: `docs/guides/configs/subscriptions.md` documents the action field as `action_id`, but `ActionDef` requires `id`. Anyone copying that example gets a validation error. Filed separately rather than fixed here.

## Screenshots (if applicable)

N/A — Markdown only. Worth previewing the rendered README on the branch, since the section includes a table and a fenced YAML block.

## AI assistance (optional)

Written by Claude Code, including this description.

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [x] If this adds or changes a public contract, the contract is classified and versioned. — N/A. It documents existing contracts; it does not add or change one.
- [x] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included. — N/A. Everything described is already public in this repository.
- [x] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit. — N/A.

---

Conflicts with #337, which adds a Discord badge and two paragraphs to the README's Contributing section. Different regions, so it should auto-merge; whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
