### PR TITLE
test(factory): prove deterministic AI SaaS golden path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Generated SaaS plan limits now survive AppGenerator assembly and export**:
+  `usage_limits` and `token_allowances` are preserved in
+  `config/subscriptions.yaml`, and the canonical module API helper no longer
+  creates a false missing-action failure during export acceptance.
 - **Ask-mode messages now render immediately**: optimistic user messages and
   live assistant frames retain their general-chat provenance, so the active
   chat no longer hides either side until the persisted transcript is reloaded.

--- a/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
+++ b/factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import yaml
 
+from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
 from mozaiksai.core.workflow.generator_support.connector_request import (
     collect_integration_needs,
 )
@@ -63,7 +64,7 @@ def _subscriptions_config_file(context_variables: Any) -> dict[str, Any] | None:
         raw = _context_get(context_variables, key)
         if isinstance(raw, dict):
             cfg = raw.get("subscription_config_file")
-            if isinstance(cfg, dict) and cfg.get("schema_version") == "mozaiks.subscriptions.v1":
+            if isinstance(cfg, dict):
                 return cfg
     return None
 
@@ -81,52 +82,14 @@ def _materialize_subscriptions_yaml(*, context_variables: Any) -> str | None:
     if cfg is None:
         return None
 
-    # Rebuild the document deterministically so field order matches the runtime
-    # loader's expected shape (mozaiksai.core.runtime.app.subscriptions_loader).
-    doc: dict[str, Any] = {"schema_version": "mozaiks.subscriptions.v1"}
-    if cfg.get("label"):
-        doc["label"] = str(cfg["label"])
-    if cfg.get("default_plan_id"):
-        doc["default_plan_id"] = str(cfg["default_plan_id"])
-
-    assignment_store = cfg.get("assignment_store")
-    if isinstance(assignment_store, dict) and assignment_store.get("data_alias"):
-        store: dict[str, Any] = {"data_alias": str(assignment_store["data_alias"])}
-        for field in (
-            "app_id_field", "tenant_id_field", "workspace_id_field", "user_id_field",
-            "plan_id_field", "status_field", "starts_at_field", "expires_at_field",
-            "capabilities_field", "plan_snapshot_field",
-        ):
-            if assignment_store.get(field) is not None:
-                store[field] = str(assignment_store[field])
-        active_statuses = assignment_store.get("active_statuses")
-        if isinstance(active_statuses, list) and active_statuses:
-            store["active_statuses"] = [str(s) for s in active_statuses]
-        doc["assignment_store"] = store
-
-    plans = cfg.get("plans")
-    if isinstance(plans, list):
-        plan_docs: list[dict[str, Any]] = []
-        for plan in plans:
-            if not isinstance(plan, dict) or not plan.get("plan_id"):
-                continue
-            plan_doc: dict[str, Any] = {"plan_id": str(plan["plan_id"])}
-            if plan.get("label"):
-                plan_doc["label"] = str(plan["label"])
-            if plan.get("description"):
-                plan_doc["description"] = str(plan["description"])
-            capabilities = plan.get("capabilities")
-            plan_doc["capabilities"] = [str(c) for c in capabilities] if isinstance(capabilities, list) else []
-            plan_docs.append(plan_doc)
-        doc["plans"] = plan_docs
-
-    for list_key in ("token_wallets", "top_up_products", "add_on_products", "usage_charge_policies"):
-        val = cfg.get(list_key)
-        doc[list_key] = [_safe_dict(item) if isinstance(item, dict) else _safe_scalar(item) for item in val] if isinstance(val, list) else []
-
-    pricing_catalog = cfg.get("pricing_catalog")
-    if isinstance(pricing_catalog, dict):
-        doc["pricing_catalog"] = _safe_dict(pricing_catalog)
+    # Validate and serialize through the canonical runtime contract rather than
+    # reconstructing selected fields. This preserves every supported v1/v2
+    # field and fails closed when a future field or schema version is not yet
+    # understood instead of silently dropping it from the generated bundle.
+    doc = SubscriptionsConfig.model_validate(cfg).model_dump(
+        mode="json",
+        exclude_unset=True,
+    )
 
     return str(yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, allow_unicode=True))
 

--- a/mozaiksai/core/validation/functional_generated_app.py
+++ b/mozaiksai/core/validation/functional_generated_app.py
@@ -40,6 +40,83 @@ _BUILT_IN_ROUTE_COMPONENTS = {
 }
 
 
+def _javascript_lexical_view(source: str) -> tuple[str, frozenset[int]]:
+    """Blank JS comments and identify offsets that are executable code."""
+    out: list[str] = []
+    code_offsets: set[int] = set()
+    index = 0
+    contexts: list[dict[str, Any]] = [{"kind": "code", "template_depth": None}]
+    while index < len(source):
+        char = source[index]
+        following = source[index + 1] if index + 1 < len(source) else ""
+        context = contexts[-1]
+        kind = context["kind"]
+        if kind == "string":
+            out.append(char)
+            if char == "\\" and index + 1 < len(source):
+                index += 1
+                out.append(source[index])
+            elif char == context["quote"]:
+                contexts.pop()
+            index += 1
+            continue
+        if kind == "template":
+            out.append(char)
+            if char == "\\" and index + 1 < len(source):
+                index += 1
+                out.append(source[index])
+            elif char == "`":
+                contexts.pop()
+            elif char == "$" and following == "{":
+                index += 1
+                out.append(source[index])
+                contexts.append({"kind": "code", "template_depth": 1})
+            index += 1
+            continue
+        code_offsets.add(index)
+        if char == "/" and following == "/":
+            out.extend((" ", " "))
+            index += 2
+            while index < len(source) and source[index] not in {"\r", "\n"}:
+                out.append(" ")
+                index += 1
+            continue
+        if char == "/" and following == "*":
+            out.extend((" ", " "))
+            index += 2
+            while index < len(source):
+                char = source[index]
+                following = source[index + 1] if index + 1 < len(source) else ""
+                if char == "*" and following == "/":
+                    out.extend((" ", " "))
+                    index += 2
+                    break
+                out.append(char if char in {"\r", "\n"} else " ")
+                index += 1
+            continue
+        if char in {"'", '"'}:
+            out.append(char)
+            contexts.append({"kind": "string", "quote": char})
+            index += 1
+            continue
+        if char == "`":
+            out.append(char)
+            contexts.append({"kind": "template"})
+            index += 1
+            continue
+        template_depth = context["template_depth"]
+        if template_depth is not None:
+            if char == "{":
+                context["template_depth"] = template_depth + 1
+            elif char == "}":
+                context["template_depth"] = template_depth - 1
+                if context["template_depth"] == 0:
+                    contexts.pop()
+        out.append(char)
+        index += 1
+    return "".join(out), frozenset(code_offsets)
+
+
 def _safe_path(raw: Any) -> str:
     if not isinstance(raw, str):
         return ""
