### PR TITLE
test(docs): align README checks with concise setup help

### DIFF
--- a/tests/test_user_facing_docs_language.py
+++ b/tests/test_user_facing_docs_language.py
@@ -9,10 +9,10 @@ def _read(relative_path: str) -> str:
     return (ROOT / relative_path).read_text(encoding="utf-8")
 
 
-def test_readme_uses_plain_tool_framing() -> None:
+def test_readme_uses_concise_setup_guidance() -> None:
     readme = _read("README.md")
 
-    assert "### Which Tool To Use" in readme
+    assert "If setup fails, check three things first:" in readme
     assert "Mozaiks is not published as a public PyPI package yet." in readme
     assert 'python -m pip install -e ".[dev]"' in readme
     assert "python -m mozaiks quickstart --dir .\\mozaiks-workspace" in readme
@@ -22,8 +22,7 @@ def test_readme_uses_plain_tool_framing() -> None:
     assert "pipx" not in readme
     assert "python -m venv .venv" not in readme
     assert "python -m pip install mozaiks" not in readme
-    assert "The **CLI** is just how you set up the" in readme
-    assert "Most users can start from Studio" in readme
+    assert "set an LLM API key before running builds." in readme
     assert "developer entrypoint" not in readme
     assert "internal host name" not in readme
 


### PR DESCRIPTION
## Summary

Update the stale README language test to match the intentional setup-help simplification from commit f7ad988e.

## Evidence

Commit f7ad988e is titled docs: shorten README setup help and deliberately removed the Which Tool To Use section, the CLI setup sentence, and the Most users can start from Studio sentence. The test predated that change and continued requiring all three removed strings.

This PR keeps the shortened README and checks its replacement troubleshooting guidance instead.

## Scope

- Changes only tests/test_user_facing_docs_language.py.
- Does not modify PR #398 or any factory/runtime files.
- No changelog entry is needed for a stale-test correction.

## Validation

- Affected test: 1 passed.
- Complete tests/test_user_facing_docs_language.py: 5 passed.
- Ruff on the changed Python test: passed.
- git diff --check: passed.