### PR TITLE
fix(entitlement): unwrap the FastAPI detail envelope in generated-app clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Generated custom-route clients now recognize real entitlement denials**:
+  module-action and workflow-start failures unwrap FastAPI's structured
+  `detail` envelope, so HTTP 402 responses reach the app's upgrade flow while
+  flat object responses remain compatible. Declarative page rendering is
+  unchanged.
 - **ADR 0007 Slice 0 closes proven generator and refinement defects**:
   generated app/workflow writers now use the canonical build-scoped staging
   roots, required artifact and DesignDocs persistence fails closed, lineage

--- a/factory_app/workflows/AppGenerator/tools/module_api_template.py
+++ b/factory_app/workflows/AppGenerator/tools/module_api_template.py
@@ -108,6 +108,13 @@ export function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+function parseErrorPayload(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const detail = body.detail
+  if (detail && typeof detail === 'object' && !Array.isArray(detail)) return detail
+  return body
+}
+
 function tokenRecoveryMetadata(err) {
   const data = err?.data || {}
   return data.extra_data || data.metadata || data
@@ -134,10 +141,15 @@ export function insufficientTokensRecoveryPath(err, fallback = '/billing') {
 }
 
 export function isEntitlementRequiredError(err) {
+  // HTTP 402 is the canonical signal — the backend maps ENTITLEMENT_REQUIRED to
+  // it in one place. Checking status as well as error_code means a denial is
+  // still recognised if the body is unreadable or reshaped in transit.
   return (
+    err?.status === 402 ||
     err?.error_code === 'ENTITLEMENT_REQUIRED' ||
     err?.code === 'ENTITLEMENT_REQUIRED' ||
-    err?.data?.error_code === 'ENTITLEMENT_REQUIRED'
+    err?.data?.error_code === 'ENTITLEMENT_REQUIRED' ||
+    err?.data?.detail?.error_code === 'ENTITLEMENT_REQUIRED'
   )
 }
 
@@ -167,17 +179,21 @@ export async function moduleAction(moduleName, actionName, input = {}) {
     // backend error fields such as error_code, code, and action-specific data.
     let body = null
     try { body = await response.json() } catch { /* non-JSON body — ignore */ }
+    // FastAPI serializes HTTPException(detail={...}) as {"detail": {...}}, so
+    // the structured fields live one level down. Fall back to the raw body for
+    // responses that are already flat (proxies, non-FastAPI intermediaries).
+    const payload = parseErrorPayload(body)
     const err = new Error(
-      body?.error || body?.message ||
+      payload?.error || payload?.message ||
       `Module action failed: ${moduleName}.${actionName} ${response.status}`
     )
     // Attach structured fields so catch blocks can branch on backend states.
-    if (body?.error_code) err.error_code = body.error_code
-    if (body?.code)       err.code       = body.code
+    if (payload?.error_code) err.error_code = payload.error_code
+    if (payload?.code)       err.code       = payload.code
     err.status = response.status
-    // Preserve the full body for callers that need additional context fields.
-    // Do not attach secrets or provider credentials here.
-    if (body != null) err.data = body
+    // Preserve the unwrapped payload for callers that need additional context
+    // fields. Do not attach secrets or provider credentials here.
+    if (payload != null) err.data = payload
     throw err
   }
 
@@ -199,13 +215,16 @@ export async function startWorkflow(workflowName, contextVariables = {}) {
   if (!response.ok) {
     let body = null
     try { body = await response.json() } catch { /* non-JSON */ }
+    // Use the same strict envelope parser as moduleAction so workflow and
+    // module errors cannot drift or accept arrays/primitive JSON as payloads.
+    const payload = parseErrorPayload(body)
     const err = new Error(
-      body?.error || body?.message ||
+      payload?.error || payload?.message ||
       `Failed to start ${workflowName}: ${response.status}`
     )
-    if (body?.error_code) err.error_code = body.error_code
+    if (payload?.error_code) err.error_code = payload.error_code
     err.status = response.status
-    if (body != null) err.data = body
+    if (payload != null) err.data = payload
     throw err
   }
   return response.json()

--- a/tests/fixtures/module_error_envelope.json
+++ b/tests/fixtures/module_error_envelope.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Canonical wire shape of a failed module dispatch. Asserted through the real platform router by tests/test_module_error_envelope_contract.py, and consumed by web_shell/playwright/generated-ui/entitlement-upgrade.spec.js so the browser mock cannot drift from the backend. Do not hand-edit: change mozaiksai/hosts/routers/modules.py and let the contract test tell you what to update.",
+  "entitlement_required": {
+    "status": 402,
+    "body": {
+      "detail": {
+        "error": "Entitlement required for premium_reports.generate_report: premium.reports.generate",
+        "error_code": "ENTITLEMENT_REQUIRED",
+        "module": "premium_reports",
+        "action": "generate_report"
+      }
+    }
+  }
+}

--- a/tests/test_appgenerator_module_api_template.py
+++ b/tests/test_appgenerator_module_api_template.py
@@ -164,6 +164,14 @@ class TestModuleApiRequestShape:
 
 class TestModuleApiStructuredErrors:
 
+    def test_module_and_workflow_errors_share_one_strict_payload_parser(self):
+        """Both request paths reject primitive/array JSON and share one parser."""
+        js = _template_js()
+        assert "function parseErrorPayload(body)" in js
+        assert "Array.isArray(body)" in js
+        assert "Array.isArray(detail)" in js
+        assert js.count("const payload = parseErrorPayload(body)") == 2
+
     def test_json_parse_attempt_on_error_body(self):
         """Template attempts to parse the error body as JSON."""
         js = _template_js()
@@ -177,10 +185,17 @@ class TestModuleApiStructuredErrors:
         )
 
     def test_error_code_attached_to_error(self):
