### PR TITLE
fix(tests): make the Docker entitlement e2e alias contract resolvable

### DIFF
--- a/tests/test_entitlement_dispatch_docker_integration.py
+++ b/tests/test_entitlement_dispatch_docker_integration.py
@@ -263,6 +263,7 @@ def _collection_name_for_billing_subscriptions() -> str:
                     "collections": [
                         {
                             "name": "subscriptions",
+                            "mongo_collection": "subscriptions",
                             "ownership": {"surface_id": "entitlement_dispatch", "surface_kind": "module"},
                             "data_alias": "billing.subscriptions",
                         }


### PR DESCRIPTION
## Summary

The env-gated Docker/real-Mongo entitlement integration test (`test_entitlement_dispatch_docker_integration.py`) was latently broken: its inline data-contract fixture declared the `billing.subscriptions` collection with only a `name` key, but `aliases_from_data_contract` resolves collections via `mongo_collection`/`collection`. Anyone running it with `MOZAIKS_RUN_REAL_MONGO_TESTS=1` hit `AppDataAliasError: Unknown app data alias 'billing.subscriptions'` before the test body ran. (The real `entitlement_dispatch` pack migration correctly emits `mongo_collection`, so generated apps were unaffected — only this fixture drifted.)

Found during the ring-3 monetization dogfood run. One-line fixture fix; **verified the gated test now actually passes** against a real MongoDB container: `1 passed`.

## OSS Change Impact
- **Layer changed**: tests only
- **Build workflow / runtime / app workspace impact**: none
- **Tests run**: gated e2e with real Mongo — 1 passed; full `pytest -q --no-cov` — 13461 passed, 78 skipped; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3