### PR TITLE
fix(smoke): make usage metering opt-in-able in live smokes

### DIFF
--- a/scripts/run_live_context_expression_task_batch_smoke.py
+++ b/scripts/run_live_context_expression_task_batch_smoke.py
@@ -339,7 +339,10 @@ async def run_live_context_expression_task_batch_smoke(
     _require_live_env()
     if enable_telemetry:
         os.environ["AG2_OTEL_ENABLED"] = "true"
-    os.environ["USAGE_EVENTS_ENABLED"] = "false"
+    # Default usage metering off for hermetic runs, but honour an explicit
+    # USAGE_EVENTS_ENABLED=true so live smokes can record per-build token
+    # costs in the runtime usage ledger when a Mongo sink is available.
+    os.environ.setdefault("USAGE_EVENTS_ENABLED", "false")
     os.environ["MOZAIKS_LLM_CONFIG_SKIP_MONGO"] = "true"
     try:
         cache_ttl = int(os.getenv("LLM_CONFIG_CACHE_TTL") or "0")

--- a/scripts/smoke_agentgenerator_live_pack.py
+++ b/scripts/smoke_agentgenerator_live_pack.py
@@ -707,7 +707,10 @@ async def run_live_agentgenerator_pack_smoke(
     _require_live_env()
     if enable_telemetry:
         os.environ["AG2_OTEL_ENABLED"] = "true"
-    os.environ["USAGE_EVENTS_ENABLED"] = "false"
+    # Default usage metering off for hermetic runs, but honour an explicit
+    # USAGE_EVENTS_ENABLED=true so live smokes can record per-build token
+    # costs in the runtime usage ledger when a Mongo sink is available.
+    os.environ.setdefault("USAGE_EVENTS_ENABLED", "false")
     os.environ["MOZAIKS_LLM_CONFIG_SKIP_MONGO"] = "true"
     if int(str(os.getenv("LLM_CONFIG_CACHE_TTL") or "0") or "0") <= 0:
         os.environ["LLM_CONFIG_CACHE_TTL"] = "300"


### PR DESCRIPTION
## Summary

Follow-up to #371, closing the last gap in headless build COGS measurement. Two live smokes (`smoke_agentgenerator_live_pack.py`, `run_live_context_expression_task_batch_smoke.py`) hard-set `USAGE_EVENTS_ENABLED=false` internally, silently defeating per-build token metering even when a Mongo ledger sink was available — a passing live pack build recorded zero usage with no diagnostic. (Root-causing this took several instrumented live runs because the manager's guard makes the drop completely silent.)

The scripts now `setdefault` the flag: the hermetic default is unchanged (metering stays off unless asked), but `USAGE_EVENTS_ENABLED=true` in the environment enables recording.

**Verified live**: a metered pack run recorded all 4 LLM calls (coordinator, two parallel workflow-bundle workers, metadata) in `mozaiksai.RuntimeUsageEvents` with catalog-priced costs — **~30.0K tokens / ~$0.0037** for a full two-bundle AgentGenerator generation, the second archetype segment in the build-cost table (first: ~30.6K/$0.0037 for the two-task subscription app-bundle segment via #371).

## OSS Change Impact
- **Layer changed**: `scripts/` only — smoke harnesses; no runtime/factory behavior
- **Tests run**: full `pytest -q --no-cov` — 13471 passed, 78 skipped, 1 failed pre-rebase (the machine-local governance-guardrail issue fixed by #370; after rebasing onto main with that fix, the governance file passes 11/11); ruff clean; live metered pack run passed end-to-end
- **Compatibility risk**: none — default behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3