### PR TITLE
refactor(ui): rename AppWorkbench panes from *Artifact to *Pane; clarify preview messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Changed
 
+- **AppWorkbench pane naming and preview messaging cleaned up**: the internal
+  panes of the Studio `AppWorkbench` artifact are now named `*Pane.js`
+  (`PreviewPane`, `FileTreePane`, `CodeEditorPane`, `BuildStatusPane`) instead
+  of the misleading `*Artifact.js`, since only `AppWorkbench` itself is a
+  registered UI artifact. The preview pane's empty state now explains when a
+  live preview is available (e2b or Docker sandbox validation) instead of
+  referencing e2b internals. The workflow UI docs gain an explicit
+  artifact-vs-pane naming convention.
+
 - **README onboarding restructured around the documented first-run path**: the
   Quickstart now opens with a prerequisites list and five numbered steps
   (install, MongoDB, LLM key, `quickstart`, first app), and sits above the

--- a/docs/architecture/builder/app-validation-sandboxes.md
+++ b/docs/architecture/builder/app-validation-sandboxes.md
@@ -59,7 +59,8 @@ For the hosted product (users have no local Docker):
 
 1. Set `E2B_API_KEY` on the platform environment. Strategy auto-resolves to
    `e2b`; the Studio conversation renders the preview iframe
-   (`E2BPreviewArtifact`) from the validation result's preview URL.
+   (the `PreviewPane` inside the `AppWorkbench` artifact) from the validation
+   result's preview URL.
 2. **Cost posture:** e2b bills per sandbox-minute. Sessions carry a kill
    deadline (`E2B_TIMEOUT` for validation runs, `SANDBOX_TTL_MINUTES` for
    artifact preview sessions) and identity metadata — audit orphans by

--- a/docs/architecture/mozaiksai/ui-interaction-patterns.md
+++ b/docs/architecture/mozaiksai/ui-interaction-patterns.md
@@ -175,6 +175,15 @@ lifecycle_tools: []
 - `UI_Surface` = one-way artifact/status surface emitted via `emit_ui_surface(...)`
 - `Agent_Tool` = backend-only logic; omit the `ui` block entirely
 
+**Component naming convention**:
+- Only components registered in the workflow's `ui/index.js` and referenced by
+  a `ui.component` entry in `tools.yaml` are artifacts or inline components.
+- Internal sub-components that render *inside* a registered artifact (tabs,
+  split panes, status strips) are **panes** — name them `*Pane.js` (e.g.
+  `PreviewPane`, `FileTreePane`), never `*Artifact.js`. An `Artifact` suffix
+  on an unregistered component misleads readers (and future generator agents)
+  into treating it as an independently registered surface.
+
 ---
 
 ## Implementation Guidelines for Generator Agents

--- a/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
+++ b/factory_app/workflows/AppGenerator/ui/AppWorkbench.js
@@ -10,11 +10,11 @@ import { useChatUI } from '@mozaiks/chat-ui/context/ChatUIContext.jsx';
 import { workflowSurfaceStyles, workflowToolbarButtonClass } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
 import { useAppValidationWorkbench } from './useAppValidationWorkbench';
 import { useSandbox } from './useSandbox';
-import BuildStatusArtifact from './BuildStatusArtifact';
-import CodeEditorArtifact from './CodeEditorArtifact';
-import E2BPreviewArtifact from './E2BPreviewArtifact';
+import BuildStatusPane from './BuildStatusPane';
+import CodeEditorPane from './CodeEditorPane';
+import PreviewPane from './PreviewPane';
 import ExportActions from './ExportActions';
-import FileTreeArtifact from './FileTreeArtifact';
+import FileTreePane from './FileTreePane';
 import HarnessDecisionCard from '../../../app/ui/components/HarnessDecisionCard.jsx';
 import { studioFetch } from '../../../app/admin/pages/studioApi.js';
 
