### PR TITLE
test(studio): use a canonical three-app demo fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Changed
 
+- **Factory Studio demo mode now uses a three-app canonical fleet**: the six
+  disconnected pseudo-app records were replaced by three accepted archetypes
+  (authenticated CRUD, admin operations, and monetized AI SaaS). Usage,
+  billing, deployment, users, activity, integrations, workflows, runs,
+  sessions, and artifact history now stay closed over the same three app IDs,
+  with current passing bundles and healthy deployed states for meaningful
+  cross-portal testing.
 - **AppWorkbench leads with the app, speaks the user's language**: the
   file-tree/editor/preview grid now renders directly under the status strip
   (previously it sat below the review and refinement panels), build logs

--- a/docs/guides/studio/canonical-demo-fleet.md
+++ b/docs/guides/studio/canonical-demo-fleet.md
@@ -1,0 +1,23 @@
+# Canonical Studio demo fleet
+
+Factory Studio mock mode uses three reference apps. The fleet is intentionally
+small so every workspace and app-admin surface can exercise the same identities
+instead of accumulating unrelated placeholder rows.
+
+| App | Canonical archetype | Primary portal coverage |
+| --- | --- | --- |
+| Campaign Revision Workbench | `authenticated_crud_projects` | overview, branding, access, settings, support |
+| Partner Delivery Studio | `admin_operations_dashboard` | building, launch, integrations, governance |
+| Member Growth Studio | `monetized_saas_reports` | billing, usage, access, activity |
+
+All three records represent accepted, runnable archetypes from the generated-app
+acceptance matrix. Demo usage, billing, deployment, users, activity, workflows,
+runs, sessions, connectors, and artifact history must stay closed over these
+same three app IDs. A new demo app is therefore a fleet-contract change, not a
+one-page fixture addition.
+
+`mozaiks-app` is not embedded as one of these records. App Zero is a real,
+proprietary consumer workspace and is tested in its own repository. Hardcoding
+it into the OSS Factory fixture would couple the framework to a sibling checkout
+and blur the hosted-product boundary.
+

