### PR TITLE
fix(factory): stop unchanged app repair loops

### DIFF
--- a/docs/architecture/builder/appgenerator-output-assembly-contract.md
+++ b/docs/architecture/builder/appgenerator-output-assembly-contract.md
@@ -461,6 +461,16 @@ Agent prompts may propose a patch, but they do not decide whether the loop
 continues. The acceptance gate, failure fingerprint, ownership table, and retry
 budget are the control authority.
 
+The automated repair controller currently covers workflow-integration failures
+and generated-bundle scanner failures. Other acceptance failures still fail
+closed to the user. Browser interaction evidence (console errors, failed network
+requests, screenshots, and replayable user-flow assertions) is not yet a
+first-class automatic repair input. Closing that gap requires a typed,
+environment-scoped verification-evidence contract that maps each failure to an
+owning agent and replays the same scenario after the patch. Browser evidence may
+inform repair, but it must not bypass deterministic acceptance, review, or
+promotion.
+
 The target must be the narrowest owning agent: `AppSchemaAgent` for page/schema
 endpoint drift, `ConfigMiddlewareAgent` for config or managed-capability client
 drift, `ServiceAgent` for backend Python/service drift, and `FrontendStubAgent`

--- a/docs/architecture/builder/appgenerator-output-assembly-contract.md
+++ b/docs/architecture/builder/appgenerator-output-assembly-contract.md
@@ -440,6 +440,27 @@ acceptance gate writes a bundle repair contract before export can proceed:
 - `bundle_repair_errors`
 - `bundle_repair_result`
 
+Both workflow-integration and generated-bundle repair contracts also persist a
+stable failure fingerprint and a `no_progress` flag. The acceptance gate
+normalizes the current failure evidence and hashes it before scheduling a repair.
+If validation after a repair produces the identical fingerprint, the gate marks
+the repair `blocked` immediately instead of spending another model turn on the
+same unchanged failure. A changed fingerprint may consume the next bounded
+attempt. Passing validation clears the fingerprint and no-progress state.
+
+This makes the repair controller deterministic:
+
+1. observe validation evidence
+2. classify the narrowest owning agent
+3. emit a bounded repair request
+4. apply only that agent's owned file delta
+5. re-run the authoritative acceptance gate
+6. stop on pass, repeated evidence, or attempt exhaustion
+
+Agent prompts may propose a patch, but they do not decide whether the loop
+continues. The acceptance gate, failure fingerprint, ownership table, and retry
+budget are the control authority.
+
 The target must be the narrowest owning agent: `AppSchemaAgent` for page/schema
 endpoint drift, `ConfigMiddlewareAgent` for config or managed-capability client
 drift, `ServiceAgent` for backend Python/service drift, and `FrontendStubAgent`

--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -24,6 +24,10 @@ Reviewed on August 14, 2026 against:
   - <https://docs.ag2.ai/latest/docs/beta/network/task_observation/>
   - <https://docs.ag2.ai/latest/docs/beta/tasks/>
   - <https://docs.ag2.ai/latest/docs/beta/ag2_compatibility/>
+  - <https://docs.ag2.ai/docs/blog/2026/05/14/AG2-Action-Driven-Network/>
+  - <https://docs.ag2.ai/docs/blog/2026/05/16/AG2-Network-What-Survives/>
+  - <https://docs.ag2.ai/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/>
+  - <https://docs.ag2.ai/docs/blog/2026/06/17/AG2-Agent-Harness/>
 
 AG2 currently owns the primitives Mozaiks should not recreate:
 
@@ -119,6 +123,31 @@ changes under `mozaiksai/core/workflow`, `mozaiksai/core/adapters`, or
 ## Current Decision Log
 
 ### August 22, 2026