@@ -431,9 +508,11 @@ def _collect_module_refs(
                     refs.append((path, match.group(1), match.group(2), value.strip()))
             continue
         if pure.suffix.lower() in {".js", ".jsx", ".ts", ".tsx"}:
-            for match in _MODULE_ACTION_CALL_RE.finditer(content):
-                refs.append((path, match.group("module"), match.group("action"), "moduleAction(...)"))
-            for match in _MODULE_ENDPOINT_ANYWHERE_RE.finditer(content):
+            searchable_content, code_offsets = _javascript_lexical_view(content)
+            for match in _MODULE_ACTION_CALL_RE.finditer(searchable_content):
+                if match.start() in code_offsets:
+                    refs.append((path, match.group("module"), match.group("action"), "moduleAction(...)"))
+            for match in _MODULE_ENDPOINT_ANYWHERE_RE.finditer(searchable_content):
                 refs.append((path, match.group(1), match.group(2), match.group(0)))
     return refs
 

--- a/tests/test_ai_research_workspace_golden_path.py
+++ b/tests/test_ai_research_workspace_golden_path.py
@@ -1,0 +1,749 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+
+from factory_app.workflows.AgentGenerator.tools.workflow_converter import (
+    promote_generated_workflow,
+)
+from factory_app.workflows.AppGenerator.tools import generate_and_download as download_module
+from factory_app.workflows.AppGenerator.tools.app_build_plan import app_build_plan
+from factory_app.workflows.AppGenerator.tools.app_validation import (
+    validate_app_bundle_from_request,
+)
+from factory_app.workflows.AppGenerator.tools.assemble_app_tasks import (
+    assemble_app_tasks,
+)
+from factory_app.workflows.AppGenerator.tools.export_app_code import resolve_export_gate
+from factory_app.workflows.SubscriptionContractDesigner.tools import (
+    save_subscription_contract as subscription_module,
+)
+from mozaiksai.core.runtime.app.loader import AppLoader
+from mozaiksai.core.session.build_context import (
+    build_provider_values,
+    load_build_context,
+)
+from mozaiksai.core.workflow.workflow_manager import UnifiedWorkflowManager
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MOZAIKSPAY_CONTEXT_ROOT = REPO_ROOT / "factory_app" / "build_context" / "mozaikspay"
+
+
+class _Context:
+    def __init__(self, values: dict[str, Any] | None = None) -> None:
+        self.values = dict(values or {})
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.values.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+    def __getitem__(self, key: str) -> Any:
+        return self.values[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+def _subscription_contract() -> dict[str, Any]:
+    usage_limit = {
+        "meter_id": "research_executions",
+        "label": "Research executions",
+        "unit": "requests",
+        "capability_id": "research.execute",
+    }
+    return {
+        "agent_message": "AI Research Workspace subscription contract ready.",
+        "contract_required": True,
+        "rationale": (
+            "The workspace offers plan-gated AI research with declared monthly "
+            "execution limits. The limits are contract metadata, not proof of runtime counting."
+        ),
+        "app_id": "research",
+        "app_name": "AI Research Workspace",
+        "subscription_config_file": {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "AI Research Workspace Plans",
+            "default_plan_id": "free",
+            "assignment_store": {
+                "data_alias": "billing.subscriptions",
+                "app_id_field": "app_id",
+                "tenant_id_field": "tenant_id",
+                "user_id_field": "user_id",
+                "plan_id_field": "plan_id",
+                "status_field": "status",
+                "capabilities_field": "granted_capabilities",
+                "plan_snapshot_field": "plan_snapshot",
+                "active_statuses": ["active", "trialing"],
+            },
+            "plans": [
+                {
+                    "plan_id": "free",
+                    "label": "Free",
+                    "description": "Explore the research workspace.",
+                    "capabilities": ["research.view", "research.execute"],
+                    "usage_limits": [{**usage_limit, "monthly_limit": 20}],
+                },
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "description": "Higher-volume AI research.",
+                    "capabilities": ["research.view", "research.execute"],
+                    "usage_limits": [{**usage_limit, "monthly_limit": 500}],
+                },
+            ],
+        },
+        "plan_design_rationale": [
+            {
+                "source_context": "product_request",
+                "signal": "The requested Free and Pro tiers declare 20 and 500 monthly research executions.",
+                "decision": "Preserve both limits on the research_executions meter.",
+                "affected_plan_ids": ["free", "pro"],
+                "affected_pricing_group_ids": [],
+            }
+        ],
+        "metering_declarations": [
+            {
+                "surface_type": "workflow",
+                "surface_id": "ResearchWorkflow",
+                "action_id": "research.execute",
+                "scope": "user",
+                "enforcement": "declaration_only",
+                "idempotency_key_source": "workflow_run_id",
+            }
+        ],
+        "module_contract_updates": [
+            {
+                "module_id": "research",
+                "action_id": "execute_research",
+                "entitlement_gate": "research.execute",
+                "metering": None,
+            }
+        ],
+        "workflow_contract_updates": [
+            {
+                "workflow_id": "ResearchWorkflow",
+                "capability_id": "research.execute",
+                "metering": {"meter_id": "research_executions", "unit": "requests"},
+            }
+        ],
+        "page_surface_requirements": [
+            {
+                "page_id": "usage",
+                "route": "/usage",
+                "purpose": "Show declared plan limits and available runtime usage.",
+                "required_runtime_endpoints": ["/api/me/usage"],
+            }
+        ],
+        "app_generator_instructions": [],
+        "validation_notes": [
+            "Execution-count enforcement is not currently implemented by the OSS runtime."
+        ],
+        "forbidden_outputs": [],
+        "code_files": [],
+    }
+
+
+def _subscription_task() -> dict[str, Any]:
+    return {
+        "task_id": "research.subscription_config",
+        "task_type": "subscription_config",
+        "capability_pack_id": None,
+        "surface_id": "subscription_contract",
+        "surface_kind": "app_policy",
+        "execution_target": "AppGenerator",
+        "initial_agent": "ConfigMiddlewareAgent",
+        "description": "Materialize the confirmed subscription contract.",
+        "initial_message": "Write config/subscriptions.yaml from the confirmed contract.",
+        "owned_paths": ["config/subscriptions.yaml"],
+        "depends_on": [],
+        "acceptance_criteria": ["Free and Pro research execution limits are preserved."],
+    }
+
+
+def _research_module_task() -> dict[str, Any]:
+    return {
+        "task_id": "research.module",
+        "task_type": "module_contract",
+        "capability_pack_id": "research",
+        "surface_id": "research",
+        "surface_kind": "module",
+        "execution_target": "AppGenerator",
+        "initial_agent": "ConfigMiddlewareAgent",
+        "description": "Declare saved research and workflow launch actions.",
+        "initial_message": "Generate the canonical research module contract.",
+        "owned_paths": ["modules/research/module.yaml"],
+        "depends_on": ["research.subscription_config"],
+        "acceptance_criteria": ["execute_research is gated by research.execute."],
+    }
+
+
+def _research_page_task() -> dict[str, Any]:
+    return {
+        "task_id": "research.pages",
+        "task_type": "page_bundle",
+        "capability_pack_id": None,
+        "surface_id": "research_workspace",
+        "surface_kind": "ui_only",
+        "execution_target": "AppGenerator",
+        "initial_agent": "AppSchemaAgent",
+        "description": "Generate the research workspace page.",
+        "initial_message": "Generate a schema page for saved research and research execution.",
+        "owned_paths": ["app.json", "ui/pages/research.yaml"],
+        "depends_on": ["research.module"],
+        "acceptance_criteria": ["Research actions bind through the research module."],
+    }
+
+
+def _build_plan(mozaikspay_pack: dict[str, Any]) -> dict[str, Any]:
+    tasks = [_subscription_task(), _research_module_task(), _research_page_task()]
+    return {
+        "agent_message": "Deterministic AI Research Workspace plan ready.",
+        "app_kind": "saas",
+        "pages": [
+            {
+                "name": "Research",
+                "route": "/research",
+                "purpose": "Run AI research and inspect saved results.",
+            }
+        ],
+        "entities": [
+            {
+                "name": "ResearchResult",
+                "operations": ["read", "create"],
+                "notes": "Saved result produced by the research workflow.",
+            }
+        ],
+        "roles": ["user"],
+        "auth_strategy": "basic",
+        "service_scope": ["research"],
+        "frontend_scope": ["research", "billing", "pricing", "usage"],
+        "monetization_provider": "mozaiks_pay",
+        "capability_packs": [
+            mozaikspay_pack,
+            {
+                "capability_pack_id": "research",
+                "surface_id": "research",
+                "surface_kind": "module",
+                "label": "AI research",
+                "operations": ["list_results", "execute_research"],
+            },
+        ],
+        "external_integrations": [],
+        "agent_backend_required": False,
+        "build_tasks": tasks,
+        "generation_order": [task["task_id"] for task in tasks],
+    }
+
+
+def _research_files() -> dict[str, str]:
+    module_yaml = textwrap.dedent(
+        """
+        schema_version: mozaiks.module.v1
+        module:
+          id: research
+          display_name: Research
+          version: 1.0.0
+          description: Saved AI research results and workflow launches.
+          owner: app
+          visibility: private
+          handler: backend.handler:ResearchHandler
+        permissions:
+          - id: research.read
+            description: Read saved research results.
+          - id: research.execute
+            description: Start AI research.
+        actions:
+          - id: list_results
+            description: List saved research results.
+            handler_method: list_results
+            input_schema:
+              type: object
+              properties: {}
+            output_schema:
+              type: object
+              required: [results]
+              properties:
+                results: {type: array}
+            permissions: [research.read]
+          - id: execute_research
+            description: Save a research request and start the AI research workflow.
+            handler_method: execute_research
+            emits: [domain.research.requested]
+            input_schema:
+              type: object
+              required: [query]
+              properties:
+                query: {type: string}
+            output_schema:
+              type: object
+              required: [research_id, status]
+              properties:
+                research_id: {type: string}
+                status: {type: string}
+            permissions: [research.execute]
+        capabilities:
+          - capability_id: research.view
+            kind: action
+            target: list_results
+            title: View research
+          - capability_id: research.execute
+            kind: workflow
+            target: ResearchWorkflow
+            title: Execute research
+        """
+    ).strip() + "\n"
+    return {
+        "app.json": json.dumps(
+            {
+                "appId": "research",
+                "appName": "AI Research Workspace",
+                "version": "1.0.0",
+                "startup": {"landing_spot": "/research"},
+            }
+        ),
+        "config/ai.json": json.dumps(
+            {"chat": {"chat_startup_mode": "ask"}, "workflows": {"entry_point": "ResearchWorkflow"}}
+        ),
+        "config/shell.json": json.dumps(
+            {"navigation": {"autoFromPages": True}, "header": {"show": True}}
+        ),
+        "data/contract.json": json.dumps(
+            {
+                "version": "1",
+                "app_id": "research",
+                "surfaces": [
+                    {
+                        "surface_id": "research",
+                        "surface_kind": "module",
+                        "collections": [
+                            {
+                                "name": "research_results",
+                                "ownership": {"surface_id": "research", "surface_kind": "module"},
+                            }
+                        ],
+                    }
+                ],
+                "shared_collections": [
+                    {"name": "subscription_assignments", "data_alias": "billing.subscriptions"}
+                ],
+            }
+        ),
+        "ui/route_manifest.json": json.dumps(
+            {
+                "pages": [
+                    {
+                        "path": "/research",
+                        "component": "SchemaPage",
+                        "label": "Research",
+                        "order": 10,
+                        "schema": "research",
+                        "navigation": {"group": "main"},
+                        "meta": {"title": "Research"},
+                    }
+                ]
+            }
+        ),
+        "ui/pages/research.yaml": textwrap.dedent(
+            """
+            schema_version: mozaiks.app_page.v1
+            name: Research
+            route: /research
+            title: AI Research Workspace
+            page_type: record_list
+            layout: full-width
+            sections:
+              - id: saved-research
+                primitive: DataTable
+                title: Saved research
+                config:
+                  api_endpoint: /api/modules/research/list_results
+                  columns:
+                    - key: research_id
+                      label: Research
+                    - key: status
+                      label: Status
+              - id: run-research
+                primitive: Form
+                title: Run research
+                config:
+                  fields:
+                    - name: query
+                      label: Research question
+                      type: text
+                  submit_action:
+                    label: Research
+                    action_type: submit
+                    href: /api/modules/research/execute_research
+            """
+        ).strip() + "\n",
+        "modules/research/module.yaml": module_yaml,
+        "modules/research/contracts/events.yaml": textwrap.dedent(
+            """
+            schema_version: mozaiks.events.v1
+            events:
+              - type: domain.research.requested
+                version: 1
+                description: A user requested AI research.
+                producer: research
+                payload_schema:
+                  type: object
+                  properties:
+                    research_id: {type: string}
+                    query: {type: string}
+            """
+        ).strip() + "\n",
+        "modules/research/contracts/reactions.yaml": textwrap.dedent(
+            """
+            schema_version: mozaiks.reactions.v1
+            reactions:
+              - id: run_research_workflow
+                event_type: domain.research.requested
+                target:
+                  kind: capability
+                  capability_id: research.execute
+            """
+        ).strip() + "\n",
+        "modules/research/backend/__init__.py": "",
+        "modules/research/backend/handler.py": textwrap.dedent(
+            """
+            from .service import ResearchService
+
+
+            class ResearchHandler:
+                def __init__(self):
+                    self.service = ResearchService()
+
+                async def list_results(self, ctx, **params):
+                    return await self.service.list_results(ctx, **params)
+
+                async def execute_research(self, ctx, **params):
+                    return await self.service.execute_research(ctx, **params)
+            """
+        ).strip() + "\n",
+        "modules/research/backend/service.py": textwrap.dedent(
+            """
+            from .repo import ResearchRepo
+            from .schemas import research_request
+
+
+            class ResearchService:
+                async def list_results(self, ctx, **_params):
+                    return {"results": await ResearchRepo(ctx).list_results()}
+
+                async def execute_research(self, ctx, *, query, **_params):
+                    record = research_request(query=query)
+                    await ResearchRepo(ctx).save(record)
+                    return {"research_id": record["research_id"], "status": record["status"]}
+            """
+        ).strip() + "\n",
+        "modules/research/backend/repo.py": textwrap.dedent(
+            """
+            class ResearchRepo:
+                def __init__(self, ctx):
+                    self.collection = ctx.persistence.collection("research", "research_results")
+
+                async def list_results(self):
+                    cursor = self.collection.find({})
+                    return await cursor.to_list(length=100)
+
+                async def save(self, record):
+                    await self.collection.insert_one(record)
+                    return record
+            """
+        ).strip() + "\n",
+        "modules/research/backend/policy.py": textwrap.dedent(
+            """
+            class ResearchPolicy:
+                @staticmethod
+                def scope_query(query, *, user_id=None):
+                    scoped = dict(query or {})
+                    if user_id:
+                        scoped["user_id"] = user_id
+                    return scoped
+            """
+        ).strip() + "\n",
+        "modules/research/backend/schemas.py": textwrap.dedent(
+            """
+            from uuid import uuid4
+
+
+            def research_request(*, query):
+                return {
+                    "research_id": uuid4().hex,
+                    "query": str(query).strip(),
+                    "status": "requested",
+                }
+            """
+        ).strip() + "\n",
+    }
+
+
+def _research_workflow_files() -> dict[str, str]:
+    return {
+        "orchestrator.yaml": textwrap.dedent(
+            """
+            workflow_name: ResearchWorkflow
+            workflow_startup_mode: UserDriven
+            orchestration_pattern: ag2_network
+            initial_agent: ResearchAgent
+            initial_message: Research the requested topic and synthesize a saved result.
+            max_turns: 4
+            human_in_the_loop: false
+            triggers:
+              - type: event
+                event: domain.research.requested
+                description: Start research for a saved request.
+            """
+        ).strip() + "\n",
+        "agents.yaml": textwrap.dedent(
+            """
+            agents:
+              - name: ResearchAgent
+                structured_outputs_required: false
+                system_message: Research the supplied question using configured tools and return cited findings.
+              - name: SynthesisAgent
+                structured_outputs_required: false
+                system_message: Synthesize findings into a concise saved research result.
+            """
+        ).strip() + "\n",
+        "transition_graph.yaml": textwrap.dedent(
+            """
+            transition_rules:
+              - source_agent: ResearchAgent
+                target_agent: SynthesisAgent
+                transition_type: after_turn
+              - source_agent: SynthesisAgent
+                target_agent: terminate
+                transition_type: after_turn
+                transition_target: TerminateTarget
+            """
+        ).strip() + "\n",
+        "context_variables.yaml": textwrap.dedent(
+            """
+            definitions:
+              research_id:
+                type: string
+                source: {type: state, default: ""}
+              query:
+                type: string
+                source: {type: state, default: ""}
+            agents:
+              ResearchAgent:
+                variables: [research_id, query]
+              SynthesisAgent:
+                variables: [research_id, query]
+            """
+        ).strip() + "\n",
+    }
+
+
+def _workflow_metadata() -> dict[str, Any]:
+    return {
+        "contract_version": "1.0",
+        "bundle_name": "AI Research Workflow",
+        "primary_workflow": "ResearchWorkflow",
+        "workflows": [
+            {
+                "workflow_name": "ResearchWorkflow",
+                "capability_id": "research.execute",
+                "startup_mode": "UserDriven",
+                "trigger_events": [{"event_type": "domain.research.requested"}],
+            }
+        ],
+    }
+
+
+def _write_files(root: Path, files: dict[str, str]) -> None:
+    for relative_path, content in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_ai_research_workspace_offline_golden_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay agent outputs through production assembly, validation, load, and export.
+
+    The subscription, AppBuildPlan, app-file, and workflow-file dictionaries are
+    deterministic fixtures for structured outputs normally produced by model
+    agents. This test does not prove raw-prompt generation, live AG2 execution,
+    live MozaiksPay fulfillment, or monthly execution-count enforcement.
+    """
+    product_request = (
+        "Build an AI Research Workspace with saved results, Free and Pro plans, "
+        "MozaiksPay billing, gated AI research, usage visibility, and deployment output."
+    )
+    pack_config = load_build_context(MOZAIKSPAY_CONTEXT_ROOT / "context.yaml")
+    provider_values = build_provider_values(root=MOZAIKSPAY_CONTEXT_ROOT, config=pack_config)
+    mozaikspay_pack = provider_values["capability_packs"][0]
+    assert mozaikspay_pack["id"] == "mozaikspay"
+    assert mozaikspay_pack["capability_source"] == "managed_capability"
+
+    context = _Context(
+        {
+            "workflow_name": "SubscriptionContractDesigner",
+            "app_id": "research",
+            "chat_id": "golden",
+            "user_id": "offline-test-user",
+            "product_request": product_request,
+            "structured_output": _subscription_contract(),
+            "capability_packs": [mozaikspay_pack],
+            "available_managed_capabilities": [mozaikspay_pack],
+            "workflow_integration_metadata": _workflow_metadata(),
+            "generated_workflow_name": "ResearchWorkflow",
+            "generated_workflow_capability_id": "research.execute",
+        }
+    )
+
+    async def approve_review(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"action": "confirm", "approved": True, "status": "approved"}
+
+    async def persist_contract(**_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(id="av_subscription_contract_offline")
+
+    monkeypatch.setattr(subscription_module, "use_ui_tool", approve_review)
+    monkeypatch.setattr(subscription_module, "persist_summary_artifact", persist_contract)
+    subscription_result = await subscription_module.save_subscription_contract(context)
+    assert subscription_result["success"] is True
+
+    plan_result = app_build_plan(
+        AppBuildPlan=_build_plan(mozaikspay_pack),
+        context_variables=context,
+    )
+    assert "AI Research Workspace plan ready" in plan_result
+    assert context["app_plan_ready"] is True
+    normalized_plan = context["app_build_plan"]
+    assert normalized_plan["monetization_provider"] == "mozaiks_pay"
+    assert {
+        pack.get("capability_pack_id") or pack.get("pack_id") or pack.get("id")
+        for pack in normalized_plan["capability_packs"]
+    } >= {
+        "mozaikspay",
+        "research",
+    }
+
+    generated_workflow = tmp_path / "generated" / "ResearchWorkflow"
+    _write_files(generated_workflow, _research_workflow_files())
+    active_workflows_root = tmp_path / "active" / "workflows"
+    promotion = promote_generated_workflow(generated_workflow, active_workflows_root)
+    assert Path(promotion["target_dir"]).is_dir()
+    monkeypatch.setattr(UnifiedWorkflowManager, "_instance", None)
+    workflow_manager = UnifiedWorkflowManager(workflows_base_path=str(active_workflows_root))
+    workflow_info = workflow_manager.get_workflow_info("ResearchWorkflow")
+    assert workflow_info is not None
+    assert workflow_info["status"] == "loaded", workflow_info
+
+    context.set(
+        "code_files",
+        [{"filename": path, "content": content} for path, content in _research_files().items()],
+    )
+    context.set("workflow_name", "AppGenerator")
+    assembled = await assemble_app_tasks(context_variables=context)
+    files = {entry["filename"]: entry["content"] for entry in assembled["code_files"]}
+
+    subscriptions = yaml.safe_load(files["config/subscriptions.yaml"])
+    limits = {
+        plan["plan_id"]: plan["usage_limits"][0]["monthly_limit"]
+        for plan in subscriptions["plans"]
+    }
+    assert limits == {"free": 20, "pro": 500}
+    research_module = yaml.safe_load(files["modules/research/module.yaml"])
+    execute_action = next(action for action in research_module["actions"] if action["id"] == "execute_research")
+    assert execute_action["entitlement_gate"] == "research.execute"
+    assert "services/integrations/mozaikspay_client.py" in files
+    assert {"ui/pages/billing.yaml", "ui/pages/pricing.yaml", "ui/pages/usage.yaml"} <= set(files)
+
+    context.set("generated_files", files)
+    context.set("code_files", assembled["code_files"])
+    validation = await validate_app_bundle_from_request(
+        {"validation_strategy": "skip", "start_dev_server": False},
+        context_variables=context,
+    )
+    acceptance = validation["app_bundle_acceptance_result"]
+    assert acceptance["passed"] is True, acceptance["failed_tests"]
+    assert set(acceptance["validation_evidence"]["completed"]) == {
+        "agent_backend",
+        "app_runtime_load",
+        "bundle_scan",
+        "functional_completeness",
+        "module_implementation",
+        "module_runtime_quality",
+        "module_wiring",
+        "workflow_integration",
+    }
+    assert acceptance["agent_backend"]["checks"][0]["id"] == "agent_backend_integration_not_required"
+    assert acceptance["workflow_integration"]["checks"][0]["id"] == "workflow_integration_contract"
+    assert context["app_validation_status"] == "skipped"
+    assert context["integration_tests_passed"] is True
+    export_gate = resolve_export_gate(context)
+    assert export_gate["allow_export"] is True, export_gate["reasons"]
+
+    class _Persistence:
+        async def gather_latest_agent_jsons(self, **_kwargs: Any) -> dict[str, Any]:
+            return {}
+
+    async def no_op(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def download_ui(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"action": "download", "status": "confirmed"}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(download_module, "AG2PersistenceManager", lambda: _Persistence())
+    monkeypatch.setattr(download_module, "get_latest_workflow_export", no_op)
+    monkeypatch.setattr(download_module, "_register_app_bundle_artifact_version", no_op)
+    monkeypatch.setattr(download_module, "update_build_status", no_op)
+    monkeypatch.setattr(download_module, "use_ui_tool", download_ui)
+
+    exported = await download_module.generate_and_download(
+        {
+            "storage_backend": "none",
+            "include_dockerfiles": True,
+            "include_workflow": True,
+            "include_compose": True,
+            "deployment_profile": "generic_container",
+        },
+        "AI Research Workspace bundle ready.",
+        context_variables=context,
+    )
+    assert exported["status"] == "success", exported
+    exported_paths = set(exported["files_written"])
+    assert {
+        "Dockerfile",
+        "docker-compose.yml",
+        ".env.example",
+        "deployment.manifest.json",
+        ".github/workflows/deploy.yml",
+    } <= exported_paths
+    assert Path(exported["bundle_zip"]).is_file()
+
+    loaded = await AppLoader.load(exported["bundle_dir"])
+    assert loaded.failed_module_names == []
+    assert {module.name for module in loaded.modules} >= {"research", "billing_portal"}
+    # App and workflow bundles have distinct canonical roots. Their connection
+    # is proven above by workflow loading and by the app acceptance gate's
+    # workflow_integration check, not by copying workflows into the app bundle.
+    assert loaded.definition.workflows == []
+    assert loaded.subscriptions_config is not None
+    loaded_limits = {
+        plan.plan_id: plan.usage_limits[0].monthly_limit
+        for plan in loaded.subscriptions_config.plans
+    }
+    assert loaded_limits == {"free": 20, "pro": 500}
+
+    # This proof deliberately stops at declared contract preservation. The OSS
+    # runtime does not yet count or enforce generic monthly research executions.
+    assert context["subscription_contract"]["validation_notes"] == [
+        "Execution-count enforcement is not currently implemented by the OSS runtime."
+    ]

--- a/tests/test_appgenerator_config_materializer.py
+++ b/tests/test_appgenerator_config_materializer.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 
+import pytest
 import yaml
+from pydantic import ValidationError
 
 from factory_app.workflows.AppGenerator.tools.assemble_app_tasks import (
     _apply_entitlement_gates,
@@ -11,6 +14,7 @@ from factory_app.workflows.AppGenerator.tools.materialize_app_config_contracts i
     _materialize_subscriptions_yaml,
     materialize_app_config_contracts,
 )
+from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
 
 
 class _Context:
@@ -116,9 +120,34 @@ def _saas_subscription_config_file() -> dict:
                 "plan_id": "pro",
                 "label": "Pro",
                 "capabilities": ["analytics.view", "exports.download"],
+                "usage_limits": [
+                    {
+                        "meter_id": "exports",
+                        "label": "Exports",
+                        "unit": "requests",
+                        "monthly_limit": 500,
+                        "capability_id": "exports.download",
+                    }
+                ],
+                "token_allowances": [
+                    {
+                        "wallet_id": "ai_tokens",
+                        "amount": 1000,
+                        "cadence": "monthly",
+                        "label": "Monthly AI tokens",
+                    }
+                ],
             },
         ],
-        "token_wallets": [],
+        "token_wallets": [
+            {
+                "wallet_id": "ai_tokens",
+                "label": "AI tokens",
+                "unit": "tokens",
+                "usage_meter_id": "ai_tokens",
+                "scope": "user",
+            }
+        ],
         "top_up_products": [],
         "add_on_products": [
             {
@@ -159,8 +188,8 @@ def test_materialize_subscriptions_yaml_returns_none_for_non_saas() -> None:
     assert result is None
 
 
-def test_materialize_subscriptions_yaml_returns_none_for_wrong_schema() -> None:
-    """Contract with wrong schema_version is ignored."""
+def test_materialize_subscriptions_yaml_rejects_unknown_schema() -> None:
+    """A present future contract fails closed instead of disappearing."""
     context = _Context(
         {
             "subscription_contract": {
@@ -171,12 +200,13 @@ def test_materialize_subscriptions_yaml_returns_none_for_wrong_schema() -> None:
             }
         }
     )
-    result = _materialize_subscriptions_yaml(context_variables=context)
-    assert result is None
+    with pytest.raises(ValidationError, match="schema_version"):
+        _materialize_subscriptions_yaml(context_variables=context)
 
 
 def test_materialize_subscriptions_yaml_emits_valid_yaml_for_saas_app() -> None:
     cfg = _saas_subscription_config_file()
+    original = deepcopy(cfg)
     context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
 
     result = _materialize_subscriptions_yaml(context_variables=context)
@@ -191,8 +221,175 @@ def test_materialize_subscriptions_yaml_emits_valid_yaml_for_saas_app() -> None:
     assert len(doc["plans"]) == 2
     assert doc["plans"][1]["plan_id"] == "pro"
     assert doc["plans"][1]["capabilities"] == ["analytics.view", "exports.download"]
+    assert doc["plans"][1]["usage_limits"][0]["monthly_limit"] == 500
+    assert doc["plans"][1]["token_allowances"][0]["amount"] == 1000
     assert doc["add_on_products"][0]["add_on_id"] == "priority_review"
     assert doc["pricing_catalog"]["groups"][0]["add_on_ids"] == ["priority_review"]
+    assert doc["plans"][0]["capabilities"] == []
+    assert doc["top_up_products"] == []
+    assert doc["usage_charge_policies"] == []
+    assert "products" not in doc
+    assert "tenant_id_field" not in doc["assignment_store"]
+    assert "usage_limits" not in doc["plans"][0]
+    assert "token_allowances" not in doc["plans"][0]
+    assert cfg == original
+    assert SubscriptionsConfig.model_validate(doc) == SubscriptionsConfig.model_validate(cfg)
+
+    reordered = dict(reversed(list(cfg.items())))
+    reordered_context = _Context(
+        {"subscription_contract": {"subscription_config_file": reordered}}
+    )
+    assert _materialize_subscriptions_yaml(context_variables=reordered_context) == result
+
+
+def test_materialize_subscriptions_yaml_preserves_v2_multi_product_plans() -> None:
+    cfg = {
+        "schema_version": "mozaiks.subscriptions.v2",
+        "label": "Workspace Products",
+        "default_product_id": "research",
+        "products": [
+            {
+                "product_id": "research",
+                "label": "Research",
+                "default_plan_id": "free",
+                "assignment_store": {
+                    "data_alias": "research.subscriptions",
+                    "tenant_id_field": None,
+                },
+                "token_wallets": [],
+                "top_up_products": [],
+                "usage_charge_policies": [],
+                "pricing_catalog_group": {
+                    "group_id": "research",
+                    "label": "Research",
+                    "plan_ids": ["free", "pro"],
+                    "capability_groups": [],
+                    "add_on_ids": [],
+                },
+                "plans": [
+                    {
+                        "plan_id": "free",
+                        "label": "Free",
+                        "capabilities": ["research.execute"],
+                        "usage_limits": [
+                            {
+                                "meter_id": "research_executions",
+                                "unit": "requests",
+                                "monthly_limit": 20,
+                                "capability_id": "research.execute",
+                            }
+                        ],
+                    },
+                    {
+                        "plan_id": "pro",
+                        "label": "Pro",
+                        "capabilities": ["research.execute"],
+                        "usage_limits": [
+                            {
+                                "meter_id": "research_executions",
+                                "unit": "requests",
+                                "monthly_limit": 500,
+                                "capability_id": "research.execute",
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "product_id": "collaboration",
+                "label": "Collaboration",
+                "default_plan_id": "team",
+                "plans": [
+                    {
+                        "plan_id": "team",
+                        "label": "Team",
+                        "capabilities": ["workspace.share"],
+                    }
+                ],
+            },
+        ],
+    }
+    original = deepcopy(cfg)
+    context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
+
+    result = _materialize_subscriptions_yaml(context_variables=context)
+
+    assert result is not None
+    doc = yaml.safe_load(result)
+    assert doc["schema_version"] == "mozaiks.subscriptions.v2"
+    assert doc["default_product_id"] == "research"
+    assert [product["product_id"] for product in doc["products"]] == [
+        "research",
+        "collaboration",
+    ]
+    research_plans = doc["products"][0]["plans"]
+    assert [plan["usage_limits"][0]["monthly_limit"] for plan in research_plans] == [20, 500]
+    assert "plans" not in doc
+    assert doc["products"][0]["assignment_store"]["tenant_id_field"] is None
+    assert doc["products"][0]["token_wallets"] == []
+    assert doc["products"][0]["top_up_products"] == []
+    assert doc["products"][0]["usage_charge_policies"] == []
+    assert doc["products"][0]["pricing_catalog_group"]["capability_groups"] == []
+    assert cfg == original
+    assert SubscriptionsConfig.model_validate(doc) == SubscriptionsConfig.model_validate(cfg)
+
+
+def test_materialize_subscriptions_yaml_preserves_explicit_false_and_zero() -> None:
+    cfg = _saas_subscription_config_file()
+    cfg["add_on_products"][0]["active"] = False
+    cfg["usage_charge_policies"] = [
+        {
+            "meter_id": "ai_tokens",
+            "markup_percent": 0,
+            "minimum_charge_usd": 0,
+        }
+    ]
+    context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
+
+    result = _materialize_subscriptions_yaml(context_variables=context)
+
+    assert result is not None
+    doc = yaml.safe_load(result)
+    assert doc["add_on_products"][0]["active"] is False
+    assert doc["usage_charge_policies"][0]["markup_percent"] == 0
+    assert doc["usage_charge_policies"][0]["minimum_charge_usd"] == 0
+
+
+def test_materialize_subscriptions_yaml_preserves_explicit_null_over_default() -> None:
+    cfg = _saas_subscription_config_file()
+    cfg["assignment_store"]["tenant_id_field"] = None
+    context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
+
+    result = _materialize_subscriptions_yaml(context_variables=context)
+
+    assert result is not None
+    doc = yaml.safe_load(result)
+    assert "tenant_id_field" in doc["assignment_store"]
+    assert doc["assignment_store"]["tenant_id_field"] is None
+
+
+def test_materialize_subscriptions_yaml_preserves_explicit_empty_mapping() -> None:
+    cfg = _saas_subscription_config_file()
+    cfg["assignment_store"] = {}
+    context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
+
+    result = _materialize_subscriptions_yaml(context_variables=context)
+
+    assert result is not None
+    doc = yaml.safe_load(result)
+    assert doc["assignment_store"] == {}
+    assert SubscriptionsConfig.model_validate(doc) == SubscriptionsConfig.model_validate(cfg)
+
+
+def test_materialize_subscriptions_yaml_rejects_unknown_plan_fields() -> None:
+    cfg = _saas_subscription_config_file()
+    cfg["plans"][0]["future_allowance"] = {"amount": 12}
+    context = _Context({"subscription_contract": {"subscription_config_file": cfg}})
+
+    with pytest.raises(ValidationError, match="future_allowance") as exc_info:
+        _materialize_subscriptions_yaml(context_variables=context)
+
+    assert exc_info.value.errors()[0]["loc"] == ("plans", 0, "future_allowance")
 
 
 def test_materialize_subscriptions_yaml_reads_artifact_fallback() -> None:

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -12,6 +12,9 @@ from fastapi.testclient import TestClient
 from factory_app.workflows.AppGenerator.tools.app_validation import (
     run_app_bundle_acceptance_gate,
 )
+from factory_app.workflows.AppGenerator.tools.module_api_template import (
+    get_module_api_template,
+)
 from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
 from mozaiksai.core.validation import (
     GeneratedAppValidationRequest,
@@ -580,6 +583,98 @@ def _prepare_platform_test_runtime(platform: Any, monkeypatch: pytest.MonkeyPatc
 
 def test_functional_scanner_accepts_basic_authenticated_crud_bundle() -> None:
     assert scan_functional_generated_app(_basic_crud_files()) == []
+
+
+def test_functional_scanner_ignores_canonical_module_api_documentation_example() -> None:
+    files = _basic_crud_files()
+    files["ui/lib/moduleApi.js"] = get_module_api_template()
+
+    assert scan_functional_generated_app(files) == []
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["ui/lib/moduleApi.js", "ui/lib/copied/moduleApi.js"],
+)
+def test_functional_scanner_validates_executable_calls_in_module_api_files(path: str) -> None:
+    files = _basic_crud_files()
+    files[path] = get_module_api_template() + "\nmoduleAction('inventory', 'missing_action', {})\n"
+
+    diagnostics = scan_functional_generated_app(files)
+
+    assert any(
+        item.code == "MISSING_MODULE_ACTION" and item.path == path
+        for item in diagnostics
+    )
+
+
+def test_functional_scanner_handles_javascript_comment_and_string_boundaries() -> None:
+    files = _basic_crud_files()
+    files["ui/pages/custom/orders.jsx"] = r'''
+// moduleAction('inventory', 'line_comment', {})
+/* moduleAction('inventory', 'block_comment', {}) */
+const url = "https://example.test/a//b"
+const quotedDocs = "moduleAction('inventory', 'quoted_docs', {}) // text"
+const escapedQuote = "say \"// moduleAction('inventory', 'escaped_docs', {})\""
+const templateDocs = `// moduleAction('inventory', 'template_docs', {})`
+const expression = `${/* moduleAction('inventory', 'expression_docs', {}) */ "ok"}`
+const endpoint = "https://example.test/api/modules/orders/create_order"
+await moduleAction('orders', 'create_order', {})
+'''
+
+    assert scan_functional_generated_app(files) == []
+
+
+def test_functional_scanner_validates_module_action_in_template_expression() -> None:
+    files = _basic_crud_files()
+    files["ui/pages/custom/orders.jsx"] = (
+        "const result = `${await moduleAction('inventory', 'missing_action', {})}`\n"
+    )
+
+    diagnostics = scan_functional_generated_app(files)
+
+    assert any(item.code == "MISSING_MODULE_ACTION" for item in diagnostics)
+
+
+def test_functional_scanner_handles_nested_template_expression_boundaries() -> None:
+    files = _basic_crud_files()
+    files["ui/pages/custom/orders.jsx"] = r'''
+const docs = `outer ${`inner moduleAction('inventory', 'template_docs', {})`}`
+const strings = `outer ${"moduleAction('inventory', 'string_docs', {})"}`
+const comments = `outer ${/* moduleAction('inventory', 'comment_docs', {}) */ "ok"}`
+const result = `outer ${`inner ${await moduleAction('orders', 'create_order', {})}`}`
+'''
+
+    assert scan_functional_generated_app(files) == []
+
+
+def test_functional_scanner_finds_action_in_nested_template_expression() -> None:
+    files = _basic_crud_files()
+    files["ui/pages/custom/orders.jsx"] = (
+        "const result = `outer ${`inner ${await "
+        "moduleAction('inventory', 'missing_action', {})}`}`\n"
+    )
+
+    diagnostics = scan_functional_generated_app(files)
+
+    assert any(item.code == "MISSING_MODULE_ACTION" for item in diagnostics)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "const docs = 'moduleAction(\\\"inventory\\\", \\\"string_docs\\\", {})\\\\",
+        'const docs = "moduleAction(\\\'inventory\\\', \\\'string_docs\\\', {})\\\\',
+        "const docs = `moduleAction('inventory', 'template_docs', {})\\\\",
+        "/* moduleAction('inventory', 'block_docs', {})",
+        "// moduleAction('inventory', 'line_docs', {})",
+    ],
+)
+def test_functional_scanner_terminates_on_unterminated_javascript(source: str) -> None:
+    files = _basic_crud_files()
+    files["ui/pages/custom/orders.jsx"] = source
+
+    assert scan_functional_generated_app(files) == []
 
 
 def test_public_generated_app_validation_runs_functional_completeness() -> None:


### PR DESCRIPTION
## 1. Production defects corrected

- AppGenerator now validates subscription output through the canonical SubscriptionsConfig model and serializes every supported v1/v2 field without dropping plan usage_limits or token_allowances.
- Serialization omits unset defaults while preserving explicit null, false, zero, empty-list, and supported empty-mapping values recursively.
- Unsupported schema versions and fields fail closed with canonical validation paths.
- Generated-app functional validation now ignores documentation-only JavaScript references while retaining executable moduleAction and module endpoint bindings, including nested template expressions.

## 2. Deterministic integration path proven

The offline golden-path test exercises MozaiksPay build-context selection, SubscriptionContractDesigner persistence boundaries, AppBuildPlan normalization, deterministic app and workflow structured-output fixtures, workflow promotion and loading, AppGenerator assembly, managed facade materialization, bundle validation and wiring, export acceptance, deployment artifact rendering, ZIP output, and AppLoader runtime loading.

It proves Free and Pro monthly declarations of 20 and 500 research executions survive assembly and reload, and that research.execute protects the generated research action.

## 3. External boundaries replaced with doubles

The test replaces only review UI interaction, artifact and workflow-export persistence, build-status persistence, bundle registration, stored agent-output lookup, and download UI confirmation. It uses no provider credentials, live model calls, or live MozaiksPay calls.

## 4. Explicitly unproven behavior

- Raw-prompt-to-app generation and live model behavior are not proven.
- Live AG2 workflow execution is not proven.
- Generic monthly research-execution counting and enforcement are not implemented.
- Live MozaiksPay readiness, checkout, settlement, and fulfillment are not proven.

## 5. Validation results and origin/main baseline

- PR #399 repaired the stale main documentation-language test.
- After rebasing onto repaired main, local documentation-language tests passed: 5 passed.
- Focused changed-area tests: 42 passed.
- Golden-path dependency slice: 400 passed.
- Ruff on changed Python files: passed.
- git diff --check: passed.
- PR #398 complete GitHub CI and DCO checks: passed.