### PR TITLE
fix(runtime): complete the context-authority writer taxonomy; unbreak all workflow graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Every workflow failed instantly under context-authority enforcement**:
+  the routing-variable validation added in #298/#344 required deterministic
+  writers that the runtime never actually produced — agent-sentinel triggers
+  ("say NEXT") wrote as freeform `agent_text` and declared workflow tools
+  wrote as `tool_writeback`/`context_bridge`, all banned for routing state.
+  Every graph compile raised `ContextAuthorityError` before any agent spoke,
+  so every Studio conversation "completed" in under a second with zero agent
+  activity. The writer taxonomy is now complete: exact-match `equals`
+  triggers write as a new deterministic `sentinel_text_trigger` writer
+  (freeform contains/regex-capture stays banned from routing), auto-invoked
+  tools write as `deterministic_tool`, closed routing/quality state accepts
+  the deterministic tool/lifecycle/structured-output machinery, and the AG2
+  runner elevates bridge/derive writes to the declared deterministic writer
+  per variable. A new drift guard
+  (`tests/test_workflow_context_authority_compile.py`) compiles all 14
+  factory workflows against their real policies on every PR — the test that
+  would have caught this before merge.
+- **ExistingAppDiscovery crashed at persist time**: twelve context variables
+  declared `type: object` with list defaults/values, which the replay type
+  guard fail-closes on. Declarations corrected to `type: array`, and the new
+  drift guard also validates every declared default against its declared
+  type.
 - **AppWorkbench live-preview refresh actually works now**: the preview
   sandbox API the workbench calls after a scoped refinement
   (`/api/artifacts/{id}/sandbox`, `/api/sandbox/*`, `/ws/sandbox/*`) was

--- a/factory_app/workflows/ExistingAppDiscovery/context_variables.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/context_variables.yaml
@@ -445,7 +445,7 @@ definitions:
       default: {}
 
   evidence_sources:
-    type: object
+    type: array
     description: Deterministic evidence sources used before chat.
     source:
       type: state
@@ -494,7 +494,7 @@ definitions:
       default: {}
 
   unresolved_questions:
-    type: object
+    type: array
     description: Gaps the collector could not determine.
     source:
       type: state
@@ -523,7 +523,7 @@ definitions:
       default: false
 
   detected_connectors:
-    type: object
+    type: array
     description: >
       List of ConnectorSpec objects detected from package manifests and source imports.
       Each item has: provider_id, package_or_import, category, confidence,
@@ -623,7 +623,7 @@ definitions:
   # ---------------------------------------------------------------------------
 
   capabilities:
-    type: object
+    type: array
     description: Existing product capabilities identified during discovery.
     source:
       type: state
@@ -651,7 +651,7 @@ definitions:
       default: null
 
   key_entities:
-    type: object
+    type: array
     description: Main data entities already present in the host app.
     source:
       type: state
@@ -665,21 +665,21 @@ definitions:
       default: false
 
   service_surfaces:
-    type: object
+    type: array
     description: Existing service-facing surfaces such as APIs, hubs, or workers.
     source:
       type: state
       default: []
 
   route_surfaces:
-    type: object
+    type: array
     description: Existing frontend routes or route modules relevant to adoption.
     source:
       type: state
       default: []
 
   agent_ready_capabilities:
-    type: object
+    type: array
     description: Capability ids that are technically ready for agent access.
     source:
       type: state
@@ -734,7 +734,7 @@ definitions:
       default: null
 
   ai_accessible_capabilities:
-    type: object
+    type: array
     description: Capability ids approved for initial AI access.
     source:
       type: state
@@ -748,14 +748,14 @@ definitions:
       default: null
 
   initial_workflows:
-    type: object
+    type: array
     description: Initial workflows or agentic experiences to attach first.
     source:
       type: state
       default: []
 
   ecosystem_bindings:
-    type: object
+    type: array
     description: Mozaiks ecosystem modules to connect now or next.
     source:
       type: state
