### PR TITLE
fix(cli): make a silent no-op generation loudly fail (issue #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ This project follows a practical pre-1.0 changelog format:
   guard fail-closes on. Declarations corrected to `type: array`, and the new
   drift guard also validates every declared default against its declared
   type.
+- **`mozaiks gen` no longer reports a silent no-op as success** (issue #379):
+  the CLI now initialises real logging (workflow-engine INFO records and file
+  sinks were previously swallowed), asserts on the orchestration result —
+  failed runs, runs paused awaiting a user reply, and runs where no agent
+  ever produced a turn now exit 1 with distinct messages — points
+  `MOZAIKS_GENERATED_ARTIFACTS_PATH` at the CLI output directory so the
+  empty-output check inspects where tools actually write, and warns loudly
+  when `MONGO_URI` is unset. The orchestration result payload now carries
+  `agents_created` / `agent_turns` evidence, echoed in the completion
+  summary as `agents=N turns=M`.
 - **AppWorkbench live-preview refresh actually works now**: the preview
   sandbox API the workbench calls after a scoped refinement
   (`/api/artifacts/{id}/sandbox`, `/api/sandbox/*`, `/ws/sandbox/*`) was

--- a/mozaiks_cli/commands/gen.py
+++ b/mozaiks_cli/commands/gen.py
@@ -74,6 +74,41 @@ def _check_api_key() -> bool:
     return False
 
 
+def _warn_if_no_mongo():
+    """Warn loudly (without failing) when MONGO_URI is unset.
+
+    Local generation without Mongo is a legitimate flow, but the operator
+    should know that build records, artifacts, and usage events will not
+    persist anywhere.
+    """
+    if not os.environ.get("MONGO_URI"):
+        _print(
+            "Warning: MONGO_URI is not set. Generation will still run, but "
+            "build records, artifacts, and usage events will NOT persist.",
+            style="bold yellow",
+        )
+
+
+def _init_logging():
+    """Initialise real logging so workflow-engine INFO records reach the operator.
+
+    Without this, the engine's degradation warnings (middleware import
+    failures, zero-turn runs) are swallowed and gen can exit "successfully"
+    after a silent no-op (issue #379). Also creates the file log sinks.
+    """
+    try:
+        from logs.logging_config import setup_development_logging
+
+        setup_development_logging()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        import logging
+
+        logging.basicConfig(level=logging.INFO)
+        logging.getLogger(__name__).warning(
+            "Could not initialise mozaiks logging (%s); using basicConfig.", exc
+        )
+
+
 def _find_generator_source() -> Path | None:
     """Locate the AgentGenerator workflow source directory."""
     candidates = [
@@ -423,7 +458,7 @@ def _stage_workflow(source_dir: Path, staging_root: Path, workflow_name: str) ->
 
 
 
-def _setup_environment(repo_root: Path, staging_workflows: Path):
+def _setup_environment(repo_root: Path, staging_workflows: Path, output_dir: Path):
     """Configure sys.path and env vars for workflow execution."""
     for p in (str(repo_root), str(repo_root / "mozaiksai")):
         if p not in sys.path:
@@ -431,6 +466,11 @@ def _setup_environment(repo_root: Path, staging_workflows: Path):
 
     # Point the workflow manager at our staging directory
     os.environ["MOZAIKS_WORKFLOWS_PATH"] = str(staging_workflows)
+
+    # Point artifact-writing tools (workflow_converter et al.) at the CLI
+    # output directory, so the post-run empty-output check inspects the
+    # directory the tools actually write to (issue #379).
+    os.environ["MOZAIKS_GENERATED_ARTIFACTS_PATH"] = str(output_dir)
 
 
 # ── Runner ─────────────────────────────────────────────────────────
@@ -516,6 +556,79 @@ def _create_output_structure(output_dir: Path, mode: str):
         (output_dir / "frontend").mkdir(exist_ok=True)
 
 
+def _report_run_outcome(result: dict[str, Any], output_dir: Path, mode: str) -> int:
+    """Assert on the orchestration result and report success or a loud failure.
+
+    ``mozaiks gen`` used to treat any non-exception return as success; a run
+    that failed, paused for user input, or never executed a single agent turn
+    still printed "Generation complete!" (issue #379). Success now requires an
+    actually-completed run with agent activity and files on disk.
+    """
+    if not result.get("success"):
+        _print_error(f"Generation failed: {result.get('error', 'Unknown error')}")
+        return 1
+
+    raw_payload = result.get("result")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+
+    if payload.get("failed") or payload.get("error"):
+        _print_error(
+            f"Workflow run failed: {payload.get('error') or 'unknown workflow error'} "
+            "— check the logs above."
+        )
+        return 1
+
+    if payload.get("awaiting_user_input"):
+        _print_error(
+            "Workflow paused waiting for a user reply — this is not a completed "
+            "generation. Drive this workflow from Studio, which supports replies."
+        )
+        return 1
+
+    if not payload.get("run_completed"):
+        _print_error(
+            f"Workflow did not complete (run_status: {payload.get('run_status', 'unknown')}). "
+            "Treating this as a failed generation."
+        )
+        return 1
+
+    agents_created = payload.get("agents_created")
+    agent_turns = payload.get("agent_turns")
+    if agent_turns == 0:
+        _print_error(
+            "Workflow completed but no agent ever produced a reply — this is "
+            "the silent no-op from issue #379. Check the logs above for "
+            "middleware or agent-creation failures."
+        )
+        return 1
+
+    written = [f for f in sorted(output_dir.rglob("*")) if f.is_file()]
+    if not written:
+        _print_error(
+            "Generation finished but wrote no files under the artifact root "
+            f"({output_dir}). Agents ran, but no tool persisted any output "
+            "there — check the logs above for tool failures."
+        )
+        return 1
+
+    _print_success("Generation complete!")
+    if agents_created is not None or agent_turns is not None:
+        _print_info(f"agents={agents_created} turns={agent_turns}")
+    _print_info(f"Files written to: {output_dir}")
+
+    _print("\nGenerated files:", style="bold")
+    for f in written:
+        _print_info(f"  {f.relative_to(output_dir)}")
+
+    _print("\nNext steps:", style="bold")
+    _print_info(f"  cd {output_dir}")
+    _print_info("  # Review and customise the generated files")
+    if mode == "app":
+        _print_info("  Promote the generated app bundle into an active app root before running it")
+        _print_info("  Open Studio: python -m mozaiks studio --dir . --open")
+    return 0
+
+
 def run(args):
     """Execute the gen command."""
     mode = args.mode
@@ -536,6 +649,9 @@ def run(args):
         _print_error("No LLM API key found.")
         _print_info("Set one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, or AZURE_OPENAI_API_KEY")
         return 1
+
+    _warn_if_no_mongo()
+    _init_logging()
 
     source_path = _find_generator_source()
     if not source_path:
@@ -563,7 +679,7 @@ def run(args):
         _stage_workflow(source_path, staging_dir, "AgentGenerator")
 
         # Set up runtime environment pointing at staged workflows
-        _setup_environment(repo_root, staging_dir)
+        _setup_environment(repo_root, staging_dir, output_dir)
 
         _create_output_structure(output_dir, mode)
 
@@ -575,10 +691,14 @@ def run(args):
         _print("\nGenerating... (this may take a few minutes)\n", style="yellow")
 
         if RICH_AVAILABLE:
+            # transient=True clears the spinner when done; rich's live display
+            # redirects stdout/stderr by default, so workflow log lines print
+            # above the spinner instead of being garbled or swallowed.
             with Progress(
                 SpinnerColumn(),
                 TextColumn("[progress.description]{task.description}"),
                 console=console,
+                transient=True,
             ) as progress:
                 task = progress.add_task("Running AgentGenerator...", total=None)
                 result = asyncio.run(
@@ -601,33 +721,7 @@ def run(args):
                 )
             )
 
-        if result.get("success"):
-            written = [f for f in sorted(output_dir.rglob("*")) if f.is_file()]
-            if not written:
-                _print_error(
-                    "Generation finished but wrote no files. The workflow "
-                    "degraded or its outputs were lost — check the logs above "
-                    "(middleware import failures are a common cause)."
-                )
-                return 1
-
-            _print_success("Generation complete!")
-            _print_info(f"Files written to: {output_dir}")
-
-            _print("\nGenerated files:", style="bold")
-            for f in written:
-                _print_info(f"  {f.relative_to(output_dir)}")
-
-            _print("\nNext steps:", style="bold")
-            _print_info(f"  cd {output_dir}")
-            _print_info("  # Review and customise the generated files")
-            if mode == "app":
-                _print_info("  Promote the generated app bundle into an active app root before running it")
-                _print_info("  Open Studio: python -m mozaiks studio --dir . --open")
-            return 0
-        else:
-            _print_error(f"Generation failed: {result.get('error', 'Unknown error')}")
-            return 1
+        return _report_run_outcome(result, output_dir, mode)
 
     except KeyboardInterrupt:
         _print("\n\nGeneration cancelled.", style="yellow")

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -681,6 +681,50 @@ async def _run_ag2_network_phase(
     )
 
 
+def _assemble_result_payload(
+    *,
+    workflow_name: str,
+    chat_id: str,
+    app_id: str,
+    user_id: str | None,
+    workflow_complete: bool,
+    awaiting_user_input: bool,
+    run_failed: bool,
+    run_error: Any,
+    workflow_status_value: int,
+    agents_created: int,
+    agent_turns: int,
+    ag2_channel_id: Any,
+    ag2_close_reason: Any,
+    structured_outputs: Any,
+) -> dict[str, Any]:
+    """Final orchestration result contract handed back to callers (Studio, CLI).
+
+    ``agents_created`` and ``agent_turns`` are the evidence a caller needs to
+    distinguish a real generation from a silent no-op where the graph loaded
+    but no agent ever produced a reply (issue #379).
+    """
+    return {
+        "workflow_name": workflow_name,
+        "chat_id": chat_id,
+        "app_id": app_id,
+        "user_id": user_id,
+        "messages": None,
+        "max_turns_reached": False,
+        "response": None,
+        "run_completed": workflow_complete,
+        "awaiting_user_input": awaiting_user_input,
+        "run_status": "failed" if run_failed else workflow_status_value,
+        "failed": run_failed,
+        "error": run_error,
+        "agents_created": agents_created,
+        "agent_turns": agent_turns,
+        "ag2_channel_id": ag2_channel_id,
+        "ag2_close_reason": ag2_close_reason,
+        "structured_outputs": structured_outputs,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Main orchestration entry point
 # ---------------------------------------------------------------------------
@@ -1315,23 +1359,22 @@ async def run_workflow_orchestration(
         duration_sec = perf_counter() - start_time
         wf_logger.info("[EXECUTION_COMPLETE] Duration: %.2fs", duration_sec)
 
-        result_payload = {
-            "workflow_name": workflow_name,
-            "chat_id": chat_id,
-            "app_id": app_id,
-            "user_id": user_id,
-            "messages": None,
-            "max_turns_reached": False,
-            "response": None,
-            "run_completed": workflow_complete,
-            "awaiting_user_input": awaiting_user_input,
-            "run_status": "failed" if run_failed else workflow_status_value,
-            "failed": run_failed,
-            "error": run_error,
-            "ag2_channel_id": runner_result.channel_id,
-            "ag2_close_reason": runner_result.close_reason,
-            "structured_outputs": runner_result.structured_outputs,
-        }
+        result_payload = _assemble_result_payload(
+            workflow_name=workflow_name,
+            chat_id=chat_id,
+            app_id=app_id,
+            user_id=user_id,
+            workflow_complete=workflow_complete,
+            awaiting_user_input=awaiting_user_input,
+            run_failed=run_failed,
+            run_error=run_error,
+            workflow_status_value=workflow_status_value,
+            agents_created=len(agents),
+            agent_turns=sequence_counter,
+            ag2_channel_id=runner_result.channel_id,
+            ag2_close_reason=runner_result.close_reason,
+            structured_outputs=runner_result.structured_outputs,
+        )
 
     except Exception as e:
         logger.error("[%s] Orchestration failed: %s", workflow_name_upper, e, exc_info=True)

--- a/tests/test_cli_gen_loud_failures.py
+++ b/tests/test_cli_gen_loud_failures.py
@@ -1,0 +1,182 @@
+"""mozaiks gen must loudly fail on silent no-op generations (issue #379).
+
+A run that failed, paused for user input, or never executed a single agent
+turn used to print "Generation complete!" and exit 0. These tests pin the
+new contract: success requires a completed run with agent activity and files
+under the artifact root, and the artifact root env var points at the CLI
+output directory so the empty-output check inspects the directory tools
+actually write to.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from mozaiks_cli.commands.gen import _report_run_outcome, _setup_environment
+from mozaiksai.core.workflow.orchestration_patterns import _assemble_result_payload
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "run_completed": True,
+        "awaiting_user_input": False,
+        "failed": False,
+        "error": None,
+        "run_status": 1,
+        "agents_created": 5,
+        "agent_turns": 12,
+    }
+    base.update(overrides)
+    return base
+
+
+def _result(payload: dict[str, Any] | None) -> dict[str, Any]:
+    return {"success": True, "result": payload}
+
+
+def _write_artifact(output_dir: Path) -> None:
+    (output_dir / "workflows").mkdir(parents=True, exist_ok=True)
+    (output_dir / "workflows" / "orchestrator.yaml").write_text(
+        "workflow_name: X\n", encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _report_run_outcome
+# ---------------------------------------------------------------------------
+
+class TestReportRunOutcome:
+    def test_zero_agent_turns_fails_with_distinct_message(self, tmp_path, capsys):
+        _write_artifact(tmp_path)
+        rc = _report_run_outcome(_result(_payload(agent_turns=0)), tmp_path, "workflow")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "379" in out
+        assert "no agent" in out
+
+    def test_awaiting_user_input_fails_with_paused_message(self, tmp_path, capsys):
+        _write_artifact(tmp_path)
+        rc = _report_run_outcome(
+            _result(_payload(run_completed=False, awaiting_user_input=True)),
+            tmp_path,
+            "workflow",
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "paused" in out
+        assert "not a completed" in out
+
+    def test_failed_payload_fails(self, tmp_path, capsys):
+        _write_artifact(tmp_path)
+        rc = _report_run_outcome(
+            _result(_payload(run_completed=False, failed=True, error="boom")),
+            tmp_path,
+            "workflow",
+        )
+        assert rc == 1
+        assert "boom" in capsys.readouterr().out
+
+    def test_not_run_completed_fails(self, tmp_path, capsys):
+        _write_artifact(tmp_path)
+        rc = _report_run_outcome(
+            _result(_payload(run_completed=False, run_status=0)), tmp_path, "workflow"
+        )
+        assert rc == 1
+        assert "did not complete" in capsys.readouterr().out
+
+    def test_none_payload_fails_instead_of_succeeding(self, tmp_path):
+        _write_artifact(tmp_path)
+        assert _report_run_outcome(_result(None), tmp_path, "workflow") == 1
+
+    def test_exception_result_still_fails(self, tmp_path):
+        assert _report_run_outcome({"success": False, "error": "x"}, tmp_path, "workflow") == 1
+
+    def test_empty_output_dir_fails_with_artifact_root_message(self, tmp_path, capsys):
+        rc = _report_run_outcome(_result(_payload()), tmp_path, "workflow")
+        assert rc == 1
+        assert "artifact root" in capsys.readouterr().out
+
+    def test_completed_run_with_files_succeeds_and_prints_evidence(self, tmp_path, capsys):
+        _write_artifact(tmp_path)
+        rc = _report_run_outcome(_result(_payload()), tmp_path, "workflow")
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "agents=5" in out
+        assert "turns=12" in out
+
+    def test_legacy_payload_without_turn_evidence_still_succeeds(self, tmp_path):
+        payload = _payload()
+        payload.pop("agents_created")
+        payload.pop("agent_turns")
+        _write_artifact(tmp_path)
+        assert _report_run_outcome(_result(payload), tmp_path, "workflow") == 0
+
+
+# ---------------------------------------------------------------------------
+# _setup_environment
+# ---------------------------------------------------------------------------
+
+def test_setup_environment_points_artifact_root_at_output_dir(tmp_path, monkeypatch):
+    # Pre-seed via monkeypatch so originals are restored on teardown even
+    # though _setup_environment writes os.environ directly.
+    monkeypatch.setitem(os.environ, "MOZAIKS_WORKFLOWS_PATH", "sentinel")
+    monkeypatch.setitem(os.environ, "MOZAIKS_GENERATED_ARTIFACTS_PATH", "sentinel")
+
+    staging = tmp_path / "staging"
+    output = tmp_path / "generated"
+    _setup_environment(tmp_path, staging, output)
+
+    assert os.environ["MOZAIKS_WORKFLOWS_PATH"] == str(staging)
+    assert os.environ["MOZAIKS_GENERATED_ARTIFACTS_PATH"] == str(output)
+
+
+# ---------------------------------------------------------------------------
+# orchestration result payload evidence
+# ---------------------------------------------------------------------------
+
+def test_result_payload_carries_agent_evidence():
+    payload = _assemble_result_payload(
+        workflow_name="AgentGenerator",
+        chat_id="c1",
+        app_id="a1",
+        user_id="u1",
+        workflow_complete=True,
+        awaiting_user_input=False,
+        run_failed=False,
+        run_error=None,
+        workflow_status_value=1,
+        agents_created=7,
+        agent_turns=42,
+        ag2_channel_id="ch",
+        ag2_close_reason="done",
+        structured_outputs=None,
+    )
+    assert payload["agents_created"] == 7
+    assert payload["agent_turns"] == 42
+    assert payload["run_completed"] is True
+    assert payload["failed"] is False
+    assert payload["run_status"] == 1
+
+
+def test_result_payload_failed_run_status():
+    payload = _assemble_result_payload(
+        workflow_name="AgentGenerator",
+        chat_id="c1",
+        app_id="a1",
+        user_id=None,
+        workflow_complete=False,
+        awaiting_user_input=False,
+        run_failed=True,
+        run_error="agent blew up",
+        workflow_status_value=0,
+        agents_created=3,
+        agent_turns=0,
+        ag2_channel_id=None,
+        ag2_close_reason="error",
+        structured_outputs=None,
+    )
+    assert payload["run_status"] == "failed"
+    assert payload["failed"] is True
+    assert payload["error"] == "agent blew up"
+    assert payload["agent_turns"] == 0


### PR DESCRIPTION
Part of #379 — implements PR 1 of the fix plan from the observability audit (silent no-op generations reported success).

## Changes

1. **CLI logging init**: `mozaiks gen` now calls `setup_development_logging()` from `logs/logging_config.py`, so workflow-engine INFO records (the per-agent evidence) reach the operator and the file sinks exist. The rich `Progress` spinner is now `transient=True` so log lines print cleanly instead of being garbled/swallowed.
2. **Assert on the run result**: the CLI reads the orchestration `result` payload. `failed`/`error` → exit 1; `awaiting_user_input` → exit 1 with "Workflow paused waiting for a user reply — this is not a completed generation"; success requires `run_completed` truthy.
3. **Artifact root**: `_setup_environment` sets `MOZAIKS_GENERATED_ARTIFACTS_PATH` to the CLI output dir, so tools (`workflow_converter._resolve_generated_artifacts_root`) write where the #366 empty-output check looks. That check's misleading message ("middleware import failures are a common cause") now describes the real contract: no files were produced under the artifact root.
4. **Agent-turn evidence**: the orchestration result payload (extracted into `_assemble_result_payload`) now carries `agents_created` and `agent_turns`; the CLI prints `agents=N turns=M` and exits 1 on zero turns ("the silent no-op from issue #379").
5. **MONGO_URI preflight**: loud warning (not a hard fail — Mongo-less local generation is legitimate) that build records, artifacts, and usage events will not persist.

Follow-ups stay on #379: usage middleware mounting, tool-failure counters, dead agent-outputs banner, `gen app` semantics.

## Validation

- `ruff check .` — clean
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped` — clean (565 files)
- `pytest -q --no-cov` full suite: 13503 passed, 78 skipped, 1 failed — `tests/test_runtime_database_migrations.py::test_platform_startup_calls_migration_application_after_index_application` fails identically on a clean `origin/main` worktree in this environment (index/migration ordering assertion), pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)