### PR TITLE
docs: codify the eval and build-intelligence ownership boundary

### DIFF
--- a/.claude/rules/eval-and-build-intelligence.md
+++ b/.claude/rules/eval-and-build-intelligence.md
@@ -1,0 +1,23 @@
+# Eval And Build Intelligence Rules
+
+Use these rules when changing `factory_app/eval/`, acceptance gates, bundle
+scorers, or anything described as evaluation, scoring, learning, or build
+intelligence.
+
+Canonical boundary:
+[docs/architecture/foundations/eval-and-build-intelligence-boundary.md](../../docs/architecture/foundations/eval-and-build-intelligence-boundary.md)
+
+- Deterministic, rule-based scoring of canonical artifacts stays OSS:
+  builder-specific policy in `factory_app/eval/`, generic scoring mechanics
+  (if any emerge) in `mozaiksai/`.
+- Learning loops, cross-tenant signal aggregation, and learned generation
+  policy belong in the hosted product. OSS may only emit declared, app-scoped
+  signals for the hosted side to consume.
+- No OSS runtime call-outs to proprietary intelligence services. Learned
+  policy enters the factory only as explicit, inspectable declared inputs
+  (catalogs, config overlays, context assets).
+- Evals are user-visible. Persist scores as artifacts; never run hidden evals
+  on user builds.
+- Declarative app-facing eval contracts (`eval.yaml` + bounded scorer stubs)
+  are target state, not current behavior. Do not document them as current
+  until a schema and loader exist.

--- a/docs/architecture/foundations/eval-and-build-intelligence-boundary.md
+++ b/docs/architecture/foundations/eval-and-build-intelligence-boundary.md
@@ -1,0 +1,78 @@
+# Eval And Build Intelligence Boundary
+
+This document fixes the ownership boundary between generated-artifact
+evaluation and build intelligence so the split is decided once, not
+re-litigated per change.
+
+Two different things get called "eval". They belong on different sides of the
+OSS/hosted boundary.
+
+## Deterministic evaluation — OSS
+
+Deterministic evaluation is rule-based scoring of canonical Mozaiks artifacts:
+the bundle scanner, acceptance gates, and the bundle-quality scorers and
+regression eval under `factory_app/eval/`. Same inputs produce the same score
+on every run. No learned state, no cross-tenant data.
+
+This stays in the OSS repo, and specifically in `factory_app/` when the policy
+being scored is builder-specific:
+
+- It is the quality gate on open contracts. Contributors and self-hosters must
+  be able to run the same gates the factory runs, or the OSS framework is not
+  trustworthy.
+- Transparency is a feature. Nothing about a deterministic checklist is a
+  competitive asset, and hiding evals from OSS users would undermine the
+  contract-first model.
+- Per the repo decision rules: generic scoring mechanics would belong in
+  `mozaiksai/`; builder-specific scoring policy (which scorers, which
+  thresholds, which fixture corpus) belongs in `factory_app/`. Today the
+  scorers and the policy are small enough to live together in
+  `factory_app/eval/`. If a generic scoring engine emerges, move the engine to
+  `mozaiksai/` and leave the policy and fixtures in `factory_app/`.
+
+## Build intelligence — hosted product
+
+Build intelligence is the learning loop: aggregating signals across many
+builds and tenants, learning which generation patterns produce better apps,
+ranking or steering generation from fleet data, and any model or service
+trained on hosted usage.
+
+This belongs in the hosted product (`mozaiks-app`), not in this repo:
+
+- The data is the moat, not the scorer code. Cross-tenant learning signals are
+  hosted-product assets and must never be aggregated inside OSS runtime code.
+- OSS code may *emit* neutral, app-scoped signals through declared contracts
+  (events, usage ledger records, eval scores). The hosted product consumes
+  them through its own ingestion — OSS never reaches into hosted stores, and
+  hosted learning never becomes a hidden dependency of OSS generation.
+- A learned policy that the factory should apply must arrive as an explicit,
+  inspectable input (a catalog, a config overlay, a declared context asset),
+  never as an opaque runtime call from OSS to a proprietary service.
+
+## Target state: declarative eval contracts (not implemented)
+
+The intended long-term shape for app-leverageable evals follows the
+contract-declared customization rule:
+
+- an `eval.yaml` (or equivalent) declares scorers, thresholds, and fixture
+  references as a structured-output-first contract;
+- bounded Python scorer stubs are referenced explicitly by the contract, local
+  to the declaring boundary, deterministic, and side-effect free;
+- eval runs execute as ordinary workflow steps or acceptance-gate hooks, with
+  scores persisted as artifacts the user can see.
+
+Do not present this as current behavior. Until a loader and schema exist,
+`factory_app/eval/` remains a repo-internal regression suite invoked by tests
+and scripts, not an app-facing contract.
+
+## Review checklist
+
+When a change touches evaluation or intelligence:
+
+- Deterministic scorer or gate on canonical artifacts → OSS
+  (`factory_app/eval/`, or `mozaiksai/` if generic mechanics).
+- Anything that learns from, aggregates, or ranks across tenants/builds →
+  hosted product; OSS side limited to emitting declared, app-scoped signals.
+- No OSS runtime call-outs to proprietary intelligence services; learned
+  policy enters the factory only as explicit declared inputs.
+- Evals visible to the user; scores persisted as artifacts, never hidden.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - Platform Information Architecture: architecture/foundations/platform-information-architecture.md
           - Core vs Product vs App Bundle: architecture/foundations/core-product-app-bundle-boundary.md
           - Public Architecture & OSS Boundary: architecture/foundations/public-architecture-and-oss-boundary.md
+          - Eval & Build Intelligence Boundary: architecture/foundations/eval-and-build-intelligence-boundary.md
           - Framework & Operator Intelligence Boundary: architecture/foundations/framework-operator-intelligence-boundary.md
           - App Intelligence Plane: architecture/foundations/app-intelligence-plane.md
           - App Intelligence User Journey: architecture/foundations/app-intelligence-user-journey.md


### PR DESCRIPTION
## Summary

`factory_app/eval/` (landed in #355) raised the placement question: should eval live in OSS, `mozaiksai/`, or the hosted product? This PR answers it durably with a foundations doc + scoped rule:

- **Deterministic evaluation stays OSS**: rule-based scoring of canonical artifacts (scanner, acceptance gates, bundle scorers/regression eval) is the quality gate on open contracts — contributors must be able to run it, and a checklist is not a competitive asset. Builder-specific policy in `factory_app/eval/`; generic scoring mechanics (if they emerge) in `mozaiksai/`.
- **Build intelligence is hosted-product territory**: learning loops, cross-tenant signal aggregation, learned generation policy. The data is the moat, not the scorer code. OSS may only emit declared, app-scoped signals; learned policy re-enters the factory only as explicit, inspectable declared inputs — never opaque OSS→proprietary service calls.
- **Evals are user-visible**: scores persist as artifacts; no hidden evals on user builds.
- **Declarative eval contracts** (`eval.yaml` + bounded scorer stubs, run as workflow steps) documented as **target state** per the current-vs-target rule — not built.

Files: `docs/architecture/foundations/eval-and-build-intelligence-boundary.md`, mkdocs nav entry, `.claude/rules/eval-and-build-intelligence.md`.

## OSS Change Impact
- **Layer changed**: docs + rules only
- **Tests run**: full `pytest -q --no-cov` — **13473 passed, 78 skipped, 0 failed**; ruff clean
- **Compatibility risk**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqcaLjo62gtRaG9itUHRF3