### PR TITLE
ci: shard the test suite into 4 parallel jobs with a coverage fan-in gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  # The full pytest suite, split into 4 deterministic shards that run in
+  # parallel jobs. scripts/ci/split_tests.py partitions the top-level
+  # collection units of tests/ exhaustively, and each shard preserves the
+  # relative alphabetical file order of the previous single-job run (the suite
+  # has latent inter-file ordering hazards, so order preservation is load-
+  # bearing — see the script docstring). Coverage is measured per shard,
+  # combined and gated at the same 70% threshold in the fan-in `test` job
+  # below, which keeps the required-check name `test` unchanged.
+  test-shard:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
 
     services:
       mongodb:
@@ -46,8 +58,66 @@ jobs:
           ENV: test
           AUTH_ENABLED: "false"
           OPENAI_API_KEY: "sk-test-placeholder"
+        # --cov-fail-under=0 defers the coverage gate to the fan-in job: one
+        # shard only runs a quarter of the suite, so a per-shard threshold
+        # would be meaningless. --durations=20 records the slowest tests so
+        # suite-time regressions stay attributable.
         run: |
-          pytest tests/ -v --cov=mozaiksai --cov-report=xml --cov-report=term-missing --cov-fail-under=70
+          pytest $(python scripts/ci/split_tests.py --shard "${{ matrix.shard }}" --num-shards 4) \
+            -v --durations=20 --cov=mozaiksai --cov-report=term --cov-fail-under=0
+          mv .coverage "coverage-data-shard-${{ matrix.shard }}"
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: coverage-data-shard-${{ matrix.shard }}
+          retention-days: 1
+          if-no-files-found: error
+
+  test:
+    # Fan-in gate for the shard matrix. Holds the required-check name `test`:
+    # it fails unless every shard succeeded, then enforces the same combined
+    # coverage threshold the previous single `test` job enforced.
+    runs-on: ubuntu-latest
+    needs: test-shard
+    # always() so shard failures cannot leave this job skipped — a skipped
+    # required check would satisfy branch protection.
+    if: always()
+    steps:
+      - name: Fail unless every shard succeeded
+        if: needs.test-shard.result != 'success'
+        run: |
+          echo "test-shard result: ${{ needs.test-shard.result }}" >&2
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        # Same install as the shards so the coverage data format and source
+        # analysis match exactly.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Download shard coverage data
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-shard-*
+          merge-multiple: true
+
+      - name: Combine coverage and enforce threshold
+        run: |
+          coverage combine coverage-data-shard-*
+          coverage xml -o coverage.xml
+          coverage report --fail-under=70
 
       - name: Upload coverage
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,31 @@ jobs:
           merge-multiple: true
 
       - name: Combine coverage and enforce threshold
+        # Fails closed on incomplete coverage evidence: exactly one artifact
+        # per shard must exist, and each must combine cleanly. Combining one
+        # input per invocation is load-bearing — a multi-file `coverage
+        # combine` skips an unreadable data file with only a warning, while a
+        # single unreadable input leaves the invocation with no usable data,
+        # which is a hard error.
         run: |
-          coverage combine coverage-data-shard-*
+          set -euo pipefail
+          shopt -s nullglob
+          artifacts=(coverage-data-shard-*)
+          if [ "${#artifacts[@]}" -ne 4 ]; then
+            echo "expected exactly 4 shard coverage artifacts, found ${#artifacts[@]}: ${artifacts[*]-none}" >&2
+            exit 1
+          fi
+          for k in 0 1 2 3; do
+            # -s: a zero-byte artifact must fail too — coverage combine
+            # silently treats an empty data file as "no data yet".
+            if [ ! -s "coverage-data-shard-$k" ]; then
+              echo "missing or empty coverage data artifact for shard $k" >&2
+              exit 1
+            fi
+          done
+          for k in 0 1 2 3; do
+            coverage combine --append "coverage-data-shard-$k"
+          done
           coverage xml -o coverage.xml
           coverage report --fail-under=70
 

