### PR TITLE
fix(factory): wire the subscription contract HITL revision loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ This project follows a practical pre-1.0 changelog format:
   pricing landing page can render the plan catalog before login. The scanner
   now also requires `ui/pages/pricing.yaml` in mozaikspay SaaS bundles and
   verifies it binds to `list_plans`.
+- **Rejecting the subscription contract review no longer silently produces a
+  non-SaaS build**: when a reviewer requests changes,
+  SubscriptionContractDesigner now loops back to the designer agent to revise
+  and re-submit instead of terminating without an approved contract, and the
+  downstream generator context hook fails loudly if an unapproved
+  (changes-requested) contract state ever reaches AppGenerator/AgentGenerator.
 
 ### Added
 

--- a/factory_app/workflows/SubscriptionContractDesigner/transition_graph.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/transition_graph.yaml
@@ -1,4 +1,15 @@
 transition_rules:
+  # HITL revision loop: when the reviewer requests changes,
+  # save_subscription_contract clears the contract and records
+  # subscription_contract_review_status=changes_requested. Route back to the
+  # designer so it revises the structured output and re-submits for review
+  # instead of terminating with no approved contract. Conditional rules are
+  # evaluated before unconditional after_turn fallbacks.
+  - source_agent: ContractDesignerAgent
+    target_agent: ContractDesignerAgent
+    transition_type: condition
+    condition_type: context_expression
+    context_expression: "${subscription_contract_review_status} == 'changes_requested'"
   - source_agent: ContractDesignerAgent
     target_agent: terminate
     transition_type: after_turn

