### PR TITLE
fix(factory): close entitlement-gate emission gaps in generated SaaS bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **SaaS bundles can no longer sell capabilities they never enforce**: the
+  generated-bundle scanner now fails a bundle whose
+  `config/subscriptions.yaml` grants plan capabilities while no module action
+  declares an `entitlement_gate` — previously such bundles passed validation
+  and shipped a decorative subscription contract. Token/usage-only plans
+  (no capabilities) are unaffected.
+- **Public /pricing page works anonymously in MozaiksPay SaaS apps**: the
+  mozaikspay pack's `billing_portal.list_plans` action now declares
+  `api_surface: public_readonly` with no permission requirement, so the
+  pricing landing page can render the plan catalog before login. The scanner
+  now also requires `ui/pages/pricing.yaml` in mozaikspay SaaS bundles and
+  verifies it binds to `list_plans`.
+
 ### Added
 
 - **Generic usage instrumentation and rollups**: the platform host records

--- a/factory_app/build_context/AppGenerator/capability_routing.yaml
+++ b/factory_app/build_context/AppGenerator/capability_routing.yaml
@@ -263,9 +263,11 @@ layers:
           - event: hosted.billing.subscription.cancelled
             reaction: revoke gated capabilities
         operator_pack_note: >
-          When the user explicitly selects monetization_provider=mozaiks_pay and
-          the managed mozaikspay pack is available in capability_packs, use it
-          as the recommended SaaS monetization provider. Generate only the app-owned
+          When the build resolves monetization_provider=mozaiks_pay — the
+          default for SaaS builds unless the user explicitly selects the
+          self-managed OSS path — and the managed mozaikspay pack is available
+          in capability_packs, use it as the SaaS monetization provider.
+          Generate only the app-owned
           billing_portal facade, MozaiksPay client, subscriptions.yaml plan contract,
           pricing/billing/usage pages, and entitlement gates. The generated app calls
           the hosted MozaiksPay API for subscription status and billing portal sessions.

--- a/factory_app/build_context/mozaikspay/templates/modules/billing_portal/module.yaml
+++ b/factory_app/build_context/mozaikspay/templates/modules/billing_portal/module.yaml
@@ -82,8 +82,10 @@ actions:
     description: >
       Return the available plan catalog declared in app/config/subscriptions.yaml.
       Safe plan display fields only — never exposes managed-capability internals
-      or granted capability identifiers.
+      or granted capability identifiers. Public so the /pricing landing page can
+      render the catalog without authentication.
     handler_method: list_plans
+    api_surface: public_readonly
     input_schema:
       type: object
       properties: {}
@@ -105,7 +107,7 @@ actions:
               token_allowances: {type: array}
         top_up_products: {type: array}
         pricing_catalog: {type: object}
-    permissions: [billing_portal.read]
+    permissions: []
 
   - id: start_subscription_checkout
     description: >

--- a/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
+++ b/factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py
@@ -833,6 +833,7 @@ def _scan_mozaikspay_saas_contract(
         "modules/billing_portal/backend/schemas.py",
         "ui/pages/billing.yaml",
         "ui/pages/usage.yaml",
+        "ui/pages/pricing.yaml",
     }
     missing = sorted(path for path in required_paths if path not in normalized_files)
     if missing:
@@ -883,13 +884,33 @@ def _scan_mozaikspay_saas_contract(
     module_content = normalized_files.get("modules/billing_portal/module.yaml", "")
     if module_content:
         actions = _module_actions_from_yaml("modules/billing_portal/module.yaml", module_content)
-        required_actions = {"get_subscription_status", "get_usage_status", "open_billing_portal"}
+        required_actions = {
+            "get_subscription_status",
+            "get_usage_status",
+            "list_plans",
+            "open_billing_portal",
+        }
         missing_actions = sorted(required_actions - actions)
         if missing_actions:
             errors.append(
                 "modules/billing_portal/module.yaml must expose app-owned SaaS billing facade "
                 f"actions: {missing_actions}."
             )
+        parsed_module, module_parse_error = _load_yaml_mapping_from_file(
+            {"modules/billing_portal/module.yaml": module_content},
+            "modules/billing_portal/module.yaml",
+        )
+        if not module_parse_error and isinstance(parsed_module, dict):
+            for action in parsed_module.get("actions") or []:
+                if not isinstance(action, dict) or action.get("id") != "list_plans":
+                    continue
+                surface = str(action.get("api_surface") or "").strip()
+                if surface not in {"public", "public_readonly"} or action.get("permissions"):
+                    errors.append(
+                        "modules/billing_portal/module.yaml: 'list_plans' is the canonical "
+                        "anonymous data source for the public /pricing page and must declare "
+                        "api_surface public_readonly with no permissions."
+                    )
         declared_module_id = _declared_module_id_from_yaml(
             "modules/billing_portal/module.yaml",
             module_content,
@@ -937,6 +958,9 @@ def _scan_mozaikspay_saas_contract(
         },
         "ui/pages/usage.yaml": {
             "/api/modules/billing_portal/get_usage_status",
+        },
+        "ui/pages/pricing.yaml": {
+            "/api/modules/billing_portal/list_plans",
         },
     }
     for page_path, required_endpoints in page_requirements.items():
@@ -1246,7 +1270,23 @@ def _scan_entitlement_gate_capability_alignment(files_map: dict[str, str]) -> li
             gate_contexts.append((path, action_id, gate))
 
     if not gate_contexts:
-        # No gated actions in any module — nothing to validate.
+        module_paths = sorted(
+            path
+            for path in normalized_files
+            if path.startswith("modules/") and path.endswith("/module.yaml")
+        )
+        if plan_capabilities and module_paths:
+            # The bundle sells plan capabilities but gates nothing, so every
+            # declared capability is unenforceable at dispatch time and the
+            # subscription contract is decorative.
+            return [
+                "config/subscriptions.yaml grants plan capabilities "
+                f"{sorted(plan_capabilities)} but no module action declares an "
+                "entitlement_gate. A SaaS bundle that sells capabilities must "
+                "enforce at least one of them: set actions[].entitlement_gate "
+                "to a granted capability_id on each plan-gated action in "
+                f"{module_paths}."
+            ]
         return []
 
     errors: list[str] = []

--- a/tests/test_build_context_mozaikspay_pack.py
+++ b/tests/test_build_context_mozaikspay_pack.py
@@ -255,12 +255,21 @@ def test_billing_portal_module_permissions_are_declared() -> None:
 
 def test_billing_portal_read_actions_require_read_permission() -> None:
     module_yaml = _read_yaml(TEMPLATES / "modules" / "billing_portal" / "module.yaml")
-    read_actions = {"get_subscription_status", "get_usage_status", "get_token_status", "list_plans"}
+    # list_plans is excluded: it is the anonymous public catalog behind /pricing
+    # (api_surface public_readonly, no permissions).
+    read_actions = {"get_subscription_status", "get_usage_status", "get_token_status"}
     for action in (module_yaml.get("actions") or []):
         if action["id"] in read_actions:
             assert "billing_portal.read" in action.get("permissions", []), (
                 f"{action['id']} must require billing_portal.read"
             )
+
+
+def test_billing_portal_list_plans_is_public_catalog() -> None:
+    module_yaml = _read_yaml(TEMPLATES / "modules" / "billing_portal" / "module.yaml")
+    list_plans = next(a for a in module_yaml["actions"] if a["id"] == "list_plans")
+    assert list_plans.get("api_surface") == "public_readonly"
+    assert not list_plans.get("permissions")
 
 
 def test_billing_portal_manage_actions_require_manage_permission() -> None:

--- a/tests/test_entitlement_gate_closure.py
+++ b/tests/test_entitlement_gate_closure.py
@@ -312,9 +312,22 @@ class TestEntitlementGateClosurePositive:
         )
         assert _scan_entitlement_gate_capability_alignment(bundle) == []
 
-    def test_app_with_no_gated_actions_and_subscriptions_passes(self) -> None:
+    def test_capability_free_subscriptions_with_no_gates_passes(self) -> None:
+        """Token/usage-only SaaS: no plan grants capabilities, so no gate is required."""
+        subs_no_caps = textwrap.dedent("""\
+            schema_version: mozaiks.subscriptions.v1
+            label: Token Only SaaS
+            default_plan_id: free
+            plans:
+              - plan_id: free
+                label: Free
+                capabilities: []
+              - plan_id: pro
+                label: Pro
+                capabilities: []
+        """)
         bundle = _bundle(
-            subs=_SUBS_V1_WITH_STORE,
+            subs=subs_no_caps,
             modules={
                 "modules/tasks/module.yaml": _module_yaml(
                     "tasks",
@@ -322,6 +335,11 @@ class TestEntitlementGateClosurePositive:
                 )
             },
         )
+        assert _scan_entitlement_gate_capability_alignment(bundle) == []
+
+    def test_capabilities_without_module_files_passes(self) -> None:
+        """A bundle fragment with no modules has nothing to gate; other scans own file completeness."""
+        bundle = _bundle(subs=_SUBS_V1_WITH_STORE)
         assert _scan_entitlement_gate_capability_alignment(bundle) == []
 
     def test_v2_multi_product_subscriptions_valid_gate(self) -> None:
@@ -364,6 +382,36 @@ class TestEntitlementGateClosurePositive:
 
 class TestEntitlementGateClosureNegative:
     """Invalid bundles must produce at least one error."""
+
+    def test_sold_capabilities_with_zero_gated_actions_fails(self) -> None:
+        """Plan capabilities with no gated action anywhere = unenforceable monetization."""
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "list_tasks"}],
+                )
+            },
+        )
+        errors = _scan_entitlement_gate_capability_alignment(bundle)
+        assert len(errors) == 1
+        assert "no module action declares an entitlement_gate" in errors[0]
+        assert "tasks.create" in errors[0]
+        assert "modules/tasks/module.yaml" in errors[0]
+
+    def test_zero_gate_error_reaches_scan_generated_bundle(self) -> None:
+        bundle = _bundle(
+            subs=_SUBS_V1_WITH_STORE,
+            modules={
+                "modules/tasks/module.yaml": _module_yaml(
+                    "tasks",
+                    actions=[{"id": "list_tasks"}],
+                )
+            },
+        )
+        errors = scan_generated_bundle(bundle)
+        assert any("no module action declares an entitlement_gate" in error for error in errors)
 
     def test_unknown_gate_fails(self) -> None:
         bundle = _bundle(

--- a/tests/test_generated_bundle_scanner.py
+++ b/tests/test_generated_bundle_scanner.py
@@ -147,7 +147,7 @@ plans:
         cadence: monthly
   - plan_id: pro
     label: Pro
-    capabilities: [billing_portal.read]
+    capabilities: [billing_portal.read, reports.generate]
     usage_limits:
       - meter_id: ai_tokens
         unit: tokens
@@ -187,8 +187,21 @@ actions:
     handler_method: get_subscription_status
   - id: get_usage_status
     handler_method: get_usage_status
+  - id: list_plans
+    handler_method: list_plans
+    api_surface: public_readonly
   - id: open_billing_portal
     handler_method: open_billing_portal
+""",
+        "modules/reports/module.yaml": """
+schema_version: mozaiks.module.v1
+module:
+  id: reports
+  handler: backend.handler:ReportsHandler
+actions:
+  - id: generate_report
+    handler_method: generate_report
+    entitlement_gate: reports.generate
 """,
         "modules/billing_portal/backend/handler.py": """
 class BillingPortalHandler:
@@ -249,6 +262,20 @@ sections:
         - key: id
           label: ID
       api_endpoint: /api/modules/billing_portal/get_usage_status
+""",
+        "ui/pages/pricing.yaml": """
+schema_version: mozaiks.app_page.v1
+name: pricing
+route: /pricing
+title: Pricing
+page_type: landing
+layout: full-width
+sections:
+  - id: plan-catalog
+    primitive: PricingCatalog
+    config:
+      title: Plans
+      api_endpoint: /api/modules/billing_portal/list_plans
 """,
     }
     if include_deployment:
@@ -869,7 +896,7 @@ plans:
     capabilities: []
   - plan_id: pro
     label: Pro
-    capabilities: [billing_portal.read]
+    capabilities: [billing_portal.read, reports.generate]
 """
 
     errors = scan_generated_bundle(

--- a/tests/test_mozaikspay_managed_capability_contract.py
+++ b/tests/test_mozaikspay_managed_capability_contract.py
@@ -127,6 +127,35 @@ plans:
 """
 
 
+def _golden_gated_reports_module_yaml() -> str:
+    return """
+schema_version: mozaiks.module.v1
+module:
+  id: reports
+  display_name: Reports
+  version: 1.0.0
+  description: Golden gated feature module
+  handler: backend.handler:ReportsHandler
+permissions:
+  - id: reports.read
+    description: Read generated reports.
+actions:
+  - id: generate_report
+    description: Generate a report for the current workspace.
+    handler_method: generate_report
+    entitlement_gate: reports.generate
+    permissions: [reports.read]
+    input_schema:
+      type: object
+      properties: {}
+    output_schema:
+      type: object
+      required: [success]
+      properties:
+        success: {type: boolean}
+"""
+
+
 def _golden_mozaikspay_saas_bundle() -> tuple[dict[str, str], list[dict]]:
     pack_descriptor = dict(_read_yaml(_CONTEXT_YAML)["pack"])
     pack_descriptor.setdefault("pack_source_path", str(_PACK_ROOT))
@@ -137,6 +166,9 @@ def _golden_mozaikspay_saas_bundle() -> tuple[dict[str, str], list[dict]]:
     }
     files["app.json"] = '{"name":"Golden MozaiksPay SaaS","version":"1.0.0"}\n'
     files["config/subscriptions.yaml"] = _golden_subscriptions_yaml()
+    # A real SaaS bundle gates at least one feature action behind a sold
+    # capability; the scanner rejects capability catalogs with zero gates.
+    files["modules/reports/module.yaml"] = _golden_gated_reports_module_yaml()
 
     deployment_env = _deployment_env_for_capability_packs(capability_packs)
     files.update(
@@ -448,6 +480,18 @@ class TestBillingPortalModuleYaml:
         action_ids = {a["id"] for a in doc.get("actions", [])}
         assert {"get_subscription_status", "get_usage_status", "open_billing_portal"} <= action_ids
 
+    def test_list_plans_is_public_readonly(self):
+        doc = _read_yaml(_MODULE_YAML)
+        list_plans = next(a for a in doc["actions"] if a["id"] == "list_plans")
+        assert list_plans.get("api_surface") == "public_readonly", (
+            "list_plans feeds the public /pricing landing page and must be "
+            "anonymously dispatchable"
+        )
+        assert not list_plans.get("permissions"), (
+            "list_plans must not require permissions — the /pricing page renders "
+            "before authentication"
+        )
+
     def test_no_raw_provider_credentials_in_output_schema(self):
         content = _MODULE_YAML.read_text(encoding="utf-8")
         for forbidden in ("payment_provider_customer_id", "payment_provider_subscription_id", "PAYMENT_PROVIDER_"):
@@ -520,6 +564,7 @@ class TestGoldenGeneratedMozaiksPaySaasBundle:
             "config/subscriptions.yaml",
             "ui/pages/billing.yaml",
             "ui/pages/usage.yaml",
+            "ui/pages/pricing.yaml",
             ".env.example",
             "deployment.manifest.json",
         } <= set(files)


### PR DESCRIPTION
## Summary

End-to-end audit of the subscription → entitlement → feature-gate chain found the runtime side solid (gate enforcement at dispatch, `ConfiguredEntitlementAdapter`, Docker e2e all covered) but two emission-side holes in what the factory validates for generated SaaS bundles:

1. **Gate closure was one-directional.** `_scan_entitlement_gate_capability_alignment` validated that every declared `entitlement_gate` resolves to a plan capability, but a bundle whose `config/subscriptions.yaml` grants capabilities while gating **zero** actions passed clean — a decorative subscription contract whose sold capabilities are unenforceable at dispatch time (and the generated in-app coverage test is only emitted when gates exist, so nothing downstream caught it either). The scanner now fails such bundles. Token/usage-only plans (no capabilities) are unaffected.

2. **The public `/pricing` page could not render anonymously.** The mozaikspay pack's `pricing.yaml` binds to `billing_portal.list_plans`, but the module template declared `permissions: [billing_portal.read]` with no `api_surface` — anonymous visitors were denied the plan catalog on a public landing page. `list_plans` is now `api_surface: public_readonly` with no permissions; the scanner requires `ui/pages/pricing.yaml` in mozaikspay SaaS bundles, verifies it binds to `list_plans`, and verifies `list_plans` stays public.

Also rewords the `capability_routing.yaml` `operator_pack_note` left stale by #348 (mozaikspay is the *default* SaaS provider now, not an explicit selection) and updates fixtures to the new contract shape — golden/scanner SaaS bundles now carry a gated feature module, as real SaaS output must.

## OSS Change Impact
- **Layer changed**: framework capability — `factory_app/build_context/` (mozaikspay pack template, AppGenerator routing catalog) and `factory_app/workflows/AppGenerator/tools/generated_bundle_scanner.py`; no runtime/substrate change
- **Build workflow impact**: AppGenerator bundle acceptance tightens for SaaS bundles; no sequence/transition/entrypoint changes
- **Runtime/platform impact**: none (runtime enforcement unchanged)
- **App workspace impact**: newly generated mozaikspay SaaS apps get a public plan catalog and must gate at least one sold capability
- **Tests run**: `ruff check .` clean; full `pytest -q --no-cov` — **13419 passed, 78 skipped**
- **Docs updated**: `CHANGELOG.md` (Unreleased → Fixed)
- **Compatibility risk**: bundles that previously passed with capability catalogs and zero gates now fail validation — intended

## Managed Capability Boundary Check
- mozaikspay pack facade surface changed (one action made public_readonly); facade boundary preserved — pages still bind only through `billing_portal`
- no provider internals copied; examples remain provider-neutral

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3