### PR TITLE
fix(chat): show Ask replies while streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Ask-mode assistant replies now render while they stream**: live text frames
+  retain their general-chat provenance, so the active chat no longer hides the
+  reply until the persisted transcript is reloaded.
 - **Every workflow failed instantly under context-authority enforcement**:
   the routing-variable validation added in #298/#344 required deterministic
   writers that the runtime never actually produced — agent-sentinel triggers

--- a/chat-ui/src/pages/ChatPage.js
+++ b/chat-ui/src/pages/ChatPage.js
@@ -2453,6 +2453,7 @@ const ChatPage = () => {
         const agentNameChunk = extractAgentName(data);
         const chunkContent = data.content || '';
         const streamId = data.stream_id || null;
+        const streamChunkMetadata = data.metadata || data.data?.metadata || null;
         if (!chunkContent) return;
         // Hide init spinner on first streaming token
         if (showInitSpinner) setShowInitSpinner(false);
@@ -2470,6 +2471,7 @@ const ChatPage = () => {
               updated[i] = {
                 ...m,
                 content: `${m.content || ''}${chunkContent}`,
+                metadata: streamChunkMetadata || m.metadata || null,
               };
               return updated;
             }
@@ -2486,6 +2488,7 @@ const ChatPage = () => {
             isStructuredCapable: !!(data.is_structured_capable),
             isVisual: data.is_visual !== undefined ? !!data.is_visual : true,
             isToolAgent: !!(data.is_tool_agent),
+            metadata: streamChunkMetadata,
           });
           return updated;
         });

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -745,8 +745,19 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                         "STREAM_TEXT_CHUNK agent=%s chat_id=%s len=%d",
                         _agent, chat_id, len(_content),
                     )
