### PR TITLE
fix: validate build context before projection

### DIFF
--- a/docs/architecture/workflows/build-context-packs.md
+++ b/docs/architecture/workflows/build-context-packs.md
@@ -114,6 +114,9 @@ Required fields:
 
 Optional fields:
 
+- `description`: short structural registry metadata for human inspection. It is
+  not projected into workflow context variables unless repeated through
+  `values` or an explicit projection source.
 - `pack`: marks the context as a selectable build pack.
 - `pack.version`: required version string for selectable packs.
 - `pack.required_integrations`: connector requirements that selected packs add
@@ -124,7 +127,8 @@ Optional fields:
   API base URLs and client ids may be frontend safe.
 - `capabilities`, `facades`: structured pack metadata for planning agents.
 - `projections.context_variables`: values projected into workflow launch state.
-- `values`: static provider values used by projection rules.
+- `values`: static provider values used by projection rules. Put custom
+  projection inputs here rather than adding free-form top-level keys.
 
 Keep `context.yaml` structural. Do not put human guidance, semantic purpose
 text, generated file mappings, endpoint rewrites, resolver code, build tasks,

--- a/factory_app/build_context/infra/context.yaml
+++ b/factory_app/build_context/infra/context.yaml
@@ -1,7 +1,5 @@
 context_id: infra
-pack_id: infra
-label: Infra Scaffold
-version: 1
+description: Provider-neutral deployment scaffold templates.
 
 applies_to_workflows:
   - AppGenerator

--- a/factory_app/build_context/webapp_builder/context.yaml
+++ b/factory_app/build_context/webapp_builder/context.yaml
@@ -1,34 +1,12 @@
 context_id: webapp_builder
-pack_id: webapp_builder
-label: Web Application
-version: 2
+description: Web application build profile.
 
 applies_to_workflows:
   - AppGenerator
 
-# Context variables projected by this pack at workflow launch time.
-# These seed domain identity into the workflow session so the harness
-# and hooks resolve the correct pack-specific behavior.
-context_variable_projections:
+values:
   dev_pack_id: webapp_builder
   build_task_model: AppBuildTask
-
-# Validation hooks declared by this pack. The middleware loader runs
-# these for the webapp domain; non-webapp packs declare their own set.
-# This replaces the previous always-on hook wiring in middleware.yaml.
-validation_hooks:
-  - id: hook_module_contract_quality_gate
-    agent: ModuleContractQualityAgent
-    function: run_module_contract_quality_gate
-  - id: hook_module_runtime_quality_gate
-    agent: ModuleRuntimeQualityAgent
-    function: run_module_runtime_quality_gate
-  - id: hook_primitive_catalog
-    agent: AppSchemaAgent
-    function: inject_primitive_catalog
-  - id: hook_app_ui_quality_gate
-    agent: AppUIQualityAgent
-    function: run_app_ui_quality_gate
 
 assets:
   - path: templates