@@ -843,7 +843,7 @@ definitions:
       default: null
 
   capability_specs:
-    type: object
+    type: array
     description: Canonical existing capability artifacts persisted after discovery.
     source:
       type: state

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -41,7 +41,9 @@ from mozaiksai.core.ports.orchestration import RunStatus
 from mozaiksai.core.workflow.context.authority import (
     AGENT_TEXT_WRITER,
     CONTEXT_BRIDGE_WRITER,
+    DETERMINISTIC_TOOL_WRITER,
     LIVE_USER_CONTEXT_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
     ContextAuthorityPolicy,
 )
 from mozaiksai.core.workflow.execution.network_graph import compile_transition_rules_to_graph
@@ -86,11 +88,33 @@ def _json_safe_dict(value: Mapping[str, Any] | None) -> dict[str, Any]:
     return serialized if isinstance(serialized, dict) else {}
 
 
+def _resolve_declared_writer(
+    key: str,
+    *,
+    base_writer: str,
+    elevated_writer: str,
+    context_authority_policy: ContextAuthorityPolicy | None,
+) -> str:
+    """Label a write with the highest-fidelity writer the declaration
+    authorizes for this mechanism. The policy stays the single authority —
+    this only picks between the mechanism's base writer and its declared
+    deterministic form (e.g. a bridge write to a variable whose declaration
+    authorizes deterministic tools, or an agent-text derive for a variable
+    declared with an exact-match sentinel trigger)."""
+    if context_authority_policy is None:
+        return base_writer
+    authority = context_authority_policy.variables.get(key)
+    if authority is not None and elevated_writer in authority.writer_ids:
+        return elevated_writer
+    return base_writer
+
+
 def _authorized_context_updates(
     updates: Mapping[str, Any] | None,
     *,
     writer_id: str,
     context_authority_policy: ContextAuthorityPolicy | None,
+    elevated_writer_id: str | None = None,
 ) -> dict[str, Any]:
     if not updates:
         return {}
