### PR TITLE
fix(mozaikspay): declare the Pricing page in the pack contract

### DIFF
--- a/factory_app/build_context/mozaikspay/contract.yaml
+++ b/factory_app/build_context/mozaikspay/contract.yaml
@@ -152,6 +152,14 @@ facades:
       - create_token_top_up_session
       - start_token_top_up
     pages:
+      - name: Pricing
+        route: /pricing
+        page_type_hint: landing
+        primary_entities:
+          - subscription
+        primary_actions:
+          - list_plans
+          - open_billing_portal
       - name: Billing
         route: /billing
         page_type_hint: analytics_dashboard

--- a/tests/test_build_context_mozaikspay_pack.py
+++ b/tests/test_build_context_mozaikspay_pack.py
@@ -357,6 +357,28 @@ def test_mozaikspay_usage_page_template_ships() -> None:
     assert content.get("page_type") == "analytics_dashboard"
 
 
+def test_mozaikspay_contract_declares_every_shipped_page() -> None:
+    """The bundle scanner hard-requires the Pricing page, so the pack contract
+    must declare it: contract.yaml facades[].pages is the single source of
+    truth for the pack's page surface and must not drift from the shipped
+    templates."""
+    contract = _read_yaml(MOZAIKSPAY / "contract.yaml")
+    declared_routes = {
+        page.get("route")
+        for facade in contract.get("facades") or []
+        for page in facade.get("pages") or []
+    }
+    template_routes = {
+        _read_yaml(page_file).get("route")
+        for page_file in (TEMPLATES / "ui" / "pages").glob("*.yaml")
+    }
+    assert template_routes <= declared_routes, (
+        f"pack templates ship pages {sorted(template_routes - declared_routes)} "
+        "that contract.yaml facades[].pages does not declare"
+    )
+    assert "/pricing" in declared_routes
+
+
 def test_mozaikspay_pages_bind_through_billing_portal_facade() -> None:
     """Pages must call billing_portal actions, never the hosted MozaiksPay API directly."""
     for page_file in (TEMPLATES / "ui" / "pages").glob("*.yaml"):


### PR DESCRIPTION
Follow-up to #356, which made the bundle scanner hard-require a public Pricing page for mozaikspay SaaS bundles. The pack's contract.yaml facades[].pages still declared only Billing and Usage, so the declarative contract had drifted from the mandatory page surface.

- Declares the Pricing page (route /pricing, landing hint, list_plans + open_billing_portal) in facades[].pages
- Adds a drift guard test: every shipped page template route must be declared in contract.yaml

## Impact
Factory build-context change only; no runtime or generator code paths touched. Scanner behavior is unchanged — this aligns the declarative contract with what the scanner already enforces.

## Tests
- tests/test_build_context_mozaikspay_pack.py (34 passed, incl. new drift guard)
- tests/test_generated_bundle_scanner.py + tests/test_mozaikspay_managed_capability_contract.py (165 passed combined)
- Full suite: 13,438 passed, 78 skipped, 1 failed — test_runtime_database_migrations.py::test_platform_startup_calls_migration_application_after_index_application, verified failing identically on clean origin/main (pre-existing, not from this change)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)