### PR TITLE
feat(validation): canonicalize browser acceptance decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Removed
 
+- **Generated UI browser acceptance retired result vocabulary**: the
+  `scripts/generated_ui_acceptance.py` output no longer exposes top-level
+  `status`, `findings`, `revision_count`, or `revision_request` fields. Browser
+  validation now returns the canonical `ValidationRun` and one
+  `RepairDecision` (`accept`, `repair`, or `block`) from the shared acceptance
+  controller. No aliases or compatibility translation are retained; consumers
+  must read `validation_run.gate_results` and `repair_decision` before adopting
+  this version.
+
 - **`AppPageSchema.extensions` / `AppPageSlotExtension`**: the page slot-override
   contract is removed from structured outputs, generator prompts, and the UI
   quality audit. It was a schema-only promise — `PageRenderer` never rendered

--- a/docs/architecture/frontend/ui-system/generated-frontend-surface-contract.md
+++ b/docs/architecture/frontend/ui-system/generated-frontend-surface-contract.md
@@ -261,15 +261,16 @@ declarative form submission, and responsive layout regressions.
 Browser findings flow through `scripts/generated_ui_acceptance.py` when they
 need to become structured production-readiness feedback:
 
-- output status: `passed`, `needs_revision`, or `blocked`
-- structured findings: severity, route, category, message, suggested fix
-- revision text: concrete rendered issue, not generic prompt advice
+- canonical `ValidationRun` with the `generated_ui_browser` gate result
+- structured `ValidationIssue` entries with code, severity, route, message,
+  suggested fix, and repair owner
+- one `RepairDecision`: `accept`, `repair`, or `block`
 
 This keeps strictness bounded. Playwright failures should be converted into
-specific findings such as route, severity, category, message, and suggested fix;
-they should not become an open-ended agent loop. The acceptance script has its
-own revision-budget vocabulary and can block to user/operator review when the
-generated UI keeps failing browser checks.
+specific canonical issues; they should not become an open-ended agent loop. The
+shared acceptance controller owns the repair budget and blocks to user/operator
+review when the evidence is unchanged or the budget is exhausted. The script
+does not maintain a second browser-specific retry state machine.
 
 To run the generic rendered-app smoke against a generated app root instead of
 the checked-in fixture:

--- a/docs/architecture/frontend/ui-system/ui-system-quality-gates.md
+++ b/docs/architecture/frontend/ui-system/ui-system-quality-gates.md
@@ -50,28 +50,29 @@ Runner:
 
 Output:
 
-- `status`
-- `findings`
-- `revision_request`
+- `validation_run` with ordered gate results and canonical issues
+- `repair_decision` with `accept`, `repair`, or `block`
 - `returncode`
 
 Browser findings are structured:
 
 ```json
 {
+  "gate_id": "generated_ui_browser",
+  "code": "layout",
   "severity": "error",
   "route": "/tickets",
-  "category": "layout",
   "message": "Horizontal overflow on mobile.",
-  "suggested_fix": "Use ResourceTable responsive behavior or reduce columns."
+  "suggested_fix": "Use ResourceTable responsive behavior or reduce columns.",
+  "repair_owner": "AppSchemaAgent"
 }
 ```
 
-Production readiness should use the same bounded status vocabulary:
+The canonical acceptance controller owns the bounded routing decision:
 
-- `passed` -> continue delivery
-- `needs_revision` -> revise generated artifacts before promotion
-- `blocked` -> user/operator review
+- `accept` -> continue delivery
+- `repair` -> revise generated artifacts within budget
+- `block` -> user/operator review
 
 ## Why Two Gates
 

