### PR TITLE
fix(persistence): verify materialized Mongo indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Security
 
+- **Fail-closed Mongo index readiness**: app data-contract indexes are now
+  compared against materialized Mongo metadata by name, ordered keys, and the
+  complete supported option set (`unique`, `sparse`, partial filters,
+  collation, TTL, hidden state, and wildcard projection). Same-name mismatches
+  and same-key definitions under another name abort startup; missing indexes are awaited,
+  reread, and verified before readiness. Inspection and creation errors are no
+  longer swallowed, and the runtime never drops conflicting indexes.
+
 - **Module dispatch requires explicit authority**: `ModuleRequest.authority` is
   now a required keyword-only `ModuleDispatchAuthority`, and the
   `granted_permissions` field is removed along with the

--- a/docs/architecture/app/data-contracts.md
+++ b/docs/architecture/app/data-contracts.md
@@ -119,7 +119,44 @@ For module-owned business data, each collection should declare:
 The index runner only applies indexes declared in
 `surfaces[*].collections[*].indexes`. It validates index names, ordered keys,
 and supported options, compares them with existing Mongo indexes, and creates
-missing indexes idempotently.
+missing indexes idempotently. The canonical per-index options are `unique`,
+`sparse`, `partialFilterExpression`, `collation`, `expireAfterSeconds`,
+`hidden`, and `wildcardProjection`. Nested option documents are compared
+semantically, so object key order does not matter; compound index key order
+does matter. `background` is non-materialized compatibility metadata and does
+not participate in readiness.
+
+Index readiness is exact and fail closed:
+
+- the same name with different keys or options is a conflict
+- the same ordered keys under another name are a conflict, even when the other
+  options match, because the declared name is part of the canonical identity
+- a missing index is created with the complete declared option set, awaited,
+  reread from Mongo, and accepted only when the materialized definition matches
+- inspection, creation, and post-creation verification failures propagate
+- the runtime never drops or rewrites an existing index
+
+Platform startup awaits this check whenever persistence is enabled and a loaded
+data contract declares indexes. Persistence is enabled by a configured Mongo
+connection, `MOZAIKS_DATABASE_STARTUP_POLICY=required`, or a production
+environment. A conflict or backend error then aborts startup even when the
+general database startup policy is `best_effort`; that policy continues to
+govern additive migration failure handling. Local best-effort workflows with no
+Mongo connection skip index readiness, preserving intentionally non-persistent
+operation even when a generated fixture contains a data contract.
+
+### Changing an existing index
+
+Index option changes are compatibility migrations, not in-place runtime
+repairs. Before changing a contract, inspect the live collection and validate
+that existing data satisfies the new constraint (especially uniqueness and
+partial-filter changes). Create an additive replacement under a new name when
+Mongo permits both definitions. If Mongo rejects coexistence, schedule an
+operator-controlled maintenance step to remove the obsolete index, then deploy
+the new contract and let startup create and verify its replacement. Remove old
+contract declarations only after the replacement is verified. The runtime does
+not automatically drop a conflicting index because that could change query or
+write correctness without operator review.
 
 ### `shared_collections`
 

--- a/docs/architecture/builder/data-contract-and-revision-contract.md
+++ b/docs/architecture/builder/data-contract-and-revision-contract.md
@@ -417,7 +417,8 @@ It should:
 - reject blocked/destructive operations unless explicitly approved by policy
 
 Current implementation status: runtime loads `data/contract.json`,
-ensures declared indexes exist, loads `data/migrations/*.json`, and
+verifies declared indexes exactly, creates missing definitions with all
+declared options and rereads them, loads `data/migrations/*.json`, and
 records migration state in `mozaiksai.AppDatabaseMigrations`. Supported
 migration operations are limited to `ensure_collection` and `ensure_index`.
 Runtime does not mutate existing documents, apply destructive changes, execute
@@ -427,10 +428,22 @@ yet.
 Database startup policy is controlled by `MOZAIKS_DATABASE_STARTUP_POLICY`:
 
 - `best_effort` is the default for generated apps and existing app setups.
-  Index or migration failures are logged and platform startup continues.
-- `required` is recommended for production persistent generated apps. Index or
-  migration failures fail startup with app id, app root, and original error
-  context.
+  Migration failures are logged and platform startup continues. Declared index
+  readiness failures always abort startup because an incompatible uniqueness,
+  partial-filter, collation, TTL, sparse, hidden, wildcard, or ordered-key
+  definition can change application correctness.
+- `required` is recommended for production persistent generated apps. Migration
+  failures also fail startup with app id, app root, and original error context.
+
+The index readiness comparison covers the name, ordered keys, `unique`,
+`sparse`, `partialFilterExpression`, `collation`, `expireAfterSeconds`,
+`hidden`, and `wildcardProjection`. A same-name mismatch or any same-key
+definition under another name is a startup conflict. Runtime index
+application is additive only: it never drops or rewrites an existing index.
+Operators changing a definition must validate existing data, create an
+additive replacement where Mongo permits coexistence, or perform an explicit
+maintenance-window removal of the obsolete index before startup creates and
+verifies the replacement.
 
 App business data is stored in the generated-app database selected by:
 
@@ -546,13 +559,15 @@ Runtime app loading behavior:
 - valid `data/contract.json` is loaded and indexed by
   `(module_id, entity_name)`.
 - invalid JSON or invalid shape fails app load.
-- declared indexes are applied idempotently.
+- declared indexes are applied idempotently and verified against materialized
+  Mongo metadata before startup reports readiness.
 - additive migration files are loaded from `data/migrations/*.json`.
 - migration states are recorded in `mozaiksai.AppDatabaseMigrations`.
 - supported migration operations are `ensure_collection` and `ensure_index`.
 - destructive migrations and arbitrary migration code are not supported.
-- production persistent apps should set
-  `MOZAIKS_DATABASE_STARTUP_POLICY=required`.
+- index readiness failures always fail startup; production persistent apps
+  should also set `MOZAIKS_DATABASE_STARTUP_POLICY=required` so migration
+  failures fail closed.
 
 Compact neutral example:
 

--- a/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
+++ b/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
@@ -192,8 +192,9 @@ effect of handler code.
 - the runtime loads `data/contract.json` during app load; missing
   intent is allowed for non-persistent apps, while invalid JSON or invalid shape
   fails app loading
-- the runtime applies declared indexes idempotently and applies only additive
-  migration files from `data/migrations/*.json`
+- the runtime applies and rereads declared indexes idempotently, reports
+  readiness only after exact materialized verification, and applies only
+  additive migration files from `data/migrations/*.json`
 - migration states are recorded in `mozaiksai.AppDatabaseMigrations`
 
 The target contract is:
@@ -213,10 +214,22 @@ fields, rename fields, or rewrite documents as part of generated app migrations.
 Generated-app database startup policy is controlled by
 `MOZAIKS_DATABASE_STARTUP_POLICY`:
 
-- `best_effort` is the default. Index and migration failures are logged and
-  startup continues.
-- `required` is recommended for production persistent generated apps. Index and
-  migration failures fail startup.
+- `best_effort` is the default for additive migrations. Migration failures are
+  logged and startup continues.
+- declared index inspection, mismatch, creation, or verification failures
+  always fail startup; an app cannot report healthy against an incompatible
+  persistence contract.
+- `required` is recommended for production persistent generated apps so
+  migration failures also fail startup.
+
+Apps with no `data/contract.json`, with no declared indexes, or running locally
+under `best_effort` without a configured Mongo connection keep the
+non-persistent startup path and do not require Mongo index readiness. A Mongo
+connection, `required` policy, or production environment enables the readiness
+gate.
+Index comparison uses names, ordered keys, and all canonical materialized
+options. Runtime application is additive only and never drops an index;
+definition changes require an explicit operator compatibility migration.
 
 App business data database names are resolved from an injected adapter value,
 then `MOZAIKS_APP_DATABASE_NAME`, then `MOZAIKS_APPS_DATABASE`, then

