### PR TITLE
Reject boolean values in normalize_app_id

### DIFF
--- a/mozaiksai/core/multitenant/app_ids.py
+++ b/mozaiksai/core/multitenant/app_ids.py
@@ -6,10 +6,16 @@ from typing import Any
 def normalize_app_id(value: Any) -> str | None:
     if value is None:
         return None
+    # bool is a subclass of int, so True/False would otherwise become the
+    # scope strings "True"/"False" and silently pass the tenant boundary.
+    # A boolean is never a valid app id, so reject it up front.
+    if isinstance(value, bool):
+        return None
     if isinstance(value, str):
         trimmed = value.strip()
         return trimmed or None
-    return str(value) or None
+    trimmed = str(value).strip()
+    return trimmed or None
 
 
 def coalesce_app_id(*, app_id: Any = None) -> str | None:

--- a/tests/test_event_serialization_and_app_ids.py
+++ b/tests/test_event_serialization_and_app_ids.py
@@ -338,6 +338,15 @@ class TestNormalizeAppId:
         result = normalize_app_id(12345)
         assert result == "12345"
 
+    def test_bool_false_returns_none(self):
+        assert normalize_app_id(False) is None
+
+    def test_bool_true_returns_none(self):
+        assert normalize_app_id(True) is None
+
+    def test_bool_does_not_leak_into_scope_filter(self):
+        assert build_app_scope_filter(False) == {"app_id": "__invalid__"}
+
 
 # ---------------------------------------------------------------------------
 # 5. coalesce_app_id


### PR DESCRIPTION
normalize_app_id only guarded string inputs and fell through to str(value) for everything else. Because bool is a subclass of int, normalize_app_id(False) returned the string "False" and normalize_app_id(True) returned "True". Those values then flowed into build_app_scope_filter and dual_write_app_scope, so a boolean silently became a valid-looking tenant scope and defeated the multitenancy boundary.

Add an explicit bool guard that returns None, and strip non-string values uniformly before the empty check. Integer and other non-string inputs keep their existing conversion behaviour.

Tests cover False and True returning None and a boolean not leaking into the scope filter.

Fixes #335