--- a/mozaiksai/core/validation/__init__.py
+++ b/mozaiksai/core/validation/__init__.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+from .acceptance import (
+    AcceptanceController,
+    AcceptanceResult,
+    RepairDecision,
+    ValidationGate,
+    ValidationGateResult,
+    ValidationIssue,
+    ValidationRegistry,
+    ValidationRun,
+)
 from .functional_generated_app import (
     FunctionalGeneratedAppDiagnostic,
     scan_functional_generated_app,
@@ -12,10 +22,18 @@ from .generated_app import (
 )
 
 __all__ = [
+    "AcceptanceController",
+    "AcceptanceResult",
     "FunctionalGeneratedAppDiagnostic",
     "GeneratedAppValidationDiagnostic",
     "GeneratedAppValidationRequest",
     "GeneratedAppValidationResult",
+    "RepairDecision",
+    "ValidationGate",
+    "ValidationGateResult",
+    "ValidationIssue",
+    "ValidationRegistry",
+    "ValidationRun",
     "scan_functional_generated_app",
     "validate_generated_app_bundle",
 ]

--- a/mozaiksai/core/validation/acceptance.py
+++ b/mozaiksai/core/validation/acceptance.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ValidationSeverity = Literal["error", "warning", "info"]
+ValidationStatus = Literal["passed", "failed"]
+RepairDisposition = Literal["accept", "repair", "block"]
+
+
+class ValidationIssue(BaseModel):
+    """One actionable finding emitted by a registered validation gate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    gate_id: str
+    code: str
+    message: str
+    severity: ValidationSeverity = "error"
+    path: str | None = None
+    route: str | None = None
+    source: str | None = None
+    suggested_fix: str | None = None
+    repair_owner: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def fingerprint_payload(self) -> dict[str, str]:
+        return {
+            "gate_id": self.gate_id.strip().lower(),
+            "code": self.code.strip().lower(),
+            "message": " ".join(self.message.split()).lower(),
+            "path": (self.path or "").replace("\\", "/").strip().lower(),
+            "route": (self.route or "").strip().lower(),
+            "repair_owner": (self.repair_owner or "").strip().lower(),
+        }
+
+
+class ValidationGateResult(BaseModel):
+    """Result of exactly one registered gate execution."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    gate_id: str
+    status: ValidationStatus
+    issues: tuple[ValidationIssue, ...] = Field(default_factory=tuple)
+    artifacts: tuple[str, ...] = Field(default_factory=tuple)
+    duration_ms: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_status_matches_issues(self) -> ValidationGateResult:
+        has_errors = any(issue.severity == "error" for issue in self.issues)
+        if self.status == "passed" and has_errors:
+            raise ValueError("passed validation gate result cannot contain error issues")
+        if self.status == "failed" and not has_errors:
+            raise ValueError("failed validation gate result must contain an error issue")
+        return self
+
+
+class ValidationRun(BaseModel):
+    """Canonical evidence for one ordered acceptance pass."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    run_id: str = Field(default_factory=lambda: str(uuid4()))
+    status: ValidationStatus
+    gate_results: tuple[ValidationGateResult, ...]
+    started_at: datetime
+    completed_at: datetime
+    attempt: int = Field(default=0, ge=0)
+    failure_fingerprint: str | None = None
+
+    @property
+    def issues(self) -> tuple[ValidationIssue, ...]:
+        return tuple(issue for result in self.gate_results for issue in result.issues)
+
+
+class RepairDecision(BaseModel):
+    """Single routing decision derived from a canonical validation run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    disposition: RepairDisposition
+    reason: str
+    attempt: int = Field(ge=0)
+    max_attempts: int = Field(ge=0)
+    failure_fingerprint: str | None = None
+    repair_owners: tuple[str, ...] = Field(default_factory=tuple)
+    issue_codes: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class AcceptanceResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    validation_run: ValidationRun
+    repair_decision: RepairDecision
+
+    @property
+    def accepted(self) -> bool:
+        return self.repair_decision.disposition == "accept"
+
+
+GateHandler = Callable[[Mapping[str, Any]], ValidationGateResult | Iterable[ValidationIssue]]
+
+
+@dataclass(frozen=True)
+class ValidationGate:
+    gate_id: str
+    handler: GateHandler
+    description: str = ""
+
+
+class ValidationRegistry:
+    """Ordered, duplicate-safe registry for acceptance gates."""
+
+    def __init__(self) -> None:
+        self._gates: dict[str, ValidationGate] = {}
+
+    def register(self, gate: ValidationGate) -> None:
+        gate_id = gate.gate_id.strip()
+        if not gate_id:
+            raise ValueError("validation gate_id must not be empty")
+        if gate_id in self._gates:
+            raise ValueError(f"validation gate already registered: {gate_id}")
+        self._gates[gate_id] = gate
+
+    def resolve(self, gate_ids: Sequence[str] | None = None) -> tuple[ValidationGate, ...]:
+        if gate_ids is None:
+            return tuple(self._gates.values())
+        missing = [gate_id for gate_id in gate_ids if gate_id not in self._gates]
+        if missing:
+            raise KeyError(f"unknown validation gates: {', '.join(missing)}")
+        return tuple(self._gates[gate_id] for gate_id in gate_ids)
+
+    @property
+    def gate_ids(self) -> tuple[str, ...]:
+        return tuple(self._gates)
+
+
+class AcceptanceController:
+    """Run registered gates and make the only repair/promotion decision."""
+
+    def __init__(self, registry: ValidationRegistry) -> None:
+        self._registry = registry
+
+    def run(
+        self,
+        *,
+        context: Mapping[str, Any],
+        gate_ids: Sequence[str] | None = None,
+        attempt: int = 0,
+        max_attempts: int = 1,
+        prior_failure_fingerprint: str | None = None,
+    ) -> AcceptanceResult:
+        if attempt < 0:
+            raise ValueError("attempt must be non-negative")
+        if max_attempts < 0:
+            raise ValueError("max_attempts must be non-negative")
+
+        started_at = datetime.now(UTC)
+        gate_results = tuple(self._run_gate(gate, context) for gate in self._registry.resolve(gate_ids))
+        blocking_issues = tuple(
+            issue
+            for result in gate_results
+            for issue in result.issues
+            if issue.severity == "error"
+        )
+        fingerprint = _failure_fingerprint(blocking_issues) if blocking_issues else None
+        run = ValidationRun(
+            status="failed" if blocking_issues else "passed",
+            gate_results=gate_results,
+            started_at=started_at,
+            completed_at=datetime.now(UTC),
+            attempt=attempt,
+            failure_fingerprint=fingerprint,
+        )
+        return AcceptanceResult(
+            validation_run=run,
+            repair_decision=_decide_repair(
+                blocking_issues,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                failure_fingerprint=fingerprint,
+                prior_failure_fingerprint=prior_failure_fingerprint,
+            ),
+        )
+
+    @staticmethod
+    def _run_gate(gate: ValidationGate, context: Mapping[str, Any]) -> ValidationGateResult:
+        started_at = datetime.now(UTC)
+        try:
+            raw_result = gate.handler(context)
+            if isinstance(raw_result, ValidationGateResult):
+                if raw_result.gate_id != gate.gate_id:
+                    raise ValueError(
+                        f"validation gate {gate.gate_id} returned result for {raw_result.gate_id}"
+                    )
+                return raw_result.model_copy(
+                    update={"duration_ms": _duration_ms(started_at)},
+                )
+            issues = tuple(raw_result)
+            for issue in issues:
+                if not isinstance(issue, ValidationIssue):
+                    raise TypeError(f"validation gate {gate.gate_id} returned a non-ValidationIssue")
+                if issue.gate_id != gate.gate_id:
+                    raise ValueError(
+                        f"validation gate {gate.gate_id} emitted issue for {issue.gate_id}"
+                    )
+            return ValidationGateResult(
+                gate_id=gate.gate_id,
+                status="failed" if any(issue.severity == "error" for issue in issues) else "passed",
+                issues=issues,
+                duration_ms=_duration_ms(started_at),
+            )
+        except Exception as exc:
+            issue = ValidationIssue(
+                gate_id=gate.gate_id,
+                code="validator_exception",
+                message=f"Validation gate {gate.gate_id} failed to execute: {exc}",
+                source=gate.gate_id,
+                suggested_fix="Fix the validator or its execution environment before promotion.",
+            )
+            return ValidationGateResult(
+                gate_id=gate.gate_id,
+                status="failed",
+                issues=(issue,),
+                duration_ms=_duration_ms(started_at),
+            )
+
+
+def _decide_repair(
+    issues: tuple[ValidationIssue, ...],
+    *,
+    attempt: int,
+    max_attempts: int,
+    failure_fingerprint: str | None,
+    prior_failure_fingerprint: str | None,
+) -> RepairDecision:
+    owners = tuple(sorted({issue.repair_owner for issue in issues if issue.repair_owner}))
+    codes = tuple(sorted({issue.code for issue in issues}))
+    if not issues:
+        return RepairDecision(
+            disposition="accept",
+            reason="All registered validation gates passed.",
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+    if prior_failure_fingerprint and failure_fingerprint == prior_failure_fingerprint:
+        return RepairDecision(
+            disposition="block",
+            reason="Validation evidence is unchanged after repair; operator review is required.",
+            attempt=attempt,
+            max_attempts=max_attempts,
+            failure_fingerprint=failure_fingerprint,
+            repair_owners=owners,
+            issue_codes=codes,
+        )
+    if attempt < max_attempts:
+        return RepairDecision(
+            disposition="repair",
+            reason="Blocking validation issues remain within the repair budget.",
+            attempt=attempt,
+            max_attempts=max_attempts,
+            failure_fingerprint=failure_fingerprint,
+            repair_owners=owners,
+            issue_codes=codes,
+        )
+    return RepairDecision(
+        disposition="block",
+        reason="Blocking validation issues remain after the repair budget; operator review is required.",
+        attempt=attempt,
+        max_attempts=max_attempts,
+        failure_fingerprint=failure_fingerprint,
+        repair_owners=owners,
+        issue_codes=codes,
+    )
+
+
+def _failure_fingerprint(issues: tuple[ValidationIssue, ...]) -> str:
+    payload = sorted(
+        (issue.fingerprint_payload() for issue in issues),
+        key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+    )
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _duration_ms(started_at: datetime) -> int:
+    return max(0, int((datetime.now(UTC) - started_at).total_seconds() * 1000))
+
+
+__all__ = [
+    "AcceptanceController",
+    "AcceptanceResult",
+    "RepairDecision",
+    "ValidationGate",
+    "ValidationGateResult",
+    "ValidationIssue",
+    "ValidationRegistry",
+    "ValidationRun",
+]

--- a/scripts/generated_ui_acceptance.py
+++ b/scripts/generated_ui_acceptance.py
@@ -1,8 +1,7 @@
 """Production-readiness helper for generated UI browser acceptance.
 
-This script keeps Playwright outside the live AppGenerator agent loop. It can run
-the generic generated-app browser smoke, parse Playwright JSON output, and emit
-structured findings that a human or later promotion gate can inspect.
+This script runs the generic generated-app browser smoke through the canonical
+validation registry and acceptance controller.
 """
 
 from __future__ import annotations
@@ -15,6 +14,15 @@ import subprocess
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+
+from mozaiksai.core.validation import (
+    AcceptanceController,
+    ValidationGate,
+    ValidationIssue,
+    ValidationRegistry,
+)
+
+_GATE_ID = "generated_ui_browser"
 
 
 def _string(value: Any) -> str:
@@ -29,21 +37,22 @@ def _finding(
     category: str = "render",
     source: str = "playwright",
     suggested_fix: str | None = None,
-) -> dict[str, str]:
-    out = {
-        "severity": severity,
-        "route": route or "",
-        "category": category,
-        "message": message,
-        "source": source,
-        "suggested_fix": suggested_fix
+) -> ValidationIssue:
+    return ValidationIssue(
+        gate_id=_GATE_ID,
+        code=category,
+        severity=severity,
+        route=route,
+        message=message,
+        source=source,
+        suggested_fix=suggested_fix
         or "Revise the generated page schema or bounded custom React for the affected route.",
-    }
-    return {key: value for key, value in out.items() if value}
+        repair_owner="AppSchemaAgent",
+    )
 
 
-def normalize_ui_acceptance_findings(value: Any) -> list[dict[str, str]]:
-    """Normalize arbitrary finding payloads into structured dictionaries."""
+def normalize_ui_acceptance_findings(value: Any) -> list[ValidationIssue]:
+    """Normalize arbitrary finding payloads into canonical validation issues."""
 
     if value is None:
         return []
@@ -65,17 +74,17 @@ def normalize_ui_acceptance_findings(value: Any) -> list[dict[str, str]]:
             )
         ]
     if isinstance(value, Iterable):
