### PR TITLE
feat(studio): promote triggers App Intelligence refresh; no validation override for coding-produced artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Promotion now triggers an App Intelligence refresh**: promoting an
+  artifact into the live app root enqueues a context index job automatically
+  (best-effort, reported in the promote response as
+  `app_intelligence_refresh`) — previously the refresh was a manual three-step
+  operator flow, so every refinement cycle after a promotion classified,
+  scoped, and validated against a stale context snapshot.
+
+### Security
+
+- **Coding-produced artifacts can no longer be promoted or accepted with a
+  validation override**: artifacts created by the refinement coding lane
+  (structured or ACP provider output) require `validation_status='passed'`;
+  the `allow_validation_override` escape hatch now returns 409 for them
+  instead of letting unvalidated model output into the live app root.
+
 - **Deterministic coding-provider selection with a fail-closed fallback
   ladder**: the refinement coding worker now dispatches each approved patch to
   a provider via pure policy (`select_coding_provider`) — the ACP provider is

--- a/mozaiksai/hosts/studio.py
+++ b/mozaiksai/hosts/studio.py
@@ -342,6 +342,18 @@ def _validation_override_required(version) -> bool:  # noqa: ANN001
     return version.validation_status in {ArtifactValidationStatus.PENDING, ArtifactValidationStatus.SKIPPED}
 
 
