### PR TITLE
feat(factory): route subscription contract refinements through the contract designer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Added
+
+- **Subscription contract refinement routing**: the refinement harness now has
+  a `subscription_contract` build family. Post-build monetization change
+  requests (plans, pricing tiers, entitlement gates) route to new
+  `subscription_patch` (`SubscriptionContractDesigner → AppGenerator`) and
+  `subscription_revision` (`SubscriptionContractDesigner → AgentGenerator →
+  AppGenerator`) sequences instead of silently falling back to `app_bundle`
+  routes that skipped the contract designer. New closure tests enforce that
+  every harness route resolves to a declared sequence, every refinable family
+  has explicit routes, and any sequence claiming to refresh
+  `subscription_contract` actually runs SubscriptionContractDesigner.
+
 ### Fixed
 
 - **SaaS bundles can no longer sell capabilities they never enforce**: the

--- a/factory_app/refinement_harness/config/harness.yaml
+++ b/factory_app/refinement_harness/config/harness.yaml
@@ -24,6 +24,17 @@ routing:
           workflow_sequence: design_revision
         core:
           workflow_sequence: full_rebuild
+    - build_family: subscription_contract
+      label: subscription contract
+      routes:
+        patch:
+          workflow_sequence: subscription_patch
+        design:
+          workflow_sequence: subscription_revision
+        feature:
+          workflow_sequence: subscription_revision
+        core:
+          workflow_sequence: full_rebuild
     - build_family: workflow_bundle
       label: workflow bundle
       routes:

--- a/factory_app/refinement_harness/prompts/change_classifier_system.yaml
+++ b/factory_app/refinement_harness/prompts/change_classifier_system.yaml
@@ -9,8 +9,12 @@ content: |
   - core: change in value proposition, target user, product identity, business model, architecture direction, or anything that should reopen ValueEngine
 
   ## Artifact family dependency order (upstream → downstream)
-  concept → design_docs → workflow_bundle → app_bundle
+  concept → design_docs → subscription_contract → workflow_bundle → app_bundle
   concept → brand → app_bundle
+
+  Requests about plans, pricing tiers, entitlement gating, token allowances, or
+  monetization scope target the subscription_contract family when the refined
+  artifact is the subscription contract itself.
 
   ## Staleness-aware routing rules
 