-        findings: list[dict[str, str]] = []
+        findings: list[ValidationIssue] = []
         for item in value:
             findings.extend(normalize_ui_acceptance_findings(item))
         return findings
     return [_finding(message=str(value))]
 
 
-def parse_playwright_json_report(report: dict[str, Any]) -> list[dict[str, str]]:
+def parse_playwright_json_report(report: dict[str, Any]) -> list[ValidationIssue]:
     """Convert Playwright JSON reporter output into UI acceptance findings."""
 
-    findings: list[dict[str, str]] = []
+    findings: list[ValidationIssue] = []
 
     for error in report.get("errors") or []:
         if not isinstance(error, dict):
@@ -145,72 +154,6 @@ def parse_playwright_json_report(report: dict[str, Any]) -> list[dict[str, str]]
     return findings
 
 
-def review_ui_acceptance_findings(
-    findings: Any,
-    *,
-    acceptance_ran: bool = True,
-    require_acceptance_run: bool = False,
-    prior_revision_count: int = 0,
-    max_revision_attempts: int = 1,
-) -> dict[str, Any]:
-    """Return a bounded production-readiness status for browser findings."""
-
-    normalized = normalize_ui_acceptance_findings(findings)
-    if require_acceptance_run and not acceptance_ran:
-        normalized.append(
-            _finding(
-                message="Browser UI acceptance did not run before final delivery.",
-                category="acceptance",
-                suggested_fix="Run the generated UI Playwright acceptance smoke before promotion.",
-            )
-        )
-
-    if not normalized:
-        status = "passed"
-        revision_request = None
-        revision_count = prior_revision_count
-    elif prior_revision_count < max(0, max_revision_attempts):
-        status = "needs_revision"
-        revision_count = prior_revision_count + 1
-        revision_request = _format_revision_request(normalized)
-    else:
-        status = "blocked"
-        revision_count = prior_revision_count
-        revision_request = (
-            "Browser UI acceptance findings remain after the automated revision budget. "
-            "User/operator review is required:\n- "
-            + _format_findings(normalized)
-        )
-
-    return {
-        "status": status,
-        "findings": normalized,
-        "revision_count": revision_count,
-        "max_revision_attempts": max(0, max_revision_attempts),
-        "revision_request": revision_request,
-    }
-
-
-def _format_findings(findings: list[dict[str, str]]) -> str:
-    lines: list[str] = []
-    for finding in findings:
-        route = f" route={finding['route']}" if finding.get("route") else ""
-        suggestion = finding.get("suggested_fix") or "Revise the generated UI."
-        lines.append(
-            f"{finding.get('severity', 'error')} {finding.get('category', 'render')}{route}: "
-            f"{finding.get('message', '')} Suggested fix: {suggestion}"
-        )
-    return "\n- ".join(lines)
-
-
-def _format_revision_request(findings: list[dict[str, str]]) -> str:
-    return (
-        "Revise the generated UI based on browser acceptance findings. "
-        "Do not add new decorative sections; fix the concrete rendered issue:\n- "
-        + _format_findings(findings)
-    )
-
-
 def _extract_json_report(stdout: str) -> dict[str, Any]:
     text = stdout.strip()
     if not text:
