### PR TITLE
fix(cli): refuse conversational workflows before spending tokens (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ This project follows a practical pre-1.0 changelog format:
 - **Ask-mode assistant replies now render while they stream**: live text frames
   retain their general-chat provenance, so the active chat no longer hides the
   reply until the persisted transcript is reloaded.
+- **`mozaiks gen` burned tokens on runs it could never finish** (#383): the
+  CLI takes one `--prompt` and has no way to reply, but AgentGenerator opens
+  with `InterviewAgent`, which asks a clarifying question and hands the turn
+  to `user`. Every run therefore stalled at `WORKFLOW_AWAITING_INPUT` with
+  zero files written — after real LLM spend. `gen` now inspects the staged
+  workflow's own declarative config before executing anything and refuses
+  when the workflow can hand control to a user (`human_in_the_loop: true` in
+  `orchestrator.yaml`, or a `transition_graph.yaml` edge targeting `user` /
+  reverting to the user), redirecting to `mozaiks studio --dir . --open`.
+  Detection is on the property, not the workflow name, so genuinely one-shot
+  workflows still run and future interview-driven ones are covered.
+  `--allow-interactive` bypasses the refusal for anyone who wants to start a
+  run and drive it elsewhere.
 - **Every workflow failed instantly under context-authority enforcement**:
   the routing-variable validation added in #298/#344 required deterministic
   writers that the runtime never actually produced — agent-sentinel triggers

--- a/mozaiks_cli/commands/gen.py
+++ b/mozaiks_cli/commands/gen.py
@@ -9,6 +9,12 @@ and build state management — belongs to Studio. This command should not expand
 to duplicate those surfaces. If you need to review output, compare versions,
 track history, or promote artifacts, use Studio.
 
+``gen`` only supports workflows that are genuinely one-shot: a single prompt
+in, artifacts out. Conversational (interview-driven) workflows hand control
+back to the user mid-run, and the CLI has no way to carry a reply — such runs
+always stall at ``WORKFLOW_AWAITING_INPUT`` after spending real tokens
+(issue #383). Those are refused before execution and redirected to Studio.
+
 Usage:
     mozaiks gen workflow --prompt "description of what you want"
     mozaiks gen app --prompt "description of your app"
@@ -457,6 +463,94 @@ def _stage_workflow(source_dir: Path, staging_root: Path, workflow_name: str) ->
     return dst
 
 
+# ── Conversational-workflow detection (issue #383) ─────────────────
+# A workflow that can hand the conversational turn back to the user cannot
+# be driven to completion by `mozaiks gen`, which has exactly one prompt and
+# no way to reply. Detect that *property* from the workflow's own declarative
+# config rather than matching on a workflow name, so any interview-driven
+# workflow is covered and genuinely one-shot workflows still run.
+
+STUDIO_COMMAND = "mozaiks studio --dir . --open"
+ALLOW_INTERACTIVE_FLAG = "--allow-interactive"
+
+# Transition targets that yield the turn to the human participant.
+_USER_TRANSITION_TARGETS = {"reverttousertarget", "usertarget"}
+
+
+def _detect_conversational_signals(workflow_dir: Path) -> list[str]:
+    """Return declarative signals that *workflow_dir* can await a user reply.
+
+    Signals, each read straight from the workflow's own config:
+
+    * ``orchestrator.yaml``'s ``human_in_the_loop: true`` — the workflow
+      declares that a human participates in the run.
+    * a ``transition_graph.yaml`` rule whose ``target_agent`` is ``user`` or
+      whose ``transition_target`` reverts to the user — the graph declares an
+      edge that parks the run on a human turn.
+
+    An empty list means nothing in the config can hand control to a user, so
+    the workflow is safe to run one-shot.
+    """
+    signals: list[str] = []
+
+    orchestrator = _safe_load_yaml(workflow_dir / "orchestrator.yaml")
+    if orchestrator.get("human_in_the_loop") is True:
+        signals.append("orchestrator.yaml declares human_in_the_loop: true")
+
+    graph = _safe_load_yaml(workflow_dir / "transition_graph.yaml")
+    rules = graph.get("transition_rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            source = str(rule.get("source_agent", "")).strip()
+            target = str(rule.get("target_agent", "")).strip()
+            transition_target = str(rule.get("transition_target", "")).strip()
+            if target.lower() == "user" or transition_target.lower() in _USER_TRANSITION_TARGETS:
+                signals.append(
+                    "transition_graph.yaml hands control to the user "
+                    f"({source or '?'} -> {target or transition_target})"
+                )
+
+    return signals
+
+
+def _safe_load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML mapping, returning ``{}`` for missing or unreadable files."""
+    if not path.is_file():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _refuse_conversational_workflow(workflow_name: str, signals: list[str]) -> None:
+    """Print the honest redirect for a workflow the CLI cannot drive."""
+    _print_error(
+        f"{workflow_name} is a conversational workflow: it asks clarifying "
+        "questions and waits for your reply."
+    )
+    _print_info(
+        "`mozaiks gen` takes a single --prompt and cannot carry a reply, so this "
+        "run would stall waiting for input after spending tokens and writing no "
+        "files. Refusing before any model call."
+    )
+    _print("\nDetected from the workflow's own config:", style="bold")
+    for signal in signals[:4]:
+        _print_info(f"  - {signal}")
+
+    _print("\nRun this generation in Studio instead:", style="bold")
+    _print_info(f"  {STUDIO_COMMAND}")
+    _print_info("  Studio drives the conversation and supports replies.")
+    _print(
+        f"\nTo start the run anyway and drive it elsewhere, pass {ALLOW_INTERACTIVE_FLAG} "
+        "(the run will still pause at the first question).",
+        style="dim",
+    )
+
 
 def _setup_environment(repo_root: Path, staging_workflows: Path, output_dir: Path):
     """Configure sys.path and env vars for workflow execution."""
@@ -676,7 +770,14 @@ def run(args):
     staging_dir = Path(tempfile.mkdtemp(prefix="mozaiks_gen_"))
     try:
         _print_info("Staging AgentGenerator workflow...")
-        _stage_workflow(source_path, staging_dir, "AgentGenerator")
+        staged_workflow = _stage_workflow(source_path, staging_dir, "AgentGenerator")
+
+        # Refuse interview-driven workflows before any LLM call (issue #383).
+        if not getattr(args, "allow_interactive", False):
+            signals = _detect_conversational_signals(staged_workflow)
+            if signals:
+                _refuse_conversational_workflow("AgentGenerator", signals)
+                return 1
 
         # Set up runtime environment pointing at staged workflows
         _setup_environment(repo_root, staging_dir, output_dir)

--- a/mozaiks_cli/main.py
+++ b/mozaiks_cli/main.py
@@ -317,8 +317,13 @@ def create_parser():
     # mozaiks gen
     gen_parser = subparsers.add_parser(
         "gen",
-        help="Generate workflows or apps using AI",
-        description="Generate AI agent workflows or full apps from a descriptive prompt.",
+        help="Generate workflows or apps from a one-shot prompt",
+        description=(
+            "Generate AI agent workflows or full apps from a single descriptive prompt. "
+            "This supports one-shot workflows only. Conversational (interview-driven) "
+            "workflows ask clarifying questions mid-run, which the CLI cannot answer; "
+            "run those in Studio (mozaiks studio --dir . --open)."
+        ),
     )
     gen_parser.add_argument(
         "mode",
@@ -342,6 +347,15 @@ def create_parser():
         choices=["e2b", "docker", "local", "skip"],
         default=None,
         help="App validation strategy for AppGenerator runs (default: resolved from the current environment)",
+    )
+    gen_parser.add_argument(
+        "--allow-interactive",
+        action="store_true",
+        help=(
+            "Start the run even when the workflow is conversational. The run will "
+            "pause at the first question and spend tokens without writing output; "
+            "use this only to start a run you intend to drive elsewhere."
+        ),
     )
 
     # mozaiks migrations

--- a/tests/test_cli_gen_conversational_refusal.py
+++ b/tests/test_cli_gen_conversational_refusal.py
@@ -1,0 +1,219 @@
+"""mozaiks gen must refuse conversational workflows before spending tokens.
+
+AgentGenerator opens with InterviewAgent, which asks a clarifying question and
+hands control to ``user``. The CLI has one --prompt and no way to reply, so the
+run always stalls at WORKFLOW_AWAITING_INPUT with zero files written — after
+burning real LLM tokens (issue #383).
+
+These tests pin the contract: the refusal is derived from the workflow's own
+declarative config (not a name match), it happens *before* the orchestration
+entry point is ever called, and --allow-interactive bypasses it.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from mozaiks_cli.commands import gen as gen_module
+from mozaiks_cli.commands.gen import (
+    ALLOW_INTERACTIVE_FLAG,
+    STUDIO_COMMAND,
+    _detect_conversational_signals,
+)
+
+_INTERVIEW_GRAPH = """\
+transition_rules:
+- source_agent: InterviewAgent
+  target_agent: user
+  transition_type: after_turn
+  transition_target: RevertToUserTarget
+- source_agent: PatternAgent
+  target_agent: ProjectOverviewAgent
+  transition_type: after_turn
+  transition_target: AgentTarget
+"""
+
+_ONE_SHOT_GRAPH = """\
+transition_rules:
+- source_agent: PlanAgent
+  target_agent: BuildAgent
+  transition_type: after_turn
+  transition_target: AgentTarget
+- source_agent: BuildAgent
+  target_agent: WriteAgent
+  transition_type: after_turn
+  transition_target: AgentTarget
+"""
+
+
+def _write_workflow(root: Path, orchestrator: str, graph: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "orchestrator.yaml").write_text(orchestrator, encoding="utf-8")
+    (root / "transition_graph.yaml").write_text(graph, encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# _detect_conversational_signals — property, not name
+# ---------------------------------------------------------------------------
+
+class TestDetectConversationalSignals:
+    def test_user_transition_edge_is_detected(self, tmp_path: Path) -> None:
+        wf = _write_workflow(
+            tmp_path / "AnyWorkflow",
+            "workflow_name: AnyWorkflow\ninitial_agent: InterviewAgent\n",
+            _INTERVIEW_GRAPH,
+        )
+        signals = _detect_conversational_signals(wf)
+        assert signals
+        assert any("hands control to the user" in s for s in signals)
+
+    def test_human_in_the_loop_declaration_is_detected(self, tmp_path: Path) -> None:
+        wf = _write_workflow(
+            tmp_path / "HitlWorkflow",
+            "workflow_name: HitlWorkflow\nhuman_in_the_loop: true\n",
+            _ONE_SHOT_GRAPH,
+        )
+        signals = _detect_conversational_signals(wf)
+        assert any("human_in_the_loop" in s for s in signals)
+
+    def test_one_shot_workflow_yields_no_signals(self, tmp_path: Path) -> None:
+        wf = _write_workflow(
+            tmp_path / "OneShot",
+            "workflow_name: OneShot\nhuman_in_the_loop: false\n",
+            _ONE_SHOT_GRAPH,
+        )
+        assert _detect_conversational_signals(wf) == []
+
+    def test_detection_does_not_key_off_workflow_name(self, tmp_path: Path) -> None:
+        """A workflow *named* AgentGenerator with a one-shot graph still runs."""
+        wf = _write_workflow(
+            tmp_path / "AgentGenerator",
+            "workflow_name: AgentGenerator\n",
+            _ONE_SHOT_GRAPH,
+        )
+        assert _detect_conversational_signals(wf) == []
+
+    def test_missing_config_files_are_not_conversational(self, tmp_path: Path) -> None:
+        empty = tmp_path / "Empty"
+        empty.mkdir()
+        assert _detect_conversational_signals(empty) == []
+
+    def test_unreadable_yaml_does_not_raise(self, tmp_path: Path) -> None:
+        wf = tmp_path / "Broken"
+        wf.mkdir()
+        (wf / "orchestrator.yaml").write_text("::: not [ yaml", encoding="utf-8")
+        assert _detect_conversational_signals(wf) == []
+
+    def test_real_agent_generator_is_conversational(self) -> None:
+        """Guard the live signal: shipped AgentGenerator must be detected."""
+        from mozaiksai.resources import resolve_factory_workflows_root
+
+        wf = resolve_factory_workflows_root() / "AgentGenerator"
+        if not wf.is_dir():  # pragma: no cover - source checkout only
+            pytest.skip("factory workflows not available")
+        assert _detect_conversational_signals(wf)
+
+
+# ---------------------------------------------------------------------------
+# run() — refusal happens before the orchestration entry point
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def gen_args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        mode="workflow",
+        prompt="Build a customer support triage workflow with escalation rules",
+        output=str(tmp_path / "generated"),
+        validation_strategy="skip",
+        allow_interactive=False,
+    )
+
+
+@pytest.fixture
+def staged_recorder(monkeypatch, tmp_path: Path):
+    """Stub out staging, env setup, logging, and the API-key check.
+
+    ``holder['graph']`` selects the staged workflow's transition graph;
+    ``holder['ran']`` records whether the orchestration runner was reached.
+    """
+    holder: dict = {"graph": _INTERVIEW_GRAPH, "orchestrator": "workflow_name: X\n", "ran": False}
+
+    def fake_stage(source_dir, staging_root, workflow_name):
+        return _write_workflow(
+            Path(staging_root) / workflow_name, holder["orchestrator"], holder["graph"]
+        )
+
+    async def fake_run_generator(**kwargs):
+        holder["ran"] = True
+        out = Path(kwargs["output_dir"])
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "orchestrator.yaml").write_text("workflow_name: Y\n", encoding="utf-8")
+        return {"success": True, "result": {"run_completed": True, "agent_turns": 1}}
+
+    monkeypatch.setattr(gen_module, "_stage_workflow", fake_stage)
+    monkeypatch.setattr(gen_module, "_run_generator", fake_run_generator)
+    monkeypatch.setattr(gen_module, "_find_generator_source", lambda: tmp_path / "src")
+    monkeypatch.setattr(gen_module, "_check_api_key", lambda: True)
+    monkeypatch.setattr(gen_module, "_init_logging", lambda: None)
+    monkeypatch.setattr(gen_module, "_setup_environment", lambda *a, **k: None)
+    monkeypatch.setattr(gen_module, "RICH_AVAILABLE", False)
+    monkeypatch.setattr(gen_module, "console", None)
+    return holder
+
+
+def test_conversational_workflow_refuses_without_calling_the_runner(
+    gen_args, staged_recorder, capsys
+) -> None:
+    rc = gen_module.run(gen_args)
+
+    assert rc == 1
+    # The token-spend guarantee: orchestration was never entered.
+    assert staged_recorder["ran"] is False
+    out = capsys.readouterr().out
+    assert "conversational workflow" in out
+
+
+def test_refusal_message_names_studio_and_the_escape_hatch(
+    gen_args, staged_recorder, capsys
+) -> None:
+    gen_module.run(gen_args)
+    out = capsys.readouterr().out
+
+    assert STUDIO_COMMAND in out
+    assert "Studio" in out
+    assert ALLOW_INTERACTIVE_FLAG in out
+    # The refusal explains itself with the config signal it actually found.
+    assert "hands control to the user" in out
+
+
+def test_allow_interactive_bypasses_the_refusal_and_reaches_execution(
+    gen_args, staged_recorder
+) -> None:
+    gen_args.allow_interactive = True
+
+    rc = gen_module.run(gen_args)
+
+    assert staged_recorder["ran"] is True
+    assert rc == 0
+
+
+def test_one_shot_workflow_is_unaffected_and_proceeds(gen_args, staged_recorder) -> None:
+    staged_recorder["graph"] = _ONE_SHOT_GRAPH
+
+    rc = gen_module.run(gen_args)
+
+    assert staged_recorder["ran"] is True
+    assert rc == 0
+
+
+def test_missing_allow_interactive_attribute_defaults_to_refusing(
+    gen_args, staged_recorder
+) -> None:
+    """Callers that never set the flag still get the safe behavior."""
+    del gen_args.allow_interactive
+
+    assert gen_module.run(gen_args) == 1
+    assert staged_recorder["ran"] is False


### PR DESCRIPTION
## Problem

`mozaiks gen` takes a single `--prompt` and has no way to reply. AgentGenerator opens with `InterviewAgent`, which asks a clarifying question and hands the turn to `user`. Every run therefore stalled at `WORKFLOW_AWAITING_INPUT` having written zero files — **after real LLM spend** (verified live: 7 agents registered, 3,091 tokens, no output).

Since #382 this exits 1 with a clear message, but only *after* the tokens are gone. This is option 3 from #383 (honest redirect), not option 1 or 2: `gen` keeps its one-shot promise and points conversational generation at Studio, which already does it well.

## The fix

`gen` now inspects the **staged workflow's own declarative config** before executing anything, and refuses when the workflow can hand control to a user.

The detection is on the *property*, not the name — no `if workflow_name == "AgentGenerator"` anywhere:

| Signal | Source | Why it's honest |
|---|---|---|
| `human_in_the_loop: true` | `orchestrator.yaml` | the workflow itself declares that a human participates in the run |
| a rule whose `target_agent` is `user`, or whose `transition_target` reverts to the user | `transition_graph.yaml` | the graph declares an edge that parks the run on a human turn |

Both are exactly the edges that produce the stall, read from the config that causes it. Any future interview-driven workflow is covered without a code change, and a genuinely one-shot workflow — including one *named* `AgentGenerator` — still runs (pinned by a test).

Live output on this branch:

```
Error: AgentGenerator is a conversational workflow: it asks clarifying questions and waits for your reply.
  `mozaiks gen` takes a single --prompt and cannot carry a reply, so this run
  would stall waiting for input after spending tokens and writing no files.
  Refusing before any model call.

Detected from the workflow's own config:
    - orchestrator.yaml declares human_in_the_loop: true
    - transition_graph.yaml hands control to the user (InterviewAgent -> user)
    ...

Run this generation in Studio instead:
    mozaiks studio --dir . --open
```

Exit code 1, and no LLM call is made.

## Escape hatch

`--allow-interactive` bypasses the refusal and preserves today's post-#382 behavior, for anyone who wants to start a run and drive it elsewhere. It is named in the refusal message and documented in `--help`. Verified live: with the flag, the run proceeds past staging into orchestration.

The `gen` command help/description now advertises what it actually does: one-shot workflows here, conversational generation in Studio.

## Not in scope

AgentGenerator is unchanged, no interview-skipping mode was added (that is option 1, explicitly not chosen), and Studio is untouched.

## Tests

New `tests/test_cli_gen_conversational_refusal.py` (12 tests):
- a conversational workflow refuses **and the orchestration runner is never invoked** — `_run_generator` is stubbed with a recorder and the test asserts it stayed `False`. That assertion *is* the no-token-spend guarantee.
- `--allow-interactive` bypasses the refusal and reaches execution (recorder `True`, rc 0)
- a one-shot graph is unaffected and proceeds
- the refusal message names Studio, the exact `mozaiks studio --dir . --open` command, and `--allow-interactive`
- detection unit tests for each signal, name-independence, missing files, and malformed YAML
- a drift guard asserting the *shipped* AgentGenerator is still detected as conversational

## Validation

- `ruff check .` — clean
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped` — clean (565 files)
- full `pytest -q --no-cov` — 13,548 passed. `tests/test_runtime_database_migrations.py::test_platform_startup_calls_migration_application_after_index_application` fails identically on clean `origin/main` in this environment (verified by stashing); pre-existing, unrelated.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