--- a/factory_app/workflows/AppGenerator/tools/pack_context_schema.py
+++ b/factory_app/workflows/AppGenerator/tools/pack_context_schema.py
@@ -1,221 +1,27 @@
-"""Schema validation for capability pack context.yaml files.
+"""Compatibility re-export for the canonical build-context schema validator."""
 
-Validates that pack context entries conform to the allowlisted schema before
-catalog content is injected into AG2 reasoning or materialization runs.
-
-This is structural allowlisting — not semantic prompt-injection detection.
-Malformed or untrusted arbitrary YAML must not become free-form prompt context
-merely because it exists in build_context.
-"""
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass, field
-from typing import Any
-
-_SAFE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$")
-
-# Allowlisted keys in context.yaml root
-_ALLOWED_ROOT_KEYS: frozenset[str] = frozenset({
-    "context_id",
-    "applies_to_workflows",
-    "assets",
-    "pack",
-    "capabilities",
-    "facades",
-    "projections",
-})
-
-# Allowlisted keys in the pack: block
-_ALLOWED_PACK_KEYS: frozenset[str] = frozenset({
-    "id",
-    "version",
-    "author",
-    "license",
-    "source",
-    "status",
-    "capability_source",
-    "required_integrations",
-    "deployment_env",
-    "description",
-    "display_name",
-})
-
-_VALID_STATUS: frozenset[str] = frozenset({"active", "inactive", "archived"})
-
-_VALID_CAPABILITY_SOURCES: frozenset[str] = frozenset({
-    "config_file",
-    "managed_capability",
-    "generated_module",
-    "operator_extension",
-    "external_adapter",
-    "framework_pack",
-})
-
-_ALLOWED_ASSET_KEYS: frozenset[str] = frozenset({"path", "kind", "description", "projections"})
-_VALID_ASSET_KINDS: frozenset[str] = frozenset({"catalog", "contract", "templates"})
-
-
-@dataclass
-class PackContextDiagnostic:
-    """A single diagnostic from pack context.yaml validation."""
-
-    field: str
-    message: str
-    severity: str = "error"  # "error" | "warning"
-
-
-@dataclass
-class PackContextValidationResult:
-    """Result of validating a pack context.yaml."""
-
-    pack_id: str
-    valid: bool
-    diagnostics: list[PackContextDiagnostic] = field(default_factory=list)
-
-    @property
-    def errors(self) -> list[PackContextDiagnostic]:
-        return [d for d in self.diagnostics if d.severity == "error"]
-
-    @property
-    def warnings(self) -> list[PackContextDiagnostic]:
-        return [d for d in self.diagnostics if d.severity == "warning"]
-
-
-def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResult:
-    """Validate a pack context.yaml dict against the allowlisted schema.
-
-    Called before any pack context is used for catalog injection into AG2
-    reasoning or template materialization.  Rejects unexpected keys and invalid
-    field values through structural allowlisting.
-
-    Returns a :class:`PackContextValidationResult` with ``valid=True`` when no
-    error-severity diagnostics are found.  Warnings do not fail validation.
-    """
-    diagnostics: list[PackContextDiagnostic] = []
-
-    if not isinstance(context, dict):
-        return PackContextValidationResult(
-            pack_id="",
-            valid=False,
-            diagnostics=[PackContextDiagnostic("root", "context.yaml must be a YAML mapping")],
-        )
-
-    # --- Root key allowlist ---
-    for key in sorted(set(context.keys()) - _ALLOWED_ROOT_KEYS):
-        diagnostics.append(PackContextDiagnostic(
-            field=key,
-            message=(
-                f"Unexpected top-level key '{key}' in context.yaml. "
-                f"Allowed: {sorted(_ALLOWED_ROOT_KEYS)}"
-            ),
-        ))
-
-    assets = context.get("assets")
-    if assets is not None:
-        if not isinstance(assets, list):
-            diagnostics.append(PackContextDiagnostic("assets", "assets must be a list"))
-        else:
-            for index, asset in enumerate(assets):
-                field = f"assets[{index}]"
-                if not isinstance(asset, dict):
-                    diagnostics.append(PackContextDiagnostic(field, "asset must be a mapping"))
-                    continue
-                unknown_asset_keys = sorted(set(asset) - _ALLOWED_ASSET_KEYS)
-                if unknown_asset_keys:
-                    diagnostics.append(PackContextDiagnostic(
-                        field,
-                        f"asset has unsupported fields: {unknown_asset_keys}",
-                    ))
-                asset_path = str(asset.get("path") or "").strip()
-                asset_kind = str(asset.get("kind") or "").strip()
-                if not asset_path:
-                    diagnostics.append(PackContextDiagnostic(f"{field}.path", "asset.path is required"))
-                if asset_kind not in _VALID_ASSET_KINDS:
-                    diagnostics.append(PackContextDiagnostic(
-                        f"{field}.kind",
-                        f"asset.kind must be one of: {sorted(_VALID_ASSET_KINDS)}",
-                    ))
-
-    # --- pack: block ---
-    pack = context.get("pack")
-    if pack is None:
-        # Pack block is optional; contexts like AppGenerator omit it.
-        errors = [d for d in diagnostics if d.severity == "error"]
-        return PackContextValidationResult(
-            pack_id="",
-            valid=len(errors) == 0,
-            diagnostics=diagnostics,
-        )
-
-    if not isinstance(pack, dict):
-        diagnostics.append(PackContextDiagnostic("pack", "'pack' must be a YAML mapping"))
-        return PackContextValidationResult(
-            pack_id="",
-            valid=False,
-            diagnostics=diagnostics,
-        )
-
-    # --- pack.id ---
-    pack_id = str(pack.get("id") or "").strip()
-    if not pack_id:
-        diagnostics.append(PackContextDiagnostic("pack.id", "pack.id is required"))
-    elif not _SAFE_ID_RE.match(pack_id):
-        diagnostics.append(PackContextDiagnostic(
-            "pack.id",
-            f"pack.id '{pack_id}' must match [a-z][a-z0-9_]* "
-            "(dot-separated segments allowed)",
-        ))
-
-    # --- pack.status ---
-    status = str(pack.get("status") or "active").strip()
-    if status not in _VALID_STATUS:
-        diagnostics.append(PackContextDiagnostic(
-            "pack.status",
-            f"pack.status '{status}' must be one of: {sorted(_VALID_STATUS)}",
-        ))
-
-    version = pack.get("version")
-    if version is None or not isinstance(version, str) or not version.strip():
-        diagnostics.append(PackContextDiagnostic("pack.version", "pack.version is required and must be a string"))
-
-    # --- pack.capability_source ---
-    cap_source = pack.get("capability_source")
-    if cap_source is not None:
-        cap_source_str = str(cap_source).strip()
-        if cap_source_str not in _VALID_CAPABILITY_SOURCES:
-            diagnostics.append(PackContextDiagnostic(
-                "pack.capability_source",
-                f"pack.capability_source '{cap_source_str}' is not a known value; "
-                f"expected one of: {sorted(_VALID_CAPABILITY_SOURCES)}",
-            ))
-
-    # --- Optional string identity fields ---
-    for str_field in ("author", "license", "source", "description", "display_name"):
-        val = pack.get(str_field)
-        if val is not None and not isinstance(val, str):
-            diagnostics.append(PackContextDiagnostic(
-                f"pack.{str_field}",
-                f"pack.{str_field} must be a string, got {type(val).__name__}",
-            ))
-
-    # --- Unexpected keys in pack block ---
-    for key in sorted(set(pack.keys()) - _ALLOWED_PACK_KEYS):
-        diagnostics.append(PackContextDiagnostic(
-            f"pack.{key}",
-            f"Unexpected key '{key}' in pack block. Allowed: {sorted(_ALLOWED_PACK_KEYS)}",
-        ))
-
-    errors = [d for d in diagnostics if d.severity == "error"]
-    return PackContextValidationResult(
-        pack_id=pack_id,
-        valid=len(errors) == 0,
-        diagnostics=diagnostics,
-    )
-
+from mozaiksai.core.session.build_context_schema import (
+    ALLOWED_ASSET_KEYS,
+    ALLOWED_PACK_KEYS,
+    ALLOWED_ROOT_KEYS,
+    VALID_ASSET_KINDS,
+    VALID_CAPABILITY_SOURCES,
+    VALID_STATUS,
+    PackContextDiagnostic,
+    PackContextValidationResult,
+    validate_pack_context,
+)
 
 __all__ = [
+    "ALLOWED_ASSET_KEYS",
+    "ALLOWED_PACK_KEYS",
+    "ALLOWED_ROOT_KEYS",
     "PackContextDiagnostic",
     "PackContextValidationResult",
+    "VALID_ASSET_KINDS",
+    "VALID_CAPABILITY_SOURCES",
+    "VALID_STATUS",
     "validate_pack_context",
 ]