@@ -275,15 +218,21 @@ def run_playwright_acceptance(
                 suggested_fix="Inspect Playwright runner output and fix the generated app or test environment.",
             )
         ]
-    review = review_ui_acceptance_findings(findings, acceptance_ran=True)
+    registry = ValidationRegistry()
+    registry.register(
+        ValidationGate(
+            gate_id=_GATE_ID,
+            description="Generated app browser rendering acceptance.",
+            handler=lambda _context: findings,
+        )
+    )
+    acceptance = AcceptanceController(registry).run(context={})
     result = {
-        "success": completed.returncode == 0 and review["status"] == "passed",
+        "success": completed.returncode == 0 and acceptance.accepted,
         "returncode": completed.returncode,
-        "status": review["status"],
-        "findings": review["findings"],
-        "revision_request": review["revision_request"],
+        **acceptance.model_dump(mode="json"),
     }
-    if not result["success"] and not review["findings"]:
+    if not result["success"] and not findings:
         result["runner_error"] = (completed.stderr or completed.stdout or "").strip()[-2000:]
     return result
 
@@ -322,6 +271,5 @@ if __name__ == "__main__":
 __all__ = [
     "normalize_ui_acceptance_findings",
     "parse_playwright_json_report",
-    "review_ui_acceptance_findings",
     "run_playwright_acceptance",
 ]

