### PR TITLE
docs: require semantic ADR context review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,18 @@ Before editing Mozaiks OSS:
 - architectural changes that contradict the frozen north star require an ADR or
   explicit architecture decision
 
+## ADR Authoring Context
+
+For an ADR that changes or extends app generation, semantic authority,
+compilation/materialization, or refinement, review
+[issue #411](https://github.com/BlocUnited-LLC/mozaiks/issues/411) and state
+explicitly whether the ADR adopts, modifies, rejects, or defers that direction.
+
+Issue #411 is a design prompt, not architecture authority. Current source and
+Accepted ADRs remain authoritative. Any ADR using the issue must verify its
+claims against the repository and must not make a typed decision ledger a
+second authority for application meaning.
+
 ## Deterministic Generation Rule
 
 Generated-app reliability takes precedence over maximum schema expressiveness.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,18 @@ For nontrivial OSS changes:
 - include the appropriate impact section from `.claude/rules/testing.md` in the
   final report and always list tests run
 
+## ADR Authoring Context
+
+For an ADR that changes or extends app generation, semantic authority,
+compilation/materialization, or refinement, review
+[issue #411](https://github.com/BlocUnited-LLC/mozaiks/issues/411) and state
+explicitly whether the ADR adopts, modifies, rejects, or defers that direction.
+
+Issue #411 is a design prompt, not architecture authority. Current source and
+Accepted ADRs remain authoritative. Any ADR using the issue must verify its
+claims against the repository and must not make a typed decision ledger a
+second authority for application meaning.
+
 ## Pre-Production Cleanup Policy
 
 This repo is **not in production**. Optimize for the cleanest canonical implementation, not for preserving outdated behavior.


### PR DESCRIPTION
## Summary

- require ADR authors working on generation, semantic authority, compilation/materialization, or refinement to review #411
- require each relevant ADR to state whether it adopts, modifies, rejects, or defers that direction
- clarify that #411 is a design prompt rather than architecture authority
- guard against a typed decision ledger becoming a second authority for application meaning

Closes no issue; #411 remains the durable design prompt.

## OSS change impact

- **Layer changed:** contributor/agent guidance only
- **Build workflow impact:** none
- **Runtime/platform impact:** none
- **App workspace impact:** none
- **Docs updated:** `AGENTS.md`, `CLAUDE.md`
- **Compatibility risk:** none; no production contract or behavior changes

## Validation

- `ruff check .` — passed
- `pytest -q --no-cov tests/test_production_readiness_gate.py` — 8 passed
- `git diff --check` — passed
- #411 link/state verification — passed
- `pytest -q --no-cov` — timed out after 10 minutes without a final result; no failure output was produced