### PR TITLE
docs(rules): codify the cross-module composition rule

### DIFF
--- a/factory_app/.claude/rules/modules.md
+++ b/factory_app/.claude/rules/modules.md
@@ -33,4 +33,26 @@ app/modules/{module_id}/
 - Typed payloads and document shapes belong in `schemas.py`.
 - Publish domain events through declared contracts; do not hardcode workflow starts in module code.
 - Use `runtime_extensions.yaml` for API routers or startup services only when the module needs them.
+
+## Cross-Module Composition
+
+Two sanctioned mechanisms exist for one module using another. Choose by
+this rule, not by mimicking the nearest neighbor:
+
+- **Events (`contracts/reactions.yaml`)** — for reacting to *state changes*.
+  When module A changes state that module B cares about, A emits a declared
+  event and B subscribes with a reaction. This is the only sanctioned way a
+  module triggers behavior in another module. Reaction targets of
+  `kind: handler` must name a method that actually exists on the module's
+  handler class.
+- **Direct service import** — for *synchronous reads only*. A module may
+  import another module's Service class (deferred import to avoid cycles),
+  instantiate it, and call a read method with the caller's ctx, wrapped so a
+  failure degrades instead of breaking the caller's own read path.
+
+Never direct-import another module's service to perform a **write** — writes
+cross module boundaries only through declared events, or through an explicit
+bridge the owning module publishes for that purpose (with its own
+permission-wrapping context and idempotency). Never import another module's
+repo, and never touch another module's collections directly.
 <!-- END MOZAIKS MANAGED: agent-guidance -->

--- a/mozaiks_cli/agent_guidance/rules/modules.md
+++ b/mozaiks_cli/agent_guidance/rules/modules.md
@@ -32,3 +32,25 @@ app/modules/{module_id}/
 - Typed payloads and document shapes belong in `schemas.py`.
 - Publish domain events through declared contracts; do not hardcode workflow starts in module code.
 - Use `runtime_extensions.yaml` for API routers or startup services only when the module needs them.
+
+## Cross-Module Composition
+
+Two sanctioned mechanisms exist for one module using another. Choose by
+this rule, not by mimicking the nearest neighbor:
+
+- **Events (`contracts/reactions.yaml`)** — for reacting to *state changes*.
+  When module A changes state that module B cares about, A emits a declared
+  event and B subscribes with a reaction. This is the only sanctioned way a
+  module triggers behavior in another module. Reaction targets of
+  `kind: handler` must name a method that actually exists on the module's
+  handler class.
+- **Direct service import** — for *synchronous reads only*. A module may
+  import another module's Service class (deferred import to avoid cycles),
+  instantiate it, and call a read method with the caller's ctx, wrapped so a
+  failure degrades instead of breaking the caller's own read path.
+
+Never direct-import another module's service to perform a **write** — writes
+cross module boundaries only through declared events, or through an explicit
+bridge the owning module publishes for that purpose (with its own
+permission-wrapping context and idempotency). Never import another module's
+repo, and never touch another module's collections directly.


### PR DESCRIPTION
## Summary
The canonical structure had two coexisting cross-module composition mechanisms — event reactions and direct service imports — with no written rule for choosing between them; humans and agents chose by mimicking the nearest neighbor. This codifies the rule in the managed module rules (`mozaiks_cli/agent_guidance/rules/modules.md` + the factory_app managed copy; app workspaces pick it up via the managed guidance sync):

- **Events** (`contracts/reactions.yaml`) for reacting to state changes — the only sanctioned way one module triggers behavior in another; handler targets must exist
- **Direct service import** for synchronous **reads only** (deferred import, caller's ctx, failure-isolated)
- **Writes never cross module boundaries** except through declared events or an explicit bridge the owning module publishes (own permission-wrapping ctx + idempotency — e.g. build_intelligence's outcome_bridge)
- Never import another module's repo or touch its collections

Companion to mozaiks-app#248, which enforces the structural half (reaction targets exist, events declared, aliases registered) as repo-wide drift guards.

## Testing
- `ruff check .` clean; full suite 13385 passed, 77 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012thGtQXpM6eNYoSxKvGm5w