@@ -99,8 +123,16 @@ def _authorized_context_updates(
         clean_key = str(key or "").strip()
         if not clean_key:
             continue
+        effective_writer = writer_id
+        if elevated_writer_id is not None:
+            effective_writer = _resolve_declared_writer(
+                clean_key,
+                base_writer=writer_id,
+                elevated_writer=elevated_writer_id,
+                context_authority_policy=context_authority_policy,
+            )
         if context_authority_policy is not None:
-            context_authority_policy.require_can_write(clean_key, writer_id=writer_id, operation="set")  # type: ignore[arg-type]
+            context_authority_policy.require_can_write(clean_key, writer_id=effective_writer, operation="set")  # type: ignore[arg-type]
         safe[clean_key] = value
     return safe
 
@@ -779,6 +811,7 @@ def _install_context_update_handler(
                                 candidate_updates,
                                 writer_id=AGENT_TEXT_WRITER,
                                 context_authority_policy=context_authority_policy,
+                                elevated_writer_id=SENTINEL_TEXT_TRIGGER_WRITER,
                             )
                 if (
                     bridge_updates.get("set")
@@ -790,11 +823,13 @@ def _install_context_update_handler(
                         bridge_updates.get("set") or {},
                         writer_id=CONTEXT_BRIDGE_WRITER,
                         context_authority_policy=context_authority_policy,
+                        elevated_writer_id=DETERMINISTIC_TOOL_WRITER,
                     )
                     existing_set = _authorized_context_updates(
                         existing.get("set") or {},
                         writer_id=CONTEXT_BRIDGE_WRITER,
                         context_authority_policy=context_authority_policy,
+                        elevated_writer_id=DETERMINISTIC_TOOL_WRITER,
                     )
                     merged_set = {
                         **_json_safe_dict(existing_set),

--- a/mozaiksai/core/events/auto_tool_handler.py
+++ b/mozaiksai/core/events/auto_tool_handler.py
@@ -22,7 +22,7 @@ from mozaiksai.core.events.event_serialization import serialize_event_content
 from mozaiksai.core.workflow.agents.tools import load_agent_tool_functions
 from mozaiksai.core.workflow.context.adapter import create_context_container
 from mozaiksai.core.workflow.context.authority import (
-    TOOL_WRITEBACK_WRITER,
+    DETERMINISTIC_TOOL_WRITER,
     build_context_authority_policy,
 )
 from mozaiksai.core.workflow.declarative import parse_tools_config
@@ -388,7 +388,7 @@ class AutoToolEventHandler:
                     chat_id=context.get("chat_id"),
                     app_id=context.get("app_id"),
                     authority_policy=authority_policy,
-                    writer_id=TOOL_WRITEBACK_WRITER,
+                    writer_id=DETERMINISTIC_TOOL_WRITER,
                 )
                 for key in ("chat_id", "app_id", "workflow_name", "turn_idempotency_key", "agent_name"):
                     value = context.get(key)

--- a/mozaiksai/core/workflow/context/authority.py
+++ b/mozaiksai/core/workflow/context/authority.py
@@ -48,6 +48,7 @@ ContextWriterId = Literal[
     "structured_output",
     "lifecycle_tool",
     "deterministic_tool",
+    "sentinel_text_trigger",
 ]
 
 RUNTIME_SYSTEM_WRITER: ContextWriterId = "runtime_system"
@@ -64,6 +65,12 @@ TASK_BATCH_WRITER: ContextWriterId = "task_batch"
 STRUCTURED_OUTPUT_WRITER: ContextWriterId = "structured_output"
 LIFECYCLE_TOOL_WRITER: ContextWriterId = "lifecycle_tool"
 DETERMINISTIC_TOOL_WRITER: ContextWriterId = "deterministic_tool"
+# Sentinel extraction: an agent_text trigger whose match is an exact `equals`
+# token mapped to a fixed declared value (e.g. "NEXT" -> true). The model only
+# emits the token; the value written is decided by the declaration and an
+# exact string comparison, so the write is deterministic runtime machinery —
+# unlike freeform contains/regex-capture triggers, which stay AGENT_TEXT.
+SENTINEL_TEXT_TRIGGER_WRITER: ContextWriterId = "sentinel_text_trigger"
 CONTEXT_AUTHORITY_WRITER_DEP = "mozaiks.context_authority.scoped_writer"
 
 _ALL_WRITERS = {
@@ -81,6 +88,7 @@ _ALL_WRITERS = {
     STRUCTURED_OUTPUT_WRITER,
     LIFECYCLE_TOOL_WRITER,
     DETERMINISTIC_TOOL_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
 }
 _DETERMINISTIC_WRITERS = {
     RUNTIME_SYSTEM_WRITER,
@@ -90,6 +98,7 @@ _DETERMINISTIC_WRITERS = {
     STRUCTURED_OUTPUT_WRITER,
     LIFECYCLE_TOOL_WRITER,
     DETERMINISTIC_TOOL_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
 }
 _ORDINARY_MUTATION_WRITERS = {
     CALLER_INPUT_WRITER,
@@ -103,6 +112,7 @@ _ORDINARY_MUTATION_WRITERS = {
     STRUCTURED_OUTPUT_WRITER,
     LIFECYCLE_TOOL_WRITER,
     DETERMINISTIC_TOOL_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
 }
 _IMMUTABLE_EXACT = {
     "app_id",
@@ -406,6 +416,12 @@ def infer_context_authority(
     triggers = list(_value(source, "triggers", []) or [])
     trigger_types = {str(_value(trigger, "type", "") or "").strip() for trigger in triggers}
     task_keys = task_batch_context_keys or set()
+    sentinel_trigger = any(
+        str(_value(trigger, "type", "") or "").strip() == "agent_text"
+        and str(_value(_value(trigger, "match", None), "equals", "") or "").strip()
+        and str(_value(trigger, "value", "") or "") != "$1"
+        for trigger in triggers
+    )
 
     authority_class = metadata.authority_class
     if authority_class is None:
@@ -424,7 +440,9 @@ def infer_context_authority(
     }
     writer_ids = set(metadata.writer_ids)
     if not writer_ids:
-        writer_ids = _infer_writer_ids(authority_class, source_type, trigger_types, clean_key, task_keys)
+        writer_ids = _infer_writer_ids(
+            authority_class, source_type, trigger_types, clean_key, task_keys, sentinel_trigger
+        )
 
     if authority_class is ContextAuthorityClass.IMMUTABLE_RUNTIME_AUTHORITY:
         writer_ids = set()
@@ -530,10 +548,32 @@ def _infer_writer_ids(
     trigger_types: set[str],
     key: str,
     task_batch_context_keys: set[str],
+    sentinel_trigger: bool = False,
 ) -> set[ContextWriterId]:
     if authority_class is ContextAuthorityClass.DERIVED_INFORMATION and "agent_text" in trigger_types:
-        return {AGENT_TEXT_WRITER}
+        derived_writers: set[ContextWriterId] = {AGENT_TEXT_WRITER}
+        if sentinel_trigger:
+            derived_writers.add(SENTINEL_TEXT_TRIGGER_WRITER)
+        return derived_writers
     writers: set[ContextWriterId] = set()
+    if authority_class in {
+        ContextAuthorityClass.CLOSED_WRITER_ROUTING_STATE,
+        ContextAuthorityClass.CLOSED_WRITER_QUALITY_STATE,
+    }:
+        # Closed state may only be advanced by deterministic runtime
+        # machinery. Declared workflow tools (auto-invoked on validated
+        # structured output), lifecycle hooks, and structured-output
+        # projection are that machinery; freeform model text and replay
+        # remain excluded. Without this baseline, closed variables written
+        # by tools have an empty writer set and every graph that routes on
+        # them fails to compile.
+        writers.update({
+            DETERMINISTIC_TOOL_WRITER,
+            LIFECYCLE_TOOL_WRITER,
+            STRUCTURED_OUTPUT_WRITER,
+        })
+    if sentinel_trigger:
+        writers.add(SENTINEL_TEXT_TRIGGER_WRITER)
     if "ui_response" in trigger_types:
         writers.add(UI_RESPONSE_TRIGGER_WRITER)
     if "user_text" in trigger_types:
@@ -640,6 +680,7 @@ def _clean_key(value: Any) -> str:
 
 __all__ = [
     "AGENT_TEXT_WRITER",
+    "SENTINEL_TEXT_TRIGGER_WRITER",
     "CALLER_INPUT_WRITER",
     "CONTEXT_BRIDGE_WRITER",
     "DETERMINISTIC_TOOL_WRITER",

--- a/mozaiksai/core/workflow/context/derived.py
+++ b/mozaiksai/core/workflow/context/derived.py
@@ -12,6 +12,7 @@ from logs.logging_config import get_workflow_logger
 from .authority import (
     AGENT_TEXT_WRITER,
     RUNTIME_SYSTEM_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
     UI_RESPONSE_TRIGGER_WRITER,
     USER_TEXT_TRIGGER_WRITER,
     ContextWriterId,
@@ -19,6 +20,16 @@ from .authority import (
 from .schema import load_context_variables_config
 
 logger = get_workflow_logger("derived_context")
+
+
+def _agent_text_writer_for(trigger: Any) -> ContextWriterId:
+    """Exact-equals triggers with a fixed declared value are deterministic
+    sentinel extraction; anything freeform (contains/regex/capture) is not."""
+    equals = str(getattr(trigger, "equals", "") or "").strip()
+    value = getattr(trigger, "value", None)
+    if equals and value != "$1":
+        return SENTINEL_TEXT_TRIGGER_WRITER
+    return AGENT_TEXT_WRITER
 
 
 def _provider_set_with_writer(provider: Any, key: str, value: Any, writer_id: ContextWriterId) -> None:
@@ -262,7 +273,7 @@ class DerivedVariableSpec:
                             if current != trigger.from_state:
                                 continue
                         try:
-                            _provider_set_with_writer(provider, self.name, trigger.value, AGENT_TEXT_WRITER)
+                            _provider_set_with_writer(provider, self.name, trigger.value, _agent_text_writer_for(trigger))
                         except Exception as err:  # pragma: no cover
                             logger.debug("Derived variable update failed: %s", err)
                 return True
@@ -487,11 +498,16 @@ class DerivedContextManager:
             return {}
 
         updated_vars: dict[str, Any] = {}
+        trigger_by_var = {var.name: list(var.triggers) for var in self.variables}
         for name, value in updates.items():
+            matched = trigger_by_var.get(name) or []
+            writer = AGENT_TEXT_WRITER
+            if matched and all(_agent_text_writer_for(t) == SENTINEL_TEXT_TRIGGER_WRITER for t in matched):
+                writer = SENTINEL_TEXT_TRIGGER_WRITER
             for provider in self.providers:
                 if hasattr(provider, "set"):
                     try:
-                        _provider_set_with_writer(provider, name, value, AGENT_TEXT_WRITER)
+                        _provider_set_with_writer(provider, name, value, writer)
                         updated_vars[name] = value
                     except Exception as err:  # pragma: no cover
                         logger.debug("[DERIVED_CONTEXT] apply_agent_text update failed: %s", err)

--- a/tests/test_workflow_context_authority_compile.py
+++ b/tests/test_workflow_context_authority_compile.py
@@ -1,0 +1,173 @@
+"""Drift guard: every factory workflow must compile under context authority.
+
+The context authority policy (#298/#344) validates at graph-compile time that
+every routing context variable has an authorized deterministic writer. That
+validation runs at runtime, so a contract change that breaks it produces a
+green CI and a dead product: workflows fail instantly with zero agent
+activity the moment a user starts a conversation.
+
+This test replays the runtime's own construction (definitions ->
+build_context_authority_policy -> validate_transition_context_authority) for
+every shipped factory workflow, so any future policy/YAML drift fails a PR
+instead of a user session.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mozaiksai.core.workflow.context.authority import (
+    AGENT_TEXT_WRITER,
+    DETERMINISTIC_TOOL_WRITER,
+    SENTINEL_TEXT_TRIGGER_WRITER,
+    build_context_authority_policy,
+    validate_transition_context_authority,
+)
+
+WORKFLOWS_ROOT = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
+
+
+def _workflow_dirs() -> list[Path]:
+    dirs = []
+    for entry in sorted(WORKFLOWS_ROOT.iterdir()):
+        if (entry / "context_variables.yaml").exists() and (entry / "transition_graph.yaml").exists():
+            dirs.append(entry)
+    assert dirs, "no factory workflows found — path drift in this test"
+    return dirs
+
+
+def _load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+@pytest.mark.parametrize("workflow_dir", _workflow_dirs(), ids=lambda p: p.name)
+def test_workflow_routing_context_has_deterministic_writers(workflow_dir: Path):
+    definitions = _load(workflow_dir / "context_variables.yaml").get("definitions") or {}
+    transition_rules = _load(workflow_dir / "transition_graph.yaml").get("transition_rules") or []
+
+    policy = build_context_authority_policy(
+        workflow_name=workflow_dir.name,
+        definitions=definitions,
+        transition_rules=transition_rules,
+    )
+    # Raises ContextAuthorityError on any routing variable without an
+    # authorized deterministic writer — exactly what graph compile does.
+    validate_transition_context_authority(
+        workflow_name=workflow_dir.name,
+        policy=policy,
+        transition_rules=transition_rules,
+    )
+
+
+@pytest.mark.parametrize("workflow_dir", _workflow_dirs(), ids=lambda p: p.name)
+def test_workflow_declared_defaults_match_declared_types(workflow_dir: Path):
+    """A default that violates the declared type poisons persistence: the
+    replay guard fail-closes on it and the whole run crashes at persist time
+    (e.g. `type: object` with `default: []`)."""
+    from mozaiksai.core.workflow.context.authority import _is_valid_context_value
+
+    definitions = _load(workflow_dir / "context_variables.yaml").get("definitions") or {}
+    mismatches = []
+    for key, definition in definitions.items():
+        if not isinstance(definition, dict):
+            continue
+        source = definition.get("source") or {}
+        if not isinstance(source, dict) or "default" not in source:
+            continue
+        default = source["default"]
+        if default is not None and not _is_valid_context_value(default, value_type=definition.get("type")):
+            mismatches.append(f"{key}: type={definition.get('type')} default={default!r}")
+    assert not mismatches, f"{workflow_dir.name} declared defaults violate declared types: {mismatches}"
+
+
+def test_sentinel_trigger_is_deterministic_writer():
+    definitions = {
+        "interview_complete": {
+            "type": "boolean",
+            "source": {
+                "type": "state",
+                "default": False,
+                "triggers": [
+                    {"type": "agent_text", "agent": "InterviewAgent", "match": {"equals": "NEXT"}}
+                ],
+            },
+        }
+    }
+    rules = [
+        {
+            "source_agent": "InterviewAgent",
+            "target_agent": "PlanAgent",
+            "transition_type": "condition",
+            "condition_type": "context_equals",
+            "condition_key": "interview_complete",
+            "condition_value": True,
+        }
+    ]
+    policy = build_context_authority_policy(
+        workflow_name="SentinelSmoke", definitions=definitions, transition_rules=rules
+    )
+    authority = policy.variables["interview_complete"]
+    assert SENTINEL_TEXT_TRIGGER_WRITER in authority.writer_ids
+    assert policy.can_write("interview_complete", writer_id=SENTINEL_TEXT_TRIGGER_WRITER)
+    # Freeform model text is still banned from routing state.
+    assert not policy.can_write("interview_complete", writer_id=AGENT_TEXT_WRITER)
+    validate_transition_context_authority(
+        workflow_name="SentinelSmoke", policy=policy, transition_rules=rules
+    )
+
+
+def test_freeform_capture_trigger_is_not_deterministic():
+    definitions = {
+        "captured_note_complete": {
+            "type": "string",
+            "source": {
+                "type": "state",
+                "triggers": [
+                    {
+                        "type": "agent_text",
+                        "agent": "NoteAgent",
+                        "match": {"regex": "NOTE: (.+)"},
+                        "value": "$1",
+                    }
+                ],
+            },
+        }
+    }
+    policy = build_context_authority_policy(
+        workflow_name="CaptureSmoke", definitions=definitions, transition_rules=[]
+    )
+    authority = policy.variables["captured_note_complete"]
+    assert SENTINEL_TEXT_TRIGGER_WRITER not in authority.writer_ids
+
+
+def test_routing_state_accepts_deterministic_tool_writer():
+    definitions = {
+        "concept_presented": {
+            "type": "boolean",
+            "source": {"type": "state", "default": False},
+        }
+    }
+    rules = [
+        {
+            "source_agent": "GapAnalysisAgent",
+            "target_agent": "user",
+            "transition_type": "condition",
+            "condition_type": "context_equals",
+            "condition_key": "concept_presented",
+            "condition_value": True,
+        }
+    ]
+    policy = build_context_authority_policy(
+        workflow_name="ToolRoutingSmoke", definitions=definitions, transition_rules=rules
+    )
+    assert policy.can_write("concept_presented", writer_id=DETERMINISTIC_TOOL_WRITER)
+    # Freeform writers stay banned for closed routing state.
+    assert not policy.can_write("concept_presented", writer_id=AGENT_TEXT_WRITER)
+    assert not policy.can_write("concept_presented", writer_id="tool_writeback")
+    validate_transition_context_authority(
+        workflow_name="ToolRoutingSmoke", policy=policy, transition_rules=rules
+    )


### PR DESCRIPTION
## What

**Every workflow on main fails instantly at graph compile** — this PR restores the product loop while preserving the context-authority contract's intent.

### Root cause

The routing-variable validation from #298/#344 requires routing context variables to have authorized *deterministic* writers — but the runtime never produced those writers. Agent-sentinel triggers ("say NEXT") write as freeform `agent_text`; declared workflow tools write as `tool_writeback` (auto-tool handler) or `context_bridge` (AG2 round-end bridge) — all excluded from the deterministic set and therefore banned for routing state. Result: `compile_transition_rules_to_graph` raises `ContextAuthorityError` for every workflow **before any agent speaks**. Every Studio conversation and `mozaiks gen` run "completed" in <1s with zero agent activity (this was dogfood finding #5). CI stayed green because no test compiled the real factory workflows against the real policy.

Reproduced live in Studio: ValueEngine failed on `concept_presented`/`interview_complete`, ExistingAppDiscovery on 4 more, and a second crash at persist time (`invalid_value key=evidence_sources`) from wrong type declarations.

### Fix — complete the taxonomy, keep the contract

Freeform model text and replay remain banned from routing. What changes is that deterministic machinery is now *recognized* as deterministic:

1. **`sentinel_text_trigger` (new deterministic writer)**: an `agent_text` trigger with an exact `match.equals` token and a fixed declared value is deterministic extraction — the model emits a token, the declaration + exact string compare decide the write. `contains`/regex-capture triggers stay `AGENT_TEXT` and stay banned from routing.
2. **Auto-invoked tools → `deterministic_tool`**: they run on validated structured output, not model whim (`auto_tool_handler`).
3. **Closed routing/quality state gets the deterministic machinery baseline** (`deterministic_tool`, `lifecycle_tool`, `structured_output`) instead of an empty writer set that nothing could ever satisfy.
4. **AG2 runner elevates per declared policy**: bridge writes and agent-text derives are labeled with the declared deterministic writer for that variable when the declaration authorizes it — the policy stays the single authority (`_resolve_declared_writer`).
5. **ExistingAppDiscovery data fix**: 12 variables declared `type: object` with list values; the replay guard fail-closes on that at persist. Corrected to `type: array`.

### The missing drift guard

`tests/test_workflow_context_authority_compile.py` — compiles **all 14 factory workflows** against their real authority policies (exact runtime construction) and validates every declared default against its declared type, on every PR. This is the test that would have caught #298/#344's runtime impact before merge.

## Verification

- Full suite: **13517 passed, 78 skipped, 0 failed**
- All existing authority suites green: `test_context_authority_policy`, `test_context_authority_hostile`, `test_context_exposure`, `test_auto_tool_handler_persistence`, `test_ag2_network_execution_alignment` (119 tests)
- `ruff` clean; `mypy mozaiksai/ factory_app/` clean
- Live-verified: Studio backend restarted on this branch for an in-progress founder dogfood session

## OSS Change Impact

- Layer changed: universal substrate (context authority, AG2 runner, auto-tool handler) + factory workflow declarations (ExistingAppDiscovery types)
- Build workflow impact: all 14 workflows compile again; no YAML contract shape changes beyond the type corrections
- Runtime/platform impact: writer labeling only — no change to what freeform text or replay may write
- Tests run: listed above
- Docs updated: CHANGELOG (Fixed)
- Compatibility risk: low — strictly widens the authorized-deterministic set for closed state; nothing previously-allowed becomes disallowed

cc @elCaptnCode — this touches the #298/#344 enforcement; the design note in `authority.py` documents why exact-equals sentinel extraction and auto-tool writeback qualify as deterministic. Happy to adjust if the taxonomy intent differed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012thGtQXpM6eNYoSxKvGm5w