-        """err.error_code is attached when the body contains error_code."""
+        """err.error_code is read from the unwrapped payload, not the raw body.
+
+        FastAPI nests HTTPException detail, so `body.error_code` is always
+        undefined for a real backend error.
+        """
         js = _template_js()
-        assert "err.error_code = body.error_code" in js or "err.error_code=body.error_code" in js, (
-            "err.error_code must be assigned from body.error_code on non-ok responses"
+        assert "err.error_code = payload.error_code" in js, (
+            "err.error_code must be assigned from the unwrapped payload"
+        )
+        assert "body.error_code" not in js, (
+            "reading body.error_code ignores FastAPI's 'detail' nesting"
         )
 
     def test_code_field_attached_to_error(self):
@@ -190,19 +205,15 @@ class TestModuleApiStructuredErrors:
             "err.code must be assigned from body.code on non-ok responses"
         )
 
-    def test_error_message_prefers_body_error(self):
-        """Error message prefers body.error over body.message and fallback."""
+    def test_error_message_prefers_payload_error(self):
+        """Error message prefers the unwrapped payload's error field."""
         js = _template_js()
-        assert "body?.error" in js or "body.error" in js, (
-            "Error message must prefer body.error"
-        )
+        assert "payload?.error" in js, "Error message must prefer payload.error"
 
-    def test_error_message_falls_back_to_body_message(self):
-        """Error message falls back to body.message when error is absent."""
+    def test_error_message_falls_back_to_payload_message(self):
+        """Error message falls back to payload.message when error is absent."""
         js = _template_js()
-        assert "body?.message" in js or "body.message" in js, (
-            "Error message must fall back to body.message"
-        )
+        assert "payload?.message" in js, "Error message must fall back to payload.message"
 
     def test_non_json_body_handled_gracefully(self):
         """Non-JSON error bodies (HTML gateway errors) are handled without crashing."""
@@ -220,11 +231,31 @@ class TestModuleApiStructuredErrors:
             "err.status must be assigned from response.status"
         )
 
-    def test_data_preserves_full_body(self):
-        """err.data preserves the full parsed body for caller inspection."""
+    def test_data_preserves_unwrapped_payload(self):
+        """err.data carries the unwrapped payload for caller inspection.
+
+        Callers branch on err.data.error_code, so it must hold the same level
+        the structured fields were read from.
+        """
         js = _template_js()
