### PR TITLE
feat(runtime): add ADR 0007 Slice 1 taxonomy registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Advisory semantic taxonomy (`mozaiks.taxonomy.v1`)**: development and
+  test callers can now validate registered event, capability, and artifact-
+  family identifiers consistently across module loading, subscriptions,
+  layout resolution, and event dispatch. Production name enforcement remains
+  unchanged while later ADR 0007 authority-cutover slices are pending, and
+  outbound dispatcher envelopes now declare `mozaiks.ui.event.v1` explicitly.
+
 - **Coding provider observability**: ACP provider executions now capture a
   bounded list of operational events (plan updates, tool invocations, mode
   changes — model reasoning is never recorded) on the

--- a/factory_app/workflows/AgentGenerator/tools/export_to_github.py
+++ b/factory_app/workflows/AgentGenerator/tools/export_to_github.py
@@ -566,7 +566,11 @@ async def _emit_deployment_event(
 
         transport = await SimpleTransport.get_instance()
         await transport.send_event_to_ui(
-            {"type": f"chat.deployment_{status}", "data": {"timestamp": datetime.now(UTC).isoformat(), **data}},
+            {
+                "schema_version": "mozaiks.ui.event.v1",
+                "type": f"chat.deployment_{status}",
+                "data": {"timestamp": datetime.now(UTC).isoformat(), **data},
+            },
             chat_id,
         )
     except Exception:

--- a/factory_app/workflows/AppGenerator/tools/generate_and_download.py
+++ b/factory_app/workflows/AppGenerator/tools/generate_and_download.py
@@ -499,7 +499,11 @@ async def _emit_deployment_event(*, chat_id: str | None, status: str, data: dict
 
         transport = await SimpleTransport.get_instance()
         await transport.send_event_to_ui(
-            {"type": f"chat.deployment_{status}", "data": {"timestamp": datetime.now(UTC).isoformat(), **data}},
+            {
+                "schema_version": "mozaiks.ui.event.v1",
+                "type": f"chat.deployment_{status}",
+                "data": {"timestamp": datetime.now(UTC).isoformat(), **data},
+            },
             chat_id,
         )
     except Exception:

--- a/mozaiksai/core/events/unified_event_dispatcher.py
+++ b/mozaiksai/core/events/unified_event_dispatcher.py
@@ -34,7 +34,12 @@ from mozaiksai.core.events.runtime_events import (
 )
 from mozaiksai.core.events.usage_ingest import get_usage_ingest_client
 from mozaiksai.core.ports.orchestration import DomainEvent
-from mozaiksai.core.transport.event_contract import MozaiksEventType
+from mozaiksai.core.taxonomy import SemanticCategory, validate_registered_identifier
+from mozaiksai.core.transport.event_contract import (
+    EVENT_ENVELOPE_SCHEMA_VERSION,
+    MozaiksEventType,
+    validate_event_envelope_schema_version,
+)
 from mozaiksai.core.workflow.runtime_signals import SYSTEM_RESUME_SIGNAL
 from mozaiksai.core.workflow.startup_messages import matches_hidden_initial_message
 from mozaiksai.core.workflow.workflow_manager import workflow_manager
@@ -158,8 +163,9 @@ class UnifiedEventDispatcher:
     AG2 events flow: AG2 -> event_serialization.py -> WebSocket transport
     Business/UI events flow: Code -> UnifiedEventDispatcher -> Handlers
     """
-    def __init__(self):
+    def __init__(self, *, taxonomy_advisory: bool = False):
         self.handlers: list[EventHandler] = []
+        self._taxonomy_advisory = taxonomy_advisory
         self._event_handlers: dict[str, list[Callable[[dict[str, Any]], Awaitable[Any] | Any]]] = {}
         # Greeting echo dedup: tracks (chat_id, agent_name) pairs where
         # ws_protocol already sent the greeting before the workflow started.
@@ -226,6 +232,11 @@ class UnifiedEventDispatcher:
         self.register_handler(canonical_event_type, handler)
 
     async def emit(self, event_type: str, payload: dict[str, Any]) -> None:
+        validate_registered_identifier(
+            SemanticCategory.EVENT,
+            event_type,
+            advisory=self._taxonomy_advisory,
+        )
         listeners = list(self._event_handlers.get(event_type, []))
         if not listeners:
             logger.debug("No listeners registered for event_type=%s", event_type)
@@ -349,6 +360,26 @@ class UnifiedEventDispatcher:
         }
 
     def build_outbound_event_envelope(
+        self,
+        *,
+        raw_event: Any,
+        chat_id: str | None,
+        get_sequence_cb: Any | None = None,
+        workflow_name: str | None = None,
+    ) -> dict[str, Any] | None:
+        envelope = self._build_outbound_event_envelope(
+            raw_event=raw_event,
+            chat_id=chat_id,
+            get_sequence_cb=get_sequence_cb,
+            workflow_name=workflow_name,
+        )
+        if envelope is None:
+            return None
+        versioned = {"schema_version": EVENT_ENVELOPE_SCHEMA_VERSION, **envelope}
+        validate_event_envelope_schema_version(versioned)
+        return versioned
+
+    def _build_outbound_event_envelope(
         self,
         *,
         raw_event: Any,

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -424,6 +424,37 @@ def validate_registered_path(
     return default_app_layout_registry().validate_registered_path(path, assignment_kind, scope)
 
 
+def resolve_taxonomy_artifact_family(
+    identifier: str,
+    *,
+    taxonomy_registry: Any = None,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> tuple[ArtifactFamily, ...]:
+    """Resolve a taxonomy name to authoritative layout rows.
+
+    The taxonomy supplies only the ``ArtifactKind`` identifier. Every path,
+    validator, consumer, owner, and security classification returned here
+    comes from this layout registry.
+    """
+    from mozaiksai.core.taxonomy import SemanticCategory, default_taxonomy_registry
+
+    taxonomy = taxonomy_registry or default_taxonomy_registry()
+    entry = taxonomy.resolve(SemanticCategory.ARTIFACT_FAMILY, identifier)
+    try:
+        kind = ArtifactKind(entry.identifier)
+    except ValueError as exc:
+        raise ValueError(
+            f"taxonomy artifact-family {entry.identifier!r} has no ArtifactKind"
+        ) from exc
+    registry = layout_registry or default_app_layout_registry()
+    rows = tuple(family for family in registry.families if family.kind is kind)
+    if not rows:
+        raise ValueError(
+            f"taxonomy artifact-family {entry.identifier!r} has no layout_registry row"
+        )
+    return rows
+
+
 def default_app_layout_registry() -> AppLayoutRegistry:
     return build_app_layout_registry()
 
@@ -934,4 +965,5 @@ __all__ = [
     "kinds_for_assignment",
     "match_path",
     "validate_registered_path",
+    "resolve_taxonomy_artifact_family",
 ]

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -1445,6 +1445,15 @@ class ModuleLoader:
             declared_permission_ids = {permission.id for permission in definition.permissions}
             for reaction in manifests.reactions.reactions:
                 event_type = str(reaction.event_type or "").strip()
+                if self._taxonomy_advisory and event_type:
+                    try:
+                        validate_registered_identifier(
+                            SemanticCategory.EVENT, event_type, advisory=True
+                        )
+                    except ValueError as exc:
+                        raise ModuleLoadError(
+                            f"reactions.yaml references unknown event {event_type!r}: {exc}"
+                        ) from exc
                 if event_type and not self._is_known_or_canonical_event(event_type, declared_events):
                     raise ModuleLoadError(
                         f"reactions.yaml references non-canonical event {event_type!r}"
@@ -1455,10 +1464,29 @@ class ModuleLoader:
                             f"reactions.yaml reaction {reaction.id!r} references undeclared "
                             f"permission {permission_id!r}; add it to the module-level permissions block"
                         )
+                capability_id = reaction.target.capability_id
+                if self._taxonomy_advisory and capability_id:
+                    try:
+                        validate_registered_identifier(
+                            SemanticCategory.CAPABILITY, capability_id, advisory=True
+                        )
+                    except ValueError as exc:
+                        raise ModuleLoadError(
+                            f"reactions.yaml references unknown capability {capability_id!r}: {exc}"
+                        ) from exc
 
         if manifests.notifications is not None:
             for notification in manifests.notifications.notifications:
                 event_type = str(getattr(notification, "event_type", "") or "").strip()
+                if self._taxonomy_advisory and event_type:
+                    try:
+                        validate_registered_identifier(
+                            SemanticCategory.EVENT, event_type, advisory=True
+                        )
+                    except ValueError as exc:
+                        raise ModuleLoadError(
+                            f"notifications.yaml references unknown event {event_type!r}: {exc}"
+                        ) from exc
                 if event_type and not self._is_known_or_canonical_event(event_type, declared_events):
                     raise ModuleLoadError(
                         f"notifications.yaml references non-canonical event {event_type!r}"

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -34,6 +34,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from logs.logging_config import get_workflow_logger
+from mozaiksai.core.taxonomy import SemanticCategory, validate_registered_identifier
 
 logger = get_workflow_logger("module_loader")
 
@@ -1152,8 +1153,9 @@ class ModuleLoader:
         "policy_hooks": ("policy_hooks.yaml", ModulePolicyHooksManifest),
     }
 
-    def __init__(self, base_path: str) -> None:
+    def __init__(self, base_path: str, *, taxonomy_advisory: bool = False) -> None:
         self._base = Path(base_path)
+        self._taxonomy_advisory = taxonomy_advisory
         import_roots = [self._base.parent, self._base] if self._base.name == "app" else [self._base]
         for root in import_roots:
             root_text = str(root.resolve())
@@ -1209,6 +1211,24 @@ class ModuleLoader:
             definition = ModuleDefinition.model_validate(_load_yaml_file(yaml_path))
         except Exception as exc:
             raise ModuleLoadError(f"Invalid module.yaml for {name!r}: {exc}") from exc
+
+        if self._taxonomy_advisory:
+            try:
+                for capability in definition.capabilities:
+                    validate_registered_identifier(
+                        SemanticCategory.CAPABILITY,
+                        capability.capability_id,
+                        advisory=True,
+                    )
+                for action in definition.actions:
+                    if action.entitlement_gate:
+                        validate_registered_identifier(
+                            SemanticCategory.CAPABILITY,
+                            action.entitlement_gate,
+                            advisory=True,
+                        )
+            except ValueError as exc:
+                raise ModuleLoadError(f"Invalid module.yaml taxonomy for {name!r}: {exc}") from exc
 
         if definition.name != name:
             raise ModuleLoadError(
@@ -1384,6 +1404,18 @@ class ModuleLoader:
 
         manifests = ModuleCompanionManifests.model_validate(parsed)
         declared_events: set[str] = manifests.events.event_types if manifests.events is not None else set()
+        if self._taxonomy_advisory:
+            try:
+                for event_type in sorted(declared_events):
+                    validate_registered_identifier(
+                        SemanticCategory.EVENT,
+                        event_type,
+                        advisory=True,
+                    )
+            except ValueError as exc:
+                raise ModuleLoadError(
+                    f"Invalid events.yaml taxonomy for {definition.name!r}: {exc}"
+                ) from exc
         if manifests.events is not None:
             for event in manifests.events.events:
                 if event.producer != definition.name:

--- a/mozaiksai/core/runtime/app/subscriptions_loader.py
+++ b/mozaiksai/core/runtime/app/subscriptions_loader.py
@@ -85,11 +85,18 @@ Example::
 """
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from mozaiksai.core.taxonomy import (
+    SemanticCategory,
+    validate_identifier_grammar,
+    validate_registered_identifier,
+)
 
 # ---------------------------------------------------------------------------
 # Validation helpers
@@ -97,7 +104,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 _PLAN_ID_RE = re.compile(r"^[a-z0-9_-]+$")
 _PRODUCT_ID_RE = re.compile(r"^[a-z0-9_-]+$")
-_CAPABILITY_ID_RE = re.compile(r"^[a-z0-9_.]+$")
 _METER_ID_RE = re.compile(r"^[a-z0-9_.-]+$")
 _WALLET_ID_RE = re.compile(r"^[a-z0-9_.-]+$")
 _DATA_ALIAS_RE = re.compile(r"^[a-z0-9_.-]+$")
@@ -107,6 +113,10 @@ _CAPABILITY_GROUP_RE = re.compile(r"^[a-z0-9_.-]+$")
 _ROUTE_RE = re.compile(r"^/[A-Za-z0-9._~!$&'()*+,;=:@/%-]*(?:\?[A-Za-z0-9._~!$&'()*+,;=:@/?%-]*)?$")
 
 _CONFIG_PATH = Path("config") / "subscriptions.yaml"
+
+
+def _validate_capability_identifier(value: str) -> str:
+    return validate_identifier_grammar(SemanticCategory.CAPABILITY, value)
 
 
 # ---------------------------------------------------------------------------
@@ -152,11 +162,7 @@ class UsageLimitDef(BaseModel):
         value = value.strip()
         if not value:
             return None
-        if not _CAPABILITY_ID_RE.match(value):
-            raise ValueError(
-                f"capability_id must match [a-z0-9_.]+, got {value!r}"
-            )
-        return value
+        return _validate_capability_identifier(value)
 
 
 class TokenWalletRecoveryDef(BaseModel):
@@ -432,11 +438,7 @@ class AddOnProductDef(BaseModel):
         value = value.strip()
         if not value:
             return None
-        if not _CAPABILITY_ID_RE.match(value):
-            raise ValueError(
-                f"capability_id must match [a-z0-9_.]+, got {value!r}"
-            )
-        return value
+        return _validate_capability_identifier(value)
 
     @field_validator("capability_groups", mode="before")
     @classmethod
@@ -552,10 +554,7 @@ class PlanDef(BaseModel):
             cap = str(raw).strip()
             if not cap:
                 continue
-            if not _CAPABILITY_ID_RE.match(cap):
-                raise ValueError(
-                    f"capability_id must match [a-z0-9_.]+, got {cap!r}"
-                )
+            _validate_capability_identifier(cap)
             if cap in seen:
                 duplicates.append(cap)
             else:
@@ -1159,7 +1158,11 @@ class SubscriptionsConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def load_subscriptions_config(app_root: Path) -> SubscriptionsConfig | None:
+def load_subscriptions_config(
+    app_root: Path,
+    *,
+    taxonomy_advisory: bool = False,
+) -> SubscriptionsConfig | None:
     """Load app/config/subscriptions.yaml.
 
     Returns:
@@ -1187,11 +1190,35 @@ def load_subscriptions_config(app_root: Path) -> SubscriptionsConfig | None:
         )
 
     try:
-        return SubscriptionsConfig.model_validate(raw)
+        config = SubscriptionsConfig.model_validate(raw)
+        if taxonomy_advisory:
+            _validate_subscription_taxonomy(config)
+        return config
     except Exception as exc:
         raise SubscriptionsLoadError(
             f"Invalid config/subscriptions.yaml: {exc}"
         ) from exc
+
+
+def _validate_subscription_taxonomy(config: SubscriptionsConfig) -> None:
+    """Resolve every capability reference without mutating the validated input."""
+
+    def _walk(value: object, key: str | None = None) -> Iterator[str]:
+        if isinstance(value, dict):
+            for child_key, child in value.items():
+                yield from _walk(child, str(child_key))
+        elif isinstance(value, list):
+            for child in value:
+                yield from _walk(child, key)
+        elif isinstance(value, str) and key in {"capability_id", "required_capability", "capabilities"}:
+            yield value
+
+    for capability_id in sorted(set(_walk(config.model_dump(mode="python")))):
+        validate_registered_identifier(
+            SemanticCategory.CAPABILITY,
+            capability_id,
+            advisory=True,
+        )
 
 
 __all__ = [

--- a/mozaiksai/core/session/launcher.py
+++ b/mozaiksai/core/session/launcher.py
@@ -465,6 +465,7 @@ async def emit_workflow_launch_navigation(
         transport = await SimpleTransport.get_instance()
         await transport.send_event_to_ui(
             {
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.navigate",
                 "data": {
                     "chat_id": workflow_launch.chat_id,

--- a/mozaiksai/core/taxonomy.py
+++ b/mozaiksai/core/taxonomy.py
@@ -1,0 +1,462 @@
+"""Versioned semantic identifier registry for ADR 0007 Slice 1.
+
+The taxonomy owns names and reference grammar only.  In particular, artifact
+entries identify ``layout_registry`` rows; they intentionally cannot carry
+paths, renderers, validators, or any other layout metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+SCHEMA_VERSION: Literal["mozaiks.taxonomy.v1"] = "mozaiks.taxonomy.v1"
+
+
+class TaxonomyError(ValueError):
+    """Base error for an invalid registry or unresolved semantic name."""
+
+
+class UnknownTaxonomyIdentifier(TaxonomyError):
+    """Raised when advisory validation cannot resolve an identifier."""
+
+
+class SemanticCategory(StrEnum):
+    EVENT = "event"
+    CAPABILITY = "capability"
+    ARTIFACT_FAMILY = "artifact_family"
+
+
+class NamespaceKind(StrEnum):
+    CORE = "core"
+    EXTENSION = "extension"
+
+
+_GRAMMARS: dict[SemanticCategory, re.Pattern[str]] = {
+    SemanticCategory.EVENT: re.compile(r"^[a-z0-9_]+(?:\.[a-z0-9_]+)+$"),
+    SemanticCategory.CAPABILITY: re.compile(r"^[a-z0-9_]+(?:\.[a-z0-9_]+)*$"),
+    SemanticCategory.ARTIFACT_FAMILY: re.compile(r"^[a-z][a-z0-9_]*$"),
+}
+
+
+def validate_identifier_grammar(category: SemanticCategory | str, identifier: str) -> str:
+    """Validate one category's canonical grammar and return a trimmed value."""
+    resolved_category = SemanticCategory(category)
+    value = str(identifier or "").strip()
+    if not value or _GRAMMARS[resolved_category].fullmatch(value) is None:
+        if resolved_category is SemanticCategory.CAPABILITY:
+            expected = "[a-z0-9_.]+"
+        elif resolved_category is SemanticCategory.EVENT:
+            expected = "a dot-namespaced lowercase event identifier"
+        else:
+            expected = "a lowercase underscore artifact-family identifier"
+        raise TaxonomyError(
+            f"{resolved_category.value} identifier must match {expected}, got {value!r}"
+        )
+    return value
+
+
+class TaxonomyModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class TaxonomyEntry(TaxonomyModel):
+    category: SemanticCategory
+    identifier: str
+
+    @field_validator("identifier", mode="before")
+    @classmethod
+    def _normalize_identifier(cls, value: str) -> str:
+        return str(value or "").strip()
+
+    @model_validator(mode="after")
+    def _validate_identifier(self) -> TaxonomyEntry:
+        validate_identifier_grammar(self.category, self.identifier)
+        return self
+
+    @property
+    def identity_payload(self) -> dict[str, str]:
+        return {"category": self.category.value, "identifier": self.identifier}
+
+
+class TaxonomyNamespace(TaxonomyModel):
+    namespace_id: str
+    version: int = Field(ge=1)
+    kind: NamespaceKind
+    grants: tuple[str, ...] = Field(default_factory=tuple)
+    entries: tuple[TaxonomyEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("namespace_id")
+    @classmethod
+    def _namespace_id(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if re.fullmatch(r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*", text) is None:
+            raise ValueError("namespace_id must be a lowercase dotted identifier")
+        return text
+
+    @field_validator("grants")
+    @classmethod
+    def _grants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(sorted({str(item or "").strip().rstrip(".") for item in value}))
+        if any(re.fullmatch(r"[a-z][a-z0-9_]*", item) is None for item in normalized):
+            raise ValueError("namespace grants must be lowercase identifier prefixes")
+        return normalized
+
+    @field_validator("entries")
+    @classmethod
+    def _entries(cls, value: tuple[TaxonomyEntry, ...]) -> tuple[TaxonomyEntry, ...]:
+        return tuple(sorted(value, key=lambda item: (item.category.value, item.identifier)))
+
+    @model_validator(mode="after")
+    def _validate_extension_grants(self) -> TaxonomyNamespace:
+        identities = [(entry.category, entry.identifier) for entry in self.entries]
+        if len(identities) != len(set(identities)):
+            raise ValueError(f"duplicate identifiers in namespace {self.namespace_id!r}")
+        if self.kind is NamespaceKind.EXTENSION:
+            if not self.grants:
+                raise ValueError("extension namespaces require at least one granted prefix")
+            for entry in self.entries:
+                if entry.category is SemanticCategory.ARTIFACT_FAMILY:
+                    raise ValueError(
+                        "Slice 1 extensions cannot introduce artifact-family identifiers"
+                    )
+                if not any(
+                    entry.identifier == grant or entry.identifier.startswith(f"{grant}.")
+                    for grant in self.grants
+                ):
+                    raise ValueError(
+                        f"extension entry {entry.identifier!r} is outside granted prefixes {self.grants!r}"
+                    )
+        return self
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "namespace_id": self.namespace_id,
+            "version": self.version,
+            "kind": self.kind.value,
+            "grants": list(self.grants),
+            "entries": [entry.identity_payload for entry in self.entries],
+        }
+
+
+class TaxonomyRegistry(TaxonomyModel):
+    schema_version: Literal["mozaiks.taxonomy.v1"] = SCHEMA_VERSION
+    namespaces: tuple[TaxonomyNamespace, ...] = Field(min_length=1)
+    registry_digest: str = Field(min_length=64, max_length=64)
+
+    @field_validator("namespaces")
+    @classmethod
+    def _namespaces(cls, value: tuple[TaxonomyNamespace, ...]) -> tuple[TaxonomyNamespace, ...]:
+        return tuple(sorted(value, key=lambda item: (item.namespace_id, item.version)))
+
+    @model_validator(mode="after")
+    def _validate_registry(self) -> TaxonomyRegistry:
+        identities = [(item.namespace_id, item.version) for item in self.namespaces]
+        if len(identities) != len(set(identities)):
+            raise ValueError("duplicate namespace/version identity")
+
+        seen_entries: dict[tuple[SemanticCategory, str], TaxonomyNamespace] = {}
+        grants: list[tuple[str, NamespaceKind, str]] = []
+        for namespace in self.namespaces:
+            for grant in namespace.grants:
+                for prior_grant, prior_kind, prior_namespace in grants:
+                    if (
+                        grant == prior_grant
+                        or grant.startswith(f"{prior_grant}.")
+                        or prior_grant.startswith(f"{grant}.")
+                    ):
+                        if namespace.namespace_id != prior_namespace:
+                            raise ValueError(
+                                f"namespace grant {grant!r} conflicts with {prior_kind.value} namespace {prior_namespace!r}"
+                            )
+                grants.append((grant, namespace.kind, namespace.namespace_id))
+            for entry in namespace.entries:
+                key = (entry.category, entry.identifier)
+                previous = seen_entries.get(key)
+                if previous is not None:
+                    raise ValueError(
+                        f"duplicate or conflicting {entry.category.value} identifier {entry.identifier!r} "
+                        f"in {previous.namespace_id!r} and {namespace.namespace_id!r}"
+                    )
+                seen_entries[key] = namespace
+
+        expected = _stable_digest(self.canonical_payload(include_digest=False))
+        if self.registry_digest != expected:
+            raise ValueError("registry_digest does not match taxonomy content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "namespaces": [namespace.identity_payload for namespace in self.namespaces],
+        }
+        if include_digest:
+            payload["registry_digest"] = self.registry_digest
+        return payload
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            self.canonical_payload(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        )
+
+    def resolve(self, category: SemanticCategory | str, identifier: str) -> TaxonomyEntry:
+        resolved_category = SemanticCategory(category)
+        value = validate_identifier_grammar(resolved_category, identifier)
+        for namespace in self.namespaces:
+            for entry in namespace.entries:
+                if entry.category is resolved_category and entry.identifier == value:
+                    return entry
+        raise UnknownTaxonomyIdentifier(f"unknown {resolved_category.value} identifier {value!r}")
+
+    def validate_closure(self, references: Iterable[tuple[SemanticCategory | str, str]]) -> None:
+        for category, identifier in references:
+            self.resolve(category, identifier)
+
+
+def build_taxonomy_registry(namespaces: Iterable[TaxonomyNamespace]) -> TaxonomyRegistry:
+    ordered = tuple(sorted(tuple(namespaces), key=lambda item: (item.namespace_id, item.version)))
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "namespaces": [namespace.identity_payload for namespace in ordered],
+    }
+    return TaxonomyRegistry(
+        namespaces=ordered,
+        registry_digest=_stable_digest(payload),
+    )
+
+
+_CORE_EVENTS = (
+    "ack.artifact_action",
+    "ack.tool_call_response",
+    "artifact.action.completed",
+    "artifact.action.failed",
+    "artifact.action.started",
+    "artifact.action",
+    "artifact.created",
+    "artifact.deleted",
+    "artifact.ready",
+    "artifact.state.updated",
+    "artifact.updated",
+    "build.completed",
+    "build.failed",
+    "build.started",
+    "client.resume",
+    "runtime.agent_output_validated",
+    "runtime.handoff",
+    "runtime.process_completed",
+    "runtime.reaction.dead_lettered",
+    "runtime.workflow_paused",
+    "notification.count_changed",
+    "notification.created",
+    "platform.workflow_capability_started",
+    "user.input.submit",
+    "workflow.completed",
+    "chat.tool_call_complete",
+    "chat.transition_requested",
+    "ui.dismiss",
+    "ui.render",
+    "ui.update",
+    "domain.app_registry.app_created",
+    "domain.app_registry.app_deleted",
+    "domain.app_registry.app_promoted",
+    "domain.app_registry.status_changed",
+    "domain.commerce.cart.updated",
+    "domain.commerce.checkout.failed",
+    "domain.commerce.checkout.requested",
+    "domain.commerce.inventory.adjusted",
+    "domain.commerce.order.paid",
+    "domain.commerce.order.updated",
+    "domain.commerce.product.archived",
+    "domain.commerce.product.created",
+    "domain.commerce.product.updated",
+    "domain.files.file_deleted",
+    "domain.files.file_uploaded",
+    "domain.messages.message_sent",
+    "domain.messages.thread_created",
+    "domain.messages.thread_read",
+    "domain.messaging_core.message_sent",
+    "domain.onboarding.dismissed",
+    "domain.onboarding.step_completed",
+    "domain.reports.generated",
+    "domain.social.activity.recorded",
+    "domain.social.friend_request.declined",
+    "domain.social.friend_request.sent",
+    "domain.social.friend_request.withdrawn",
+    "domain.social.friendship.created",
+    "domain.social.friendship.removed",
+    "domain.social.post.comment_deleted",
+    "domain.social.post.commented",
+    "domain.social.post.deleted",
+    "domain.social.post.published",
+    "domain.social.post.reacted",
+    "domain.support.request_created",
+    "domain.support.status_changed",
+    "domain.support_ticket.batch_requested",
+    "domain.task_manager.task_created",
+    "domain.users.user_created",
+    "domain.workspace_integrations.declaration_removed",
+    "domain.workspace_integrations.declarations_saved",
+    "domain.workspace_integrations.note_updated",
+    "domain.workspace_support.message_added",
+    "domain.workspace_support.negative_feedback",
+    "domain.workspace_support.request_created",
+    "domain.workspace_support.request_deleted",
+    "domain.workspace_support.request_status_changed",
+    "hosted.billing.subscription.activated",
+    "hosted.billing.subscription.cancelled",
+    "hosted.billing.subscription.updated",
+    "hosted.onboarding.step_completed",
+)
+
+_CORE_CAPABILITIES = (
+    "app_registry.create",
+    "app_registry.list",
+    "billing_portal",
+    "cloud.deployment.health",
+    "cloud.deployment.rollback",
+    "cloud.deployment.status",
+    "cloud.deployment.submit",
+    "cloud.domain.connect",
+    "cloud.domain.disconnect",
+    "cloud.domain.status",
+    "cloud.environment.endpoints",
+    "cloud.usage.report",
+    "commerce.cart.manage",
+    "commerce.checkout.start",
+    "commerce.inventory.manage",
+    "commerce.orders.manage",
+    "commerce.products.browse",
+    "commerce.products.manage",
+    "files.delete",
+    "files.read",
+    "files.upload",
+    "messaging.messages.send",
+    "messaging.threads.list",
+    "mozaikspay.billing_portal",
+    "mozaikspay.checkout.create_session",
+    "mozaikspay.subscription_checkout",
+    "mozaikspay.subscription_status",
+    "mozaikspay.token_status",
+    "mozaikspay.token_top_up",
+    "mozaikspay.usage_status",
+    "notifications.email.send",
+    "notifications.preferences.read",
+    "notifications.preferences.write",
+    "notifications.push.send",
+    "onboarding.tour.dismiss",
+    "onboarding.tour.progress.read",
+    "onboarding.tour.show",
+    "operator_readiness.evidence.local",
+    "operator_readiness.launch.check",
+    "operator_readiness.profile.select",
+    "social.feed.read",
+    "social.friends.connect",
+    "social.friends.list",
+    "social.posts.comment",
+    "social.posts.create",
+    "social.posts.list",
+    "social.posts.react",
+    "support.requests.create",
+    "support.requests.list",
+    "support.requests.update_status",
+    "subscriptions",
+    "usage_billing",
+    "workspace_integrations.get",
+    "workspace_integrations.list",
+)
+
+
+def default_taxonomy_registry() -> TaxonomyRegistry:
+    from mozaiksai.core.runtime.app.layout_registry import default_app_layout_registry
+    from mozaiksai.core.transport.event_contract import MozaiksEventType
+
+    event_names = sorted({*_CORE_EVENTS, *(item.value for item in MozaiksEventType)})
+    artifact_kinds = default_app_layout_registry().iter_artifact_kinds()
+    namespaces = (
+        TaxonomyNamespace(
+            namespace_id="mozaiks.events",
+            version=1,
+            kind=NamespaceKind.CORE,
+            grants=(
+                "ack",
+                "artifact",
+                "build",
+                "chat",
+                "client",
+                "domain",
+                "hosted",
+                "mozaikspay",
+                "notification",
+                "platform",
+                "runtime",
+                "ui",
+                "user",
+                "workflow",
+            ),
+            entries=tuple(
+                TaxonomyEntry(category=SemanticCategory.EVENT, identifier=item)
+                for item in event_names
+            ),
+        ),
+        TaxonomyNamespace(
+            namespace_id="mozaiks.capabilities",
+            version=1,
+            kind=NamespaceKind.CORE,
+            entries=tuple(
+                TaxonomyEntry(category=SemanticCategory.CAPABILITY, identifier=item)
+                for item in _CORE_CAPABILITIES
+            ),
+        ),
+        TaxonomyNamespace(
+            namespace_id="mozaiks.artifact_families",
+            version=1,
+            kind=NamespaceKind.CORE,
+            entries=tuple(
+                TaxonomyEntry(category=SemanticCategory.ARTIFACT_FAMILY, identifier=item.value)
+                for item in artifact_kinds
+            ),
+        ),
+    )
+    return build_taxonomy_registry(namespaces)
+
+
+def validate_registered_identifier(
+    category: SemanticCategory | str,
+    identifier: str,
+    *,
+    advisory: bool,
+    registry: TaxonomyRegistry | None = None,
+) -> str:
+    """Fail closed only on the explicit Slice 1 advisory path."""
+    value = str(identifier or "").strip()
+    if advisory:
+        (registry or default_taxonomy_registry()).resolve(category, value)
+    return value
+
+
+def _stable_digest(value: Any) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("ascii")).hexdigest()
+
+
+__all__ = [
+    "NamespaceKind",
+    "SCHEMA_VERSION",
+    "SemanticCategory",
+    "TaxonomyEntry",
+    "TaxonomyError",
+    "TaxonomyNamespace",
+    "TaxonomyRegistry",
+    "UnknownTaxonomyIdentifier",
+    "build_taxonomy_registry",
+    "default_taxonomy_registry",
+    "validate_identifier_grammar",
+    "validate_registered_identifier",
+]

--- a/mozaiksai/core/taxonomy.py
+++ b/mozaiksai/core/taxonomy.py
@@ -44,12 +44,23 @@ _GRAMMARS: dict[SemanticCategory, re.Pattern[str]] = {
     SemanticCategory.ARTIFACT_FAMILY: re.compile(r"^[a-z][a-z0-9_]*$"),
 }
 
+_GRANDFATHERED_EVENT_IDENTIFIERS = frozenset({"error"})
+
 
 def validate_identifier_grammar(category: SemanticCategory | str, identifier: str) -> str:
     """Validate one category's canonical grammar and return a trimmed value."""
     resolved_category = SemanticCategory(category)
     value = str(identifier or "").strip()
-    if not value or _GRAMMARS[resolved_category].fullmatch(value) is None:
+    if (
+        not value
+        or (
+            _GRAMMARS[resolved_category].fullmatch(value) is None
+            and not (
+                resolved_category is SemanticCategory.EVENT
+                and value in _GRANDFATHERED_EVENT_IDENTIFIERS
+            )
+        )
+    ):
         if resolved_category is SemanticCategory.CAPABILITY:
             expected = "[a-z0-9_.]+"
         elif resolved_category is SemanticCategory.EVENT:
@@ -259,6 +270,7 @@ def build_taxonomy_registry(namespaces: Iterable[TaxonomyNamespace]) -> Taxonomy
 
 
 _CORE_EVENTS = (
+    "error",
     "ack.artifact_action",
     "ack.tool_call_response",
     "artifact.action.completed",

--- a/mozaiksai/core/taxonomy.py
+++ b/mozaiksai/core/taxonomy.py
@@ -162,6 +162,23 @@ class TaxonomyRegistry(TaxonomyModel):
         if len(identities) != len(set(identities)):
             raise ValueError("duplicate namespace/version identity")
 
+        namespace_ids: dict[str, TaxonomyNamespace] = {}
+        for namespace in self.namespaces:
+            previous = namespace_ids.get(namespace.namespace_id)
+            if previous is not None:
+                raise ValueError(
+                    f"namespace id {namespace.namespace_id!r} is already owned by "
+                    f"{previous.kind.value} namespace version {previous.version}"
+                )
+            namespace_ids[namespace.namespace_id] = namespace
+
+        protected_core_roots = {
+            (entry.category, entry.identifier.split(".", 1)[0])
+            for namespace in self.namespaces
+            if namespace.kind is NamespaceKind.CORE
+            for entry in namespace.entries
+        }
+
         seen_entries: dict[tuple[SemanticCategory, str], TaxonomyNamespace] = {}
         grants: list[tuple[str, NamespaceKind, str]] = []
         for namespace in self.namespaces:
@@ -178,6 +195,15 @@ class TaxonomyRegistry(TaxonomyModel):
                             )
                 grants.append((grant, namespace.kind, namespace.namespace_id))
             for entry in namespace.entries:
+                if (
+                    namespace.kind is NamespaceKind.EXTENSION
+                    and (entry.category, entry.identifier.split(".", 1)[0])
+                    in protected_core_roots
+                ):
+                    raise ValueError(
+                        f"extension namespace {namespace.namespace_id!r} cannot occupy protected "
+                        f"core {entry.category.value} root {entry.identifier.split('.', 1)[0]!r}"
+                    )
                 key = (entry.category, entry.identifier)
                 previous = seen_entries.get(key)
                 if previous is not None:
@@ -260,6 +286,11 @@ _CORE_EVENTS = (
     "workflow.completed",
     "chat.tool_call_complete",
     "chat.transition_requested",
+    "chat.revision_requested",
+    "chat.deployment_started",
+    "chat.deployment_progress",
+    "chat.deployment_completed",
+    "chat.deployment_failed",
     "ui.dismiss",
     "ui.render",
     "ui.update",
@@ -356,6 +387,8 @@ _CORE_CAPABILITIES = (
     "operator_readiness.evidence.local",
     "operator_readiness.launch.check",
     "operator_readiness.profile.select",
+    "reports.export",
+    "reports.view",
     "social.feed.read",
     "social.friends.connect",
     "social.friends.list",

--- a/mozaiksai/core/transport/event_contract.py
+++ b/mozaiksai/core/transport/event_contract.py
@@ -19,6 +19,7 @@ EVENT_ENVELOPE_SCHEMA_VERSION: Literal["mozaiks.ui.event.v1"] = "mozaiks.ui.even
 
 
 class MozaiksEventType(StrEnum):
+    ERROR = "error"  # Grandfathered pre-namespaced application error envelope.
     # ── Outbound: AG2 chat stream events ──────────────────────────────────────
     CHAT_TEXT = "chat.text"
     CHAT_PRINT = "chat.print"
@@ -109,11 +110,18 @@ def validate_event_envelope_schema_version(envelope: Mapping[str, Any]) -> None:
         )
 
 
+async def send_event_envelope(websocket: Any, envelope: Mapping[str, Any]) -> None:
+    """Validate an application event envelope at the direct WebSocket boundary."""
+    validate_event_envelope_schema_version(envelope)
+    await websocket.send_json(dict(envelope))
+
+
 __all__ = [
     "NAMESPACE_MOZAIKS",
     "EVENT_ENVELOPE_SCHEMA_VERSION",
     "MozaiksEventType",
     "MozaiksEventEnvelope",
     "compute_event_id",
+    "send_event_envelope",
     "validate_event_envelope_schema_version",
 ]

--- a/mozaiksai/core/transport/event_contract.py
+++ b/mozaiksai/core/transport/event_contract.py
@@ -7,12 +7,15 @@ and UI layer import from this module. Wire-format strings are stable.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from enum import StrEnum
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 # Deterministic event ID namespace
 NAMESPACE_MOZAIKS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # uuid.NAMESPACE_URL
+EVENT_ENVELOPE_SCHEMA_VERSION: Literal["mozaiks.ui.event.v1"] = "mozaiks.ui.event.v1"
 
 
 class MozaiksEventType(StrEnum):
@@ -90,14 +93,27 @@ class MozaiksEventEnvelope(BaseModel):
 
     model_config = {"extra": "allow"}
 
+    schema_version: Literal["mozaiks.ui.event.v1"]
     type: MozaiksEventType
     event_id: str | None = None
     corr: str | None = None  # correlation / trace ID
 
 
+def validate_event_envelope_schema_version(envelope: Mapping[str, Any]) -> None:
+    """Fail closed when an outbound envelope omits or changes its wire version."""
+    version = envelope.get("schema_version")
+    if version != EVENT_ENVELOPE_SCHEMA_VERSION:
+        raise ValueError(
+            "event envelope schema_version must be "
+            f"{EVENT_ENVELOPE_SCHEMA_VERSION!r}, got {version!r}"
+        )
+
+
 __all__ = [
     "NAMESPACE_MOZAIKS",
+    "EVENT_ENVELOPE_SCHEMA_VERSION",
     "MozaiksEventType",
     "MozaiksEventEnvelope",
     "compute_event_id",
+    "validate_event_envelope_schema_version",
 ]

--- a/mozaiksai/core/transport/handlers/input_handlers.py
+++ b/mozaiksai/core/transport/handlers/input_handlers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket
 
+from mozaiksai.core.transport.event_contract import send_event_envelope
 from mozaiksai.core.transport.session_registry import session_registry
 
 from .base import logger, utc_timestamp
@@ -55,7 +56,7 @@ async def handle_user_input_submit(
                 user_message=text,
                 ui_context=ui_context_payload,
             )
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.input_ack",
                 "data": {"chat_id": chat_id, "status": "accepted"},
@@ -130,7 +131,7 @@ async def handle_user_input_submit(
                 source='ws'
             )
 
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.input_ack",
             "data": {"chat_id": target_chat_id, "status": "accepted"},
@@ -155,7 +156,7 @@ async def handle_tool_call_response(
     try:
         ok = await transport.submit_tool_call_response(event_id, response_data)
         logger.debug("TOOL_CALL_RESPONSE_RECEIVED event=%s accepted=%s", event_id, ok)
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "ack.tool_call_response",
             "data": {"tool_call_id": event_id, "status": "accepted" if ok else "rejected"},

--- a/mozaiksai/core/transport/handlers/input_handlers.py
+++ b/mozaiksai/core/transport/handlers/input_handlers.py
@@ -56,6 +56,7 @@ async def handle_user_input_submit(
                 ui_context=ui_context_payload,
             )
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.input_ack",
                 "data": {"chat_id": chat_id, "status": "accepted"},
                 "timestamp": utc_timestamp()
@@ -130,6 +131,7 @@ async def handle_user_input_submit(
             )
 
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.input_ack",
             "data": {"chat_id": target_chat_id, "status": "accepted"},
             "timestamp": utc_timestamp()
@@ -154,6 +156,7 @@ async def handle_tool_call_response(
         ok = await transport.submit_tool_call_response(event_id, response_data)
         logger.debug("TOOL_CALL_RESPONSE_RECEIVED event=%s accepted=%s", event_id, ok)
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "ack.tool_call_response",
             "data": {"tool_call_id": event_id, "status": "accepted" if ok else "rejected"},
             "timestamp": utc_timestamp()

--- a/mozaiksai/core/transport/handlers/mode_handlers.py
+++ b/mozaiksai/core/transport/handlers/mode_handlers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket
 
+from mozaiksai.core.transport.event_contract import send_event_envelope
 from mozaiksai.core.transport.session_registry import session_registry
 
 from .base import logger, utc_timestamp
@@ -37,7 +38,7 @@ async def handle_enter_general_mode(
 
     logger.debug("GENERAL_MODE_ENTERED ws_id=%s general_chat=%s", ws_id, general_chat_id)
 
-    await websocket.send_json({
+    await send_event_envelope(websocket, {
         "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.mode_changed",
         "data": {
@@ -64,7 +65,7 @@ async def handle_start_general_chat(
     session_registry.enter_general_mode(ws_id)
     general_ctx = await transport._ensure_general_chat_context(chat_id=chat_id, force_new=True)
 
-    await websocket.send_json({
+    await send_event_envelope(websocket, {
         "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.general_session_created",
         "data": {

--- a/mozaiksai/core/transport/handlers/mode_handlers.py
+++ b/mozaiksai/core/transport/handlers/mode_handlers.py
@@ -38,6 +38,7 @@ async def handle_enter_general_mode(
     logger.debug("GENERAL_MODE_ENTERED ws_id=%s general_chat=%s", ws_id, general_chat_id)
 
     await websocket.send_json({
+        "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.mode_changed",
         "data": {
             "mode": "general",
@@ -64,6 +65,7 @@ async def handle_start_general_chat(
     general_ctx = await transport._ensure_general_chat_context(chat_id=chat_id, force_new=True)
 
     await websocket.send_json({
+        "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.general_session_created",
         "data": {
             "general_chat_id": general_ctx.get("chat_id"),

--- a/mozaiksai/core/transport/handlers/workflow_handlers.py
+++ b/mozaiksai/core/transport/handlers/workflow_handlers.py
@@ -100,6 +100,7 @@ async def handle_switch_workflow(
 
     try:
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.context_switched",
             "data": {
                 "from_chat_id": chat_id,
@@ -196,6 +197,7 @@ async def handle_switch_workflow(
                     text_payload.setdefault("sender", text_payload.get("agent", "user"))
                     text_payload.setdefault("replay", True)
                     envelope = {
+                        "schema_version": "mozaiks.ui.event.v1",
                         "type": "chat.text",
                         "data": text_payload,
                         "timestamp": utc_timestamp(),
@@ -204,6 +206,7 @@ async def handle_switch_workflow(
                 elif kind == "resume_boundary":
                     boundary = {k: v for k, v in event_dict.items() if k != "kind"}
                     envelope = {
+                        "schema_version": "mozaiks.ui.event.v1",
                         "type": "chat.resume_boundary",
                         "data": boundary,
                         "timestamp": utc_timestamp(),
@@ -212,6 +215,7 @@ async def handle_switch_workflow(
                 elif kind == "awaiting_reply":
                     awaiting = {k: v for k, v in event_dict.items() if k != "kind"}
                     envelope = {
+                        "schema_version": "mozaiks.ui.event.v1",
                         "type": "chat.awaiting_reply",
                         "data": awaiting,
                         "timestamp": utc_timestamp(),
@@ -273,6 +277,7 @@ async def handle_start_workflow(
     resolved_workflow = route_decision.workflow_id
     if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.workflow_rerouted",
             "data": {
                 "requested_workflow_name": str(target_workflow),
@@ -327,6 +332,7 @@ async def handle_start_workflow(
     logger.debug("WORKFLOW_STARTED workflow=%s chat=%s ws_id=%s", resolved_workflow, new_chat_id, ws_id)
 
     await websocket.send_json({
+        "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.workflow_started",
         "data": {
             "chat_id": new_chat_id,
@@ -456,6 +462,7 @@ async def handle_start_workflow_batch(
 
         if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.workflow_rerouted",
                 "data": {
                     "requested_workflow_name": str(target_workflow),
@@ -468,6 +475,7 @@ async def handle_start_workflow_batch(
             })
 
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.workflow_started",
             "data": {
                 "chat_id": new_chat_id,
@@ -500,6 +508,7 @@ async def handle_start_workflow_batch(
 
     # Summary ack
     await websocket.send_json({
+        "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.workflow_batch_started",
         "data": {
             "count": len(started),

--- a/mozaiksai/core/transport/handlers/workflow_handlers.py
+++ b/mozaiksai/core/transport/handlers/workflow_handlers.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket
 
+from mozaiksai.core.transport.event_contract import send_event_envelope
 from mozaiksai.core.transport.session_registry import session_registry
 
 from .base import logger, utc_timestamp
@@ -99,7 +100,7 @@ async def handle_switch_workflow(
     logger.debug("WORKFLOW_CONTEXT_SWITCHED from=%s to=%s ws_id=%s", chat_id, target_chat_id, ws_id)
 
     try:
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.context_switched",
             "data": {
@@ -202,7 +203,7 @@ async def handle_switch_workflow(
                         "data": text_payload,
                         "timestamp": utc_timestamp(),
                     }
-                    await websocket.send_json(transport._serialize_ag2_events(envelope))
+                    await send_event_envelope(websocket, transport._serialize_ag2_events(envelope))
                 elif kind == "resume_boundary":
                     boundary = {k: v for k, v in event_dict.items() if k != "kind"}
                     envelope = {
@@ -211,7 +212,7 @@ async def handle_switch_workflow(
                         "data": boundary,
                         "timestamp": utc_timestamp(),
                     }
-                    await websocket.send_json(transport._serialize_ag2_events(envelope))
+                    await send_event_envelope(websocket, transport._serialize_ag2_events(envelope))
                 elif kind == "awaiting_reply":
                     awaiting = {k: v for k, v in event_dict.items() if k != "kind"}
                     envelope = {
@@ -220,7 +221,7 @@ async def handle_switch_workflow(
                         "data": awaiting,
                         "timestamp": utc_timestamp(),
                     }
-                    await websocket.send_json(transport._serialize_ag2_events(envelope))
+                    await send_event_envelope(websocket, transport._serialize_ag2_events(envelope))
 
             await replayer.handle_resume_request(
                 chat_id=str(target_chat_id),
@@ -276,7 +277,7 @@ async def handle_start_workflow(
     )
     resolved_workflow = route_decision.workflow_id
     if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.workflow_rerouted",
             "data": {
@@ -331,7 +332,7 @@ async def handle_start_workflow(
 
     logger.debug("WORKFLOW_STARTED workflow=%s chat=%s ws_id=%s", resolved_workflow, new_chat_id, ws_id)
 
-    await websocket.send_json({
+    await send_event_envelope(websocket, {
         "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.workflow_started",
         "data": {
@@ -461,7 +462,7 @@ async def handle_start_workflow_batch(
         })
 
         if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.workflow_rerouted",
                 "data": {
@@ -474,7 +475,7 @@ async def handle_start_workflow_batch(
                 "timestamp": utc_timestamp(),
             })
 
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.workflow_started",
             "data": {
@@ -507,7 +508,7 @@ async def handle_start_workflow_batch(
             transport._background_tasks[new_chat_id] = _batch_task
 
     # Summary ack
-    await websocket.send_json({
+    await send_event_envelope(websocket, {
         "schema_version": "mozaiks.ui.event.v1",
         "type": "chat.workflow_batch_started",
         "data": {

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -294,6 +294,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             return
         try:
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.error",
                 "data": {"message": message, "error_code": error_code},
                 "timestamp": _utc_timestamp(),
@@ -771,6 +772,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                     )
                     await self._broadcast_to_websockets(
                         {
+                            "schema_version": "mozaiks.ui.event.v1",
                             "type": "chat.stream_end",
                             "data": {
                                 "agent": _agent,
@@ -872,6 +874,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                 chunk_data["metadata"] = dict(metadata)
             await self._broadcast_to_websockets(
                 {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.stream_chunk",
                     "data": chunk_data,
                 },
@@ -933,6 +936,9 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
 
     async def _broadcast_to_websockets(self, event_data: dict[str, Any], target_chat_id: str | None = None) -> None:
         """Broadcast event data to relevant WebSocket connections."""
+        from mozaiksai.core.transport.event_contract import validate_event_envelope_schema_version
+
+        validate_event_envelope_schema_version(event_data)
         active_connections = list(self.connections.items())
 
         # If a chat_id is specified, only send to that connection
@@ -1229,6 +1235,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             promotion_target = str(params.get("promotion_target") or params.get("target") or "artifact").strip()
             if action_id:
                 await websocket.send_json({
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.started",
                     "data": {
                         "action_id": action_id,
@@ -1250,6 +1257,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                     promoted_by=str(user_id),
                 )
                 await websocket.send_json({
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.completed",
                     "data": {
                         "action_id": action_id,
@@ -1267,6 +1275,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                 })
             except Exception as exc:
                 await websocket.send_json({
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.failed",
                     "data": {
                         "action_id": action_id,
@@ -1303,6 +1312,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             resolved_workflow = route_decision.workflow_id
             if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
                 await websocket.send_json({
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.workflow_rerouted",
                     "data": {
                         "requested_workflow_name": str(target_workflow),
@@ -1331,6 +1341,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             
             # Notify frontend to navigate to new chat
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.navigate",
                 "data": {
                     "chat_id": new_session["_id"],
@@ -1359,6 +1370,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             
             # Broadcast state update to all connections for this artifact
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "artifact.state.updated",
                 "data": {
                     "artifact_id": artifact_id,
@@ -1373,6 +1385,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         logger.debug("ARTIFACT_ACTION_RECEIVED action=%s chat=%s", action, chat_id)
         # Future: route to agent or handle other action types
         await websocket.send_json({
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "ack.artifact_action",
             "data": {
                 "action": action,
@@ -1508,6 +1521,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         if extra_data:
             data.update(extra_data)
         event_data = {
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "error",
             "data": data,
             "timestamp": datetime.now(UTC).isoformat()

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -584,10 +584,20 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         Serializes and sends a raw AG2 event to the UI.
         This is the primary method for forwarding AG2 native events.
         """
+        is_transport_envelope = (
+            isinstance(event, dict) and 'type' in event and 'data' in event and 'kind' not in event
+        )
+        if is_transport_envelope:
+            from mozaiksai.core.transport.event_contract import (
+                validate_event_envelope_schema_version,
+            )
+
+            validate_event_envelope_schema_version(event)
+
         try:
             # Allow callers to provide a fully-formed transport envelope (e.g., ack.tool_call_response)
             # without forcing another serialization pass through the dispatcher.
-            if isinstance(event, dict) and 'type' in event and 'data' in event and 'kind' not in event:
+            if is_transport_envelope:
                 logger.debug(
                     "TRANSPORT_ENVELOPE_PASSTHROUGH type=%s",
                     event.get('type')

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -23,6 +23,7 @@ from logs.logging_config import get_core_logger
 from mozaiksai.core.events.runtime_events import RUNTIME_PROCESS_COMPLETED
 
 # Extracted mixins for separation of concerns
+from mozaiksai.core.transport.event_contract import send_event_envelope
 from mozaiksai.core.transport.general_mode import GeneralModeMixin
 
 # Message handlers (extracted for maintainability)
@@ -293,7 +294,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         if getattr(websocket, "client_state", None) is WebSocketState.DISCONNECTED:
             return
         try:
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.error",
                 "data": {"message": message, "error_code": error_code},
@@ -1234,7 +1235,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             asset_id = str(params.get("asset_id") or payload.get("asset_id") or "").strip()
             promotion_target = str(params.get("promotion_target") or params.get("target") or "artifact").strip()
             if action_id:
-                await websocket.send_json({
+                await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.started",
                     "data": {
@@ -1256,7 +1257,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                     promotion_target=promotion_target,
                     promoted_by=str(user_id),
                 )
-                await websocket.send_json({
+                await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.completed",
                     "data": {
@@ -1274,7 +1275,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                     "timestamp": datetime.now(UTC).isoformat(),
                 })
             except Exception as exc:
-                await websocket.send_json({
+                await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "artifact.action.failed",
                     "data": {
@@ -1311,7 +1312,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             )
             resolved_workflow = route_decision.workflow_id
             if route_decision.rerouted_by_dependency and route_decision.unmet_dependency is not None:
-                await websocket.send_json({
+                await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.workflow_rerouted",
                     "data": {
@@ -1340,7 +1341,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             logger.debug("Created new session %s with artifact %s", new_session['_id'], artifact['_id'])
             
             # Notify frontend to navigate to new chat
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.navigate",
                 "data": {
@@ -1369,7 +1370,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             logger.debug("Updated artifact state for %s: %s", artifact_id, list(state_updates.keys()))
             
             # Broadcast state update to all connections for this artifact
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "artifact.state.updated",
                 "data": {
@@ -1384,7 +1385,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         # Route: other actions (forward to agent as tool_call or handle directly)
         logger.debug("ARTIFACT_ACTION_RECEIVED action=%s chat=%s", action, chat_id)
         # Future: route to agent or handle other action types
-        await websocket.send_json({
+        await send_event_envelope(websocket, {
             "schema_version": "mozaiks.ui.event.v1",
             "type": "ack.artifact_action",
             "data": {

--- a/mozaiksai/core/transport/websocket.py
+++ b/mozaiksai/core/transport/websocket.py
@@ -111,9 +111,15 @@ class WebSocketSessionManager:
         for idx, message in enumerate(messages_to_send):
             try:
                 if isinstance(message, dict) and "type" in message and "data" in message:
+                    from mozaiksai.core.transport.event_contract import (
+                        validate_event_envelope_schema_version,
+                    )
+
+                    validate_event_envelope_schema_version(message)
                     await websocket.send_json(message)
                 else:
                     await websocket.send_json({
+                        "schema_version": "mozaiks.ui.event.v1",
                         "type": "log",
                         "data": {"message": self._stringify_unknown(message)},
                     })
@@ -219,6 +225,7 @@ class WebSocketSessionManager:
             while chat_id in self.connections:
                 await asyncio.sleep(self._heartbeat_interval)
                 ping_data = {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "ping",
                     "timestamp": datetime.now(UTC).isoformat(),
                 }

--- a/mozaiksai/core/transport/ws_protocol.py
+++ b/mozaiksai/core/transport/ws_protocol.py
@@ -105,6 +105,11 @@ class WebSocketProtocolMixin:
                 try:
                     # Check if message is already in proper format for WebSocket
                     if isinstance(message, dict) and "type" in message and "data" in message:
+                        from mozaiksai.core.transport.event_contract import (
+                            validate_event_envelope_schema_version,
+                        )
+
+                        validate_event_envelope_schema_version(message)
                         # Ensure the 'data' payload is JSON-serializable (may contain AG2 objects)
                         try:
                             safe_message = message.copy()
@@ -235,6 +240,7 @@ class WebSocketProtocolMixin:
 
                 # Send ping
                 ping_data = {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "ping",
                     "timestamp": datetime.now(UTC).isoformat(),
                 }

--- a/mozaiksai/core/workflow/pack/journey_orchestrator.py
+++ b/mozaiksai/core/workflow/pack/journey_orchestrator.py
@@ -155,6 +155,7 @@ class JourneyOrchestrator:
         if advance.next_transition_id:
             await transport.send_event_to_ui(
                 {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.transition_requested",
                     "data": {
                         "transition_id": advance.next_transition_id,
@@ -209,6 +210,7 @@ class JourneyOrchestrator:
                 )
                 await transport.send_event_to_ui(
                     {
+                        "schema_version": "mozaiks.ui.event.v1",
                         "type": "chat.error",
                         "data": {
                             "message": reason,
@@ -326,6 +328,7 @@ class JourneyOrchestrator:
 
         await transport.send_event_to_ui(
             {
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.context_switched",
                 "data": {
                     "from_chat_id": chat_id,

--- a/mozaiksai/core/workflow/ui_tools.py
+++ b/mozaiksai/core/workflow/ui_tools.py
@@ -384,6 +384,7 @@ async def use_ui_tool(
 
                 transport = await SimpleTransport.get_instance()
                 completion_event = {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.tool_call_complete",
                     "data": {
                         "tool_call_id": event_id,

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -3397,6 +3397,7 @@ async def websocket_endpoint(
             user_id,
         )
 
+    from mozaiksai.core.transport.event_contract import send_event_envelope
     from mozaiksai.core.transport.session_registry import session_registry
 
     ws_id = id(websocket)
@@ -3411,7 +3412,7 @@ async def websocket_endpoint(
         if not is_valid:
             try:
                 await websocket.accept()
-                await websocket.send_json({
+                await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
                     "data": {
@@ -3430,7 +3431,7 @@ async def websocket_endpoint(
         logger.error("WS_PREREQ_VALIDATION_FAILED: %s", dep_err, exc_info=True)
         try:
             await websocket.accept()
-            await websocket.send_json({
+            await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.error",
                 "data": {

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -3412,6 +3412,7 @@ async def websocket_endpoint(
             try:
                 await websocket.accept()
                 await websocket.send_json({
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
                     "data": {
                         "message": error_msg,
@@ -3430,6 +3431,7 @@ async def websocket_endpoint(
         try:
             await websocket.accept()
             await websocket.send_json({
+                "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.error",
                 "data": {
                     "message": "Failed to validate workflow prerequisites. Please try again.",

--- a/mozaiksai/hosts/runtime.py
+++ b/mozaiksai/hosts/runtime.py
@@ -883,6 +883,7 @@ async def websocket_endpoint(
         from mozaiksai.core.data.persistence.persistence_manager import extract_last_artifact
         from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
         from mozaiksai.core.session.router import get_session_router
+        from mozaiksai.core.transport.event_contract import send_event_envelope
         from mozaiksai.core.transport.session_registry import session_registry
         from mozaiksai.core.workflow.workflow_manager import workflow_manager
 
@@ -937,7 +938,7 @@ async def websocket_endpoint(
         except Exception as prereq_exc:
             logger.error("WS_PREREQ_VALIDATION_FAILED workflow=%s chat=%s: %s", resolved_workflow_name, chat_id, prereq_exc, exc_info=True)
             await websocket.accept()
-            await websocket.send_json(
+            await send_event_envelope(websocket,
                 {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
@@ -955,7 +956,7 @@ async def websocket_endpoint(
 
         if not prereqs_ok:
             await websocket.accept()
-            await websocket.send_json(
+            await send_event_envelope(websocket,
                 {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",

--- a/mozaiksai/hosts/runtime.py
+++ b/mozaiksai/hosts/runtime.py
@@ -939,6 +939,7 @@ async def websocket_endpoint(
             await websocket.accept()
             await websocket.send_json(
                 {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
                     "data": {
                         "message": "Failed to validate workflow prerequisites. Please try again.",
@@ -956,6 +957,7 @@ async def websocket_endpoint(
             await websocket.accept()
             await websocket.send_json(
                 {
+                    "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
                     "data": {
                         "message": prereq_reason or "Workflow prerequisites are not met.",

--- a/tests/test_event_contract.py
+++ b/tests/test_event_contract.py
@@ -1,5 +1,6 @@
 """Tests for the mozaiks.ui.event.v1 canonical event contract."""
 from mozaiksai.core.transport.event_contract import (
+    EVENT_ENVELOPE_SCHEMA_VERSION,
     MozaiksEventEnvelope,
     MozaiksEventType,
     compute_event_id,
@@ -67,13 +68,21 @@ def test_compute_event_id_uses_session_when_no_run():
 
 
 def test_envelope_accepts_extra_fields():
-    env = MozaiksEventEnvelope(type=MozaiksEventType.CHAT_TEXT, text="hello", seq=5)
+    env = MozaiksEventEnvelope(
+        schema_version=EVENT_ENVELOPE_SCHEMA_VERSION,
+        type=MozaiksEventType.CHAT_TEXT,
+        text="hello",
+        seq=5,
+    )
     assert env.type == "chat.text"
 
 
 def test_envelope_type_compares_as_string():
     """MozaiksEventType is a StrEnum — it must compare equal to its string value."""
-    env = MozaiksEventEnvelope(type=MozaiksEventType.UI_RENDER)
+    env = MozaiksEventEnvelope(
+        schema_version=EVENT_ENVELOPE_SCHEMA_VERSION,
+        type=MozaiksEventType.UI_RENDER,
+    )
     assert env.type == "ui.render"
     assert env.type == MozaiksEventType.UI_RENDER
 
@@ -88,7 +97,7 @@ def test_ns_map_uses_canonical_types():
 
     from mozaiksai.core.events.unified_event_dispatcher import UnifiedEventDispatcher
 
-    src = inspect.getsource(UnifiedEventDispatcher.build_outbound_event_envelope)
+    src = inspect.getsource(UnifiedEventDispatcher._build_outbound_event_envelope)
     # Extract string values that look like event type strings from the ns_map block.
     # We match 'MozaiksEventType.XYZ' patterns and verify they resolve correctly.
     enum_refs = re.findall(r"MozaiksEventType\.(\w+)", src)

--- a/tests/test_event_contract.py
+++ b/tests/test_event_contract.py
@@ -1,16 +1,19 @@
 """Tests for the mozaiks.ui.event.v1 canonical event contract."""
+import pytest
+
 from mozaiksai.core.transport.event_contract import (
     EVENT_ENVELOPE_SCHEMA_VERSION,
     MozaiksEventEnvelope,
     MozaiksEventType,
     compute_event_id,
+    send_event_envelope,
 )
 
 
 def test_event_type_strings_are_namespaced():
     """All event types must have a dot-namespaced format."""
     for et in MozaiksEventType:
-        assert "." in et, f"{et} is not namespaced"
+        assert "." in et or et is MozaiksEventType.ERROR, f"{et} is not namespaced"
 
 
 def test_ui_event_types_present():
@@ -85,6 +88,25 @@ def test_envelope_type_compares_as_string():
     )
     assert env.type == "ui.render"
     assert env.type == MozaiksEventType.UI_RENDER
+
+
+def test_envelope_accepts_grandfathered_error_type():
+    env = MozaiksEventEnvelope(
+        schema_version=EVENT_ENVELOPE_SCHEMA_VERSION,
+        type=MozaiksEventType.ERROR,
+        data={"message": "failed"},
+    )
+    assert env.type == "error"
+
+
+@pytest.mark.asyncio
+async def test_direct_websocket_boundary_rejects_missing_schema_version():
+    class _WebSocket:
+        async def send_json(self, _payload):  # noqa: ANN001
+            raise AssertionError("invalid envelope reached socket")
+
+    with pytest.raises(ValueError, match="schema_version"):
+        await send_event_envelope(_WebSocket(), {"type": "chat.error", "data": {}})
 
 
 def test_ns_map_uses_canonical_types():

--- a/tests/test_runtime_websocket_contract.py
+++ b/tests/test_runtime_websocket_contract.py
@@ -355,6 +355,7 @@ async def test_runtime_websocket_endpoint_emits_chat_error_when_prereqs_fail(mon
     assert websocket.accepted is True
     assert websocket.sent == [
         {
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.error",
             "data": {
                 "message": "Studio setup is incomplete.",
@@ -415,6 +416,7 @@ async def test_runtime_websocket_endpoint_emits_validation_error_when_prereq_che
     assert websocket.accepted is True
     assert websocket.sent == [
         {
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.error",
             "data": {
                 "message": "Failed to validate workflow prerequisites. Please try again.",

--- a/tests/test_semantic_taxonomy.py
+++ b/tests/test_semantic_taxonomy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from copy import deepcopy
 from pathlib import Path
 
@@ -109,6 +110,7 @@ def test_registry_validation_does_not_mutate_inputs() -> None:
         (SemanticCategory.EVENT, "build.started"),
         (SemanticCategory.EVENT, "build.completed"),
         (SemanticCategory.EVENT, "build.failed"),
+        (SemanticCategory.EVENT, "error"),
         (SemanticCategory.EVENT, "chat.revision_requested"),
         (SemanticCategory.EVENT, "chat.deployment_started"),
         (SemanticCategory.EVENT, "chat.deployment_progress"),
@@ -462,3 +464,32 @@ def test_dispatcher_builds_versioned_envelopes_for_transport_consumer() -> None:
     )
     assert envelope is not None
     validate_event_envelope_schema_version(envelope)
+
+
+def test_literal_wire_event_producers_declare_schema_version() -> None:
+    wire_methods = {"send_json", "send_event_to_ui", "_broadcast_to_websockets"}
+    missing: list[str] = []
+    for source_root in (ROOT / "mozaiksai", ROOT / "factory_app"):
+        for path in source_root.rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                call = node.value if isinstance(node, ast.Await) else node
+                if not isinstance(call, ast.Call) or not call.args:
+                    continue
+                if not isinstance(call.func, ast.Attribute) or call.func.attr not in wire_methods:
+                    continue
+                payload = call.args[0]
+                if not isinstance(payload, ast.Dict):
+                    continue
+                keys = {
+                    key.value
+                    for key in payload.keys
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+                if {"type", "data"} <= keys and "schema_version" not in keys:
+                    missing.append(f"{path.relative_to(ROOT)}:{payload.lineno}")
+
+    assert missing == []

--- a/tests/test_semantic_taxonomy.py
+++ b/tests/test_semantic_taxonomy.py
@@ -109,9 +109,16 @@ def test_registry_validation_does_not_mutate_inputs() -> None:
         (SemanticCategory.EVENT, "build.started"),
         (SemanticCategory.EVENT, "build.completed"),
         (SemanticCategory.EVENT, "build.failed"),
+        (SemanticCategory.EVENT, "chat.revision_requested"),
+        (SemanticCategory.EVENT, "chat.deployment_started"),
+        (SemanticCategory.EVENT, "chat.deployment_progress"),
+        (SemanticCategory.EVENT, "chat.deployment_completed"),
+        (SemanticCategory.EVENT, "chat.deployment_failed"),
         (SemanticCategory.CAPABILITY, "commerce.checkout.start"),
         (SemanticCategory.CAPABILITY, "messaging.messages.send"),
         (SemanticCategory.CAPABILITY, "mozaikspay.subscription_status"),
+        (SemanticCategory.CAPABILITY, "reports.view"),
+        (SemanticCategory.CAPABILITY, "reports.export"),
     ],
 )
 def test_grandfathered_current_identifiers_resolve(
@@ -126,8 +133,9 @@ def test_all_shipped_module_event_and_capability_names_are_grandfathered() -> No
     event_names: set[str] = set()
     capability_names: set[str] = set()
 
-    for path in (ROOT / "factory_app").rglob("*.yaml"):
-        if path.name not in {"events.yaml", "module.yaml"}:
+    shipped_roots = (ROOT / "factory_app", ROOT / "examples" / "canonical-apps")
+    for path in (path for root in shipped_roots for path in root.rglob("*.yaml")):
+        if path.name not in {"events.yaml", "module.yaml", "subscriptions.yaml"}:
             continue
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
@@ -143,6 +151,15 @@ def test_all_shipped_module_event_and_capability_names_are_grandfathered() -> No
             for action in raw.get("actions") or []:
                 if isinstance(action, dict) and isinstance(action.get("entitlement_gate"), str):
                     capability_names.add(action["entitlement_gate"])
+        if (
+            path.name == "subscriptions.yaml"
+            and raw.get("schema_version") == "mozaiks.subscriptions.v1"
+        ):
+            for plan in raw.get("plans") or []:
+                if isinstance(plan, dict):
+                    capability_names.update(
+                        item for item in plan.get("capabilities") or [] if isinstance(item, str)
+                    )
 
     assert event_names
     assert capability_names
@@ -236,6 +253,28 @@ def test_extension_namespace_isolation_and_core_protection() -> None:
     with pytest.raises(ValueError, match="conflicts|duplicate or conflicting"):
         build_taxonomy_registry((core, redefining))
 
+    core_registry = default_taxonomy_registry()
+    core_events = next(
+        namespace for namespace in core_registry.namespaces if namespace.namespace_id == "mozaiks.events"
+    )
+    reused_core_id = _namespace(
+        "mozaiks.events",
+        _entry(SemanticCategory.EVENT, "vendor.changed"),
+        kind=NamespaceKind.EXTENSION,
+        grants=("vendor",),
+    ).model_copy(update={"version": 2})
+    with pytest.raises(ValueError, match="namespace id.*already owned"):
+        build_taxonomy_registry((core_events, reused_core_id))
+
+    commerce_extension = _namespace(
+        "vendor.capabilities",
+        _entry(SemanticCategory.CAPABILITY, "commerce.vendor_extra"),
+        kind=NamespaceKind.EXTENSION,
+        grants=("commerce",),
+    )
+    with pytest.raises(ValueError, match="protected core capability root"):
+        build_taxonomy_registry((*core_registry.namespaces, commerce_extension))
+
 
 def test_event_reference_closure_fails_on_unknown_name() -> None:
     registry = default_taxonomy_registry()
@@ -311,6 +350,67 @@ def test_module_event_advisory_rejects_unknown_registered_prefix_name(tmp_path: 
         event_type="domain.unknown.changed",
     )
     with pytest.raises(ModuleLoadError, match="unknown event"):
+        ModuleLoader(str(tmp_path), taxonomy_advisory=True).load("sample")
+
+
+@pytest.mark.parametrize("manifest_name", ["reactions.yaml", "notifications.yaml"])
+def test_module_advisory_closes_companion_event_references(
+    tmp_path: Path, manifest_name: str
+) -> None:
+    _write_module(
+        tmp_path,
+        capability_id="commerce.checkout.start",
+        event_type="domain.commerce.checkout.requested",
+    )
+    contracts = tmp_path / "modules" / "sample" / "contracts"
+    if manifest_name == "reactions.yaml":
+        content = """schema_version: mozaiks.reactions.v1
+reactions:
+  - id: unknown_event
+    event_type: domain.not_registered
+    target:
+      kind: capability
+      capability_id: commerce.checkout.start
+"""
+    else:
+        content = """schema_version: mozaiks.notifications.v1
+notifications:
+  - id: unknown_event
+    event_type: domain.not_registered
+    channels: [in_app]
+    audience: {}
+    template:
+      title: Unknown
+      body: Unknown
+"""
+    (contracts / manifest_name).write_text(content, encoding="utf-8")
+
+    assert ModuleLoader(str(tmp_path)).load("sample").name == "sample"
+    with pytest.raises(ModuleLoadError, match="unknown event"):
+        ModuleLoader(str(tmp_path), taxonomy_advisory=True).load("sample")
+
+
+def test_module_advisory_closes_reaction_capability_target(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        capability_id="commerce.checkout.start",
+        event_type="domain.commerce.checkout.requested",
+    )
+    reactions = tmp_path / "modules" / "sample" / "contracts" / "reactions.yaml"
+    reactions.write_text(
+        """schema_version: mozaiks.reactions.v1
+reactions:
+  - id: unknown_capability
+    event_type: domain.commerce.checkout.requested
+    target:
+      kind: capability
+      capability_id: commerce.not_registered
+""",
+        encoding="utf-8",
+    )
+
+    assert ModuleLoader(str(tmp_path)).load("sample").name == "sample"
+    with pytest.raises(ModuleLoadError, match="unknown capability"):
         ModuleLoader(str(tmp_path), taxonomy_advisory=True).load("sample")
 
 

--- a/tests/test_semantic_taxonomy.py
+++ b/tests/test_semantic_taxonomy.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from mozaiksai.core.events.runtime_events import (
+    ARTIFACT_EVENT_CREATED,
+    ARTIFACT_EVENT_DELETED,
+    ARTIFACT_EVENT_READY,
+    ARTIFACT_EVENT_UPDATED,
+    RUNTIME_AGENT_OUTPUT_VALIDATED,
+    RUNTIME_PROCESS_COMPLETED,
+)
+from mozaiksai.core.events.unified_event_dispatcher import UnifiedEventDispatcher
+from mozaiksai.core.runtime.app.layout_registry import (
+    ArtifactKind,
+    default_app_layout_registry,
+    resolve_taxonomy_artifact_family,
+)
+from mozaiksai.core.runtime.app.module_loader import ModuleLoader, ModuleLoadError
+from mozaiksai.core.runtime.app.subscriptions_loader import (
+    SubscriptionsLoadError,
+    load_subscriptions_config,
+)
+from mozaiksai.core.taxonomy import (
+    NamespaceKind,
+    SemanticCategory,
+    TaxonomyEntry,
+    TaxonomyNamespace,
+    TaxonomyRegistry,
+    UnknownTaxonomyIdentifier,
+    build_taxonomy_registry,
+    default_taxonomy_registry,
+    validate_identifier_grammar,
+)
+from mozaiksai.core.transport.event_contract import (
+    EVENT_ENVELOPE_SCHEMA_VERSION,
+    MozaiksEventEnvelope,
+    MozaiksEventType,
+    validate_event_envelope_schema_version,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _entry(category: SemanticCategory, identifier: str) -> TaxonomyEntry:
+    return TaxonomyEntry(category=category, identifier=identifier)
+
+
+def _namespace(
+    namespace_id: str,
+    *entries: TaxonomyEntry,
+    kind: NamespaceKind = NamespaceKind.CORE,
+    grants: tuple[str, ...] = (),
+    version: int = 1,
+) -> TaxonomyNamespace:
+    return TaxonomyNamespace(
+        namespace_id=namespace_id,
+        version=version,
+        kind=kind,
+        grants=grants,
+        entries=entries,
+    )
+
+
+def test_registry_serialization_digest_and_input_order_are_deterministic() -> None:
+    left = _namespace(
+        "example.events",
+        _entry(SemanticCategory.EVENT, "example.second"),
+        _entry(SemanticCategory.EVENT, "example.first"),
+    )
+    right = _namespace(
+        "example.capabilities",
+        _entry(SemanticCategory.CAPABILITY, "example.read"),
+    )
+
+    first = build_taxonomy_registry((left, right))
+    second = build_taxonomy_registry((right, left))
+
+    assert first.registry_digest == second.registry_digest
+    assert first.canonical_json() == second.canonical_json()
+    assert first.canonical_json() == first.canonical_json()
+
+
+def test_registry_validation_does_not_mutate_inputs() -> None:
+    registry = default_taxonomy_registry()
+    payload = registry.model_dump(mode="json")
+    original = deepcopy(payload)
+
+    TaxonomyRegistry.model_validate(payload)
+
+    assert payload == original
+
+
+@pytest.mark.parametrize(
+    "category,identifier",
+    [(SemanticCategory.EVENT, item.value) for item in MozaiksEventType]
+    + [
+        (SemanticCategory.EVENT, RUNTIME_AGENT_OUTPUT_VALIDATED),
+        (SemanticCategory.EVENT, RUNTIME_PROCESS_COMPLETED),
+        (SemanticCategory.EVENT, ARTIFACT_EVENT_CREATED),
+        (SemanticCategory.EVENT, ARTIFACT_EVENT_UPDATED),
+        (SemanticCategory.EVENT, ARTIFACT_EVENT_READY),
+        (SemanticCategory.EVENT, ARTIFACT_EVENT_DELETED),
+        (SemanticCategory.EVENT, "build.started"),
+        (SemanticCategory.EVENT, "build.completed"),
+        (SemanticCategory.EVENT, "build.failed"),
+        (SemanticCategory.CAPABILITY, "commerce.checkout.start"),
+        (SemanticCategory.CAPABILITY, "messaging.messages.send"),
+        (SemanticCategory.CAPABILITY, "mozaikspay.subscription_status"),
+    ],
+)
+def test_grandfathered_current_identifiers_resolve(
+    category: SemanticCategory,
+    identifier: str,
+) -> None:
+    assert default_taxonomy_registry().resolve(category, identifier).identifier == identifier
+
+
+def test_all_shipped_module_event_and_capability_names_are_grandfathered() -> None:
+    registry = default_taxonomy_registry()
+    event_names: set[str] = set()
+    capability_names: set[str] = set()
+
+    for path in (ROOT / "factory_app").rglob("*.yaml"):
+        if path.name not in {"events.yaml", "module.yaml"}:
+            continue
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            continue
+        if path.name == "events.yaml" and raw.get("schema_version") == "mozaiks.events.v1":
+            for event in raw.get("events") or []:
+                if isinstance(event, dict) and isinstance(event.get("type"), str):
+                    event_names.add(event["type"])
+        if path.name == "module.yaml" and raw.get("schema_version") == "mozaiks.module.v1":
+            for capability in raw.get("capabilities") or []:
+                if isinstance(capability, dict) and isinstance(capability.get("capability_id"), str):
+                    capability_names.add(capability["capability_id"])
+            for action in raw.get("actions") or []:
+                if isinstance(action, dict) and isinstance(action.get("entitlement_gate"), str):
+                    capability_names.add(action["entitlement_gate"])
+
+    assert event_names
+    assert capability_names
+    registry.validate_closure((SemanticCategory.EVENT, value) for value in event_names)
+    registry.validate_closure(
+        (SemanticCategory.CAPABILITY, value) for value in capability_names
+    )
+
+
+def test_all_layout_artifact_families_resolve_to_authoritative_rows() -> None:
+    registry = default_app_layout_registry()
+    taxonomy = default_taxonomy_registry()
+    artifact_entries = [
+        entry
+        for namespace in taxonomy.namespaces
+        for entry in namespace.entries
+        if entry.category is SemanticCategory.ARTIFACT_FAMILY
+    ]
+    for entry in artifact_entries:
+        kind = ArtifactKind(entry.identifier)
+        rows = resolve_taxonomy_artifact_family(entry.identifier)
+        assert rows
+        assert all(row in registry.families and row.kind is kind for row in rows)
+
+
+def test_taxonomy_entry_cannot_copy_layout_path_or_metadata() -> None:
+    with pytest.raises(ValidationError, match="extra"):
+        TaxonomyEntry.model_validate(
+            {
+                "category": "artifact_family",
+                "identifier": "app_manifest",
+                "path_template": "shadow/app.json",
+                "renderer": "shadow_renderer",
+            }
+        )
+
+
+def test_missing_layout_family_target_fails() -> None:
+    registry = build_taxonomy_registry(
+        (
+            _namespace(
+                "example.artifacts", _entry(SemanticCategory.ARTIFACT_FAMILY, "missing_family")
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="no ArtifactKind"):
+        resolve_taxonomy_artifact_family("missing_family", taxonomy_registry=registry)
+
+
+def test_duplicate_identifiers_and_namespace_versions_fail() -> None:
+    duplicate_entry = _entry(SemanticCategory.EVENT, "example.changed")
+    with pytest.raises(ValueError, match="duplicate or conflicting"):
+        build_taxonomy_registry(
+            (
+                _namespace("first.events", duplicate_entry),
+                _namespace("second.events", duplicate_entry),
+            )
+        )
+
+    namespace = _namespace("example.events", duplicate_entry)
+    with pytest.raises(ValueError, match="duplicate namespace/version"):
+        build_taxonomy_registry((namespace, namespace))
+
+
+def test_extension_namespace_isolation_and_core_protection() -> None:
+    extension = _namespace(
+        "vendor.events",
+        _entry(SemanticCategory.EVENT, "vendor.changed"),
+        kind=NamespaceKind.EXTENSION,
+        grants=("vendor",),
+    )
+    assert build_taxonomy_registry((extension,)).resolve(SemanticCategory.EVENT, "vendor.changed")
+
+    with pytest.raises(ValueError, match="outside granted"):
+        _namespace(
+            "vendor.events",
+            _entry(SemanticCategory.EVENT, "other.changed"),
+            kind=NamespaceKind.EXTENSION,
+            grants=("vendor",),
+        )
+
+    core = _namespace(
+        "core.events", _entry(SemanticCategory.EVENT, "runtime.changed"), grants=("runtime",)
+    )
+    redefining = _namespace(
+        "vendor.events",
+        _entry(SemanticCategory.EVENT, "runtime.changed"),
+        kind=NamespaceKind.EXTENSION,
+        grants=("runtime",),
+    )
+    with pytest.raises(ValueError, match="conflicts|duplicate or conflicting"):
+        build_taxonomy_registry((core, redefining))
+
+
+def test_event_reference_closure_fails_on_unknown_name() -> None:
+    registry = default_taxonomy_registry()
+    registry.validate_closure(((SemanticCategory.EVENT, "runtime.process_completed"),))
+    with pytest.raises(UnknownTaxonomyIdentifier, match="unknown event"):
+        registry.validate_closure(((SemanticCategory.EVENT, "runtime.not_registered"),))
+
+
+def test_module_and_subscription_capabilities_share_one_grammar() -> None:
+    assert (
+        validate_identifier_grammar(SemanticCategory.CAPABILITY, "reports.generate")
+        == "reports.generate"
+    )
+    with pytest.raises(ValueError, match=r"\[a-z0-9_.\]\+"):
+        validate_identifier_grammar(SemanticCategory.CAPABILITY, "Reports-Generate")
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_advisory_rejects_unknown_but_production_behavior_is_unchanged() -> None:
+    production = UnifiedEventDispatcher()
+    await production.emit("runtime.not_registered", {})
+
+    advisory = UnifiedEventDispatcher(taxonomy_advisory=True)
+    with pytest.raises(UnknownTaxonomyIdentifier, match="runtime.not_registered"):
+        await advisory.emit("runtime.not_registered", {})
+
+
+def _write_module(root: Path, *, capability_id: str, event_type: str) -> None:
+    module_dir = root / "modules" / "sample"
+    (module_dir / "backend").mkdir(parents=True)
+    (module_dir / "contracts").mkdir()
+    (module_dir / "backend" / "handler.py").write_text(
+        "class SampleModule:\n    pass\n",
+        encoding="utf-8",
+    )
+    (module_dir / "module.yaml").write_text(
+        f"""schema_version: mozaiks.module.v1
+module:
+  id: sample
+  handler: backend.handler:SampleModule
+capabilities:
+  - capability_id: {capability_id}
+    kind: page
+    target: /sample
+    title: Sample
+actions: []
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "contracts" / "events.yaml").write_text(
+        f"""schema_version: mozaiks.events.v1
+events:
+  - type: {event_type}
+    version: 1
+    producer: sample
+    payload_schema: {{}}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_module_loader_advisory_is_explicit_and_fail_closed(tmp_path: Path) -> None:
+    _write_module(tmp_path, capability_id="unknown.capability", event_type="domain.unknown.changed")
+    assert ModuleLoader(str(tmp_path)).load("sample").name == "sample"
+    with pytest.raises(ModuleLoadError, match="unknown capability"):
+        ModuleLoader(str(tmp_path), taxonomy_advisory=True).load("sample")
+
+
+def test_module_event_advisory_rejects_unknown_registered_prefix_name(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        capability_id="commerce.checkout.start",
+        event_type="domain.unknown.changed",
+    )
+    with pytest.raises(ModuleLoadError, match="unknown event"):
+        ModuleLoader(str(tmp_path), taxonomy_advisory=True).load("sample")
+
+
+def test_subscription_loader_advisory_is_explicit_and_does_not_mutate(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    path = config_dir / "subscriptions.yaml"
+    content = """schema_version: mozaiks.subscriptions.v1
+label: Example subscriptions
+default_plan_id: free
+plans:
+  - plan_id: free
+    label: Free
+    capabilities: [unknown.capability]
+"""
+    path.write_text(content, encoding="utf-8")
+
+    assert load_subscriptions_config(tmp_path) is not None
+    assert path.read_text(encoding="utf-8") == content
+    with pytest.raises(SubscriptionsLoadError, match="unknown capability"):
+        load_subscriptions_config(tmp_path, taxonomy_advisory=True)
+    assert path.read_text(encoding="utf-8") == content
+
+
+def test_event_envelope_schema_version_is_required_and_guarded() -> None:
+    valid = {
+        "schema_version": EVENT_ENVELOPE_SCHEMA_VERSION,
+        "type": "chat.text",
+    }
+    assert (
+        MozaiksEventEnvelope.model_validate(valid).schema_version == EVENT_ENVELOPE_SCHEMA_VERSION
+    )
+    validate_event_envelope_schema_version(valid)
+
+    with pytest.raises(ValidationError, match="schema_version"):
+        MozaiksEventEnvelope.model_validate({"type": "chat.text"})
+    with pytest.raises(ValueError, match="got None"):
+        validate_event_envelope_schema_version({"type": "chat.text"})
+    with pytest.raises(ValueError, match="mozaiks.ui.event.v2"):
+        validate_event_envelope_schema_version(
+            {"schema_version": "mozaiks.ui.event.v2", "type": "chat.text"}
+        )
+
+
+def test_dispatcher_builds_versioned_envelopes_for_transport_consumer() -> None:
+    envelope = UnifiedEventDispatcher().build_outbound_event_envelope(
+        raw_event={"kind": "text", "content": "hello"},
+        chat_id="chat-1",
+    )
+    assert envelope is not None
+    validate_event_envelope_schema_version(envelope)

--- a/tests/test_session_launcher.py
+++ b/tests/test_session_launcher.py
@@ -677,8 +677,9 @@ async def test_emit_workflow_launch_navigation_sends_chat_navigate_envelope(monk
     assert sent is True
     assert captured == [
         (
-            {
-                "type": "chat.navigate",
+                {
+                    "schema_version": "mozaiks.ui.event.v1",
+                    "type": "chat.navigate",
                 "data": {
                     "chat_id": "chat_launched",
                     "workflow_name": "ValueEngine",

--- a/tests/test_simple_transport_serialization.py
+++ b/tests/test_simple_transport_serialization.py
@@ -20,10 +20,15 @@ def test_pre_connection_buffer_overflow_logs_once_per_chat(monkeypatch):
     import asyncio
 
     async def _run() -> None:
-        await transport._broadcast_to_websockets({"type": "chat.text", "data": {"content": "one"}}, "chat-1")
-        await transport._broadcast_to_websockets({"type": "chat.text", "data": {"content": "two"}}, "chat-1")
-        await transport._broadcast_to_websockets({"type": "chat.text", "data": {"content": "three"}}, "chat-1")
-        await transport._broadcast_to_websockets({"type": "chat.text", "data": {"content": "four"}}, "chat-1")
+        for content in ("one", "two", "three", "four"):
+            await transport._broadcast_to_websockets(
+                {
+                    "schema_version": EVENT_ENVELOPE_SCHEMA_VERSION,
+                    "type": "chat.text",
+                    "data": {"content": content},
+                },
+                "chat-1",
+            )
 
     asyncio.run(_run())
 

--- a/tests/test_simple_transport_serialization.py
+++ b/tests/test_simple_transport_serialization.py
@@ -1,5 +1,8 @@
+import pytest
+
 from mozaiksai.core.events import unified_event_dispatcher as _dispatcher_mod
 from mozaiksai.core.transport import simple_transport as _transport_mod
+from mozaiksai.core.transport.event_contract import EVENT_ENVELOPE_SCHEMA_VERSION
 from mozaiksai.core.transport.simple_transport import SimpleTransport
 
 
@@ -27,6 +30,31 @@ def test_pre_connection_buffer_overflow_logs_once_per_chat(monkeypatch):
     assert len(warnings) == 1
     assert "suppressing repeated overflow logs" in warnings[0]
     assert transport._pre_connection_buffer_overflow_counts["chat-1"] == 2
+
+
+def test_transport_passthrough_requires_versioned_envelope(monkeypatch):
+    transport = SimpleTransport()
+    sent = []
+    monkeypatch.setattr(
+        transport,
+        "_broadcast_to_websockets",
+        lambda event, chat_id=None: _record_broadcast(sent, event, chat_id),
+    )
+
+    import asyncio
+
+    with pytest.raises(ValueError, match="schema_version"):
+        asyncio.run(
+            transport.send_event_to_ui({"type": "chat.deployment_started", "data": {}}, "chat-1")
+        )
+
+    event = {
+        "schema_version": EVENT_ENVELOPE_SCHEMA_VERSION,
+        "type": "chat.deployment_started",
+        "data": {},
+    }
+    asyncio.run(transport.send_event_to_ui(event, "chat-1"))
+    assert sent == [(event, "chat-1")]
 
 
 def test_chunk_text_for_stream_preserves_short_messages_word_level():

--- a/tests/test_transport_input_handlers.py
+++ b/tests/test_transport_input_handlers.py
@@ -77,6 +77,7 @@ async def test_handle_user_input_submit_routes_general_mode_messages_to_general_
     assert transport.errors == []
     assert websocket.sent == [
         {
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.input_ack",
             "data": {"chat_id": "chat-1", "status": "accepted"},
             "timestamp": websocket.sent[0]["timestamp"],
@@ -127,6 +128,7 @@ async def test_handle_user_input_submit_routes_workflow_mode_messages_back_to_or
     assert transport.errors == []
     assert websocket.sent == [
         {
+            "schema_version": "mozaiks.ui.event.v1",
             "type": "chat.input_ack",
             "data": {"chat_id": "chat-1", "status": "accepted"},
             "timestamp": websocket.sent[0]["timestamp"],


### PR DESCRIPTION
## Summary
- add the deterministic `mozaiks.taxonomy.v1` registry for event, capability, and artifact-family identifiers
- integrate explicit test/development advisory validation with the module loader, subscriptions loader, layout registry, and unified event dispatcher
- require and validate `mozaiks.ui.event.v1` on dispatcher-built outbound event envelopes
- preserve production name enforcement until later ADR 0007 authority-cutover slices

## Scope
Implements only ADR 0007 Slice 1. No manifest, semantic graph, binding, compilation plan, renderer cutover, capability advertisement, journey execution, or live-model work is included.

## Validation
- `python -m pytest tests/test_semantic_taxonomy.py tests/test_event_contract.py tests/test_event_dispatcher_domain_event.py tests/test_module_loader_contracts.py tests/test_module_loader_pydantic_validators.py tests/test_subscriptions_loader.py tests/test_app_layout_registry.py tests/test_app_layout_validation.py tests/test_simple_transport_serialization.py tests/test_production_readiness_gate.py -q --no-cov` (390 passed before the final exhaustive grandfathered-name test; that focused file then passed 68 tests)
- `ruff check .`
- production-readiness source-hygiene scan (0 violations)
- `git diff --check`

## Rollout
The new unknown-name rejection is reachable only through explicit `taxonomy_advisory=True` arguments. Default production behavior remains unchanged. Auto-merge must remain disabled; this PR requires all CI checks and one independent exact-head engineering review.

## Rebase and baseline-repair history (2026-08-28)

- The original `test-shard (0)` failure on this PR (`assert 1 >= 25` in `test_active_workspace_app_intelligence_feeds_refinement_and_chat_ui`) was **reproduced on `main` (`a6e0d512`) without any Slice 1 code**: pytest's `monkeypatch.delenv(..., raising=False)` records no restore entry for an absent key, so `PLATFORM_PATH` written by `configure_repo_host_defaults` leaked a tiny temporary workspace into later tests. This PR's added test files only reshuffled deterministic shard membership and exposed that latent order dependency — they did not cause it.
- PR #418 (squash `3eaf7987`) repaired the baseline environment leak in `tests/test_host_composition_contract.py` and `tests/test_host_bootstrap.py`; post-merge main CI was fully green.
- This branch was then rebased onto `3eaf7987` (old head `f3d88815` → rebased head `19878ed9`). **Slice 1 content is unchanged**: the rebased diff against the new base is byte-identical (modulo git index lines) to the independently reviewed diff of exact head `f3d88815` against `a6e0d512`, with zero file overlap with PR #418. All five commits retain their DCO sign-offs.
- Independent exact-head engineering review of `f3d88815` found no blocking defects; advisory taxonomy validation remains default-off (`taxonomy_advisory: bool = False` at every constructor).
- Known separate follow-up (not addressed here): importing `mozaiksai.hosts.studio` runs `configure_repo_host_defaults("studio")` at module import time, mutating `PLATFORM_PATH`/`MOZAIKS_WORKFLOWS_PATH` outside test monkeypatch scope; tracked as a test/runtime-hardening follow-up.