+                    # Stream frames need the same provenance as stream_end so
+                    # clients can enforce mode isolation before the turn ends.
+                    # Keep the per-frame payload compact: classification only.
+                    _message_metadata = _d.get('metadata')
+                    _chunk_metadata = None
+                    if isinstance(_message_metadata, dict) and _message_metadata.get('source'):
+                        _chunk_metadata = {'source': _message_metadata['source']}
                     await self._emit_text_as_chunks(
-                        _content, str(_agent), chat_id or '', _stream_id
+                        _content,
+                        str(_agent),
+                        chat_id or '',
+                        _stream_id,
+                        metadata=_chunk_metadata,
                     )
                     await self._broadcast_to_websockets(
                         {
@@ -825,6 +836,8 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         agent_name: str,
         chat_id: str,
         stream_id: str,
+        *,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Split *content* into adaptive text chunks and emit each as chat.stream_chunk.
 
@@ -834,19 +847,23 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
 
         A minimal async yield between chunks ensures React 18's automatic
         batching doesn't collapse all updates into a single render. The caller
-        is responsible for sending chat.stream_end afterwards.
+        is responsible for sending chat.stream_end afterwards. ``metadata`` is
+        compact message provenance forwarded with every chunk.
         """
         chunks = self._chunk_text_for_stream(content)
         for seq, token in enumerate(chunks):
+            chunk_data: dict[str, Any] = {
+                "agent": agent_name,
+                "content": token,
+                "stream_id": stream_id,
+                "chunk_seq": seq,
+            }
+            if metadata:
+                chunk_data["metadata"] = dict(metadata)
             await self._broadcast_to_websockets(
                 {
                     "type": "chat.stream_chunk",
-                    "data": {
-                        "agent": agent_name,
-                        "content": token,
-                        "stream_id": stream_id,
-                        "chunk_seq": seq,
-                    },
+                    "data": chunk_data,
                 },
                 chat_id or None,
             )

--- a/tests/test_general_chat_persistence_contracts.py
+++ b/tests/test_general_chat_persistence_contracts.py
@@ -157,6 +157,16 @@ def test_ask_bootstrap_sessions_do_not_count_as_workflow_runs() -> None:
     assert "askCarrierMode ? { transportPurpose: 'ask_carrier' } : {}" in chat_page_source
 
 
+def test_ask_live_stream_keeps_general_agent_provenance() -> None:
+    chat_page_source = _read("chat-ui/src/pages/ChatPage.js")
+    transport_source = _read("mozaiksai/core/transport/simple_transport.py")
+
+    assert "metadata=_chunk_metadata" in transport_source
+    assert "const streamChunkMetadata = data.metadata || data.data?.metadata || null;" in chat_page_source
+    assert "metadata: streamChunkMetadata || m.metadata || null" in chat_page_source
+    assert "metadata: streamChunkMetadata" in chat_page_source
+
+
 def test_workflow_mode_switch_resumes_before_starting_new_workflow_run() -> None:
     storage_source = _read("chat-ui/src/session/chatSessionStorage.js")
     controller_source = _read("chat-ui/src/hooks/useConversationModeController.js")

--- a/tests/test_simple_transport_serialization.py
+++ b/tests/test_simple_transport_serialization.py
@@ -52,6 +52,49 @@ def test_chunk_text_for_stream_compacts_long_messages_without_losing_content():
     assert all(chunk for chunk in chunks)
 
 
+def test_stream_chunks_preserve_message_source_metadata(monkeypatch):
+    transport = SimpleTransport()
+    transport.connections = {"chat-ask": {"workflow_name": "ExistingAppDiscovery", "user_id": "user-1"}}
+    sent = []
+
+    class _FakeDispatcher:
+        def build_outbound_event_envelope(self, *, raw_event, chat_id, get_sequence_cb, workflow_name):  # noqa: ANN001
+            return {
+                "type": "chat.text",
+                "data": {
+                    "agent": "Assistant",
+                    "content": "Visible while streaming.",
+                    "metadata": {
+                        "source": "general_agent",
+                        "general_chat_id": "generalchat-app-1-user-1-0001",
+                    },
+                },
+            }
+
+    monkeypatch.setattr(_dispatcher_mod, "get_event_dispatcher", lambda: _FakeDispatcher())
+    monkeypatch.setattr(transport, "should_show_to_user", lambda agent_name, chat_id: True)
+    monkeypatch.setattr(
+        transport,
+        "_broadcast_to_websockets",
+        lambda event, chat_id=None: _record_broadcast(sent, event, chat_id),
+    )
+
+    import asyncio
+
+    asyncio.run(
+        transport.send_event_to_ui(
+            {"kind": "text", "agent": "Assistant", "content": "Visible while streaming."},
+            "chat-ask",
+        )
+    )
+
+    chunk_events = [event for event, _chat_id in sent if event["type"] == "chat.stream_chunk"]
+    assert chunk_events
+    assert all(event["data"]["metadata"] == {"source": "general_agent"} for event in chunk_events)
+    assert sent[-1][0]["type"] == "chat.stream_end"
+    assert sent[-1][0]["data"]["metadata"]["source"] == "general_agent"
+
+
 class RecursiveString:
     def __str__(self) -> str:
         return str(self)


### PR DESCRIPTION
## Summary
- preserve general-chat provenance on every `chat.stream_chunk` frame
- retain chunk metadata on live ChatPage streaming bubbles so Ask-mode isolation does not remove them
- add transport and frontend contract regressions plus an Unreleased changelog entry

## Root cause
`chat.stream_end` carried `metadata.source=general_agent`, but `chat.stream_chunk` did not. Ask mode correctly filters unclassified workflow traffic, so its sanitizer removed each live assistant bubble; persisted history later restored the completed message.

The repeated `/api/admin/users` and `/api/studio/{overview,build}` 404s are separate optional Studio/admin route probes and are not the chat rendering cause.

## Validation
- `ruff check .` — pass
- focused transport/general-chat persistence tests — 29 passed
- transport + WebSocket + event contracts — 49 passed
- `python -m mypy mozaiksai/core/transport/simple_transport.py` — pass
- `npm run build` — pass
- `npm run test:ui-primitives` — pass
- full default suite — 13,536 passed, 78 skipped, 1 failed, 2 rerun
  - lone failure: `test_platform_startup_calls_migration_application_after_index_application`
  - reproduced identically on clean `origin/main` (database indexes skipped under local best-effort persistence), so not attributable to this change
- `git diff --check` — pass

## OSS Change Impact
- Layer changed: universal runtime Event transport + framework `chat-ui` consumer
- Build workflow impact: none
- Runtime/platform impact: stream chunks retain compact source provenance
- App workspace impact: none; no declarative contracts changed
- Docs updated: `CHANGELOG.md` Unreleased/Fixed
- Compatibility risk: low; additive metadata on stream chunk envelopes

## Architecture review
- Affected primitives: Event and live Run presentation
- Engine coupling: none
- Tenant isolation: unchanged
- Workflow isolation: strengthened; Ask mode still rejects non-general workflow traffic
- Persistence remains durability/reload authority, not a live-render workaround