-        assert "err.data = body" in js or "err.data=body" in js, (
-            "err.data must be assigned to the full parsed body"
+        assert "err.data = payload" in js, (
+            "err.data must be assigned the unwrapped payload"
+        )
+
+    def test_detail_envelope_is_unwrapped(self):
+        """The unwrap itself — the fix for a denial reaching the user as a raw
+        'Module action failed: ... 402' instead of an upgrade prompt."""
+        js = _template_js()
+        assert "body.detail" in js, "template must inspect the FastAPI 'detail' envelope"
+        assert "const payload" in js, "template must bind an unwrapped payload"
+
+    def test_entitlement_detector_accepts_http_402(self):
+        """402 is the canonical denial signal and must be recognised on status
+        alone, so a reshaped or unreadable body still routes to the upgrade
+        path."""
+        js = _template_js()
+        assert "err?.status === 402" in js, (
+            "isEntitlementRequiredError must treat HTTP 402 as a denial"
         )
 
     def test_no_secret_shaped_named_attrs(self):

--- a/tests/test_module_error_envelope_contract.py
+++ b/tests/test_module_error_envelope_contract.py
@@ -1,0 +1,160 @@
+"""Cross-language contract for the module-dispatch error envelope.
+
+Three tests in this repo asserted three different shapes for the same
+response, and all three were green:
+
+- ``tests/test_generated_app_archetype_matrix.py`` asserted
+  ``denied.json()["detail"]["error_code"]`` — correct, and passing.
+- the generated-app client template read ``body.error_code`` flat, so
+  ``isEntitlementRequiredError`` returned false for every real denial and a
+  user saw ``"Module action failed: ... 402"`` instead of an upgrade prompt.
+- the Playwright spec mocked a *third* shape — flat body **and** status 403 —
+  so the browser test certified a response the backend has never produced.
+
+A mock that encodes the wrong shape is worse than no test: it spends
+confidence without buying any. This module makes the wire shape a single
+checked-in fixture, proves the fixture matches what FastAPI actually
+serializes from the router's own construction, and the Playwright spec reads
+that same file rather than hand-rolling a body.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mozaiksai.core.runtime.composition.module_executor import ModuleResult
+from mozaiksai.hosts import platform as platform_host
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "module_error_envelope.json"
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _entitlement_case() -> dict:
+    return _fixture()["entitlement_required"]
+
+
+def test_platform_router_produces_the_checked_in_entitlement_envelope(monkeypatch) -> None:
+    """Exercise the real router and compare its wire response to the fixture."""
+    case = _entitlement_case()
+
+    class _DenyingExecutor:
+        async def execute(self, request, context=None):
+            return ModuleResult(
+                success=False,
+                error=case["body"]["detail"]["error"],
+                error_code="ENTITLEMENT_REQUIRED",
+            )
+
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    platform_host.app.state.failed_module_names = []
+    platform_host.app.state.module_action_surfaces = {}
+    platform_host.app.state.executor_registry = SimpleNamespace(
+        module_executor=_DenyingExecutor()
+    )
+    response = TestClient(
+        platform_host.app, raise_server_exceptions=False
+    ).post("/api/modules/premium_reports/generate_report", json={})
+
+    assert response.status_code == case["status"]
+    assert response.json() == case["body"]
+    assert "error_code" not in response.json(), "structured fields are never top-level"
+
+
+def test_entitlement_required_maps_to_402_in_the_router() -> None:
+    """403 would be a plausible guess; the router uses 402.
+
+    The Playwright mock guessed 403, which is why a status-based check would
+    have failed there too.
+    """
+    assert _entitlement_case()["status"] == 402
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "factory_app/workflows/AppGenerator/tools/module_api_template.py",
+        "web_shell/playwright/generated-ui/entitlement-upgrade.spec.js",
+    ],
+)
+def test_js_consumers_do_not_read_structured_fields_off_the_top_level(path: str) -> None:
+    """Guard the specific regression: ``body.error_code`` with no unwrap.
+
+    Reading ``body?.error_code`` directly is the defect. The fix reads it from
+    an unwrapped payload, so the literal ``body?.error_code`` and
+    ``body.error_code`` forms must not reappear.
+    """
+    source = (REPO_ROOT / path).read_text(encoding="utf-8")
+    for bad in ("body?.error_code", "body.error_code", "body?.code"):
+        assert bad not in source, (
+            f"{path} reads {bad} — FastAPI nests structured fields under "
+            "'detail'. Unwrap first: const payload = body?.detail ?? body"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The Playwright fixture app carries a hand-maintained copy of the template's
+# client. Its header says "Keep in sync with module_api_template.py" — a
+# convention nothing enforced, so the browser tests could exercise different
+# code than generated apps ship.
+# ---------------------------------------------------------------------------
+
+FIXTURE_CLIENT = (
+    REPO_ROOT / "web_shell" / "playwright" / "fixtures" / "generated-app"
+    / "app" / "ui" / "lib" / "moduleApi.js"
+)
+TEMPLATE = REPO_ROOT / "factory_app" / "workflows" / "AppGenerator" / "tools" / "module_api_template.py"
+
+# Functions whose behavior the browser tests depend on. Compared body-for-body
+# rather than whole-file, because the fixture legitimately omits helpers the
+# fixture app does not use.
+SHARED_FUNCTIONS = ("parseErrorPayload", "isEntitlementRequiredError", "moduleAction")
+
+
+def _js_function_body(source: str, name: str) -> str:
+    """Extract `export function NAME(...)`/`export async function NAME(...)` body."""
+    for prefix in (
+        f"export async function {name}(",
+        f"export function {name}(",
+        f"function {name}(",
+    ):
+        start = source.find(prefix)
+        if start != -1:
+            break
+    else:  # pragma: no cover - guarded by the test below
+        raise AssertionError(f"{name} not found")
+
+    depth, i, started = 0, start, False
+    while i < len(source):
+        if source[i] == "{":
+            depth += 1
+            started = True
+        elif source[i] == "}":
+            depth -= 1
+            if started and depth == 0:
+                return " ".join(source[start : i + 1].split())
+        i += 1
+    raise AssertionError(f"unbalanced braces reading {name}")
+
+
+@pytest.mark.parametrize("function_name", SHARED_FUNCTIONS)
+def test_playwright_fixture_client_matches_the_template(function_name: str) -> None:
+    """The browser tests must exercise the code generated apps actually ship.
+
+    Without this, the fixture copy silently drifts and Playwright certifies
+    behavior no real app has.
+    """
+    template_body = _js_function_body(TEMPLATE.read_text(encoding="utf-8"), function_name)
+    fixture_body = _js_function_body(FIXTURE_CLIENT.read_text(encoding="utf-8"), function_name)
+    assert fixture_body == template_body, (
+        f"{FIXTURE_CLIENT.relative_to(REPO_ROOT).as_posix()} has drifted from "
+        f"module_api_template.py in {function_name}(). The Playwright suite would "
+        "test code that no generated app ships. Copy the template's version across."
+    )

--- a/web_shell/playwright/fixtures/generated-app/app/ui/lib/moduleApi.js
+++ b/web_shell/playwright/fixtures/generated-app/app/ui/lib/moduleApi.js
@@ -46,6 +46,13 @@ export function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+function parseErrorPayload(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const detail = body.detail
+  if (detail && typeof detail === 'object' && !Array.isArray(detail)) return detail
+  return body
+}
+
 function tokenRecoveryMetadata(err) {
   const data = err?.data || {}
   return data.extra_data || data.metadata || data
@@ -72,10 +79,15 @@ export function insufficientTokensRecoveryPath(err, fallback = '/billing') {
 }
 
 export function isEntitlementRequiredError(err) {
+  // HTTP 402 is the canonical signal — the backend maps ENTITLEMENT_REQUIRED to
+  // it in one place. Checking status as well as error_code means a denial is
+  // still recognised if the body is unreadable or reshaped in transit.
   return (
+    err?.status === 402 ||
     err?.error_code === 'ENTITLEMENT_REQUIRED' ||
     err?.code === 'ENTITLEMENT_REQUIRED' ||
-    err?.data?.error_code === 'ENTITLEMENT_REQUIRED'
+    err?.data?.error_code === 'ENTITLEMENT_REQUIRED' ||
+    err?.data?.detail?.error_code === 'ENTITLEMENT_REQUIRED'
   )
 }
 
@@ -103,14 +115,18 @@ export async function moduleAction(moduleName, actionName, input = {}) {
   if (!response.ok) {
     let body = null
     try { body = await response.json() } catch { /* non-JSON body */ }
+    // FastAPI serializes HTTPException(detail={...}) as {"detail": {...}}, so
+    // the structured fields live one level down. Fall back to the raw body for
+    // responses that are already flat.
+    const payload = parseErrorPayload(body)
     const err = new Error(
-      body?.error || body?.message ||
+      payload?.error || payload?.message ||
       `Module action failed: ${moduleName}.${actionName} ${response.status}`
     )
-    if (body?.error_code) err.error_code = body.error_code
-    if (body?.code)       err.code       = body.code
+    if (payload?.error_code) err.error_code = payload.error_code
+    if (payload?.code)       err.code       = payload.code
     err.status = response.status
-    if (body != null) err.data = body
+    if (payload != null) err.data = payload
     throw err
   }
 

--- a/web_shell/playwright/generated-ui/entitlement-upgrade.spec.js
+++ b/web_shell/playwright/generated-ui/entitlement-upgrade.spec.js
@@ -24,7 +24,30 @@
  *     generated-ui/entitlement-upgrade.spec.js
  */
 
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { expect, test } from '@playwright/test'
+
+// The denial response is NOT hand-written here. It is loaded from the same
+// fixture that tests/test_module_error_envelope_contract.py asserts against the
+// real router construction, so this mock cannot drift from the backend.
+//
+// It had drifted: this spec mocked a flat body with status 403, while the
+// backend returns {"detail": {...}} with status 402. The spec passed and
+// certified a response the backend has never produced — which is why every real
+// denial fell through to a raw "Module action failed" message in generated apps.
+const ENVELOPE_FIXTURE = JSON.parse(
+  readFileSync(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../tests/fixtures/module_error_envelope.json'
+    ),
+    'utf-8'
+  )
+)
+const ENTITLEMENT_DENIAL = ENVELOPE_FIXTURE.entitlement_required
 
 // ---------------------------------------------------------------------------
 // Helper: suppress expected console noise from mocked API failures
@@ -85,16 +108,16 @@ async function mockShellAndTheme(page) {
 }
 
 async function mockEntitlementDenial(page, { upgradePath } = {}) {
-  const extra = upgradePath ? { upgrade_route: upgradePath } : {}
+  // Build from the fixture so status and nesting always match the backend.
+  const detail = {
+    ...ENTITLEMENT_DENIAL.body.detail,
+    ...(upgradePath ? { upgrade_route: upgradePath } : {}),
+  }
   await page.route('**/api/modules/premium_reports/generate_report', (route) =>
     route.fulfill({
-      status: 403,
+      status: ENTITLEMENT_DENIAL.status,
       contentType: 'application/json',
-      body: JSON.stringify({
-        error: 'Entitlement required for premium_reports.generate_report: premium.reports.generate',
-        error_code: 'ENTITLEMENT_REQUIRED',
-        ...extra,
-      }),
+      body: JSON.stringify({ detail }),
     })
   )
 }


### PR DESCRIPTION
## Summary

Fixes generated custom-route clients that read FastAPI `HTTPException(detail={...})` fields from the wrong level. Real module denials arrive as `{"detail": {...}}` with HTTP 402, so entitlement recovery previously fell through to a generic error while the browser test mocked a noncanonical flat 403 response.

- one strict `parseErrorPayload` is shared by `moduleAction` and `startWorkflow`
- canonical nested envelopes and backward-compatible flat object bodies are supported
- primitive and array JSON bodies are rejected as structured payloads
- HTTP 402 remains a safe entitlement signal for the current module endpoint
- a checked-in wire fixture is exercised through the real platform router and consumed by Playwright
- the Playwright fixture client is contract-checked against the generated template
- the declarative page renderer remains explicitly deferred and unchanged

## Review corrections

Independent review found the original parser was duplicated and accepted arrays as structured objects, while its router proof used AST inspection rather than the real endpoint. The corrected implementation consolidates the parser, rejects malformed payload shapes, and verifies the fixture through an actual platform-router request. A fresh independent reviewer found no remaining technical blocker.

## Validation

- final Python contract/integration suite, including Slice 3 compatibility: 102 passed
- generated entitlement Playwright: 22 passed
- web-shell UI primitive validation and production build: passed
- production-readiness quick gate: 750 passed, 4 skipped
- `ruff check .`: passed
- source hygiene: passed
- `git diff --check`: passed
- all commits signed off

## Impact and boundaries

Generated `ui/lib/moduleApi.js` behavior changes only for bounded custom-route clients. Server serialization and production authority are unchanged. Flat error objects remain compatible. The declarative renderer is not covered by this PR.

Exact base: `45be0734103dd6d9e929f7cc09f591a3fe2cca65`
Exact head: `4b73cc36e2099ecf747926a1738fb41536f75357`

Auto-merge remains disabled.