+
+- **AG2 Harness and deployable-network series reviewed; build repair remains
+  Mozaiks-owned deterministic policy**: reviewed the Agent Harness, Networks You
+  Can Deploy, and What Survives posts alongside the Action-Driven Network review.
+  Conclusions:
+  - `MemoryStream`, retry/telemetry middleware, token observers, tools, and
+    human-input hooks are useful execution and observability primitives. Mozaiks
+    already uses the applicable primitives behind adapter boundaries.
+  - AG2 `LoopDetector` observes repeated tool calls; it does not replace the
+    AppGenerator acceptance gate. AppGenerator therefore fingerprints normalized
+    validation failures and deterministically blocks an unchanged repair result.
+  - AG2 compaction, aggregation, and `KnowledgeStore` are conversation-memory
+    concerns. App context, validation evidence, artifact lineage, staleness,
+    acceptance, and promotion remain typed Mozaiks records rather than agent
+    memory.
+  - Hub WAL, checkpoint storage, at-least-once delivery, authentication, dynamic
+    membership, and federation matter when workflow workers cross process or
+    trust boundaries. They are not prerequisites for the local build-repair
+    loop. Mozaiks should adopt the native durable channel path when it can
+    preserve tenant scope and exact resumability, rather than creating a second
+    agent network.
+  - None of the four posts changes the ownership boundary: AG2 may execute agent
+    turns and preserve channel events; Mozaiks selects the artifact version,
+    classifies impact, validates generated files, bounds repair, requires review,
+    and authorizes promotion.
 
 - **Action-Driven Network blog post reviewed, layering confirmed**: reviewed
   AG2's Action-Driven Network post

--- a/factory_app/workflows/AppGenerator/context_variables.yaml
+++ b/factory_app/workflows/AppGenerator/context_variables.yaml
@@ -839,6 +839,18 @@ definitions:
     source:
       type: computed
       default: []
+  workflow_integration_repair_failure_fingerprint:
+    type: string
+    description: Stable digest of the last workflow-integration failure evidence.
+    source:
+      type: computed
+      default: null
+  workflow_integration_repair_no_progress:
+    type: boolean
+    description: True when a repair pass reproduces the identical workflow-integration failure.
+    source:
+      type: computed
+      default: false
   workflow_integration_repair_result:
     type: object
     description: Full workflow integration repair scheduling result.
@@ -885,6 +897,18 @@ definitions:
     source:
       type: computed
       default: []
+  bundle_repair_failure_fingerprint:
+    type: string
+    description: Stable digest of the last targeted generated-bundle failure evidence.
+    source:
+      type: computed
+      default: null
+  bundle_repair_no_progress:
+    type: boolean
+    description: True when a repair pass reproduces the identical targeted bundle failure.
+    source:
+      type: computed
+      default: false
   bundle_repair_result:
     type: object
     description: Full generated-bundle scanner repair scheduling result.

--- a/factory_app/workflows/AppGenerator/tools/app_validation.py
+++ b/factory_app/workflows/AppGenerator/tools/app_validation.py
@@ -12,6 +12,7 @@ This tool can:
 import ast
 import asyncio
 import builtins
+import hashlib
 import json
 import logging
 import os
@@ -1876,6 +1877,19 @@ def _select_bundle_repair_target(classified: dict[str, list[str]]) -> str | None
     return None
 
 
