### PR TITLE
docs: require DCO sign-off in agent branch-workflow guidance

### DIFF
--- a/.claude/rules/multi-agent-coordination.md
+++ b/.claude/rules/multi-agent-coordination.md
@@ -63,11 +63,21 @@ Never push directly to `main`. Always:
 ```bash
 git checkout main && git reset --hard origin/main
 git checkout -b cc/<short-description>    # cc/ prefix = Claude Code
-# ... do work, commit ...
+# ... do work, commit -s ...
 git push -u origin cc/<short-description>
 gh pr create --title "..." --body "..."
 gh pr merge <number> --squash --delete-branch --auto
 ```
+
+**Every commit must be signed off (DCO) — always use `git commit -s`, never
+plain `git commit -m`.** This repo is under the Developer Certificate of
+Origin (see [DCO.md](../../DCO.md)); a commit without a `Signed-off-by:`
+trailer fails the `dco` check. That check is not yet in the `main` branch
+protection required-checks list, so `--auto` can still merge a PR with a
+failing `dco` check — do not treat a green auto-merge as proof you signed off
+correctly. If you forgot on the last commit, fix it before pushing (or before
+leaving a PR open) with `git commit --amend -s --no-edit && git push --force-with-lease`;
+for several unsigned commits use `git rebase --signoff origin/main` first.
 
 Auto-merge is enabled repo-wide. Request it right when you open the PR — do
 not wait around watching CI yourself. GitHub merges automatically once every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ there concurrently and will switch branches or sweep in unrelated edits.
 ```bash
 git checkout main && git reset --hard origin/main
 git checkout -b cc/<description>  # cc/ = Claude Code, codex/ = Codex
-# ... work, commit ...
+# ... work, commit -s ...
 git push -u origin cc/<description>
 gh pr create --title "..." --body "..."
 gh pr merge <number> --squash --delete-branch --auto   # auto-merge is enabled repo-wide; request it right away, don't wait on CI
@@ -337,6 +337,14 @@ the worktree. If a check still fails, confirm via `git show origin/main:<path>`
 whether it's pre-existing on `main` before assuming it's your bug — and if a
 check fails identically across multiple unrelated PRs, it's a repo-wide `main`
 regression blocking everyone; fix it first with a small isolated hotfix PR.
+
+**Every commit must carry a DCO sign-off — use `git commit -s`, never plain
+`-m`.** See [DCO.md](DCO.md). A commit without a `Signed-off-by:` trailer
+fails the `dco` check, and that check is *not* in `main`'s required-checks
+list — `--auto` can merge right past a failing `dco` check, so a green
+auto-merge is not proof you signed off. Forgot on the last commit? Fix it
+before pushing with `git commit --amend -s --no-edit`; for several unsigned
+commits, `git rebase --signoff origin/main`.
 
 Primary repo ownership (avoids overlap by default):
 


### PR DESCRIPTION
## Summary

The branch-workflow command snippets in `AGENTS.md` and
`.claude/rules/multi-agent-coordination.md` — the ones agents (Claude Code,
Codex) actually copy commands from — never mentioned `git commit -s`. The DCO
requirement is documented in `DCO.md`, `CONTRIBUTING.md`, and
`.github/AI_POLICY.md`, but none of those are in the procedural path an agent
follows while executing the branch workflow, so it was easy to miss.

Concretely: my own recent doc PRs (#402, #410) both failed the `dco` check
because I committed with plain `git commit -m`. #402 still merged because
`dco` is not currently in `main`'s required-checks list (`test`, `lint`,
`frontend`, `secret-scan`) — `--auto` merges past a failing non-required
check, so the gap was silent.

- Adds `-s` to the `git commit` step in both branch-workflow snippets.
- Adds a short callout: use `git commit -s` always, link to `DCO.md`, and an
  explicit note that a green auto-merge does *not* prove the commit was signed
  off (since `dco` isn't required yet) — plus the amend/rebase recipe to fix
  an unsigned commit before it lands.

Does not touch branch protection settings — flagging that `dco" isn't a
required check is a separate, repo-admin-level decision; this PR only fixes
the guidance agents follow.

Documentation only.

## Validation

- `python -m mkdocs build --strict` — clean
- `git diff --check` — clean
- `ruff check .` — clean (no Python touched)
- No pytest run — pure Markdown/guidance change, no code or contract touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)