### PR TITLE
fix(runtime): order context replay persistence authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Fixed workflow run context persistence and replay to require resolved workflow
+  declarations, omit non-persisted authority fields, reject malformed known
+  values, safely drop stale unknown keys, and surface required storage failures.
 - Fixed `validate_module_implementation_contract` to resolve handler methods through single-level base class inheritance within the same module's `backend/` directory. The `base_handler.py`/`handler.py` split pattern previously caused the acceptance gate to report every action as missing a handler method on the thin workspace subclass.
 - Fixed messaging and support pack `module.yaml` handler entrypoints: after the `base_handler.py`/`handler.py` split renamed workspace subclasses from `MessagesModule`/`SupportModule` to `MessagesHandler`/`SupportHandler`, `module.yaml` still declared the old class names, causing `ModuleLoadError` at runtime and in tests.
 - Fixed the MozaiksPay generated billing and usage page contract to emit canonical `analytics_dashboard` page types through both the build-context pack hints and the replayed page schema fixtures, removing stale `dashboard` page-type drift from the generated SaaS path.

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -122,6 +122,10 @@ def _context_authority_policy_for_workflow(workflow_name: str):
         workflow_name=workflow_name,
         definitions=definitions,
         transition_rules=transition_rules,
+        # An unloaded workflow yields an empty config, which would otherwise
+        # look identical to "every stored key is stale" and silently discard
+        # the whole persisted context.
+        declarations_resolved=bool(workflow_config),
     )
 
 
@@ -442,9 +446,14 @@ class AG2PersistenceManager:
                     session_doc[k] = v
 
             session_doc = dual_write_app_scope(session_doc, resolved_app_id)
-            await coll.insert_one(session_doc)
+            result = await coll.insert_one(session_doc)
+            if getattr(result, "acknowledged", True) is False:
+                raise RuntimeError(
+                    f"failed to create chat session for chat_id={chat_id}: write was not acknowledged"
+                )
         except Exception as e:  # pragma: no cover
             logger.error("Failed to create chat session %s: %s", chat_id, e, exc_info=True)