+def _is_coding_produced_artifact(version) -> bool:  # noqa: ANN001
+    """True when this artifact version was produced by the refinement coding lane.
+
+    Covers both the coding worker's staged bundles (``bundle_mode``) and
+    staged-refinement artifacts carrying a ``refinement`` metadata envelope.
+    """
+    metadata = _version_metadata(version)
+    if str(metadata.get("bundle_mode") or "").strip() == "staged_refinement_bundle":
+        return True
+    return isinstance(metadata.get("refinement"), dict)
+
+
 def _enforce_artifact_validation_gate(
     version,  # noqa: ANN001
     *,
@@ -356,6 +368,17 @@ def _enforce_artifact_validation_gate(
     if version.validation_status == ArtifactValidationStatus.PASSED:
         return
     if allow_validation_override and _validation_override_required(version):
+        # Coding-produced artifacts (structured or ACP provider output) must
+        # pass real validation; an override would let unvalidated model output
+        # into acceptance/promotion, so it is refused outright.
+        if _is_coding_produced_artifact(version):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Artifact cannot be {action}; coding-produced artifacts require "
+                    "validation_status='passed' and do not accept a validation override."
+                ),
+            )
         return
     raise HTTPException(
         status_code=409,
@@ -1831,6 +1854,7 @@ class BuildArtifactPromotionRequest(BaseModel):
 @app.post("/api/studio/build/artifacts/{artifact_version_id}/promote")
 async def promote_build_artifact_version(
     artifact_version_id: str,
+    background_tasks: BackgroundTasks,
     body: BuildArtifactPromotionRequest | None = None,
     app_id: str | None = None,
     principal: UserPrincipal = Depends(require_user_scope),
@@ -1921,6 +1945,22 @@ async def promote_build_artifact_version(
             logger.warning("promote_build conflict app=%s build=%s: %s", app_id, promotion_build_registry_id, exc)
             raise HTTPException(status_code=409, detail="Conflict promoting build.") from exc
 
+    # A promoted bundle changes the live app root, so the App Intelligence
+    # context must be rebuilt or the next refinement cycle classifies, scopes,
+    # and validates against a stale snapshot. Enqueued best-effort: a refresh
+    # failure is logged and reported but never rolls back the promotion.
+    app_intelligence_refresh: dict[str, Any] | None = None
+    try:
+        app_intelligence_refresh = await _start_studio_app_intelligence_index_job(
+            app_id=app_id,
+            user_id=user_id,
+            body=AppIntelligenceIndexRequest(),
+            background_tasks=background_tasks,
+        )
+    except Exception as exc:
+        logger.warning("POST_PROMOTE_APP_INTELLIGENCE_REFRESH_FAILED app=%s: %s", app_id, exc)
+        app_intelligence_refresh = {"status": "failed", "error": str(exc)}
+
     payload = await _build_artifact_review_payload(
         app_id=app_id,
         version=version,
@@ -1947,6 +1987,7 @@ async def promote_build_artifact_version(
         "restored_files": restore_summary["restored"],
         "skipped_files": restore_summary["skipped"],
         "app_registry": app_registry_result,
+        "app_intelligence_refresh": app_intelligence_refresh,
         **payload,
     }
 

--- a/tests/test_studio_artifact_restore.py
+++ b/tests/test_studio_artifact_restore.py
@@ -219,9 +219,16 @@ def test_promote_restores_current_app_bundle_from_staged_refinement(monkeypatch,
     assert store.updated_sessions[-1]["status"] == RefinementSessionStatus.PROMOTED
     assert body["app_registry"] is None
     assert body["review"]["review_status"] == "promoted"
+    # promotion changes the live app root, so an App Intelligence refresh is
+    # always attempted and reported (best-effort: failure never blocks promote)
+    assert "app_intelligence_refresh" in body
+    assert body["app_intelligence_refresh"] is not None
 
 
-def test_promote_requires_override_for_skipped_validation(monkeypatch, tmp_path: Path) -> None:
+def test_promote_refuses_override_for_coding_produced_artifacts(monkeypatch, tmp_path: Path) -> None:
+    # Artifacts produced by the refinement coding lane must pass real
+    # validation; the override escape hatch would let unvalidated model output
+    # into the live app root, so the gate refuses it outright.
     bundle_zip = tmp_path / "bundle.zip"
     _write_bundle_zip(
         bundle_zip,
@@ -249,8 +256,39 @@ def test_promote_requires_override_for_skipped_validation(monkeypatch, tmp_path:
     assert "validation_status='passed' is required" in blocked.json()["detail"]
     assert not (runtime_root / "GeneratedApp" / "src" / "App.jsx").exists()
 
-    allowed = client.post(
+    overridden = client.post(
         "/api/studio/build/artifacts/av_skipped_validation_1/promote",
+        json={"allow_validation_override": True},
+    )
+
+    assert overridden.status_code == 409
+    assert "coding-produced" in overridden.json()["detail"]
+    assert not (runtime_root / "GeneratedApp" / "src" / "App.jsx").exists()
+
+
+def test_promote_allows_override_for_non_coding_artifacts(monkeypatch, tmp_path: Path) -> None:
+    bundle_zip = tmp_path / "bundle.zip"
+    _write_bundle_zip(
+        bundle_zip,
+        {
+            "GeneratedApp/src/App.jsx": "export default function App() { return <div>Promoted</div>; }\n",
+        },
+    )
+    version = _version(
+        artifact_version_id="av_skipped_plain_1",
+        zip_path=bundle_zip,
+        lifecycle_status=ArtifactLifecycleStatus.CURRENT,
+        validation_status=ArtifactValidationStatus.SKIPPED,
+        files_manifest=[
+            {"path": "GeneratedApp/src/App.jsx", "sha256": "sha-app", "size_bytes": 62},
+        ],
+    )
+    runtime_root = tmp_path / "runtime_app"
+    store = _PromoteStore(version)
+    _, client = _promote_client(monkeypatch, runtime_root, store)
+
+    allowed = client.post(
+        "/api/studio/build/artifacts/av_skipped_plain_1/promote",
         json={"allow_validation_override": True},
     )
 


### PR DESCRIPTION
## What

PR-7 of the approved ACP coding-provider plan (follows #403–#407; the larger observability PR-6 is intentionally reordered after this smaller, higher-value slice). Closes two lifecycle gaps the ACP architecture trace surfaced.

### 1. Promotion now refreshes App Intelligence

Promotion restores a bundle into the live app root but never refreshed the context — and refinement validation resolves its workspace from the *latest index job* (`app_validation.py`), so every cycle after a promotion classified, scoped, and validated against a **stale snapshot**, compounding across cycles. The promote endpoint now enqueues the existing context index job automatically (reusing `_start_studio_app_intelligence_index_job`, best-effort: a refresh failure is logged and reported in the response as `app_intelligence_refresh`, never rolling back the promotion). The manual three-step operator flow remains as the explicit path.

### 2. Coding-produced artifacts cannot use the validation override

`validation_strategy` defaults to `skip`, `skipped` maps to a persisted DRAFT with `validation_status=SKIPPED`, and `allow_validation_override` could promote that artifact — entirely unvalidated model output — into the live root. `_enforce_artifact_validation_gate` now refuses the override for coding-produced artifacts (`bundle_mode: staged_refinement_bundle` or a `refinement` metadata envelope) on **both accept and promote**, with a distinct 409 message. Non-coding artifacts keep the override unchanged.

## Tests

- `test_promote_refuses_override_for_coding_produced_artifacts` (rewritten from the old override test, which pinned the now-closed hole) — override → 409, nothing restored.
- `test_promote_allows_override_for_non_coding_artifacts` (new) — the override still works where it should.
- Happy-path promote asserts `app_intelligence_refresh` is present and non-null.
- Full suite in worktree: **13,658 passed, 79 skipped, 0 failed**; `ruff check .` clean.

## OSS Change Impact

- **Layer changed:** Studio host (`mozaiksai/hosts/studio.py`) + tests.
- **Build workflow impact:** none.
- **Runtime/platform impact:** promote response gains `app_intelligence_refresh` (additive); one deliberate behavioral restriction (override refusal) called out above.
- **App workspace impact:** none.
- **Control-plane / refinement impact:** no classification/routing/sequence changes; acceptance and promotion gates strengthened as described.
- **Docs updated:** `CHANGELOG.md` (Added + Security).
- **Compatibility risk:** low — the restricted path was a footgun, and the old behavior is preserved for non-coding artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)