### PR TITLE
docs: batch AG2 watchpoints updates; make governance tests hermetic

### DIFF
--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -63,7 +63,7 @@ Mozaiks still owns deterministic product contracts around those primitives:
 | Approved-generation smoke coordinator uses AG2 task primitive | `scripts/smoke_agentgenerator_live_pack.py` | Live AgentGenerator pack smoke found the single-agent AG2 Network coordinator/metadata path timing out before packet emission, while direct AG2 task calls completed reliably. The smoke keeps the production-critical parallel workflow generation path on the real AG2 task batch runner and keeps this one-shot approved-boundary coordinator outside Mozaiks runtime code. | The AG2 Consulting channel shape (one question, one reply, auto-close) is the likely native primitive for these one-shot coordinator/metadata calls. If Consulting channels gain deterministic packet emission/close behavior, move the smoke calls back through `AG2NetworkRunner` or a Consulting-channel path. |
 | Refinement Engine LLM checkpoints | `mozaiksai/control_plane/implementations/*`, `mozaiksai/core/adapters/ag2_agent_runner.py` | The Refinement Engine is deterministic artifact-aware policy; AG2 should only own the LLM call used for classifier/proposer/coding-plan structured output. | Each LLM checkpoint is semantically an AG2 Consulting interaction: one question, one structured reply, hard close. If AG2's Consulting channel shape hardens into a typed one-shot primitive with `response_schema` support, adapt `AG2StructuredAgentRunner` to use it. Do not move artifact routing, promotion, invalidation, or scoped patch policy into AG2. |
 | Studio/platform event projection | `_project_ag2_wal_to_mozaiks_transport(...)` in `mozaiksai/core/adapters/ag2_network_runner.py` | The frontend consumes Mozaiks websocket events and app-scoped chat persistence, not raw AG2 envelopes. | Prefer AG2 Hub listeners or channel event subscriptions for live projection when they support app-scoped transport and chat persistence boundaries. |
-| Durable resume boundary | `AG2OrchestrationAdapter.cancel(...)`, `AG2OrchestrationAdapter.resume(...)`, process-live handles registered by `SimpleTransport` | Current in-process continuation uses the live AG2 Hub/channel when available. After backend restart or live-handle loss, resume re-enters Mozaiks orchestration from persisted AG2 stream events rather than hydrating a durable AG2 channel. | Move durable restart resume to AG2 if AG2 exposes tenant-safe channel hydration/continuation over a durable KnowledgeStore. |
+| Durable resume boundary | `AG2OrchestrationAdapter.cancel(...)`, `AG2OrchestrationAdapter.resume(...)`, process-live handles registered by `SimpleTransport` | Current in-process continuation uses the live AG2 Hub/channel when available. After backend restart or live-handle loss, resume re-enters Mozaiks orchestration from persisted AG2 stream events rather than hydrating a durable AG2 channel. | Move durable restart resume to AG2 if AG2 exposes tenant-safe channel hydration/continuation over a durable KnowledgeStore. AG2's published direction covers the mechanics: `Hub.hydrate()` reconstructs channel state as a pure WAL fold (<https://docs.ag2.ai/docs/blog/2026/05/16/AG2-Network-What-Survives/>), and `HubClient.attach()` + `since_envelope_id` replay with `HubBackedCheckpointStore` cover reconnect/checkpoint (<https://docs.ag2.ai/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/>). Evaluate these against tenant/session boundaries at the next alignment pass. |
 
 ## Too-Much-Ownership Flags
 
@@ -135,6 +135,22 @@ changes under `mozaiksai/core/workflow`, `mozaiksai/core/adapters`, or
   carry `sandbox_session_id`/`sandbox_provider`; preview sandboxes are
   created with identity metadata and provider-side kill deadlines), closing
   the orphaned-sandbox billing vector ahead of hosted e2b activation.
+- **Upstream questions filed as AG2 discussion #3201**: the declarative-network
+  asks (serialized TransitionGraph schema, per-agent `response_schema` on
+  workflow channels, composable/serializable transition conditions, a public
+  round-end packet hook, a typed one-shot Consulting primitive) are now posted
+  at <https://github.com/ag2ai/ag2/discussions/3201>. Check that thread before
+  the next alignment pass; fold maintainer answers into the divergence rows
+  above.
+- **AG2 skills user guide reviewed** (<https://docs.ag2.ai/docs/user-guide/skills/>):
+  no impact on current Mozaiks surfaces. Two standing rules from the review:
+  - If factory prompt catalogs (capability routing, module archetypes) ever
+    move to on-demand loading for token efficiency, AG2 `SkillPlugin`
+    progressive disclosure is the sanctioned mechanism — do not build a
+    Mozaiks-owned lazy prompt loader.
+  - Runtime skill installation (`SkillSearchToolkit.install_skill` against the
+    skills registry) must never be wired into factory or generated-app agents:
+    it is nondeterministic and a supply-chain vector into the build pipeline.
 
 ### August 22, 2026
 

--- a/tests/test_governance_guardrails.py
+++ b/tests/test_governance_guardrails.py
@@ -28,6 +28,18 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True, capture_output=True)
+    # Keep the temp repo hermetic: a contributor's global gitignore
+    # (core.excludesFile) may ignore paths like .claude/settings.local.json,
+    # which makes plain `git add` of fixture files fail locally while CI passes.
+    # git rejects os.devnull ("nul" on Windows) as an excludes file, so point
+    # at an empty file inside the temp repo instead.
+    empty_excludes = repo / ".git" / "empty-global-ignore"
+    empty_excludes.write_text("", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.excludesFile", str(empty_excludes)],
+        check=True,
+        capture_output=True,
+    )
 
 
 def _git(repo: Path, *args: str) -> None:


### PR DESCRIPTION
## Summary

Two small, independent hygiene changes:

**1. AG2 watchpoints doc batch** (`docs/architecture/workflows/ag2-update-watchpoints.md`)
- Durable-resume divergence row now names the concrete AG2 primitives to evaluate at the next alignment pass — `Hub.hydrate()` (pure WAL fold), `HubClient.attach()` + `since_envelope_id` replay, `HubBackedCheckpointStore` — with links to the two AG2 posts describing them.
- New decision-log entry: the upstream declarative-network questions are filed as [ag2ai/ag2 discussion #3201](https://github.com/ag2ai/ag2/discussions/3201) (check before the next alignment pass); AG2 skills guide reviewed with two standing rules — `SkillPlugin` is the sanctioned mechanism if factory prompt catalogs ever move to on-demand loading, and runtime `install_skill` is banned from factory/generated-app agents.

**2. Hermetic governance guardrail tests** (`tests/test_governance_guardrails.py`)
- `_init_git_repo` now sets `core.excludesFile` to an empty in-repo file. Without this, a contributor whose **global** gitignore covers `**/.claude/settings.local.json` (as on this machine) sees `git add` of fixture files fail locally while CI stays green — a false local failure in 1 test. Verified: all 11 governance tests now pass locally with that global ignore present. (`git` rejects `os.devnull`/`nul` as an excludes file on Windows, hence the empty file.)

## OSS Change Impact
- **Layer changed**: docs + tests only; no runtime/factory behavior
- **Tests run**: full `pytest -q --no-cov` on this branch — 13462 passed, 78 skipped, 1 failed (the exact env-specific governance failure this PR fixes; confirmed pre-existing on origin/main under this machine's git config); `tests/test_governance_guardrails.py` re-run after the fix — 11 passed; ruff clean
- **Compatibility risk**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3