+            raise
 
     async def fetch_chat_session_extra_context(
         self,
@@ -469,56 +478,81 @@ class AG2PersistenceManager:
         if not resolved_app_id:
             raise ValueError("app_id is required")
 
+        clean_workflow_name = str(workflow_name or "").strip()
+        query = {"_id": chat_id, **build_app_scope_filter(str(resolved_app_id))}
+        if clean_workflow_name:
+            query["workflow_name"] = clean_workflow_name
+
         try:
             coll = await self._coll()
             doc = await coll.find_one(
-                {"_id": chat_id, **build_app_scope_filter(str(resolved_app_id))},
+                query,
                 {"messages": 0},
             )
-            if not isinstance(doc, dict):
-                return {}
-
-            protected = {
-                "_id",
-                "chat_id",
-                "app_id",
-                "workflow_name",
-                "user_id",
-                "status",
-                "created_at",
-                "last_updated_at",
-                "last_sequence",
-                "messages",
-                "workflow_ui_state",
-                "last_artifact",
-                "pending_input_request",
-            }
-            extra: dict[str, Any] = {}
-            for k, v in doc.items():
-                if not isinstance(k, str) or not k.strip():
-                    continue
-                if k in protected:
-                    continue
-                extra[k] = v
-            if workflow_name:
-                try:
-                    from mozaiksai.core.workflow.context.authority import (
-                        PERSISTED_REPLAY_WRITER,
-                        ContextAuthorityError,
-                    )
-
-                    policy = _context_authority_policy_for_workflow(str(workflow_name))
-                    extra = policy.filter_for_replay(extra, writer_id=PERSISTED_REPLAY_WRITER)
-                except ContextAuthorityError:
-                    raise
-                except Exception as policy_err:
-                    logger.debug("[FETCH_EXTRA_CONTEXT] Authority policy unavailable workflow=%s: %s", workflow_name, policy_err)
-            return extra
-        except ContextAuthorityError:
-            raise
         except Exception as e:  # pragma: no cover
-            logger.debug("[FETCH_EXTRA_CONTEXT] Failed chat_id=%s: %s", chat_id, e)
+            raise RuntimeError(
+                f"failed to fetch persisted workflow context for chat_id={chat_id}"
+            ) from e
+
+        if not isinstance(doc, dict):
             return {}
+
+        protected = {
+            "_id",
+            "chat_id",
+            "app_id",
+            "ag2_stream_id",
+            "workflow_name",
+            "user_id",
+            "status",
+            "created_at",
+            "last_updated_at",
+            "last_sequence",
+            "session_version",
+            "messages",
+            "workflow_ui_state",
+            "last_artifact",
+            "pending_input_request",
+        }
+        extra: dict[str, Any] = {}
+        for k, v in doc.items():
+            if not isinstance(k, str) or not k.strip():
+                continue
+            if k in protected:
+                continue
+            extra[k] = v
+        if not extra:
+            return {}
+        if not clean_workflow_name:
+            raise ContextAuthorityError(
+                "context_authority.workflow_required workflow=<missing> op=replay"
+            )
+
+        try:
+            from mozaiksai.core.workflow.context.authority import PERSISTED_REPLAY_WRITER
+
+            policy = _context_authority_policy_for_workflow(clean_workflow_name)
+        except Exception as e:  # pragma: no cover
+            if isinstance(e, ContextAuthorityError):
+                raise
+            raise ContextAuthorityError(
+                f"context_authority.policy_unavailable workflow={clean_workflow_name} op=replay"
+            ) from e
+
+        replay_diagnostics: list[str] = []
+        filtered = policy.filter_for_replay(
+            extra,
+            writer_id=PERSISTED_REPLAY_WRITER,
+            diagnostics=replay_diagnostics,
+        )
+        if replay_diagnostics:
+            logger.debug(
+                "[FETCH_EXTRA_CONTEXT] Replay diagnostics workflow=%s chat_id=%s diagnostics=%s",
+                clean_workflow_name,
+                chat_id,
+                replay_diagnostics,
+            )
+        return filtered
 
     async def persist_context_variables(
         self,
@@ -540,6 +574,27 @@ class AG2PersistenceManager:
         if not isinstance(variables, dict) or not variables:
             return
 
+        from mozaiksai.core.workflow.context.authority import ContextAuthorityError
+
+        clean_workflow_name = str(workflow_name or "").strip()
+        if not clean_workflow_name:
+            raise ContextAuthorityError(
+                "context_authority.workflow_required workflow=<missing> op=persist"
+            )
+        try:
+            policy = _context_authority_policy_for_workflow(clean_workflow_name)
+        except Exception as policy_err:
+            if isinstance(policy_err, ContextAuthorityError):
+                raise
+            raise ContextAuthorityError(
+                f"context_authority.policy_unavailable workflow={clean_workflow_name} op=persist"
+            ) from policy_err
+        if not policy.declarations_resolved:
+            raise ContextAuthorityError(
+                f"context_authority.unresolved_declarations workflow={clean_workflow_name} "
+                "writer=persisted_replay op=persist"
+            )
+
         protected = {
             "_id",
             "chat_id",
@@ -556,23 +611,29 @@ class AG2PersistenceManager:
             "last_artifact",
             "pending_input_request",
         }
-        safe_updates: dict[str, Any] = {}
-        policy = None
-        if workflow_name:
-            try:
-                policy = _context_authority_policy_for_workflow(str(workflow_name))
-            except Exception as policy_err:
-                logger.debug("[PERSIST_CONTEXT_VARIABLES] Authority policy unavailable workflow=%s: %s", workflow_name, policy_err)
+        candidate_updates: dict[str, Any] = {}
         for key, value in variables.items():
             if not isinstance(key, str) or not key.strip() or key in protected:
                 continue
-            if policy is not None:
-                from mozaiksai.core.workflow.context.authority import PERSISTED_REPLAY_WRITER
+            candidate_updates[key] = value
+        if not candidate_updates:
+            return
 
-                policy.require_can_write(key, writer_id=PERSISTED_REPLAY_WRITER)
-                authority = policy.variables.get(key)
-                if authority is not None and not authority.persisted:
-                    continue
+        persist_diagnostics: list[str] = []
+        candidate_updates = policy.filter_for_persistence(
+            candidate_updates,
+            diagnostics=persist_diagnostics,
+        )
+        if persist_diagnostics:
+            logger.debug(
+                "[PERSIST_CONTEXT_VARIABLES] Persistence diagnostics workflow=%s chat_id=%s diagnostics=%s",
+                clean_workflow_name,
+                chat_id,
+                persist_diagnostics,
+            )
+
+        safe_updates: dict[str, Any] = {}
+        for key, value in candidate_updates.items():
             safe_updates[key] = deepcopy(value)
 
         if not safe_updates:
@@ -580,14 +641,24 @@ class AG2PersistenceManager:
 
         safe_updates["last_updated_at"] = datetime.now(UTC)
 
-        try:
-            coll = await self._coll()
-            await coll.update_one(
-                {"_id": chat_id, **build_app_scope_filter(str(resolved_app_id))},
-                {"$set": safe_updates, "$inc": {"session_version": 1}},
+        coll = await self._coll()
+        result = await coll.update_one(
+            {
+                "_id": chat_id,
+                **build_app_scope_filter(str(resolved_app_id)),
+                "workflow_name": clean_workflow_name,
+            },
+            {"$set": safe_updates, "$inc": {"session_version": 1}},
+        )
+        if getattr(result, "acknowledged", True) is False:
+            raise RuntimeError(
+                f"failed to persist workflow context for chat_id={chat_id}: write was not acknowledged"
             )
-        except Exception as e:  # pragma: no cover
-            logger.debug("[PERSIST_CONTEXT_VARIABLES] Failed chat_id=%s: %s", chat_id, e)
+        matched_count = getattr(result, "matched_count", None)
+        if matched_count is not None and matched_count == 0:
+            raise RuntimeError(
+                f"failed to persist workflow context for chat_id={chat_id}: scoped session was not found"
+            )
 
     async def create_general_chat_session(
         self,

--- a/mozaiksai/core/transport/workflow_bridge.py
+++ b/mozaiksai/core/transport/workflow_bridge.py
@@ -37,15 +37,16 @@ def _persist_context_kwargs(
     app_id: str,
     variables: dict[str, Any],
     workflow_name: str | None,
-    persistence_manager: Any,
 ) -> dict[str, Any]:
+    resolved_workflow_name = str(workflow_name or "").strip()
+    if not resolved_workflow_name:
+        raise ValueError("workflow_name is required to persist workflow context")
     kwargs: dict[str, Any] = {
         "chat_id": chat_id,
         "app_id": app_id,
+        "workflow_name": resolved_workflow_name,
         "variables": variables,
     }
-    if workflow_name and persistence_manager.__class__.__name__ == "AG2PersistenceManager":
-        kwargs["workflow_name"] = workflow_name
     return kwargs
 
 
@@ -156,32 +157,38 @@ class WorkflowBridgeMixin:
 
         manager = getattr(self, "_derived_context_managers", {}).get(chat_id)
         if manager is None:
+            persisted_context: dict[str, Any] = {}
+            if persistence_manager is not None:
+                persisted_context = await persistence_manager.fetch_chat_session_extra_context(
+                    chat_id=chat_id,
+                    app_id=str(app_id),
+                    workflow_name=str(workflow_name),
+                )
             try:
                 from mozaiksai.core.workflow.context.adapter import create_context_container
                 from mozaiksai.core.workflow.context.authority import build_context_authority_policy
                 from mozaiksai.core.workflow.context.derived import DerivedContextManager
+                from mozaiksai.core.workflow.execution.run_bootstrap import (
+                    merge_persisted_extra_context,
+                )
                 from mozaiksai.core.workflow.workflow_manager import workflow_manager
 
-                persisted_context: dict[str, Any] = {}
-                if persistence_manager is not None:
-                    persisted_context = await persistence_manager.fetch_chat_session_extra_context(
-                        chat_id=chat_id,
-                        app_id=str(app_id),
-                        workflow_name=str(workflow_name),
-                    )
                 workflow_config = workflow_manager.get_config(str(workflow_name)) or {}
                 authority_policy = build_context_authority_policy(
                     workflow_name=str(workflow_name),
                     definitions=(workflow_config.get("context_variables") or {}).get("definitions") or {},
                     transition_rules=(workflow_config.get("transition_graph") or {}).get("transition_rules") or [],
                 )
+                context_container = create_context_container(
+                    initial={},
+                    authority_policy=authority_policy,
+                )
+                if persisted_context:
+                    merge_persisted_extra_context(context_container, persisted_context)
                 manager = DerivedContextManager(
                     str(workflow_name),
                     {},
-                    create_context_container(
-                        initial=persisted_context,
-                        authority_policy=authority_policy,
-                    ),
+                    context_container,
                 )
             except Exception as err:
                 logger.debug("[SMART_ROUTING] Failed to build user_text manager for %s: %s", chat_id, err)
@@ -197,18 +204,14 @@ class WorkflowBridgeMixin:
             return {}
 
         if updated and persistence_manager is not None:
-            try:
-                await persistence_manager.persist_context_variables(
-                    **_persist_context_kwargs(
-                        chat_id=chat_id,
-                        app_id=str(app_id),
-                        workflow_name=str(workflow_name),
-                        variables=updated,
-                        persistence_manager=persistence_manager,
-                    )
+            await persistence_manager.persist_context_variables(
+                **_persist_context_kwargs(
+                    chat_id=chat_id,
+                    app_id=str(app_id),
+                    workflow_name=str(workflow_name),
+                    variables=updated,
                 )
-            except Exception as err:
-                logger.debug("[SMART_ROUTING] Failed persisting user_text updates for %s: %s", chat_id, err)
+            )
 
         return updated
 
@@ -594,18 +597,14 @@ class WorkflowBridgeMixin:
         )
 
         if ctx:
-            try:
-                await pm.persist_context_variables(
-                    **_persist_context_kwargs(
-                        chat_id=chat_id,
-                        app_id=app_id,
-                        workflow_name=workflow_name,
-                        variables=ctx,
-                        persistence_manager=pm,
-                    )
+            await pm.persist_context_variables(
+                **_persist_context_kwargs(
+                    chat_id=chat_id,
+                    app_id=app_id,
+                    workflow_name=workflow_name,
+                    variables=ctx,
                 )
-            except Exception as persist_err:
-                logger.debug("LIVE_AG2_CONTEXT_PERSIST_FAILED chat=%s: %s", chat_id, persist_err)
+            )
 
         run_failed = runner_result.status is RunStatus.FAILED
         awaiting_user_input = runner_result.status is RunStatus.PAUSED

--- a/mozaiksai/core/workflow/context/adapter.py
+++ b/mozaiksai/core/workflow/context/adapter.py
@@ -16,10 +16,16 @@ Returned object supports:
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
-from .authority import RUNTIME_SYSTEM_WRITER, ContextAuthorityPolicy, ContextWriterId
+from .authority import (
+    PERSISTED_REPLAY_WRITER,
+    RUNTIME_SYSTEM_WRITER,
+    ContextAuthorityError,
+    ContextAuthorityPolicy,
+    ContextWriterId,
+)
 from .frozen import detach, freeze
 
 logger = logging.getLogger(__name__)
@@ -50,41 +56,6 @@ class _RuntimeContextVariables:
             policy.require_can_write(key, writer_id=writer_id, operation="set")
         self.__data[key] = detach(value)
 
-        # Auto-persist if context is bound to a session
-        if self._chat_id and self._app_id:
-            try:
-                import asyncio
-
-                from mozaiksai.core.data.persistence.persistence_manager import (
-                    AG2PersistenceManager,
-                )
-                # Fire and forget persistence to avoid blocking the runtime call path.
-                # Errors are logged at WARNING so operators can detect persistence drift
-                # without crashing the active workflow.
-                pm = AG2PersistenceManager()
-                _task = asyncio.create_task(pm.persist_context_variables(
-                    chat_id=self._chat_id,
-                    app_id=self._app_id,
-                    variables=self.snapshot(),
-                ))
-                _task.add_done_callback(
-                    lambda t: logger.warning(
-                        "CONTEXT_PERSIST_FAILED chat=%s app=%s: %s",
-                        self._chat_id,
-                        self._app_id,
-                        t.exception(),
-                    )
-                    if not t.cancelled() and t.exception() is not None
-                    else None
-                )
-            except Exception as exc:
-                logger.warning(
-                    "CONTEXT_PERSIST_TASK_CREATION_FAILED chat=%s app=%s: %s",
-                    self._chat_id,
-                    self._app_id,
-                    exc,
-                )
-
     def remove(self, key: str) -> bool:
         policy = getattr(self, "_mozaiks_context_authority_policy", None)
         writer_id = getattr(self, "_mozaiks_context_writer_id", RUNTIME_SYSTEM_WRITER)
@@ -102,6 +73,33 @@ class _RuntimeContextVariables:
     def snapshot(self) -> dict[str, Any]:
         data = detach(self.__data)
         return data if isinstance(data, dict) else {}
+
+    def _hydrate_persisted_context(
+        self,
+        values: Mapping[str, Any],
+    ) -> None:
+        """Validate and atomically hydrate a persisted replay snapshot."""
+
+        policy = self._mozaiks_context_authority_policy
+        if not isinstance(policy, ContextAuthorityPolicy):
+            raise ContextAuthorityError("context_authority.replay_policy_unavailable")
+
+        diagnostics: list[str] = []
+        accepted = policy.filter_for_replay(
+            values,
+            writer_id=PERSISTED_REPLAY_WRITER,
+            diagnostics=diagnostics,
+        )
+        prepared = detach(accepted)
+        if not isinstance(prepared, dict):  # pragma: no cover - detach preserves mappings
+            raise ContextAuthorityError("context_authority.invalid_replay_snapshot")
+
+        new_data = dict(self.__data)
+        new_data.update(prepared)
+        self.__data = new_data
+
+        for diagnostic in diagnostics:
+            logger.debug("[CONTEXT_REPLAY] %s", diagnostic)
 
     def to_dict(self) -> dict[str, Any]:
         return self.snapshot()
@@ -128,6 +126,17 @@ def create_context_container(
         authority_policy=authority_policy,
         writer_id=writer_id,
     )
+
+
+def _hydrate_persisted_context(
+    context: Any,
+    values: Mapping[str, Any],
+) -> None:
+    """Trusted runtime entry point for persisted loader-context hydration."""
+
+    if type(context) is not _RuntimeContextVariables:
+        raise TypeError("persisted context hydration requires the canonical runtime context container")
+    context._hydrate_persisted_context(values)
 
 __all__ = ["create_context_container"]
 

--- a/mozaiksai/core/workflow/context/authority.py
+++ b/mozaiksai/core/workflow/context/authority.py
@@ -99,7 +99,6 @@ _ORDINARY_MUTATION_WRITERS = {
     TOOL_WRITEBACK_WRITER,
     UI_RESPONSE_TRIGGER_WRITER,
     USER_TEXT_TRIGGER_WRITER,
-    PERSISTED_REPLAY_WRITER,
     TASK_BATCH_WRITER,
     STRUCTURED_OUTPUT_WRITER,
     LIFECYCLE_TOOL_WRITER,
@@ -184,6 +183,7 @@ class ContextVariableAuthority:
     routing: bool
     authorization: bool
     writer_ids: frozenset[ContextWriterId] = field(default_factory=frozenset)
+    value_type: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,6 +192,11 @@ class ContextAuthorityPolicy:
 
     workflow_name: str
     variables: Mapping[str, ContextVariableAuthority]
+    # False when the caller could not resolve this workflow's declarations at
+    # all (for example the workflow is not loaded in this process). An empty
+    # declaration set is NOT the same as "this key is stale": the former must
+    # fail closed so durable state is never silently discarded wholesale.
+    declarations_resolved: bool = True
 
     def require_can_write(self, key: str, *, writer_id: ContextWriterId, operation: str = "set") -> None:
         clean_key = _clean_key(key)
@@ -214,6 +219,8 @@ class ContextAuthorityPolicy:
             return False
         if writer_id == RUNTIME_SYSTEM_WRITER:
             return True
+        if writer_id == PERSISTED_REPLAY_WRITER:
+            return False
         if authority.authority_class is ContextAuthorityClass.IMMUTABLE_RUNTIME_AUTHORITY:
             return writer_id == RUNTIME_SYSTEM_WRITER
         if writer_id == AGENT_TEXT_WRITER:
@@ -232,16 +239,108 @@ class ContextAuthorityPolicy:
             return writer_id in authority.writer_ids
         return writer_id in _ORDINARY_MUTATION_WRITERS
 
-    def filter_for_replay(self, values: Mapping[str, Any], *, writer_id: ContextWriterId) -> dict[str, Any]:
+    def _require_resolved_declarations(self, values: Mapping[str, Any], *, operation: str) -> None:
+        """Fail closed when this workflow's declarations were never resolved.
+
+        Dropping an individual unknown key is correct: it is stale stored state.
+        Dropping every key because the policy itself is empty is not - that
+        silently discards durable workflow state. The two cases are only
+        distinguishable here, so an unresolved policy raises instead.
+        """
+
+        if not values or self.declarations_resolved:
+            return
+        raise ContextAuthorityError(
+            f"context_authority.unresolved_declarations workflow={self.workflow_name} "
+            f"writer={PERSISTED_REPLAY_WRITER} op={operation}"
+        )
+
+    def require_replayable_value(self, key: str, value: Any, *, operation: str) -> None:
+        clean_key = _clean_key(key)
+        if not clean_key:
+            raise ContextAuthorityError("context_authority.empty_key")
+        authority = self.variables.get(clean_key)
+        if authority is None:
+            raise ContextAuthorityError(
+                f"context_authority.unknown_key workflow={self.workflow_name} key={clean_key} writer={PERSISTED_REPLAY_WRITER} op={operation}"
+            )
+        if not authority.persisted:
+            return
+        if not _is_replayable_authority(authority):
+            raise ContextAuthorityError(
+                f"context_authority.non_replayable workflow={self.workflow_name} key={clean_key} writer={PERSISTED_REPLAY_WRITER} op={operation}"
+            )
+        if not _is_valid_context_value(value, value_type=authority.value_type):
+            raise ContextAuthorityError(
+                f"context_authority.invalid_value workflow={self.workflow_name} key={clean_key} writer={PERSISTED_REPLAY_WRITER} op={operation}"
+            )
+
+    def filter_for_replay(
+        self,
+        values: Mapping[str, Any],
+        *,
+        writer_id: ContextWriterId,
+        diagnostics: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self._require_resolved_declarations(values, operation="replay")
         accepted: dict[str, Any] = {}
         for key, value in values.items():
             clean_key = _clean_key(key)
             if not clean_key:
                 continue
-            self.require_can_write(clean_key, writer_id=writer_id)
             authority = self.variables.get(clean_key)
+            if authority is None:
+                if writer_id == PERSISTED_REPLAY_WRITER:
+                    if diagnostics is not None:
+                        diagnostics.append(
+                            f"context_authority.replay_dropped_unknown workflow={self.workflow_name} key={clean_key}"
+                        )
+                    continue
+                self.require_can_write(clean_key, writer_id=writer_id)
             if authority is not None and not authority.persisted:
+                if diagnostics is not None:
+                    diagnostics.append(
+                        f"context_authority.replay_skipped_non_persisted workflow={self.workflow_name} key={clean_key}"
+                    )
                 continue
+            self.require_replayable_value(clean_key, value, operation="replay")
+            accepted[clean_key] = value
+        return accepted
+
+    def filter_for_persistence(
+        self,
+        values: Mapping[str, Any],
+        *,
+        diagnostics: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Filter live, already-authorized context state for durable hydration.
+
+        Persistence receives a live snapshot after normal writer authorization has
+        happened at mutation time. Replay receives stored state later. Both paths
+        use the same persisted/replayable/value validation, but only replay has a
+        stored-state writer identity.
+        """
+
+        self._require_resolved_declarations(values, operation="persist")
+        accepted: dict[str, Any] = {}
+        for key, value in values.items():
+            clean_key = _clean_key(key)
+            if not clean_key:
+                continue
+            authority = self.variables.get(clean_key)
+            if authority is None:
+                if diagnostics is not None:
+                    diagnostics.append(
+                        f"context_authority.persistence_dropped_unknown workflow={self.workflow_name} key={clean_key}"
+                    )
+                continue
+            if not authority.persisted:
+                if diagnostics is not None:
+                    diagnostics.append(
+                        f"context_authority.persistence_skipped_non_persisted workflow={self.workflow_name} key={clean_key}"
+                    )
+                continue
+            self.require_replayable_value(clean_key, value, operation="persist")
             accepted[clean_key] = value
         return accepted
 
@@ -269,6 +368,7 @@ def build_context_authority_policy(
     definitions: Mapping[str, Any],
     transition_rules: Any = None,
     task_batch_context_keys: set[str] | None = None,
+    declarations_resolved: bool = True,
 ) -> ContextAuthorityPolicy:
     routing_keys = _transition_context_keys(transition_rules)
     task_keys = set(task_batch_context_keys or set())
@@ -277,13 +377,19 @@ def build_context_authority_policy(
         key = _clean_key(raw_key)
         if not key:
             continue
-        variables[key] = infer_context_authority(
+        authority = infer_context_authority(
             key,
             definition=definition,
             routing_keys=routing_keys,
             task_batch_context_keys=task_keys,
         )
-    return ContextAuthorityPolicy(workflow_name=str(workflow_name or ""), variables=variables)
+        _validate_replay_contract(workflow_name=str(workflow_name or ""), authority=authority)
+        variables[key] = authority
+    return ContextAuthorityPolicy(
+        workflow_name=str(workflow_name or ""),
+        variables=variables,
+        declarations_resolved=declarations_resolved,
+    )
 
 
 def infer_context_authority(
@@ -337,6 +443,7 @@ def infer_context_authority(
         routing=routing,
         authorization=authorization,
         writer_ids=frozenset(writer_ids),
+        value_type=_definition_type(definition),
     )
 
 
@@ -376,6 +483,11 @@ def _metadata_from_definition(definition: Any | None) -> ContextAuthorityMetadat
         "writer_ids": _value(definition, "writer_ids", []) or [],
     }
     return ContextAuthorityMetadata.model_validate(raw)
+
+
+def _definition_type(definition: Any | None) -> str | None:
+    text = str(_value(definition, "type", "") or "").strip().lower()
+    return text or None
 
 
 def _definition_source(definition: Any | None) -> Any:
@@ -439,10 +551,52 @@ def _infer_writer_ids(
             TRANSITION_ROUTER_WRITER,
             CONTEXT_BRIDGE_WRITER,
             TOOL_WRITEBACK_WRITER,
-            PERSISTED_REPLAY_WRITER,
             LIVE_USER_CONTEXT_WRITER,
         })
     return writers
+
+
+def _is_replayable_authority(authority: ContextVariableAuthority) -> bool:
+    if authority.authorization:
+        return False
+    return authority.authority_class in {
+        ContextAuthorityClass.CLOSED_WRITER_ROUTING_STATE,
+        ContextAuthorityClass.CLOSED_WRITER_QUALITY_STATE,
+        ContextAuthorityClass.MUTABLE_WORKFLOW_STATE,
+        ContextAuthorityClass.MODEL_VISIBLE_INFORMATION,
+        ContextAuthorityClass.DERIVED_INFORMATION,
+    }
+
+
+def _is_valid_context_value(value: Any, *, value_type: str | None) -> bool:
+    if value is None:
+        return True
+    if value_type in {None, "", "any"}:
+        return True
+    if value_type in {"string", "str"}:
+        return isinstance(value, str)
+    if value_type in {"boolean", "bool"}:
+        return isinstance(value, bool)
+    if value_type in {"integer", "int"}:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if value_type in {"number", "float"}:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if value_type in {"object", "dict", "map"}:
+        return isinstance(value, Mapping)
+    if value_type in {"array", "list"}:
+        return isinstance(value, list)
+    return True
+
+
+def _validate_replay_contract(*, workflow_name: str, authority: ContextVariableAuthority) -> None:
+    if not authority.persisted:
+        return
+    if _is_replayable_authority(authority):
+        return
+    raise ContextAuthorityError(
+        f"{workflow_name} context authority contract mismatch: persisted context variable "
+        f"{authority.key!r} is not replayable"
+    )
 
 
 def _transition_context_keys(transition_rules: Any) -> frozenset[str]:

--- a/mozaiksai/core/workflow/execution/run_bootstrap.py
+++ b/mozaiksai/core/workflow/execution/run_bootstrap.py
@@ -12,24 +12,12 @@ from typing import Any
 
 
 def merge_persisted_extra_context(context: Any, extra_ctx: dict[str, Any]) -> None:
-    """Apply persisted run context over workflow-declared defaults."""
+    """Hydrate validated persisted state over workflow-declared defaults."""
     if not isinstance(extra_ctx, dict) or not extra_ctx:
         return
-    for k, v in extra_ctx.items():
-        if not isinstance(k, str) or not k.strip():
-            continue
-        try:
-            if hasattr(context, "set"):
-                context.set(k, v)
-            elif hasattr(context, "__setitem__"):
-                context[k] = v
-        except Exception:
-            continue
-    try:
-        if extra_ctx.get("parent_chat_id") and hasattr(context, "set"):
-            context.set("automated_workflow_run", True)
-    except Exception:
-        pass
+    from ..context.adapter import _hydrate_persisted_context
+
+    _hydrate_persisted_context(context, extra_ctx)
 
 
 def _hidden_config_seed(config: dict[str, Any], *, suppress: bool) -> dict[str, Any] | None:
@@ -124,15 +112,12 @@ async def bootstrap_run_messages(
             })
 
         current_user_id = user_id or "system_user"
-        try:
-            await persistence_manager.create_chat_session(
-                chat_id=chat_id,
-                app_id=app_id,
-                workflow_name=workflow_name,
-                user_id=current_user_id,
-            )
-        except Exception as cs_err:
-            wf_logger.error("Failed to create chat session for %s: %s", chat_id, cs_err)
+        await persistence_manager.create_chat_session(
+            chat_id=chat_id,
+            app_id=app_id,
+            workflow_name=workflow_name,
+            user_id=current_user_id,
+        )
 
     if not seed_messages and config.get("workflow_startup_mode", "").strip().lower() == "userdriven":
         seed_messages = [{

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -75,14 +75,6 @@ def _messages_to_network_prompt(messages: list[dict[str, Any]]) -> str:
     return "\n\n".join(rendered).strip() or "."
 
 
-def _supports_workflow_name_kw(callable_obj: Callable[..., Any]) -> bool:
-    try:
-        signature = inspect.signature(callable_obj)
-    except (TypeError, ValueError):
-        return False
-    return "workflow_name" in signature.parameters
-
-
 async def _fetch_chat_session_extra_context(
     persistence_manager: Any,
     *,
@@ -90,10 +82,14 @@ async def _fetch_chat_session_extra_context(
     app_id: str,
     workflow_name: str,
 ) -> dict[str, Any]:
-    kwargs: dict[str, Any] = {"chat_id": chat_id, "app_id": app_id}
-    if _supports_workflow_name_kw(persistence_manager.fetch_chat_session_extra_context):
-        kwargs["workflow_name"] = workflow_name
-    return cast(dict[str, Any], await persistence_manager.fetch_chat_session_extra_context(**kwargs))
+    return cast(
+        dict[str, Any],
+        await persistence_manager.fetch_chat_session_extra_context(
+            chat_id=chat_id,
+            app_id=app_id,
+            workflow_name=workflow_name,
+        ),
+    )
 
 
 async def _persist_context_variables(
@@ -104,10 +100,12 @@ async def _persist_context_variables(
     workflow_name: str,
     variables: dict[str, Any],
 ) -> None:
-    kwargs: dict[str, Any] = {"chat_id": chat_id, "app_id": app_id, "variables": variables}
-    if _supports_workflow_name_kw(persistence_manager.persist_context_variables):
-        kwargs["workflow_name"] = workflow_name
-    await persistence_manager.persist_context_variables(**kwargs)
+    await persistence_manager.persist_context_variables(
+        chat_id=chat_id,
+        app_id=app_id,
+        workflow_name=workflow_name,
+        variables=variables,
+    )
 
 
 def _first_agent_payload_from_runner_result(runner_result: Any, agent_name: str) -> dict[str, Any] | None:
@@ -814,19 +812,16 @@ async def run_workflow_orchestration(
                 except Exception as _ctx_err:
                     wf_logger.debug("[%s] frontend_context inject failed key=%s: %s", workflow_name_upper, prefixed, _ctx_err)
 
-        try:
-            if context is not None:
-                extra_ctx = await _fetch_chat_session_extra_context(
-                    persistence_manager,
-                    chat_id=chat_id,
-                    app_id=app_id,
-                    workflow_name=workflow_name,
-                )
-                if isinstance(extra_ctx, dict) and extra_ctx:
-                    persisted_extra_ctx = dict(extra_ctx)
-                    merge_persisted_extra_context(context, extra_ctx)
-        except Exception as seed_err:
-            wf_logger.debug("[%s] Persisted extra context merge failed: %s", workflow_name_upper, seed_err)
+        if context is not None:
+            extra_ctx = await _fetch_chat_session_extra_context(
+                persistence_manager,
+                chat_id=chat_id,
+                app_id=app_id,
+                workflow_name=workflow_name,
+            )
+            if isinstance(extra_ctx, dict) and extra_ctx:
+                persisted_extra_ctx = dict(extra_ctx)
+                merge_persisted_extra_context(context, extra_ctx)
 
         context_time = (perf_counter() - context_start) * 1000
         performance_logger.info("context_load_duration_ms", extra={
@@ -1282,17 +1277,16 @@ async def run_workflow_orchestration(
             "sequence_counter": sequence_counter,
         }
 
-        # 11) Persist final context snapshot
-        try:
-            await _persist_context_variables(
-                persistence_manager,
-                chat_id=chat_id,
-                app_id=app_id,
-                workflow_name=workflow_name,
-                variables=dict(ctx_dict),
-            )
-        except Exception as persist_ctx_err:
-            wf_logger.debug("[%s] Final context persist failed: %s", workflow_name_upper, persist_ctx_err)
+        # 11) Persist the final AG2 orchestration/network snapshot. The agent
+        # context bridge is a detached store and is intentionally not overlaid
+        # here; unifying those stores is a separate runtime architecture change.
+        await _persist_context_variables(
+            persistence_manager,
+            chat_id=chat_id,
+            app_id=app_id,
+            workflow_name=workflow_name,
+            variables=dict(ctx_dict),
+        )
 
         workflow_complete = run_completed and not awaiting_user_input and not run_failed
         workflow_status_value = 1 if workflow_complete else 0

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -36,6 +36,8 @@ import mozaiksai.core.workflow.workflow_manager as workflow_manager_module
 from mozaiksai.core.adapters.ag2_network_runner import AG2NetworkRunner, AG2NetworkRunnerRequest
 from mozaiksai.core.ports.orchestration import RunStatus
 from mozaiksai.core.workflow.agents.factory import ContextVariablesBridge
+from mozaiksai.core.workflow.context.adapter import create_context_container
+from mozaiksai.core.workflow.context.authority import build_context_authority_policy
 from mozaiksai.core.workflow.orchestration_patterns import run_workflow_orchestration
 from mozaiksai.core.workflow.task_batches import parse_task_batches_config
 
@@ -859,12 +861,16 @@ async def test_ag2_network_runner_fails_invalid_structured_output_contract() -> 
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("persistence_failure", [None, "fetch", "persist"])
 async def test_run_workflow_orchestration_uses_ag2_network_runner(
     monkeypatch: pytest.MonkeyPatch,
+    persistence_failure: str | None,
 ) -> None:
     class _Persistence:
         def __init__(self) -> None:
             self.persisted_context: dict[str, Any] | None = None
+            self.persisted_scope: tuple[str, str, str] | None = None
+            self.fetched_scope: tuple[str, str, str] | None = None
             self.assistant_messages: list[dict[str, Any]] = []
             self.completed: list[tuple[str, str]] = []
             self.created_sessions: list[dict[str, Any]] = []
@@ -881,7 +887,16 @@ async def test_run_workflow_orchestration_uses_ag2_network_runner(
         async def get_or_assign_cache_seed(self, chat_id: str, app_id: str) -> int:
             return 7
 
-        async def fetch_chat_session_extra_context(self, *, chat_id: str, app_id: str) -> dict[str, Any]:
+        async def fetch_chat_session_extra_context(
+            self,
+            *,
+            chat_id: str,
+            app_id: str,
+            workflow_name: str,
+        ) -> dict[str, Any]:
+            self.fetched_scope = (chat_id, app_id, workflow_name)
+            if persistence_failure == "fetch":
+                raise RuntimeError("context fetch failed")
             return {}
 
         async def persist_context_variables(
@@ -889,9 +904,13 @@ async def test_run_workflow_orchestration_uses_ag2_network_runner(
             *,
             chat_id: str,
             app_id: str,
+            workflow_name: str,
             variables: dict[str, Any],
         ) -> None:
+            self.persisted_scope = (chat_id, app_id, workflow_name)
             self.persisted_context = dict(variables)
+            if persistence_failure == "persist":
+                raise RuntimeError("context update failed")
 
         async def append_run_assistant_message(self, **kwargs: Any) -> None:
             self.assistant_messages.append(dict(kwargs))
@@ -971,15 +990,28 @@ async def test_run_workflow_orchestration_uses_ag2_network_runner(
     from mozaiksai.core.workflow.execution import lifecycle as lifecycle_module
     monkeypatch.setattr(lifecycle_module, "get_lifecycle_manager", lambda _workflow: _PreloadLifecycle())
 
-    result = await run_workflow_orchestration(
-        workflow_name="AlignmentSmoke",
-        app_id="app-1",
-        chat_id="chat-1",
-        user_id="user-1",
-        initial_message="Build the alignment smoke.",
-        agents_factory=_agents_factory,
-        context_factory=lambda: {"seed": "context"},
-    )
+    run_kwargs = {
+        "workflow_name": "AlignmentSmoke",
+        "app_id": "app-1",
+        "chat_id": "chat-1",
+        "user_id": "user-1",
+        "initial_message": "Build the alignment smoke.",
+        "agents_factory": _agents_factory,
+        "context_factory": lambda: {"seed": "context"},
+    }
+
+    if persistence_failure is not None:
+        expected_error = "context fetch failed" if persistence_failure == "fetch" else "context update failed"
+        with pytest.raises(RuntimeError, match=expected_error):
+            await run_workflow_orchestration(**run_kwargs)
+        assert persistence.fetched_scope == ("chat-1", "app-1", "AlignmentSmoke")
+        if persistence_failure == "fetch":
+            assert persistence.persisted_scope is None
+        else:
+            assert persistence.persisted_scope == ("chat-1", "app-1", "AlignmentSmoke")
+        return
+
+    result = await run_workflow_orchestration(**run_kwargs)
 
     assert result is not None
     assert result["run_completed"] is True
@@ -992,6 +1024,10 @@ async def test_run_workflow_orchestration_uses_ag2_network_runner(
     assert worker_agent.ask_calls
     assert [event["kind"] for _, event in transport.events].count("chat.text") == 2
     assert transport.events[-1][1]["kind"] == "run_complete"
+    assert persistence.fetched_scope == ("chat-1", "app-1", "AlignmentSmoke")
+    assert persistence.persisted_scope == ("chat-1", "app-1", "AlignmentSmoke")
+    assert persistence.persisted_context is not None
+    assert persistence.persisted_context["preload_status"] == "ready"
     assert persistence.completed == [("chat-1", "app-1")]
     assert [message["agent_name"] for message in persistence.assistant_messages] == [
         "PlannerAgent",
@@ -1020,7 +1056,14 @@ async def test_run_workflow_orchestration_resolves_user_reentry_to_next_agent(
         async def get_or_assign_cache_seed(self, chat_id: str, app_id: str) -> int:
             return 7
 
-        async def fetch_chat_session_extra_context(self, *, chat_id: str, app_id: str) -> dict[str, Any]:
+        async def fetch_chat_session_extra_context(
+            self,
+            *,
+            chat_id: str,
+            app_id: str,
+            workflow_name: str,
+        ) -> dict[str, Any]:
+            assert workflow_name == "AgentGenerator"
             return {
                 "interview_complete": True,
                 "workflow_review_approved": True,
@@ -1032,8 +1075,10 @@ async def test_run_workflow_orchestration_resolves_user_reentry_to_next_agent(
             *,
             chat_id: str,
             app_id: str,
+            workflow_name: str,
             variables: dict[str, Any],
         ) -> None:
+            assert workflow_name == "AgentGenerator"
             self.persisted_context = dict(variables)
 
         async def append_run_assistant_message(self, **kwargs: Any) -> None:
@@ -1128,11 +1173,28 @@ async def test_run_workflow_orchestration_resolves_user_reentry_to_next_agent(
         user_id="user-1",
         initial_agent_name_override="user",
         agents_factory=_agents_factory,
-        context_factory=lambda: {
-            "interview_complete": False,
-            "workflow_review_approved": False,
-            "workflow_review_revision_requested": False,
-        },
+        context_factory=lambda: create_context_container(
+            initial={
+                "interview_complete": False,
+                "workflow_review_approved": False,
+                "workflow_review_revision_requested": False,
+            },
+            authority_policy=build_context_authority_policy(
+                workflow_name="AgentGenerator",
+                definitions={
+                    key: {
+                        "type": "boolean",
+                        "source": {"type": "state", "default": False},
+                    }
+                    for key in (
+                        "interview_complete",
+                        "workflow_review_approved",
+                        "workflow_review_revision_requested",
+                    )
+                },
+                transition_rules=[],
+            ),
+        ),
     )
 
     assert result is not None
@@ -1163,7 +1225,14 @@ async def test_run_workflow_orchestration_executes_task_batches_between_ag2_phas
         async def get_or_assign_cache_seed(self, chat_id: str, app_id: str) -> int:
             return 7
 
-        async def fetch_chat_session_extra_context(self, *, chat_id: str, app_id: str) -> dict[str, Any]:
+        async def fetch_chat_session_extra_context(
+            self,
+            *,
+            chat_id: str,
+            app_id: str,
+            workflow_name: str,
+        ) -> dict[str, Any]:
+            assert workflow_name == "TaskBatchAlignmentSmoke"
             return {}
 
         async def persist_context_variables(
@@ -1171,8 +1240,10 @@ async def test_run_workflow_orchestration_executes_task_batches_between_ag2_phas
             *,
             chat_id: str,
             app_id: str,
+            workflow_name: str,
             variables: dict[str, Any],
         ) -> None:
+            assert workflow_name == "TaskBatchAlignmentSmoke"
             self.persisted_context = dict(variables)
 
         async def append_run_assistant_message(self, **kwargs: Any) -> None:
@@ -1342,7 +1413,14 @@ async def test_task_batch_preface_handoff_to_user_pauses_without_second_ag2_phas
         async def get_or_assign_cache_seed(self, chat_id: str, app_id: str) -> int:
             return 7
 
-        async def fetch_chat_session_extra_context(self, *, chat_id: str, app_id: str) -> dict[str, Any]:
+        async def fetch_chat_session_extra_context(
+            self,
+            *,
+            chat_id: str,
+            app_id: str,
+            workflow_name: str,
+        ) -> dict[str, Any]:
+            assert workflow_name == "AgentGenerator"
             return {}
 
         async def persist_context_variables(
@@ -1350,8 +1428,10 @@ async def test_task_batch_preface_handoff_to_user_pauses_without_second_ag2_phas
             *,
             chat_id: str,
             app_id: str,
+            workflow_name: str,
             variables: dict[str, Any],
         ) -> None:
+            assert workflow_name == "AgentGenerator"
             return None
 
         async def append_run_assistant_message(self, **kwargs: Any) -> None:

--- a/tests/test_auto_tool_handler_persistence.py
+++ b/tests/test_auto_tool_handler_persistence.py
@@ -104,6 +104,7 @@ async def test_handle_tool_dispatch_persists_updated_context(monkeypatch):
     persisted = persist_mock.await_args.kwargs
     assert persisted["chat_id"] == "chat-1"
     assert persisted["app_id"] == "app-1"
+    assert persisted["workflow_name"] == "SmokeParent"
     assert persisted["variables"]["app_task_batch_status"] == "consumed"
     assert persisted["variables"]["app_task_batch_consumed_nonce"] == "nonce-123"
     assert persisted["variables"]["smoke_presented_summary"] == "Smoke path summarized."
@@ -227,15 +228,35 @@ async def test_handle_tool_dispatch_runs_multiple_bindings_in_order(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_persist_context_variables_filters_canonical_fields():
+async def test_persist_context_variables_filters_canonical_fields(monkeypatch):
+    authority_mod = import_module_directly("mozaiksai.core.workflow.context.authority")
+    policy = authority_mod.build_context_authority_policy(
+        workflow_name="SmokeParent",
+        definitions={
+            "app_task_batch_status": {
+                "type": "string",
+                "source": {"type": "state", "default": None},
+            },
+        },
+        transition_rules=[],
+    )
+    monkeypatch.setattr(
+        _persistence_mod,
+        "_context_authority_policy_for_workflow",
+        lambda _workflow_name: policy,
+    )
+
     manager = AG2PersistenceManager.__new__(AG2PersistenceManager)
     fake_coll = MagicMock()
-    fake_coll.update_one = AsyncMock()
+    fake_coll.update_one = AsyncMock(
+        return_value=MagicMock(acknowledged=True, matched_count=1, modified_count=1)
+    )
     manager._coll = AsyncMock(return_value=fake_coll)
 
     await manager.persist_context_variables(
         chat_id="chat-1",
         app_id="app-1",
+        workflow_name="SmokeParent",
         variables={
             "chat_id": "override-me",
             "workflow_name": "override-me",
@@ -249,11 +270,12 @@ async def test_persist_context_variables_filters_canonical_fields():
     filter_doc, update_doc = fake_coll.update_one.await_args.args
     assert filter_doc["_id"] == "chat-1"
     assert filter_doc["app_id"] == "app-1"
+    assert filter_doc["workflow_name"] == "SmokeParent"
     assert "chat_id" not in update_doc["$set"]
     assert "workflow_name" not in update_doc["$set"]
     assert "session_version" not in update_doc["$set"]
     assert update_doc["$inc"] == {"session_version": 1}
     assert update_doc["$set"]["app_task_batch_status"] == "consumed"
-    assert update_doc["$set"]["smoke_presented_summary"] == "Smoke path summarized."
+    assert "smoke_presented_summary" not in update_doc["$set"]
     assert isinstance(update_doc["$set"]["last_updated_at"], datetime)
 

--- a/tests/test_context_authority_hostile.py
+++ b/tests/test_context_authority_hostile.py
@@ -363,20 +363,28 @@ def test_vector7_live_resume_ordinary_key_is_allowed() -> None:
 # Vector 8: EV_CONTEXT_SET / persisted replay
 # ---------------------------------------------------------------------------
 
-def test_vector8_persisted_replay_rejects_immutable_key() -> None:
-    """filter_for_replay with PERSISTED_REPLAY_WRITER must reject immutable keys."""
+def test_vector8_persisted_replay_skips_non_persisted_immutable_key() -> None:
+    """filter_for_replay skips declared non-persisted immutable keys before authorization."""
+    policy = _hostile_policy()
+    diagnostics: list[str] = []
+
+    result = policy.filter_for_replay(
+        {"app_id": "evil"},
+        writer_id=PERSISTED_REPLAY_WRITER,
+        diagnostics=diagnostics,
+    )
+
+    assert result == {}
+    assert diagnostics == ["context_authority.replay_skipped_non_persisted workflow=HostileTestFlow key=app_id"]
+
+
+def test_vector8_persisted_replay_allows_persisted_quality_key() -> None:
+    """filter_for_replay allows known replayable quality state."""
     policy = _hostile_policy()
 
-    with pytest.raises(ContextAuthorityError, match="context_authority"):
-        policy.filter_for_replay({"app_id": "evil"}, writer_id=PERSISTED_REPLAY_WRITER)
+    result = policy.filter_for_replay({"app_validation_status": "passed"}, writer_id=PERSISTED_REPLAY_WRITER)
 
-
-def test_vector8_persisted_replay_rejects_quality_key() -> None:
-    """filter_for_replay with PERSISTED_REPLAY_WRITER must reject quality-gate keys."""
-    policy = _hostile_policy()
-
-    with pytest.raises(ContextAuthorityError, match="context_authority"):
-        policy.filter_for_replay({"app_validation_status": "passed"}, writer_id=PERSISTED_REPLAY_WRITER)
+    assert result == {"app_validation_status": "passed"}
 
 
 def test_vector8_persisted_replay_allows_ordinary_key() -> None:
@@ -385,6 +393,14 @@ def test_vector8_persisted_replay_allows_ordinary_key() -> None:
 
     result = policy.filter_for_replay({"ordinary_state": "restored"}, writer_id=PERSISTED_REPLAY_WRITER)
     assert result == {"ordinary_state": "restored"}
+
+
+def test_vector8_persisted_replay_identity_cannot_mutate_live_context() -> None:
+    """The stored-state replay identity is not live write authority."""
+    policy = _hostile_policy()
+
+    with pytest.raises(ContextAuthorityError, match="context_authority.rejected"):
+        policy.require_can_write("ordinary_state", writer_id=PERSISTED_REPLAY_WRITER)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_context_authority_policy.py
+++ b/tests/test_context_authority_policy.py
@@ -165,11 +165,82 @@ def test_ui_and_user_triggers_reject_undeclared_keys() -> None:
         policy.require_can_write("undeclared_ready", writer_id=USER_TEXT_TRIGGER_WRITER)
 
 
-def test_persisted_replay_rejects_unauthorized_authority_value() -> None:
+def test_persisted_replay_skips_declared_non_persisted_authority_before_authorization() -> None:
+    policy = _policy()
+    diagnostics: list[str] = []
+
+    result = policy.filter_for_replay(
+        {"app_id": {"spoofed": True}},
+        writer_id=PERSISTED_REPLAY_WRITER,
+        diagnostics=diagnostics,
+    )
+
+    assert result == {}
+    assert diagnostics == ["context_authority.replay_skipped_non_persisted workflow=AuthorityFlow key=app_id"]
+
+
+def test_persistence_skips_declared_non_persisted_authority_before_value_validation() -> None:
+    policy = _policy()
+    diagnostics: list[str] = []
+
+    result = policy.filter_for_persistence(
+        {"app_id": {"spoofed": True}, "ordinary_state": "saved"},
+        diagnostics=diagnostics,
+    )
+
+    assert result == {"ordinary_state": "saved"}
+    assert diagnostics == [
+        "context_authority.persistence_skipped_non_persisted workflow=AuthorityFlow key=app_id"
+    ]
+
+
+def test_persisted_replay_allows_known_replayable_quality_state() -> None:
     policy = _policy()
 
-    with pytest.raises(ContextAuthorityError):
-        policy.filter_for_replay({"app_id": "evil"}, writer_id=PERSISTED_REPLAY_WRITER)
+    result = policy.filter_for_replay(
+        {"app_validation_status": "passed"},
+        writer_id=PERSISTED_REPLAY_WRITER,
+    )
+
+    assert result == {"app_validation_status": "passed"}
+
+
+def test_persisted_replay_rejects_persisted_immutable_runtime_authority() -> None:
+    plan = load_context_variables_config(
+        {
+            "definitions": {
+                "app_id": {
+                    "type": "string",
+                    "persisted": True,
+                    "source": {"type": "state", "default": "app_1"},
+                },
+            },
+            "agents": {},
+        }
+    )
+
+    with pytest.raises(ContextAuthorityError, match="not replayable"):
+        build_context_authority_policy(
+            workflow_name="PersistedImmutableFlow",
+            definitions=plan.definitions,
+            transition_rules=[],
+        )
+
+
+def test_persisted_replay_drops_stale_unknown_historical_keys_with_diagnostics() -> None:
+    policy = _policy()
+    diagnostics: list[str] = []
+
+    result = policy.filter_for_replay(
+        {"unknown_historical_key": "old", "ordinary_state": "restored"},
+        writer_id=PERSISTED_REPLAY_WRITER,
+        diagnostics=diagnostics,
+    )
+
+    assert result == {"ordinary_state": "restored"}
+    assert diagnostics == [
+        "context_authority.replay_dropped_unknown workflow=AuthorityFlow key=unknown_historical_key"
+    ]
 
 
 def test_packet_and_raw_context_set_guards_reject_bypass_attempts() -> None:
@@ -401,3 +472,75 @@ def test_factory_context_inventory_classifies_authority_like_keys() -> None:
                 checked += 1
 
     assert checked > 0
+
+
+def test_persisted_replay_rejects_known_malformed_value() -> None:
+    policy = _policy()
+
+    with pytest.raises(ContextAuthorityError, match="invalid_value"):
+        policy.filter_for_replay({"review_complete": "true"}, writer_id=PERSISTED_REPLAY_WRITER)
+
+
+def test_unresolved_workflow_declarations_fail_replay_closed() -> None:
+    """An unresolved policy must not masquerade as 'every stored key is stale'."""
+
+    policy = build_context_authority_policy(
+        workflow_name="UnloadedFlow",
+        definitions={},
+        transition_rules=[],
+        declarations_resolved=False,
+    )
+
+    with pytest.raises(ContextAuthorityError, match="unresolved_declarations"):
+        policy.filter_for_replay(
+            {"interview_complete": True},
+            writer_id=PERSISTED_REPLAY_WRITER,
+        )
+
+
+def test_unresolved_workflow_declarations_fail_persistence_closed() -> None:
+    policy = build_context_authority_policy(
+        workflow_name="UnloadedFlow",
+        definitions={},
+        transition_rules=[],
+        declarations_resolved=False,
+    )
+
+    with pytest.raises(ContextAuthorityError, match="unresolved_declarations"):
+        policy.filter_for_persistence({"interview_complete": True})
+
+
+def test_unresolved_declarations_tolerate_empty_value_sets() -> None:
+    """Nothing to write is not a failure, even when declarations are unresolved."""
+
+    policy = build_context_authority_policy(
+        workflow_name="UnloadedFlow",
+        definitions={},
+        transition_rules=[],
+        declarations_resolved=False,
+    )
+
+    assert policy.filter_for_replay({}, writer_id=PERSISTED_REPLAY_WRITER) == {}
+    assert policy.filter_for_persistence({}) == {}
+
+
+def test_resolved_workflow_with_no_declarations_still_drops_stale_keys() -> None:
+    """A workflow that legitimately declares nothing keeps stale-key drop semantics."""
+
+    policy = build_context_authority_policy(
+        workflow_name="NoContextFlow",
+        definitions={},
+        transition_rules=[],
+    )
+    diagnostics: list[str] = []
+
+    result = policy.filter_for_replay(
+        {"stale_key": "old"},
+        writer_id=PERSISTED_REPLAY_WRITER,
+        diagnostics=diagnostics,
+    )
+
+    assert result == {}
+    assert diagnostics == [
+        "context_authority.replay_dropped_unknown workflow=NoContextFlow key=stale_key"
+    ]

--- a/tests/test_context_exposure.py
+++ b/tests/test_context_exposure.py
@@ -93,26 +93,47 @@ async def test_create_agents_exposes_declared_context_variables_without_explicit
 
 
 def test_persisted_session_context_overrides_declared_defaults() -> None:
+    from mozaiksai.core.workflow.context.adapter import create_context_container
+    from mozaiksai.core.workflow.context.authority import build_context_authority_policy
     from mozaiksai.core.workflow.execution.run_bootstrap import (
         merge_persisted_extra_context as _merge_persisted_extra_context,
     )
 
-    class _Context:
-        def __init__(self) -> None:
-            self.data = {
-                "interview_complete": False,
-                "app_plan_ready": False,
-                "capability_packs": [],
-                "app_build_plan": None,
-            }
-
-        def get(self, key: str, default=None):
-            return self.data.get(key, default)
-
-        def set(self, key: str, value) -> None:
-            self.data[key] = value
-
-    context = _Context()
+    definitions = {
+        "interview_complete": {
+            "type": "boolean",
+            "authority_class": "closed_writer_routing_state",
+            "routing": True,
+            "writer_ids": ["user_text_trigger"],
+            "source": {"type": "state", "default": False},
+        },
+        "app_plan_ready": {
+            "type": "boolean",
+            "source": {"type": "state", "default": False},
+        },
+        "capability_packs": {
+            "type": "array",
+            "source": {"type": "state", "default": []},
+        },
+        "app_build_plan": {
+            "type": "object",
+            "source": {"type": "state", "default": None},
+        },
+    }
+    policy = build_context_authority_policy(
+        workflow_name="AppGenerator",
+        definitions=definitions,
+        transition_rules=[],
+    )
+    context = create_context_container(
+        initial={
+            "interview_complete": False,
+            "app_plan_ready": False,
+            "capability_packs": [],
+            "app_build_plan": None,
+        },
+        authority_policy=policy,
+    )
 
     _merge_persisted_extra_context(
         context,
@@ -121,15 +142,14 @@ def test_persisted_session_context_overrides_declared_defaults() -> None:
             "app_plan_ready": True,
             "capability_packs": [{"pack_id": "wallet"}],
             "app_build_plan": {"app_name": "Support Operations"},
-            "parent_chat_id": "chat-parent",
         },
     )
 
+    snapshot = context.snapshot()
     assert context.get("interview_complete") is True
     assert context.get("app_plan_ready") is True
-    assert context.get("capability_packs") == [{"pack_id": "wallet"}]
-    assert context.get("app_build_plan") == {"app_name": "Support Operations"}
-    assert context.get("automated_workflow_run") is True
+    assert snapshot["capability_packs"] == [{"pack_id": "wallet"}]
+    assert snapshot["app_build_plan"] == {"app_name": "Support Operations"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestration_seed_persistence.py
+++ b/tests/test_orchestration_seed_persistence.py
@@ -34,6 +34,12 @@ class _StubPersistenceManager:
         self.persisted_run_messages.append(kwargs)
 
 
+class _FailingSessionPersistenceManager(_StubPersistenceManager):
+    async def create_chat_session(self, **kwargs):
+        self.created_sessions.append(kwargs)
+        raise RuntimeError("required session persistence unavailable")
+
+
 @pytest.mark.asyncio
 async def test_run_bootstrap_keeps_direct_initial_message_out_of_persisted_transcript() -> None:
     pm = _StubPersistenceManager()
@@ -96,6 +102,33 @@ async def test_run_bootstrap_keeps_config_seed_out_of_persisted_transcript() -> 
         }
     ]
     assert pm.persisted_batches == []
+
+
+@pytest.mark.asyncio
+async def test_run_bootstrap_propagates_required_session_creation_failure() -> None:
+    pm = _FailingSessionPersistenceManager()
+
+    with pytest.raises(RuntimeError, match="required session persistence unavailable"):
+        await _bootstrap_run_messages(
+            persistence_manager=pm,
+            config={},
+            chat_id="chat-create-fails",
+            app_id="app-1",
+            workflow_name="RuntimeSmoke",
+            user_id="user-1",
+            initial_message="Hello runtime",
+            initial_agent_name=None,
+            wf_logger=logging.getLogger("test.orchestration.seed"),
+        )
+
+    assert pm.created_sessions == [
+        {
+            "chat_id": "chat-create-fails",
+            "app_id": "app-1",
+            "workflow_name": "RuntimeSmoke",
+            "user_id": "user-1",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_persistence_initial_messages.py
+++ b/tests/test_persistence_initial_messages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 from ag2.events import ModelResponse
@@ -17,8 +18,21 @@ PersistenceManager = _persistence_mod.PersistenceManager
 
 
 class _FakeUpdateResult:
-    def __init__(self, modified_count: int):
+    def __init__(
+        self,
+        modified_count: int,
+        *,
+        matched_count: int | None = None,
+        acknowledged: bool = True,
+    ):
         self.modified_count = modified_count
+        self.matched_count = modified_count if matched_count is None else matched_count
+        self.acknowledged = acknowledged
+
+
+class _FakeInsertResult:
+    def __init__(self, *, acknowledged: bool = True):
+        self.acknowledged = acknowledged
 
 
 def _apply_set(target: dict, dotted_path: str, value) -> None:  # noqa: ANN001
@@ -30,27 +44,61 @@ def _apply_set(target: dict, dotted_path: str, value) -> None:  # noqa: ANN001
 
 
 class _FakeCollection:
-    def __init__(self, doc: dict):
+    def __init__(
+        self,
+        doc: dict,
+        *,
+        find_error: Exception | None = None,
+        update_error: Exception | None = None,
+        insert_error: Exception | None = None,
+        update_result: _FakeUpdateResult | None = None,
+        insert_result: _FakeInsertResult | None = None,
+    ):
         self.doc = doc
+        self.find_error = find_error
+        self.update_error = update_error
+        self.insert_error = insert_error
+        self.update_result = update_result
+        self.insert_result = insert_result
+        self.find_filters: list[dict] = []
+        self.update_filters: list[dict] = []
 
     async def find_one(self, filter_doc, projection=None):  # noqa: ANN001
+        self.find_filters.append(deepcopy(filter_doc))
+        if self.find_error is not None:
+            raise self.find_error
         if self.doc.get("_id") != filter_doc.get("_id"):
             return None
         expected_app_id = filter_doc.get("app_id")
         if expected_app_id and self.doc.get("app_id") != expected_app_id:
+            return None
+        expected_workflow = filter_doc.get("workflow_name")
+        if expected_workflow and self.doc.get("workflow_name") != expected_workflow:
             return None
         return deepcopy(self.doc)
 
     async def update_one(self, filter_doc, update_doc, array_filters=None):  # noqa: ANN001
+        self.update_filters.append(deepcopy(filter_doc))
+        if self.update_error is not None:
+            raise self.update_error
         if self.doc.get("_id") != filter_doc.get("_id"):
-            return _FakeUpdateResult(0)
+            return _FakeUpdateResult(0, matched_count=0)
         expected_app_id = filter_doc.get("app_id")
         if expected_app_id and self.doc.get("app_id") != expected_app_id:
-            return _FakeUpdateResult(0)
+            return _FakeUpdateResult(0, matched_count=0)
+        expected_workflow = filter_doc.get("workflow_name")
+        if expected_workflow and self.doc.get("workflow_name") != expected_workflow:
+            return _FakeUpdateResult(0, matched_count=0)
 
         for dotted_path, value in (update_doc.get("$set") or {}).items():
             _apply_set(self.doc, dotted_path, value)
-        return _FakeUpdateResult(1)
+        return self.update_result or _FakeUpdateResult(1, matched_count=1)
+
+    async def insert_one(self, document):  # noqa: ANN001
+        if self.insert_error is not None:
+            raise self.insert_error
+        self.doc = deepcopy(document)
+        return self.insert_result or _FakeInsertResult()
 
 
 def _apply_unset(target: dict, dotted_path: str) -> None:
@@ -105,6 +153,501 @@ class _FakeLegacyCollection:
                 _apply_unset(doc, dotted_path)
         return _FakeUpdateResult(len(operations))
 
+
+@pytest.fixture
+def authentic_workflow_policies():
+    """Pin these round trips to the real factory workflow root.
+
+    An unresolvable workflow fails closed rather than silently dropping state.
+    This local fixture explicitly binds the canonical Factory declarations for
+    these persistence assertions and restores the previously active root afterward.
+    """
+
+    from mozaiksai.core.workflow.workflow_manager import (
+        get_workflow_manager,
+        initialize_workflows,
+    )
+
+    previous_root = str(get_workflow_manager().workflows_base_path)
+    canonical_root = str(Path(__file__).resolve().parents[1] / "factory_app" / "workflows")
+    initialize_workflows(canonical_root)
+    try:
+        yield
+    finally:
+        initialize_workflows(previous_root)
+
+@pytest.mark.asyncio
+async def test_context_variable_persistence_resume_round_trip_honors_authority_policy(
+    monkeypatch,
+    authentic_workflow_policies,
+    caplog,
+):
+    manager = AG2PersistenceManager()
+    doc = {
+        "_id": "chat-1",
+        "app_id": "app-1",
+        "workflow_name": "ValueEngine",
+    }
+    coll = _FakeCollection(doc)
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    await manager.persist_context_variables(
+        chat_id="chat-1",
+        app_id="app-1",
+        workflow_name="ValueEngine",
+        variables={
+            "build_registry_id": "registry-1",
+            "chat_app_id": "authority-app-1",
+            "build_mode": "revision",
+            "app_name": "Round Trip App",
+            "stale_unknown_context_key": "old",
+        },
+    )
+
+    assert "build_registry_id" not in doc
+    assert "chat_app_id" not in doc
+    assert "stale_unknown_context_key" not in doc
+    assert doc["build_mode"] == "revision"
+    assert doc["app_name"] == "Round Trip App"
+    assert coll.update_filters[-1]["workflow_name"] == "ValueEngine"
+
+    doc["build_registry_id"] = "stale-registry"
+    doc["chat_app_id"] = "stale-authority-app"
+    doc["ag2_stream_id"] = "stale-stream"
+    doc["session_version"] = 7
+    doc["stale_historical_key"] = "SECRET_STALE_CONTEXT_VALUE"
+    caplog.set_level(10)
+
+    replayed = await manager.fetch_chat_session_extra_context(
+        chat_id="chat-1",
+        app_id="app-1",
+        workflow_name="ValueEngine",
+    )
+
+    assert replayed == {
+        "build_mode": "revision",
+        "app_name": "Round Trip App",
+    }
+    assert coll.find_filters[-1]["workflow_name"] == "ValueEngine"
+    assert "stale_historical_key" in caplog.text
+    assert "ValueEngine" in caplog.text
+    assert "SECRET_STALE_CONTEXT_VALUE" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_registered_factory_workflow_persistence_resume_round_trip(
+    monkeypatch,
+    authentic_workflow_policies,
+):
+    workflow_name = "AppGenerator"
+    variables = {
+        "task_run_mode": True,
+        "workflow_integration_repair_status": "needs_revision",
+        "app_validation_status": "failed",
+    }
+    expected = dict(variables)
+    manager = AG2PersistenceManager()
+    doc = {
+        "_id": f"chat-{workflow_name}",
+        "app_id": "app-1",
+        "workflow_name": workflow_name,
+    }
+    coll = _FakeCollection(doc)
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    await manager.persist_context_variables(
+        chat_id=f"chat-{workflow_name}",
+        app_id="app-1",
+        workflow_name=workflow_name,
+        variables={**variables, "stale_unknown_context_key": "old"},
+    )
+
+    for key, value in expected.items():
+        assert doc[key] == value
+    assert "stale_unknown_context_key" not in doc
+
+    doc["stale_unknown_context_key"] = "old"
+    replayed = await manager.fetch_chat_session_extra_context(
+        chat_id=f"chat-{workflow_name}",
+        app_id="app-1",
+        workflow_name=workflow_name,
+    )
+
+    assert replayed == expected
+
+
+@pytest.mark.asyncio
+async def test_known_malformed_persisted_value_fails_closed(monkeypatch, authentic_workflow_policies):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection({"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"})
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match="invalid_value"):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            variables={"interview_complete": "true"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_malformed_stored_value_fails_replay_closed(monkeypatch, authentic_workflow_policies):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {
+            "_id": "chat-1",
+            "app_id": "app-1",
+            "workflow_name": "ValueEngine",
+            "interview_complete": "true",
+            "concept_presented": True,
+        }
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match="invalid_value"):
+        await manager.fetch_chat_session_extra_context(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+        )
+
+
+@pytest.mark.parametrize("workflow_name", [None, "", "   "])
+@pytest.mark.asyncio
+async def test_nonempty_context_persistence_requires_workflow_identity(
+    monkeypatch,
+    workflow_name,
+):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"}
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match=r"workflow_required .*op=persist"):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name=workflow_name,
+            variables={"app_name": "Bounded App"},
+        )
+
+    assert coll.update_filters == []
+
+
+@pytest.mark.asyncio
+async def test_protected_only_nonempty_context_requires_workflow_identity(monkeypatch):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"}
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match=r"workflow_required .*op=persist"):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name=None,
+            variables={"chat_id": "forged-chat-id"},
+        )
+
+    assert coll.update_filters == []
+
+
+@pytest.mark.asyncio
+async def test_protected_only_nonempty_context_requires_resolved_declarations(monkeypatch):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"}
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(
+        ValueError,
+        match=r"unresolved_declarations workflow=NotARegisteredWorkflow .*op=persist",
+    ):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="NotARegisteredWorkflow",
+            variables={"chat_id": "forged-chat-id"},
+        )
+
+    assert coll.update_filters == []
+
+
+@pytest.mark.parametrize("workflow_name", [None, "", "   "])
+@pytest.mark.asyncio
+async def test_nonempty_context_replay_requires_workflow_identity(
+    monkeypatch,
+    workflow_name,
+):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {
+            "_id": "chat-1",
+            "app_id": "app-1",
+            "workflow_name": "ValueEngine",
+            "app_name": "Bounded App",
+        }
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match=r"workflow_required .*op=replay"):
+        await manager.fetch_chat_session_extra_context(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name=workflow_name,
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_persistence_policy_resolution_failure_is_not_silenced(monkeypatch):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"}
+    )
+
+    async def _fake_coll():
+        return coll
+
+    def _fail_policy(_workflow_name):
+        raise RuntimeError("SECRET_POLICY_RESOLUTION_VALUE")
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+    monkeypatch.setattr(_persistence_mod, "_context_authority_policy_for_workflow", _fail_policy)
+
+    with pytest.raises(ValueError, match=r"policy_unavailable workflow=ValueEngine op=persist") as exc_info:
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            variables={"app_name": "Bounded App"},
+        )
+
+    assert "SECRET_POLICY_RESOLUTION_VALUE" not in str(exc_info.value)
+    assert coll.update_filters == []
+
+
+@pytest.mark.asyncio
+async def test_context_replay_policy_resolution_failure_is_not_silenced(monkeypatch):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {
+            "_id": "chat-1",
+            "app_id": "app-1",
+            "workflow_name": "ValueEngine",
+            "app_name": "Bounded App",
+        }
+    )
+
+    async def _fake_coll():
+        return coll
+
+    def _fail_policy(_workflow_name):
+        raise RuntimeError("SECRET_POLICY_RESOLUTION_VALUE")
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+    monkeypatch.setattr(_persistence_mod, "_context_authority_policy_for_workflow", _fail_policy)
+
+    with pytest.raises(ValueError, match=r"policy_unavailable workflow=ValueEngine op=replay") as exc_info:
+        await manager.fetch_chat_session_extra_context(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+        )
+
+    assert "SECRET_POLICY_RESOLUTION_VALUE" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_context_replay_storage_failure_propagates(monkeypatch):
+    manager = AG2PersistenceManager()
+    storage_error = RuntimeError("find failed")
+    coll = _FakeCollection({}, find_error=storage_error)
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(RuntimeError, match="failed to fetch persisted workflow context") as exc_info:
+        await manager.fetch_chat_session_extra_context(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+        )
+
+    assert exc_info.value.__cause__ is storage_error
+
+
+@pytest.mark.asyncio
+async def test_context_update_storage_failure_propagates(
+    monkeypatch,
+    authentic_workflow_policies,
+):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"},
+        update_error=RuntimeError("update failed"),
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            variables={"app_name": "Bounded App"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("update_result", "message"),
+    [
+        (
+            _FakeUpdateResult(0, matched_count=1, acknowledged=False),
+            "write was not acknowledged",
+        ),
+        (
+            _FakeUpdateResult(0, matched_count=0, acknowledged=True),
+            "scoped session was not found",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_context_update_rejects_unacknowledged_or_unmatched_writes(
+    monkeypatch,
+    authentic_workflow_policies,
+    update_result,
+    message,
+):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"},
+        update_result=update_result,
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(RuntimeError, match=message):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            variables={"app_name": "Bounded App"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_update_accepts_matched_noop_write(
+    monkeypatch,
+    authentic_workflow_policies,
+):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection(
+        {"_id": "chat-1", "app_id": "app-1", "workflow_name": "ValueEngine"},
+        update_result=_FakeUpdateResult(0, matched_count=1, acknowledged=True),
+    )
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    await manager.persist_context_variables(
+        chat_id="chat-1",
+        app_id="app-1",
+        workflow_name="ValueEngine",
+        variables={"app_name": "Bounded App"},
+    )
+
+    assert coll.update_filters[-1] == {
+        "_id": "chat-1",
+        "app_id": "app-1",
+        "workflow_name": "ValueEngine",
+    }
+
+
+@pytest.mark.asyncio
+async def test_required_chat_session_insert_failure_propagates(monkeypatch):
+    manager = AG2PersistenceManager()
+    insert_error = RuntimeError("insert failed")
+    coll = _FakeCollection({}, insert_error=insert_error)
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(RuntimeError, match="insert failed") as exc_info:
+        await manager.create_chat_session(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            user_id="user-1",
+        )
+
+    assert exc_info.value is insert_error
+
+
+@pytest.mark.asyncio
+async def test_required_chat_session_rejects_unacknowledged_insert(monkeypatch):
+    manager = AG2PersistenceManager()
+    coll = _FakeCollection({}, insert_result=_FakeInsertResult(acknowledged=False))
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(RuntimeError, match="write was not acknowledged"):
+        await manager.create_chat_session(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="ValueEngine",
+            user_id="user-1",
+        )
 
 
 @pytest.mark.asyncio
@@ -513,3 +1056,35 @@ async def test_persistence_manager_backfills_pre_migration_workflow_ui_state_wit
     assert modern["workflow_ui_state"]["last_artifact"] == {"tool_name": "CurrentArtifact"}
     assert coll.bulk_write_calls == 1
 
+
+
+@pytest.mark.asyncio
+async def test_unloaded_workflow_fails_closed_instead_of_dropping_all_state(
+    monkeypatch, authentic_workflow_policies
+):
+    """A workflow absent from this process must not silently lose persisted state."""
+
+    manager = AG2PersistenceManager()
+    doc = {"_id": "chat-1", "app_id": "app-1", "workflow_name": "NotARegisteredWorkflow"}
+    coll = _FakeCollection(doc)
+
+    async def _fake_coll():
+        return coll
+
+    monkeypatch.setattr(manager, "_coll", _fake_coll)
+
+    with pytest.raises(ValueError, match="unresolved_declarations"):
+        await manager.persist_context_variables(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="NotARegisteredWorkflow",
+            variables={"interview_complete": True},
+        )
+
+    doc["interview_complete"] = True
+    with pytest.raises(ValueError, match="unresolved_declarations"):
+        await manager.fetch_chat_session_extra_context(
+            chat_id="chat-1",
+            app_id="app-1",
+            workflow_name="NotARegisteredWorkflow",
+        )

--- a/tests/test_runtime_output_validation.py
+++ b/tests/test_runtime_output_validation.py
@@ -23,19 +23,27 @@ Covers:
 
   resume.merge_persisted_extra_context:
     - empty/None extra_ctx → no-op
-    - non-str keys skipped
-    - uses context.set() when available
-    - uses context[key] = value when __setitem__ available
-    - parent_chat_id sets automated_workflow_run=True
-    - parent_chat_id absent → automated_workflow_run not set
+    - canonical loader context and resolved replay policy are required
+    - valid persisted values hydrate atomically
+    - stale/non-persisted keys are skipped without exposing values
+    - malformed known values and unresolved policies fail closed
+    - persisted replay authority is not retained for live writes
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from pydantic import BaseModel
 
+from mozaiksai.core.workflow.context.adapter import create_context_container
+from mozaiksai.core.workflow.context.authority import (
+    RUNTIME_SYSTEM_WRITER,
+    ContextAuthorityError,
+    build_context_authority_policy,
+)
 from mozaiksai.core.workflow.execution.run_bootstrap import merge_persisted_extra_context
 from mozaiksai.core.workflow.outputs.runtime_validation import (
     reply_body_to_data,
@@ -54,6 +62,45 @@ class _SampleModel(BaseModel):
 class _ObjectWithBody:
     def __init__(self, body: Any):
         self.body = body
+
+
+def _replay_policy():
+    return build_context_authority_policy(
+        workflow_name="ReplayFlow",
+        definitions={
+            "app_id": {
+                "type": "string",
+                "source": {"type": "state", "default": "app-canonical"},
+            },
+            "key": {
+                "type": "string",
+                "source": {"type": "state", "default": "default"},
+            },
+            "valid": {
+                "type": "string",
+                "source": {"type": "state", "default": "default"},
+            },
+            "review_complete": {
+                "type": "boolean",
+                "source": {"type": "state", "default": False},
+            },
+        },
+        transition_rules=[],
+    )
+
+
+def _replay_context(
+    initial: dict[str, Any] | None = None,
+    *,
+    policy=None,
+    bind_session: bool = False,
+):
+    return create_context_container(
+        initial=initial,
+        authority_policy=policy or _replay_policy(),
+        chat_id="chat-1" if bind_session else None,
+        app_id="app-1" if bind_session else None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -230,43 +277,87 @@ class TestMergePersistedExtraContext:
         merge_persisted_extra_context(ctx, "not a dict")  # type: ignore[arg-type]
         ctx.set.assert_not_called()
 
-    def test_uses_context_set_when_available(self):
-        ctx = MagicMock()
-        ctx.set = MagicMock()
-        merge_persisted_extra_context(ctx, {"key": "value"})
-        ctx.set.assert_any_call("key", "value")
+    def test_hydrates_valid_state_into_canonical_loader_context(self):
+        ctx = _replay_context({"key": "default"})
 
-    def test_uses_setitem_when_no_set(self):
-        ctx: dict = {}
         merge_persisted_extra_context(ctx, {"key": "value"})
-        assert ctx["key"] == "value"
+
+        assert ctx.snapshot() == {"key": "value"}
+        assert ctx._mozaiks_context_writer_id == RUNTIME_SYSTEM_WRITER
+
+    def test_rejects_noncanonical_context_for_nonempty_replay(self):
+        ctx: dict[str, Any] = {}
+
+        with pytest.raises(TypeError, match="canonical runtime context container"):
+            merge_persisted_extra_context(ctx, {"key": "value"})
+
+        assert ctx == {}
+
+    def test_requires_bound_replay_policy(self):
+        ctx = create_context_container(initial={"key": "default"})
+
+        with pytest.raises(ContextAuthorityError, match="replay_policy_unavailable"):
+            merge_persisted_extra_context(ctx, {"key": "value"})
+
+        assert ctx.snapshot() == {"key": "default"}
 
     def test_skips_non_str_keys(self):
-        ctx = MagicMock()
-        ctx.set = MagicMock()
-        merge_persisted_extra_context(ctx, {42: "value", "valid": "v"})
-        # Only "valid" should be set, 42 is not a str
-        call_keys = [call[0][0] for call in ctx.set.call_args_list]
-        assert "valid" in call_keys
-        assert 42 not in call_keys
+        ctx = _replay_context({"valid": "default"})
+
+        merge_persisted_extra_context(ctx, {42: "value", "valid": "v"})  # type: ignore[dict-item]
+
+        assert ctx.snapshot() == {"valid": "v"}
 
     def test_skips_whitespace_only_keys(self):
-        ctx = MagicMock()
-        ctx.set = MagicMock()
-        merge_persisted_extra_context(ctx, {"   ": "value"})
-        ctx.set.assert_not_called()
+        ctx = _replay_context({"valid": "default"})
 
-    def test_parent_chat_id_sets_automated_workflow_run(self):
-        ctx = MagicMock()
-        ctx.set = MagicMock()
-        merge_persisted_extra_context(ctx, {"parent_chat_id": "chat-123"})
-        # automated_workflow_run should be set to True
-        set_calls = {call[0][0]: call[0][1] for call in ctx.set.call_args_list}
-        assert set_calls.get("automated_workflow_run") is True
+        merge_persisted_extra_context(ctx, {"   ": "value", "valid": "v"})
 
-    def test_no_parent_chat_id_no_automated_workflow_run(self):
-        ctx = MagicMock()
-        ctx.set = MagicMock()
-        merge_persisted_extra_context(ctx, {"some_key": "value"})
-        call_keys = [call[0][0] for call in ctx.set.call_args_list]
-        assert "automated_workflow_run" not in call_keys
+        assert ctx.snapshot() == {"valid": "v"}
+
+    def test_non_persisted_authority_identifier_is_not_restored(self):
+        ctx = _replay_context({"app_id": "app-canonical", "key": "default"})
+
+        merge_persisted_extra_context(
+            ctx,
+            {"app_id": "app-attacker", "key": "restored"},
+        )
+
+        assert ctx.snapshot() == {"app_id": "app-canonical", "key": "restored"}
+
+    def test_stale_key_is_dropped_without_losing_valid_sibling_or_logging_value(self, caplog):
+        ctx = _replay_context({"key": "default"})
+
+        with caplog.at_level(logging.DEBUG, logger="mozaiksai.core.workflow.context.adapter"):
+            merge_persisted_extra_context(
+                ctx,
+                {"stale_historical_key": "sensitive-old-value", "key": "restored"},
+            )
+
+        assert ctx.snapshot() == {"key": "restored"}
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("workflow=ReplayFlow key=stale_historical_key" in message for message in messages)
+        assert all("sensitive-old-value" not in message for message in messages)
+
+    def test_known_malformed_value_fails_without_partial_hydration(self):
+        ctx = _replay_context({"key": "default", "review_complete": False})
+
+        with pytest.raises(ContextAuthorityError, match="invalid_value"):
+            merge_persisted_extra_context(
+                ctx,
+                {"key": "would-be-partial", "review_complete": "true"},
+            )
+
+        assert ctx.snapshot() == {"key": "default", "review_complete": False}
+
+    def test_session_bound_loader_set_does_not_start_background_persistence(self, monkeypatch):
+        import asyncio
+
+        create_task = MagicMock()
+        monkeypatch.setattr(asyncio, "create_task", create_task)
+        ctx = _replay_context({"key": "default"}, bind_session=True)
+
+        ctx.set("key", "live-update")
+
+        assert ctx.snapshot() == {"key": "live-update"}
+        create_task.assert_not_called()

--- a/tests/test_workflow_bridge.py
+++ b/tests/test_workflow_bridge.py
@@ -292,6 +292,7 @@ async def test_handle_user_input_from_api_prefers_live_ag2_network_channel(monke
         {
             "chat_id": "chat-1",
             "app_id": "app-1",
+            "workflow_name": "ValueEngine",
             "variables": {"target_user": "founders"},
         }
     ]
@@ -300,6 +301,92 @@ async def test_handle_user_input_from_api_prefers_live_ag2_network_channel(monke
         "chat.text",
         "awaiting_reply",
         "run_complete",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_ag2_context_persistence_failure_propagates(monkeypatch) -> None:
+    class _FailingPersistenceManager(_FakePersistenceManager):
+        async def persist_context_variables(self, **kwargs):  # noqa: ANN003
+            self.persisted_context.append(kwargs)
+            raise RuntimeError("context update failed")
+
+    persistence_manager = _FailingPersistenceManager()
+    transport = _DummyTransport(persistence_manager)
+    live_run = _FakeLiveRun(result=_LiveRunResult(status=RunStatus.PAUSED))
+
+    async def _context_updates(**_kwargs):  # noqa: ANN003
+        return {}
+
+    monkeypatch.setattr(transport, "_apply_user_text_context_updates", _context_updates)
+
+    with pytest.raises(RuntimeError, match="context update failed"):
+        await transport._continue_live_ag2_workflow_run(
+            live_run=live_run,
+            chat_id="chat-1",
+            user_id="user-1",
+            workflow_name="ValueEngine",
+            message="continue",
+            app_id="app-1",
+        )
+
+    assert persistence_manager.persisted_context == [
+        {
+            "chat_id": "chat-1",
+            "app_id": "app-1",
+            "workflow_name": "ValueEngine",
+            "variables": {"target_user": "founders"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_text_context_fetch_failure_propagates() -> None:
+    class _FailingFetchPersistenceManager(_FakePersistenceManager):
+        async def fetch_chat_session_extra_context(self, **_kwargs):  # noqa: ANN003
+            raise RuntimeError("context fetch failed")
+
+    transport = _DummyTransport(_FailingFetchPersistenceManager())
+
+    with pytest.raises(RuntimeError, match="context fetch failed"):
+        await transport._apply_user_text_context_updates(
+            chat_id="chat-1",
+            workflow_name="ValueEngine",
+            app_id="app-1",
+            user_input="continue",
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_text_context_update_failure_propagates() -> None:
+    class _FailingUpdatePersistenceManager(_FakePersistenceManager):
+        async def persist_context_variables(self, **kwargs):  # noqa: ANN003
+            self.persisted_context.append(kwargs)
+            raise RuntimeError("context update failed")
+
+    class _DerivedContextManager:
+        def apply_user_text(self, _candidate: str) -> dict[str, str]:
+            return {"target_user": "founders"}
+
+    persistence_manager = _FailingUpdatePersistenceManager()
+    transport = _DummyTransport(persistence_manager)
+    transport._derived_context_managers["chat-1"] = _DerivedContextManager()
+
+    with pytest.raises(RuntimeError, match="context update failed"):
+        await transport._apply_user_text_context_updates(
+            chat_id="chat-1",
+            workflow_name="ValueEngine",
+            app_id="app-1",
+            user_input="founders",
+        )
+
+    assert persistence_manager.persisted_context == [
+        {
+            "chat_id": "chat-1",
+            "app_id": "app-1",
+            "workflow_name": "ValueEngine",
+            "variables": {"target_user": "founders"},
+        }
     ]
 
 


### PR DESCRIPTION
## Summary

Bounded persistence/replay hardening for workflow run context. This PR contains exactly one commit touching 16 files (runtime persistence/replay paths, their tests, and CHANGELOG). It does not change workflow declarations, the scoped-writer model, producer closure, lifecycle, task batches, structured-output projection, tool context, MCP, or event reactions.

### What it changes

- **Fail closed on unresolved declarations.** `ContextAuthorityPolicy` now carries `declarations_resolved`; persisting or replaying a nonempty context for a workflow whose declarations cannot be resolved raises `ContextAuthorityError` instead of silently producing `{}` or dropping all durable state.
- **Persistence is policy-filtered.** `persist_context_variables` requires a workflow identity, resolves the workflow's authority policy, and filters the snapshot through `filter_for_persistence`: declared `persisted: false` keys are skipped before any replay/value validation, unknown stale keys are dropped with key-identity-only diagnostics (never values), and known malformed or non-replayable values fail closed.
- **Replay is policy-filtered and hydrates through the trusted loader path.** `fetch_chat_session_extra_context` scopes its query by workflow, strips protected canonical fields, and filters stored state through `filter_for_replay`. `merge_persisted_extra_context` now hydrates through the canonical `_RuntimeContextVariables` hydration entry point; `persisted_replay` has no live writer authority anywhere (`_can_write` returns `False` for it, and it was removed from ordinary/inferred writer sets).
- **Immutable authority state never round-trips.** Immutable runtime authority, authorization state, and credential/secret-shaped keys are non-replayable; a declaration that marks such a key `persisted` fails policy construction (`_validate_replay_contract`).
- **Required storage failures propagate.** Session creation, context fetch, and context update no longer swallow errors; unacknowledged writes and scoped-session-not-found updates raise. The final persisted snapshot is the orchestration `ctx_dict`; the detached agent context bridge is intentionally not overlaid onto it.

### Explicitly out of scope

Producer closure, `ScopedContextWriter` redesign, workflow writer-declaration changes (`factory_app/` has zero net diff), lifecycle/task-batch/structured-output/tool-context/MCP/event-reaction changes, and all mozaiks-app work.

## Validation (independent final review at d492299d, Python 3.11.16 / ag2 1.0.1)

- Focused persistence/context-authority suite (9 files) run twice plus reversed order: 168 passed in reversed order; forward order reproduces one known **pre-existing** order-dependent failure (`test_ag2_structured_outputs_emit_runtime_event_and_update_context` monkeypatch import-path resolution) that fails identically at the PR base and passes in isolation and in CI order — tracked as a follow-up, not part of this PR.
- Registered workflow load/persist/resume order combinations (`test_workflow_manager_reload`, `test_workflow_manager_reinitialize_identity`, `test_workflow_manager_a2a_config` interleaved with the persistence round-trip tests): all passed.
- Stale-key, malformed-value, unresolved-policy, and required-database-failure tests: all passed; round trips use the real factory workflow declarations (`initialize_workflows` against `factory_app/workflows`), not mocked policies.
- Full clean suite (`pytest -q --no-cov`): passed.
- `ruff check .` clean; `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped` clean; governance guardrails passed; source hygiene scan passed on repo sources; `git diff --check` clean.
- Local merge of this head with current `origin/main` (through 5d5d3f80): clean merge, focused suite passes; the main advancement (MozaiksPay factory defaults, build-context validation, `normalize_app_id` boolean rejection, docs) shares no files and no semantic surface with this diff.

## Follow-ups (documented, not in this PR)

- Pre-existing order-dependent test pollution: running `tests/test_persistence_initial_messages.py` or `tests/test_auto_tool_handler_persistence.py` before `tests/test_ag2_network_execution_alignment.py` breaks monkeypatch import-path resolution of `mozaiksai.core`; identical at the PR base.
- `create_chat_session(extra_fields=...)` seeds context into the session document without persistence-policy filtering; the replay boundary added here gates it on load, but creation-time filtering would be a cleaner contract.
- Mid-run incremental persists in `auto_tool_handler` still swallow persistence errors (pre-existing); the final orchestration snapshot persist now propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