--- a/factory_app/workflows/_shared/subscription_contract_context.py
+++ b/factory_app/workflows/_shared/subscription_contract_context.py
@@ -134,8 +134,20 @@ def inject_subscription_contract_context(agent: Any, messages: list[dict[str, An
     agent_name = str(getattr(agent, "name", "") or "").strip()
     if agent_name not in _TARGET_AGENTS:
         return
-    contract = _find_contract(_context_data(agent))
+    data = _context_data(agent)
+    contract = _find_contract(data)
     if not contract:
+        # A cleared contract with a changes_requested review status means the
+        # reviewer rejected the last submission and no approved contract exists.
+        # Downstream generation must not silently proceed as a non-SaaS build;
+        # the SubscriptionContractDesigner revision loop owns re-approval.
+        review_status = str(data.get("subscription_contract_review_status") or "").strip()
+        if review_status == "changes_requested":
+            raise RuntimeError(
+                "Subscription contract review requested changes and no approved "
+                "contract is available. Re-run SubscriptionContractDesigner to "
+                "revise and approve the contract before downstream generation."
+            )
         return
     _apply_text(agent, _render_contract(contract))
 

--- a/tests/test_subscription_contract_designer.py
+++ b/tests/test_subscription_contract_designer.py
@@ -607,6 +607,100 @@ async def test_save_subscription_contract_blocks_downstream_context_when_review_
     assert context["subscription_contract_review_status"] == "changes_requested"
 
 
+def test_transition_graph_routes_changes_requested_back_to_designer() -> None:
+    """The HITL revision loop must exist: changes_requested re-enters the designer."""
+    graph = _read_yaml(SUBSCRIPTION_WORKFLOW / "transition_graph.yaml")
+    rules = graph["transition_rules"]
+
+    loop_back = next(
+        (
+            rule
+            for rule in rules
+            if rule["source_agent"] == "ContractDesignerAgent"
+            and rule["target_agent"] == "ContractDesignerAgent"
+        ),
+        None,
+    )
+    assert loop_back is not None, (
+        "SubscriptionContractDesigner must loop back to the designer on "
+        "changes_requested instead of terminating without an approved contract"
+    )
+    assert loop_back["transition_type"] == "condition"
+    assert loop_back["condition_type"] == "context_expression"
+    assert "changes_requested" in loop_back["context_expression"]
+    assert "subscription_contract_review_status" in loop_back["context_expression"]
+
+    terminate = [
+        rule
+        for rule in rules
+        if rule["source_agent"] == "ContractDesignerAgent" and rule["target_agent"] == "terminate"
+    ]
+    assert terminate, "designer must still terminate once review is not requesting changes"
+
+    # The declared rules must compile into a valid AG2 TransitionGraph.
+    from mozaiksai.core.workflow.execution.network_graph import (
+        compile_transition_rules_to_graph,
+    )
+
+    compiled = compile_transition_rules_to_graph(
+        rules,
+        initial_agent_name="ContractDesignerAgent",
+        agent_id_by_name={"ContractDesignerAgent": "contract_designer"},
+    )
+    assert compiled is not None
+
+
+def _generator_agent_stub(name: str, context: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        context_variables=SimpleNamespace(data=context),
+        system_message="base",
+    )
+
+
+def test_inject_subscription_contract_context_raises_on_unapproved_changes_requested() -> None:
+    from factory_app.workflows._shared.subscription_contract_context import (
+        inject_subscription_contract_context,
+    )
+
+    agent = _generator_agent_stub(
+        "AppPlanAgent",
+        {
+            "subscription_contract": None,
+            "subscription_contract_review_status": "changes_requested",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="requested changes"):
+        inject_subscription_contract_context(agent, [])
+
+
+def test_inject_subscription_contract_context_noop_without_contract_or_rejection() -> None:
+    from factory_app.workflows._shared.subscription_contract_context import (
+        inject_subscription_contract_context,
+    )
+
+    agent = _generator_agent_stub("AppPlanAgent", {})
+    inject_subscription_contract_context(agent, [])
+    assert agent.system_message == "base"
+
+
+def test_inject_subscription_contract_context_ignores_rejection_for_untargeted_agents() -> None:
+    from factory_app.workflows._shared.subscription_contract_context import (
+        inject_subscription_contract_context,
+    )
+
+    agent = _generator_agent_stub(
+        "SomeOtherAgent",
+        {
+            "subscription_contract": None,
+            "subscription_contract_review_status": "changes_requested",
+        },
+    )
+    inject_subscription_contract_context(agent, [])
+    assert agent.system_message == "base"
+
+
 def test_subscription_contract_normalizer_rejects_hosted_product_terms() -> None:
     from factory_app.workflows.SubscriptionContractDesigner.tools.save_subscription_contract import (
         normalize_subscription_contract,


### PR DESCRIPTION
## Summary

Rejecting the subscription contract review silently produced a non-SaaS build. `save_subscription_contract` cleared the contract and told the agent to revise, but `SubscriptionContractDesigner/transition_graph.yaml` terminated unconditionally after the turn — the promised revision loop was never wired. The build sequence then advanced and the generators, seeing no contract context, built the app as non-SaaS with no diagnostic.

- **Revision loop wired**: a deterministic `context_expression` rule routes `subscription_contract_review_status == 'changes_requested'` back to `ContractDesignerAgent` (conditional rules compile ahead of the `after_turn` terminate fallback), so request-changes produces a revised contract and a fresh review. This protects both first builds and refinement re-entries through sequences containing SubscriptionContractDesigner.
- **Loud downstream guard**: `inject_subscription_contract_context` now raises when a `changes_requested` state reaches AppGenerator/AgentGenerator with no approved contract, so any future routing regression fails loudly.
- Tests cover the graph shape, AG2 compilation of the new rule, and the guard's raise/no-op/untargeted-agent cases. CHANGELOG updated.

## OSS Change Impact
- **Layer changed**: framework capability — `factory_app/workflows/SubscriptionContractDesigner/` + `factory_app/workflows/_shared/`; no runtime/substrate change
- **Build workflow impact**: workflow-local agent routing only (`transition_graph.yaml`); no `workflow_sequence`/transition/entrypoint changes
- **Runtime/platform impact**: none
- **App workspace impact**: SaaS builds where the reviewer requests changes now revise instead of silently degrading to non-SaaS
- **Tests run**: `ruff check .` clean; full `pytest -q --no-cov` — **13419 passed, 78 skipped**
- **Docs updated**: CHANGELOG.md
- **Compatibility risk**: low — behavior change only in the previously-broken rejection path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3