### PR TITLE
fix(cli,docs): make Gemini the consistent default LLM provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Gemini is consistently the documented default LLM provider** (#367): the
+  README quickstart now leads with `GEMINI_API_KEY` (matching
+  `docs/getting-started.md` and `.env.example`), and the `quickstart` CLI's
+  no-key warning checks and names `GEMINI_API_KEY` instead of telling Gemini
+  users they have no API key.
 - **SaaS bundles can no longer sell capabilities they never enforce**: the
   generated-bundle scanner now fails a bundle whose
   `config/subscriptions.yaml` grants plan capabilities while no module action

--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ $env:MONGO_URI="<your MongoDB connection string>"
 
 ### 3. Set an LLM key
 
-Builds call an LLM, so set a key before running real builds:
+Builds call an LLM, so set a key before running real builds. The default
+provider is Google Gemini, which has a free tier (no credit card required):
 
 ```powershell
-$env:OPENAI_API_KEY="sk-..."
+$env:GEMINI_API_KEY="your-key-here"
 ```
+
+OpenAI and Anthropic work too — set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`
+instead and select the provider in Studio or via `--provider`.
 
 ### 4. Create your workspace and open Studio
 

--- a/mozaiks_cli/commands/quickstart.py
+++ b/mozaiks_cli/commands/quickstart.py
@@ -59,9 +59,12 @@ def _print_environment_warnings(args) -> None:
         warnings.append(
             f"{provider.upper()} provider selected. Make sure the matching provider credentials are available."
         )
-    elif provider is None and not any(os.environ.get(key) for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")):
+    elif provider is None and not any(
+        os.environ.get(key) for key in ("GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+    ):
         warnings.append(
-            "No provider API key detected. Set OPENAI_API_KEY or ANTHROPIC_API_KEY before starting a build."
+            "No provider API key detected. Set GEMINI_API_KEY (default provider, free tier), "
+            "OPENAI_API_KEY, or ANTHROPIC_API_KEY before starting a build."
         )
 
     if not warnings:

--- a/tests/test_cli_quickstart.py
+++ b/tests/test_cli_quickstart.py
@@ -85,3 +85,21 @@ def test_quickstart_bootstraps_workspace_and_launches_studio(monkeypatch, tmp_pa
     assert launched["frontend_port"] == 3010
     assert launched["open_browser"] is False
 
+
+
+def test_env_warnings_accept_gemini_key_as_default_provider(monkeypatch, capsys) -> None:
+    for key in ("GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "MONGO_URI"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017/mozaiks")
+
+    args = Namespace(provider=None)
+
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-test-1234")
+    quickstart_command._print_environment_warnings(args)
+    assert "No provider API key detected" not in capsys.readouterr().out
+
+    monkeypatch.delenv("GEMINI_API_KEY")
+    quickstart_command._print_environment_warnings(args)
+    warning_out = capsys.readouterr().out
+    assert "No provider API key detected" in warning_out
+    assert "GEMINI_API_KEY" in warning_out


### PR DESCRIPTION
## Why

Fixes #367 — the repo contradicted itself on the first-run LLM provider. `docs/getting-started.md`, `.env.example`, and `test_selfhost_clean_install.py` all pin **Gemini** as the intentional default (free tier), but the README quickstart step (as restructured in #369) documents `OPENAI_API_KEY`, and the `quickstart` CLI's no-key warning checks only `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` — so a Gemini user following the official Getting Started guide is told they have no API key.

## What changed

- **README step 3** now leads with `GEMINI_API_KEY` (free tier, matching the docs site) and lists OpenAI/Anthropic as alternatives.
- **`_print_environment_warnings`** in `mozaiks_cli/commands/quickstart.py` adds `GEMINI_API_KEY` to the checked keys and names it in the warning.
- Regression test: `test_env_warnings_accept_gemini_key_as_default_provider` — a set `GEMINI_API_KEY` silences the warning; with no keys the warning names `GEMINI_API_KEY`.

## Validation

`ruff check .` clean; `pytest tests/test_cli_quickstart.py tests/test_selfhost_clean_install.py tests/test_startup_validation.py tests/test_contributor_quickstart.py` — 84 passed.

Credit to @sarthak-here for the precise diagnosis in #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)