### PR TITLE
fix(core): sanitize boolean app_ids and normalize TXT challenge domai…

### DIFF
--- a/mozaiksai/core/multitenant/app_ids.py
+++ b/mozaiksai/core/multitenant/app_ids.py
@@ -4,12 +4,13 @@ from typing import Any
 
 
 def normalize_app_id(value: Any) -> str | None:
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     if isinstance(value, str):
         trimmed = value.strip()
         return trimmed or None
-    return str(value) or None
+    s = str(value).strip()
+    return s or None
 
 
 def coalesce_app_id(*, app_id: Any = None) -> str | None:

--- a/mozaiksai/core/utils/domain_ownership.py
+++ b/mozaiksai/core/utils/domain_ownership.py
@@ -44,7 +44,8 @@ def challenge_name_for_domain(domain: str) -> str:
         challenge_name_for_domain("example.com")
         # → "_mozaiks-verify.example.com"
     """
-    return f"{_CHALLENGE_PREFIX}.{domain}"
+    normalized = (domain or "").strip().lower().rstrip(".")
+    return f"{_CHALLENGE_PREFIX}.{normalized}"
 
 
 def challenge_value_for_token(token: str) -> str:


### PR DESCRIPTION
…ns (fixes #335, fixes #334)

<!--
  Thanks for contributing to Mozaiks! Please fill out this template so
  maintainers have what they need to review efficiently. See CONTRIBUTING.md
  for the full contribution path.
-->

## Related issue

<!-- Link the issue this PR addresses, e.g. "Closes #123". Write "N/A" if none. -->

## Summary

Fixed boolean type coercion in `normalize_app_id` (#335) and added domain string normalization to `challenge_name_for_domain` (#334).
- **`mozaiksai/core/multitenant/app_ids.py`**: Updated `normalize_app_id` to return `None` for boolean values (`False`/`True`), preventing invalid `"False"`/`"True"` tenant scopes.
- **`mozaiksai/core/utils/domain_ownership.py`**: Updated `challenge_name_for_domain` to strip whitespace, lowercase, and remove trailing dots from domain inputs.


## Tests run

- Verified `normalize_app_id(False) is None`, `normalize_app_id(True) is None`, and `challenge_name_for_domain("  EXAMPLE.COM.  ") == "_mozaiks-verify.example.com"`. All test cases passed cleanly.
## Screenshots (if applicable)

### 💳 Payment & Bounty Details
- **PayPal Link:** https://paypal.me/mgarg1102
- 
## Boundary confirmation

- [ ] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [ ] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [ ] If this adds or changes a public contract, the contract is classified and versioned.
- [ ] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included.
- [ ] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit.