--- a/tests/test_acceptance_controller.py
+++ b/tests/test_acceptance_controller.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from mozaiksai.core.validation import (
+    AcceptanceController,
+    ValidationGate,
+    ValidationGateResult,
+    ValidationIssue,
+    ValidationRegistry,
+)
+
+
+def _issue(*, code: str = "broken_route") -> ValidationIssue:
+    return ValidationIssue(
+        gate_id="routes",
+        code=code,
+        message="Route points to a missing page.",
+        path="app/ui/route_manifest.json",
+        suggested_fix="Generate the referenced page.",
+        repair_owner="AppSchemaAgent",
+    )
+
+
+def test_controller_accepts_when_every_registered_gate_passes() -> None:
+    registry = ValidationRegistry()
+    registry.register(ValidationGate(gate_id="routes", handler=lambda _context: []))
+
+    result = AcceptanceController(registry).run(context={"files": {}})
+
+    assert result.accepted is True
+    assert result.validation_run.status == "passed"
+    assert result.repair_decision.disposition == "accept"
+    assert result.validation_run.gate_results[0].gate_id == "routes"
+
+
+def test_controller_returns_one_canonical_repair_decision() -> None:
+    registry = ValidationRegistry()
+    registry.register(ValidationGate(gate_id="routes", handler=lambda _context: [_issue()]))
+
+    result = AcceptanceController(registry).run(context={}, attempt=0, max_attempts=1)
+
+    assert result.validation_run.status == "failed"
+    assert result.repair_decision.disposition == "repair"
+    assert result.repair_decision.repair_owners == ("AppSchemaAgent",)
+    assert result.repair_decision.issue_codes == ("broken_route",)
+    assert result.validation_run.failure_fingerprint
+
+
+def test_controller_blocks_when_failure_evidence_is_unchanged() -> None:
+    registry = ValidationRegistry()
+    registry.register(ValidationGate(gate_id="routes", handler=lambda _context: [_issue()]))
+    controller = AcceptanceController(registry)
+    first = controller.run(context={}, attempt=0, max_attempts=2)
+
+    second = controller.run(
+        context={},
+        attempt=1,
+        max_attempts=2,
+        prior_failure_fingerprint=first.validation_run.failure_fingerprint,
+    )
+
+    assert second.repair_decision.disposition == "block"
+    assert "unchanged" in second.repair_decision.reason
+
+
+def test_controller_allows_changed_evidence_within_budget() -> None:
+    registry = ValidationRegistry()
+    registry.register(
+        ValidationGate(gate_id="routes", handler=lambda context: [_issue(code=str(context["code"]))])
+    )
+    controller = AcceptanceController(registry)
+    first = controller.run(context={"code": "broken_route"}, attempt=0, max_attempts=2)
+
+    second = controller.run(
+        context={"code": "missing_component"},
+        attempt=1,
+        max_attempts=2,
+        prior_failure_fingerprint=first.validation_run.failure_fingerprint,
+    )
+
+    assert second.repair_decision.disposition == "repair"
+    assert second.validation_run.failure_fingerprint != first.validation_run.failure_fingerprint
+
+
+def test_registry_rejects_duplicate_and_unknown_gates() -> None:
+    registry = ValidationRegistry()
+    registry.register(ValidationGate(gate_id="routes", handler=lambda _context: []))
+
+    try:
+        registry.register(ValidationGate(gate_id="routes", handler=lambda _context: []))
+    except ValueError as exc:
+        assert "already registered" in str(exc)
+    else:
+        raise AssertionError("duplicate validation gate was accepted")
+
+    try:
+        registry.resolve(["missing"])
+    except KeyError as exc:
+        assert "unknown validation gates" in str(exc)
+    else:
+        raise AssertionError("unknown validation gate was accepted")
+
+
+def test_validator_exception_fails_closed() -> None:
+    def broken(_context):
+        raise RuntimeError("boom")
+
+    registry = ValidationRegistry()
+    registry.register(ValidationGate(gate_id="routes", handler=broken))
+
+    result = AcceptanceController(registry).run(context={})
+
+    assert result.validation_run.status == "failed"
+    assert result.validation_run.issues[0].code == "validator_exception"
+    assert result.repair_decision.disposition == "repair"
+
+
+def test_gate_result_status_cannot_disagree_with_issues() -> None:
+    try:
+        ValidationGateResult(gate_id="routes", status="failed", issues=())
+    except ValidationError as exc:
+        assert "must contain an error issue" in str(exc)
+    else:
+        raise AssertionError("inconsistent validation result was accepted")

