### PR TITLE
fix(studio): remove duplicate Create App action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ This project follows a practical pre-1.0 changelog format:
   when `MONGO_URI` is unset. The orchestration result payload now carries
   `agents_created` / `agent_turns` evidence, echoed in the completion
   summary as `agents=N turns=M`.
+- **Apps no longer shows a duplicate Create App action**: app creation remains
+  available from the shell header while the Apps management page focuses on
+  searching, filtering, and opening existing apps.
 - **AppWorkbench live-preview refresh actually works now**: the preview
   sandbox API the workbench calls after a scoped refinement
   (`/api/artifacts/{id}/sandbox`, `/api/sandbox/*`, `/ws/sandbox/*`) was

--- a/factory_app/app/admin/pages/AppsPage.jsx
+++ b/factory_app/app/admin/pages/AppsPage.jsx
@@ -31,8 +31,6 @@ const FILTER_OPTIONS = [
   { label: 'Building', value: 'building' },
   { label: 'Live', value: 'live' },
 ]
-const CREATE_APP_PATH = '/create'
-
 function matchesFilter(row, activeFilter) {
   if (activeFilter === 'all') return true
   return row.filterBucket === activeFilter
@@ -285,11 +283,6 @@ export default function AppsPage() {
             filters={filterOptions}
             activeFilter={activeFilter}
             onFilterChange={setActiveFilter}
-            actions={(
-              <ActionButton onClick={() => navigate(CREATE_APP_PATH)}>
-                Create App
-              </ActionButton>
-            )}
           />
           {visibleRows.length > 0 ? (
             <AppsTable rows={visibleRows} onOpen={handleOpen} onDashboard={handleDashboard} onDelete={handleDelete} />

--- a/tests/test_build_surface.py
+++ b/tests/test_build_surface.py
@@ -208,9 +208,12 @@ def test_apps_page_fetches_workspace_apps_endpoint() -> None:
     assert "Manage your apps" in layout_source
     assert "App workspace" in layout_source
     assert "Mozaiks Studio" not in layout_source
-    assert "Create App" in source
+    shell_source = _read("factory_app/app/config/shell.json")
+    assert "Create App" not in source
+    assert '"id": "create-app"' in shell_source
+    assert '"path": "/create"' in shell_source
     assert "Import App" not in source
-    assert "const CREATE_APP_PATH = '/create'" in source
+    assert "const CREATE_APP_PATH = '/create'" not in source
     assert "/chat?workflow=ValueEngine&mode=workflow&defer_start=1" not in source
     assert "/chat?workflow=ValueEngine&mode=workflow&new=1" not in source
     assert "row.primaryAction?.href" in source

--- a/web_shell/playwright/apps.responsive.smoke.spec.js
+++ b/web_shell/playwright/apps.responsive.smoke.spec.js
@@ -966,7 +966,8 @@ test('apps route stays responsive across desktop and mobile widths', async ({ pa
   const main = page.locator('main');
 
   await expect(page.getByRole('heading', { name: 'Apps' })).toBeVisible();
-  await expect(main.getByRole('button', { name: 'Create App' })).toBeVisible();
+  await expect(page.locator('header').getByRole('button', { name: 'Create App' })).toBeVisible();
+  await expect(main.getByRole('button', { name: 'Create App' })).toHaveCount(0);
   await expect(main.getByRole('button', { name: 'Import App' })).toHaveCount(0);
   await expect(main.getByPlaceholder('Search apps...')).toBeVisible();
   await expectNoHorizontalOverflow(page);
@@ -1008,9 +1009,8 @@ test('create app transition overlay can return to Apps', async ({ page, isMobile
   test.skip(isMobile, 'Overlay navigation assertion is flaky on mobile CI; desktop-only');
 
   await page.goto('/apps');
-  const main = page.locator('main');
 
-  await main.getByRole('button', { name: 'Create App' }).click();
+  await page.locator('header').getByRole('button', { name: 'Create App' }).click();
 
   await expect(page).toHaveURL(/\/create$/);
   await expect(page.getByRole('heading', { name: 'Choose Your App Journey' })).toBeVisible();
@@ -1493,7 +1493,10 @@ test('mobile workspace Studio navigation keeps route transitions stable', async 
     {
       href: '/apps',
       heading: 'Apps',
-      detail: async () => expect(main.getByRole('button', { name: 'Create App' })).toBeVisible(),
+      detail: async () => {
+        await expect(page.locator('header').getByRole('button', { name: 'Create App' })).toBeVisible();
+        await expect(main.getByRole('button', { name: 'Create App' })).toHaveCount(0);
+      },
     },
   ];
 


### PR DESCRIPTION
Removes the redundant page-level Create App button from the Apps management page. App creation remains available through the shell header action. Updates the build-surface contract test and Unreleased changelog. Testing: 28 passed, 6 skipped targeted; Ruff passed; UI primitive validation passed; git diff --check passed. Full suite: 13466 passed, 78 skipped, 20 failed; all 20 failures reproduced unchanged on clean origin/main (AG2 task lifecycle/runtime migration tests, with the governance scan caused by its repo-local pytest temp tree).