### PR TITLE
test: restore host env vars leaked past monkeypatch.delenv on absent keys

### DIFF
--- a/tests/test_host_bootstrap.py
+++ b/tests/test_host_bootstrap.py
@@ -6,10 +6,26 @@ from pathlib import Path
 from mozaiksai.hosts.bootstrap import configure_repo_host_defaults
 
 
+def _delenv_restoring(monkeypatch, name: str) -> None:
+    """Delete ``name`` from the environment and guarantee it is restored.
+
+    ``monkeypatch.delenv(name, raising=False)`` records nothing when the key
+    is already absent, so a value written afterwards by
+    ``configure_repo_host_defaults`` (it sets ``PLATFORM_PATH`` and
+    ``MOZAIKS_WORKFLOWS_PATH``) would survive teardown and leak host
+    configuration into every later test in the process.  Setting the key first
+    forces monkeypatch to record a restore entry for it; undo replays in
+    reverse, ending at the original value or original absence.
+    """
+    monkeypatch.setenv(name, "")
+    monkeypatch.delenv(name)
+
+
+
 def test_runtime_host_does_not_inject_repo_defaults(monkeypatch) -> None:
-    monkeypatch.delenv("PLATFORM_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_FACTORY_APP_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_FACTORY_APP_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
 
     configure_repo_host_defaults("runtime")
 
@@ -19,9 +35,9 @@ def test_runtime_host_does_not_inject_repo_defaults(monkeypatch) -> None:
 
 def test_studio_host_without_workspace_defaults_platform_path_to_factory_app_bundle(monkeypatch) -> None:
     """Repo-local Studio bootstrap should bind to the shared builder workflow root."""
-    monkeypatch.delenv("PLATFORM_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_APP_WORKSPACE_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_APP_WORKSPACE_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
 
     configure_repo_host_defaults("studio")
 
@@ -44,10 +60,10 @@ def test_studio_host_uses_external_workspace_root_when_provided(monkeypatch, tmp
     (workspace_root / "workflows").mkdir(parents=True)
     (app_root / "app.json").write_text('{"appName": "External App Zero"}', encoding="utf-8")
 
-    monkeypatch.delenv("PLATFORM_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_FACTORY_APP_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_FACTORY_APP_PATH")
     monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace_root))
-    monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
 
     configure_repo_host_defaults("studio")
 
@@ -67,9 +83,9 @@ def test_platform_host_uses_workspace_root_workflows_when_present(monkeypatch, t
     (app_root / "app.json").write_text('{"appName": "External App Zero"}', encoding="utf-8")
 
     monkeypatch.setenv("PLATFORM_PATH", str(workspace_root))
-    monkeypatch.delenv("MOZAIKS_FACTORY_APP_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_APP_WORKSPACE_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "MOZAIKS_FACTORY_APP_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_APP_WORKSPACE_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
 
     configure_repo_host_defaults("platform")
 
@@ -79,8 +95,8 @@ def test_platform_host_uses_workspace_root_workflows_when_present(monkeypatch, t
 
 def test_studio_host_normalizes_repo_root_platform_path_to_factory_app_bundle(monkeypatch) -> None:
     monkeypatch.setenv("PLATFORM_PATH", str(Path.cwd().resolve()))
-    monkeypatch.delenv("MOZAIKS_APP_WORKSPACE_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "MOZAIKS_APP_WORKSPACE_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
 
     configure_repo_host_defaults("studio")
 

--- a/tests/test_host_composition_contract.py
+++ b/tests/test_host_composition_contract.py
@@ -7,6 +7,21 @@ from pathlib import Path
 from mozaiksai.hosts.bootstrap import configure_repo_host_defaults
 
 
+def _delenv_restoring(monkeypatch, name: str) -> None:
+    """Delete ``name`` from the environment and guarantee it is restored.
+
+    ``monkeypatch.delenv(name, raising=False)`` records nothing when the key
+    is already absent, so a value written afterwards by production code
+    (``configure_repo_host_defaults`` sets ``PLATFORM_PATH`` and
+    ``MOZAIKS_WORKFLOWS_PATH``) would survive teardown and leak the temporary
+    workspace into every later test in the process.  Setting the key first
+    forces monkeypatch to record a restore entry for it; undo replays in
+    reverse, ending at the original value or original absence.
+    """
+    monkeypatch.setenv(name, "")
+    monkeypatch.delenv(name)
+
+
 def test_host_composition_contract_documents_supported_app_local_studio_composition() -> None:
     doc = Path("docs/architecture/hosts/host-composition-contract.md").read_text(encoding="utf-8")
 
@@ -28,7 +43,7 @@ def test_host_composition_contract_resolves_workspace_environment(monkeypatch, t
     (app_root / "app.json").write_text('{"appName":"Contract App","appId":"contract-app"}', encoding="utf-8")
 
     monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace))
-    monkeypatch.delenv("PLATFORM_PATH", raising=False)
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
     monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(workflows_root))
 
     configure_repo_host_defaults("studio")


### PR DESCRIPTION
## Summary

Fixes the latent test-order dependency that failed PR #417's `test-shard (0)` with `assert 1 >= 25` in `test_active_workspace_app_intelligence_feeds_refinement_and_chat_ui`. **PR #417 exposed this; it did not cause it** — the same ordered pair fails on current `main` (`a6e0d512`) with no Slice 1 code involved (reproduction below). Test-only change; PR #417 is untouched.

## Leaked state and mechanism

pytest's `monkeypatch.delenv(name, raising=False)` records **no restore entry when the key is already absent** (`MonkeyPatch.delitem` returns early on `name not in dic`). Several host tests use exactly that call for `PLATFORM_PATH`/`MOZAIKS_WORKFLOWS_PATH` and then invoke `configure_repo_host_defaults(...)` — which writes those keys into `os.environ` directly. With nothing recorded, teardown never removes them:

- `test_host_composition_contract_resolves_workspace_environment` leaks `PLATFORM_PATH` pointing at its **tiny tmp canonical-app** (one `app.json`, 49 bytes).
- Five tests in `test_host_bootstrap.py` leak `PLATFORM_PATH`/`MOZAIKS_WORKFLOWS_PATH` pointing at `factory_app/app` — the identical defect class with a different value.

`tests/conftest.py`'s `_resolve_active_app_root` then sees `PLATFORM_PATH` set, so the `app_root` fixture stops skipping workspace-dependent tests and hands them the leaked path. In PR #417's reshuffled shard 0, the App Intelligence acceptance test received the 1-file tmp app and failed `indexed_file_count >= 25`. The failing CI traceback shows it directly: `app_root = PosixPath('/tmp/pytest-of-runner/pytest-0/test_host_composition_contract0/canonical-app/app')`. On pre-#417 shard layouts the ordering happened to leave a benign value in place, which is why `main` stayed green — by ordering luck, not by isolation.

## Base reproduction (exact main, no PR #417)

On `a6e0d512` in a Linux container (`python:3.11`, CI env vars):

```
pytest -q --no-cov \
  tests/test_host_composition_contract.py::test_host_composition_contract_resolves_workspace_environment \
  tests/test_workspace_app_intelligence_acceptance.py::test_active_workspace_app_intelligence_feeds_refinement_and_chat_ui
# → FAILED ... AssertionError: assert 1 >= 25   (1 failed, 1 passed, 2 rerun)
```

(The pair does not reproduce on a Windows host: the Windows env layer leaves the leaked key as an empty string, which conftest treats as unset, so the second test skips. CI runs on Linux, where the leak carries the real path.)

## Correction

A small `_delenv_restoring(monkeypatch, name)` helper in each affected test file: `monkeypatch.setenv(name, "")` immediately followed by `monkeypatch.delenv(name)`. The setenv forces monkeypatch to record the key's original state; undo replays in reverse and ends at the original value or original absence — whether or not production code re-set the key mid-test. All 6 defective `delenv` call sites across the two files now use it (plus the remaining absent-key `delenv`s in those tests, hardened uniformly).

Explicitly **not** changed: production indexing behavior, the `indexed_file_count >= 25` threshold, test selection/ordering/retries, CI sharding, `tests/conftest.py`, ADRs, Slice 1 code, PR #417.

## Validation (Linux container on this branch, CI env)

- Each affected test passes independently; the acceptance test correctly **skips** when run alone (no workspace configured).
- Ordered pair passes in **both orders**, and **5× repeated**.
- Full `test_host_composition_contract.py` + `test_host_bootstrap.py` + `test_workspace_app_intelligence_acceptance.py`: 9 passed.
- Restoration probe: running all delenv-class tests in-process leaves `PLATFORM_PATH`, `MOZAIKS_WORKFLOWS_PATH`, `MOZAIKS_APP_WORKSPACE_PATH`, `MOZAIKS_FACTORY_APP_PATH` byte-identical to their pre-run state.
- Shard 0 via the repository's current splitter: 3186 passed; the only failure was `test_quickstart_workspace_is_gitignored`, a container mount artifact (the bind-mounted worktree's gitdir path is invalid inside the container — `git status` itself fails there); it passes on the host and in GitHub CI.
- `ruff check .`, governance guardrails, source-hygiene scan, `git diff --check`: clean. Commit is DCO-signed.

## Known adjacent issue, deliberately not masked

Importing `mozaiksai.hosts.studio` runs `configure_repo_host_defaults("studio")` at module import time, which sets `PLATFORM_PATH`/`MOZAIKS_WORKFLOWS_PATH` to `factory_app` paths outside any test's monkeypatch scope. That import-time side effect predates this PR, is production behavior (out of scope for a test-only fix), and currently determines whether workspace-dependent tests skip or run against `factory_app` in a given shard. Follow-up candidate: make host modules import-inert and configure at startup instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
