### PR TITLE
feat(control-plane): ACP-backed CLI coding provider, dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **ACP-backed CLI coding provider (dark)**: `ACPCodingProvider` drives an
+  ACP-compatible coding agent (Claude Code, Codex, OpenCode) for one bounded
+  turn inside a disposable staged workspace, then accepts only what the
+  deterministic hash harvest verifies — out-of-scope edits, timeouts, empty
+  results, and budget overruns all fail closed with typed statuses. Headless
+  hardening is explicit: allowlisted subprocess env (provider API keys only),
+  `expose_tools=False`, terminal capability not advertised,
+  `elicitation_policy="decline"`. Disabled by default in refinement policy,
+  packaged behind the new optional `mozaiks[acp-coding]` extra
+  (`agent-client-protocol` pinned to 0.12.0 — 0.12.1 breaks ag2 1.0.2's
+  dispatcher import), and not yet reachable from any production path:
+  provider selection ships separately.
+
 - **Typed refinement lanes and coding provider policy**: the eight refinement
   lanes (`ui_patch`, `experience_design`, `feature_addition`, `integration`,
   `managed_capability_change`, `data_model_migration`, `architecture_replan`,

--- a/mozaiksai/control_plane/__init__.py
+++ b/mozaiksai/control_plane/__init__.py
@@ -83,6 +83,7 @@ from .executor import (
     resolve_control_plane_tool_entrypoint,
 )
 from .implementations import (
+    ACPCodingProvider,
     ArtifactKind,
     ArtifactScopeProposer,
     ChangeClass,
@@ -97,6 +98,7 @@ from .implementations import (
     RefinementTriggerRouteResolver,
     ScopedRefinementCodingWorker,
     StructuredOutputCodingProvider,
+    acp_available,
     get_change_classifier,
     get_coding_worker,
     get_harness_decision_policy,
@@ -222,6 +224,7 @@ __all__ = [
     "ControlPlaneArtifactChangeRoutesManifest",
     "ControlPlaneArtifactRoutingManifest",
     "ControlPlaneChangeRouteManifest",
+    "ACPCodingProvider",
     "ControlPlaneACPProviderConfig",
     "ControlPlaneCapabilityConfig",
     "ControlPlaneCodingCapabilityConfig",
@@ -279,6 +282,7 @@ __all__ = [
     "WorkspaceScopeViolation",
     "harvest_coding_workspace",
     "materialize_coding_workspace",
+    "acp_available",
     "safe_artifact_relpath",
     "build_selected_control_plane_harness",
     "build_refinement_review_package",

--- a/mozaiksai/control_plane/contracts.py
+++ b/mozaiksai/control_plane/contracts.py
@@ -400,7 +400,16 @@ class StagedPatchProposal(BaseModel):
     proposal_id: str = Field(min_length=1)
     provider_id: str = Field(min_length=1)
     provider_model: str | None = None
-    status: Literal["completed", "failed"]
+    status: Literal[
+        "completed",
+        "failed",
+        "empty",
+        "rejected_scope",
+        "timeout",
+        "budget_exceeded",
+        "unavailable",
+    ]
+    usage: dict[str, int] | None = None
     summary: str = ""
     rationale: str = ""
     changed_files: list[ProposedFileChange] = Field(default_factory=list)

--- a/mozaiksai/control_plane/implementations/__init__.py
+++ b/mozaiksai/control_plane/implementations/__init__.py
@@ -1,3 +1,4 @@
+from .acp_coding_provider import ACPCodingProvider, acp_available
 from .change_classifier import ChangeClassifierResult, LLMChangeClassifier, get_change_classifier
 from .coding_worker import ScopedRefinementCodingWorker, get_coding_worker
 from .harness_decision import FirstPartyHarnessDecisionPolicy, get_harness_decision_policy
@@ -19,6 +20,7 @@ from .scope_proposer import ArtifactScopeProposer, get_scope_proposer
 from .structured_coding_provider import StructuredOutputCodingProvider
 
 __all__ = [
+    "ACPCodingProvider",
     "ArtifactKind",
     "ArtifactScopeProposer",
     "ChangeClass",
@@ -33,6 +35,7 @@ __all__ = [
     "RefinementRoutingDecision",
     "RefinementTriggerRouteResolver",
     "StructuredOutputCodingProvider",
+    "acp_available",
     "get_change_classifier",
     "get_coding_worker",
     "get_harness_decision_policy",

--- a/mozaiksai/control_plane/implementations/acp_coding_provider.py
+++ b/mozaiksai/control_plane/implementations/acp_coding_provider.py
@@ -1,0 +1,361 @@
+"""ACP-backed CLI coding provider for the refinement control plane.
+
+Implements :class:`~mozaiksai.control_plane.ports.CodingExecutionProvider` by
+driving an ACP-compatible CLI coding agent (Claude Code, Codex, OpenCode) for
+one bounded prompt turn inside a disposable staged workspace, then harvesting
+the workspace diff deterministically.
+
+Authority model: the provider receives an explicitly scoped
+:class:`CodingWorkerRequest` and returns a :class:`StagedPatchProposal`. It
+holds no routing, scope, acceptance, or promotion authority, and nothing in
+this module trusts the CLI agent: the workspace contains only copies of the
+scoped files, the subprocess environment is an explicit allowlist, the agent's
+question/permission channels are closed (``elicitation_policy="decline"``,
+terminal capability not advertised), and every accepted change comes from the
+post-run hash harvest — never from the agent's own claims. Out-of-scope edits
+reject the whole proposal.
+
+This provider is dark by default: ``refinement_policy.yaml``'s
+``coding.providers.acp.enabled`` is ``false``, the ``ag2[acp]`` extra is
+optional, and no production path constructs it yet (provider selection lands
+separately).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from mozaiksai.control_plane.config import (
+    ControlPlaneACPProviderConfig,
+    ControlPlaneConfig,
+    load_control_plane_config,
+)
+from mozaiksai.control_plane.contracts import (
+    CodingWorkerRequest,
+    ProposedFileChange,
+    StagedPatchProposal,
+)
+from mozaiksai.control_plane.workspace import (
+    StagedCodingWorkspace,
+    WorkspaceHarvest,
+    harvest_coding_workspace,
+    materialize_coding_workspace,
+)
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - exercised via the availability branch in tests
+    from ag2 import Agent as _AG2Agent
+    from ag2.acp import ACPConfig, ClaudeCodeConfig, CodexConfig, OpenCodeConfig
+
+    _ACP_IMPORT_ERROR: Exception | None = None
+except Exception as _import_exc:  # ImportError or missing-optional stub errors
+    _AG2Agent = None  # type: ignore[misc, assignment]
+    ACPConfig = None  # type: ignore[misc, assignment]
+    _ACP_IMPORT_ERROR = _import_exc
+
+DEFAULT_ACP_STAGING_ROOT = Path(".refinement_staging") / "acp_workspaces"
+
+# The only host environment variables that may reach the CLI agent subprocess.
+# Everything else — including the Mozaiks runtime's own provider keys, Mongo
+# URIs, and platform secrets — is withheld. Model-selection variables are
+# adapter-owned and intentionally not forwarded from the host.
+_ENV_PASSTHROUGH_KEYS = ("ANTHROPIC_API_KEY", "CODEX_API_KEY", "OPENAI_API_KEY")
+
+_ADAPTERS = ("claude_code", "codex", "opencode")
+
+
+def acp_available() -> bool:
+    """True when the ``ag2[acp]`` extra is importable in this environment."""
+    return _ACP_IMPORT_ERROR is None
+
+
+def build_acp_agent_config(
+    *,
+    adapter: str,
+    workspace_root: Path,
+    turn_timeout_seconds: int,
+    env_source: dict[str, str],
+) -> Any:
+    """Build the hardened ACPConfig for one provider execution.
+
+    Every safety-relevant field is set explicitly rather than defaulted:
+    the workspace is both ``cwd`` and ``fs_root``; the subprocess env is an
+    explicit allowlist over ``env_source``; ``expose_tools=False`` (the AG2
+    default is True) so no MCP gateway is started; ``allow_terminal=False``
+    because agent-requested terminal commands inherit the full host
+    environment in ag2 1.0.2 (``ag2/acp/bridge.py:123``); and
+    ``elicitation_policy="decline"`` so the question capability is never
+    advertised in headless execution. ``permission_policy="auto"`` is safe
+    only because the blast radius is the disposable workspace plus the
+    harvest filter.
+    """
+    if not acp_available():  # pragma: no cover - guarded by caller
+        raise RuntimeError(f"ag2[acp] extra is not installed: {_ACP_IMPORT_ERROR}")
+    if adapter not in _ADAPTERS:
+        raise ValueError(f"Unknown ACP adapter {adapter!r}; expected one of {_ADAPTERS}")
+
+    env = {key: env_source[key] for key in _ENV_PASSTHROUGH_KEYS if env_source.get(key)}
+    preset = {
+        "claude_code": ClaudeCodeConfig,
+        "codex": CodexConfig,
+        "opencode": OpenCodeConfig,
+    }[adapter]
+    return preset(
+        cwd=str(workspace_root),
+        fs_root=str(workspace_root),
+        env=env or None,
+        permission_policy="auto",
+        elicitation_policy="decline",
+        expose_tools=False,
+        allow_terminal=False,
+        turn_timeout=float(turn_timeout_seconds),
+    )
+
+
+def build_provider_prompt(request: CodingWorkerRequest, workspace: StagedCodingWorkspace) -> str:
+    """Task framing for the CLI agent.
+
+    Informative only — nothing here is load-bearing for safety. The editable
+    set is enforced by the harvest, not by these instructions.
+    """
+    editable = "\n".join(f"- {path}" for path in sorted(workspace.editable_manifest))
+    return "\n".join(
+        [
+            "You are performing one bounded, pre-approved code change in this",
+            "workspace. The workspace contains copies of exactly the files in",
+            "scope; there is no wider repository.",
+            "",
+            f"Request: {request.raw_user_request}",
+            "",
+            "Editable files (changes anywhere else are discarded):",
+            editable,
+            "",
+            "Edit the files in place to satisfy the request. Do not create new",
+            "files, do not delete files, and do not run commands. When you are",
+            "done, reply with a short summary of what you changed and why.",
+        ]
+    )
+
+
+class ACPCodingProvider:
+    """One bounded CLI-agent execution per request, harvest-verified."""
+
+    def __init__(
+        self,
+        *,
+        config_loader: Any = load_control_plane_config,
+        staging_root: Path | None = None,
+        acp_config_factory: Callable[..., Any] | None = None,
+        env_source: dict[str, str] | None = None,
+    ) -> None:
+        self._config_loader = config_loader
+        self._staging_root = Path(staging_root) if staging_root is not None else DEFAULT_ACP_STAGING_ROOT
+        self._acp_config_factory = acp_config_factory or build_acp_agent_config
+        self._env_source = env_source
+
+    @property
+    def provider_id(self) -> str:
+        return f"acp_{self._provider_config().adapter}"
+
+    def _load_config(self) -> ControlPlaneConfig:
+        config = self._config_loader()
+        return config if isinstance(config, ControlPlaneConfig) else ControlPlaneConfig.model_validate(config)
+
+    def _provider_config(self) -> ControlPlaneACPProviderConfig:
+        return self._load_config().coding.providers.acp
+
+    def _proposal(self, *, status: str, provider_id: str, **fields: Any) -> StagedPatchProposal:
+        return StagedPatchProposal(
+            proposal_id=uuid.uuid4().hex,
+            provider_id=provider_id,
+            status=status,  # type: ignore[arg-type]
+            **fields,
+        )
+
+    async def execute(self, request: CodingWorkerRequest) -> StagedPatchProposal:
+        provider_config = self._provider_config()
+        provider_id = f"acp_{provider_config.adapter}"
+
+        if not provider_config.enabled:
+            return self._proposal(
+                status="unavailable",
+                provider_id=provider_id,
+                error="ACP coding provider is disabled in refinement policy (coding.providers.acp.enabled).",
+            )
+        if not acp_available():
+            return self._proposal(
+                status="unavailable",
+                provider_id=provider_id,
+                error=f"ag2[acp] extra is not installed: {_ACP_IMPORT_ERROR}",
+            )
+        budget = provider_config.budget
+        if len(request.files) > budget.max_files:
+            return self._proposal(
+                status="budget_exceeded",
+                provider_id=provider_id,
+                error=(
+                    f"scoped file count {len(request.files)} exceeds the ACP provider budget "
+                    f"max_files={budget.max_files}"
+                ),
+            )
+
+        workspace_root = self._staging_root / request.app_id / uuid.uuid4().hex[:12]
+        workspace: StagedCodingWorkspace | None = None
+        try:
+            workspace = materialize_coding_workspace(dict(request.files), workspace_root=workspace_root)
+            return await self._run_turn(
+                request=request,
+                workspace=workspace,
+                provider_config=provider_config,
+                provider_id=provider_id,
+            )
+        except Exception as exc:
+            logger.warning("ACP_CODING_PROVIDER_FAILED app=%s: %s", request.app_id, exc, exc_info=True)
+            return self._proposal(status="failed", provider_id=provider_id, error=str(exc))
+        finally:
+            if workspace is not None:
+                workspace.cleanup()
+
+    async def _run_turn(
+        self,
+        *,
+        request: CodingWorkerRequest,
+        workspace: StagedCodingWorkspace,
+        provider_config: ControlPlaneACPProviderConfig,
+        provider_id: str,
+    ) -> StagedPatchProposal:
+        import os
+
+        acp_config = self._acp_config_factory(
+            adapter=provider_config.adapter,
+            workspace_root=workspace.workspace_root,
+            turn_timeout_seconds=provider_config.budget.max_wall_seconds,
+            env_source=self._env_source if self._env_source is not None else dict(os.environ),
+        )
+
+        summary_text = ""
+        finish_reason: str | None = None
+        usage: dict[str, int] | None = None
+        provider_model: str | None = None
+
+        async with acp_config:
+            agent = _AG2Agent("MozaiksACPCodingProvider", config=acp_config)
+            prompt = build_provider_prompt(request, workspace)
+            async with agent.run(prompt) as run:
+                reply = await run.result()
+            response = reply.response
+            message = getattr(response, "message", None)
+            summary_text = str(getattr(message, "content", "") or "").strip()
+            finish_reason = getattr(response, "finish_reason", None)
+            provider_model = getattr(response, "model", None)
+            raw_usage = getattr(response, "usage", None)
+            if raw_usage is not None:
+                usage = {
+                    key: value
+                    for key, value in (
+                        ("prompt_tokens", getattr(raw_usage, "prompt_tokens", None)),
+                        ("completion_tokens", getattr(raw_usage, "completion_tokens", None)),
+                        ("total_tokens", getattr(raw_usage, "total_tokens", None)),
+                    )
+                    if isinstance(value, int)
+                }
+
+        harvest = harvest_coding_workspace(workspace, allow_new_files=False, allow_deletes=False)
+
+        if finish_reason == "timeout":
+            return self._proposal(
+                status="timeout",
+                provider_id=provider_id,
+                provider_model=provider_model,
+                usage=usage,
+                error=(
+                    f"ACP turn exceeded the provider budget max_wall_seconds="
+                    f"{provider_config.budget.max_wall_seconds}; no changes were accepted."
+                ),
+            )
+        if not harvest.clean:
+            details = "; ".join(f"{violation.path} ({violation.kind})" for violation in harvest.violations)
+            return self._proposal(
+                status="rejected_scope",
+                provider_id=provider_id,
+                provider_model=provider_model,
+                usage=usage,
+                error=f"workspace harvest found out-of-scope modifications: {details}",
+            )
+
+        return self._build_result_proposal(
+            harvest=harvest,
+            provider_id=provider_id,
+            provider_model=provider_model,
+            usage=usage,
+            summary_text=summary_text,
+            max_diff_bytes=provider_config.budget.max_diff_bytes,
+        )
+
+    def _build_result_proposal(
+        self,
+        *,
+        harvest: WorkspaceHarvest,
+        provider_id: str,
+        provider_model: str | None,
+        usage: dict[str, int] | None,
+        summary_text: str,
+        max_diff_bytes: int,
+    ) -> StagedPatchProposal:
+        changed = [entry for entry in harvest.files if entry.modified]
+        if not changed:
+            return self._proposal(
+                status="empty",
+                provider_id=provider_id,
+                provider_model=provider_model,
+                usage=usage,
+                error="ACP agent completed the turn without modifying any scoped file.",
+            )
+
+        diff_bytes = sum(len((entry.content or "").encode("utf-8")) for entry in changed)
+        if diff_bytes > max_diff_bytes:
+            return self._proposal(
+                status="budget_exceeded",
+                provider_id=provider_id,
+                provider_model=provider_model,
+                usage=usage,
+                error=(
+                    f"harvested diff of {diff_bytes} bytes exceeds the ACP provider budget "
+                    f"max_diff_bytes={max_diff_bytes}; no changes were accepted."
+                ),
+            )
+
+        summary = summary_text or "ACP coding provider patch."
+        return self._proposal(
+            status="completed",
+            provider_id=provider_id,
+            provider_model=provider_model,
+            usage=usage,
+            summary=summary[:2000],
+            rationale=summary[:2000],
+            changed_files=[
+                ProposedFileChange(
+                    path=entry.path,
+                    op="create" if entry.op == "create" else "update",
+                    content=entry.content or "",
+                )
+                for entry in changed
+            ],
+            owned_paths=[entry.path for entry in changed],
+            validation_strategy_hint="local",
+            needs_human_review=True,
+        )
+
+
+__all__ = [
+    "ACPCodingProvider",
+    "DEFAULT_ACP_STAGING_ROOT",
+    "acp_available",
+    "build_acp_agent_config",
+    "build_provider_prompt",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,17 @@ gemini = [
 anthropic = [
     "ag2[anthropic]==1.0.2",
 ]
+# ACP-backed CLI coding provider (Codex, Claude Code, OpenCode) for the
+# refinement control plane. The adapter binaries (e.g. the
+# @agentclientprotocol/claude-agent-acp npm package) are deployment-time
+# dependencies and are NOT installed by this extra.
+acp-coding = [
+    "ag2[acp]==1.0.2",
+    # ag2 1.0.2 allows agent-client-protocol <0.13, but 0.12.1 removed
+    # acp.task.DefaultMessageDispatcher, which ag2's dispatch imports.
+    # Pin the last compatible version; re-check at every ag2 upgrade.
+    "agent-client-protocol==0.12.0",
+]
 azure = [
     "azure-identity>=1.15.0",
     "azure-keyvault-secrets>=4.7.0",
@@ -71,6 +82,12 @@ dev = [
     "watchdog",
     "types-PyYAML>=6.0",
     "mypy>=1.5.0",
+    # dev installs the ACP extra so the fake-driven provider tests run in CI;
+    # extra-free installs skip them via importorskip. The
+    # agent-client-protocol pin matches the acp-coding extra (0.12.1 breaks
+    # ag2 1.0.2's dispatcher import).
+    "ag2[acp]==1.0.2",
+    "agent-client-protocol==0.12.0",
 ]
 docs = [
     "mkdocs>=1.6.1,<2.0",

--- a/tests/test_acp_coding_provider.py
+++ b/tests/test_acp_coding_provider.py
@@ -1,0 +1,312 @@
+"""Tests for the ACP-backed coding provider — no subprocess, no live model.
+
+Every ACP interaction here runs through ``ag2.acp.testing.fake_acp_config``:
+scripted in-process turns that drive the real bridge, session lifecycle, and
+timeout machinery. The provider's safety properties are asserted from the
+outside: workspace disposal, env allowlisting, harvest-based acceptance, and
+fail-closed statuses for every non-happy path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("acp", reason="ag2[acp] extra not installed")
+
+from acp import schema  # noqa: E402
+from ag2.acp.testing import ACPTurn, fake_acp_config  # noqa: E402
+
+from mozaiksai.control_plane import (  # noqa: E402
+    ControlPlaneCodingCapabilityConfig,
+    ControlPlaneConfig,
+)
+from mozaiksai.control_plane.implementations.acp_coding_provider import (  # noqa: E402
+    ACPCodingProvider,
+    build_acp_agent_config,
+    build_provider_prompt,
+)
+
+_SCOPED_PATH = "app/ui/pages/Dashboard.jsx"
+_ORIGINAL = "export default function Dashboard() {}\n"
+_PATCHED = "export default function Dashboard() { return 1; }\n"
+
+
+def _policy(**acp_overrides: Any):
+    def _load() -> ControlPlaneConfig:
+        return ControlPlaneConfig(
+            enabled=True,
+            coding=ControlPlaneCodingCapabilityConfig.model_validate(
+                {"enabled": True, "providers": {"acp": {"enabled": True, **acp_overrides}}}
+            ),
+        )
+
+    return _load
+
+
+def _request_files() -> dict[str, str]:
+    return {_SCOPED_PATH: _ORIGINAL}
+
+
+def _request(**overrides: Any):
+    from mozaiksai.control_plane import CodingWorkerRequest
+
+    payload: dict[str, Any] = {
+        "app_id": "app_1",
+        "artifact_kind": "app_bundle",
+        "artifact_key": "app_bundle",
+        "artifact_version_id": "av_123",
+        "raw_user_request": "Make the dashboard return 1",
+        "change_class": "patch",
+        "files": _request_files(),
+    }
+    payload.update(overrides)
+    return CodingWorkerRequest(**payload)
+
+
+class _FakeConfigFactory:
+    """Builds a FakeACPConfig per execution, letting turns write via the bridge."""
+
+    def __init__(self, *turns: ACPTurn) -> None:
+        self.turns = turns
+        self.configs: list[Any] = []
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, *, adapter: str, workspace_root: Path, turn_timeout_seconds: int, env_source: dict) -> Any:
+        self.calls.append(
+            {
+                "adapter": adapter,
+                "workspace_root": workspace_root,
+                "turn_timeout_seconds": turn_timeout_seconds,
+            }
+        )
+        config = fake_acp_config(
+            *self.turns,
+            cwd=str(workspace_root),
+            fs_root=str(workspace_root),
+            permission_policy="auto",
+            elicitation_policy="decline",
+            expose_tools=False,
+            allow_terminal=False,
+            turn_timeout=float(turn_timeout_seconds),
+        )
+        self.configs.append(config)
+        return config
+
+
+def _writing_turn(factory_ref: list, path: str, content: str, *, message: str = "Patched the file.") -> ACPTurn:
+    async def _write() -> None:
+        config = factory_ref[0].configs[-1]
+        session = next(iter(config.sessions.values()))
+        await session.bridge.write_text_file(content=content, path=path, session_id="fake-session-1")
+
+    return ACPTurn(
+        on_prompt=_write,
+        updates=[schema.AgentMessageChunk(content=schema.TextContentBlock(text=message, type="text"), session_update="agent_message_chunk")],
+        usage=schema.Usage(input_tokens=100, output_tokens=20, total_tokens=120),
+    )
+
+
+def _provider(factory: _FakeConfigFactory, tmp_path: Path, **acp_overrides: Any) -> ACPCodingProvider:
+    return ACPCodingProvider(
+        config_loader=_policy(**acp_overrides),
+        staging_root=tmp_path / "acp_staging",
+        acp_config_factory=factory,
+        env_source={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_harvests_modified_file(tmp_path: Path) -> None:
+    factory_ref: list = []
+    factory = _FakeConfigFactory(_writing_turn(factory_ref, _SCOPED_PATH, _PATCHED))
+    factory_ref.append(factory)
+
+    provider = _provider(factory, tmp_path)
+    proposal = await provider.execute(_request())
+
+    assert proposal.status == "completed"
+    assert proposal.provider_id == "acp_claude_code"
+    assert [c.path for c in proposal.changed_files] == [_SCOPED_PATH]
+    assert proposal.changed_files[0].op == "update"
+    # the bridge's mediated write uses text mode, so Windows hosts produce
+    # CRLF; harvest reports the exact on-disk bytes, which is the contract.
+    assert proposal.changed_files[0].content.replace("\r\n", "\n") == _PATCHED
+    assert proposal.owned_paths == [_SCOPED_PATH]
+    assert proposal.validation_strategy_hint == "local"
+    assert proposal.needs_human_review is True
+    assert proposal.summary == "Patched the file."
+    assert proposal.usage == {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+    # the disposable workspace must be gone (empty parent dirs may remain)
+    staging = tmp_path / "acp_staging"
+    leftovers = [p for p in staging.rglob("*") if p.is_file()] if staging.exists() else []
+    assert leftovers == []
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_file_rejects_whole_proposal(tmp_path: Path) -> None:
+    factory_ref: list = []
+    factory = _FakeConfigFactory(_writing_turn(factory_ref, "app/rogue.py", "print('x')\n"))
+    factory_ref.append(factory)
+
+    proposal = await _provider(factory, tmp_path).execute(_request())
+
+    assert proposal.status == "rejected_scope"
+    assert proposal.changed_files == []
+    assert "app/rogue.py" in str(proposal.error)
+    assert "outside_allowlist" in str(proposal.error)
+
+
+@pytest.mark.asyncio
+async def test_no_modification_returns_empty(tmp_path: Path) -> None:
+    factory = _FakeConfigFactory(
+        ACPTurn(updates=[schema.AgentMessageChunk(content=schema.TextContentBlock(text="Nothing to do.", type="text"), session_update="agent_message_chunk")])
+    )
+    proposal = await _provider(factory, tmp_path).execute(_request())
+
+    assert proposal.status == "empty"
+    assert proposal.changed_files == []
+
+
+@pytest.mark.asyncio
+async def test_hanging_turn_times_out_and_accepts_nothing(tmp_path: Path) -> None:
+    factory_ref: list = []
+    # the agent writes a file, then hangs past the turn budget: the write must
+    # NOT be accepted, because the turn did not complete inside policy.
+    async def _write_then_never_finish() -> None:
+        config = factory_ref[0].configs[-1]
+        session = next(iter(config.sessions.values()))
+        await session.bridge.write_text_file(content=_PATCHED, path=_SCOPED_PATH, session_id="fake-session-1")
+
+    factory = _FakeConfigFactory(ACPTurn(on_prompt=_write_then_never_finish, hang=True))
+    factory_ref.append(factory)
+
+    provider = ACPCodingProvider(
+        config_loader=_policy(budget={"max_wall_seconds": 30}),
+        staging_root=tmp_path / "acp_staging",
+        acp_config_factory=lambda **kw: factory(**{**kw, "turn_timeout_seconds": 1}),
+        env_source={},
+    )
+    proposal = await provider.execute(_request())
+
+    assert proposal.status == "timeout"
+    assert proposal.changed_files == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_provider_is_unavailable(tmp_path: Path) -> None:
+    factory = _FakeConfigFactory()
+    provider = ACPCodingProvider(
+        config_loader=_policy(enabled=False),
+        staging_root=tmp_path,
+        acp_config_factory=factory,
+        env_source={},
+    )
+    proposal = await provider.execute(_request())
+
+    assert proposal.status == "unavailable"
+    assert factory.calls == []  # never even built a config
+
+
+@pytest.mark.asyncio
+async def test_file_count_over_budget_fails_before_any_execution(tmp_path: Path) -> None:
+    factory = _FakeConfigFactory()
+    provider = _provider(factory, tmp_path, budget={"max_files": 1})
+    files = {_SCOPED_PATH: _ORIGINAL, "app/other.py": "x = 1\n"}
+
+    proposal = await provider.execute(_request(files=files))
+
+    assert proposal.status == "budget_exceeded"
+    assert factory.calls == []
+
+
+@pytest.mark.asyncio
+async def test_diff_over_budget_rejects_harvested_changes(tmp_path: Path) -> None:
+    factory_ref: list = []
+    factory = _FakeConfigFactory(_writing_turn(factory_ref, _SCOPED_PATH, "x" * 4096))
+    factory_ref.append(factory)
+
+    proposal = await _provider(factory, tmp_path, budget={"max_diff_bytes": 1024}).execute(_request())
+
+    assert proposal.status == "budget_exceeded"
+    assert proposal.changed_files == []
+
+
+@pytest.mark.asyncio
+async def test_secret_scoped_file_fails_closed(tmp_path: Path) -> None:
+    factory = _FakeConfigFactory()
+    proposal = await _provider(factory, tmp_path).execute(
+        _request(files={"config/secrets.yaml": "key: old"})
+    )
+
+    assert proposal.status == "failed"
+    assert "WORKSPACE_SECRET_PATH" in str(proposal.error)
+    assert factory.calls == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_is_cleaned_up_even_on_rejection(tmp_path: Path) -> None:
+    factory_ref: list = []
+    factory = _FakeConfigFactory(_writing_turn(factory_ref, "app/rogue.py", "x\n"))
+    factory_ref.append(factory)
+    staging = tmp_path / "acp_staging"
+
+    await _provider(factory, tmp_path).execute(_request())
+
+    leftovers = [p for p in staging.rglob("*") if p.is_file()] if staging.exists() else []
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# Hardened config construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_acp_agent_config_is_hardened(tmp_path: Path) -> None:
+    env_source = {
+        "ANTHROPIC_API_KEY": "sk-ant-x",
+        "OPENAI_API_KEY": "sk-oai-x",
+        "MONGO_URI": "mongodb://secret",
+        "MOZAIKSPAY_CLIENT_SECRET": "mps_secret",
+        "PATH": "/usr/bin",
+    }
+    config = build_acp_agent_config(
+        adapter="claude_code",
+        workspace_root=tmp_path,
+        turn_timeout_seconds=300,
+        env_source=env_source,
+    )
+
+    assert config.cwd == str(tmp_path)
+    assert config.fs_root == str(tmp_path)
+    assert config.permission_policy == "auto"
+    assert config.elicitation_policy == "decline"
+    assert config.expose_tools is False
+    assert config.allow_terminal is False
+    assert config.turn_timeout == 300.0
+    # env allowlist: provider keys only — never platform secrets or PATH
+    assert config.env == {"ANTHROPIC_API_KEY": "sk-ant-x", "OPENAI_API_KEY": "sk-oai-x"}
+    assert config.command == ["claude-agent-acp"]
+
+
+def test_build_acp_agent_config_rejects_unknown_adapter(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unknown ACP adapter"):
+        build_acp_agent_config(
+            adapter="mystery",
+            workspace_root=tmp_path,
+            turn_timeout_seconds=60,
+            env_source={},
+        )
+
+
+def test_provider_prompt_lists_only_editable_files(tmp_path: Path) -> None:
+    from mozaiksai.control_plane.workspace import materialize_coding_workspace
+
+    workspace = materialize_coding_workspace(_request_files(), workspace_root=tmp_path / "ws")
+    prompt = build_provider_prompt(_request(), workspace)
+
+    assert _SCOPED_PATH in prompt
+    assert "Make the dashboard return 1" in prompt
+    assert "changes anywhere else are discarded" in prompt


### PR DESCRIPTION
## What

PR-4 of the approved ACP coding-provider plan (follows #403, #404, #405). `ACPCodingProvider` implements the `CodingExecutionProvider` boundary by driving an ACP-compatible CLI coding agent (`claude-agent-acp`, `codex-acp`, `opencode`) for **one bounded prompt turn inside a disposable staged workspace**, then harvesting the workspace diff deterministically. It ships **dark**: `coding.providers.acp.enabled: false`, optional dependency extra, and no production path constructs it — deterministic provider selection is PR-5.

## Fail-closed by construction — nothing trusts the agent

- **Workspace-copy isolation**: `cwd` = `fs_root` = a per-request workspace containing only copies of the explicitly scoped files (built by #404's materializer, which refuses unsafe/secret paths loudly).
- **Env allowlist**: the subprocess env carries provider API keys only (`ANTHROPIC_API_KEY`/`CODEX_API_KEY`/`OPENAI_API_KEY`); host secrets, Mongo URIs, and platform credentials are withheld. Pinned by test.
- **Channels closed**: `expose_tools=False` (AG2 defaults it to True), terminal capability **not advertised** (agent-requested terminal commands inherit the full host env in ag2 1.0.2 — `ag2/acp/bridge.py:123`), `elicitation_policy="decline"`, `permission_policy="auto"` justified only by the disposable blast radius.
- **Acceptance = harvest, never claims**: sha256 diff of the real tree decides everything. Out-of-scope writes → `rejected_scope` (whole proposal discarded); hung turn → cooperative cancel → `timeout` accepting nothing (pinned by a test where the agent writes a file *then* hangs); no modification → `empty`; file-count and diff-byte ceilings → `budget_exceeded`. Workspace cleanup in `finally` on every path.
- `StagedPatchProposal` gains the richer status vocabulary + optional `usage` (additive; the worker still treats non-`completed` as failed).

## Packaging

- New optional extra **`mozaiks[acp-coding]`** = `ag2[acp]==1.0.2` + `agent-client-protocol==0.12.0`. The explicit pin exists because **ag2 1.0.2 allows `agent-client-protocol <0.13` but 0.12.1 removed `acp.task.DefaultMessageDispatcher`, which ag2's dispatcher imports** — an upstream break inside ag2's own range, recorded as an AG2 upgrade watchpoint.
- `dev` includes the extra so CI runs the ACP suite; the test module `importorskip`s for extra-free installs.
- Adapter binaries (npm `@agentclientprotocol/*`) are deployment-time deps, deliberately not installed by any extra.

## Tests

12 new tests in `tests/test_acp_coding_provider.py`, driven entirely by `ag2.acp.testing.fake_acp_config` — scripted in-process turns through the real bridge/session/timeout machinery, **no subprocess, no live model, no network**: happy path with usage propagation, out-of-scope rejection, empty result, timeout-accepts-nothing, disabled→unavailable, both budget ceilings, secret-scoped file fail-closed, cleanup-on-rejection, hardened-config construction (env allowlist + every safety field), unknown-adapter rejection, prompt content.

Full suite in worktree: **13,641 passed, 79 skipped, 0 failed**; `ruff check .` clean; `mypy mozaiksai/control_plane/` clean.

## OSS Change Impact

- **Layer changed:** `mozaiksai/control_plane` + packaging.
- **Build workflow impact:** none.
- **Runtime/platform impact:** none reachable — provider is unconstructed in production; contract extension is additive.
- **App workspace impact:** none.
- **Control-plane / refinement impact:** no classification, routing, sequence, or checkpoint changes.
- **Docs updated:** `CHANGELOG.md`.
- **Compatibility risk:** low; the only behavioral surface is opt-in and disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)