--- a/factory_app/workflows/extended_orchestration/extension_registry.json
+++ b/factory_app/workflows/extended_orchestration/extension_registry.json
@@ -586,6 +586,52 @@
       ]
     },
     {
+      "id": "subscription_patch",
+      "description": "Scoped subscription contract revision owned by SubscriptionContractDesigner, then an app-bundle refresh to re-emit the contract's generated config and gated action declarations.",
+      "affected_declarative_families": [
+        "subscription_contract",
+        "app_bundle"
+      ],
+      "steps": [
+        {
+          "workflows": [
+            "SubscriptionContractDesigner"
+          ]
+        },
+        {
+          "workflows": [
+            "AppGenerator"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "subscription_revision",
+      "description": "Subscription contract revision that refreshes workflow metering and regenerated app artifacts.",
+      "affected_declarative_families": [
+        "subscription_contract",
+        "workflow_bundle",
+        "app_bundle"
+      ],
+      "steps": [
+        {
+          "workflows": [
+            "SubscriptionContractDesigner"
+          ]
+        },
+        {
+          "workflows": [
+            "AgentGenerator"
+          ]
+        },
+        {
+          "workflows": [
+            "AppGenerator"
+          ]
+        }
+      ]
+    },
+    {
       "id": "workflow_patch",
       "description": "Scoped workflow-bundle revision owned by AgentGenerator.",
       "affected_declarative_families": [

--- a/tests/test_refinement_router.py
+++ b/tests/test_refinement_router.py
@@ -2557,3 +2557,136 @@ def test_docs_do_not_say_carry_forward_is_only_manual() -> None:
     )
     doc = doc_path.read_text(encoding="utf-8").lower()
     assert "only manually" not in doc
+
+
+# ---------------------------------------------------------------------------
+# subscription_contract build family routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscription_contract_patch_routes_to_subscription_patch() -> None:
+    resolver = _factory_resolver(
+        _FakeChangeClassifier(
+            change_class="patch",
+            rationale="Rename the pro plan label.",
+        )
+    )
+    request = resolver.request_from_payload(
+        payload={
+            "refinement_request": {
+                "artifact_kind": "subscription_contract",
+                "raw_user_request": "Rename the Pro plan to Team.",
+            }
+        },
+        app_id="app_1",
+    )
+
+    assert request is not None
+    decision = await resolver.route(request)
+
+    assert decision.workflow_sequence == "subscription_patch"
+    assert decision.impact_set.affected_declarative_families == [
+        "subscription_contract",
+        "app_bundle",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_subscription_contract_design_routes_to_subscription_revision() -> None:
+    resolver = _factory_resolver(
+        _FakeChangeClassifier(
+            change_class="design",
+            rationale="Restructure the plan tiers and gated capabilities.",
+        )
+    )
+    request = resolver.request_from_payload(
+        payload={
+            "refinement_request": {
+                "artifact_kind": "subscription_contract",
+                "raw_user_request": "Split the pro tier into pro and enterprise with different gates.",
+            }
+        },
+        app_id="app_1",
+    )
+
+    assert request is not None
+    decision = await resolver.route(request)
+
+    assert decision.workflow_sequence == "subscription_revision"
+    assert decision.impact_set.affected_declarative_families == [
+        "subscription_contract",
+        "workflow_bundle",
+        "app_bundle",
+    ]
+
+
+def _factory_registry() -> dict:
+    registry_path = (
+        Path(__file__).resolve().parents[1]
+        / "factory_app" / "workflows" / "extended_orchestration" / "extension_registry.json"
+    )
+    return json.loads(registry_path.read_text(encoding="utf-8"))
+
+
+def _factory_harness_routes() -> dict:
+    harness_path = (
+        Path(__file__).resolve().parents[1]
+        / "factory_app" / "refinement_harness" / "config" / "harness.yaml"
+    )
+    return yaml.safe_load(harness_path.read_text(encoding="utf-8"))
+
+
+def test_every_harness_route_sequence_exists_in_extension_registry() -> None:
+    """Route → sequence closure: harness.yaml must never reference a sequence
+    that extension_registry.json does not declare."""
+    harness = _factory_harness_routes()
+    registry = _factory_registry()
+    declared = {seq["id"] for seq in registry["workflow_sequences"]}
+
+    for artifact in harness["routing"]["artifacts"]:
+        for change_class, route in artifact["routes"].items():
+            sequence_id = route["workflow_sequence"]
+            assert sequence_id in declared, (
+                f"harness.yaml routes {artifact['build_family']}/{change_class} to "
+                f"'{sequence_id}' which extension_registry.json does not declare"
+            )
+
+
+def test_every_persisted_refinable_family_has_a_harness_route() -> None:
+    """Family → route closure: every artifact family the harness is expected to
+    refine must have explicit routes, so refinements never silently fall back
+    to the app_bundle default and skip that family's owning workflow."""
+    harness = _factory_harness_routes()
+    routed = {artifact["build_family"] for artifact in harness["routing"]["artifacts"]}
+    expected = {
+        "concept",
+        "design_docs",
+        "subscription_contract",
+        "workflow_bundle",
+        "app_bundle",
+        "theme_config",
+    }
+    missing = expected - routed
+    assert not missing, (
+        f"harness.yaml routing.artifacts is missing families {sorted(missing)}; "
+        "unrouted families silently fall back to default_build_family routes"
+    )
+
+
+def test_sequences_claiming_subscription_contract_run_the_contract_designer() -> None:
+    """A sequence that claims to refresh subscription_contract must actually run
+    SubscriptionContractDesigner in its steps."""
+    registry = _factory_registry()
+    for seq in registry["workflow_sequences"]:
+        if "subscription_contract" not in (seq.get("affected_declarative_families") or []):
+            continue
+        step_workflows = {
+            workflow
+            for step in seq["steps"]
+            for workflow in (step.get("workflows") or [])
+        }
+        assert "SubscriptionContractDesigner" in step_workflows, (
+            f"sequence '{seq['id']}' claims subscription_contract in "
+            "affected_declarative_families but never runs SubscriptionContractDesigner"
+        )


### PR DESCRIPTION
## Summary

Closes the last gap from the entitlement-chain audit: `subscription_contract` is a persisted artifact family, but the refinement harness had no route for it — post-build monetization requests fell back to `app_bundle` routes (`app_revision`, `app_surface_revision`) whose sequences never run SubscriptionContractDesigner.

- **`harness.yaml`**: new `subscription_contract` build family — `patch → subscription_patch`, `design`/`feature` → `subscription_revision`, `core → full_rebuild`.
- **`extension_registry.json`**: new `subscription_patch` (`SubscriptionContractDesigner → AppGenerator`) and `subscription_revision` (`SubscriptionContractDesigner → AgentGenerator → AppGenerator`) sequences. Both start at the contract designer, so revised contracts pass the HITL review loop wired in #358.
- **Change classifier prompt**: dependency order now places `subscription_contract` between `design_docs` and `workflow_bundle` so staleness-aware upgrades account for it.
- **Closure meta-tests** (`tests/test_refinement_router.py`): every harness route resolves to a declared sequence; every refinable family has explicit routes (no silent `default_build_family` fallback); any sequence claiming `subscription_contract` in `affected_declarative_families` actually runs the designer. Plus routed-decision tests for the new family through the real factory pack.

## Build Workflow Sequence Impact
- **workflow_sequence affected**: `subscription_patch`, `subscription_revision` (new); no existing sequence modified
- **workflows affected**: none modified; sequences compose existing SubscriptionContractDesigner/AgentGenerator/AppGenerator
- **transitions/entrypoints affected**: none
- **downstream artifacts affected**: `subscription_contract`, `workflow_bundle`, `app_bundle` per sequence declarations
- **rollback risk**: low — additive routing; existing families unchanged

## Control-Plane / Refinement Impact
- **classification affected**: classifier prompt dependency order only (change classes unchanged)
- **artifact routing affected**: new `subscription_contract` family in `routing.artifacts[]`
- **checkpoint/re-entry behavior**: unchanged mechanics; new family now re-enters at the correct workflow
- **Tests run**: `ruff check .` clean; full `pytest -q --no-cov` — 13460 passed, 1 failed (provider-neutrality wording in a sequence description, fixed; affected files re-run green: 111 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3