+def _repair_failure_fingerprint(*, repair_kind: str, evidence: Any) -> str:
+    """Return a stable digest for deterministic repair no-progress checks."""
+
+    normalized = json.dumps(
+        {"repair_kind": repair_kind, "evidence": evidence},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
 def _bundle_repair_request(
     *,
     target: str,
@@ -1915,6 +1929,9 @@ def _prepare_bundle_repair(
         _context_get(context_variables, "bundle_repair_attempt_count", 0),
         0,
     )
+    previous_fingerprint = str(
+        _context_get(context_variables, "bundle_repair_failure_fingerprint", "") or ""
+    ).strip()
     max_attempts = max(0, _as_int(max_attempts, 2))
 
     if bundle_scan_result.get("passed"):
@@ -1929,12 +1946,16 @@ def _prepare_bundle_repair(
             "errors": [],
             "target_errors": [],
             "deferred_errors": [],
+            "failure_fingerprint": None,
+            "no_progress": False,
         }
         _context_set(context_variables, "bundle_repair_status", "passed")
         _context_set(context_variables, "bundle_repair_target", None)
         _context_set(context_variables, "bundle_repair_max_attempts", max_attempts)
         _context_set(context_variables, "bundle_repair_request", None)
         _context_set(context_variables, "bundle_repair_errors", [])
+        _context_set(context_variables, "bundle_repair_failure_fingerprint", None)
+        _context_set(context_variables, "bundle_repair_no_progress", False)
         _context_set(context_variables, "bundle_repair_result", result)
         return result
 
@@ -1954,12 +1975,16 @@ def _prepare_bundle_repair(
             "errors": errors,
             "target_errors": [],
             "deferred_errors": errors,
+            "failure_fingerprint": None,
+            "no_progress": False,
         }
         _context_set(context_variables, "bundle_repair_status", status)
         _context_set(context_variables, "bundle_repair_target", None)
         _context_set(context_variables, "bundle_repair_max_attempts", max_attempts)
         _context_set(context_variables, "bundle_repair_request", None)
         _context_set(context_variables, "bundle_repair_errors", errors)
+        _context_set(context_variables, "bundle_repair_failure_fingerprint", None)
+        _context_set(context_variables, "bundle_repair_no_progress", False)
         _context_set(context_variables, "bundle_repair_result", result)
         return result
 
@@ -1974,8 +1999,20 @@ def _prepare_bundle_repair(
         target_errors=target_errors,
         deferred_errors=deferred_errors,
     )
+    failure_fingerprint = _repair_failure_fingerprint(
+        repair_kind=f"bundle:{target}",
+        evidence={
+            "target_errors": sorted(target_errors),
+            "deferred_errors": sorted(deferred_errors),
+        },
+    )
+    no_progress = bool(
+        prior_attempts > 0
+        and previous_fingerprint
+        and previous_fingerprint == failure_fingerprint
+    )
 
-    if prior_attempts >= max_attempts:
+    if no_progress or prior_attempts >= max_attempts:
         status = "blocked"
         attempt = prior_attempts
         repairable = False
@@ -1997,6 +2034,8 @@ def _prepare_bundle_repair(
         "errors": errors,
         "target_errors": target_errors,
         "deferred_errors": deferred_errors,
+        "failure_fingerprint": failure_fingerprint,
+        "no_progress": no_progress,
     }
     _context_set(context_variables, "bundle_repair_status", status)
     _context_set(context_variables, "bundle_repair_target", repair_target)
@@ -2004,6 +2043,8 @@ def _prepare_bundle_repair(
     _context_set(context_variables, "bundle_repair_max_attempts", max_attempts)
     _context_set(context_variables, "bundle_repair_request", repair_request)
     _context_set(context_variables, "bundle_repair_errors", errors)
+    _context_set(context_variables, "bundle_repair_failure_fingerprint", failure_fingerprint)
+    _context_set(context_variables, "bundle_repair_no_progress", no_progress)
     _context_set(context_variables, "bundle_repair_result", result)
     return result
 
@@ -2027,9 +2068,13 @@ def _prepare_workflow_integration_repair(
             "attempt": _as_int(_context_get(context_variables, "workflow_integration_repair_count", 0), 0),
             "max_attempts": max_attempts,
             "repair_request": None,
+            "failure_fingerprint": None,
+            "no_progress": False,
         }
         _context_set(context_variables, "workflow_integration_repair_status", "passed")
         _context_set(context_variables, "workflow_integration_repair_request", None)
+        _context_set(context_variables, "workflow_integration_repair_failure_fingerprint", None)
+        _context_set(context_variables, "workflow_integration_repair_no_progress", False)
         _context_set(context_variables, "workflow_integration_repair_result", result)
         return result
     if not failed_tests:
@@ -2040,16 +2085,35 @@ def _prepare_workflow_integration_repair(
             "attempt": _as_int(_context_get(context_variables, "workflow_integration_repair_count", 0), 0),
             "max_attempts": max_attempts,
             "repair_request": None,
+            "failure_fingerprint": None,
+            "no_progress": False,
         }
         _context_set(context_variables, "workflow_integration_repair_status", "not_applicable")
+        _context_set(context_variables, "workflow_integration_repair_failure_fingerprint", None)
+        _context_set(context_variables, "workflow_integration_repair_no_progress", False)
         _context_set(context_variables, "workflow_integration_repair_result", result)
         return result
 
     prior_attempts = _as_int(_context_get(context_variables, "workflow_integration_repair_count", 0), 0)
+    previous_fingerprint = str(
+        _context_get(context_variables, "workflow_integration_repair_failure_fingerprint", "") or ""
+    ).strip()
     max_attempts = max(0, _as_int(max_attempts, 2))
     repair_request = _workflow_integration_repair_request(failed_tests)
+    failure_fingerprint = _repair_failure_fingerprint(
+        repair_kind="workflow_integration",
+        evidence=sorted(
+            failed_tests,
+            key=lambda item: json.dumps(item, sort_keys=True, default=str),
+        ),
+    )
+    no_progress = bool(
+        prior_attempts > 0
+        and previous_fingerprint
+        and previous_fingerprint == failure_fingerprint
+    )
 
-    if prior_attempts >= max_attempts:
+    if no_progress or prior_attempts >= max_attempts:
         status = "blocked"
         attempt = prior_attempts
         repairable = False
@@ -2066,12 +2130,16 @@ def _prepare_workflow_integration_repair(
         "max_attempts": max_attempts,
         "repair_request": repair_request,
         "failed_tests": failed_tests,
+        "failure_fingerprint": failure_fingerprint,
+        "no_progress": no_progress,
     }
     _context_set(context_variables, "workflow_integration_repair_status", status)
     _context_set(context_variables, "workflow_integration_repair_count", attempt)
     _context_set(context_variables, "workflow_integration_repair_max_attempts", max_attempts)
     _context_set(context_variables, "workflow_integration_repair_request", repair_request)
     _context_set(context_variables, "workflow_integration_repair_failed_tests", failed_tests)
+    _context_set(context_variables, "workflow_integration_repair_failure_fingerprint", failure_fingerprint)
+    _context_set(context_variables, "workflow_integration_repair_no_progress", no_progress)
     _context_set(context_variables, "workflow_integration_repair_result", result)
     return result
 

--- a/tests/test_app_validation_strategy.py
+++ b/tests/test_app_validation_strategy.py
@@ -747,6 +747,127 @@ async def test_app_bundle_acceptance_blocks_bundle_repair_after_max_attempts() -
     assert context.get("bundle_repair_attempt_count") == 2
 
 
+@pytest.mark.asyncio
+async def test_app_bundle_acceptance_blocks_identical_no_progress_repair() -> None:
+    module = importlib.import_module("factory_app.workflows.AppGenerator.tools.app_validation")
+    from scripts.smoke_appgenerator_live_acceptance import (
+        build_appgenerator_acceptance_files,
+        default_workflow_integration,
+    )
+
+    integration = default_workflow_integration()
+    files = build_appgenerator_acceptance_files(integration)
+    files["modules/support_tickets/backend/token_wallet_ledger.py"] = (
+        "class TokenWalletLedger:\n"
+        "    pass\n"
+    )
+    context = _Context(
+        {
+            "generated_files": files,
+            "generated_workflow_name": integration["workflow_name"],
+            "generated_workflow_capability_id": integration["capability_id"],
+            "generated_workflow_startup_mode": integration["startup_mode"],
+            "generated_workflow_trigger_events": integration["trigger_events"],
+        }
+    )
+
+    first = await module.run_app_bundle_acceptance_gate(files=files, context_variables=context)
+    repeated = await module.run_app_bundle_acceptance_gate(files=files, context_variables=context)
+
+    assert first["bundle_repair"]["status"] == "needs_revision"
+    assert repeated["bundle_repair"]["status"] == "blocked"
+    assert repeated["bundle_repair"]["no_progress"] is True
+    assert repeated["bundle_repair"]["failure_fingerprint"] == first["bundle_repair"]["failure_fingerprint"]
+    assert repeated["bundle_repair"]["attempt"] == 1
+    assert context.get("bundle_repair_no_progress") is True
+    assert context.get("bundle_repair_target") is None
+
+
+def test_bundle_repair_allows_changed_failure_within_budget() -> None:
+    module = importlib.import_module("factory_app.workflows.AppGenerator.tools.app_validation")
+    first_error = "modules/support/backend/token_wallet_ledger.py: forbidden helper"
+    changed_error = "modules/support/backend/provider_client.py: raw provider secret key literal"
+    first_fingerprint = module._repair_failure_fingerprint(
+        repair_kind="bundle:ServiceAgent",
+        evidence={"target_errors": [first_error], "deferred_errors": []},
+    )
+    context = _Context(
+        {
+            "bundle_repair_attempt_count": 1,
+            "bundle_repair_failure_fingerprint": first_fingerprint,
+        }
+    )
+
+    result = module._prepare_bundle_repair(
+        {"passed": False, "errors": [changed_error]},
+        context,
+    )
+
+    assert result["status"] == "needs_revision"
+    assert result["no_progress"] is False
+    assert result["attempt"] == 2
+    assert result["failure_fingerprint"] != first_fingerprint
+    assert context.get("bundle_repair_target") == "ServiceAgent"
+
+
+@pytest.mark.asyncio
+async def test_workflow_integration_repair_blocks_identical_no_progress_failure() -> None:
+    module = importlib.import_module("factory_app.workflows.AppGenerator.tools.app_validation")
+    from scripts.smoke_appgenerator_live_acceptance import (
+        build_appgenerator_acceptance_files,
+        default_workflow_integration,
+    )
+
+    integration = default_workflow_integration()
+    files = build_appgenerator_acceptance_files(integration)
+    del files["modules/support_tickets/contracts/reactions.yaml"]
+    context = _Context(
+        {
+            "generated_files": files,
+            "generated_workflow_name": integration["workflow_name"],
+            "generated_workflow_capability_id": integration["capability_id"],
+            "generated_workflow_startup_mode": integration["startup_mode"],
+            "generated_workflow_trigger_events": integration["trigger_events"],
+        }
+    )
+
+    first = await module.run_app_bundle_acceptance_gate(files=files, context_variables=context)
+    repeated = await module.run_app_bundle_acceptance_gate(files=files, context_variables=context)
+
+    assert first["workflow_integration_repair"]["status"] == "needs_revision"
+    assert repeated["workflow_integration_repair"]["status"] == "blocked"
+    assert repeated["workflow_integration_repair"]["no_progress"] is True
+    assert (
+        repeated["workflow_integration_repair"]["failure_fingerprint"]
+        == first["workflow_integration_repair"]["failure_fingerprint"]
+    )
+    assert repeated["workflow_integration_repair"]["attempt"] == 1
+    assert context.get("workflow_integration_repair_no_progress") is True
+
+
+def test_workflow_integration_fingerprint_ignores_failed_test_order() -> None:
+    module = importlib.import_module("factory_app.workflows.AppGenerator.tools.app_validation")
+    failed_tests = [
+        {"test": "event", "path": "modules/a/contracts/events.yaml", "error": "missing event"},
+        {"test": "reaction", "path": "modules/a/contracts/reactions.yaml", "error": "missing reaction"},
+    ]
+    context = _Context({})
+
+    first = module._prepare_workflow_integration_repair(
+        {"passed": False, "failed_tests": failed_tests},
+        context,
+    )
+    repeated = module._prepare_workflow_integration_repair(
+        {"passed": False, "failed_tests": list(reversed(failed_tests))},
+        context,
+    )
+
+    assert first["status"] == "needs_revision"
+    assert repeated["status"] == "blocked"
+    assert repeated["no_progress"] is True
+    assert repeated["failure_fingerprint"] == first["failure_fingerprint"]
+
+
 def test_validate_wiring_tool_annotations_are_runtime_resolved() -> None:
     from factory_app.workflows.AppGenerator.tools.validate_wiring import validate_wiring
 


### PR DESCRIPTION
## Summary
- fingerprint normalized AppGenerator repair failures
- block deterministic repair immediately when validation evidence is unchanged
- preserve bounded retries when the failure evidence changes
- record the AG2 Harness/Network ownership decision and repair-loop contract

## Validation
- python -m pytest tests/test_app_validation_strategy.py tests/test_workflow_network_graph.py tests/test_appgenerator_module_contracts.py tests/test_workflow_declarative_contracts.py tests/test_ag2_agent_runner.py --no-cov -q (100 passed)
- python -m ruff check factory_app/workflows/AppGenerator/tools/app_validation.py tests/test_app_validation_strategy.py
- git diff --check origin/main...HEAD

## Boundary
The deterministic acceptance, retry-budget, no-progress, and promotion policy remains Mozaiks-owned. AG2 remains the agent execution/observability substrate; no proprietary App Zero behavior is included.