--- a/scripts/ci/split_tests.py
+++ b/scripts/ci/split_tests.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Emit the pytest path list for one CI test shard.
+
+Splits the top-level collection units of ``tests/`` — ``test_*.py`` files plus
+subdirectories (pytest recurses into directories exactly as ``pytest tests/``
+does) — across N shards by round-robin over the alphabetically sorted unit
+list.  The partition is exhaustive and disjoint by construction, so the union
+of every shard's selection is identical to running ``pytest tests/``.
+
+Why round-robin over a *sorted* list: each shard then executes an alphabetical
+subsequence of the full serial collection order, preserving the relative
+inter-file order of the single-job suite.  The suite currently holds latent
+inter-file ordering hazards (for example, ``sys.modules.pop("factory_app")``
+in later files breaks dotted-path ``monkeypatch.setattr`` in earlier files if
+their order inverts) that stay dormant only in that relative order.  This is
+also why the CI job does not use pytest-xdist: its dynamic file-to-worker
+assignment reorders files nondeterministically and was observed to trip those
+hazards.  Do not change this split to a timing-, hash-, or size-based scheme
+without revalidating suite-order safety.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+IGNORED_DIRS = {"__pycache__"}
+
+
+def collection_units(tests_dir: Path) -> list[str]:
+    """Top-level collection units of tests_dir, sorted like pytest sorts them."""
+    units: list[str] = []
+    for entry in tests_dir.iterdir():
+        if entry.is_dir() and entry.name not in IGNORED_DIRS:
+            units.append(entry.as_posix())
+        elif entry.is_file() and entry.name.startswith("test_") and entry.suffix == ".py":
+            units.append(entry.as_posix())
+    return sorted(units)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shard", type=int, required=True, help="0-based shard index")
+    parser.add_argument("--num-shards", type=int, required=True)
+    parser.add_argument("--tests-dir", default="tests")
+    args = parser.parse_args()
+
+    if not 0 <= args.shard < args.num_shards:
+        print(f"--shard must be in [0, {args.num_shards})", file=sys.stderr)
+        return 2
+
+    tests_dir = Path(args.tests_dir)
+    if not tests_dir.is_dir():
+        print(f"tests directory not found: {tests_dir}", file=sys.stderr)
+        return 2
+
+    units = collection_units(tests_dir)
+    selected = [u for i, u in enumerate(units) if i % args.num_shards == args.shard]
+    if not selected:
+        print(
+            f"shard {args.shard}/{args.num_shards} selected no units "
+            f"(only {len(units)} units exist)",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(" ".join(selected))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/split_tests.py
+++ b/scripts/ci/split_tests.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
 """Emit the pytest path list for one CI test shard.
 
-Splits the top-level collection units of ``tests/`` — ``test_*.py`` files plus
+Splits the top-level collection units of ``tests/`` — test files plus
 subdirectories (pytest recurses into directories exactly as ``pytest tests/``
 does) — across N shards by round-robin over the alphabetically sorted unit
 list.  The partition is exhaustive and disjoint by construction, so the union
 of every shard's selection is identical to running ``pytest tests/``.
+
+Which top-level files count as test files is taken from the repository's
+active pytest configuration: the ``python_files`` patterns in
+``pyproject.toml`` ``[tool.pytest.ini_options]``, falling back to pytest's
+built-in default (``test_*.py`` and ``*_test.py``) when the key is unset.
+There is deliberately no second hardcoded pattern list here.  If a pytest
+config file that would take precedence over ``pyproject.toml`` appears
+(``pytest.ini``, ``setup.cfg`` with a ``[tool:pytest]`` section, or
+``tox.ini`` with a ``[pytest]`` section), this script fails closed so the
+shard selection can never silently diverge from what pytest collects.
 
 Why round-robin over a *sorted* list: each shard then executes an alphabetical
 subsequence of the full serial collection order, preserving the relative
@@ -21,19 +31,71 @@ without revalidating suite-order safety.
 from __future__ import annotations
 
 import argparse
+import configparser
 import sys
+import tomllib
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 IGNORED_DIRS = {"__pycache__"}
 
+# pytest's built-in default for python_files, used only when the active
+# configuration does not set the key.
+PYTEST_DEFAULT_PYTHON_FILES = ("test_*.py", "*_test.py")
 
-def collection_units(tests_dir: Path) -> list[str]:
+
+def _fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def python_file_patterns(repo_root: Path) -> tuple[str, ...]:
+    """Return the active pytest ``python_files`` patterns for repo_root.
+
+    Fails closed on config layouts this script does not read, since those
+    would take precedence over ``pyproject.toml`` and could make the shard
+    selection silently diverge from ``pytest tests/``.
+    """
+    if (repo_root / "pytest.ini").exists():
+        _fail(
+            "pytest.ini found: it takes precedence over pyproject.toml and this "
+            "script does not read it. Update scripts/ci/split_tests.py first."
+        )
+    for candidate, section in (("setup.cfg", "tool:pytest"), ("tox.ini", "pytest")):
+        path = repo_root / candidate
+        if path.exists():
+            parser = configparser.ConfigParser()
+            parser.read(path, encoding="utf-8")
+            if parser.has_section(section):
+                _fail(
+                    f"{candidate} has a [{section}] section: it takes precedence "
+                    "over pyproject.toml and this script does not read it. "
+                    "Update scripts/ci/split_tests.py first."
+                )
+
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        _fail(f"pyproject.toml not found at {pyproject}")
+
+    config = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    ini_options = config.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    configured = ini_options.get("python_files")
+    if configured is None:
+        return PYTEST_DEFAULT_PYTHON_FILES
+    if isinstance(configured, str):
+        configured = configured.split()
+    if not configured or not all(isinstance(p, str) for p in configured):
+        _fail(f"unsupported python_files value in pyproject.toml: {configured!r}")
+    return tuple(configured)
+
+
+def collection_units(tests_dir: Path, patterns: tuple[str, ...]) -> list[str]:
     """Top-level collection units of tests_dir, sorted like pytest sorts them."""
     units: list[str] = []
     for entry in tests_dir.iterdir():
         if entry.is_dir() and entry.name not in IGNORED_DIRS:
             units.append(entry.as_posix())
-        elif entry.is_file() and entry.name.startswith("test_") and entry.suffix == ".py":
+        elif entry.is_file() and any(fnmatchcase(entry.name, p) for p in patterns):
             units.append(entry.as_posix())
     return sorted(units)
 
@@ -43,9 +105,14 @@ def main() -> int:
     parser.add_argument("--shard", type=int, required=True, help="0-based shard index")
     parser.add_argument("--num-shards", type=int, required=True)
     parser.add_argument("--tests-dir", default="tests")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="directory holding the active pytest configuration",
+    )
     args = parser.parse_args()
 
-    if not 0 <= args.shard < args.num_shards:
+    if args.num_shards < 1 or not 0 <= args.shard < args.num_shards:
         print(f"--shard must be in [0, {args.num_shards})", file=sys.stderr)
         return 2
 
@@ -54,7 +121,8 @@ def main() -> int:
         print(f"tests directory not found: {tests_dir}", file=sys.stderr)
         return 2
 
-    units = collection_units(tests_dir)
+    patterns = python_file_patterns(Path(args.repo_root))
+    units = collection_units(tests_dir, patterns)
     selected = [u for i, u in enumerate(units) if i % args.num_shards == args.shard]
     if not selected:
         print(

--- a/scripts/ci/split_tests.py
+++ b/scripts/ci/split_tests.py
@@ -11,11 +11,13 @@ Which top-level files count as test files is taken from the repository's
 active pytest configuration: the ``python_files`` patterns in
 ``pyproject.toml`` ``[tool.pytest.ini_options]``, falling back to pytest's
 built-in default (``test_*.py`` and ``*_test.py``) when the key is unset.
-There is deliberately no second hardcoded pattern list here.  If a pytest
-config file that would take precedence over ``pyproject.toml`` appears
-(``pytest.ini``, ``setup.cfg`` with a ``[tool:pytest]`` section, or
-``tox.ini`` with a ``[pytest]`` section), this script fails closed so the
-shard selection can never silently diverge from what pytest collects.
+There is deliberately no second hardcoded pattern list here.  If another
+supported pytest config source appears (``pytest.ini``, ``setup.cfg`` with a
+``[tool:pytest]`` section, or ``tox.ini`` with a ``[pytest]`` section), this
+script fails closed rather than reproducing pytest's config-discovery rules.
+``pytest.ini`` takes precedence over ``pyproject.toml``; ``tox.ini`` and
+``setup.cfg`` are lower-precedence at the same root but are rejected as
+competing configuration sources so selection cannot silently drift later.
 
 Why round-robin over a *sorted* list: each shard then executes an alphabetical
 subsequence of the full serial collection order, preserving the relative
@@ -52,9 +54,10 @@ def _fail(message: str) -> None:
 def python_file_patterns(repo_root: Path) -> tuple[str, ...]:
     """Return the active pytest ``python_files`` patterns for repo_root.
 
-    Fails closed on config layouts this script does not read, since those
-    would take precedence over ``pyproject.toml`` and could make the shard
-    selection silently diverge from ``pytest tests/``.
+    Fails closed on competing config layouts this script does not read.
+    ``pytest.ini`` takes precedence over ``pyproject.toml``; ``tox.ini`` and
+    ``setup.cfg`` are currently lower-precedence at the same root but are
+    rejected conservatively so shard selection cannot silently diverge later.
     """
     if (repo_root / "pytest.ini").exists():
         _fail(
@@ -68,8 +71,8 @@ def python_file_patterns(repo_root: Path) -> tuple[str, ...]:
             parser.read(path, encoding="utf-8")
             if parser.has_section(section):
                 _fail(
-                    f"{candidate} has a [{section}] section: it takes precedence "
-                    "over pyproject.toml and this script does not read it. "
+                    f"{candidate} has a competing [{section}] pytest section "
+                    "that this script does not read. "
                     "Update scripts/ci/split_tests.py first."
                 )
 


### PR DESCRIPTION
## Summary

CI wall-clock turnaround is gated entirely by the `test` job (10–15 min; every other job finishes in under 2 min). This PR splits the pytest suite into **4 deterministic parallel shards** with a fan-in gate that keeps the required check name `test` and enforces the identical combined-coverage threshold. Expected turnaround: roughly half of baseline. No test, check, coverage threshold, or security gate is removed or weakened.

## Baseline measurements (before)

Four recent successful runs of `CI` (2 pull_request, 2 push-to-main):

| Job | PR run 33098717868 | PR run 33082428375 | main run 33083873990 | main run 33007839037 |
|---|---|---|---|---|
| **test** | **14m50s** | **14m27s** | **10m15s** | **11m17s** |
| frontend | 1m56s | 1m41s | 1m37s | 1m32s |
| visual-regression (chained after frontend) | 1m03s | 1m03s | 1m10s | 1m20s |
| infra-build | 1m22s | 1m18s | 1m24s | 1m35s |
| package | 1m02s | 1m13s | 0m57s | 0m53s |
| lint | 0m58s | 1m00s | 1m08s | 0m52s |
| dependency-audit | 0m45s | 0m42s | 0m40s | 0m45s |
| secret-scan | 0m21s | 0m16s | 0m13s | 0m16s |
| **Total wall clock** | **~14m54s** | **~14m30s** | **~10m23s** | **~11m40s** |

Step-level breakdown of the `test` job (run 33098717868): container init 22s, checkout 2s, setup-python 2s (pip cache hit), dependency install 22s (cache hit), **pytest 13m57s**, coverage upload 0s. The pytest time is ~50s collection/startup plus ~783s of execution spread across 609 test files with no dominant hot spot (slowest file: 75s). Caching and setup are already efficient — only parallel execution can move the needle.

Other audit findings:
- Pip and npm caching already configured and hitting.
- `concurrency` cancellation already effective (superseded main-push runs observed cancelled).
- No duplicated setup inside any single job; cross-job installs run in parallel jobs off the critical path.
- Required checks on `main` branch protection: `test`, `lint`, `frontend`, `secret-scan`, `dco` — all preserved by this PR (`test` is now the fan-in gate; `test-shard (N)` checks are additional, not required).

## Why not pytest-xdist (investigated first, rejected with evidence)

`pytest -n 4 --dist loadfile` was measured locally at **6m32s vs ~14m** — but two full-suite runs produced **different, nondeterministic failure sets** (2 failures, then 3). Root cause was isolated to a **minimal 2-file serial reproduction**:

```
pytest tests/test_studio_app_context_operator_api.py tests/test_check_workspace_integrations_tool.py
# → 2 failed (passes in the opposite order)
```

Several test files call `sys.modules.pop("factory_app")`; if any of them runs *before* a file that later does `monkeypatch.setattr("factory_app.workflows...", ...)` on the same worker, the freshly re-imported `factory_app` parent lacks the `workflows` attribute and the monkeypatch resolution fails. Today's serial alphabetical order keeps every polluter *after* every victim, so the hazard is dormant. xdist assigns files to workers by completion timing (verified from per-worker `[gwN]` execution order: dozens of alphabetical-order inversions per worker), so it trips these hazards nondeterministically. Fixing the hygiene lives in `tests/` — out of this PR's allowed scope; it is listed below as a follow-up. `--reruns=2` does not mask this (it only reruns `AssertionError`/`TimeoutError`, and one observed failure exhausted reruns anyway).

## Change

Two files: `.github/workflows/ci.yml` and new `scripts/ci/split_tests.py` (CI-only helper).

1. **`scripts/ci/split_tests.py`** — partitions the top-level collection units of `tests/` (pytest-configured test files—built-in `test_*.py` and `*_test.py` when unset—plus subdirectories) across N shards by round-robin over the **alphabetically sorted** unit list. Exhaustive and disjoint by construction. Each shard therefore executes an **alphabetical subsequence of the exact serial order that passes today**, so the order-inversion hazard class above cannot fire. The split is fully deterministic — no timing data, no hashing — so local validation transfers to CI.
2. **`test-shard` matrix job (×4)** — identical service container, checkout, setup, and install as the old `test` job; runs its quarter of the suite with the same flags plus `--cov-fail-under=0` (per-shard thresholds are meaningless on a quarter of the suite) and `--durations=20` (observability); uploads its coverage data file as an artifact.
3. **`test` fan-in job** — keeps the required-check name. `if: always()` plus an explicit shard-result check, so a failed or cancelled shard can never produce a green or skipped-but-satisfying `test` check. Requires exactly four nonempty artifacts with identities 0–3, combines each independently as a hard-error boundary, then runs `coverage xml` and **`coverage report --fail-under=70`** — the same threshold over the same combined measurement as before. The codecov upload (main pushes only, unchanged condition) moves here with the same `coverage.xml`.

## Safety validation (all local, against real `mongo:7`, CI env vars)

- **Collection equivalence**: `pytest tests/ --collect-only` vs the union of the 4 shard selections — **13,752 test ids, byte-identical sets** (`diff` clean).
- **Shard runs**: all 4 shards green — 3187 / 3426 / 3556 / 3507 passed (+0/10/52/15 skipped), run concurrently against 4 separate Mongo databases (mirroring CI's per-job service containers). Local shard wall times under shared-CPU contention: 4m03s / 2m30s / 5m55s / 2m41s.
- **Combined coverage**: `coverage combine` of the 4 shard data files reports **75.88%** over 53,076 statements — reproducing the single-run measurement (75.89%), so the fan-in gate measures the same thing the old single job measured. `--fail-under=70` passes.
- Repo gates re-run locally on the changed tree: `ruff check` clean, governance guardrails pass, source-hygiene scan clean, workflow YAML parses.

## Before/after

- Before: total wall clock ≈ test job ≈ **10m15s–14m54s** across the four baseline runs (high runner variance on identical code).
- After — **measured on this PR's own CI run** (run 33103903584, all checks green): **total wall clock 7m59s**. Shards: 4m41s / 3m54s / **7m03s** / 4m13s; fan-in `test`: 50s; critical path = shard 2 + fan-in. Combined coverage on CI: 76% over 53,076 statements, `--fail-under=70` enforced in the fan-in, `coverage.xml` produced as before.
- Measured vs estimate: the 7m59s is one measured sample. Against the two pull_request baselines (14m54s, 14m30s) that is a measured ~6.5 min (~45%) reduction; against the fastest observed baseline (10m23s, a main push on a lucky runner) the floor of the improvement is ~2.4 min. Baseline itself varied ~4.5 min on identical code, so expect the steady-state gain to land in that 2.4–6.9 min band, most PR runs near the upper end.
- Shard 2 (7m03s) carries a disproportionate share of the slow files under the alphabetical round-robin; rebalancing is listed under deferred opportunities.

## Explicitly not changed

- No test removed, skipped, or excluded; selection is provably identical (see collection equivalence).
- Coverage threshold (70%), coverage scope (`--cov=mozaiksai`), and codecov upload condition unchanged.
- secret-scan, dependency-audit, DCO, package, infra-build, frontend, visual-regression jobs untouched.
- Required-check names preserved; `test` remains the gating check and cannot pass unless all shards pass and combined coverage ≥ 70%.
- No changes to `pyproject.toml`, `tests/`, `mozaiksai/`, `factory_app/`, or any file touched by PR #415.

## Rollback

Revert the commit (restores the single `test` job verbatim) and delete `scripts/ci/split_tests.py`. No state, cache, or branch-protection change is involved.

## Deferred opportunities (deliberately not implemented)

- **Fix the test-order hygiene in `tests/`** (out of scope here): make the `sys.modules.pop("factory_app")` call sites restore what they removed (or pop the full `factory_app.*` subtree). Once fixed and verified, `pytest-xdist -n 4` inside each shard (or instead of sharding) roughly halves test time again — measured 6m32s for the whole suite locally.
- `visual-regression` `needs: frontend` serializes a ~3-min chain; it consumes no artifact from `frontend` and could run in parallel. Off the critical path both before and after this change, and the gating may be intentional.
- Shard count is 4; 6–8 shards would shave another ~1 min each but add VMs and latent-subset risk for little gain since fixed per-job overhead (~1.5 min) starts to dominate.
- `dependency-audit` reinstalls the package to audit the environment; could audit a lockfile export instead. Far off the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Corrective-delta verification (final head)

- Corrected implementation head reviewed: `1b57b6dedcecb1dd30825125f21d0b044db5f9a6`; exact-head CI run `33107293543` completed successfully in approximately 7m34s with all four shards and the required `test` fan-in green, and 76% combined coverage over 53,076 statements.
- Filename proof: built-in `test_*.py` and `*_test.py` both selected when `python_files` is unset; valid pyproject overrides honored; unrelated Python files excluded; competing pytest configuration sources fail closed.
- Artifact proof: exactly identities 0–3 are required and nonempty; all-four succeeds; each independently missing shard, a fifth artifact, an empty artifact, a corrupt artifact, wrong identities, and incomplete high-coverage evidence all fail.
- Local collection-only proof on the final tree: the four shards are exhaustive, disjoint, deterministic, and preserve the full `pytest tests/` node-ID order.
- Follow-up wording-only commit corrects pytest precedence documentation: `pytest.ini` precedes a valid `pyproject.toml`, while same-root `tox.ini` and `setup.cfg` are lower-precedence but deliberately rejected as competing sources. No selection behavior changed.