@@ -356,7 +356,7 @@ const AppWorkbench = ({
       </div>
 
       <div className="p-4 space-y-4">
-        <BuildStatusArtifact
+        <BuildStatusPane
           config={config}
           validationResult={validationResult}
           validationStatus={validationStatus}
@@ -574,7 +574,7 @@ const AppWorkbench = ({
         <div className={['grid gap-4', showSplit ? 'grid-cols-12' : 'grid-cols-12'].join(' ')}>
           {(showSplit || showCode) && (
             <div className={showSplit ? 'col-span-3' : 'col-span-4'}>
-              <FileTreeArtifact
+              <FileTreePane
                 filesMap={filesMap}
                 config={config}
                 selectedPath={selectedPath}
@@ -585,7 +585,7 @@ const AppWorkbench = ({
 
           {(showSplit || showCode) && (
             <div className={showSplit ? 'col-span-5' : 'col-span-8'}>
-              <CodeEditorArtifact
+              <CodeEditorPane
                 config={config}
                 filePath={selectedPath}
                 content={currentContent}
@@ -599,7 +599,7 @@ const AppWorkbench = ({
 
           {(showSplit || showPreview) && (
             <div className={showSplit ? 'col-span-4' : 'col-span-12'}>
-              <E2BPreviewArtifact
+              <PreviewPane
                 previewUrl={livePreviewUrl || previewUrl}
                 sandboxStatus={sandboxStatus}
                 sandboxSyncing={sandboxSyncing}

--- a/factory_app/workflows/AppGenerator/ui/BuildStatusPane.js
+++ b/factory_app/workflows/AppGenerator/ui/BuildStatusPane.js
@@ -1,12 +1,12 @@
 // ==============================================================================
-// FILE: ChatUI/src/workflows/AppGenerator/components/BuildStatusArtifact.js
+// FILE: ChatUI/src/workflows/AppGenerator/components/BuildStatusPane.js
 // DESCRIPTION: Build/test validation status summary
 // ==============================================================================
 
 import React, { useMemo, useRef, useEffect, useState } from 'react';
 import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, XCircle } from 'lucide-react';
 
-const BuildStatusArtifact = ({
+const BuildStatusPane = ({
   validationResult = {},
   validationStatus = 'pending',
   validationStrategy = null,
@@ -275,4 +275,4 @@ const BuildStatusArtifact = ({
   );
 };
 
-export default BuildStatusArtifact;
+export default BuildStatusPane;

--- a/factory_app/workflows/AppGenerator/ui/CodeEditorPane.js
+++ b/factory_app/workflows/AppGenerator/ui/CodeEditorPane.js
@@ -1,5 +1,5 @@
 // ==============================================================================
-// FILE: ChatUI/src/workflows/AppGenerator/components/CodeEditorArtifact.js
+// FILE: ChatUI/src/workflows/AppGenerator/components/CodeEditorPane.js
 // DESCRIPTION: Monaco code editor wrapper for AppWorkbench
 // ==============================================================================
 
@@ -28,7 +28,7 @@ const getLanguageFromPath = (filePath, fallback = 'javascript') => {
   return languageMap[ext] || 'plaintext';
 };
 
-const CodeEditorArtifact = ({ filePath, content, onChange, config = {}, readOnly = false }) => {
+const CodeEditorPane = ({ filePath, content, onChange, config = {}, readOnly = false }) => {
   const editorCfg = useMemo(() => config?.artifacts?.['code-editor'] || {}, [config]);
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -111,4 +111,4 @@ const CodeEditorArtifact = ({ filePath, content, onChange, config = {}, readOnly
   );
 };
 
-export default CodeEditorArtifact;
+export default CodeEditorPane;

--- a/factory_app/workflows/AppGenerator/ui/FileTreePane.js
+++ b/factory_app/workflows/AppGenerator/ui/FileTreePane.js
@@ -1,5 +1,5 @@
 // ==============================================================================
-// FILE: ChatUI/src/workflows/AppGenerator/components/FileTreeArtifact.js
+// FILE: ChatUI/src/workflows/AppGenerator/components/FileTreePane.js
 // DESCRIPTION: Generated file browser (tree) for AppWorkbench
 // ==============================================================================
 
@@ -96,7 +96,7 @@ const TreeNode = ({ name, node, depth, onSelectFile, selectedPath, defaultExpand
   );
 };
 
-const FileTreeArtifact = ({ filesMap = {}, config = {}, selectedPath, onSelectFile }) => {
+const FileTreePane = ({ filesMap = {}, config = {}, selectedPath, onSelectFile }) => {
   const treeConfig = useMemo(() => config?.artifacts?.['file-tree'] || {}, [config]);
   const tree = useMemo(() => buildTree(filesMap), [filesMap]);
   const entries = useMemo(() => sortEntries(Object.entries(tree), treeConfig.sortFoldersFirst !== false), [tree, treeConfig]);
@@ -133,4 +133,4 @@ const FileTreeArtifact = ({ filesMap = {}, config = {}, selectedPath, onSelectFi
   );
 };
 
-export default FileTreeArtifact;
+export default FileTreePane;

--- a/factory_app/workflows/AppGenerator/ui/PreviewPane.js
+++ b/factory_app/workflows/AppGenerator/ui/PreviewPane.js
@@ -1,12 +1,12 @@
 // ==============================================================================
-// FILE: factory_app/workflows/AppGenerator/ui/E2BPreviewArtifact.js
+// FILE: factory_app/workflows/AppGenerator/ui/PreviewPane.js
 // DESCRIPTION: Preview iframe with basic controls
 // ==============================================================================
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { ExternalLink, RefreshCw } from 'lucide-react';
 
-const E2BPreviewArtifact = ({ previewUrl, sandboxStatus, sandboxSyncing, sandboxError, config = {} }) => {
+const PreviewPane = ({ previewUrl, sandboxStatus, sandboxSyncing, sandboxError, config = {} }) => {
   const previewCfg = config?.artifacts?.['e2b-preview'] || {};
   const [iframeKey, setIframeKey] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -36,9 +36,9 @@ const E2BPreviewArtifact = ({ previewUrl, sandboxStatus, sandboxSyncing, sandbox
           </div>
         ) : (
           <>
-            <div className="text-sm text-[var(--color-text-muted)]">No preview URL available.</div>
+            <div className="text-sm text-[var(--color-text-muted)]">Live preview not available for this build.</div>
             <div className="text-xs text-[var(--color-text-muted)] mt-1">
-              Preview URLs are typically available for <span className="font-mono">e2b</span> validation runs with <span className="font-mono">start_dev_server=true</span>.
+              Previews appear when app validation runs in a sandbox (<span className="font-mono">e2b</span> with an API key, or local <span className="font-mono">docker</span>). Builds validated with the <span className="font-mono">local</span> or <span className="font-mono">skip</span> strategy have no live preview.
             </div>
           </>
         )}
@@ -137,4 +137,4 @@ const E2BPreviewArtifact = ({ previewUrl, sandboxStatus, sandboxSyncing, sandbox
   );
 };
 
-export default E2BPreviewArtifact;
+export default PreviewPane;


### PR DESCRIPTION
## What

Cleans up the AppGenerator workflow UI taxonomy so the artifact-vs-pane distinction is self-evident.

- Only `AppWorkbench` (mode: artifact) and `AgentAPIKeysBundleInput` (mode: inline) are registered UI components in `tools.yaml` / `ui/index.js`. The internal panes rendered inside AppWorkbench were misleadingly named `*Artifact.js`.
- Renamed: `E2BPreviewArtifact` → `PreviewPane` (also provider-accurate — Docker previews work since #364), `FileTreeArtifact` → `FileTreePane`, `CodeEditorArtifact` → `CodeEditorPane`, `BuildStatusArtifact` → `BuildStatusPane`. All imports/usages updated; the `config.artifacts['e2b-preview']` config key is untouched (external contract).
- Preview pane empty state now explains *when* a live preview is available (e2b with API key, or local Docker; local/skip strategies have none) instead of referencing e2b internals.
- `docs/architecture/mozaiksai/ui-interaction-patterns.md` gains an explicit component naming convention (registered artifact/inline vs internal `*Pane`); stale reference in `app-validation-sandboxes.md` updated; CHANGELOG entry added.

Scanned all other workflow `ui/` folders — AppGenerator was the only offender.

## OSS Change Impact

- Layer changed: framework capability (factory workflow UI + docs)
- Build workflow impact: none (no tools.yaml/registry changes; registered component names unchanged)
- Runtime/platform impact: none
- Tests run: `ruff check .` clean; `pytest -q --no-cov` → 13471 passed, 78 skipped, 1 failed (`test_governance_guardrails.py::test_governance_guardrail_default_and_all_agree_on_tracked_authority` — pre-existing environmental failure in an isolated temp repo, unrelated to this change; PR #370 makes these tests hermetic). Targeted `tests/test_workflow_ui_tool_contracts.py` fully green.
- Docs updated: yes
- Compatibility risk: none — internal component files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012thGtQXpM6eNYoSxKvGm5w