### PR TITLE
docs: add factory_app/eval/ to the Where to Put Code table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ Deterministic app behavior belongs in generated app/module contracts hosted by `
 | First-party admin/Studio pages | `factory_app/app/admin/pages/` |
 | Admin portal registry | `factory_app/app/admin/admin_registry.yaml` |
 | Shared factory workflows | `factory_app/workflows/` |
+| Factory bundle-quality scorers and regression eval | `factory_app/eval/` |
 | Generated app/workflow artifacts | `generated/` |
 
 ## App Backend Integration


### PR DESCRIPTION
Review follow-up from #355: `factory_app/eval/` (bundle scorers + regression eval) landed without a row in the CLAUDE.md placement table, so the next agent or contributor has no guidance that it exists and might relocate it. One-line docs change.

## Tests
Docs-only; no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)