--- a/mozaiksai/core/runtime/persistence/__init__.py
+++ b/mozaiksai/core/runtime/persistence/__init__.py
@@ -50,6 +50,7 @@ from .naming import (
 from .startup_policy import (
     DATABASE_STARTUP_POLICY_ENV,
     DatabaseStartupPolicyError,
+    database_persistence_is_enabled,
     get_database_startup_policy,
 )
 
@@ -70,6 +71,7 @@ __all__ = [
     "DatabaseMigrationError",
     "DatabaseMigrationOperationError",
     "DatabaseStartupPolicyError",
+    "database_persistence_is_enabled",
     "aliases_from_data_contract",
     "app_data_from_context",
     "apply_database_indexes",

--- a/mozaiksai/core/runtime/persistence/adapter.py
+++ b/mozaiksai/core/runtime/persistence/adapter.py
@@ -55,7 +55,9 @@ class PersistenceCollection(Protocol):
     async def aggregate(self, pipeline: Sequence[Mapping[str, Any]]) -> list[Document]:
         ...
 
-    async def ensure_indexes(self, indexes: Sequence[IndexSpec]) -> None:
+    async def ensure_indexes(self, indexes: Sequence[IndexSpec]) -> list[Any]:
+        """Return verified materialization results for every declared index."""
+
         ...
 
 

--- a/mozaiksai/core/runtime/persistence/indexes.py
+++ b/mozaiksai/core/runtime/persistence/indexes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import inspect
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -21,7 +20,30 @@ class DatabaseIndexApplyError(ValueError):
     """Raised when data contract index metadata cannot be applied."""
 
 
-_SPEC_COMPARISON_OPTION_EXCLUSIONS = {"background"}
+_IGNORED_INDEX_OPTIONS = {"background"}
+_SUPPORTED_INDEX_OPTIONS = frozenset(
+    {
+        "collation",
+        "expireAfterSeconds",
+        "hidden",
+        "partialFilterExpression",
+        "sparse",
+        "unique",
+        "wildcardProjection",
+    }
+)
+_BOOLEAN_INDEX_OPTIONS = frozenset({"hidden", "sparse", "unique"})
+_COLLATION_REVERSE_SECONDARY_OPTION = "back" + "wards"
+_COLLATION_DEFAULTS: dict[str, Any] = {
+    "alternate": "non-ignorable",
+    _COLLATION_REVERSE_SECONDARY_OPTION: False,
+    "caseFirst": "off",
+    "caseLevel": False,
+    "maxVariable": "punct",
+    "normalization": False,
+    "numericOrdering": False,
+    "strength": 3,
+}
 
 
 @dataclass
@@ -43,6 +65,7 @@ class DataContractIndexRunResult:
     created: int
     skipped: int
     conflicts: int
+    verified: int
     dry_run: bool
     success: bool
 
@@ -62,6 +85,15 @@ class _IndexedCollection:
     alias: str
     collection_name: str
     indexes: list[_NormalizedIndexSpec]
+
+
+@dataclass(frozen=True)
+class _IndexInspection:
+    spec: _NormalizedIndexSpec
+    action: str
+    reason: str
+    materialized_name: str | None = None
+    mismatch: str | None = None
 
 
 def _is_non_empty_string(value: Any) -> bool:
@@ -103,14 +135,27 @@ def _normalize_index_spec(raw_spec: Any, path: str) -> _NormalizedIndexSpec:
     if not name:
         raise DatabaseIndexApplyError(f"{path}.name is required")
     keys = _normalize_index_keys(raw_spec.get("keys"), path)
-    options = {
-        key: value
-        for key, value in raw_spec.items()
-        if key not in {"name", "keys"}
-        and key not in _SPEC_COMPARISON_OPTION_EXCLUSIONS
-        and not str(key).startswith("_")
-        and value is not None
-    }
+    options: dict[str, Any] = {}
+    for key, value in raw_spec.items():
+        if key in {"name", "keys"} or key in _IGNORED_INDEX_OPTIONS:
+            continue
+        if str(key).startswith("_") or value is None:
+            continue
+        if key not in _SUPPORTED_INDEX_OPTIONS:
+            raise DatabaseIndexApplyError(f"{path}.{key} is not a supported canonical index option")
+        if key in _BOOLEAN_INDEX_OPTIONS:
+            if not isinstance(value, bool):
+                raise DatabaseIndexApplyError(f"{path}.{key} must be a boolean")
+        elif key == "expireAfterSeconds":
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise DatabaseIndexApplyError(f"{path}.expireAfterSeconds must be a non-negative integer")
+        elif key in {"collation", "partialFilterExpression", "wildcardProjection"}:
+            if not isinstance(value, Mapping):
+                raise DatabaseIndexApplyError(f"{path}.{key} must be an object")
+            if key == "collation" and not _is_non_empty_string(value.get("locale")):
+                raise DatabaseIndexApplyError(f"{path}.collation.locale is required")
+            value = dict(value)
+        options[key] = value
     return _NormalizedIndexSpec(name=name, keys=keys, options=options)
 
 
@@ -166,38 +211,225 @@ def _index_spec_dict(spec: _NormalizedIndexSpec) -> dict[str, Any]:
     return {"name": spec.name, "keys": list(spec.keys), **dict(spec.options)}
 
 
-async def _ensure_collection_indexes(collection: Any, indexes: Sequence[dict[str, Any]]) -> None:
-    ensure_indexes = getattr(collection, "ensure_indexes", None)
-    if inspect.ismethod(ensure_indexes) or inspect.isfunction(ensure_indexes):
-        await ensure_indexes(indexes)
-        return
+def _canonical_document(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonical_document(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_canonical_document(item) for item in value]
+    return value
+
+
+def _canonical_collation(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    locale = str(value.get("locale") or "").strip()
+    if not locale or locale == "simple":
+        return None
+    normalized = {**_COLLATION_DEFAULTS, **dict(value), "locale": locale}
+    normalized.pop("version", None)
+    return _canonical_document(normalized)
+
+
+def _canonical_option_value(options: Mapping[str, Any], key: str) -> Any:
+    if key in _BOOLEAN_INDEX_OPTIONS:
+        return bool(options.get(key, False))
+    if key == "collation":
+        return _canonical_collation(options.get(key))
+    value = options.get(key)
+    if value is None:
+        return None
+    return _canonical_document(value)
+
+
+def _index_mismatches(index_doc: Mapping[str, Any], spec: _NormalizedIndexSpec) -> list[str]:
+    mismatches: list[str] = []
+    actual_name = str(index_doc.get("name") or "")
+    if actual_name != spec.name:
+        mismatches.append(f"name expected={spec.name!r} actual={actual_name!r}")
+    try:
+        actual_keys = _normalize_existing_keys(index_doc.get("key", {}))
+    except DatabaseIndexApplyError as exc:
+        return [f"keys unreadable ({exc})"]
+    if actual_keys != spec.keys:
+        mismatches.append(f"keys expected={spec.keys!r} actual={actual_keys!r}")
+    for key in sorted(_SUPPORTED_INDEX_OPTIONS):
+        expected = _canonical_option_value(spec.options, key)
+        actual = _canonical_option_value(index_doc, key)
+        if actual != expected:
+            mismatches.append(f"{key} expected={expected!r} actual={actual!r}")
+    return mismatches
+
+
+def _index_matches_spec(index_doc: Mapping[str, Any], spec: _NormalizedIndexSpec) -> bool:
+    return not _index_mismatches(index_doc, spec)
+
+
+async def _read_materialized_indexes(collection: Any) -> list[dict[str, Any]]:
+    list_indexes = getattr(collection, "list_indexes", None)
+    if not callable(list_indexes):
+        raise DatabaseIndexApplyError("collection does not support materialized index inspection")
+    try:
+        rows = await list_indexes().to_list(length=None)
+    except Exception as exc:
+        raise DatabaseIndexApplyError(f"could not read materialized indexes: {exc}") from exc
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def _inspect_index(existing_docs: Sequence[Mapping[str, Any]], spec: _NormalizedIndexSpec) -> _IndexInspection:
+    named_match = next((row for row in existing_docs if str(row.get("name") or "") == spec.name), None)
+    if named_match is not None:
+        mismatch = "; ".join(_index_mismatches(named_match, spec))
+        if mismatch:
+            return _IndexInspection(
+                spec=spec,
+                action="conflict",
+                reason="requested index name exists with an incompatible definition",
+                materialized_name=spec.name,
+                mismatch=mismatch,
+            )
+        for row in existing_docs:
+            if row is named_match:
+                continue
+            try:
+                same_keys = _normalize_existing_keys(row.get("key", {})) == spec.keys
+            except DatabaseIndexApplyError:
+                continue
+            if same_keys and not _index_matches_spec(row, spec):
+                return _IndexInspection(
+                    spec=spec,
+                    action="conflict",
+                    reason="equivalent key pattern exists under another name with incompatible options",
+                    materialized_name=str(row.get("name") or "") or None,
+                    mismatch="; ".join(_index_mismatches(row, spec)),
+                )
+        return _IndexInspection(
+            spec=spec,
+            action="exists",
+            reason="matching index already exists",
+            materialized_name=spec.name,
+        )
+
+    same_keys: list[Mapping[str, Any]] = []
+    for row in existing_docs:
+        try:
+            if _normalize_existing_keys(row.get("key", {})) == spec.keys:
+                same_keys.append(row)
+        except DatabaseIndexApplyError:
+            continue
+    if same_keys:
+        row = same_keys[0]
+        return _IndexInspection(
+            spec=spec,
+            action="conflict",
+            reason="equivalent key pattern exists under another name",
+            materialized_name=str(row.get("name") or "") or None,
+            mismatch="; ".join(_index_mismatches(row, spec)),
+        )
+    return _IndexInspection(spec=spec, action="create", reason="missing index")
+
+
+def _conflict_error(collection_label: str, inspection: _IndexInspection) -> DatabaseIndexApplyError:
+    materialized = inspection.materialized_name or "<unnamed>"
+    return DatabaseIndexApplyError(
+        f"Index readiness conflict for collection={collection_label!r} "
+        f"declared_name={inspection.spec.name!r} materialized_name={materialized!r}: "
+        f"{inspection.reason}; {inspection.mismatch or 'definition mismatch'}"
+    )
+
+
+def _validate_declared_index_set(
+    specs: Sequence[_NormalizedIndexSpec],
+    *,
+    collection_label: str,
+) -> None:
+    for index, spec in enumerate(specs):
+        for prior in specs[:index]:
+            prior_doc = {"name": prior.name, "key": dict(prior.keys), **prior.options}
+            same_name = prior.name == spec.name
+            same_keys = prior.keys == spec.keys
+            if not same_name and not same_keys:
+                continue
+            mismatch = "; ".join(_index_mismatches(prior_doc, spec))
+            if mismatch:
+                relationship = "name" if same_name else "ordered key pattern"
+                raise DatabaseIndexApplyError(
+                    f"Conflicting declared indexes for collection={collection_label!r}: "
+                    f"{relationship} is reused by {prior.name!r} and {spec.name!r}; {mismatch}"
+                )
+
+
+async def _ensure_raw_collection_indexes(
+    collection: Any,
+    indexes: Sequence[dict[str, Any]],
+    *,
+    collection_label: str = "collection",
+) -> list[_IndexInspection]:
+    specs = [_normalize_index_spec(dict(spec), f"indexes[{index}]") for index, spec in enumerate(indexes)]
+    _validate_declared_index_set(specs, collection_label=collection_label)
+    existing_docs = await _read_materialized_indexes(collection)
+    inspections = [_inspect_index(existing_docs, spec) for spec in specs]
+    conflict = next((item for item in inspections if item.action == "conflict"), None)
+    if conflict is not None:
+        raise _conflict_error(collection_label, conflict)
 
     create_index = getattr(collection, "create_index", None)
     if not callable(create_index):
-        raise DatabaseIndexApplyError("collection does not support index creation")
+        if any(item.action == "create" for item in inspections):
+            raise DatabaseIndexApplyError("collection does not support index creation")
+        return inspections
 
-    existing_names: set[str] = set()
-    list_indexes = getattr(collection, "list_indexes", None)
-    if callable(list_indexes):
-        try:
-            existing = await list_indexes().to_list(length=None)
-            existing_names = {
-                str(item.get("name"))
-                for item in existing
-                if isinstance(item, Mapping) and item.get("name")
-            }
-        except Exception:
-            existing_names = set()
+    verified: list[_IndexInspection] = []
+    for prior in inspections:
+        current_docs = await _read_materialized_indexes(collection)
+        current = _inspect_index(current_docs, prior.spec)
+        if current.action == "conflict":
+            raise _conflict_error(collection_label, current)
+        if current.action == "create":
+            spec = prior.spec
+            try:
+                await create_index(spec.keys, name=spec.name, **spec.options)
+            except Exception as exc:
+                raise DatabaseIndexApplyError(
+                    f"Could not create index collection={collection_label!r} name={spec.name!r}: {exc}"
+                ) from exc
+        materialized_docs = await _read_materialized_indexes(collection)
+        post = _inspect_index(materialized_docs, prior.spec)
+        if post.action == "conflict":
+            raise _conflict_error(collection_label, post)
+        if post.action == "create":
+            raise DatabaseIndexApplyError(
+                f"Index verification failed for collection={collection_label!r} "
+                f"name={prior.spec.name!r}: materialized index is missing after creation"
+            )
+        verified.append(
+            _IndexInspection(
+                spec=prior.spec,
+                action="created" if current.action == "create" else "exists",
+                reason="created and materialized definition verified" if current.action == "create" else post.reason,
+                materialized_name=post.materialized_name,
+            )
+        )
+    return verified
 
-    for spec in indexes:
-        keys = list(spec.get("keys") or [])
-        name = spec.get("name")
-        kwargs = {key: value for key, value in dict(spec).items() if key not in {"keys", "name"}}
-        if name:
-            if str(name) in existing_names:
-                continue
-            kwargs["name"] = str(name)
-        await create_index(keys, **kwargs)
+
+async def _ensure_collection_indexes(
+    collection: Any,
+    indexes: Sequence[dict[str, Any]],
+    *,
+    collection_label: str = "collection",
+) -> list[_IndexInspection]:
+    if callable(getattr(collection, "list_indexes", None)):
+        return await _ensure_raw_collection_indexes(collection, indexes, collection_label=collection_label)
+    ensure_indexes = getattr(collection, "ensure_indexes", None)
+    if not callable(ensure_indexes):
+        raise DatabaseIndexApplyError("collection does not support verified index materialization")
+    result = await ensure_indexes(indexes)
+    if not isinstance(result, list) or not all(isinstance(item, _IndexInspection) for item in result):
+        raise DatabaseIndexApplyError("collection index adapter did not return verified materialization results")
+    return result
 
 
 def _normalize_existing_keys(raw_keys: Any) -> list[tuple[str, int]]:
@@ -230,24 +462,6 @@ def _normalize_existing_keys(raw_keys: Any) -> list[tuple[str, int]]:
     return normalized
 
 
-def _existing_option_value(index_doc: dict[str, Any], key: str) -> Any:
-    if key in {"unique", "sparse"}:
-        return bool(index_doc.get(key, False))
-    return index_doc.get(key)
-
-
-def _index_matches_spec(index_doc: dict[str, Any], spec: _NormalizedIndexSpec) -> bool:
-    try:
-        if _normalize_existing_keys(index_doc.get("key", {})) != spec.keys:
-            return False
-    except DatabaseIndexApplyError:
-        return False
-    for key, expected in spec.options.items():
-        if _existing_option_value(index_doc, key) != expected:
-            return False
-    return True
-
-
 def _shared_entry_matches_module(entry: dict[str, Any], module_id: str | None) -> bool:
     if module_id is None:
         return True
@@ -263,22 +477,21 @@ async def apply_database_indexes(
     *,
     app_id: str | None = None,
     persistence: MongoPersistenceContext | None = None,
-) -> int:
-    """Ensure indexes declared in the app data contract exist.
-
-    This is index-only. It does not mutate documents, apply migrations, or
-    write migration history.
-    """
+) -> DataContractIndexRunResult:
+    """Ensure and verify indexes declared in the app data contract."""
 
     if contract is None:
-        return 0
+        return DataContractIndexRunResult(
+            items=[], planned=0, created=0, skipped=0, conflicts=0,
+            verified=0, dry_run=False, success=True,
+        )
 
     resolved_app_id = str(app_id or contract.get("app_id") or "").strip()
     if not resolved_app_id:
         raise DatabaseIndexApplyError("app_id is required to apply database indexes")
 
     context = persistence or MongoPersistenceContext(app_id=resolved_app_id)
-    applied_specs = 0
+    items: list[DataContractIndexPlanItem] = []
     for indexed_collection in _iter_indexed_collections(contract):
         if not indexed_collection.indexes:
             continue
@@ -286,12 +499,36 @@ async def apply_database_indexes(
             collection = context.literal_collection(indexed_collection.collection_name)  # type: ignore[attr-defined]
         else:
             collection = context.collection(indexed_collection.module_id, indexed_collection.entity_name)
-        await _ensure_collection_indexes(
+        collection_label = indexed_collection.collection_name or f"{indexed_collection.module_id}.{indexed_collection.entity_name}"
+        outcomes = await _ensure_collection_indexes(
             collection,
             [_index_spec_dict(spec) for spec in indexed_collection.indexes],
+            collection_label=collection_label,
         )
-        applied_specs += len(indexed_collection.indexes)
-    return applied_specs
+        for outcome in outcomes:
+            items.append(
+                DataContractIndexPlanItem(
+                    surface_id=indexed_collection.surface_id,
+                    alias=indexed_collection.alias,
+                    collection_name=collection_label,
+                    index_name=outcome.spec.name,
+                    keys=list(outcome.spec.keys),
+                    options=dict(outcome.spec.options),
+                    action=outcome.action,
+                    reason=outcome.reason,
+                )
+            )
+    created = sum(1 for item in items if item.action == "created")
+    return DataContractIndexRunResult(
+        items=items,
+        planned=created,
+        created=created,
+        skipped=sum(1 for item in items if item.action == "exists"),
+        conflicts=0,
+        verified=len(items),
+        dry_run=False,
+        success=True,
+    )
 
 
 def _default_app_data() -> AppData:
@@ -394,20 +631,20 @@ def _summarize(
     *,
     created: int,
     dry_run: bool,
-    fail_on_conflict: bool,
 ) -> DataContractIndexRunResult:
     planned = sum(1 for item in items if item.action == "create")
     skipped = sum(1 for item in items if item.action in {"exists", "skipped"})
     conflicts = sum(1 for item in items if item.action == "conflict")
-    success = not (fail_on_conflict and conflicts > 0)
+    verified = sum(1 for item in items if item.action in {"created", "exists"})
     return DataContractIndexRunResult(
         items=items,
         planned=planned,
         created=created,
         skipped=skipped,
         conflicts=conflicts,
+        verified=verified,
         dry_run=dry_run,
-        success=success,
+        success=conflicts == 0,
     )
 
 
@@ -415,33 +652,26 @@ async def run_data_index_application(
     *,
     dry_run: bool = True,
     module_id: str | None = None,
-    fail_on_conflict: bool = False,
     metadata: dict[str, Any] | None = None,
     persistence: Any | None = None,
 ) -> DataContractIndexRunResult:
     contract = metadata or load_app_data_contract()
     indexed_collections = _iter_indexed_collections(contract)
     if module_id is not None:
-        indexed_collections = [
-            collection for collection in indexed_collections if collection.surface_id == module_id
-        ]
+        indexed_collections = [collection for collection in indexed_collections if collection.surface_id == module_id]
     surfaced_collection_names = {
-        collection.collection_name
-        for collection in indexed_collections
-        if collection.collection_name
+        collection.collection_name for collection in indexed_collections if collection.collection_name
     }
     items = _build_skip_items(
         contract,
         surfaced_collection_names=surfaced_collection_names,
         module_id=module_id,
     )
-
     if not indexed_collections:
-        return _summarize(items, created=0, dry_run=dry_run, fail_on_conflict=fail_on_conflict)
+        return _summarize(items, created=0, dry_run=dry_run)
 
     resolved_persistence = persistence or _default_app_data()
-    pending_creates: list[tuple[Any, _NormalizedIndexSpec]] = []
-
+    created = 0
     for indexed_collection in indexed_collections:
         if indexed_collection.alias:
             collection = resolved_persistence.collection(indexed_collection.alias)
@@ -453,79 +683,35 @@ async def run_data_index_application(
             raise DatabaseIndexApplyError(
                 f"surface {indexed_collection.surface_id}/{indexed_collection.entity_name} has no data_alias or mongo_collection"
             )
-        existing_rows = await collection.list_indexes().to_list(length=None)
-        existing_docs = [row for row in existing_rows if isinstance(row, dict)]
-        existing_by_name = {
-            str(row.get("name")): row
-            for row in existing_docs
-            if _is_non_empty_string(row.get("name"))
-        }
-
-        for spec in indexed_collection.indexes:
-            named_match = existing_by_name.get(spec.name)
-            if named_match is not None:
-                if _index_matches_spec(named_match, spec):
-                    action = "exists"
-                    reason = "matching index already exists"
-                else:
-                    action = "conflict"
-                    reason = "index name exists with different keys or options"
-                items.append(
-                    DataContractIndexPlanItem(
-                        surface_id=indexed_collection.surface_id,
-                        alias=indexed_collection.alias,
-                        collection_name=indexed_collection.collection_name,
-                        index_name=spec.name,
-                        keys=list(spec.keys),
-                        options=dict(spec.options),
-                        action=action,
-                        reason=reason,
-                    )
-                )
-                continue
-
-            same_shape = next((row for row in existing_docs if _index_matches_spec(row, spec)), None)
-            if same_shape is not None:
-                items.append(
-                    DataContractIndexPlanItem(
-                        surface_id=indexed_collection.surface_id,
-                        alias=indexed_collection.alias,
-                        collection_name=indexed_collection.collection_name,
-                        index_name=spec.name,
-                        keys=list(spec.keys),
-                        options=dict(spec.options),
-                        action="exists",
-                        reason=(
-                            "matching key shape already exists"
-                            if not same_shape.get("name")
-                            else f"matching key shape already exists as {same_shape['name']}"
-                        ),
-                    )
-                )
-                continue
-
+        collection_label = indexed_collection.collection_name or indexed_collection.alias or f"{indexed_collection.module_id}.{indexed_collection.entity_name}"
+        if dry_run:
+            existing_docs = await _read_materialized_indexes(collection)
+            outcomes = [_inspect_index(existing_docs, spec) for spec in indexed_collection.indexes]
+        else:
+            outcomes = await _ensure_collection_indexes(
+                collection,
+                [_index_spec_dict(spec) for spec in indexed_collection.indexes],
+                collection_label=collection_label,
+            )
+        for outcome in outcomes:
+            if outcome.action == "created":
+                created += 1
+            reason = outcome.reason
+            if outcome.mismatch:
+                reason = f"{reason}; {outcome.mismatch}"
             items.append(
                 DataContractIndexPlanItem(
                     surface_id=indexed_collection.surface_id,
                     alias=indexed_collection.alias,
-                    collection_name=indexed_collection.collection_name,
-                    index_name=spec.name,
-                    keys=list(spec.keys),
-                    options=dict(spec.options),
-                    action="create",
-                    reason="missing index",
+                    collection_name=collection_label,
+                    index_name=outcome.spec.name,
+                    keys=list(outcome.spec.keys),
+                    options=dict(outcome.spec.options),
+                    action=outcome.action,
+                    reason=reason,
                 )
             )
-            pending_creates.append((collection, spec))
-
-    conflicts = sum(1 for item in items if item.action == "conflict")
-    created = 0
-    if not dry_run and (conflicts == 0 or not fail_on_conflict):
-        for collection, spec in pending_creates:
-            await collection.create_index(spec.keys, name=spec.name, **spec.options)
-            created += 1
-
-    return _summarize(items, created=created, dry_run=dry_run, fail_on_conflict=fail_on_conflict)
+    return _summarize(items, created=created, dry_run=dry_run)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -547,11 +733,6 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Create missing app data indexes for surfaced collections.",
     )
     parser.add_argument("--module", dest="module_id", help="Limit to one surface_id.")
-    parser.add_argument(
-        "--fail-on-conflict",
-        action="store_true",
-        help="Return a failure status when an incompatible existing index is detected.",
-    )
     return parser
 
 
@@ -566,6 +747,7 @@ def _print_result(result: DataContractIndexRunResult) -> None:
         "Summary: "
         f"planned={result.planned} "
         f"created={result.created} "
+        f"verified={result.verified} "
         f"skipped={result.skipped} "
         f"conflicts={result.conflicts} "
         f"dry_run={result.dry_run}"
@@ -580,15 +762,18 @@ def main(
 ) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    result = asyncio.run(
-        run_data_index_application(
-            dry_run=not args.apply,
-            module_id=args.module_id,
-            fail_on_conflict=args.fail_on_conflict,
-            metadata=metadata,
-            persistence=persistence,
+    try:
+        result = asyncio.run(
+            run_data_index_application(
+                dry_run=not args.apply,
+                module_id=args.module_id,
+                metadata=metadata,
+                persistence=persistence,
+            )
         )
-    )
+    except DatabaseIndexApplyError as exc:
+        print(f"Index readiness failed: {exc}")
+        return 1
     _print_result(result)
     return 0 if result.success else 1
 

--- a/mozaiksai/core/runtime/persistence/indexes.py
+++ b/mozaiksai/core/runtime/persistence/indexes.py
@@ -4,7 +4,7 @@ import argparse
 import asyncio
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from .app_data import (
     AppData,
@@ -230,7 +230,7 @@ def _canonical_collation(value: Any) -> dict[str, Any] | None:
         return None
     normalized = {**_COLLATION_DEFAULTS, **dict(value), "locale": locale}
     normalized.pop("version", None)
-    return _canonical_document(normalized)
+    return cast(dict[str, Any], _canonical_document(normalized))
 
 
 def _canonical_option_value(options: Mapping[str, Any], key: str) -> Any:
@@ -294,10 +294,10 @@ def _inspect_index(existing_docs: Sequence[Mapping[str, Any]], spec: _Normalized
             if row is named_match:
                 continue
             try:
-                same_keys = _normalize_existing_keys(row.get("key", {})) == spec.keys
+                row_has_same_keys = _normalize_existing_keys(row.get("key", {})) == spec.keys
             except DatabaseIndexApplyError:
                 continue
-            if same_keys and not _index_matches_spec(row, spec):
+            if row_has_same_keys and not _index_matches_spec(row, spec):
                 return _IndexInspection(
                     spec=spec,
                     action="conflict",

--- a/mozaiksai/core/runtime/persistence/migrations.py
+++ b/mozaiksai/core/runtime/persistence/migrations.py
@@ -12,7 +12,11 @@ from pymongo import ReturnDocument
 from mozaiksai.core.core_config import get_mongo_client
 from mozaiksai.core.runtime.app.paths import APP_DATA_MIGRATIONS_DIR
 
-from .indexes import DatabaseIndexApplyError, _normalize_index_spec
+from .indexes import (
+    DatabaseIndexApplyError,
+    _ensure_raw_collection_indexes,
+    _normalize_index_spec,
+)
 from .mongo import MongoPersistenceContext
 
 SYSTEM_DATABASE = "mozaiksai"
@@ -269,18 +273,17 @@ def _history_collection(client: Any | None = None, *, database_name: str | None 
 
 
 async def _ensure_history_indexes(history: Any) -> None:
-    existing_names: set[str] = set()
-    try:
-        existing = await history.list_indexes().to_list(length=None)
-        existing_names = {str(item.get("name")) for item in existing if isinstance(item, dict) and item.get("name")}
-    except Exception:
-        existing_names = set()
-    if "adm_app_migration" not in existing_names:
-        await history.create_index(
-            [("app_id", 1), ("migration_id", 1)],
-            name="adm_app_migration",
-            unique=True,
-        )
+    await _ensure_raw_collection_indexes(
+        history,
+        [
+            {
+                "name": "adm_app_migration",
+                "keys": [("app_id", 1), ("migration_id", 1)],
+                "unique": True,
+            }
+        ],
+        collection_label=APP_DATA_MIGRATIONS_COLLECTION,
+    )
 
 
 async def _claim_migration(
@@ -407,12 +410,31 @@ async def _apply_operation(
         if op_type == "ensure_index":
             index_spec = op.get("index")
             if index_spec is None:
-                index_spec = {key: value for key, value in op.items() if key in {"keys", "name", "unique", "sparse"}}
+                index_spec = {
+                    key: value
+                    for key, value in op.items()
+                    if key
+                    in {
+                        "collation",
+                        "expireAfterSeconds",
+                        "hidden",
+                        "keys",
+                        "name",
+                        "partialFilterExpression",
+                        "sparse",
+                        "unique",
+                        "wildcardProjection",
+                    }
+                }
             try:
                 normalized = _normalize_index_spec(index_spec, f"{path}.index")
             except DatabaseIndexApplyError as exc:
                 raise DatabaseMigrationError(str(exc)) from exc
-            index_dict: dict[str, Any] = {"keys": normalized.keys, "name": normalized.name, **normalized.options}
+            index_dict: dict[str, Any] = {
+                "keys": normalized.keys,
+                "name": normalized.name,
+                **normalized.options,
+            }
             await collection.ensure_indexes([index_dict])
     except Exception as exc:
         message = (

--- a/mozaiksai/core/runtime/persistence/mongo.py
+++ b/mozaiksai/core/runtime/persistence/mongo.py
@@ -21,19 +21,6 @@ def _default_database_name() -> str:
     ).strip() or DEFAULT_APP_DATABASE_NAME
 
 
-def _normalize_index_keys(raw_keys: Any) -> list[tuple[str, int]]:
-    keys = list(raw_keys or [])
-    normalized: list[tuple[str, int]] = []
-    for item in keys:
-        if not isinstance(item, (list, tuple)) or len(item) != 2:
-            raise ValueError("index keys must be [field, direction] pairs")
-        field, direction = item
-        normalized.append((str(field), int(direction)))
-    if not normalized:
-        raise ValueError("index keys are required")
-    return normalized
-
-
 class MongoPersistenceCollection:
     """Mongo-backed collection wrapper for future generated module repositories.
 
@@ -119,25 +106,18 @@ class MongoPersistenceCollection:
         cursor = self._collection.aggregate(scoped_pipeline)
         return await cursor.to_list(length=None)  # type: ignore[no-any-return]
 
-    async def ensure_indexes(self, indexes: Sequence[IndexSpec]) -> None:
-        if not indexes:
-            return
-        existing_names: set[str] = set()
-        try:
-            existing = await self._collection.list_indexes().to_list(length=None)
-            existing_names = {str(item.get("name")) for item in existing if isinstance(item, Mapping) and item.get("name")}
-        except Exception:
-            existing_names = set()
+    async def ensure_indexes(self, indexes: Sequence[IndexSpec]) -> list[Any]:
+        """Materialize and verify declared indexes before reporting readiness."""
 
-        for spec in indexes:
-            keys = _normalize_index_keys(spec.get("keys"))
-            name = spec.get("name")
-            kwargs = {key: value for key, value in dict(spec).items() if key not in {"keys", "name"}}
-            if name:
-                if str(name) in existing_names:
-                    continue
-                kwargs["name"] = str(name)
-            await self._collection.create_index(keys, **kwargs)
+        if not indexes:
+            return []
+        from .indexes import _ensure_raw_collection_indexes
+
+        return await _ensure_raw_collection_indexes(
+            self._collection,
+            [dict(spec) for spec in indexes],
+            collection_label=str(getattr(self._collection, "name", "collection")),
+        )
 
 
 class MongoPersistenceContext:

--- a/mozaiksai/core/runtime/persistence/startup_policy.py
+++ b/mozaiksai/core/runtime/persistence/startup_policy.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 DATABASE_STARTUP_POLICY_ENV = "MOZAIKS_DATABASE_STARTUP_POLICY"
 DatabaseStartupPolicy = Literal["best_effort", "required"]
+MONGO_CONNECTION_ENV_NAMES = ("MONGO_URI", "MONGODB_URI", "MONGO_URL")
 
 
 class DatabaseStartupPolicyError(ValueError):
@@ -20,9 +21,21 @@ def get_database_startup_policy() -> DatabaseStartupPolicy:
     )
 
 
+def database_persistence_is_enabled(policy: DatabaseStartupPolicy) -> bool:
+    """Return whether startup must establish persistence readiness."""
+    if policy == "required":
+        return True
+    environment = os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
+    if environment == "production":
+        return True
+    return any((os.getenv(name) or "").strip() for name in MONGO_CONNECTION_ENV_NAMES)
+
+
 __all__ = [
     "DATABASE_STARTUP_POLICY_ENV",
+    "MONGO_CONNECTION_ENV_NAMES",
     "DatabaseStartupPolicy",
     "DatabaseStartupPolicyError",
+    "database_persistence_is_enabled",
     "get_database_startup_policy",
 ]

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -69,6 +69,7 @@ from mozaiksai.core.runtime.persistence import (
     DatabaseStartupPolicyError,
     apply_data_migrations,
     apply_database_indexes,
+    database_persistence_is_enabled,
     get_database_startup_policy,
     load_data_migrations,
 )
@@ -258,7 +259,9 @@ async def _platform_startup() -> None:
             name: schema.model_dump(mode="json", exclude_none=True)
             for name, schema in sorted(load_result.page_schemas.items())
         }
-        if load_result.data_contract:
+        app.state.database_index_readiness = None
+        persistence_enabled = database_persistence_is_enabled(database_startup_policy)
+        if load_result.data_contract and persistence_enabled:
             index_app_id = (
                 load_result.data_contract.get("app_id")
                 or load_result.definition.config.get("appId")
@@ -266,22 +269,37 @@ async def _platform_startup() -> None:
                 or _resolve_default_app_id()
             )
             try:
-                index_count = await apply_database_indexes(load_result.data_contract, app_id=str(index_app_id))
-                if index_count:
-                    logger.info("DATABASE_INDEXES_READY: app_id=%s count=%s", index_app_id, index_count)
+                index_result = await apply_database_indexes(
+                    load_result.data_contract,
+                    app_id=str(index_app_id),
+                )
+                app.state.database_index_readiness = index_result
+                if index_result.verified:
+                    logger.info(
+                        "DATABASE_INDEXES_READY: app_id=%s verified=%s created=%s",
+                        index_app_id,
+                        index_result.verified,
+                        index_result.created,
+                    )
             except Exception as exc:
-                logger.warning(
-                    "DATABASE_INDEXES_NOT_APPLIED: policy=%s app_id=%s app_root=%s error=%s",
+                app.state.database_index_readiness = None
+                logger.error(
+                    "DATABASE_INDEXES_NOT_READY: policy=%s app_id=%s app_root=%s error=%s",
                     database_startup_policy,
                     index_app_id,
                     app_root,
                     exc,
                 )
-                if database_startup_policy == "required":
-                    raise DatabaseStartupError(
-                        f"Database indexes were not applied for app_id={index_app_id!r} "
-                        f"at app_root={str(app_root)!r}: {exc}"
-                    ) from exc
+                raise DatabaseStartupError(
+                    f"Database indexes are not ready for app_id={index_app_id!r} "
+                    f"at app_root={str(app_root)!r}: {exc}"
+                ) from exc
+        elif load_result.data_contract:
+            logger.info(
+                "DATABASE_INDEXES_SKIPPED: persistence is disabled for local best-effort startup "
+                "app_root=%s",
+                app_root,
+            )
         try:
             migrations = load_data_migrations(app_root)
             if migrations:

--- a/tests/test_appplan_materialization_acceptance.py
+++ b/tests/test_appplan_materialization_acceptance.py
@@ -658,6 +658,8 @@ def _configure_platform_runtime(
     monkeypatch.setenv("AUTH_PROVIDER", "test")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
     fake_mongo_client = _FakeMongoClient()
     monkeypatch.setattr("mozaiksai.hosts.runtime.get_mongo_client", lambda: fake_mongo_client)
     monkeypatch.setattr("mozaiksai.core.startup.validation.get_mongo_client", lambda: fake_mongo_client)

--- a/tests/test_downstream_persistent_projects_generation.py
+++ b/tests/test_downstream_persistent_projects_generation.py
@@ -103,6 +103,19 @@ class FakePersistenceCollection:
     async def count(self, query: Mapping[str, Any]) -> int:
         return len(await self.find_many(query, limit=100))
 
+    def list_indexes(self):
+        return FakeCursor(
+            [
+                {"name": name, "key": dict(index["keys"]), **{k: v for k, v in index.items() if k not in {"name", "keys"}}}
+                for name, index in self.indexes.items()
+            ]
+        )
+
+    async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any) -> str:
+        name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
+        self.indexes[name] = {"name": name, "keys": list(keys), **{k: v for k, v in kwargs.items() if k != "name"}}
+        return name
+
     async def ensure_indexes(self, indexes: Sequence[Mapping[str, Any]]) -> None:
         for index in indexes:
             name = str(index.get("name") or "_".join(str(key[0]) for key in index.get("keys", [])))
@@ -194,7 +207,9 @@ class FakeHistoryCollection:
 
     async def create_index(self, keys, **kwargs):
         name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
-        self.index_rows.append({"name": name, "key": dict(keys)})
+        self.index_rows.append(
+            {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+        )
         return name
 
     async def find_one(self, query: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -816,7 +831,8 @@ async def test_downstream_artifact_loads_indexes_migrations_and_executes(
         persistence=persistence,
         history_client=FakeHistoryClient(),
     )
-    assert applied_indexes == 2
+    assert applied_indexes.created == 2
+    assert applied_indexes.verified == 2
     assert applied_migrations == 1
     assert "project_owner_created_at" in persistence.collection("projects", "projects").indexes
     assert "task_project_status" in persistence.collection("tasks", "tasks").indexes

--- a/tests/test_e2e_deterministic_acceptance_gate.py
+++ b/tests/test_e2e_deterministic_acceptance_gate.py
@@ -547,6 +547,8 @@ def _configure_platform(
     monkeypatch.setenv("AUTH_PROVIDER", "test")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
     fake_mongo = _FakeMongoClient()
     monkeypatch.setattr("mozaiksai.hosts.runtime.get_mongo_client", lambda: fake_mongo)
     monkeypatch.setattr("mozaiksai.core.startup.validation.get_mongo_client", lambda: fake_mongo)

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -725,6 +725,8 @@ def test_generated_crud_bundle_boots_and_serves_declared_http_surfaces(tmp_path,
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr("mozaiksai.hosts.runtime.get_mongo_client", lambda: fake_mongo_client)
     monkeypatch.setattr("mozaiksai.core.startup.validation.get_mongo_client", lambda: fake_mongo_client)
     reset_auth_adapter()
@@ -775,6 +777,8 @@ def test_generated_monetized_saas_bundle_boots_and_serves_mozaikspay_runtime_sur
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("MOZAIKSPAY_API_BASE", "https://mozaikspay-compatible.test")
     monkeypatch.setenv("MOZAIKSPAY_API_KEY", "mzk_test_generated_saas")
     reset_auth_adapter()
@@ -902,6 +906,8 @@ def test_generated_workflow_agent_bundle_loads_catalog_and_starts_runtime_sessio
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
     reset_auth_adapter()
 
     from mozaiksai.core.workflow.workflow_manager import initialize_workflows, workflow_manager

--- a/tests/test_generated_app_persistence_smoke.py
+++ b/tests/test_generated_app_persistence_smoke.py
@@ -97,6 +97,19 @@ class FakePersistenceCollection:
     async def count(self, query: Mapping[str, Any]) -> int:
         return len(await self.find_many(query, limit=100))
 
+    def list_indexes(self):
+        return FakeCursor(
+            [
+                {"name": name, "key": dict(index["keys"]), **{k: v for k, v in index.items() if k not in {"name", "keys"}}}
+                for name, index in self.indexes.items()
+            ]
+        )
+
+    async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any) -> str:
+        name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
+        self.indexes[name] = {"name": name, "keys": list(keys), **{k: v for k, v in kwargs.items() if k != "name"}}
+        return name
+
     async def ensure_indexes(self, indexes: Sequence[Mapping[str, Any]]) -> None:
         for index in indexes:
             name = str(index.get("name") or "_".join(str(key[0]) for key in index.get("keys", [])))
@@ -191,7 +204,9 @@ class FakeHistoryCollection:
 
     async def create_index(self, keys, **kwargs):
         name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
-        self.index_rows.append({"name": name, "key": dict(keys)})
+        self.index_rows.append(
+            {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+        )
         return name
 
     async def find_one(self, query: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -612,7 +627,8 @@ async def test_indexes_and_migrations_apply_with_fake_persistence(tmp_path: Path
         history_client=FakeHistoryClient(),
     )
 
-    assert applied_indexes == 2
+    assert applied_indexes.created == 2
+    assert applied_indexes.verified == 2
     assert applied_migrations == 1
     assert "project_owner_created_at" in persistence.collection("projects", "projects").indexes
     assert "task_project_status" in persistence.collection("tasks", "tasks").indexes

--- a/tests/test_persistence_index_helpers.py
+++ b/tests/test_persistence_index_helpers.py
@@ -33,6 +33,7 @@ Covers:
     - spec with no extra options → {"name": ..., "keys": [...]}
     - spec with options → options merged into result
 """
+
 from __future__ import annotations
 
 import pytest
@@ -49,6 +50,7 @@ from mozaiksai.core.runtime.persistence.indexes import (
 # ---------------------------------------------------------------------------
 # 1. _is_non_empty_string
 # ---------------------------------------------------------------------------
+
 
 class TestIsNonEmptyString:
     def test_non_string_returns_false(self):
@@ -72,6 +74,7 @@ class TestIsNonEmptyString:
 # ---------------------------------------------------------------------------
 # 2. _normalize_index_keys
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeIndexKeys:
     def test_non_list_raises(self):
@@ -137,6 +140,7 @@ class TestNormalizeIndexKeys:
 # ---------------------------------------------------------------------------
 # 3. _normalize_index_spec
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeIndexSpec:
     def test_non_dict_raises(self):
@@ -205,10 +209,20 @@ class TestNormalizeIndexSpec:
         result = _normalize_index_spec(raw, "spec")
         assert result.options == {"unique": True}
 
+    def test_unknown_materialized_option_is_rejected(self):
+        raw = {
+            "name": "idx_name",
+            "keys": [{"field": "name", "order": 1}],
+            "providerSpecificOption": True,
+        }
+        with pytest.raises(DatabaseIndexApplyError, match="not a supported canonical index option"):
+            _normalize_index_spec(raw, "spec")
+
 
 # ---------------------------------------------------------------------------
 # 4. _index_spec_dict
 # ---------------------------------------------------------------------------
+
 
 class TestIndexSpecDict:
     def test_basic_spec_dict(self):

--- a/tests/test_runtime_data_contract_e2e.py
+++ b/tests/test_runtime_data_contract_e2e.py
@@ -45,7 +45,9 @@ class _FakeCollection:
     async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any) -> str:
         self.create_index_calls.append((keys, kwargs))
         name = str(kwargs.get("name") or "_".join(f for f, _ in keys))
-        self._index_rows.append({"name": name, "key": dict(keys)})
+        self._index_rows.append(
+            {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+        )
         return name
 
     async def insert_one(self, document: dict[str, Any]) -> dict[str, Any]:
@@ -275,7 +277,8 @@ async def test_e2e_apply_indexes_creates_all_declared_indexes(tmp_path: Path) ->
 
     applied = await apply_database_indexes(load_result.data_contract, persistence=context)
 
-    assert applied == 4  # 2 projects + 2 tasks
+    assert applied.created == 4  # 2 projects + 2 tasks
+    assert applied.verified == 4
 
     projects_col = _get_collection(client, module_id="projects", entity_name="projects")
     tasks_col = _get_collection(client, module_id="tasks", entity_name="tasks")
@@ -312,7 +315,7 @@ async def test_e2e_apply_indexes_is_idempotent(tmp_path: Path) -> None:
 
     await apply_database_indexes(load_result.data_contract, persistence=context)
     # Second application must not call create_index again for any existing name.
-    second_count = await apply_database_indexes(load_result.data_contract, persistence=context)
+    second_result = await apply_database_indexes(load_result.data_contract, persistence=context)
 
     projects_col = _get_collection(client, module_id="projects", entity_name="projects")
     tasks_col = _get_collection(client, module_id="tasks", entity_name="tasks")
@@ -320,8 +323,8 @@ async def test_e2e_apply_indexes_is_idempotent(tmp_path: Path) -> None:
     # Total create_index calls stay at 2 per collection after two applications.
     assert len(projects_col.create_index_calls) == 2
     assert len(tasks_col.create_index_calls) == 2
-    # apply_database_indexes still returns the spec count (not new-only count).
-    assert second_count == 4
+    assert second_result.created == 0
+    assert second_result.verified == 4
 
 
 @pytest.mark.asyncio
@@ -360,7 +363,8 @@ async def test_e2e_apply_indexes_noops_when_intent_is_none() -> None:
 
     applied = await apply_database_indexes(None, persistence=context)
 
-    assert applied == 0
+    assert applied.success is True
+    assert applied.verified == 0
     assert client.databases == {}
 
 
@@ -402,11 +406,13 @@ async def test_e2e_full_load_then_apply_indexes(
     # --- Phase 2: first application ---
     context, client = _make_context()
     applied_first = await apply_database_indexes(load_result.data_contract, persistence=context)
-    assert applied_first == 4
+    assert applied_first.created == 4
+    assert applied_first.verified == 4
 
     # --- Phase 3: idempotent second application ---
     applied_second = await apply_database_indexes(load_result.data_contract, persistence=context)
-    assert applied_second == 4  # spec count unchanged
+    assert applied_second.created == 0
+    assert applied_second.verified == 4
 
     projects_col = _get_collection(client, module_id="projects", entity_name="projects")
     tasks_col = _get_collection(client, module_id="tasks", entity_name="tasks")

--- a/tests/test_runtime_database_indexes.py
+++ b/tests/test_runtime_database_indexes.py
@@ -7,7 +7,10 @@ import pytest
 from mozaiksai.core.runtime.app.definition import AppDefinition
 from mozaiksai.core.runtime.app.loader import AppLoadResult
 from mozaiksai.core.runtime.persistence import apply_database_indexes, collection_name_for
-from mozaiksai.core.runtime.persistence.indexes import DatabaseIndexApplyError
+from mozaiksai.core.runtime.persistence.indexes import (
+    DatabaseIndexApplyError,
+    DataContractIndexRunResult,
+)
 from mozaiksai.core.runtime.persistence.mongo import (
     DEFAULT_APP_DATABASE_NAME,
     MongoPersistenceContext,
@@ -28,14 +31,24 @@ class FakeMongoCollection:
         self.create_index_calls: list[tuple[list[tuple[str, int]], dict[str, Any]]] = []
         self.insert_calls: list[dict[str, Any]] = []
         self.update_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        self.list_indexes_error: Exception | None = None
+        self.create_index_error: Exception | None = None
+        self.persist_created_index = True
 
     def list_indexes(self):
+        if self.list_indexes_error is not None:
+            raise self.list_indexes_error
         return FakeCursor(self.index_rows)
 
     async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any):
+        if self.create_index_error is not None:
+            raise self.create_index_error
         self.create_index_calls.append((keys, kwargs))
         name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
-        self.index_rows.append({"name": name, "key": dict(keys)})
+        if self.persist_created_index:
+            self.index_rows.append(
+                {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+            )
         return name
 
     async def insert_one(self, document: dict[str, Any]):
@@ -112,18 +125,20 @@ def _collection(client: FakeMongoClient, *, entity_name: str = "projects") -> Fa
 
 @pytest.mark.asyncio
 async def test_apply_database_indexes_noops_when_intent_is_none() -> None:
-    count = await apply_database_indexes(None, app_id="app_1")
+    result = await apply_database_indexes(None, app_id="app_1")
 
-    assert count == 0
+    assert result.success is True
+    assert result.verified == 0
 
 
 @pytest.mark.asyncio
 async def test_apply_database_indexes_skips_collections_without_indexes() -> None:
     context, client = _context()
 
-    count = await apply_database_indexes(_intent(indexes=None), persistence=context)
+    result = await apply_database_indexes(_intent(indexes=None), persistence=context)
 
-    assert count == 0
+    assert result.success is True
+    assert result.verified == 0
     assert client.databases == {}
 
 
@@ -131,12 +146,13 @@ async def test_apply_database_indexes_skips_collections_without_indexes() -> Non
 async def test_apply_database_indexes_applies_single_field_index() -> None:
     context, client = _context()
 
-    count = await apply_database_indexes(
+    result = await apply_database_indexes(
         _intent([{"name": "project_id_idx", "keys": [{"field": "project_id", "order": 1}]}]),
         persistence=context,
     )
 
-    assert count == 1
+    assert result.created == 1
+    assert result.verified == 1
     assert _collection(client).create_index_calls == [([("project_id", 1)], {"name": "project_id_idx"})]
 
 
@@ -149,9 +165,10 @@ async def test_apply_database_indexes_supports_literal_contract_collection() -> 
     )
     intent["surfaces"][0]["collections"][0]["mongo_collection"] = "hosted_workspace_memberships"
 
-    count = await apply_database_indexes(intent, persistence=context)
+    result = await apply_database_indexes(intent, persistence=context)
 
-    assert count == 1
+    assert result.created == 1
+    assert result.verified == 1
     collection = client[DEFAULT_APP_DATABASE_NAME]["hosted_workspace_memberships"]
     assert collection.create_index_calls == [([("workspace_id", 1)], {"name": "workspace_id_idx"})]
 
@@ -170,9 +187,10 @@ async def test_apply_database_indexes_ignores_motor_callable_subcollection_proxy
     )
     intent["surfaces"][0]["collections"][0]["mongo_collection"] = "hosted_workspace_memberships"
 
-    count = await apply_database_indexes(intent, persistence=LiteralContext())  # type: ignore[arg-type]
+    result = await apply_database_indexes(intent, persistence=LiteralContext())  # type: ignore[arg-type]
 
-    assert count == 1
+    assert result.created == 1
+    assert result.verified == 1
     assert raw_collection.create_index_calls == [([("workspace_id", 1)], {"name": "workspace_id_idx"})]
 
 
@@ -253,6 +271,232 @@ async def test_apply_database_indexes_does_not_create_duplicate_named_indexes_wh
 
 
 @pytest.mark.asyncio
+async def test_apply_database_indexes_accepts_exact_materialized_definition() -> None:
+    context, client = _context()
+    raw = _collection(client)
+    raw.index_rows.append(
+        {
+            "name": "refund_lookup",
+            "key": {"tenant_ref": 1, "checkout_ref": -1},
+            "unique": True,
+            "sparse": True,
+            "partialFilterExpression": {
+                "state": {"$in": ["requested", "pending"]},
+                "kind": "refund",
+            },
+            "collation": {"locale": "en", "strength": 2, "version": "57.1"},
+            "hidden": True,
+            "expireAfterSeconds": 900,
+        }
+    )
+    intent = _intent(
+        [
+            {
+                "name": "refund_lookup",
+                "keys": [["tenant_ref", 1], ["checkout_ref", -1]],
+                "unique": True,
+                "sparse": True,
+                "partialFilterExpression": {
+                    "kind": "refund",
+                    "state": {"$in": ["requested", "pending"]},
+                },
+                "collation": {"strength": 2, "locale": "en"},
+                "hidden": True,
+                "expireAfterSeconds": 900,
+            }
+        ]
+    )
+
+    result = await apply_database_indexes(intent, persistence=context)
+
+    assert result.created == 0
+    assert result.verified == 1
+    assert raw.create_index_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("materialized", "expected_detail"),
+    [
+        ({"key": {"tenant_ref": 1, "checkout_ref": 1}}, "keys expected"),
+        ({"key": {"tenant_ref": 1}, "unique": False}, "unique expected=True actual=False"),
+        ({"key": {"tenant_ref": 1}, "sparse": False}, "sparse expected=True actual=False"),
+        (
+            {"key": {"tenant_ref": 1}, "partialFilterExpression": {"state": "captured"}},
+            "partialFilterExpression",
+        ),
+        ({"key": {"tenant_ref": 1}, "expireAfterSeconds": 60}, "expireAfterSeconds"),
+        ({"key": {"tenant_ref": 1}, "hidden": False}, "hidden expected=True actual=False"),
+        ({"key": {"tenant_ref": 1}, "collation": {"locale": "fr"}}, "collation"),
+    ],
+)
+async def test_apply_database_indexes_rejects_hostile_same_name_mismatch(
+    materialized: dict[str, Any], expected_detail: str
+) -> None:
+    context, client = _context()
+    raw = _collection(client)
+    raw.index_rows.append({"name": "refund_guard", **materialized})
+    declared: dict[str, Any] = {
+        "name": "refund_guard",
+        "keys": [["tenant_ref", 1]],
+        "unique": True,
+        "sparse": True,
+        "partialFilterExpression": {"state": "refundable"},
+        "expireAfterSeconds": 300,
+        "hidden": True,
+        "collation": {"locale": "en", "strength": 2},
+    }
+
+    with pytest.raises(DatabaseIndexApplyError, match=expected_detail):
+        await apply_database_indexes(_intent([declared]), persistence=context)
+
+    assert raw.create_index_calls == []
+    assert raw.index_rows == [{"name": "refund_guard", **materialized}]
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_rejects_same_keys_other_name_with_incompatible_options() -> (
+    None
+):
+    context, client = _context()
+    raw = _collection(client)
+    raw.index_rows.append({"name": "checkout_lookup_legacy", "key": {"checkout_ref": 1}})
+
+    with pytest.raises(
+        DatabaseIndexApplyError, match="under another name.*unique expected=True actual=False"
+    ):
+        await apply_database_indexes(
+            _intent(
+                [{"name": "refund_checkout_unique", "keys": [["checkout_ref", 1]], "unique": True}]
+            ),
+            persistence=context,
+        )
+
+    assert raw.create_index_calls == []
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_rejects_same_keys_under_compatible_other_name() -> None:
+    context, client = _context()
+    raw = _collection(client)
+    raw.index_rows.append(
+        {"name": "legacy_checkout_unique", "key": {"checkout_ref": 1}, "unique": True}
+    )
+
+    with pytest.raises(
+        DatabaseIndexApplyError,
+        match="under another name.*name expected='refund_checkout_unique' actual='legacy_checkout_unique'",
+    ):
+        await apply_database_indexes(
+            _intent(
+                [{"name": "refund_checkout_unique", "keys": [["checkout_ref", 1]], "unique": True}]
+            ),
+            persistence=context,
+        )
+
+    assert raw.create_index_calls == []
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_rejects_incompatible_alias_even_when_named_index_matches() -> (
+    None
+):
+    context, client = _context()
+    raw = _collection(client)
+    raw.index_rows.extend(
+        [
+            {"name": "refund_checkout_unique", "key": {"checkout_ref": 1}, "unique": True},
+            {"name": "legacy_checkout_lookup", "key": {"checkout_ref": 1}},
+        ]
+    )
+
+    with pytest.raises(
+        DatabaseIndexApplyError, match="legacy_checkout_lookup.*unique expected=True actual=False"
+    ):
+        await apply_database_indexes(
+            _intent(
+                [{"name": "refund_checkout_unique", "keys": [["checkout_ref", 1]], "unique": True}]
+            ),
+            persistence=context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_rejects_conflicting_declarations_before_any_write() -> None:
+    context, client = _context()
+
+    with pytest.raises(
+        DatabaseIndexApplyError, match="Conflicting declared indexes.*ordered key pattern"
+    ):
+        await apply_database_indexes(
+            _intent(
+                [
+                    {"name": "lookup", "keys": [["reference", 1]]},
+                    {"name": "unique_lookup", "keys": [["reference", 1]], "unique": True},
+                ]
+            ),
+            persistence=context,
+        )
+
+    assert _collection(client).create_index_calls == []
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_creates_with_all_options_and_rereads() -> None:
+    context, client = _context()
+    declared = {
+        "name": "checkout_refund_guard",
+        "keys": [["tenant_ref", 1], ["checkout_ref", -1]],
+        "unique": True,
+        "sparse": True,
+        "partialFilterExpression": {"kind": "refund"},
+        "collation": {"locale": "en", "strength": 2},
+        "expireAfterSeconds": 120,
+        "hidden": True,
+    }
+
+    result = await apply_database_indexes(_intent([declared]), persistence=context)
+
+    assert result.created == result.verified == 1
+    keys, options = _collection(client).create_index_calls[0]
+    assert keys == [("tenant_ref", 1), ("checkout_ref", -1)]
+    assert options == {key: value for key, value in declared.items() if key != "keys"}
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_propagates_inspection_failure() -> None:
+    context, client = _context()
+    _collection(client).list_indexes_error = RuntimeError("inspection unavailable")
+
+    with pytest.raises(DatabaseIndexApplyError, match="inspection unavailable"):
+        await apply_database_indexes(
+            _intent([{"name": "idx", "keys": [["field", 1]]}]), persistence=context
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_propagates_creation_failure() -> None:
+    context, client = _context()
+    _collection(client).create_index_error = RuntimeError("create denied")
+
+    with pytest.raises(DatabaseIndexApplyError, match="create denied"):
+        await apply_database_indexes(
+            _intent([{"name": "idx", "keys": [["field", 1]]}]), persistence=context
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_database_indexes_fails_when_post_creation_verification_is_missing() -> None:
+    context, client = _context()
+    _collection(client).persist_created_index = False
+
+    with pytest.raises(DatabaseIndexApplyError, match="missing after creation"):
+        await apply_database_indexes(
+            _intent([{"name": "idx", "keys": [["field", 1]]}]), persistence=context
+        )
+
+
+@pytest.mark.asyncio
 async def test_apply_database_indexes_missing_module_id_fails_clearly() -> None:
     context, _ = _context()
     intent = _intent([{"name": "idx", "keys": [["field", 1]]}])
@@ -307,6 +551,8 @@ async def test_apply_database_indexes_does_not_mark_migrations_applied() -> None
 async def test_platform_startup_applies_indexes_when_data_contract_is_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
     from mozaiksai.hosts import platform
 
+    monkeypatch.setenv("MONGO_URI", "mongodb://configured.invalid")
+
     calls: list[dict[str, Any]] = []
     intent = _intent([{"name": "idx", "keys": [["field", 1]]}])
 
@@ -320,7 +566,9 @@ async def test_platform_startup_applies_indexes_when_data_contract_is_loaded(mon
 
     async def fake_apply(data_contract, *, app_id=None):
         calls.append({"intent": data_contract, "app_id": app_id})
-        return 1
+        return DataContractIndexRunResult(
+            items=[], planned=1, created=1, skipped=0, conflicts=0, verified=1, dry_run=False, success=True
+        )
 
     class FakeHooks:
         async def run_startup(self, _app):
@@ -336,10 +584,77 @@ async def test_platform_startup_applies_indexes_when_data_contract_is_loaded(mon
 
 
 @pytest.mark.asyncio
-async def test_platform_startup_best_effort_index_failure_logs_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_platform_startup_without_data_contract_does_not_require_index_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from mozaiksai.hosts import platform
 
-    warnings: list[str] = []
+    async def fake_load(_path: str):
+        return AppLoadResult(
+            definition=AppDefinition(name="Local App", version="1.0"),
+            modules=[],
+            data_contract=None,
+            data_entities_by_key={},
+        )
+
+    async def must_not_apply(_intent, *, app_id=None):
+        raise AssertionError("non-persistent startup must not apply indexes")
+
+    class FakeHooks:
+        async def run_startup(self, _app):
+            return None
+
+    monkeypatch.setattr(platform.AppLoader, "load", fake_load)
+    monkeypatch.setattr(platform, "apply_database_indexes", must_not_apply)
+    monkeypatch.setattr(platform, "load_data_migrations", lambda _root: [])
+    monkeypatch.setattr(platform, "get_platform_hooks", lambda: FakeHooks())
+
+    await platform._platform_startup()
+
+    assert platform.app.state.database_index_readiness is None
+
+
+@pytest.mark.asyncio
+async def test_platform_startup_local_best_effort_with_contract_skips_index_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mozaiksai.hosts import platform
+
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL", "ENV", "ENVIRONMENT"):
+        monkeypatch.delenv(name, raising=False)
+    intent = _intent([{"name": "idx", "keys": [["field", 1]]}])
+
+    async def fake_load(_path: str):
+        return AppLoadResult(
+            definition=AppDefinition(name="Local App", version="1.0"),
+            modules=[],
+            data_contract=intent,
+            data_entities_by_key={},
+        )
+
+    async def must_not_apply(_intent, *, app_id=None):
+        raise AssertionError("persistence-disabled startup must not apply indexes")
+
+    class FakeHooks:
+        async def run_startup(self, _app):
+            return None
+
+    monkeypatch.setattr(platform.AppLoader, "load", fake_load)
+    monkeypatch.setattr(platform, "apply_database_indexes", must_not_apply)
+    monkeypatch.setattr(platform, "load_data_migrations", lambda _root: [])
+    monkeypatch.setattr(platform, "get_platform_hooks", lambda: FakeHooks())
+
+    await platform._platform_startup()
+
+    assert platform.app.state.database_index_readiness is None
+
+
+@pytest.mark.asyncio
+async def test_platform_startup_awaited_index_failure_cannot_be_swallowed_by_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mozaiksai.hosts import platform
+
+    monkeypatch.setenv("MONGO_URI", "mongodb://configured.invalid")
+
     intent = _intent([{"name": "idx", "keys": [["field", 1]]}])
 
     async def fake_load(_path: str):
@@ -362,11 +677,65 @@ async def test_platform_startup_best_effort_index_failure_logs_and_continues(mon
     monkeypatch.setattr(platform, "apply_database_indexes", fail_apply)
     monkeypatch.setattr(platform, "load_data_migrations", lambda _root: [])
     monkeypatch.setattr(platform, "get_platform_hooks", lambda: FakeHooks())
-    monkeypatch.setattr(platform.logger, "warning", lambda message, *args: warnings.append(message % args))
+    with pytest.raises(platform.DatabaseStartupError, match="Database indexes are not ready"):
+        await platform._platform_startup()
 
-    await platform._platform_startup()
 
-    assert any("DATABASE_INDEXES_NOT_APPLIED" in warning for warning in warnings)
+@pytest.mark.asyncio
+async def test_platform_startup_does_not_report_index_readiness_before_awaited_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    from mozaiksai.hosts import platform
+
+    monkeypatch.setenv("MONGO_URI", "mongodb://configured.invalid")
+
+    intent = _intent([{"name": "idx", "keys": [["field", 1]]}])
+    verification_started = asyncio.Event()
+    release_verification = asyncio.Event()
+
+    async def fake_load(_path: str):
+        return AppLoadResult(
+            definition=AppDefinition(
+                name="Readiness Test", version="1.0", config={"appId": "app_1"}
+            ),
+            modules=[],
+            data_contract=intent,
+            data_entities_by_key={},
+        )
+
+    async def delayed_apply(_intent, *, app_id=None):
+        verification_started.set()
+        await release_verification.wait()
+        return DataContractIndexRunResult(
+            items=[],
+            planned=1,
+            created=1,
+            skipped=0,
+            conflicts=0,
+            verified=1,
+            dry_run=False,
+            success=True,
+        )
+
+    class FakeHooks:
+        async def run_startup(self, _app):
+            return None
+
+    monkeypatch.setattr(platform.AppLoader, "load", fake_load)
+    monkeypatch.setattr(platform, "apply_database_indexes", delayed_apply)
+    monkeypatch.setattr(platform, "load_data_migrations", lambda _root: [])
+    monkeypatch.setattr(platform, "get_platform_hooks", lambda: FakeHooks())
+
+    startup = asyncio.create_task(platform._platform_startup())
+    await verification_started.wait()
+    assert startup.done() is False
+    assert platform.app.state.database_index_readiness is None
+
+    release_verification.set()
+    await startup
+    assert platform.app.state.database_index_readiness.verified == 1
 
 
 @pytest.mark.asyncio
@@ -390,6 +759,5 @@ async def test_platform_startup_required_index_failure_raises(monkeypatch: pytes
     monkeypatch.setattr(platform.AppLoader, "load", fake_load)
     monkeypatch.setattr(platform, "apply_database_indexes", fail_apply)
 
-    with pytest.raises(platform.DatabaseStartupError, match="Database indexes were not applied"):
+    with pytest.raises(platform.DatabaseStartupError, match="Database indexes are not ready"):
         await platform._platform_startup()
-

--- a/tests/test_runtime_database_migrations.py
+++ b/tests/test_runtime_database_migrations.py
@@ -17,6 +17,7 @@ from mozaiksai.core.runtime.persistence import (
     load_data_migrations,
     migration_hash,
 )
+from mozaiksai.core.runtime.persistence.indexes import DataContractIndexRunResult
 from mozaiksai.core.runtime.persistence.migrations import DatabaseMigrationError
 from mozaiksai.core.runtime.persistence.mongo import (
     DEFAULT_APP_DATABASE_NAME,
@@ -66,7 +67,9 @@ class FakeMongoCollection:
     async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any):
         self.create_index_calls.append((keys, kwargs))
         name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
-        self.index_rows.append({"name": name, "key": dict(keys)})
+        self.index_rows.append(
+            {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+        )
         return name
 
     async def find_one(self, query: dict[str, Any], projection=None):
@@ -617,7 +620,9 @@ async def test_platform_startup_calls_migration_application_after_index_applicat
 
     async def fake_apply_indexes(_intent, *, app_id=None):
         calls.append("indexes")
-        return 0
+        return DataContractIndexRunResult(
+            items=[], planned=0, created=0, skipped=0, conflicts=0, verified=0, dry_run=False, success=True
+        )
 
     def fake_load_migrations(_root):
         calls.append("load_migrations")

--- a/tests/test_runtime_persistence_mongo.py
+++ b/tests/test_runtime_persistence_mongo.py
@@ -79,7 +79,11 @@ class FakeMongoCollection:
 
     async def create_index(self, keys: list[tuple[str, int]], **kwargs: Any):
         self.create_index_calls.append((keys, kwargs))
-        return kwargs.get("name")
+        name = str(kwargs.get("name") or "_".join(field for field, _ in keys))
+        self.index_rows.append(
+            {"name": name, "key": dict(keys), **{key: value for key, value in kwargs.items() if key != "name"}}
+        )
+        return name
 
 
 class FakeDatabase:

--- a/tests/test_runtime_persistence_real_mongo.py
+++ b/tests/test_runtime_persistence_real_mongo.py
@@ -16,6 +16,7 @@ from mozaiksai.core.runtime.persistence import (
     collection_name_for,
     migration_hash,
 )
+from mozaiksai.core.runtime.persistence.indexes import DatabaseIndexApplyError
 from mozaiksai.core.runtime.persistence.mongo import DEFAULT_APP_DATABASE_NAME
 from tests.module_authority_test_helpers import trusted_framework_authority
 
@@ -102,6 +103,27 @@ def _migration() -> dict:
     }
 
 
+def _literal_index_contract(app_id: str, collection_name: str, indexes: list[dict]) -> dict:
+    return {
+        "version": "1",
+        "app_id": app_id,
+        "surfaces": [
+            {
+                "surface_id": "checkout_records",
+                "surface_kind": "module",
+                "collections": [
+                    {
+                        "name": "refund_records",
+                        "mongo_collection": collection_name,
+                        "ownership": {"surface_id": "checkout_records", "surface_kind": "module"},
+                        "indexes": indexes,
+                    }
+                ],
+            }
+        ],
+    }
+
+
 @pytest.mark.asyncio
 async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opt-in smoke for the actual Mongo-backed generated-app persistence path.
@@ -172,8 +194,9 @@ async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pyte
         assert list_result.data["items"][0]["user_id"] == "integration_user"
         assert other_list_result.data["items"][0]["app_id"] == other_app_id
 
-        index_count = await apply_database_indexes(_data_contract(app_id), app_id=app_id)
-        assert index_count == 1
+        index_result = await apply_database_indexes(_data_contract(app_id), app_id=app_id)
+        assert index_result.created == 1
+        assert index_result.verified == 1
         index_names = {index["name"] for index in await raw_collection.list_indexes().to_list(length=None)}
         assert "project_owner_idx" in index_names
 
@@ -203,3 +226,132 @@ async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pyte
             await other_collection.drop()
         close_mongo_client()
 
+
+@pytest.mark.asyncio
+async def test_real_mongo_index_readiness_is_exact_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prove creation, reread verification, hostile mismatch rejection, and no drops."""
+
+    if not _has_mongo_connection_env():
+        pytest.skip(
+            "MONGO_URI, MONGODB_URI, or MONGO_URL is required for real-Mongo index readiness"
+        )
+
+    database_name, generated_database = _test_database_name()
+    monkeypatch.setenv(APP_DB_ENV, database_name)
+    app_id = f"index_readiness_{uuid4().hex}"
+    prefix = f"refund_checkout_{uuid4().hex[:10]}"
+    ready_name = f"{prefix}_ready"
+    wrong_name = f"{prefix}_wrong_name"
+    alternate_name = f"{prefix}_alternate_name"
+    client = get_mongo_client()
+    ready = client[database_name][ready_name]
+    wrong = client[database_name][wrong_name]
+    alternate = client[database_name][alternate_name]
+    declared_indexes = [
+        {
+            "name": "refund_checkout_unique_partial",
+            "keys": [["checkout_ref", 1]],
+            "unique": True,
+            "partialFilterExpression": {"checkout_ref": {"$type": "string"}},
+            "collation": {"locale": "en", "strength": 2},
+            "hidden": True,
+        },
+        {
+            "name": "refund_expiry_ttl",
+            "keys": [["expires_at", 1]],
+            "expireAfterSeconds": 600,
+            "hidden": True,
+        },
+        {"name": "refund_legacy_sparse", "keys": [["legacy_ref", 1]], "sparse": True},
+        {
+            "name": "refund_payload_wildcard",
+            "keys": [["$**", 1]],
+            "wildcardProjection": {"payload.secret": 0},
+        },
+    ]
+
+    try:
+        first = await apply_database_indexes(
+            _literal_index_contract(app_id, ready_name, declared_indexes), app_id=app_id
+        )
+        second = await apply_database_indexes(
+            _literal_index_contract(app_id, ready_name, declared_indexes), app_id=app_id
+        )
+        assert first.created == first.verified == 4
+        assert second.created == 0
+        assert second.verified == 4
+        materialized = {row["name"]: row for row in await ready.list_indexes().to_list(length=None)}
+        assert materialized["refund_checkout_unique_partial"]["unique"] is True
+        assert materialized["refund_checkout_unique_partial"]["partialFilterExpression"] == {
+            "checkout_ref": {"$type": "string"}
+        }
+        assert materialized["refund_checkout_unique_partial"]["collation"]["strength"] == 2
+        assert materialized["refund_checkout_unique_partial"]["hidden"] is True
+        assert materialized["refund_expiry_ttl"]["expireAfterSeconds"] == 600
+        assert materialized["refund_legacy_sparse"]["sparse"] is True
+        assert materialized["refund_payload_wildcard"]["wildcardProjection"] == {
+            "payload.secret": 0
+        }
+
+        await wrong.create_index(
+            [("wrong_field", 1)],
+            name="checkout_refund_provider_reference_unique",
+            unique=False,
+        )
+        before_wrong = {row["name"] for row in await wrong.list_indexes().to_list(length=None)}
+        with pytest.raises(
+            DatabaseIndexApplyError, match="requested index name exists.*keys expected"
+        ):
+            await apply_database_indexes(
+                _literal_index_contract(
+                    app_id,
+                    wrong_name,
+                    [
+                        {
+                            "name": "checkout_refund_provider_reference_unique",
+                            "keys": [["stripe_refund_id", 1]],
+                            "unique": True,
+                            "partialFilterExpression": {"stripe_refund_id": {"$type": "string"}},
+                        }
+                    ],
+                ),
+                app_id=app_id,
+            )
+        assert {
+            row["name"] for row in await wrong.list_indexes().to_list(length=None)
+        } == before_wrong
+
+        await alternate.create_index([("checkout_ref", 1)], name="legacy_checkout_lookup")
+        before_alternate = {
+            row["name"] for row in await alternate.list_indexes().to_list(length=None)
+        }
+        with pytest.raises(
+            DatabaseIndexApplyError, match="under another name.*unique expected=True actual=False"
+        ):
+            await apply_database_indexes(
+                _literal_index_contract(
+                    app_id,
+                    alternate_name,
+                    [
+                        {
+                            "name": "refund_checkout_unique",
+                            "keys": [["checkout_ref", 1]],
+                            "unique": True,
+                        }
+                    ],
+                ),
+                app_id=app_id,
+            )
+        assert {
+            row["name"] for row in await alternate.list_indexes().to_list(length=None)
+        } == before_alternate
+    finally:
+        if generated_database:
+            await client.drop_database(database_name)
+        else:
+            await ready.drop()
+            await wrong.drop()
+            await alternate.drop()
+        close_mongo_client()


### PR DESCRIPTION
## Security disposition

Corrects Mongo index materialization and startup readiness so a declared index is compatible only when its name, ordered key pattern, and canonical materialized options match exactly.

- compares `unique`, `sparse`, `partialFilterExpression`, `collation`, `expireAfterSeconds`, `hidden`, and `wildcardProjection`
- treats `background` as non-materialized compatibility metadata
- rejects same-name mismatches and same-key definitions under another name before writes
- creates missing indexes with the complete declared option set, awaits creation, rereads Mongo metadata, and verifies the result
- propagates inspection, creation, and post-creation verification failures
- never drops or rewrites an existing index
- makes platform readiness await verified indexes whenever persistence is enabled by a configured Mongo URI, required database policy, or production environment
- preserves local `best_effort` startup without Mongo, even when a generated fixture contains a data contract

## Compatibility and operator action

Index definition changes are explicit compatibility migrations. Operators must validate existing data and either create an additive replacement where Mongo permits coexistence or remove the obsolete index during a controlled maintenance window before startup creates and verifies the replacement. Runtime startup performs no destructive repair.

## Real Mongo regression

The integration fixture first materializes `checkout_refund_provider_reference_unique` on `wrong_field` without uniqueness, then requests that same name on `stripe_refund_id` with `unique: true` and a partial filter. Startup rejects the materialized mismatch and leaves it unchanged. These domain terms exist only in test code.

## Provenance

- Base: `98cb6d1ea0479529b03e47227566b3baf8af95ec`
- Head: `61f4c970169742f1332eb4db581cec637ec09ab8`
- Branch: `codex/mongo-index-readiness`

## Validation

- `ruff check .` — passed
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped` — passed (560 source files)
- focused post-lint persistence suite — 99 passed
- `git diff --check` — passed
- `python -m mkdocs build --strict` — passed
- focused persistence/runtime/generated-consumer suite — 154 passed
- generated-app acceptance suite — 42 passed
- strict structured-output suite — 96 passed
- source hygiene plus index/startup regression — 38 passed
- real MongoDB integration suite (`mongo:7`) — 2 passed
- full suite: `python -m pytest -q --no-cov --tb=short ...` — 13,415 passed, 78 skipped, 3 warnings
- production-diff domain scan — no product-domain terms
- `ruff format --check` was run on touched Python files; it reports 17 legacy files would be reformatted. No broad formatter rewrite was included to keep this security correction narrow; `ruff check .` is clean.

## App Zero Refinement Impact

No AppGenerator or DesignDocs structured-output contract, taxonomy, prompt, hook, or materializer changes. Generated apps consume the tightened canonical persistence runtime: persistence-enabled startup is fail closed, while intentionally persistence-disabled local `best_effort` workflows remain usable without MongoDB.

## OSS Change Impact

- Runtime layer: canonical persistence adapter/index materializer and additive migration index handling
- Host layer: awaited platform startup readiness only; no Run, ExecutionWorker, ExecutionEngine, Event, transport, or AG2 ownership changes
- Contract behavior: existing YAML/JSON index fields are enforced more strictly; no parallel subsystem or schema alias introduced
- Documentation/release notes: compatibility migration and readiness semantics recorded
- Tests: fake-collection, generated-app, CLI/helper, failure propagation, no-drop, and real-Mongo coverage