--- a/factory_app/app/admin/pages/studioDemoData.js
+++ b/factory_app/app/admin/pages/studioDemoData.js
@@ -1,37 +1,14 @@
 const DEMO_APPS = [
   {
-    build_registry_id: 'demo_appreg_client-intake',
-    app_id: 'client-intake-copilot',
-    name: 'Client Intake Copilot',
-    description: 'Intake routing, follow-up tasks, and approval capture.',
-    status: 'draft',
-    created_at: '2025-02-02T10:00:00Z',
-    updated_at: '2025-02-02T10:00:00Z',
-  },
-  {
-    build_registry_id: 'demo_appreg_support-ops',
-    app_id: 'support-ops-assistant',
-    name: 'Support Ops Assistant',
-    description: 'Ticket triage, escalation classification, and runbook prompts.',
-    status: 'building',
-    created_at: '2025-02-01T12:30:00Z',
-    updated_at: '2025-02-03T09:15:00Z',
-  },
-  {
-    build_registry_id: 'demo_appreg_revenue-review',
-    app_id: 'revenue-review-studio',
-    name: 'Revenue Review Studio',
-    description: 'Finance review before release and deployment setup.',
-    status: 'review',
-    created_at: '2025-01-27T15:45:00Z',
-    updated_at: '2025-02-04T14:05:00Z',
-  },
-  {
     build_registry_id: 'demo_appreg_partner-deploy',
     app_id: 'partner-delivery-studio',
     name: 'Partner Delivery Studio',
-    description: 'Partner rollout, managed deployment, and release checks.',
-    status: 'deploying',
+    description: 'Authenticated partner operations with managed deployment and release checks.',
+    status: 'active',
+    archetype_id: 'admin_operations_dashboard',
+    canonical_structure: 'mozaiks.app.v1',
+    functional_acceptance: 'passed',
+    portal_focus: ['building', 'launch', 'integrations', 'governance'],
     created_at: '2025-01-19T08:00:00Z',
     updated_at: '2025-02-05T11:20:00Z',
   },
@@ -39,8 +16,12 @@ const DEMO_APPS = [
     build_registry_id: 'demo_appreg_member-growth',
     app_id: 'member-growth-studio',
     name: 'Member Growth Studio',
-    description: 'Live growth insights, campaign prompts, and operator alerts.',
+    description: 'Monetized AI workflows with usage, billing, access, and operator alerts.',
     status: 'active',
+    archetype_id: 'monetized_saas_reports',
+    canonical_structure: 'mozaiks.app.v1',
+    functional_acceptance: 'passed',
+    portal_focus: ['billing', 'usage', 'access', 'activity'],
     created_at: '2025-01-10T13:10:00Z',
     updated_at: '2025-02-05T16:40:00Z',
   },
@@ -48,8 +29,12 @@ const DEMO_APPS = [
     build_registry_id: 'demo_appreg_campaign-revision',
     app_id: 'campaign-revision-workbench',
     name: 'Campaign Revision Workbench',
-    description: 'Revision work is blocking the next approved release.',
-    status: 'needs_revision',
+    description: 'Authenticated campaign CRUD, review queues, and approval workflows.',
+    status: 'active',
+    archetype_id: 'authenticated_crud_projects',
+    canonical_structure: 'mozaiks.app.v1',
+    functional_acceptance: 'passed',
+    portal_focus: ['overview', 'branding', 'access', 'settings', 'support'],
     created_at: '2025-01-15T09:30:00Z',
     updated_at: '2025-02-04T18:25:00Z',
   },
@@ -97,43 +82,19 @@ const DEMO_RUNTIME_SUMMARY = {
 }
 
 const DEMO_APP_CONNECTORS = {
+  'partner-delivery-studio': [
+    { service: 'github', display_name: 'GitHub', secret_available: true, status: 'active' },
+  ],
   'member-growth-studio': [
     { service: 'slack', display_name: 'Slack', secret_available: true, status: 'active' },
     { service: 'segment', display_name: 'Segment', secret_available: true, status: 'active' },
   ],
-  'support-ops-assistant': [
-    { service: 'resend', display_name: 'Resend', secret_available: true, status: 'active' },
-  ],
-  'revenue-review-studio': [
-    { service: 's3', display_name: 'AWS S3', secret_available: false, status: 'metadata_only' },
-  ],
   'campaign-revision-workbench': [
-    { service: 'slack', display_name: 'Slack', secret_available: false, status: 'metadata_only' },
+    { service: 'slack', display_name: 'Slack', secret_available: true, status: 'active' },
   ],
 }
 
 const DEMO_USAGE_BY_APP = {
-  'client-intake-copilot': {
-    tokens_used: 0,
-    llm_cost_usd: 0,
-    workflow_runs: 0,
-    tool_calls: 0,
-    errors: 0,
-  },
-  'support-ops-assistant': {
-    tokens_used: 58200,
-    llm_cost_usd: 141.12,
-    workflow_runs: 810,
-    tool_calls: 2710,
-    errors: 3,
-  },
-  'revenue-review-studio': {
-    tokens_used: 126000,
-    llm_cost_usd: 301.22,
-    workflow_runs: 1400,
-    tool_calls: 5230,
-    errors: 1,
-  },
   'partner-delivery-studio': {
     tokens_used: 348000,
     llm_cost_usd: 912.4,
@@ -158,27 +119,6 @@ const DEMO_USAGE_BY_APP = {
 }
 
 const DEMO_BILLING_BY_APP = {
-  'client-intake-copilot': {
-    total_revenue_usd: 0,
-    mrr_usd: 0,
-    arr_usd: 0,
-    active_customers: 0,
-    failed_payments: 0,
-  },
-  'support-ops-assistant': {
-    total_revenue_usd: 12800,
-    mrr_usd: 2200,
-    arr_usd: 26400,
-    active_customers: 18,
-    failed_payments: 1,
-  },
-  'revenue-review-studio': {
-    total_revenue_usd: 24800,
-    mrr_usd: 4100,
-    arr_usd: 49200,
-    active_customers: 26,
-    failed_payments: 2,
-  },
   'partner-delivery-studio': {
     total_revenue_usd: 52400,
     mrr_usd: 9200,
@@ -203,45 +143,15 @@ const DEMO_BILLING_BY_APP = {
 }
 
 const DEMO_DEPLOYMENT_BY_APP = {
-  'client-intake-copilot': {
-    deployment_label: 'Draft',
-    failed: false,
-    domain_count: 0,
-    domains: [],
-    environment: 'Build',
-    bandwidth_gb: 0,
-    storage_gb: 0,
-    uptime_percent: null,
-  },
-  'support-ops-assistant': {
-    deployment_label: 'Build queue',
-    failed: false,
-    domain_count: 0,
-    domains: [],
-    environment: 'Build',
-    bandwidth_gb: 0,
-    storage_gb: 2,
-    uptime_percent: null,
-  },
-  'revenue-review-studio': {
-    deployment_label: 'Review',
-    failed: false,
-    domain_count: 0,
-    domains: [],
-    environment: 'Staging planned',
-    bandwidth_gb: 0,
-    storage_gb: 4,
-    uptime_percent: null,
-  },
   'partner-delivery-studio': {
-    deployment_label: 'Deploying',
+    deployment_label: 'Live',
     failed: false,
     domain_count: 1,
-    domains: ['partner-studio-preview.mozaiks.app'],
-    environment: 'Staging',
+    domains: ['partner-studio.mozaiks.app'],
+    environment: 'Production',
     bandwidth_gb: 180,
     storage_gb: 22,
-    uptime_percent: 99.3,
+    uptime_percent: 99.93,
   },
   'member-growth-studio': {
     deployment_label: 'Live',
@@ -254,64 +164,18 @@ const DEMO_DEPLOYMENT_BY_APP = {
     uptime_percent: 99.96,
   },
   'campaign-revision-workbench': {
-    deployment_label: 'Rollback required',
-    failed: true,
-    domain_count: 0,
-    domains: [],
-    environment: 'Pre-deploy',
-    bandwidth_gb: 0,
+    deployment_label: 'Live',
+    failed: false,
+    domain_count: 1,
+    domains: ['campaign-review.mozaiks.app'],
+    environment: 'Production',
+    bandwidth_gb: 42,
     storage_gb: 5,
-    uptime_percent: null,
+    uptime_percent: 99.89,
   },
 }
 
 const DEMO_USERS_BY_APP = {
-  'client-intake-copilot': {
-    total_users: 0,
-    active_users: 0,
-    new_users: 0,
-    churned_users: 0,
-    users: [],
-    segments: [],
-    support_history: [],
-  },
-  'support-ops-assistant': {
-    total_users: 118,
-    active_users: 83,
-    new_users: 14,
-    churned_users: 6,
-    users: [
-      { id: 'usr_sop_1', name: 'Tanya Brooks', email: 'tanya@example.com', segment: 'Ops leads', status: 'active', subscription: 'Growth', last_seen: '2 hours ago' },
-      { id: 'usr_sop_2', name: 'Luis Carter', email: 'luis@example.com', segment: 'Supervisors', status: 'active', subscription: 'Growth', last_seen: '6 hours ago' },
-      { id: 'usr_sop_3', name: 'Jade Prince', email: 'jade@example.com', segment: 'Escalation team', status: 'inactive', subscription: 'Starter', last_seen: '4 days ago' },
-    ],
-    segments: [
-      { label: 'Ops leads', count: 28 },
-      { label: 'Supervisors', count: 41 },
-      { label: 'Escalation team', count: 19 },
-    ],
-    support_history: [
-      { id: 'sup_sop_1', label: 'SLA escalation', detail: '2 unresolved support escalations in the last 7 days.' },
-    ],
-  },
-  'revenue-review-studio': {
-    total_users: 64,
-    active_users: 37,
-    new_users: 5,
-    churned_users: 3,
-    users: [
-      { id: 'usr_rev_1', name: 'Kelsey Ward', email: 'kelsey@example.com', segment: 'Finance operators', status: 'active', subscription: 'Pro', last_seen: '1 hour ago' },
-      { id: 'usr_rev_2', name: 'Milo Hart', email: 'milo@example.com', segment: 'Auditors', status: 'active', subscription: 'Enterprise', last_seen: 'Today' },
-    ],
-    segments: [
-      { label: 'Finance operators', count: 31 },
-      { label: 'Auditors', count: 12 },
-      { label: 'Reviewers', count: 21 },
-    ],
-    support_history: [
-      { id: 'sup_rev_1', label: 'Billing inquiry', detail: '1 plan question waiting on finance configuration.' },
-    ],
-  },
   'partner-delivery-studio': {
     total_users: 204,
     active_users: 163,
@@ -368,46 +232,26 @@ const DEMO_USERS_BY_APP = {
 }
 
 const DEMO_ACTIVITY_BY_APP = {
-  'client-intake-copilot': [
-    { id: 'act_client_1', title: 'Draft created', detail: 'Initial app record saved and ready for Build.', timestamp: 'Just now' },
-  ],
-  'support-ops-assistant': [
-    { id: 'act_support_1', title: 'Build brief updated', detail: 'Escalation flow changes were saved to the current Build request.', timestamp: '1 hour ago' },
-    { id: 'act_support_2', title: 'Validation ready', detail: 'Build output is ready for review before deploy.', timestamp: 'Yesterday' },
-  ],
-  'revenue-review-studio': [
-    { id: 'act_revenue_1', title: 'Review requested', detail: 'Finance release review is waiting on operator approval.', timestamp: '34 minutes ago' },
-  ],
   'partner-delivery-studio': [
-    { id: 'act_partner_1', title: 'Preview deployment started', detail: 'Deployment is provisioning the current release candidate.', timestamp: '18 minutes ago' },
-    { id: 'act_partner_2', title: 'Domain assigned', detail: 'Preview domain attached to the latest environment.', timestamp: 'Today' },
+    { id: 'act_partner_1', title: 'Acceptance passed', detail: 'Canonical admin operations checks passed for the current bundle.', timestamp: '18 minutes ago' },
+    { id: 'act_partner_2', title: 'Production domain verified', detail: 'The managed production domain is healthy.', timestamp: 'Today' },
   ],
   'member-growth-studio': [
     { id: 'act_growth_1', title: 'Usage spike detected', detail: 'Campaign scoring workflows crossed the daily run threshold.', timestamp: '12 minutes ago' },
     { id: 'act_growth_2', title: 'Customer billing synced', detail: 'Billing data refreshed from the managed billing integration.', timestamp: '1 hour ago' },
   ],
   'campaign-revision-workbench': [
-    { id: 'act_campaign_1', title: 'Revision requested', detail: 'Rollback decision recorded after the latest review pass.', timestamp: '2 hours ago' },
+    { id: 'act_campaign_1', title: 'Acceptance passed', detail: 'CRUD, authentication, and approval-route checks passed.', timestamp: '2 hours ago' },
   ],
 }
 
 const DEMO_WORKFLOWS_BY_APP = {
-  'client-intake-copilot': ['ValueEngine'],
-  'support-ops-assistant': ['AppGenerator', 'TicketTriageWorkflow', 'EscalationWorkflow'],
-  'revenue-review-studio': ['ReviewWorkflow', 'ReportsWorkflow'],
   'partner-delivery-studio': ['DeployWorkflow', 'PartnerSyncWorkflow', 'PayoutOpsWorkflow'],
   'member-growth-studio': ['GrowthScoringWorkflow', 'CampaignReviewWorkflow', 'RetentionSignalsWorkflow'],
   'campaign-revision-workbench': ['RevisionWorkflow'],
 }
 
 const DEMO_RUNS_BY_APP = {
-  'support-ops-assistant': [
-    { chat_id: 'run_support_1', workflow_name: 'TicketTriageWorkflow', user_id: 'tanya@example.com', agent_turns: 42, tool_calls: 184, errors: 1, prompt_tokens: 12400, completion_tokens: 3800, cost: 32.1, runtime_sec: 182.3, ended_at: null, started_at: '2025-02-05T17:20:00Z', status: 0 },
-    { chat_id: 'run_support_2', workflow_name: 'EscalationWorkflow', user_id: 'luis@example.com', agent_turns: 18, tool_calls: 61, errors: 0, prompt_tokens: 6400, completion_tokens: 2200, cost: 16.7, runtime_sec: 94.2, ended_at: '2025-02-05T16:10:00Z', started_at: '2025-02-05T15:58:00Z', status: 1 },
-  ],
-  'revenue-review-studio': [
-    { chat_id: 'run_revenue_1', workflow_name: 'ReviewWorkflow', user_id: 'kelsey@example.com', agent_turns: 14, tool_calls: 44, errors: 1, prompt_tokens: 9200, completion_tokens: 2800, cost: 21.6, runtime_sec: 75.8, ended_at: '2025-02-05T15:42:00Z', started_at: '2025-02-05T15:30:00Z', status: 1 },
-  ],
   'partner-delivery-studio': [
     { chat_id: 'run_partner_1', workflow_name: 'DeployWorkflow', user_id: 'mina@example.com', agent_turns: 22, tool_calls: 73, errors: 0, prompt_tokens: 13200, completion_tokens: 4100, cost: 28.9, runtime_sec: 133.4, ended_at: null, started_at: '2025-02-05T18:02:00Z', status: 0 },
     { chat_id: 'run_partner_2', workflow_name: 'PartnerSyncWorkflow', user_id: 'devin@example.com', agent_turns: 31, tool_calls: 117, errors: 0, prompt_tokens: 18800, completion_tokens: 5200, cost: 42.8, runtime_sec: 188.1, ended_at: '2025-02-05T14:32:00Z', started_at: '2025-02-05T14:08:00Z', status: 1 },
@@ -418,7 +262,7 @@ const DEMO_RUNS_BY_APP = {
     { chat_id: 'run_growth_3', workflow_name: 'RetentionSignalsWorkflow', user_id: 'ariel@example.com', agent_turns: 28, tool_calls: 102, errors: 0, prompt_tokens: 15400, completion_tokens: 4200, cost: 38.2, runtime_sec: 141.5, ended_at: '2025-02-05T12:15:00Z', started_at: '2025-02-05T12:01:00Z', status: 1 },
   ],
   'campaign-revision-workbench': [
-    { chat_id: 'run_campaign_1', workflow_name: 'RevisionWorkflow', user_id: 'owen@example.com', agent_turns: 8, tool_calls: 22, errors: 1, prompt_tokens: 3200, completion_tokens: 1200, cost: 8.4, runtime_sec: 51.2, ended_at: '2025-02-05T10:21:00Z', started_at: '2025-02-05T10:12:00Z', status: 1 },
+    { chat_id: 'run_campaign_1', workflow_name: 'RevisionWorkflow', user_id: 'owen@example.com', agent_turns: 8, tool_calls: 22, errors: 0, prompt_tokens: 3200, completion_tokens: 1200, cost: 8.4, runtime_sec: 51.2, ended_at: '2025-02-05T10:21:00Z', started_at: '2025-02-05T10:12:00Z', status: 1 },
   ],
 }
 
@@ -447,22 +291,6 @@ const DEMO_USAGE_PROFILES = {
     callsBase: 3,
     workflows: ['DeployWorkflow', 'PartnerSyncWorkflow', 'PayoutOpsWorkflow'],
     users: ['mina@example.com', 'devin@example.com', 'partners@example.com'],
-  },
-  'revenue-review-studio': {
-    baseChats: 4,
-    promptBase: 6200,
-    completionBase: 1200,
-    callsBase: 3,
-    workflows: ['ReviewWorkflow', 'ReportsWorkflow'],
-    users: ['kelsey@example.com', 'milo@example.com', 'finance@example.com'],
-  },
-  'support-ops-assistant': {
-    baseChats: 6,
-    promptBase: 5100,
-    completionBase: 980,
-    callsBase: 2,
-    workflows: ['TicketTriageWorkflow', 'EscalationWorkflow', 'AppGenerator'],
-    users: ['tanya@example.com', 'luis@example.com', 'support@example.com'],
   },
   'campaign-revision-workbench': {
     baseChats: 2,
@@ -660,14 +488,6 @@ const DEMO_SESSIONS_BY_APP = Object.fromEntries(
 )
 
 const DEMO_BUILD_HISTORY_BY_APP = {
-  'client-intake-copilot': [],
-  'support-ops-assistant': [
-    { id: 'artifact_support_1', version_number: 4, lifecycle_status: 'current', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-05T15:03:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/support-ops-assistant/4/app.zip' } } },
-    { id: 'artifact_support_0', version_number: 3, lifecycle_status: 'draft', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-04T19:14:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/support-ops-assistant/3/app.zip' } } },
-  ],
-  'revenue-review-studio': [
-    { id: 'artifact_revenue_1', version_number: 2, lifecycle_status: 'draft', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-05T14:00:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/revenue-review-studio/2/app.zip' } } },
-  ],
   'partner-delivery-studio': [
     { id: 'artifact_partner_2', version_number: 6, lifecycle_status: 'current', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-05T17:32:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/partner-delivery-studio/6/app.zip' } } },
     { id: 'artifact_partner_1', version_number: 5, lifecycle_status: 'current', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-03T12:40:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/partner-delivery-studio/5/app.zip' } } },
@@ -678,7 +498,7 @@ const DEMO_BUILD_HISTORY_BY_APP = {
     { id: 'artifact_growth_1', version_number: 9, lifecycle_status: 'draft', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-01-29T08:30:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/member-growth-studio/9/app.zip' } } },
   ],
   'campaign-revision-workbench': [
-    { id: 'artifact_campaign_1', version_number: 5, lifecycle_status: 'draft', validation_status: 'failed', artifact_key: 'app_bundle', created_at: '2025-02-05T11:18:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/campaign-revision-workbench/5/app.zip' } } },
+    { id: 'artifact_campaign_1', version_number: 5, lifecycle_status: 'current', validation_status: 'passed', artifact_key: 'app_bundle', created_at: '2025-02-05T11:18:00Z', commit_metadata: { metadata: { artifact_path: 'generated/apps/campaign-revision-workbench/5/app.zip' } } },
   ],
 }
 
@@ -716,6 +536,10 @@ export function buildStudioDemoAppSummary(appId) {
       name: app?.name,
       description: app?.description,
       build_registry_id: app?.build_registry_id,
+      archetype_id: app?.archetype_id,
+      canonical_structure: app?.canonical_structure,
+      functional_acceptance: app?.functional_acceptance,
+      portal_focus: [...(app?.portal_focus || [])],
       lifecycle_state: app?.status || 'draft',
       lifecycle_label: String(app?.status || 'draft')
         .replaceAll('_', ' ')

--- a/tests/test_studio_canonical_demo_fleet.py
+++ b/tests/test_studio_canonical_demo_fleet.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from tests.test_generated_app_archetype_matrix import _matrix_specs
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO_DATA = ROOT / "factory_app" / "app" / "admin" / "pages" / "studioDemoData.js"
+EXPECTED_APP_IDS = {
+    "campaign-revision-workbench",
+    "member-growth-studio",
+    "partner-delivery-studio",
+}
+REMOVED_PSEUDO_APP_IDS = {
+    "client-intake-copilot",
+    "revenue-review-studio",
+    "support-ops-assistant",
+}
+
+
+def _load_demo_fleet() -> dict:
+    script = f"""
+      import {{
+        buildStudioDemoApps,
+        buildStudioDemoAppSummary,
+        getStudioDemoActivity,
+        getStudioDemoAdminStats,
+        getStudioDemoBillingRecord,
+        getStudioDemoBuildHistory,
+        getStudioDemoDeploymentRecord,
+        getStudioDemoRuns,
+        getStudioDemoSessions,
+        getStudioDemoUsageRecord,
+        getStudioDemoUsersRecord,
+        getStudioDemoWorkflowNames,
+        getStudioDemoWorkspaceUsage,
+        listStudioDemoAppConnectors,
+      }} from {json.dumps(DEMO_DATA.as_uri())};
+
+      const apps = buildStudioDemoApps();
+      const records = Object.fromEntries(apps.map((app) => [app.app_id, {{
+        summary: buildStudioDemoAppSummary(app.app_id),
+        connectors: listStudioDemoAppConnectors(app.app_id),
+        usage: getStudioDemoUsageRecord(app.app_id),
+        billing: getStudioDemoBillingRecord(app.app_id),
+        deployment: getStudioDemoDeploymentRecord(app.app_id),
+        users: getStudioDemoUsersRecord(app.app_id),
+        activity: getStudioDemoActivity(app.app_id),
+        workflows: getStudioDemoWorkflowNames(app.app_id),
+        runs: getStudioDemoRuns(app.app_id),
+        sessions: getStudioDemoSessions(app.app_id),
+        build_history: getStudioDemoBuildHistory(app.app_id),
+        admin_stats: getStudioDemoAdminStats(app.app_id),
+      }}]));
+      console.log(JSON.stringify({{ apps, records, workspace_usage: getStudioDemoWorkspaceUsage() }}));
+    """
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_studio_demo_fleet_is_exactly_three_accepted_canonical_archetypes() -> None:
+    payload = _load_demo_fleet()
+    apps = payload["apps"]
+    matrix_archetypes = {spec.archetype_id for spec in _matrix_specs()}
+
+    assert len(apps) == 3
+    assert {app["app_id"] for app in apps} == EXPECTED_APP_IDS
+    assert {app["archetype_id"] for app in apps} <= matrix_archetypes
+    assert all(app["canonical_structure"] == "mozaiks.app.v1" for app in apps)
+    assert all(app["functional_acceptance"] == "passed" for app in apps)
+
+
+def test_every_demo_portal_uses_the_same_closed_app_fleet() -> None:
+    payload = _load_demo_fleet()
+
+    assert set(payload["records"]) == EXPECTED_APP_IDS
+    assert {row["app_id"] for row in payload["workspace_usage"]["by_run"]} == EXPECTED_APP_IDS
+
+    for app_id, record in payload["records"].items():
+        assert record["summary"]["app"]["functional_acceptance"] == "passed", app_id
+        assert record["connectors"], app_id
+        assert record["usage"]["workflow_runs"] > 0, app_id
+        assert record["billing"]["active_customers"] > 0, app_id
+        assert record["deployment"]["failed"] is False, app_id
+        assert record["deployment"]["domain_count"] > 0, app_id
+        assert record["users"]["users"], app_id
+        assert record["activity"], app_id
+        assert record["workflows"], app_id
+        assert record["runs"], app_id
+        assert record["sessions"], app_id
+        versions = record["build_history"]["artifact_versions"]
+        assert any(
+            version["lifecycle_status"] == "current"
+            and version["validation_status"] == "passed"
+            for version in versions
+        ), app_id
+
+
+def test_removed_pseudo_apps_leave_no_legacy_fixture_data() -> None:
+    source = DEMO_DATA.read_text(encoding="utf-8")
+    assert not (REMOVED_PSEUDO_APP_IDS & set(source.split()))
+    for app_id in REMOVED_PSEUDO_APP_IDS:
+        assert app_id not in source
+

--- a/tests/test_studio_canonical_demo_fleet.py
+++ b/tests/test_studio_canonical_demo_fleet.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from tests.test_generated_app_archetype_matrix import _matrix_specs
 
-
 ROOT = Path(__file__).resolve().parents[1]
 DEMO_DATA = ROOT / "factory_app" / "app" / "admin" / "pages" / "studioDemoData.js"
 EXPECTED_APP_IDS = {


### PR DESCRIPTION
## Summary
- replace six disconnected Studio pseudo-apps with three accepted canonical archetypes
- keep usage, billing, deployment, users, connectors, workflows, runs, sessions, activity, and build history closed over the same fleet
- document the App Zero boundary and enforce the fleet contract against the generated-app archetype matrix

## Validation
- 29 passed: generated app archetype matrix + canonical fleet contract + Studio build surface
- node --check factory_app/app/admin/pages/studioDemoData.js
- git diff --check

## Coordination
- zero file overlap with open PRs #384 and #345
- no mozaiks-app changes