--- a/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
+++ b/factory_app/workflows/AppGenerator/tools/resolve_managed_capability_templates.py
@@ -11,15 +11,13 @@ from typing import Any
 import yaml
 from jinja2 import Template
 
-from factory_app.workflows.AppGenerator.tools.pack_context_schema import (
-    validate_pack_context,
-)
 from mozaiksai.core.runtime.app.provenance import resolve_build_timestamp
 from mozaiksai.core.session.build_context import (
     BuildContextError,
     iter_context_assets,
     resolve_context_asset_path,
 )
+from mozaiksai.core.session.build_context_schema import validate_pack_context
 
 logger = logging.getLogger(__name__)
 

--- a/mozaiksai/core/session/build_context.py
+++ b/mozaiksai/core/session/build_context.py
@@ -18,6 +18,8 @@ from typing import Any
 
 import yaml
 
+from mozaiksai.core.session.build_context_schema import validate_pack_context
+
 
 class BuildContextError(RuntimeError):
     """Raised when a workspace build-context file is invalid."""
@@ -78,27 +80,10 @@ def load_build_context(context_path: Path) -> dict[str, Any]:
     if not context_path.exists():
         raise BuildContextError(f"Build context file not found: {context_path}")
     data = _load_yaml_mapping(context_path, label="Build context file")
