### PR TITLE
docs: remove link to the deleted help wanted label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,10 @@ supports rather than a prerequisite for contributing.
 
 Looking for something to work on:
 
-- **[good first issue](https://github.com/BlocUnited-LLC/mozaiks/labels/good%20first%20issue)** — scoped, self-contained, and written with file and line references so you are not hunting for context.
-- **[help wanted](https://github.com/BlocUnited-LLC/mozaiks/labels/help%20wanted)** — larger or more open-ended, and still a good entry point if you want more room.
+Browse the
+**[good first issue](https://github.com/BlocUnited-LLC/mozaiks/labels/good%20first%20issue)**
+label — scoped, self-contained work, written with file and line references so
+you are not hunting for context.
 
 Most of these need no MongoDB, Node.js, or LLM API key — see
 [What You Can Contribute Without Extra Setup](#what-you-can-contribute-without-extra-setup).


### PR DESCRIPTION
## Related issue

N/A — follow-up to #347.

## Summary

`CONTRIBUTING.md:44` on `main` links to `labels/help%20wanted`, which no longer exists. The label was deleted shortly after #347 was written, and the doc referencing it was not rechecked before that PR merged. Dead link, currently live.

The label was on four issues, all of which also carried `good first issue`, so pointing at that label alone loses nothing.

Also adds no new surface — this is a two-line edit to the existing Where to Start section.

## Tests run

```
python -m pytest tests/test_contributor_guidance_framing.py   tests/test_contributor_quickstart.py -q --no-cov   -> 20 passed
python -m mkdocs build --strict                       -> built, no warnings
```

Plus a check that every `/labels/<name>` link in the contributor-facing docs resolves against the repo's live label list:

```
all label links resolve (11 labels live)
```

## Screenshots (if applicable)

N/A.

## AI assistance (optional)

Written by Claude Code, including this description. The dead link was mine to begin with.

## Boundary confirmation

- [x] This change stays within the open-source `mozaiks` repository and does not introduce private hosted-product logic, credentials, or internal-only URLs.

## Governance check

- [x] This is an ordinary change with no new public schema, public workflow/prompt family, provider mutation path, authority bypass, eval artifact, learned optimization, or cross-customer intelligence.
- [x] If this adds or changes a public contract, the contract is classified and versioned. — N/A, documentation only.
- [x] If this touches a one-way-door area from `OSS_PUBLICATION_POLICY.md`, a short ADR is included. — N/A.
- [x] If this touches permissions, secrets, provider execution, payments, deployment, DNS, or production operations, the authority and review path are explicit. — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)