### PR TITLE
fix(cli): stage _shared helpers with gen workflows; fail on empty generation

### DIFF
--- a/mozaiks_cli/commands/gen.py
+++ b/mozaiks_cli/commands/gen.py
@@ -381,6 +381,13 @@ def _stage_workflow(source_dir: Path, staging_root: Path, workflow_name: str) ->
     dst = staging_root / workflow_name
     dst.mkdir(parents=True, exist_ok=True)
 
+    # Middleware and hooks reference helpers as ../_shared/... relative to the
+    # workflow directory; stage the sibling _shared tree or every such import
+    # fails in the temp staging root and generation silently degrades.
+    shared_src = source_dir / "_shared"
+    if shared_src.is_dir():
+        shutil.copytree(shared_src, staging_root / "_shared", dirs_exist_ok=True)
+
     for item in src.iterdir():
         if item.is_dir():
             # For tools directory, we need to adapt Python files
@@ -595,13 +602,21 @@ def run(args):
             )
 
         if result.get("success"):
+            written = [f for f in sorted(output_dir.rglob("*")) if f.is_file()]
+            if not written:
+                _print_error(
+                    "Generation finished but wrote no files. The workflow "
+                    "degraded or its outputs were lost — check the logs above "
+                    "(middleware import failures are a common cause)."
+                )
+                return 1
+
             _print_success("Generation complete!")
             _print_info(f"Files written to: {output_dir}")
 
             _print("\nGenerated files:", style="bold")
-            for f in sorted(output_dir.rglob("*")):
-                if f.is_file():
-                    _print_info(f"  {f.relative_to(output_dir)}")
+            for f in written:
+                _print_info(f"  {f.relative_to(output_dir)}")
 
             _print("\nNext steps:", style="bold")
             _print_info(f"  cd {output_dir}")

--- a/tests/test_cli_gen_staging_shared.py
+++ b/tests/test_cli_gen_staging_shared.py
@@ -1,0 +1,52 @@
+"""mozaiks gen staging must carry the _shared helper tree.
+
+Workflow middleware references helpers as ../_shared/... relative to the
+workflow directory; staging only the workflow folder silently breaks every
+such import and generation degrades to an empty output (dogfood finding,
+2026-08-23).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from mozaiks_cli.commands.gen import _stage_workflow
+
+
+def _make_source(tmp_path: Path) -> Path:
+    source = tmp_path / "workflows"
+    wf = source / "AgentGenerator"
+    (wf / "tools").mkdir(parents=True)
+    (wf / "orchestrator.yaml").write_text(
+        "workflow_name: AgentGenerator\n", encoding="utf-8"
+    )
+    (wf / "tools" / "noop.py").write_text("def noop():\n    return 1\n", encoding="utf-8")
+    shared = source / "_shared"
+    (shared / "context_graph").mkdir(parents=True)
+    (shared / "subscription_contract_context.py").write_text("X = 1\n", encoding="utf-8")
+    (shared / "context_graph" / "hook_context_graph.py").write_text("Y = 2\n", encoding="utf-8")
+    return source
+
+
+def test_stage_workflow_stages_shared_helpers(tmp_path: Path) -> None:
+    source = _make_source(tmp_path)
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    _stage_workflow(source, staging, "AgentGenerator")
+
+    assert (staging / "AgentGenerator" / "orchestrator.yaml").is_file()
+    assert (staging / "_shared" / "subscription_contract_context.py").is_file()
+    assert (staging / "_shared" / "context_graph" / "hook_context_graph.py").is_file()
+
+
+def test_stage_workflow_without_shared_dir_still_works(tmp_path: Path) -> None:
+    source = _make_source(tmp_path)
+    import shutil
+
+    shutil.rmtree(source / "_shared")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    _stage_workflow(source, staging, "AgentGenerator")
+    assert (staging / "AgentGenerator" / "orchestrator.yaml").is_file()
+    assert not (staging / "_shared").exists()


### PR DESCRIPTION
First real dogfood run of `mozaiks gen app` surfaced two CLI bugs:

1. **Staging dropped `_shared`**: `_stage_workflow` copies the workflow into a temp root, but middleware references helpers as `../_shared/...` — none were staged, four middleware imports failed, and generation silently degraded to an empty output.
2. **Silent empty success**: the degraded run printed `Generation complete!` with zero files and exit 0. Now an empty output dir fails with exit 1 and a pointer at middleware import failures.

New tests: `tests/test_cli_gen_staging_shared.py` (staged `_shared` tree present; absent-`_shared` still works).

Also logged from the same dogfood session (not fixed here): missing-Mongo preflight produces a 30s stack trace instead of a clear error, and CLI spinner glyphs crash cp1252 Windows consoles.

Tests: ruff clean, mypy (mozaiksai/ factory_app/) clean, new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012thGtQXpM6eNYoSxKvGm5w