-    context_id = str(data.get("context_id") or "").strip()
-    if not context_id:
-        raise BuildContextError(f"Build context file must declare context_id: {context_path}")
-    workflows = data.get("workflows")
-    if workflows is not None and not isinstance(workflows, Mapping):
-        raise BuildContextError(f"Build context workflows must be a mapping: {context_path}")
-    applies_to = data.get("applies_to_workflows")
-    if applies_to is not None and not isinstance(applies_to, list):
-        raise BuildContextError(f"Build context applies_to_workflows must be a list: {context_path}")
-    assets = data.get("assets")
-    if not isinstance(assets, list):
-        raise BuildContextError(f"Build context assets must be a list: {context_path}")
-    for index, asset in enumerate(assets):
-        if not isinstance(asset, Mapping):
-            raise BuildContextError(f"Build context asset #{index + 1} must be a mapping: {context_path}")
-        asset_path = str(asset.get("path") or "").strip()
-        asset_kind = str(asset.get("kind") or "").strip()
-        if not asset_path or not asset_kind:
-            raise BuildContextError(
-                f"Build context asset #{index + 1} must declare path and kind: {context_path}"
-            )
+    result = validate_pack_context(data)
+    if not result.valid:
+        error_messages = "; ".join(f"{d.field}: {d.message}" for d in result.errors)
+        raise BuildContextError(f"Build context file failed schema validation: {context_path}: {error_messages}")
     return data
 
 
@@ -224,6 +209,7 @@ def build_provider_values(*, root: Path, config: Mapping[str, Any]) -> dict[str,
         "applies_to_workflows",
         "assets",
         "projections",
+        "values",
         "workflows",
     }
     values: dict[str, Any] = {}

