### PR TITLE
fix(chat): keep Ask user messages visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
-- **Ask-mode assistant replies now render while they stream**: live text frames
-  retain their general-chat provenance, so the active chat no longer hides the
-  reply until the persisted transcript is reloaded.
+- **Ask-mode messages now render immediately**: optimistic user messages and
+  live assistant frames retain their general-chat provenance, so the active
+  chat no longer hides either side until the persisted transcript is reloaded.
 - **`mozaiks gen` burned tokens on runs it could never finish** (#383): the
   CLI takes one `--prompt` and has no way to reply, but AgentGenerator opens
   with `InterviewAgent`, which asks a clarifying question and hands the turn

--- a/chat-ui/src/pages/ChatPage.js
+++ b/chat-ui/src/pages/ChatPage.js
@@ -2748,7 +2748,9 @@ const ChatPage = () => {
           return;
         }
         if (isGeneralUserEcho) {
-          const recent = messagesRef.current[messagesRef.current.length - 1];
+          const recent = [...messagesRef.current]
+            .reverse()
+            .find(message => message && !message.isThinking);
           if (recent && recent.sender === 'user') {
             const recentText = String(recent.content || '').trim();
             if (recentText && recentText === String(content).trim()) {
@@ -4997,7 +4999,13 @@ const ChatPage = () => {
       agentName: 'You',
       content: messageContent.content,
       timestamp: Date.now(),
-      isStreaming: false
+      isStreaming: false,
+      metadata: conversationMode === 'ask'
+        ? {
+            source: 'general_agent',
+            ...(activeGeneralChatId ? { general_chat_id: activeGeneralChatId } : {})
+          }
+        : null
     };
     
     

--- a/tests/test_general_chat_persistence_contracts.py
+++ b/tests/test_general_chat_persistence_contracts.py
@@ -167,6 +167,23 @@ def test_ask_live_stream_keeps_general_agent_provenance() -> None:
     assert "metadata: streamChunkMetadata" in chat_page_source
 
 
+def test_ask_optimistic_user_message_keeps_general_agent_provenance() -> None:
+    chat_page_source = _read("chat-ui/src/pages/ChatPage.js")
+
+    send_start = chat_page_source.index("const sendMessage = async")
+    send_end = chat_page_source.index("const sendWsMessage", send_start)
+    send_block = chat_page_source[send_start:send_end]
+
+    assert "metadata: conversationMode === 'ask'" in send_block
+    assert "source: 'general_agent'" in send_block
+    assert "general_chat_id: activeGeneralChatId" in send_block
+
+    echo_start = chat_page_source.index("if (isGeneralUserEcho)")
+    echo_end = chat_page_source.index("// Enhanced suppression", echo_start)
+    echo_block = chat_page_source[echo_start:echo_end]
+    assert ".find(message => message && !message.isThinking)" in echo_block
+
+
 def test_workflow_mode_switch_resumes_before_starting_new_workflow_run() -> None:
     storage_source = _read("chat-ui/src/session/chatSessionStorage.js")
     controller_source = _read("chat-ui/src/hooks/useConversationModeController.js")


### PR DESCRIPTION
## Summary
- preserve general-chat provenance on optimistic Ask-mode user messages
- deduplicate persisted user echoes while ignoring the temporary thinking row
- pin the live visibility contract and update the unreleased note

## Validation
- ruff check .
- 13 focused persistence/Ask contract tests passed
- web shell production build passed
- chat embed production build passed
- UI primitive validation passed
- Playwright: three user messages visible immediately; switch away/back retained all three
- full pytest: 13,540 passed, 78 skipped, 1 known local baseline failure, 2 rerun
- git diff --check

## OSS Change Impact
- Layer: chat UI presentation/state only
- Runtime architecture: no Application, Run, worker, engine, transport, or AG2 behavior changed
- Contracts: existing general-agent provenance is now retained by the optimistic user row