### PR TITLE
feat(smoke): meter live subscription builds in the runtime usage ledger

### DIFF
--- a/scripts/smoke_appgenerator_live_subscription.py
+++ b/scripts/smoke_appgenerator_live_subscription.py
@@ -292,6 +292,11 @@ def _task_context(task: dict[str, Any], contract: dict[str, Any]) -> dict[str, A
     return {
         "workflow_name": "AppGenerator",
         "app_id": DEFAULT_APP_ID,
+        # chat_id/user_id give the usage ledger the full identity it requires;
+        # without them TokenManager.emit_usage_delta silently drops the event
+        # and headless smoke builds record zero token usage.
+        "chat_id": "smoke-appgenerator-live-subscription",
+        "user_id": "smoke-harness",
         "task_run_mode": True,
         "current_build_task_id": task["task_id"],
         "current_build_task_type": task["task_type"],
@@ -1169,10 +1174,21 @@ async def _run_config_task(
         "base",
         agent_name="ConfigMiddlewareAgent",
     )
+    from mozaiksai.core.usage.middleware import build_ag2_usage_middleware
+
     agent = Agent(
         "ConfigMiddlewareAgent",
         prompt=system_prompt,
         config=llm_config_to_ag2_config(llm_config),
+        # Meter this one-shot call in the runtime usage ledger so live smoke
+        # builds produce real per-build token/cost numbers.
+        middleware=[
+            build_ag2_usage_middleware(
+                agent_name="ConfigMiddlewareAgent",
+                workflow_name="AppGenerator",
+                context_variables=context,
+            )
+        ],
     )
     task_prompt = "\n\n".join(
         [


### PR DESCRIPTION
## Summary

First step of the stealth-mode COGS measurement effort: make headless factory builds actually record token usage.

The usage subsystem (`mozaiksai/core/usage/` — middleware → `chat.usage_delta` → `RuntimeUsageLedger` → `mozaiksai.RuntimeUsageEvents` with pricing-catalog cost estimates) works, but the live subscription smoke recorded nothing because of two independent drop points:

1. The smoke's model-calling agent is a **raw `Agent()`** built outside the agent factory, so the usage middleware never attached.
2. The smoke context lacked `chat_id`/`user_id` — `TokenManager.emit_usage_delta` requires `chat_id`+`app_id`+`user_id`+`workflow_name` and silently debug-drops otherwise.

This PR attaches `build_ag2_usage_middleware` to the smoke's one-shot agent and adds the missing ids to the smoke task context.

**Verified live**: a metered smoke run recorded both LLM calls with catalog-priced costs — the two-task subscription build measures **~30.6K tokens / ~$0.0037** (gpt-4o-mini). Every future smoke run is now a per-build COGS datapoint.

## OSS Change Impact
- **Layer changed**: `scripts/` only — smoke harness; no runtime/factory behavior
- **Tests run**: full `pytest -q --no-cov` — 13471 passed, 78 skipped, 1 failed (`test_governance_guardrail_default_and_all_agree_on_tracked_authority` — the known machine-local global-gitignore issue, pre-existing and fixed by #370; this branch predates that fix); ruff clean; live metered smoke run passed end-to-end
- **Compatibility risk**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3