--- a/mozaiksai/core/session/build_context_schema.py
+++ b/mozaiksai/core/session/build_context_schema.py
@@ -1,0 +1,247 @@
+"""Canonical schema validation for build-context ``context.yaml`` files.
+
+Build context is projected into workflow context variables and agent prompts
+before any selected pack reaches materialization. This module is the shared
+structural allowlist for both phases.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+_SAFE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$")
+
+ALLOWED_ROOT_KEYS: frozenset[str] = frozenset({
+    "context_id",
+    "description",
+    "applies_to_workflows",
+    "assets",
+    "pack",
+    "capabilities",
+    "facades",
+    "projections",
+    "values",
+})
+
+ALLOWED_PACK_KEYS: frozenset[str] = frozenset({
+    "id",
+    "version",
+    "author",
+    "license",
+    "source",
+    "status",
+    "capability_source",
+    "required_integrations",
+    "deployment_env",
+    "description",
+    "display_name",
+})
+
+VALID_STATUS: frozenset[str] = frozenset({"active", "inactive", "archived"})
+
+VALID_CAPABILITY_SOURCES: frozenset[str] = frozenset({
+    "config_file",
+    "managed_capability",
+    "generated_module",
+    "operator_extension",
+    "external_adapter",
+    "framework_pack",
+})
+
+ALLOWED_ASSET_KEYS: frozenset[str] = frozenset({"path", "kind", "description", "projections"})
+VALID_ASSET_KINDS: frozenset[str] = frozenset({"catalog", "contract", "templates"})
+
+
+@dataclass
+class PackContextDiagnostic:
+    """A single diagnostic from build-context validation."""
+
+    field: str
+    message: str
+    severity: str = "error"
+
+
+@dataclass
+class PackContextValidationResult:
+    """Result of validating a build-context ``context.yaml`` mapping."""
+
+    pack_id: str
+    valid: bool
+    diagnostics: list[PackContextDiagnostic] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[PackContextDiagnostic]:
+        return [d for d in self.diagnostics if d.severity == "error"]
+
+    @property
+    def warnings(self) -> list[PackContextDiagnostic]:
+        return [d for d in self.diagnostics if d.severity == "warning"]
+
+
+def _require_mapping(value: Any, field: str, diagnostics: list[PackContextDiagnostic]) -> bool:
+    if value is None or isinstance(value, dict):
+        return True
+    diagnostics.append(PackContextDiagnostic(field, f"{field} must be a mapping"))
+    return False
+
+
+def _require_list(value: Any, field: str, diagnostics: list[PackContextDiagnostic]) -> bool:
+    if isinstance(value, list):
+        return True
+    diagnostics.append(PackContextDiagnostic(field, f"{field} must be a list"))
+    return False
+
+
+def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResult:
+    """Validate a build-context ``context.yaml`` dict against the canonical schema."""
+
+    diagnostics: list[PackContextDiagnostic] = []
+
+    if not isinstance(context, dict):
+        return PackContextValidationResult(
+            pack_id="",
+            valid=False,
+            diagnostics=[PackContextDiagnostic("root", "context.yaml must be a YAML mapping")],
+        )
+
+    for key in sorted(set(context.keys()) - ALLOWED_ROOT_KEYS):
+        diagnostics.append(PackContextDiagnostic(
+            field=key,
+            message=(
+                f"Unexpected top-level key '{key}' in context.yaml. "
+                f"Allowed: {sorted(ALLOWED_ROOT_KEYS)}"
+            ),
+        ))
+
+    context_id = str(context.get("context_id") or "").strip()
+    if not context_id:
+        diagnostics.append(PackContextDiagnostic("context_id", "context_id is required"))
+
+    applies_to = context.get("applies_to_workflows")
+    if not _require_list(applies_to, "applies_to_workflows", diagnostics):
+        applies_to = []
+    if isinstance(applies_to, list):
+        for index, workflow_id in enumerate(applies_to):
+            if not str(workflow_id or "").strip():
+                diagnostics.append(PackContextDiagnostic(
+                    f"applies_to_workflows[{index}]",
+                    "workflow id must be a non-empty string",
+                ))
+
+    _require_mapping(context.get("projections"), "projections", diagnostics)
+    _require_mapping(context.get("values"), "values", diagnostics)
+
+    for list_field in ("capabilities", "facades"):
+        value = context.get(list_field)
+        if value is not None and not isinstance(value, list):
+            diagnostics.append(PackContextDiagnostic(list_field, f"{list_field} must be a list"))
+
+    description = context.get("description")
+    if description is not None and not isinstance(description, str):
+        diagnostics.append(PackContextDiagnostic("description", "description must be a string"))
+
+    assets = context.get("assets")
+    if _require_list(assets, "assets", diagnostics) and isinstance(assets, list):
+        for index, asset in enumerate(assets):
+            field = f"assets[{index}]"
+            if not isinstance(asset, dict):
+                diagnostics.append(PackContextDiagnostic(field, "asset must be a mapping"))
+                continue
+            unknown_asset_keys = sorted(set(asset) - ALLOWED_ASSET_KEYS)
+            if unknown_asset_keys:
+                diagnostics.append(PackContextDiagnostic(
+                    field,
+                    f"asset has unsupported fields: {unknown_asset_keys}",
+                ))
+            asset_path = str(asset.get("path") or "").strip()
+            asset_kind = str(asset.get("kind") or "").strip()
+            if not asset_path:
+                diagnostics.append(PackContextDiagnostic(f"{field}.path", "asset.path is required"))
+            if asset_kind not in VALID_ASSET_KINDS:
+                diagnostics.append(PackContextDiagnostic(
+                    f"{field}.kind",
+                    f"asset.kind must be one of: {sorted(VALID_ASSET_KINDS)}",
+                ))
+
+    pack = context.get("pack")
+    if pack is None:
+        errors = [d for d in diagnostics if d.severity == "error"]
+        return PackContextValidationResult(
+            pack_id="",
+            valid=len(errors) == 0,
+            diagnostics=diagnostics,
+        )
+
+    if not isinstance(pack, dict):
+        diagnostics.append(PackContextDiagnostic("pack", "pack must be a mapping"))
+        return PackContextValidationResult(
+            pack_id="",
+            valid=False,
+            diagnostics=diagnostics,
+        )
+
+    pack_id = str(pack.get("id") or "").strip()
+    if not pack_id:
+        diagnostics.append(PackContextDiagnostic("pack.id", "pack.id is required"))
+    elif not _SAFE_ID_RE.match(pack_id):
+        diagnostics.append(PackContextDiagnostic(
+            "pack.id",
+            f"pack.id '{pack_id}' must match [a-z][a-z0-9_]*; dot-separated segments allowed",
+        ))
+
+    status = str(pack.get("status") or "active").strip()
+    if status not in VALID_STATUS:
+        diagnostics.append(PackContextDiagnostic(
+            "pack.status",
+            f"pack.status '{status}' must be one of: {sorted(VALID_STATUS)}",
+        ))
+
+    version = pack.get("version")
+    if version is None or not isinstance(version, str) or not version.strip():
+        diagnostics.append(PackContextDiagnostic("pack.version", "pack.version is required and must be a string"))
+
+    cap_source = pack.get("capability_source")
+    if cap_source is not None:
+        cap_source_str = str(cap_source).strip()
+        if cap_source_str not in VALID_CAPABILITY_SOURCES:
+            diagnostics.append(PackContextDiagnostic(
+                "pack.capability_source",
+                f"pack.capability_source '{cap_source_str}' is not a known value; "
+                f"expected one of: {sorted(VALID_CAPABILITY_SOURCES)}",
+            ))
+
+    for str_field in ("author", "license", "source", "description", "display_name"):
+        value = pack.get(str_field)
+        if value is not None and not isinstance(value, str):
+            diagnostics.append(PackContextDiagnostic(
+                f"pack.{str_field}",
+                f"pack.{str_field} must be a string, got {type(value).__name__}",
+            ))
+
+    for key in sorted(set(pack.keys()) - ALLOWED_PACK_KEYS):
+        diagnostics.append(PackContextDiagnostic(
+            f"pack.{key}",
+            f"Unexpected key '{key}' in pack block. Allowed: {sorted(ALLOWED_PACK_KEYS)}",
+        ))
+
+    errors = [d for d in diagnostics if d.severity == "error"]
+    return PackContextValidationResult(
+        pack_id=pack_id,
+        valid=len(errors) == 0,
+        diagnostics=diagnostics,
+    )
+
+
+__all__ = [
+    "ALLOWED_ASSET_KEYS",
+    "ALLOWED_PACK_KEYS",
+    "ALLOWED_ROOT_KEYS",
+    "PackContextDiagnostic",
+    "PackContextValidationResult",
+    "VALID_ASSET_KINDS",
+    "VALID_CAPABILITY_SOURCES",
+    "VALID_STATUS",
+    "validate_pack_context",
+]

--- a/mozaiksai/core/session/build_context_schema.py
+++ b/mozaiksai/core/session/build_context_schema.py
@@ -119,8 +119,12 @@ def validate_pack_context(context: dict[str, Any]) -> PackContextValidationResul
     if not context_id:
         diagnostics.append(PackContextDiagnostic("context_id", "context_id is required"))
 
+    # Optional: managed-capability packs are selected by capability id and
+    # legitimately omit workflow bindings. Only reject a present-but-wrong type.
     applies_to = context.get("applies_to_workflows")
-    if not _require_list(applies_to, "applies_to_workflows", diagnostics):
+    if applies_to is not None and not _require_list(
+        applies_to, "applies_to_workflows", diagnostics
+    ):
         applies_to = []
     if isinstance(applies_to, list):
         for index, workflow_id in enumerate(applies_to):

--- a/tests/test_build_context_provider.py
+++ b/tests/test_build_context_provider.py
@@ -11,6 +11,7 @@ from mozaiksai.core.session.build_context import (
     merge_build_context,
 )
 from mozaiksai.core.session.launcher import apply_launch_context_provider
+from mozaiksai.core.workflow.context.projection import inject_build_context_projections
 
 
 def _write_yaml(path: Path, data: dict) -> None:
@@ -29,33 +30,36 @@ def _build_context_root(tmp_path: Path) -> Path:
                 "assets": [
                     {"path": "contract.yaml", "kind": "contract"},
                 ],
-                "operator_capabilities": ["enterprise_sso", "audit_export"],
-            "capability_registry": {
-                "sso": {
-                    "capability_pack_id": "enterprise_sso",
-                    "implementation_mode": "external_integration",
-                }
-            },
-            "pack": {
-                "id": "enterprise_sso",
-                "display_name": "Enterprise SSO",
-                "description": "SAML/OIDC login and group sync.",
-                "status": "active",
-            },
-            "capabilities": [{"capability_id": "sso.login"}],
+                "values": {
+                    "operator_capabilities": ["enterprise_sso", "audit_export"],
+                    "capability_registry": {
+                        "sso": {
+                            "capability_pack_id": "enterprise_sso",
+                            "implementation_mode": "external_integration",
+                        }
+                    },
+                },
+                "pack": {
+                    "id": "enterprise_sso",
+                    "version": "0.1.0",
+                    "display_name": "Enterprise SSO",
+                    "description": "SAML/OIDC login and group sync.",
+                    "status": "active",
+                },
+                "capabilities": [{"capability_id": "sso.login"}],
                 "projections": {
-                "context_variables": {
-                    "operator_capabilities": {"from": "operator_capabilities"},
-                    "capability_packs": {"from": "capability_packs"},
-                    "operator_contracts": {"from": "operator_contracts"},
-                    "capability_registry": {"from": "capability_registry"},
-                    "provider_backed_capabilities": {
-                        "from_trigger": "builder_options.provider_backed_capabilities",
-                        "default": [],
+                    "context_variables": {
+                        "operator_capabilities": {"from": "operator_capabilities"},
+                        "capability_packs": {"from": "capability_packs"},
+                        "operator_contracts": {"from": "operator_contracts"},
+                        "capability_registry": {"from": "capability_registry"},
+                        "provider_backed_capabilities": {
+                            "from_trigger": "builder_options.provider_backed_capabilities",
+                            "default": [],
+                        },
                     },
                 },
             },
-        },
     )
     _write_yaml(
         context_root / "contract.yaml",
@@ -147,6 +151,87 @@ def test_load_build_context_rejects_missing_context_id(tmp_path: Path) -> None:
         load_build_context(context_file)
 
 
+def test_load_build_context_rejects_unknown_root_key(tmp_path: Path) -> None:
+    context_file = tmp_path / "build_context" / "AcmeEnterprise" / "context.yaml"
+    _write_yaml(
+        context_file,
+        {
+            "context_id": "acme_operator",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [],
+            "secret_override": "do not project",
+        },
+    )
+
+    with pytest.raises(BuildContextError, match="secret_override"):
+        load_build_context(context_file)
+
+
+def test_load_build_context_rejects_unknown_pack_key(tmp_path: Path) -> None:
+    context_file = tmp_path / "build_context" / "AcmeEnterprise" / "context.yaml"
+    _write_yaml(
+        context_file,
+        {
+            "context_id": "acme_operator",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [],
+            "pack": {
+                "id": "acme_operator",
+                "version": "0.1.0",
+                "hidden_injection": "do not project",
+            },
+        },
+    )
+
+    with pytest.raises(BuildContextError, match="pack.hidden_injection"):
+        load_build_context(context_file)
+
+
+def test_unknown_asset_kind_rejected_before_workflow_projection(tmp_path: Path) -> None:
+    root = tmp_path / "build_context"
+    context_file = root / "AcmeEnterprise" / "context.yaml"
+    _write_yaml(
+        context_file,
+        {
+            "context_id": "acme_operator",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [{"path": "unknown.yaml", "kind": "agent_payload"}],
+            "projections": {
+                "context_variables": {
+                    "operator_payload": {"value": "must not project"},
+                },
+            },
+        },
+    )
+
+    with pytest.raises(BuildContextError, match="asset.kind"):
+        merge_build_context(build_context_root=root, workflow_id="AppGenerator", context_variables={})
+
+
+def test_malformed_assets_do_not_reach_agent_projection(tmp_path: Path) -> None:
+    root = tmp_path / "build_context"
+    context_root = root / "AcmeEnterprise"
+    _write_yaml(
+        context_root / "context.yaml",
+        {
+            "context_id": "acme_operator",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [{"path": "catalog.yaml", "kind": "catalog", "unexpected": True}],
+        },
+    )
+    _write_yaml(context_root / "catalog.yaml", {"items": [{"id": "should_not_render"}]})
+
+    class _Agent:
+        name = "AppPlanAgent"
+        _system_message = "base prompt"
+        context_variables = {"build_context_root": str(root)}
+
+    agent = _Agent()
+    inject_build_context_projections(agent, [])
+
+    assert agent._system_message == "base prompt"
+
+
 def test_load_build_context_rejects_missing_file(tmp_path: Path) -> None:
     with pytest.raises(BuildContextError, match="not found"):
         load_build_context(tmp_path / "build_context" / "AcmeEnterprise" / "context.yaml")
@@ -161,7 +246,7 @@ def test_inactive_pack_is_not_projected(tmp_path: Path) -> None:
             "context_id": "operator",
             "applies_to_workflows": ["AppGenerator"],
             "assets": [],
-            "pack": {"id": "mozaikspay", "status": "inactive"},
+            "pack": {"id": "mozaikspay", "version": "0.1.0", "status": "inactive"},
             "projections": {
                 "context_variables": {"capability_packs": {"from": "capability_packs"}},
             },
@@ -213,4 +298,71 @@ def test_factory_workflow_catalog_yamls_exist() -> None:
     }
     for path in expected:
         assert path.exists(), f"Missing factory workflow catalog: {path}"
+
+
+def test_all_first_party_build_contexts_load() -> None:
+    factory_build_context = Path(__file__).resolve().parents[1] / "factory_app" / "build_context"
+
+    for context_path in sorted(factory_build_context.glob("*/context.yaml")):
+        loaded = load_build_context(context_path)
+        assert loaded["context_id"]
+
+
+def test_load_and_materialization_accept_same_representative_pack(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        resolve_templates_for_pack,
+    )
+
+    pack_root = tmp_path / "build_context" / "valid_pack"
+    _write_yaml(
+        pack_root / "context.yaml",
+        {
+            "context_id": "valid_pack",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [{"path": "templates", "kind": "templates"}],
+            "pack": {
+                "id": "valid_pack",
+                "version": "0.1.0",
+                "status": "active",
+                "capability_source": "generated_module",
+            },
+        },
+    )
+    template = pack_root / "templates" / "modules" / "valid_pack" / "module.yaml"
+    template.parent.mkdir(parents=True)
+    template.write_text("module_id: valid_pack\n", encoding="utf-8")
+
+    assert load_build_context(pack_root / "context.yaml")["context_id"] == "valid_pack"
+    files = resolve_templates_for_pack(pack_root, "valid_pack")
+    assert files == [{"filename": "modules/valid_pack/module.yaml", "content": "module_id: valid_pack\n"}]
+
+
+def test_load_and_materialization_reject_same_representative_pack(tmp_path: Path) -> None:
+    from factory_app.workflows.AppGenerator.tools.resolve_managed_capability_templates import (
+        ManagedCapabilityTemplateError,
+        resolve_templates_for_pack,
+    )
+
+    pack_root = tmp_path / "build_context" / "invalid_pack"
+    _write_yaml(
+        pack_root / "context.yaml",
+        {
+            "context_id": "invalid_pack",
+            "applies_to_workflows": ["AppGenerator"],
+            "assets": [{"path": "templates", "kind": "templates"}],
+            "pack": {
+                "id": "invalid_pack",
+                "version": "0.1.0",
+                "status": "active",
+                "capability_source": "generated_module",
+                "hidden_injection": "reject",
+            },
+        },
+    )
+    (pack_root / "templates").mkdir()
+
+    with pytest.raises(BuildContextError, match="pack.hidden_injection"):
+        load_build_context(pack_root / "context.yaml")
+    with pytest.raises(ManagedCapabilityTemplateError, match="schema validation"):
+        resolve_templates_for_pack(pack_root, "invalid_pack")
 

--- a/tests/test_factory_build_context_contract.py
+++ b/tests/test_factory_build_context_contract.py
@@ -93,7 +93,7 @@ def test_factory_build_context_uses_named_context_roots() -> None:
 
 
 def test_context_yaml_is_structural_not_semantic_guidance() -> None:
-    semantic_context_fields = {"description", "purpose", "templates"}
+    semantic_context_fields = {"purpose", "templates"}
     semantic_projection_fields = {"purpose", "description"}
 
     for context_path in FACTORY_BUILD_CONTEXT.glob("*/context.yaml"):

--- a/tests/test_managed_capability_template_expansion.py
+++ b/tests/test_managed_capability_template_expansion.py
@@ -48,6 +48,7 @@ def _write_pack(root: Path, pack_id: str, files: dict[str, str], *, status: str 
         yaml.safe_dump(
             {
                 "context_id": pack_id,
+                "applies_to_workflows": ["AppGenerator"],
                 "assets": [
                     {"path": "templates/", "kind": "templates"},
                 ],


### PR DESCRIPTION
## Summary

- Move build-context `context.yaml` structural validation into `mozaiksai.core.session.build_context_schema` so discovery/projection and materialization share one canonical contract.
- Make `load_build_context()` fail closed on unknown root keys, unknown pack keys, unknown asset kinds, and malformed asset declarations before anything reaches workflow context or agent prompt projection.
- Keep the AppGenerator-local validator path as a compatibility re-export only; no duplicate allowlists.
- Canonicalize the legacy `infra` and `webapp_builder` first-party `context.yaml` metadata without changing templates or materialized outputs.

This links #338 only as a pre-MCP contract-hardening prerequisite. It does not implement MCP runtime code, generated-application MCP bindings, capability resolution, connection profiles, or new binding kinds.

## Tests

- `python -m pytest tests/test_build_context_provider.py tests/test_build_context_helpers.py tests/test_factory_build_context_contract.py tests/test_community_pack_foundation.py --no-cov -q`
- `python -m pytest tests/test_managed_capability_template_expansion.py tests/test_resolve_managed_capability_templates_helpers.py tests/test_appgenerator_capability_pack_selection.py --no-cov -q`
- PowerShell-resolved broader build-context/factory suite: `python -m pytest @paths --no-cov -q` over `test_build_context_*.py`, `test_hook_*context*.py`, `test_factory_build_context_contract.py`, `test_factory_workflow_context_contracts.py`, `test_pack_schema_models.py`, `test_pack_schema_helpers.py`, `test_pack_config_paths.py`, `test_pack_config_helpers.py`
- `ruff check .`
- `python scripts/governance_guardrails.py --all --errors-only`
- `git diff --check`