### PR TITLE
feat(adapters): declarative adapter registry with load-time conformance

### DIFF
--- a/docs/architecture/foundations/adapter-registry.md
+++ b/docs/architecture/foundations/adapter-registry.md
@@ -1,0 +1,131 @@
+# Adapter Registry
+
+Status: **implemented mechanism.** `mozaiksai/core/adapters/registry.py` and the
+`config/adapters.yaml` contract described here are live and loaded at app
+startup. Provider ports and implementations are not shipped by this mechanism —
+see [Ports do not live here](#ports-do-not-live-here).
+
+## What this is
+
+A declarative way for an app to say which provider adapters it has, and a
+loader that **verifies each one satisfies the port it claims** before the app
+finishes starting.
+
+```yaml
+# app/config/adapters.yaml
+schema_version: mozaiks.adapters.v1
+areas:
+  dns:
+    port: app.services.adapters.dns.port:DnsProviderPort
+    active_env: DNS_ADAPTER      # optional; overrides `active` per deployment
+    active: cloudflare           # optional default
+    providers:
+      cloudflare: app.services.adapters.dns.cloudflare:CloudflareDnsAdapter
+      stub: app.services.adapters.dns.stub:StubDnsAdapter
+```
+
+At startup `AppLoader` resolves every declared reference, checks conformance,
+and exposes the result as `AppLoadResult.adapter_registry` — surfaced on the
+platform host as `app.state.adapter_registry`. An app with no
+`config/adapters.yaml` gets `None` and is entirely unaffected.
+
+## Ports do not live here
+
+This module defines **no ports and knows no providers**. Both the port and the
+implementation are named by import reference, so they may live in the app
+bundle, in a capability pack, or in a hosted product. The runtime never needs
+to know which.
+
+That is deliberate, and it is a correction of a pattern that did not work. A
+port the OSS runtime does not call through does not belong in OSS: it becomes
+an orphaned published type that commits the project to an API with no consumer
+and no verification. The test for whether a port belongs in `mozaiksai/core/ports/`
+is simply **does OSS runtime code call through it** — `EntitlementPort` is
+checked at module dispatch, `OrchestrationPort` drives workflow execution, so
+both qualify. A DNS or SSL port has no OSS caller and belongs beside whatever
+consumes it.
+
+This loader is what makes that placement possible without giving up load-time
+verification.
+
+## Conformance is the point
+
+"Adapters are modular" is a weak property; anything with a dict of callables is
+modular. The property worth having is that **a declared adapter is verified
+against its contract at load time**.
+
+Conformance is checked by member presence, reading `__protocol_attrs__` when
+the port is a `Protocol`. Attribute presence is used rather than `issubclass`
+because `runtime_checkable` protocols only support `issubclass` for method-only
+protocols, and its failure mode is an opaque `TypeError` instead of a message
+naming the missing method. The registry instead reports:
+
+```
+adapters.yaml area 'dns' provider 'partial': <class 'PartialAdapter'> does not
+satisfy 'DnsProviderPort' — missing delete_record
+```
+
+**Every declared provider is verified, not only the active one.** A declaration
+that cannot be satisfied is a defect regardless of which provider happens to be
+switched on today, and finding it at startup is the entire purpose.
+
+## Fail-closed, deliberately
+
+Unlike `subscriptions.yaml` — which degrades to a warning and disables
+entitlement enforcement — a broken adapter declaration **raises and stops
+startup**.
+
+An adapter that cannot be imported, or that does not satisfy its port, will
+fail at the moment of use. Surfacing it at startup with a precise message is
+strictly better than an `AttributeError` in production, and degrading silently
+here would reproduce exactly the swallowed-import failure mode this mechanism
+exists to prevent.
+
+## Declaration versus runtime config
+
+The declaration answers *what implementations exist*. Runtime config answers
+*which one is on*.
+
+`active_env` names an environment variable that, when set and non-empty, wins
+over `active`. An operator can therefore switch providers per deployment
+without editing the contract. Conditional logic does **not** belong in the
+YAML — putting it there would make the declaration non-statically-checkable and
+forfeit the main benefit.
+
+An `active_env` value naming an undeclared provider fails closed rather than
+silently selecting nothing, so an operator typo is loud.
+
+## Why this scales
+
+Adding a provider is **adding a directory**. A capability pack ships the
+adapter template plus a contract fragment declaring its area, provider id, and
+port; nothing else changes:
+
+- AppGenerator selects it through existing `selection_rules` — no prompt change
+- the Jinja resolver renders it — no generator change
+- this loader resolves and verifies it — no registry change
+- Studio `/integrations` renders its credential form from the pack's
+  `required_integrations` — no UI change
+
+The generator's prompt surface does not grow with provider count. AppGenerator
+never learns "Cloudflare"; it learns "select a dns pack". A hundred providers
+cost what three cost.
+
+## Known trade-off: fix propagation
+
+Packs render adapter code **into** each app bundle, so every generated app
+carries its own copy. A bug fix in a provider adapter does **not** propagate on
+its own — it is a pack version bump plus a refinement pass per app.
+
+This is consistent with the workspace model (self-contained, portable,
+provider-neutral bundles) and the provenance manifest already records which
+pack version an app received. It is recorded here as a deliberate choice rather
+than an emergent one: the alternative — adapters as a runtime dependency apps
+import — propagates fixes instantly but couples every app to the framework for
+provider mechanics and undercuts portability.
+
+## Cross references
+
+- [Public Architecture And OSS Boundary](public-architecture-and-oss-boundary.md)
+- [OSS Boundary Family Registry](oss-boundary-families.md)
+- [Distribution And Workspace Model](distribution-and-workspace-model.md)

--- a/mozaiksai/core/adapters/registry.py
+++ b/mozaiksai/core/adapters/registry.py
@@ -1,0 +1,399 @@
+# ==============================================================================
+# FILE: mozaiksai/core/adapters/registry.py
+# DESCRIPTION: Declarative adapter registry — resolves provider adapters named
+#              in app/config/adapters.yaml and verifies each one satisfies the
+#              port it claims to implement.
+#
+#              This module is a MECHANISM only. It defines no ports and knows
+#              no providers. Both the port and the implementation are named by
+#              import reference in the app's own config, so they may live in the
+#              app bundle, in a capability pack, or in a hosted product — the
+#              runtime never needs to know which.
+#
+#              That separation is deliberate. A port the OSS runtime does not
+#              call through does not belong in OSS; it belongs beside whatever
+#              consumes it. This loader is what makes that possible without
+#              giving up load-time verification.
+# ==============================================================================
+"""Declarative, conformance-checked adapter resolution."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_CONFIG_PATH = "config/adapters.yaml"
+_SCHEMA_VERSION = "mozaiks.adapters.v1"
+
+_AREA_KEYS = {"port", "providers", "active", "active_env"}
+_ROOT_KEYS = {"schema_version", "areas"}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class AdapterConfigError(ValueError):
+    """adapters.yaml is missing required structure or declares unknown keys."""
+
+
+class AdapterResolutionError(LookupError):
+    """A declared import reference could not be resolved."""
+
+
+class AdapterConformanceError(TypeError):
+    """A resolved adapter does not satisfy the port it is declared against."""
+
+
+class UnknownAdapterError(LookupError):
+    """A lookup named an area or provider that is not registered."""
+
+
+# ---------------------------------------------------------------------------
+# Reference resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_reference(reference: str, *, what: str) -> Any:
+    """Import ``module:symbol`` (or a bare module) and return the object.
+
+    Raises:
+        AdapterResolutionError: with the failing reference named, so an
+            operator can act on the message without reading a traceback.
+    """
+    ref = str(reference or "").strip()
+    if not ref:
+        raise AdapterResolutionError(f"{what}: empty import reference")
+
+    module_name, _, symbol = ref.partition(":")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise AdapterResolutionError(
+            f"{what}: cannot import module {module_name!r} from reference {ref!r} -> {exc}"
+        ) from exc
+
+    if not symbol:
+        return module
+    try:
+        return getattr(module, symbol)
+    except AttributeError as exc:
+        raise AdapterResolutionError(
+            f"{what}: module {module_name!r} has no attribute {symbol!r}"
+        ) from exc
+
+
+def _port_members(port: Any) -> tuple[str, ...]:
+    """Public method names a port requires.
+
+    Read from ``__protocol_attrs__`` when the port is a ``Protocol``; otherwise
+    fall back to public callables declared on the class. Attribute presence is
+    checked rather than ``issubclass`` because ``runtime_checkable`` protocols
+    only support ``issubclass`` for method-only protocols, and the failure mode
+    is an opaque TypeError rather than a message naming the missing method.
+    """
+    declared = getattr(port, "__protocol_attrs__", None)
+    if declared:
+        return tuple(sorted(str(name) for name in declared))
+    return tuple(
+        sorted(
+            name
+            for name, value in vars(port).items()
+            if not name.startswith("_") and callable(value)
+        )
+    )
+
+
+def _assert_conformance(adapter: Any, port: Any, *, area: str, provider_id: str) -> None:
+    required = _port_members(port)
+    if not required:
+        raise AdapterConformanceError(
+            f"adapters.yaml area {area!r}: port {port!r} declares no members to verify; "
+            "it cannot be used as a conformance contract"
+        )
+    missing = [name for name in required if not hasattr(adapter, name)]
+    if missing:
+        raise AdapterConformanceError(
+            f"adapters.yaml area {area!r} provider {provider_id!r}: "
+            f"{adapter!r} does not satisfy {getattr(port, '__name__', port)!r} — "
+            f"missing {', '.join(missing)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdapterAreaConfig:
+    """One capability area and the providers declared for it."""
+
+    area: str
+    port_ref: str
+    providers: dict[str, str]
+    active: str | None = None
+    active_env: str | None = None
+
+    def active_provider_id(self, env: dict[str, str] | None = None) -> str | None:
+        """Resolve which provider is active.
+
+        ``active_env`` wins when set and non-empty, so an operator can switch
+        providers per deployment without editing the declaration. The
+        declaration answers *what exists*; runtime config answers *what is on*.
+        """
+        source = os.environ if env is None else env
+        if self.active_env:
+            from_env = str(source.get(self.active_env, "") or "").strip()
+            if from_env:
+                return from_env
+        return self.active
+
+
+@dataclass(frozen=True)
+class AdaptersConfig:
+    areas: dict[str, AdapterAreaConfig] = field(default_factory=dict)
+
+
+def _parse_area(area: str, raw: Any) -> AdapterAreaConfig:
+    if not isinstance(raw, dict):
+        raise AdapterConfigError(f"adapters.yaml area {area!r} must be a mapping")
+
+    unknown = set(raw) - _AREA_KEYS
+    if unknown:
+        raise AdapterConfigError(
+            f"adapters.yaml area {area!r} declares unknown key(s): {sorted(unknown)}. "
+            f"Allowed: {sorted(_AREA_KEYS)}"
+        )
+
+    port_ref = str(raw.get("port") or "").strip()
+    if not port_ref:
+        raise AdapterConfigError(f"adapters.yaml area {area!r} must declare 'port'")
+
+    providers_raw = raw.get("providers")
+    if not isinstance(providers_raw, dict) or not providers_raw:
+        raise AdapterConfigError(
+            f"adapters.yaml area {area!r} must declare a non-empty 'providers' mapping"
+        )
+
+    providers: dict[str, str] = {}
+    for provider_id, ref in providers_raw.items():
+        pid = str(provider_id or "").strip()
+        if not pid:
+            raise AdapterConfigError(f"adapters.yaml area {area!r} has an empty provider id")
+        if not str(ref or "").strip():
+            raise AdapterConfigError(
+                f"adapters.yaml area {area!r} provider {pid!r} has an empty reference"
+            )
+        providers[pid] = str(ref).strip()
+
+    active = raw.get("active")
+    active = str(active).strip() if active is not None else None
+    if active and active not in providers:
+        raise AdapterConfigError(
+            f"adapters.yaml area {area!r} declares active provider {active!r}, "
+            f"which is not in providers: {sorted(providers)}"
+        )
+
+    active_env = raw.get("active_env")
+    active_env = str(active_env).strip() if active_env is not None else None
+
+    return AdapterAreaConfig(
+        area=area,
+        port_ref=port_ref,
+        providers=providers,
+        active=active or None,
+        active_env=active_env or None,
+    )
+
+
+def parse_adapters_config(raw: Any) -> AdaptersConfig:
+    """Validate a parsed adapters.yaml document."""
+    if not isinstance(raw, dict):
+        raise AdapterConfigError("adapters.yaml must be a mapping")
+
+    unknown = set(raw) - _ROOT_KEYS
+    if unknown:
+        raise AdapterConfigError(
+            f"adapters.yaml declares unknown top-level key(s): {sorted(unknown)}. "
+            f"Allowed: {sorted(_ROOT_KEYS)}"
+        )
+
+    version = str(raw.get("schema_version") or "").strip()
+    if version != _SCHEMA_VERSION:
+        raise AdapterConfigError(
+            f"adapters.yaml schema_version must be {_SCHEMA_VERSION!r}, got {version!r}"
+        )
+
+    areas_raw = raw.get("areas")
+    if not isinstance(areas_raw, dict) or not areas_raw:
+        raise AdapterConfigError("adapters.yaml must declare a non-empty 'areas' mapping")
+
+    areas = {
+        str(area).strip(): _parse_area(str(area).strip(), body)
+        for area, body in areas_raw.items()
+    }
+    return AdaptersConfig(areas=areas)
+
+
+def load_adapters_config(app_root: Path) -> AdaptersConfig | None:
+    """Load ``app/config/adapters.yaml``.
+
+    Returns:
+        Parsed config, or None when the file does not exist — apps that declare
+        no adapters are unaffected.
+
+    Raises:
+        AdapterConfigError: when the file exists but is invalid.
+    """
+    path = Path(app_root) / _CONFIG_PATH
+    if not path.exists():
+        return None
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise AdapterConfigError(f"adapters.yaml is not valid YAML: {exc}") from exc
+    return parse_adapters_config(raw)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegisteredAdapter:
+    area: str
+    provider_id: str
+    reference: str
+    adapter: Any
+    port: Any
+
+
+class AdapterRegistry:
+    """Resolved adapters keyed by ``(area, provider_id)``.
+
+    Construction is the verification step: every declared reference is imported
+    and checked against its port before the registry exists. A registry that
+    was built successfully contains only conforming adapters.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, str], RegisteredAdapter] = {}
+        self._active: dict[str, str] = {}
+
+    def register(self, entry: RegisteredAdapter, *, active: bool = False) -> None:
+        self._entries[(entry.area, entry.provider_id)] = entry
+        if active:
+            self._active[entry.area] = entry.provider_id
+
+    def get(self, area: str, provider_id: str) -> Any:
+        try:
+            return self._entries[(area, provider_id)].adapter
+        except KeyError:
+            known = sorted(pid for a, pid in self._entries if a == area)
+            raise UnknownAdapterError(
+                f"no adapter registered for area {area!r} provider {provider_id!r}. "
+                f"Registered for this area: {known or 'none'}"
+            ) from None
+
+    def active(self, area: str) -> Any:
+        provider_id = self._active.get(area)
+        if provider_id is None:
+            raise UnknownAdapterError(
+                f"area {area!r} has no active provider. Set 'active' or its "
+                f"'active_env' variable in adapters.yaml."
+            )
+        return self.get(area, provider_id)
+
+    def active_provider_id(self, area: str) -> str | None:
+        return self._active.get(area)
+
+    def areas(self) -> tuple[str, ...]:
+        return tuple(sorted({area for area, _ in self._entries}))
+
+    def providers(self, area: str) -> tuple[str, ...]:
+        return tuple(sorted(pid for a, pid in self._entries if a == area))
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def build_adapter_registry(
+    config: AdaptersConfig,
+    *,
+    env: dict[str, str] | None = None,
+) -> AdapterRegistry:
+    """Resolve and verify every adapter declared in *config*.
+
+    Every declared provider is imported and conformance-checked, not just the
+    active one — a declaration that cannot be satisfied is a defect regardless
+    of which provider happens to be switched on today, and finding it at
+    startup is the entire point.
+
+    Raises:
+        AdapterResolutionError: a port or provider reference does not resolve.
+        AdapterConformanceError: a provider does not satisfy its declared port.
+    """
+    registry = AdapterRegistry()
+    for area, area_config in sorted(config.areas.items()):
+        port = _resolve_reference(
+            area_config.port_ref, what=f"adapters.yaml area {area!r} port"
+        )
+        active_id = area_config.active_provider_id(env)
+        if active_id and active_id not in area_config.providers:
+            raise AdapterConfigError(
+                f"adapters.yaml area {area!r}: active provider {active_id!r} is not "
+                f"declared. Available: {sorted(area_config.providers)}"
+            )
+        for provider_id, reference in sorted(area_config.providers.items()):
+            adapter = _resolve_reference(
+                reference,
+                what=f"adapters.yaml area {area!r} provider {provider_id!r}",
+            )
+            _assert_conformance(adapter, port, area=area, provider_id=provider_id)
+            registry.register(
+                RegisteredAdapter(
+                    area=area,
+                    provider_id=provider_id,
+                    reference=reference,
+                    adapter=adapter,
+                    port=port,
+                ),
+                active=(provider_id == active_id),
+            )
+    return registry
+
+
+def load_adapter_registry(
+    app_root: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> AdapterRegistry | None:
+    """Load and verify adapters.yaml for *app_root*, or None when absent."""
+    config = load_adapters_config(app_root)
+    if config is None:
+        return None
+    return build_adapter_registry(config, env=env)
+
+
+__all__ = [
+    "AdapterAreaConfig",
+    "AdapterConfigError",
+    "AdapterConformanceError",
+    "AdapterRegistry",
+    "AdapterResolutionError",
+    "AdaptersConfig",
+    "RegisteredAdapter",
+    "UnknownAdapterError",
+    "build_adapter_registry",
+    "load_adapter_registry",
+    "load_adapters_config",
+    "parse_adapters_config",
+]

--- a/mozaiksai/core/runtime/app/loader.py
+++ b/mozaiksai/core/runtime/app/loader.py
@@ -27,6 +27,10 @@ from typing import Any
 from pydantic import ValidationError
 
 from logs.logging_config import get_workflow_logger
+from mozaiksai.core.adapters.registry import (
+    AdapterRegistry,
+    load_adapter_registry,
+)
 from mozaiksai.core.runtime.app.definition import AppDefinition
 from mozaiksai.core.runtime.app.module_loader import LoadedModule, ModuleLoader
 from mozaiksai.core.runtime.app.page_schema import (
@@ -71,6 +75,8 @@ class AppLoadResult:
         data_contract:        Parsed data contract, or None
         data_entities_by_key: Data entities indexed by (module_id, entity_name)
         subscriptions_config: Parsed subscriptions config, or None for non-SaaS apps
+        adapter_registry:     Verified provider adapters, or None when the app
+                              declares no config/adapters.yaml
         provenance:           Parsed app provenance, or None when not declared
         page_schemas:         Validated declarative page schemas indexed by page name
         failed_module_names:  Names of modules that failed to load — empty on full success
@@ -80,6 +86,7 @@ class AppLoadResult:
     data_contract: dict[str, Any] | None = None
     data_entities_by_key: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
     subscriptions_config: SubscriptionsConfig | None = None
+    adapter_registry: AdapterRegistry | None = None
     provenance: AppProvenance | None = None
     page_schemas: dict[str, AppPageSchema] = field(default_factory=dict)
     failed_module_names: list[str] = field(default_factory=list)
@@ -164,6 +171,23 @@ class AppLoader:
             logger.warning(
                 "SUBSCRIPTIONS_CONFIG_INVALID: %s — entitlement enforcement disabled", exc)
 
+        # Adapter resolution deliberately does NOT degrade the way subscriptions
+        # does. A declared adapter that cannot be imported, or that does not
+        # satisfy its port, is a deployment defect that will fail at the moment
+        # of use — surfacing it at startup with a precise message is the entire
+        # purpose of declaring adapters. Apps without config/adapters.yaml get
+        # None and are unaffected.
+        adapter_registry = load_adapter_registry(base_path)
+        if adapter_registry is not None:
+            logger.info(
+                "ADAPTERS_LOADED: %s area(s) — %s",
+                len(adapter_registry.areas()),
+                ", ".join(
+                    f"{area}={adapter_registry.active_provider_id(area) or 'no-active'}"
+                    for area in adapter_registry.areas()
+                ),
+            )
+
         logger.info(
             "APP_LOADED: name=%s version=%s mode=%s workflows=%s modules=%s",
             app_def.name, app_def.version, app_def.execution_mode.value,
@@ -208,6 +232,7 @@ class AppLoader:
             data_contract=data_contract,
             data_entities_by_key=data_entities_by_key,
             subscriptions_config=subscriptions_config,
+            adapter_registry=adapter_registry,
             provenance=provenance,
             page_schemas=page_schemas,
             failed_module_names=failed_module_names,

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -371,6 +371,9 @@ async def _platform_startup() -> None:
             module_event_router.register(dispatcher)
             app.state.module_event_router = module_event_router
 
+            # Verified at load time; None when the app declares no adapters.
+            app.state.adapter_registry = load_result.adapter_registry
+
             entitlement_checker: EntitlementPort | None = None
             if load_result.subscriptions_config is not None:
                 entitlement_checker = _load_entitlement_adapter(

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -1,0 +1,325 @@
+"""Declarative adapter registry — resolution, conformance, and fail-closed behavior.
+
+The registry exists so that "adapters are modular" becomes "adapters are
+verified against their contract at load time". These tests are therefore
+mostly about the failure modes: a reference that does not import, and an
+implementation that does not satisfy the port it claims.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import pytest
+
+from mozaiksai.core.adapters.registry import (
+    AdapterConfigError,
+    AdapterConformanceError,
+    AdapterResolutionError,
+    UnknownAdapterError,
+    build_adapter_registry,
+    load_adapter_registry,
+    load_adapters_config,
+    parse_adapters_config,
+)
+
+# ── fixtures used as resolution targets ───────────────────────────────────────
+
+
+@runtime_checkable
+class SampleDnsPort(Protocol):
+    """Method-only protocol standing in for a real provider port."""
+
+    async def create_record(self, zone: str, name: str, value: str) -> dict: ...
+
+    async def delete_record(self, zone: str, record_id: str) -> dict: ...
+
+
+class ConformingAdapter:
+    async def create_record(self, zone: str, name: str, value: str) -> dict:
+        return {"status": "created"}
+
+    async def delete_record(self, zone: str, record_id: str) -> dict:
+        return {"status": "deleted"}
+
+
+class PartialAdapter:
+    """Implements only half the port — the realistic drift case."""
+
+    async def create_record(self, zone: str, name: str, value: str) -> dict:
+        return {"status": "created"}
+
+
+_THIS = "tests.test_adapter_registry"
+
+
+def _config(**overrides) -> dict:
+    body = {
+        "port": f"{_THIS}:SampleDnsPort",
+        "providers": {"good": f"{_THIS}:ConformingAdapter"},
+    }
+    body.update(overrides)
+    return {"schema_version": "mozaiks.adapters.v1", "areas": {"dns": body}}
+
+
+# ── happy path ────────────────────────────────────────────────────────────────
+
+
+def test_conforming_adapter_registers() -> None:
+    registry = build_adapter_registry(parse_adapters_config(_config()))
+    assert registry.areas() == ("dns",)
+    assert registry.providers("dns") == ("good",)
+    assert registry.get("dns", "good") is ConformingAdapter
+
+
+def test_active_provider_resolves() -> None:
+    registry = build_adapter_registry(parse_adapters_config(_config(active="good")))
+    assert registry.active("dns") is ConformingAdapter
+    assert registry.active_provider_id("dns") == "good"
+
+
+def test_active_env_overrides_declared_active() -> None:
+    cfg = _config(
+        providers={
+            "good": f"{_THIS}:ConformingAdapter",
+            "other": f"{_THIS}:ConformingAdapter",
+        },
+        active="good",
+        active_env="DNS_ADAPTER",
+    )
+    registry = build_adapter_registry(
+        parse_adapters_config(cfg), env={"DNS_ADAPTER": "other"}
+    )
+    assert registry.active_provider_id("dns") == "other"
+
+
+def test_empty_active_env_falls_back_to_declared_active() -> None:
+    cfg = _config(active="good", active_env="DNS_ADAPTER")
+    registry = build_adapter_registry(parse_adapters_config(cfg), env={"DNS_ADAPTER": ""})
+    assert registry.active_provider_id("dns") == "good"
+
+
+# ── conformance: the reason this exists ───────────────────────────────────────
+
+
+def test_partial_implementation_is_rejected_naming_the_missing_member() -> None:
+    cfg = _config(providers={"partial": f"{_THIS}:PartialAdapter"})
+    with pytest.raises(AdapterConformanceError) as exc:
+        build_adapter_registry(parse_adapters_config(cfg))
+    message = str(exc.value)
+    assert "delete_record" in message, "the error must name what is missing"
+    assert "partial" in message and "dns" in message
+
+
+def test_every_declared_provider_is_verified_not_only_the_active_one() -> None:
+    """A broken inactive provider is still a defect, and must fail at startup."""
+    cfg = _config(
+        providers={
+            "good": f"{_THIS}:ConformingAdapter",
+            "partial": f"{_THIS}:PartialAdapter",
+        },
+        active="good",
+    )
+    with pytest.raises(AdapterConformanceError):
+        build_adapter_registry(parse_adapters_config(cfg))
+
+
+def test_unrelated_object_is_rejected() -> None:
+    cfg = _config(providers={"nonsense": f"{_THIS}:_config"})
+    with pytest.raises(AdapterConformanceError):
+        build_adapter_registry(parse_adapters_config(cfg))
+
+
+# ── resolution failures ───────────────────────────────────────────────────────
+
+
+def test_missing_module_fails_closed_naming_the_reference() -> None:
+    cfg = _config(providers={"ghost": "mozaiksai.does.not.exist:Thing"})
+    with pytest.raises(AdapterResolutionError) as exc:
+        build_adapter_registry(parse_adapters_config(cfg))
+    assert "mozaiksai.does.not.exist" in str(exc.value)
+
+
+def test_missing_symbol_fails_closed() -> None:
+    cfg = _config(providers={"ghost": f"{_THIS}:NoSuchAdapter"})
+    with pytest.raises(AdapterResolutionError) as exc:
+        build_adapter_registry(parse_adapters_config(cfg))
+    assert "NoSuchAdapter" in str(exc.value)
+
+
+def test_unresolvable_port_fails_closed() -> None:
+    cfg = _config(port="mozaiksai.nope:Port")
+    with pytest.raises(AdapterResolutionError):
+        build_adapter_registry(parse_adapters_config(cfg))
+
+
+# ── schema validation ─────────────────────────────────────────────────────────
+
+
+def test_unknown_root_key_is_rejected() -> None:
+    raw = _config()
+    raw["extra"] = True
+    with pytest.raises(AdapterConfigError, match="unknown top-level key"):
+        parse_adapters_config(raw)
+
+
+def test_unknown_area_key_is_rejected() -> None:
+    raw = _config(typo_key="oops")
+    with pytest.raises(AdapterConfigError, match="unknown key"):
+        parse_adapters_config(raw)
+
+
+def test_wrong_schema_version_is_rejected() -> None:
+    raw = _config()
+    raw["schema_version"] = "mozaiks.adapters.v0"
+    with pytest.raises(AdapterConfigError, match="schema_version"):
+        parse_adapters_config(raw)
+
+
+def test_area_without_port_is_rejected() -> None:
+    raw = {"schema_version": "mozaiks.adapters.v1",
+           "areas": {"dns": {"providers": {"good": f"{_THIS}:ConformingAdapter"}}}}
+    with pytest.raises(AdapterConfigError, match="must declare 'port'"):
+        parse_adapters_config(raw)
+
+
+def test_area_without_providers_is_rejected() -> None:
+    raw = {"schema_version": "mozaiks.adapters.v1",
+           "areas": {"dns": {"port": f"{_THIS}:SampleDnsPort", "providers": {}}}}
+    with pytest.raises(AdapterConfigError, match="non-empty 'providers'"):
+        parse_adapters_config(raw)
+
+
+def test_active_naming_an_undeclared_provider_is_rejected() -> None:
+    with pytest.raises(AdapterConfigError, match="not in providers"):
+        parse_adapters_config(_config(active="nonexistent"))
+
+
+def test_active_env_naming_an_undeclared_provider_fails_closed() -> None:
+    """Operator typo in an env var must fail loudly, not silently pick nothing."""
+    cfg = _config(active="good", active_env="DNS_ADAPTER")
+    with pytest.raises(AdapterConfigError, match="not declared"):
+        build_adapter_registry(parse_adapters_config(cfg), env={"DNS_ADAPTER": "typo"})
+
+
+# ── lookup behavior ───────────────────────────────────────────────────────────
+
+
+def test_unknown_lookup_lists_what_is_registered() -> None:
+    registry = build_adapter_registry(parse_adapters_config(_config()))
+    with pytest.raises(UnknownAdapterError) as exc:
+        registry.get("dns", "missing")
+    assert "good" in str(exc.value), "the error should tell the caller what exists"
+
+
+def test_area_without_active_provider_raises() -> None:
+    registry = build_adapter_registry(parse_adapters_config(_config()))
+    with pytest.raises(UnknownAdapterError, match="no active provider"):
+        registry.active("dns")
+
+
+# ── file loading ──────────────────────────────────────────────────────────────
+
+
+def test_absent_file_returns_none(tmp_path: Path) -> None:
+    assert load_adapter_registry(tmp_path) is None
+
+
+def test_loads_from_disk(tmp_path: Path) -> None:
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "adapters.yaml").write_text(
+        textwrap.dedent(
+            f"""
+            schema_version: mozaiks.adapters.v1
+            areas:
+              dns:
+                port: {_THIS}:SampleDnsPort
+                active: good
+                providers:
+                  good: {_THIS}:ConformingAdapter
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    registry = load_adapter_registry(tmp_path)
+    assert registry is not None
+    assert registry.active("dns") is ConformingAdapter
+
+
+def test_malformed_yaml_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "adapters.yaml").write_text("areas: [unclosed\n", encoding="utf-8")
+    with pytest.raises(AdapterConfigError, match="not valid YAML"):
+        load_adapters_config(tmp_path)
+
+
+# ── AppLoader integration: the registry must actually be reachable ────────────
+
+
+def _write_minimal_app(root: Path, adapters_yaml: str | None) -> None:
+    (root / "app.json").write_text('{"appName": "Adapter Test App"}', encoding="utf-8")
+    if adapters_yaml is not None:
+        (root / "config").mkdir(exist_ok=True)
+        (root / "config" / "adapters.yaml").write_text(adapters_yaml, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_app_loader_exposes_a_verified_registry(tmp_path: Path) -> None:
+    """A declared adapter is resolvable from the load result, not just parseable."""
+    from mozaiksai.core.runtime.app.loader import AppLoader
+
+    _write_minimal_app(
+        tmp_path,
+        textwrap.dedent(
+            f"""
+            schema_version: mozaiks.adapters.v1
+            areas:
+              dns:
+                port: {_THIS}:SampleDnsPort
+                active: good
+                providers:
+                  good: {_THIS}:ConformingAdapter
+            """
+        ).strip(),
+    )
+    result = await AppLoader.load(str(tmp_path))
+    assert result.adapter_registry is not None
+    assert result.adapter_registry.active("dns") is ConformingAdapter
+
+
+@pytest.mark.asyncio
+async def test_app_without_adapters_is_unaffected(tmp_path: Path) -> None:
+    """No adapters.yaml means no registry and no behavior change."""
+    from mozaiksai.core.runtime.app.loader import AppLoader
+
+    _write_minimal_app(tmp_path, None)
+    result = await AppLoader.load(str(tmp_path))
+    assert result.adapter_registry is None
+
+
+@pytest.mark.asyncio
+async def test_nonconforming_adapter_fails_app_startup(tmp_path: Path) -> None:
+    """A broken declaration must surface at startup, not at first use.
+
+    This is the opposite of the subscriptions loader, which degrades to a
+    warning. Silently continuing here would reproduce the swallowed-import
+    failure mode this mechanism exists to prevent.
+    """
+    from mozaiksai.core.runtime.app.loader import AppLoader
+
+    _write_minimal_app(
+        tmp_path,
+        textwrap.dedent(
+            f"""
+            schema_version: mozaiks.adapters.v1
+            areas:
+              dns:
+                port: {_THIS}:SampleDnsPort
+                providers:
+                  partial: {_THIS}:PartialAdapter
+            """
+        ).strip(),
+    )
+    with pytest.raises(AdapterConformanceError, match="delete_record"):
+        await AppLoader.load(str(tmp_path))


### PR DESCRIPTION
First vertical slice of the modular-adapter work: the **mechanism**, proven end to end and actually wired in. Ports and providers come next, on top of this.

## What it does

An app declares its adapters, and the loader verifies each one satisfies the port it claims **before startup completes**:

```yaml
# app/config/adapters.yaml
schema_version: mozaiks.adapters.v1
areas:
  dns:
    port: app.services.adapters.dns.port:DnsProviderPort
    active_env: DNS_ADAPTER
    providers:
      cloudflare: app.services.adapters.dns.cloudflare:CloudflareDnsAdapter
      stub: app.services.adapters.dns.stub:StubDnsAdapter
```

Exposed as `AppLoadResult.adapter_registry` and `app.state.adapter_registry`. **Apps with no `config/adapters.yaml` get `None` and are entirely unaffected — zero regression surface.**

## The design decision worth reviewing

**This module defines no ports and knows no providers.** Port *and* implementation are both named by import reference, so they can live in the app bundle, a capability pack, or a hosted product.

That is a deliberate correction. `mozaiksai/core/ports/ssl_provider.py` currently has **zero OSS consumers** — not exported from `ports/__init__.py`, imported by hosted code only as `# noqa: F401` decoration, conformance never checked by anything. It is an orphaned published type that commits us to an API after 1.0 for no benefit. (`ports/artifact_store.py` is in the same state, and is additionally duplicated by `core/artifacts/store.py`, which is what every real consumer imports.)

The test for whether a port belongs in OSS is **does OSS runtime code call through it** — `EntitlementPort` is checked at module dispatch, `OrchestrationPort` drives execution, so both qualify. DNS/SSL ports have no OSS caller. This loader lets those ports live beside their consumers *without* giving up load-time verification, which is what made putting them in OSS tempting in the first place.

## Conformance, and why not `issubclass`

`runtime_checkable` protocols only support `issubclass` for method-only protocols, and the failure is an opaque `TypeError`. Member presence via `__protocol_attrs__` instead yields:

```
adapters.yaml area 'dns' provider 'partial': <class 'PartialAdapter'> does not
satisfy 'DnsProviderPort' — missing delete_record
```

**Every declared provider is verified, not just the active one** — a declaration that cannot be satisfied is a defect regardless of which provider is switched on today.

## Fail-closed, unlike subscriptions

`subscriptions.yaml` degrades to a warning and disables enforcement. A broken adapter declaration **raises and stops startup** instead. An unresolvable adapter will fail at first use anyway; degrading silently here would reproduce precisely the swallowed-import failure mode this mechanism exists to prevent.

## Tests — 25, failure-mode weighted

Partial implementation rejected naming the missing member; inactive-but-broken provider still rejected; unrelated object rejected; missing module/symbol/port fail closed naming the reference; unknown root and area keys rejected; wrong schema version rejected; `active` and `active_env` naming undeclared providers fail closed; unknown lookup lists what *is* registered. Plus three `AppLoader` integration tests proving the registry is genuinely reachable — including that a nonconforming adapter fails app startup, and that an app without the file is unaffected.

## Validation

- `ruff check .` clean
- Full suite: **13,559 passed**, 78 skipped
- The single failure in that run (`test_platform_startup_calls_migration_application_after_index_application`) reproduces identically on clean `origin/main` and is **not** caused by this change. Root cause found: that test depends on an untracked `.env`, so it fails in any git worktree and passes in the main checkout. Not a main regression — a test-environment contract gap, noted below.

## Follow-ups this enables (not in this PR)

1. Delete the orphaned `ports/ssl_provider.py`; reconcile the duplicate `ArtifactStore`.
2. A DNS pack shipping port + adapter templates + `required_integrations`.
3. A pack conformance test across `build_context/`.
4. `mozaiks pack new` scaffolder and an `add-adapter` skill — the "make it easy" layer, which is skill/CLI work rather than a workflow.
5. Declare `.env`-dependent tests' prerequisites, so worktree runs stop producing false failures.

## Impact
| | |
|---|---|
| Layer | Universal substrate (`mozaiksai/core/adapters`) + app loader + platform host |
| App workspace impact | New optional `app/config/adapters.yaml`; absent = unchanged behavior |
| Compatibility risk | None — additive, no existing app declares adapters |
| Docs | `docs/architecture/foundations/adapter-registry.md` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)