--- a/tests/test_acceptance_cutover_drift.py
+++ b/tests/test_acceptance_cutover_drift.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_generated_ui_acceptance_has_no_private_retry_state() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (root / "scripts" / "generated_ui_acceptance.py").read_text(encoding="utf-8")
+
+    forbidden = (
+        "review_ui_acceptance_findings",
+        "prior_revision_count",
+        "revision_count",
+        "revision_request",
+        '"needs_revision"',
+    )
+    for legacy_name in forbidden:
+        assert legacy_name not in source
+
+
+def test_generated_ui_acceptance_uses_canonical_controller() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (root / "scripts" / "generated_ui_acceptance.py").read_text(encoding="utf-8")
+
+    assert "ValidationRegistry" in source
+    assert "AcceptanceController" in source
+    assert "repair_decision" not in source

--- a/tests/test_appgenerator_ui_acceptance.py
+++ b/tests/test_appgenerator_ui_acceptance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _load_acceptance_module():
@@ -53,11 +54,12 @@ def test_parse_playwright_json_report_returns_structured_findings() -> None:
     findings = ui_acceptance.parse_playwright_json_report(report)
 
     assert len(findings) == 1
-    assert findings[0]["severity"] == "error"
-    assert findings[0]["category"] == "render"
-    assert "generated page renders" in findings[0]["message"]
-    assert "main heading" in findings[0]["message"]
-    assert "generated-mobile" in findings[0]["suggested_fix"]
+    assert findings[0].severity == "error"
+    assert findings[0].code == "render"
+    assert findings[0].gate_id == "generated_ui_browser"
+    assert "generated page renders" in findings[0].message
+    assert "main heading" in findings[0].message
+    assert "generated-mobile" in findings[0].suggested_fix
 
 
 def test_parse_playwright_json_report_normalizes_runner_errors() -> None:
@@ -75,55 +77,33 @@ def test_parse_playwright_json_report_normalizes_runner_errors() -> None:
     findings = ui_acceptance.parse_playwright_json_report(report)
 
     assert len(findings) == 1
-    assert findings[0]["category"] == "runner"
-    assert findings[0]["message"] == "Error: Process from config.webServer was not able to start. Exit code: 1"
+    assert findings[0].code == "runner"
+    assert findings[0].message == "Error: Process from config.webServer was not able to start. Exit code: 1"
     assert "SHOULD_NOT_LEAK" not in str(findings)
 
 
-def test_review_ui_acceptance_passes_when_no_findings() -> None:
-    result = ui_acceptance.review_ui_acceptance_findings([])
-
-    assert result["status"] == "passed"
-    assert result["revision_request"] is None
-
-
-def test_review_ui_acceptance_routes_findings_to_revision() -> None:
-    result = ui_acceptance.review_ui_acceptance_findings(
-        [
-            {
-                "route": "/tickets",
-                "category": "layout",
-                "message": "Horizontal overflow on mobile.",
-                "suggested_fix": "Reduce table width or use ResourceTable responsive behavior.",
-            }
-        ],
-        prior_revision_count=0,
+def test_playwright_runner_returns_only_canonical_acceptance_state(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ui_acceptance.shutil, "which", lambda _name: "npx")
+    monkeypatch.setattr(
+        ui_acceptance.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1,
+            stdout='{"suites": [], "errors": [{"message": "Browser failed"}]}',
+            stderr="",
+        ),
     )
 
-    assert result["status"] == "needs_revision"
-    assert result["revision_count"] == 1
-    assert "Horizontal overflow" in result["revision_request"]
-    assert "Reduce table width" in result["revision_request"]
-
-
-def test_review_ui_acceptance_blocks_after_budget() -> None:
-    result = ui_acceptance.review_ui_acceptance_findings(
-        ["Page throws a browser error."],
-        prior_revision_count=1,
-        max_revision_attempts=1,
+    result = ui_acceptance.run_playwright_acceptance(
+        app_root=tmp_path,
+        repo_root=Path(__file__).resolve().parents[1],
     )
 
-    assert result["status"] == "blocked"
-    assert "operator review" in result["revision_request"]
-
-
-def test_review_ui_acceptance_can_require_runner_execution() -> None:
-    result = ui_acceptance.review_ui_acceptance_findings(
-        [],
-        require_acceptance_run=True,
-        acceptance_ran=False,
-    )
-
-    assert result["status"] == "needs_revision"
-    assert "did not run" in result["revision_request"]
+    assert result["success"] is False
+    assert result["validation_run"]["status"] == "failed"
+    assert result["repair_decision"]["disposition"] == "repair"
+    assert result["validation_run"]["gate_results"][0]["gate_id"] == "generated_ui_browser"
+    assert "status" not in result
+    assert "revision_count" not in result
+    assert "revision_request" not in result
 


### PR DESCRIPTION
## Summary

- add canonical `ValidationIssue`, `ValidationRun`, `RepairDecision`, registry, and acceptance-controller primitives
- move generated-app Playwright acceptance behind that controller
- delete the browser runner's private `status` / `revision_count` / `revision_request` retry model
- fail closed on validator exceptions and unchanged repair evidence
- add drift guards preventing the deleted browser retry vocabulary from returning
- document the breaking no-aliases output cutover in `CHANGELOG.md`

## Deliberate scope

This is an independently landable first cutover slice. It does not modify AppGenerator agents, transition graphs, the archetype matrix, Factory eval, or App Zero. Its implementation and test files do not overlap any open PR. `CHANGELOG.md` is the sole shared file with #355; the entries are in different sections and this breaking vocabulary removal is documented explicitly.

## Validation

- `python -m pytest tests/test_acceptance_controller.py tests/test_appgenerator_ui_acceptance.py tests/test_acceptance_cutover_drift.py tests/test_generated_app_functional_acceptance.py tests/test_generated_app_validation_public_api.py --no-cov -q` — 28 passed
- full `ruff check .` — passed
- full CI mypy command — passed, 561 source files
- exact CI source-hygiene scan — passed
- governance guardrails — passed
- `python -m mkdocs build --strict` — passed
- `git diff --check origin/main...HEAD` — passed

## Boundary

The controller and validation contracts are generic OSS primitives. No hosted provider behavior, App Zero product logic, MozaiksPay internals, or proprietary telemetry taxonomy is included.