### PR TITLE
feat(semantics): ADR 0007 Slice 2 — immutable manifest/graph/binding contracts behind test seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Semantic-compiler contract layer (ADR 0007 Slice 2)**: strict, immutable,
+  content-digested contracts for `ApplicationManifest`
+  (`mozaiks.app_manifest.v1`), `SemanticGraph` (`mozaiks.semantic_graph.v1`),
+  and `ImplementationBinding` (`mozaiks.implementation_binding.v1`), plus the
+  full typed reference roster (`ApplicationManifestRef`, `SemanticGraphRef`,
+  `ImplementationBindingRef`, `CompilationPlanRef`, `BuildContextBindingRef`,
+  `TaxonomyNamespaceRef`, `RefinementPatchRef`, `ArtifactRevisionRef`, and
+  typed child-contract refs), one canonical serialization/digest contract
+  (`mozaiks.canonical_json.v1`), deterministic node/edge identity, and
+  fail-closed reference resolution and graph-closure validation in
+  `mozaiksai.core.semantics`. The package sits behind non-production/test
+  seams: no generator, runtime, or refinement code consumes it, and the ADR
+  0006/0007 compiler capabilities (`semantic_taxonomy_v1`,
+  `semantic_reference_contracts_v1`) remain unadvertised because Slice 1
+  taxonomy validation has not yet passed outside advisory mode.
+
 - **Advisory semantic taxonomy (`mozaiks.taxonomy.v1`)**: development and
   test callers can now validate registered event, capability, and artifact-
   family identifiers consistently across module loading, subscriptions,

--- a/mozaiksai/core/semantics/__init__.py
+++ b/mozaiksai/core/semantics/__init__.py
@@ -1,0 +1,102 @@
+"""ADR 0007 Slice 2: strict, immutable semantic-compiler contracts.
+
+This package is a contract layer behind non-production/test seams: no host,
+loader, generator, workflow, or control-plane code imports it.  It takes no
+authority from the current generator, runtime contracts, refinement system, or
+``AppBuildPlan``.  Later rollout slices wire it in; importing it never changes
+runtime behavior.
+"""
+
+from mozaiksai.core.semantics.binding import (
+    CapabilityPackSelection,
+    DeploymentProfileSelection,
+    ImplementationBinding,
+    RendererSelection,
+    build_implementation_binding,
+    validate_implementation_binding_against_graph,
+)
+from mozaiksai.core.semantics.canonical import (
+    CANONICAL_SERIALIZATION_VERSION,
+    CanonicalSerializationError,
+    canonical_digest,
+    canonical_json,
+)
+from mozaiksai.core.semantics.capabilities import (
+    SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY,
+    SEMANTIC_TAXONOMY_CAPABILITY,
+    advertised_semantic_compiler_capabilities,
+    semantic_capability_advertisement_gate,
+)
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraph,
+    SemanticNode,
+    SemanticNodeKind,
+    TaxonomyReference,
+    build_semantic_graph,
+    validate_semantic_graph_taxonomy_closure,
+)
+from mozaiksai.core.semantics.manifest import (
+    ApplicationManifest,
+    build_application_manifest,
+)
+from mozaiksai.core.semantics.refs import (
+    ApplicationManifestRef,
+    ArtifactRevisionRef,
+    BuildContextBindingRef,
+    ChildContractRef,
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    RefDocumentType,
+    RefinementPatchRef,
+    SemanticGraphRef,
+    SemanticRefError,
+    TaxonomyNamespaceRef,
+)
+from mozaiksai.core.semantics.resolver import (
+    ReferenceResolutionError,
+    SemanticReferenceResolver,
+)
+
+__all__ = [
+    "ApplicationManifest",
+    "ApplicationManifestRef",
+    "ArtifactRevisionRef",
+    "BuildContextBindingRef",
+    "CANONICAL_SERIALIZATION_VERSION",
+    "CanonicalSerializationError",
+    "CapabilityPackSelection",
+    "ChildContractRef",
+    "CompilationPlanRef",
+    "DeploymentProfileSelection",
+    "ExecutionAccessScopeRef",
+    "ImplementationBinding",
+    "ImplementationBindingRef",
+    "RefDocumentType",
+    "ReferenceResolutionError",
+    "RefinementPatchRef",
+    "RendererSelection",
+    "SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY",
+    "SEMANTIC_TAXONOMY_CAPABILITY",
+    "SemanticEdge",
+    "SemanticEdgeKind",
+    "SemanticGraph",
+    "SemanticGraphRef",
+    "SemanticNode",
+    "SemanticNodeKind",
+    "SemanticRefError",
+    "SemanticReferenceResolver",
+    "TaxonomyNamespaceRef",
+    "TaxonomyReference",
+    "advertised_semantic_compiler_capabilities",
+    "build_application_manifest",
+    "build_implementation_binding",
+    "build_semantic_graph",
+    "canonical_digest",
+    "canonical_json",
+    "semantic_capability_advertisement_gate",
+    "validate_implementation_binding_against_graph",
+    "validate_semantic_graph_taxonomy_closure",
+]

--- a/mozaiksai/core/semantics/binding.py
+++ b/mozaiksai/core/semantics/binding.py
@@ -1,0 +1,287 @@
+"""Immutable ``mozaiks.implementation_binding.v1`` contract.
+
+An implementation binding maps graph-authored requirements to verified
+capability-pack identities and digests, renderer/adapter identities and
+versions, and deployment-target implementation profiles.  Structurally it can
+only *select* implementations for requirement nodes that already exist in the
+pinned graph: it carries no fields that could add pages, actions, events,
+entitlements, data requirements, or provider obligations, and validation
+rejects any selection whose requirement node is absent from, or of the wrong
+kind for, the graph.  No private strategy, build-context input, or provider
+choice becomes a second semantic authority.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.graph import SemanticGraph, SemanticNodeKind, _validate_node_id
+from mozaiksai.core.semantics.refs import (
+    ExecutionAccessScopeRef,
+    SemanticGraphRef,
+    SemanticsModel,
+    _validate_digest,
+    _validate_identifier,
+)
+
+IMPLEMENTATION_BINDING_SCHEMA_VERSION: Literal["mozaiks.implementation_binding.v1"] = (
+    "mozaiks.implementation_binding.v1"
+)
+
+#: Node kinds each selection category may satisfy.  A selection against any
+#: other kind is an attempt to widen graph semantics and fails closed.
+CAPABILITY_PACK_REQUIREMENT_KINDS = frozenset(
+    {SemanticNodeKind.CAPABILITY, SemanticNodeKind.MODULE}
+)
+RENDERER_REQUIREMENT_KINDS = frozenset(
+    {SemanticNodeKind.SURFACE, SemanticNodeKind.PAGE, SemanticNodeKind.SECTION}
+)
+DEPLOYMENT_REQUIREMENT_KINDS = frozenset({SemanticNodeKind.DEPLOYMENT_TARGET})
+
+
+class ImplementationBindingError(ValueError):
+    """Raised when a binding violates the contract against its graph."""
+
+
+class _Selection(SemanticsModel):
+    requirement_node_id: str
+
+    @field_validator("requirement_node_id")
+    @classmethod
+    def _requirement(cls, value: str) -> str:
+        return _validate_node_id(value)
+
+
+class CapabilityPackSelection(_Selection):
+    pack_id: str
+    pack_digest: str
+
+    @field_validator("pack_id")
+    @classmethod
+    def _pack_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="pack_id")
+
+    @field_validator("pack_digest")
+    @classmethod
+    def _pack_digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="pack_digest")
+
+
+class RendererSelection(_Selection):
+    renderer_id: str
+    renderer_version: str
+
+    @field_validator("renderer_id")
+    @classmethod
+    def _renderer_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="renderer_id")
+
+    @field_validator("renderer_version")
+    @classmethod
+    def _renderer_version(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("renderer_version must be non-empty")
+        return text
+
+
+class DeploymentProfileSelection(_Selection):
+    profile_id: str
+    profile_version: str
+
+    @field_validator("profile_id")
+    @classmethod
+    def _profile_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="profile_id")
+
+    @field_validator("profile_version")
+    @classmethod
+    def _profile_version(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("profile_version must be non-empty")
+        return text
+
+
+def _sorted_unique(
+    selections: tuple[_Selection, ...], *, category: str
+) -> tuple[_Selection, ...]:
+    ordered = tuple(sorted(selections, key=lambda item: item.requirement_node_id))
+    requirements = [item.requirement_node_id for item in ordered]
+    if len(requirements) != len(set(requirements)):
+        raise ValueError(f"duplicate {category} selections for one requirement node")
+    return ordered
+
+
+class ImplementationBinding(SemanticsModel):
+    schema_version: Literal["mozaiks.implementation_binding.v1"] = (
+        IMPLEMENTATION_BINDING_SCHEMA_VERSION
+    )
+    binding_id: str
+    version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    semantic_graph_ref: SemanticGraphRef
+    capability_pack_selections: tuple[CapabilityPackSelection, ...] = Field(default_factory=tuple)
+    renderer_selections: tuple[RendererSelection, ...] = Field(default_factory=tuple)
+    deployment_profile_selections: tuple[DeploymentProfileSelection, ...] = Field(
+        default_factory=tuple
+    )
+    binding_digest: str = Field(min_length=64, max_length=64)
+
+    @field_validator("binding_id")
+    @classmethod
+    def _binding_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="binding_id")
+
+    @field_validator("capability_pack_selections")
+    @classmethod
+    def _packs(cls, value):
+        return _sorted_unique(value, category="capability-pack")
+
+    @field_validator("renderer_selections")
+    @classmethod
+    def _renderers(cls, value):
+        return _sorted_unique(value, category="renderer")
+
+    @field_validator("deployment_profile_selections")
+    @classmethod
+    def _profiles(cls, value):
+        return _sorted_unique(value, category="deployment-profile")
+
+    @model_validator(mode="after")
+    def _validate_binding(self) -> ImplementationBinding:
+        if self.semantic_graph_ref.scope != self.scope:
+            raise ValueError(
+                "semantic_graph_ref scope does not match the binding scope; "
+                "cross-scope references fail closed"
+            )
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.binding_digest != expected:
+            raise ValueError("binding_digest does not match binding content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "binding_id": self.binding_id,
+            "version": self.version,
+            "scope": self.scope.model_dump(mode="json"),
+            "semantic_graph_ref": self.semantic_graph_ref.model_dump(mode="json"),
+            "capability_pack_selections": [
+                item.model_dump(mode="json") for item in self.capability_pack_selections
+            ],
+            "renderer_selections": [
+                item.model_dump(mode="json") for item in self.renderer_selections
+            ],
+            "deployment_profile_selections": [
+                item.model_dump(mode="json") for item in self.deployment_profile_selections
+            ],
+        }
+        if include_digest:
+            payload["binding_digest"] = self.binding_digest
+        return payload
+
+
+def build_implementation_binding(**fields: Any) -> ImplementationBinding:
+    """Construct a binding with its content digest computed canonically."""
+    normalized = {
+        "capability_pack_selections": tuple(
+            sorted(
+                tuple(fields.get("capability_pack_selections", ())),
+                key=lambda item: item.requirement_node_id,
+            )
+        ),
+        "renderer_selections": tuple(
+            sorted(
+                tuple(fields.get("renderer_selections", ())),
+                key=lambda item: item.requirement_node_id,
+            )
+        ),
+        "deployment_profile_selections": tuple(
+            sorted(
+                tuple(fields.get("deployment_profile_selections", ())),
+                key=lambda item: item.requirement_node_id,
+            )
+        ),
+    }
+    payload = {
+        "schema_version": IMPLEMENTATION_BINDING_SCHEMA_VERSION,
+        "binding_id": str(fields["binding_id"]).strip(),
+        "version": fields["version"],
+        "scope": fields["scope"].model_dump(mode="json"),
+        "semantic_graph_ref": fields["semantic_graph_ref"].model_dump(mode="json"),
+        "capability_pack_selections": [
+            item.model_dump(mode="json") for item in normalized["capability_pack_selections"]
+        ],
+        "renderer_selections": [
+            item.model_dump(mode="json") for item in normalized["renderer_selections"]
+        ],
+        "deployment_profile_selections": [
+            item.model_dump(mode="json") for item in normalized["deployment_profile_selections"]
+        ],
+    }
+    return ImplementationBinding(
+        **{**fields, **normalized}, binding_digest=canonical_digest(payload)
+    )
+
+
+def validate_implementation_binding_against_graph(
+    binding: ImplementationBinding, graph: SemanticGraph
+) -> None:
+    """Fail closed unless every selection satisfies an existing typed requirement.
+
+    The binding may only choose among implementations for requirement nodes the
+    graph already declares; a selection naming an absent node, or a node of an
+    inappropriate kind, is an attempt to introduce semantics through the
+    binding and is rejected.
+    """
+    if binding.scope != graph.scope:
+        raise ImplementationBindingError("binding scope does not match graph scope")
+    if (
+        binding.semantic_graph_ref.subject_id != graph.graph_id
+        or binding.semantic_graph_ref.subject_version != graph.version
+        or binding.semantic_graph_ref.content_digest != graph.graph_digest
+    ):
+        raise ImplementationBindingError(
+            "binding does not pin this graph's id, immutable version, and digest"
+        )
+
+    known = {node.node_id: node for node in graph.nodes}
+    checks = (
+        ("capability-pack", binding.capability_pack_selections, CAPABILITY_PACK_REQUIREMENT_KINDS),
+        ("renderer", binding.renderer_selections, RENDERER_REQUIREMENT_KINDS),
+        ("deployment-profile", binding.deployment_profile_selections, DEPLOYMENT_REQUIREMENT_KINDS),
+    )
+    for category, selections, allowed_kinds in checks:
+        for selection in selections:
+            node = known.get(selection.requirement_node_id)
+            if node is None:
+                raise ImplementationBindingError(
+                    f"{category} selection targets node "
+                    f"{selection.requirement_node_id!r} that is absent from the graph; "
+                    "a binding cannot widen graph semantics"
+                )
+            if node.kind not in allowed_kinds:
+                raise ImplementationBindingError(
+                    f"{category} selection targets {node.kind.value!r} node "
+                    f"{selection.requirement_node_id!r}; allowed kinds: "
+                    f"{sorted(kind.value for kind in allowed_kinds)}"
+                )
+
+
+__all__ = [
+    "CAPABILITY_PACK_REQUIREMENT_KINDS",
+    "CapabilityPackSelection",
+    "DEPLOYMENT_REQUIREMENT_KINDS",
+    "DeploymentProfileSelection",
+    "IMPLEMENTATION_BINDING_SCHEMA_VERSION",
+    "ImplementationBinding",
+    "ImplementationBindingError",
+    "RENDERER_REQUIREMENT_KINDS",
+    "RendererSelection",
+    "build_implementation_binding",
+    "validate_implementation_binding_against_graph",
+]

--- a/mozaiksai/core/semantics/canonical.py
+++ b/mozaiksai/core/semantics/canonical.py
@@ -1,0 +1,112 @@
+"""Canonical serialization contract ``mozaiks.canonical_json.v1``.
+
+One explicit, versioned serialization defines the bytes every semantic-compiler
+digest is computed over.  Individual models never invent their own digest
+rules; they build a canonical payload and call :func:`canonical_digest`.
+
+Rules (all fail closed rather than guess):
+
+- Output is JSON text with keys sorted lexicographically by code point,
+  ``,``/``:`` separators, and every non-ASCII character escaped (``ensure_ascii``),
+  so the byte stream is pure ASCII and identical on every supported platform.
+- Mapping keys must be ``str``.  Non-string keys are rejected — JSON's silent
+  key coercion would make two distinct inputs produce identical bytes.
+- Supported values: ``None``, ``bool``, ``str``, ``int`` within signed 64-bit
+  range, finite ``float``, ``list``/``tuple``, and ``dict``.  Anything else —
+  sets, bytes, datetimes, arbitrary objects — is rejected: unordered or
+  ambiguous types must be normalized by the declaring schema into ordered,
+  supported shapes *before* serialization, never silently normalized here.
+- ``float`` values must be finite; ``NaN``/``inf`` are rejected.  Negative zero
+  normalizes to ``0.0`` so numerically equal scalars cannot yield different
+  bytes.  Floats serialize via Python's shortest round-trip ``repr``, which is
+  deterministic for IEEE-754 doubles across supported platforms.  ``bool`` is
+  serialized as JSON ``true``/``false`` and never conflated with ``int``.
+- Sequences preserve their given order (semantically ordered collections keep
+  their meaning); schemas that declare a collection unordered must sort it
+  deterministically before serializing.
+- Every field present in the payload participates in the digest.  A schema that
+  excludes non-semantic metadata must do so by omitting the field from the
+  canonical payload it builds — an explicit schema decision, never a
+  serializer-side default.
+- Input values are never mutated: normalization builds new structures.
+
+The digest is the lowercase hex SHA-256 of the ASCII bytes of the canonical
+JSON text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any, Literal
+
+CANONICAL_SERIALIZATION_VERSION: Literal["mozaiks.canonical_json.v1"] = "mozaiks.canonical_json.v1"
+
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+
+
+class CanonicalSerializationError(ValueError):
+    """Raised when a value cannot be canonically serialized."""
+
+
+def _normalize(value: Any, path: str) -> Any:
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if not _INT64_MIN <= value <= _INT64_MAX:
+            raise CanonicalSerializationError(
+                f"integer at {path} is outside the signed 64-bit range: {value!r}"
+            )
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CanonicalSerializationError(
+                f"non-finite float at {path} cannot be canonically serialized: {value!r}"
+            )
+        if value == 0.0:
+            return 0.0
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_normalize(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CanonicalSerializationError(
+                    f"mapping key at {path} must be str, got {type(key).__name__}"
+                )
+            normalized[key] = _normalize(item, f"{path}.{key}")
+        return normalized
+    raise CanonicalSerializationError(
+        f"unsupported type at {path}: {type(value).__name__}; normalize it in the "
+        "declaring schema before canonical serialization"
+    )
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize ``value`` to the canonical ASCII JSON text."""
+    normalized = _normalize(value, "$")
+    return json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def canonical_digest(value: Any) -> str:
+    """Lowercase hex SHA-256 over the canonical JSON bytes of ``value``."""
+    return hashlib.sha256(canonical_json(value).encode("ascii")).hexdigest()
+
+
+__all__ = [
+    "CANONICAL_SERIALIZATION_VERSION",
+    "CanonicalSerializationError",
+    "canonical_digest",
+    "canonical_json",
+]

--- a/mozaiksai/core/semantics/capabilities.py
+++ b/mozaiksai/core/semantics/capabilities.py
@@ -1,0 +1,59 @@
+"""ADR 0006 / ADR 0007 capability-advertisement interlock.
+
+ADR 0007 assigns two capability identifiers to its compiler contract:
+``semantic_taxonomy_v1`` and ``semantic_reference_contracts_v1``.  ADR 0007's
+rollout table requires that they are advertised **together**, and only after
+rollout slices 1 and 2 "both pass outside advisory mode".  A class existing in
+source, an advisory registry mode, or one advertised capability without the
+other does not unlock ADR 0006's production ``JourneyExecutionPort.start``.
+
+The Slice 1 taxonomy currently validates only on the explicit advisory path
+(``taxonomy_advisory=True`` / ``advisory=True``); every production consumer
+defaults it off.  Slice 1 therefore has not passed *outside* advisory mode,
+so truthful joint advertisement is not yet possible without activating
+later-slice authority-cutover behavior.  This module is the single authority
+for that answer: it advertises neither identifier and states the exact gate.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SEMANTIC_TAXONOMY_CAPABILITY: Final[str] = "semantic_taxonomy_v1"
+SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY: Final[str] = "semantic_reference_contracts_v1"
+
+#: The exact remaining gate blocking joint advertisement.
+_ADVERTISEMENT_GATE: Final[str] = (
+    "blocked: Slice 1 taxonomy validation passes only in advisory "
+    "(test/development) mode — production consumers construct with "
+    "taxonomy_advisory=False, so 'slices 1 and 2 both pass outside advisory "
+    "mode' (ADR 0007 rollout slice 2) is not yet satisfied. Flipping taxonomy "
+    "enforcement on for production consumers is authority-cutover work owned "
+    "by a later slice. Until then neither capability is advertised; partial "
+    "advertisement is prohibited."
+)
+
+
+def advertised_semantic_compiler_capabilities() -> tuple[str, ...]:
+    """Return the ADR 0007 compiler capabilities that are truthfully provable.
+
+    Returns an empty tuple: the two identifiers must be advertised jointly or
+    not at all, and the joint precondition is not met (see
+    :func:`semantic_capability_advertisement_gate`).  This function is the only
+    place a later slice may flip the answer, and it may only ever return
+    ``()`` or both identifiers together.
+    """
+    return ()
+
+
+def semantic_capability_advertisement_gate() -> str:
+    """Describe the exact remaining gate blocking joint advertisement."""
+    return _ADVERTISEMENT_GATE
+
+
+__all__ = [
+    "SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY",
+    "SEMANTIC_TAXONOMY_CAPABILITY",
+    "advertised_semantic_compiler_capabilities",
+    "semantic_capability_advertisement_gate",
+]

--- a/mozaiksai/core/semantics/graph.py
+++ b/mozaiksai/core/semantics/graph.py
@@ -1,0 +1,364 @@
+"""Immutable, scoped, content-digested ``SemanticGraph`` contract.
+
+``SemanticGraph`` is authored application intent — the document the compiler
+compiles *from*.  It is deliberately distinct from ``AppContextGraph``, which
+remains the observed/indexed view of files and runtime artifacts; the two
+authorities are never merged.  Node and edge kinds are a closed, versioned set
+seeded from the concepts in the existing ``GraphNodeType``/``GraphEdgeType``
+enums without importing their observed-view semantics.
+
+Identity rules (owned by this slice, with golden vectors in tests):
+
+- A node identity is its namespace-qualified ``node_id`` — stable across graph
+  versions, independent of list order and renderer layout.
+- An edge identity is the canonical digest of
+  ``{edge_kind, source_node_id, target_node_id, discriminator}``.  Duplicate
+  identities fail closed; reordering nodes or edges changes neither identities
+  nor the graph digest, because the canonical payload sorts both collections
+  by identity.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.refs import (
+    MUTABLE_ALIASES,
+    ExecutionAccessScopeRef,
+    SemanticsModel,
+)
+from mozaiksai.core.taxonomy import (
+    SemanticCategory,
+    TaxonomyRegistry,
+    validate_identifier_grammar,
+)
+
+SEMANTIC_GRAPH_SCHEMA_VERSION: Literal["mozaiks.semantic_graph.v1"] = "mozaiks.semantic_graph.v1"
+
+#: Core namespace root; nodes outside it must sit inside a granted namespace.
+CORE_NODE_NAMESPACE_ROOT = "mozaiks"
+
+_NODE_ID = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$")
+_GRAPH_ID = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+class SemanticGraphError(ValueError):
+    """Raised when a graph document violates the contract."""
+
+
+class SemanticNodeKind(StrEnum):
+    """Closed, versioned node-kind set for ``mozaiks.semantic_graph.v1``."""
+
+    SURFACE = "surface"
+    PAGE = "page"
+    SECTION = "section"
+    MODULE = "module"
+    ACTION = "action"
+    CAPABILITY = "capability"
+    PERMISSION = "permission"
+    EVENT = "event"
+    REACTION = "reaction"
+    NOTIFICATION = "notification"
+    DATA_COLLECTION = "data_collection"
+    DATA_ALIAS = "data_alias"
+    WORKFLOW = "workflow"
+    TRIGGER = "trigger"
+    PLAN = "plan"
+    PRODUCT = "product"
+    METER = "meter"
+    LIMIT = "limit"
+    DEPLOYMENT_TARGET = "deployment_target"
+    STUB_DECLARATION = "stub_declaration"
+
+
+class SemanticEdgeKind(StrEnum):
+    """Closed, versioned edge-kind set for ``mozaiks.semantic_graph.v1``."""
+
+    DECLARES = "declares"
+    EMITS = "emits"
+    CONSUMES = "consumes"
+    RENDERS = "renders"
+    BINDS = "binds"
+    DEPENDS_ON = "depends_on"
+    GATES = "gates"
+    OWNS = "owns"
+
+
+class TaxonomyReference(SemanticsModel):
+    """A node's reference into the Slice 1 taxonomy registry."""
+
+    category: SemanticCategory
+    identifier: str
+
+    @model_validator(mode="after")
+    def _grammar(self) -> TaxonomyReference:
+        validate_identifier_grammar(self.category, self.identifier)
+        return self
+
+    @property
+    def identity_payload(self) -> dict[str, str]:
+        return {"category": self.category.value, "identifier": self.identifier}
+
+
+def _validate_node_id(value: str) -> str:
+    text = str(value or "").strip()
+    if _NODE_ID.fullmatch(text) is None:
+        raise ValueError(
+            f"node_id must be a namespace-qualified lowercase dotted identifier, got {value!r}"
+        )
+    if text.split(".", 1)[0] in MUTABLE_ALIASES:
+        raise ValueError(f"node_id namespace must be immutable identity, got {text!r}")
+    return text
+
+
+class SemanticNode(SemanticsModel):
+    node_id: str
+    kind: SemanticNodeKind
+    taxonomy_references: tuple[TaxonomyReference, ...] = Field(default_factory=tuple)
+    node_references: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("node_id")
+    @classmethod
+    def _node_id(cls, value: str) -> str:
+        return _validate_node_id(value)
+
+    @field_validator("taxonomy_references")
+    @classmethod
+    def _taxonomy_references(
+        cls, value: tuple[TaxonomyReference, ...]
+    ) -> tuple[TaxonomyReference, ...]:
+        ordered = tuple(sorted(value, key=lambda item: (item.category.value, item.identifier)))
+        identities = [(item.category, item.identifier) for item in ordered]
+        if len(identities) != len(set(identities)):
+            raise ValueError("duplicate taxonomy references on one node")
+        return ordered
+
+    @field_validator("node_references")
+    @classmethod
+    def _node_references(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(sorted(_validate_node_id(item) for item in value))
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("duplicate node references on one node")
+        return normalized
+
+    @property
+    def namespace_root(self) -> str:
+        return self.node_id.split(".", 1)[0]
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "kind": self.kind.value,
+            "taxonomy_references": [item.identity_payload for item in self.taxonomy_references],
+            "node_references": list(self.node_references),
+        }
+
+
+class SemanticEdge(SemanticsModel):
+    kind: SemanticEdgeKind
+    source_node_id: str
+    target_node_id: str
+    discriminator: str | None = None
+
+    @field_validator("source_node_id", "target_node_id")
+    @classmethod
+    def _endpoints(cls, value: str) -> str:
+        return _validate_node_id(value)
+
+    @field_validator("discriminator")
+    @classmethod
+    def _discriminator(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            raise ValueError("discriminator must be non-empty when present")
+        return text
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "source_node_id": self.source_node_id,
+            "target_node_id": self.target_node_id,
+            "discriminator": self.discriminator,
+        }
+
+    @property
+    def edge_identity(self) -> str:
+        """Deterministic identity derived from kind, endpoints, and discriminator."""
+        return canonical_digest(self.identity_payload)
+
+
+class SemanticGraph(SemanticsModel):
+    schema_version: Literal["mozaiks.semantic_graph.v1"] = SEMANTIC_GRAPH_SCHEMA_VERSION
+    graph_id: str
+    version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    namespace_grants: tuple[str, ...] = Field(default_factory=tuple)
+    nodes: tuple[SemanticNode, ...] = Field(min_length=1)
+    edges: tuple[SemanticEdge, ...] = Field(default_factory=tuple)
+    graph_digest: str = Field(min_length=64, max_length=64)
+
+    @field_validator("graph_id")
+    @classmethod
+    def _graph_id(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if _GRAPH_ID.fullmatch(text) is None:
+            raise ValueError(f"graph_id must be a lowercase identifier, got {value!r}")
+        if text in MUTABLE_ALIASES:
+            raise ValueError(f"graph_id must be immutable identity, got {text!r}")
+        return text
+
+    @field_validator("namespace_grants")
+    @classmethod
+    def _grants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(sorted({str(item or "").strip() for item in value}))
+        for item in normalized:
+            if re.fullmatch(r"[a-z][a-z0-9_]*", item) is None:
+                raise ValueError(f"namespace grant must be a lowercase root identifier, got {item!r}")
+            if item == CORE_NODE_NAMESPACE_ROOT:
+                raise ValueError("the core namespace root cannot be granted to extensions")
+        return normalized
+
+    @field_validator("nodes")
+    @classmethod
+    def _nodes(cls, value: tuple[SemanticNode, ...]) -> tuple[SemanticNode, ...]:
+        return tuple(sorted(value, key=lambda item: item.node_id))
+
+    @field_validator("edges")
+    @classmethod
+    def _edges(cls, value: tuple[SemanticEdge, ...]) -> tuple[SemanticEdge, ...]:
+        return tuple(sorted(value, key=lambda item: item.edge_identity))
+
+    @model_validator(mode="after")
+    def _validate_graph(self) -> SemanticGraph:
+        node_ids = [node.node_id for node in self.nodes]
+        if len(node_ids) != len(set(node_ids)):
+            duplicates = sorted({item for item in node_ids if node_ids.count(item) > 1})
+            raise ValueError(f"duplicate node identities: {duplicates}")
+        known = set(node_ids)
+
+        for node in self.nodes:
+            root = node.namespace_root
+            if root != CORE_NODE_NAMESPACE_ROOT and root not in self.namespace_grants:
+                raise ValueError(
+                    f"node {node.node_id!r} is outside the core namespace and the "
+                    f"granted namespaces {list(self.namespace_grants)!r}"
+                )
+            for reference in node.node_references:
+                if reference not in known:
+                    raise ValueError(
+                        f"node {node.node_id!r} references unknown node {reference!r}"
+                    )
+
+        edge_identities: dict[str, SemanticEdge] = {}
+        for edge in self.edges:
+            if edge.source_node_id not in known:
+                raise ValueError(
+                    f"edge {edge.kind.value} has dangling source {edge.source_node_id!r}"
+                )
+            if edge.target_node_id not in known:
+                raise ValueError(
+                    f"edge {edge.kind.value} has dangling target {edge.target_node_id!r}"
+                )
+            identity = edge.edge_identity
+            if identity in edge_identities:
+                raise ValueError(
+                    f"duplicate edge identity for {edge.kind.value} "
+                    f"{edge.source_node_id!r} -> {edge.target_node_id!r} "
+                    f"(discriminator {edge.discriminator!r})"
+                )
+            edge_identities[identity] = edge
+
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.graph_digest != expected:
+            raise ValueError("graph_digest does not match graph content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "graph_id": self.graph_id,
+            "version": self.version,
+            "scope": self.scope.model_dump(mode="json"),
+            "namespace_grants": list(self.namespace_grants),
+            "nodes": [node.identity_payload for node in self.nodes],
+            "edges": [edge.identity_payload for edge in self.edges],
+        }
+        if include_digest:
+            payload["graph_digest"] = self.graph_digest
+        return payload
+
+    def node(self, node_id: str) -> SemanticNode:
+        for candidate in self.nodes:
+            if candidate.node_id == node_id:
+                return candidate
+        raise SemanticGraphError(f"unknown node {node_id!r}")
+
+
+def build_semantic_graph(
+    *,
+    graph_id: str,
+    version: int,
+    scope: ExecutionAccessScopeRef,
+    nodes: tuple[SemanticNode, ...] | list[SemanticNode],
+    edges: tuple[SemanticEdge, ...] | list[SemanticEdge] = (),
+    namespace_grants: tuple[str, ...] | list[str] = (),
+) -> SemanticGraph:
+    """Construct a graph with its content digest computed canonically."""
+    ordered_nodes = tuple(sorted(tuple(nodes), key=lambda item: item.node_id))
+    ordered_edges = tuple(sorted(tuple(edges), key=lambda item: item.edge_identity))
+    ordered_grants = tuple(sorted({str(item).strip() for item in namespace_grants}))
+    payload = {
+        "schema_version": SEMANTIC_GRAPH_SCHEMA_VERSION,
+        "graph_id": str(graph_id).strip(),
+        "version": version,
+        "scope": scope.model_dump(mode="json"),
+        "namespace_grants": list(ordered_grants),
+        "nodes": [node.identity_payload for node in ordered_nodes],
+        "edges": [edge.identity_payload for edge in ordered_edges],
+    }
+    return SemanticGraph(
+        graph_id=graph_id,
+        version=version,
+        scope=scope,
+        namespace_grants=ordered_grants,
+        nodes=ordered_nodes,
+        edges=ordered_edges,
+        graph_digest=canonical_digest(payload),
+    )
+
+
+def validate_semantic_graph_taxonomy_closure(
+    graph: SemanticGraph, registry: TaxonomyRegistry
+) -> None:
+    """Fail closed unless every taxonomy reference resolves in ``registry``.
+
+    Uses the Slice 1 taxonomy authority directly; this module introduces no
+    parallel registry.
+    """
+    for node in graph.nodes:
+        for reference in node.taxonomy_references:
+            registry.resolve(reference.category, reference.identifier)
+
+
+__all__ = [
+    "CORE_NODE_NAMESPACE_ROOT",
+    "SEMANTIC_GRAPH_SCHEMA_VERSION",
+    "SemanticEdge",
+    "SemanticEdgeKind",
+    "SemanticGraph",
+    "SemanticGraphError",
+    "SemanticNode",
+    "SemanticNodeKind",
+    "TaxonomyReference",
+    "build_semantic_graph",
+    "validate_semantic_graph_taxonomy_closure",
+]

--- a/mozaiksai/core/semantics/manifest.py
+++ b/mozaiksai/core/semantics/manifest.py
@@ -1,0 +1,161 @@
+"""Minimal versioned ``mozaiks.app_manifest.v1`` reference document.
+
+The manifest references; it does not duplicate.  Modules, pages, data, events,
+plans, and workflows live as graph nodes and rendered child contracts, never as
+inline manifest content.  Manifest versions are immutable: assigning a real
+``app_id`` to a pre-app manifest requires a new manifest version and never
+mutates the pre-app creation scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.app_context.models import AppContextMode
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.refs import (
+    ArtifactRevisionRef,
+    BuildContextBindingRef,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    SemanticGraphRef,
+    SemanticsModel,
+    TaxonomyNamespaceRef,
+    _validate_identifier,
+)
+
+APP_MANIFEST_SCHEMA_VERSION: Literal["mozaiks.app_manifest.v1"] = "mozaiks.app_manifest.v1"
+
+
+class ApplicationManifest(SemanticsModel):
+    schema_version: Literal["mozaiks.app_manifest.v1"] = APP_MANIFEST_SCHEMA_VERSION
+    manifest_id: str
+    version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    mode: AppContextMode
+    app_id: str | None = None
+    semantic_graph_ref: SemanticGraphRef
+    implementation_binding_ref: ImplementationBindingRef
+    taxonomy_refs: tuple[TaxonomyNamespaceRef, ...] = Field(min_length=1)
+    build_context_binding_ref: BuildContextBindingRef
+    artifact_revision_ref: ArtifactRevisionRef | None = None
+    compiler_version: str
+    renderer_registry_version: str
+    manifest_digest: str = Field(min_length=64, max_length=64)
+
+    @field_validator("manifest_id")
+    @classmethod
+    def _manifest_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="manifest_id")
+
+    @field_validator("app_id")
+    @classmethod
+    def _app_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_identifier(value, field_name="app_id")
+
+    @field_validator("compiler_version", "renderer_registry_version")
+    @classmethod
+    def _versions(cls, value: str, info) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError(f"{info.field_name} must be non-empty")
+        return text
+
+    @field_validator("taxonomy_refs")
+    @classmethod
+    def _taxonomy_refs(
+        cls, value: tuple[TaxonomyNamespaceRef, ...]
+    ) -> tuple[TaxonomyNamespaceRef, ...]:
+        ordered = tuple(sorted(value, key=lambda item: (item.namespace_id, item.namespace_version)))
+        identities = [item.namespace_id for item in ordered]
+        if len(identities) != len(set(identities)):
+            raise ValueError("duplicate pinned taxonomy namespaces")
+        return ordered
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> ApplicationManifest:
+        if self.app_id is None and self.scope.pre_app_scope_id is None:
+            raise ValueError(
+                "a pre-app manifest (app_id is None) requires scope.pre_app_scope_id; "
+                "it must not invent an app_id"
+            )
+        for name, ref in (
+            ("semantic_graph_ref", self.semantic_graph_ref),
+            ("implementation_binding_ref", self.implementation_binding_ref),
+            ("build_context_binding_ref", self.build_context_binding_ref),
+            ("artifact_revision_ref", self.artifact_revision_ref),
+        ):
+            if ref is not None and ref.scope != self.scope:
+                raise ValueError(
+                    f"{name} scope does not match the manifest ExecutionAccessScopeRef; "
+                    "cross-scope references fail closed"
+                )
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.manifest_digest != expected:
+            raise ValueError("manifest_digest does not match manifest content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "manifest_id": self.manifest_id,
+            "version": self.version,
+            "scope": self.scope.model_dump(mode="json"),
+            "mode": self.mode.value,
+            "app_id": self.app_id,
+            "semantic_graph_ref": self.semantic_graph_ref.model_dump(mode="json"),
+            "implementation_binding_ref": self.implementation_binding_ref.model_dump(mode="json"),
+            "taxonomy_refs": [item.model_dump(mode="json") for item in self.taxonomy_refs],
+            "build_context_binding_ref": self.build_context_binding_ref.model_dump(mode="json"),
+            "artifact_revision_ref": (
+                None
+                if self.artifact_revision_ref is None
+                else self.artifact_revision_ref.model_dump(mode="json")
+            ),
+            "compiler_version": self.compiler_version,
+            "renderer_registry_version": self.renderer_registry_version,
+        }
+        if include_digest:
+            payload["manifest_digest"] = self.manifest_digest
+        return payload
+
+
+def build_application_manifest(**fields: Any) -> ApplicationManifest:
+    """Construct a manifest with its content digest computed canonically."""
+    taxonomy_refs = tuple(
+        sorted(
+            tuple(fields["taxonomy_refs"]),
+            key=lambda item: (item.namespace_id, item.namespace_version),
+        )
+    )
+    payload = {
+        "schema_version": APP_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": str(fields["manifest_id"]).strip(),
+        "version": fields["version"],
+        "scope": fields["scope"].model_dump(mode="json"),
+        "mode": AppContextMode(fields["mode"]).value,
+        "app_id": fields.get("app_id"),
+        "semantic_graph_ref": fields["semantic_graph_ref"].model_dump(mode="json"),
+        "implementation_binding_ref": fields["implementation_binding_ref"].model_dump(mode="json"),
+        "taxonomy_refs": [item.model_dump(mode="json") for item in taxonomy_refs],
+        "build_context_binding_ref": fields["build_context_binding_ref"].model_dump(mode="json"),
+        "artifact_revision_ref": (
+            None
+            if fields.get("artifact_revision_ref") is None
+            else fields["artifact_revision_ref"].model_dump(mode="json")
+        ),
+        "compiler_version": str(fields["compiler_version"]).strip(),
+        "renderer_registry_version": str(fields["renderer_registry_version"]).strip(),
+    }
+    return ApplicationManifest(**fields, manifest_digest=canonical_digest(payload))
+
+
+__all__ = [
+    "APP_MANIFEST_SCHEMA_VERSION",
+    "ApplicationManifest",
+    "build_application_manifest",
+]

--- a/mozaiksai/core/semantics/refs.py
+++ b/mozaiksai/core/semantics/refs.py
@@ -1,0 +1,258 @@
+"""Strict immutable reference contracts for the ADR 0007 semantic compiler.
+
+Every scoped reference pins its ref schema version, typed subject identifier,
+immutable subject version, content digest, and owning
+:class:`ExecutionAccessScopeRef`.  ``TaxonomyNamespaceRef`` is the one unscoped
+registry reference: it pins namespace identifier, version, and digest without
+inventing tenant scope.  No reference resolves by bare id, path, artifact
+family, or a mutable alias such as ``latest``.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_grammar
+
+_HEX_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_PATH_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: Mutable-alias identifiers that must never masquerade as immutable identity.
+MUTABLE_ALIASES = frozenset({"latest", "current", "head", "tip", "newest"})
+
+
+class SemanticRefError(ValueError):
+    """Raised when a reference is structurally invalid."""
+
+
+class SemanticsModel(BaseModel):
+    """Base for every compiler-surface model: unknown fields rejected, frozen."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _validate_identifier(value: str, *, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text or _IDENTIFIER.fullmatch(text) is None:
+        raise ValueError(f"{field_name} must be a lowercase identifier, got {value!r}")
+    if text in MUTABLE_ALIASES:
+        raise ValueError(f"{field_name} must be immutable identity, got mutable alias {text!r}")
+    return text
+
+
+def _validate_digest(value: str, *, field_name: str) -> str:
+    text = str(value or "").strip()
+    if _HEX_DIGEST.fullmatch(text) is None:
+        raise ValueError(f"{field_name} must be a 64-char lowercase hex sha256 digest")
+    return text
+
+
+class RefDocumentType(StrEnum):
+    """The document type a reference expects its subject to be."""
+
+    APPLICATION_MANIFEST = "application_manifest"
+    SEMANTIC_GRAPH = "semantic_graph"
+    IMPLEMENTATION_BINDING = "implementation_binding"
+    COMPILATION_PLAN = "compilation_plan"
+    BUILD_CONTEXT_BINDING = "build_context_binding"
+    REFINEMENT_PATCH = "refinement_patch"
+    ARTIFACT_REVISION = "artifact_revision"
+    CHILD_CONTRACT = "child_contract"
+    TAXONOMY_NAMESPACE = "taxonomy_namespace"
+
+
+class ExecutionAccessScopeRef(SemanticsModel):
+    """Immutable owning scope: tenant, optional workspace, optional pre-app scope.
+
+    A pre-app manifest uses ``pre_app_scope_id`` as its creation scope; it never
+    fabricates an ``app_id``.  Later association of a real ``app_id`` happens in
+    a new manifest version and cannot replace, widen, or weaken this scope.
+    """
+
+    ref_schema_version: Literal["mozaiks.execution_access_scope_ref.v1"] = (
+        "mozaiks.execution_access_scope_ref.v1"
+    )
+    tenant_id: str
+    workspace_id: str | None = None
+    pre_app_scope_id: str | None = None
+
+    @field_validator("tenant_id")
+    @classmethod
+    def _tenant(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="tenant_id")
+
+    @field_validator("workspace_id", "pre_app_scope_id")
+    @classmethod
+    def _optional_ids(cls, value: str | None, info) -> str | None:
+        if value is None:
+            return None
+        return _validate_identifier(value, field_name=info.field_name)
+
+
+class _ScopedRef(SemanticsModel):
+    """Common shape of every scoped compiler reference."""
+
+    document_type: ClassVar[RefDocumentType]
+
+    subject_id: str
+    subject_version: int = Field(ge=1, strict=True)
+    content_digest: str
+    scope: ExecutionAccessScopeRef
+
+    @field_validator("subject_id")
+    @classmethod
+    def _subject_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="subject_id")
+
+    @field_validator("content_digest")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="content_digest")
+
+
+class ApplicationManifestRef(_ScopedRef):
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.APPLICATION_MANIFEST
+    ref_schema_version: Literal["mozaiks.application_manifest_ref.v1"] = (
+        "mozaiks.application_manifest_ref.v1"
+    )
+
+
+class SemanticGraphRef(_ScopedRef):
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.SEMANTIC_GRAPH
+    ref_schema_version: Literal["mozaiks.semantic_graph_ref.v1"] = "mozaiks.semantic_graph_ref.v1"
+
+
+class ImplementationBindingRef(_ScopedRef):
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.IMPLEMENTATION_BINDING
+    ref_schema_version: Literal["mozaiks.implementation_binding_ref.v1"] = (
+        "mozaiks.implementation_binding_ref.v1"
+    )
+
+
+class CompilationPlanRef(_ScopedRef):
+    """Reference contract only; ``CompilationPlan`` content is later-slice work."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.COMPILATION_PLAN
+    ref_schema_version: Literal["mozaiks.compilation_plan_ref.v1"] = (
+        "mozaiks.compilation_plan_ref.v1"
+    )
+
+
+class BuildContextBindingRef(_ScopedRef):
+    """Reference contract only; binding content assembly is later-slice work."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.BUILD_CONTEXT_BINDING
+    ref_schema_version: Literal["mozaiks.build_context_binding_ref.v1"] = (
+        "mozaiks.build_context_binding_ref.v1"
+    )
+
+
+class RefinementPatchRef(_ScopedRef):
+    """Reference contract only; ``RefinementPatch`` application is later-slice work."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.REFINEMENT_PATCH
+    ref_schema_version: Literal["mozaiks.refinement_patch_ref.v1"] = (
+        "mozaiks.refinement_patch_ref.v1"
+    )
+
+
+class ArtifactRevisionRef(_ScopedRef):
+    """Reference contract only; ``ArtifactRevision`` content is later-slice work."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.ARTIFACT_REVISION
+    ref_schema_version: Literal["mozaiks.artifact_revision_ref.v1"] = (
+        "mozaiks.artifact_revision_ref.v1"
+    )
+
+
+class ChildContractRef(_ScopedRef):
+    """Typed child-contract reference: pins artifact family, canonical relative
+    path, contract schema version, and content digest on top of scoped identity."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.CHILD_CONTRACT
+    ref_schema_version: Literal["mozaiks.child_contract_ref.v1"] = "mozaiks.child_contract_ref.v1"
+    artifact_family: str
+    canonical_relative_path: str
+    contract_schema_version: str
+
+    @field_validator("artifact_family")
+    @classmethod
+    def _family(cls, value: str) -> str:
+        return validate_identifier_grammar(SemanticCategory.ARTIFACT_FAMILY, value)
+
+    @field_validator("contract_schema_version")
+    @classmethod
+    def _contract_schema_version(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("contract_schema_version must be non-empty")
+        return text
+
+    @field_validator("canonical_relative_path")
+    @classmethod
+    def _path(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("canonical_relative_path must be non-empty")
+        if "\\" in text or text.startswith("/") or ":" in text:
+            raise ValueError(
+                "canonical_relative_path must be a POSIX relative path without "
+                f"drive or absolute components, got {text!r}"
+            )
+        segments = text.split("/")
+        for segment in segments:
+            if segment in {"", ".", ".."} or _PATH_SEGMENT.fullmatch(segment) is None:
+                raise ValueError(
+                    f"canonical_relative_path segment {segment!r} is not allowed in {text!r}"
+                )
+        return text
+
+
+class TaxonomyNamespaceRef(SemanticsModel):
+    """Unscoped registry reference pinning namespace identifier, version, digest."""
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.TAXONOMY_NAMESPACE
+    ref_schema_version: Literal["mozaiks.taxonomy_namespace_ref.v1"] = (
+        "mozaiks.taxonomy_namespace_ref.v1"
+    )
+    namespace_id: str
+    namespace_version: int = Field(ge=1, strict=True)
+    content_digest: str
+
+    @field_validator("namespace_id")
+    @classmethod
+    def _namespace_id(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if re.fullmatch(r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*", text) is None:
+            raise ValueError("namespace_id must be a lowercase dotted identifier")
+        if text in MUTABLE_ALIASES:
+            raise ValueError(f"namespace_id must be immutable identity, got {text!r}")
+        return text
+
+    @field_validator("content_digest")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="content_digest")
+
+
+__all__ = [
+    "ApplicationManifestRef",
+    "ArtifactRevisionRef",
+    "BuildContextBindingRef",
+    "ChildContractRef",
+    "CompilationPlanRef",
+    "ExecutionAccessScopeRef",
+    "ImplementationBindingRef",
+    "MUTABLE_ALIASES",
+    "RefDocumentType",
+    "RefinementPatchRef",
+    "SemanticGraphRef",
+    "SemanticRefError",
+    "SemanticsModel",
+    "TaxonomyNamespaceRef",
+]

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -17,8 +17,13 @@ from mozaiksai.core.semantics.graph import SemanticGraph
 from mozaiksai.core.semantics.manifest import ApplicationManifest
 from mozaiksai.core.semantics.refs import (
     ApplicationManifestRef,
+    ArtifactRevisionRef,
+    BuildContextBindingRef,
+    ChildContractRef,
+    CompilationPlanRef,
     ExecutionAccessScopeRef,
     RefDocumentType,
+    RefinementPatchRef,
     TaxonomyNamespaceRef,
     _ScopedRef,
 )
@@ -37,6 +42,7 @@ class _Subject:
     digest: str
     scope: ExecutionAccessScopeRef | None
     content: Any
+    reference_payload: dict[str, Any] | None = None
 
 
 class SemanticReferenceResolver:
@@ -99,12 +105,17 @@ class SemanticReferenceResolver:
         )
 
     def register_taxonomy_namespace(self, namespace: TaxonomyNamespace, digest: str) -> None:
+        ref = TaxonomyNamespaceRef(
+            namespace_id=namespace.namespace_id,
+            namespace_version=namespace.version,
+            content_digest=digest,
+        )
         self._register(
             _Subject(
                 kind=RefDocumentType.TAXONOMY_NAMESPACE,
-                subject_id=namespace.namespace_id,
-                version=namespace.version,
-                digest=digest,
+                subject_id=ref.namespace_id,
+                version=ref.namespace_version,
+                digest=ref.content_digest,
                 scope=None,
                 content=namespace,
             )
@@ -118,6 +129,9 @@ class SemanticReferenceResolver:
         version: int,
         digest: str,
         scope: ExecutionAccessScopeRef,
+        artifact_family: str | None = None,
+        canonical_relative_path: str | None = None,
+        contract_schema_version: str | None = None,
     ) -> None:
         if kind in {
             RefDocumentType.SEMANTIC_GRAPH,
@@ -128,14 +142,51 @@ class SemanticReferenceResolver:
             raise ReferenceResolutionError(
                 f"{kind.value} is content-bearing in this slice; register its document"
             )
+
+        fields: dict[str, Any] = {
+            "subject_id": subject_id,
+            "subject_version": version,
+            "content_digest": digest,
+            "scope": scope,
+        }
+        ref_types = {
+            RefDocumentType.COMPILATION_PLAN: CompilationPlanRef,
+            RefDocumentType.BUILD_CONTEXT_BINDING: BuildContextBindingRef,
+            RefDocumentType.REFINEMENT_PATCH: RefinementPatchRef,
+            RefDocumentType.ARTIFACT_REVISION: ArtifactRevisionRef,
+        }
+        if kind is RefDocumentType.CHILD_CONTRACT:
+            fields.update(
+                artifact_family=artifact_family,
+                canonical_relative_path=canonical_relative_path,
+                contract_schema_version=contract_schema_version,
+            )
+            ref: _ScopedRef = ChildContractRef(**fields)
+        else:
+            if any(
+                value is not None
+                for value in (
+                    artifact_family,
+                    canonical_relative_path,
+                    contract_schema_version,
+                )
+            ):
+                raise ReferenceResolutionError(
+                    "child-contract identity fields are valid only for child contracts"
+                )
+            ref_type = ref_types.get(kind)
+            if ref_type is None:
+                raise ReferenceResolutionError(f"unsupported opaque document type {kind!r}")
+            ref = ref_type(**fields)
         self._register(
             _Subject(
                 kind=kind,
-                subject_id=subject_id,
-                version=version,
-                digest=digest,
-                scope=scope,
+                subject_id=ref.subject_id,
+                version=ref.subject_version,
+                digest=ref.content_digest,
+                scope=ref.scope,
                 content=None,
+                reference_payload=ref.model_dump(mode="json"),
             )
         )
 
@@ -164,6 +215,13 @@ class SemanticReferenceResolver:
         if requesting_scope != subject.scope:
             raise ReferenceResolutionError(
                 f"cross-scope access to {ref.subject_id!r} fails closed"
+            )
+        if (
+            subject.reference_payload is not None
+            and ref.model_dump(mode="json") != subject.reference_payload
+        ):
+            raise ReferenceResolutionError(
+                f"typed reference identity mismatch for {ref.subject_id!r}"
             )
         return subject.content
 

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -170,7 +170,12 @@ class SemanticReferenceResolver:
     def resolve_manifest_ref(
         self, ref: ApplicationManifestRef, *, requesting_scope: ExecutionAccessScopeRef
     ) -> ApplicationManifest:
-        return self.resolve(ref, requesting_scope=requesting_scope)
+        content = self.resolve(ref, requesting_scope=requesting_scope)
+        if not isinstance(content, ApplicationManifest):
+            raise ReferenceResolutionError(
+                f"subject {ref.subject_id!r} did not resolve to an ApplicationManifest"
+            )
+        return content
 
     def resolve_taxonomy_namespace(self, ref: TaxonomyNamespaceRef) -> TaxonomyNamespace:
         subject = self._subjects.get((ref.namespace_id, ref.namespace_version))
@@ -185,6 +190,10 @@ class SemanticReferenceResolver:
         if subject.digest != ref.content_digest:
             raise ReferenceResolutionError(
                 f"content digest mismatch for taxonomy namespace {ref.namespace_id!r}"
+            )
+        if not isinstance(subject.content, TaxonomyNamespace):
+            raise ReferenceResolutionError(
+                f"subject {ref.namespace_id!r} did not resolve to a TaxonomyNamespace"
             )
         return subject.content
 

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -1,0 +1,195 @@
+"""Strict reference resolution over an in-memory subject store (test seam).
+
+Every resolution verifies required fields (enforced by the ref models), the
+expected document type, the exact immutable version, the content digest, and
+the execution scope before returning anything.  There is no bare-id, path,
+family-name, or "current"/"latest" lookup surface: the only way in is a fully
+pinned reference plus the caller's own scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mozaiksai.core.semantics.binding import ImplementationBinding
+from mozaiksai.core.semantics.graph import SemanticGraph
+from mozaiksai.core.semantics.manifest import ApplicationManifest
+from mozaiksai.core.semantics.refs import (
+    ApplicationManifestRef,
+    ExecutionAccessScopeRef,
+    RefDocumentType,
+    TaxonomyNamespaceRef,
+    _ScopedRef,
+)
+from mozaiksai.core.taxonomy import TaxonomyNamespace
+
+
+class ReferenceResolutionError(ValueError):
+    """Raised when a reference fails verification against the store."""
+
+
+@dataclass(frozen=True)
+class _Subject:
+    kind: RefDocumentType
+    subject_id: str
+    version: int
+    digest: str
+    scope: ExecutionAccessScopeRef | None
+    content: Any
+
+
+class SemanticReferenceResolver:
+    """In-memory resolver for Slice 2 contract tests.
+
+    Registration requires the full immutable identity; resolution re-verifies
+    it.  Content-bearing documents (manifest, graph, binding, taxonomy
+    namespaces) are stored with content; the ref-only document kinds of this
+    slice (compilation plan, build-context binding, refinement patch, artifact
+    revision, child contracts) register as opaque digested subjects.
+    """
+
+    def __init__(self) -> None:
+        self._subjects: dict[tuple[str, int], _Subject] = {}
+
+    def _register(self, subject: _Subject) -> None:
+        key = (subject.subject_id, subject.version)
+        existing = self._subjects.get(key)
+        if existing is not None:
+            raise ReferenceResolutionError(
+                f"subject {subject.subject_id!r} version {subject.version} is immutable "
+                "and already registered"
+            )
+        self._subjects[key] = subject
+
+    def register_semantic_graph(self, graph: SemanticGraph) -> None:
+        self._register(
+            _Subject(
+                kind=RefDocumentType.SEMANTIC_GRAPH,
+                subject_id=graph.graph_id,
+                version=graph.version,
+                digest=graph.graph_digest,
+                scope=graph.scope,
+                content=graph,
+            )
+        )
+
+    def register_application_manifest(self, manifest: ApplicationManifest) -> None:
+        self._register(
+            _Subject(
+                kind=RefDocumentType.APPLICATION_MANIFEST,
+                subject_id=manifest.manifest_id,
+                version=manifest.version,
+                digest=manifest.manifest_digest,
+                scope=manifest.scope,
+                content=manifest,
+            )
+        )
+
+    def register_implementation_binding(self, binding: ImplementationBinding) -> None:
+        self._register(
+            _Subject(
+                kind=RefDocumentType.IMPLEMENTATION_BINDING,
+                subject_id=binding.binding_id,
+                version=binding.version,
+                digest=binding.binding_digest,
+                scope=binding.scope,
+                content=binding,
+            )
+        )
+
+    def register_taxonomy_namespace(self, namespace: TaxonomyNamespace, digest: str) -> None:
+        self._register(
+            _Subject(
+                kind=RefDocumentType.TAXONOMY_NAMESPACE,
+                subject_id=namespace.namespace_id,
+                version=namespace.version,
+                digest=digest,
+                scope=None,
+                content=namespace,
+            )
+        )
+
+    def register_opaque_subject(
+        self,
+        *,
+        kind: RefDocumentType,
+        subject_id: str,
+        version: int,
+        digest: str,
+        scope: ExecutionAccessScopeRef,
+    ) -> None:
+        if kind in {
+            RefDocumentType.SEMANTIC_GRAPH,
+            RefDocumentType.APPLICATION_MANIFEST,
+            RefDocumentType.IMPLEMENTATION_BINDING,
+            RefDocumentType.TAXONOMY_NAMESPACE,
+        }:
+            raise ReferenceResolutionError(
+                f"{kind.value} is content-bearing in this slice; register its document"
+            )
+        self._register(
+            _Subject(
+                kind=kind,
+                subject_id=subject_id,
+                version=version,
+                digest=digest,
+                scope=scope,
+                content=None,
+            )
+        )
+
+    def resolve(self, ref: _ScopedRef, *, requesting_scope: ExecutionAccessScopeRef) -> Any:
+        """Verify type, exact version, digest, and scope; return stored content."""
+        subject = self._subjects.get((ref.subject_id, ref.subject_version))
+        if subject is None:
+            raise ReferenceResolutionError(
+                f"no subject {ref.subject_id!r} at immutable version "
+                f"{ref.subject_version}; refs never fall back to another version"
+            )
+        if subject.kind is not type(ref).document_type:
+            raise ReferenceResolutionError(
+                f"document type mismatch: ref expects {type(ref).document_type.value!r}, "
+                f"stored subject is {subject.kind.value!r}"
+            )
+        if subject.digest != ref.content_digest:
+            raise ReferenceResolutionError(
+                f"content digest mismatch for {ref.subject_id!r} "
+                f"version {ref.subject_version}"
+            )
+        if subject.scope != ref.scope:
+            raise ReferenceResolutionError(
+                f"scope mismatch: ref scope does not own subject {ref.subject_id!r}"
+            )
+        if requesting_scope != subject.scope:
+            raise ReferenceResolutionError(
+                f"cross-scope access to {ref.subject_id!r} fails closed"
+            )
+        return subject.content
+
+    def resolve_manifest_ref(
+        self, ref: ApplicationManifestRef, *, requesting_scope: ExecutionAccessScopeRef
+    ) -> ApplicationManifest:
+        return self.resolve(ref, requesting_scope=requesting_scope)
+
+    def resolve_taxonomy_namespace(self, ref: TaxonomyNamespaceRef) -> TaxonomyNamespace:
+        subject = self._subjects.get((ref.namespace_id, ref.namespace_version))
+        if subject is None:
+            raise ReferenceResolutionError(
+                f"no taxonomy namespace {ref.namespace_id!r} at version {ref.namespace_version}"
+            )
+        if subject.kind is not RefDocumentType.TAXONOMY_NAMESPACE:
+            raise ReferenceResolutionError(
+                f"document type mismatch: {ref.namespace_id!r} is {subject.kind.value!r}"
+            )
+        if subject.digest != ref.content_digest:
+            raise ReferenceResolutionError(
+                f"content digest mismatch for taxonomy namespace {ref.namespace_id!r}"
+            )
+        return subject.content
+
+
+__all__ = [
+    "ReferenceResolutionError",
+    "SemanticReferenceResolver",
+]

--- a/tests/test_semantic_canonical_serialization.py
+++ b/tests/test_semantic_canonical_serialization.py
@@ -1,0 +1,116 @@
+"""Adversarial tests for the mozaiks.canonical_json.v1 serialization contract."""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+
+import pytest
+
+from mozaiksai.core.semantics.canonical import (
+    CANONICAL_SERIALIZATION_VERSION,
+    CanonicalSerializationError,
+    canonical_digest,
+    canonical_json,
+)
+
+GOLDEN_VALUE = {"z": [3, 1.5, True, None], "a": {"nested": "café"}, "k": "x"}
+GOLDEN_JSON = '{"a":{"nested":"caf\\u00e9"},"k":"x","z":[3,1.5,true,null]}'
+GOLDEN_DIGEST = "a5038c06a5e632670660d86f9a20fe546be5f44669b77596ab57180b2b108d49"
+
+EMPTY_LIST_DIGEST = "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+
+
+def test_serialization_contract_is_versioned() -> None:
+    assert CANONICAL_SERIALIZATION_VERSION == "mozaiks.canonical_json.v1"
+
+
+def test_golden_vector_bytes_and_digest() -> None:
+    assert canonical_json(GOLDEN_VALUE) == GOLDEN_JSON
+    assert canonical_digest(GOLDEN_VALUE) == GOLDEN_DIGEST
+    assert canonical_digest([]) == EMPTY_LIST_DIGEST
+
+
+def test_repeated_serialization_is_byte_identical() -> None:
+    outputs = {canonical_json(GOLDEN_VALUE) for _ in range(50)}
+    assert outputs == {GOLDEN_JSON}
+
+
+def test_mapping_key_order_does_not_affect_bytes_or_digest() -> None:
+    reordered = {"k": "x", "a": {"nested": "café"}, "z": [3, 1.5, True, None]}
+    assert canonical_json(reordered) == GOLDEN_JSON
+    assert canonical_digest(reordered) == GOLDEN_DIGEST
+
+
+def test_digest_stable_across_process_restart() -> None:
+    script = (
+        "from mozaiksai.core.semantics.canonical import canonical_digest;"
+        "print(canonical_digest({'z': [3, 1.5, True, None],"
+        " 'a': {'nested': 'caf\\u00e9'}, 'k': 'x'}))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == GOLDEN_DIGEST
+
+
+def test_unicode_is_escaped_to_ascii() -> None:
+    text = canonical_json({"emoji": "\U0001f600", "accent": "é"})
+    assert text.isascii()
+    assert "\\ud83d\\ude00" in text
+    assert "\\u00e9" in text
+
+
+def test_semantically_ordered_collections_preserve_order() -> None:
+    assert canonical_json([3, 1, 2]) == "[3,1,2]"
+    assert canonical_digest([3, 1, 2]) != canonical_digest([1, 2, 3])
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_numbers_fail_closed(bad: float) -> None:
+    with pytest.raises(CanonicalSerializationError, match="non-finite"):
+        canonical_json({"x": bad})
+
+
+def test_negative_zero_normalizes() -> None:
+    assert canonical_json({"x": -0.0}) == '{"x":0.0}'
+    assert canonical_digest({"x": -0.0}) == canonical_digest({"x": 0.0})
+
+
+def test_int_and_bool_are_distinct() -> None:
+    assert canonical_json({"x": True}) == '{"x":true}'
+    assert canonical_json({"x": 1}) == '{"x":1}'
+    assert canonical_digest({"x": True}) != canonical_digest({"x": 1})
+
+
+def test_integers_outside_int64_fail_closed() -> None:
+    with pytest.raises(CanonicalSerializationError, match="64-bit"):
+        canonical_json({"x": 2**63})
+    with pytest.raises(CanonicalSerializationError, match="64-bit"):
+        canonical_json({"x": -(2**63) - 1})
+    assert canonical_json({"x": 2**63 - 1}) == f'{{"x":{2**63 - 1}}}'
+
+
+def test_non_string_mapping_keys_fail_closed() -> None:
+    with pytest.raises(CanonicalSerializationError, match="mapping key"):
+        canonical_json({1: "x"})
+
+
+@pytest.mark.parametrize("bad", [{1, 2}, frozenset({1}), b"bytes", object()])
+def test_unsupported_types_fail_closed(bad: object) -> None:
+    with pytest.raises(CanonicalSerializationError, match="unsupported type"):
+        canonical_json({"x": bad})
+
+
+def test_input_objects_are_not_mutated() -> None:
+    value = {"z": [3, {"inner": [1, 2]}], "a": {"nested": "café"}}
+    snapshot = copy.deepcopy(value)
+    canonical_json(value)
+    canonical_digest(value)
+    assert value == snapshot
+    assert list(value.keys()) == list(snapshot.keys())
+
+
+def test_tuple_and_list_serialize_identically() -> None:
+    assert canonical_json((1, 2)) == canonical_json([1, 2])

--- a/tests/test_semantic_graph_contract.py
+++ b/tests/test_semantic_graph_contract.py
@@ -1,0 +1,313 @@
+"""Adversarial tests for the immutable SemanticGraph contract."""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from mozaiksai.core.semantics import (
+    ExecutionAccessScopeRef,
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraph,
+    SemanticNode,
+    SemanticNodeKind,
+    TaxonomyReference,
+    build_semantic_graph,
+    validate_semantic_graph_taxonomy_closure,
+)
+from mozaiksai.core.taxonomy import (
+    NamespaceKind,
+    SemanticCategory,
+    TaxonomyEntry,
+    TaxonomyNamespace,
+    UnknownTaxonomyIdentifier,
+    build_taxonomy_registry,
+)
+
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="ws-1")
+OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-2")
+
+EDGE_IDENTITY_GOLDEN = "4c8bfb1bdf3d2fa3b627a7fdb6044f25a7994d340841b94c3ec162ddcdb8f1ad"
+
+
+def _node(node_id: str, kind: SemanticNodeKind = SemanticNodeKind.PAGE, **kw) -> SemanticNode:
+    return SemanticNode(node_id=node_id, kind=kind, **kw)
+
+
+def _basic_nodes() -> list[SemanticNode]:
+    return [
+        _node("mozaiks.pages.home"),
+        _node("mozaiks.events.user_created", SemanticNodeKind.EVENT),
+        _node("mozaiks.modules.users", SemanticNodeKind.MODULE),
+    ]
+
+
+def _basic_edges() -> list[SemanticEdge]:
+    return [
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.modules.users",
+            target_node_id="mozaiks.events.user_created",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.RENDERS,
+            source_node_id="mozaiks.pages.home",
+            target_node_id="mozaiks.modules.users",
+        ),
+    ]
+
+
+def _graph(**overrides):
+    fields = {
+        "graph_id": "graph-1",
+        "version": 1,
+        "scope": SCOPE,
+        "nodes": _basic_nodes(),
+        "edges": _basic_edges(),
+    }
+    fields.update(overrides)
+    return build_semantic_graph(**fields)
+
+
+def test_edge_identity_golden_vector() -> None:
+    edge = SemanticEdge(
+        kind=SemanticEdgeKind.EMITS,
+        source_node_id="mozaiks.pages.home",
+        target_node_id="mozaiks.events.user_created",
+        discriminator="primary",
+    )
+    assert edge.edge_identity == EDGE_IDENTITY_GOLDEN
+
+
+def test_edge_identity_depends_on_every_typed_component() -> None:
+    base = SemanticEdge(
+        kind=SemanticEdgeKind.EMITS,
+        source_node_id="mozaiks.a.x",
+        target_node_id="mozaiks.b.y",
+    )
+    variants = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.CONSUMES,
+            source_node_id="mozaiks.a.x",
+            target_node_id="mozaiks.b.y",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.b.y",
+            target_node_id="mozaiks.a.x",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.a.x",
+            target_node_id="mozaiks.b.y",
+            discriminator="d1",
+        ),
+    ]
+    identities = {base.edge_identity, *(v.edge_identity for v in variants)}
+    assert len(identities) == 4
+
+
+def test_ordering_does_not_change_identities_or_digest() -> None:
+    forward = _graph()
+    reversed_input = build_semantic_graph(
+        graph_id="graph-1",
+        version=1,
+        scope=SCOPE,
+        nodes=list(reversed(_basic_nodes())),
+        edges=list(reversed(_basic_edges())),
+    )
+    assert forward.graph_digest == reversed_input.graph_digest
+    assert [n.node_id for n in forward.nodes] == [n.node_id for n in reversed_input.nodes]
+
+
+def test_duplicate_node_identities_fail_closed() -> None:
+    with pytest.raises(pydantic.ValidationError, match="duplicate node"):
+        _graph(nodes=[*_basic_nodes(), _node("mozaiks.pages.home", SemanticNodeKind.SURFACE)])
+
+
+def test_duplicate_edge_identities_fail_closed() -> None:
+    edge = _basic_edges()[0]
+    with pytest.raises(pydantic.ValidationError, match="duplicate edge identity"):
+        _graph(edges=[*_basic_edges(), edge.model_copy()])
+
+
+def test_same_endpoints_with_distinct_discriminators_are_distinct_edges() -> None:
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DEPENDS_ON,
+            source_node_id="mozaiks.pages.home",
+            target_node_id="mozaiks.modules.users",
+            discriminator="d1",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.DEPENDS_ON,
+            source_node_id="mozaiks.pages.home",
+            target_node_id="mozaiks.modules.users",
+            discriminator="d2",
+        ),
+    ]
+    graph = _graph(edges=edges)
+    assert len(graph.edges) == 2
+
+
+@pytest.mark.parametrize("field", ["source_node_id", "target_node_id"])
+def test_dangling_edge_endpoints_fail_closed(field: str) -> None:
+    edge = SemanticEdge(
+        **{
+            "kind": SemanticEdgeKind.EMITS,
+            "source_node_id": "mozaiks.pages.home",
+            "target_node_id": "mozaiks.events.user_created",
+            field: "mozaiks.ghost.node",
+        }
+    )
+    with pytest.raises(pydantic.ValidationError, match="dangling"):
+        _graph(edges=[edge])
+
+
+def test_dangling_node_references_fail_closed() -> None:
+    nodes = [
+        *_basic_nodes(),
+        _node(
+            "mozaiks.pages.about",
+            node_references=("mozaiks.ghost.node",),
+        ),
+    ]
+    with pytest.raises(pydantic.ValidationError, match="unknown node"):
+        _graph(nodes=nodes)
+
+
+def test_taxonomy_reference_closure() -> None:
+    registry = build_taxonomy_registry(
+        [
+            TaxonomyNamespace(
+                namespace_id="mozaiks.events",
+                version=1,
+                kind=NamespaceKind.CORE,
+                entries=(
+                    TaxonomyEntry(
+                        category=SemanticCategory.EVENT, identifier="domain.users.user_created"
+                    ),
+                ),
+            )
+        ]
+    )
+    good = _graph(
+        nodes=[
+            *_basic_nodes(),
+            _node(
+                "mozaiks.events.declared",
+                SemanticNodeKind.EVENT,
+                taxonomy_references=(
+                    TaxonomyReference(
+                        category=SemanticCategory.EVENT,
+                        identifier="domain.users.user_created",
+                    ),
+                ),
+            ),
+        ]
+    )
+    validate_semantic_graph_taxonomy_closure(good, registry)
+
+    dangling = _graph(
+        nodes=[
+            *_basic_nodes(),
+            _node(
+                "mozaiks.events.declared",
+                SemanticNodeKind.EVENT,
+                taxonomy_references=(
+                    TaxonomyReference(
+                        category=SemanticCategory.EVENT,
+                        identifier="domain.users.unknown_event",
+                    ),
+                ),
+            ),
+        ]
+    )
+    with pytest.raises(UnknownTaxonomyIdentifier):
+        validate_semantic_graph_taxonomy_closure(dangling, registry)
+
+
+def test_extension_nodes_stay_inside_granted_namespaces() -> None:
+    with pytest.raises(pydantic.ValidationError, match="outside the core namespace"):
+        _graph(nodes=[*_basic_nodes(), _node("acme.pages.custom")])
+
+    granted = _graph(
+        nodes=[*_basic_nodes(), _node("acme.pages.custom")],
+        namespace_grants=("acme",),
+    )
+    assert any(node.node_id == "acme.pages.custom" for node in granted.nodes)
+
+    with pytest.raises(pydantic.ValidationError, match="core namespace root"):
+        _graph(namespace_grants=("mozaiks",))
+
+
+def test_unknown_fields_fail_closed() -> None:
+    graph = _graph()
+    payload = graph.model_dump()
+    payload["surprise"] = True
+    with pytest.raises(pydantic.ValidationError):
+        SemanticGraph(**payload)
+    with pytest.raises(pydantic.ValidationError):
+        SemanticNode(node_id="mozaiks.a.b", kind=SemanticNodeKind.PAGE, surprise=1)
+    with pytest.raises(pydantic.ValidationError):
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.a.b",
+            target_node_id="mozaiks.c.d",
+            surprise=1,
+        )
+
+
+def test_graph_documents_are_immutable() -> None:
+    graph = _graph()
+    with pytest.raises(pydantic.ValidationError):
+        graph.version = 2
+    with pytest.raises(pydantic.ValidationError):
+        graph.nodes[0].kind = SemanticNodeKind.SURFACE
+
+
+def test_tampered_digest_fails_closed() -> None:
+    graph = _graph()
+    payload = graph.model_dump()
+    payload["graph_digest"] = "0" * 64
+    with pytest.raises(pydantic.ValidationError, match="graph_digest"):
+        SemanticGraph(**payload)
+
+
+def test_scope_participates_in_digest() -> None:
+    assert _graph().graph_digest != _graph(scope=OTHER_SCOPE).graph_digest
+
+
+def test_every_semantic_field_participates_in_digest() -> None:
+    base = _graph()
+    assert base.graph_digest != _graph(version=2).graph_digest
+    assert base.graph_digest != _graph(graph_id="graph-2").graph_digest
+    assert base.graph_digest != _graph(edges=_basic_edges()[:1]).graph_digest
+    assert (
+        base.graph_digest
+        != _graph(namespace_grants=("acme",)).graph_digest
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_node_id",
+    ["", "single_segment", "Upper.case", "latest.thing", "mozaiks..double", ".leading"],
+)
+def test_node_identifier_grammar_fails_closed(bad_node_id: str) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        _node(bad_node_id)
+
+
+def test_node_identity_is_stable_across_graph_versions() -> None:
+    v1 = _graph()
+    v2 = _graph(version=2, edges=_basic_edges()[:1])
+    assert {n.node_id for n in v1.nodes} == {n.node_id for n in v2.nodes}
+    assert v1.graph_digest != v2.graph_digest
+
+
+def test_graph_version_zero_and_alias_ids_fail_closed() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        _graph(version=0)
+    with pytest.raises(pydantic.ValidationError, match="mutable alias|immutable"):
+        _graph(graph_id="latest")

--- a/tests/test_semantic_manifest_binding_contracts.py
+++ b/tests/test_semantic_manifest_binding_contracts.py
@@ -1,0 +1,372 @@
+"""Adversarial tests for ApplicationManifest, ImplementationBinding, and the
+ADR 0006 capability-advertisement interlock."""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from mozaiksai.core.app_context.models import AppContextMode
+from mozaiksai.core.semantics import (
+    SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY,
+    SEMANTIC_TAXONOMY_CAPABILITY,
+    ApplicationManifest,
+    ArtifactRevisionRef,
+    BuildContextBindingRef,
+    CapabilityPackSelection,
+    DeploymentProfileSelection,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    RendererSelection,
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraphRef,
+    SemanticNode,
+    SemanticNodeKind,
+    TaxonomyNamespaceRef,
+    advertised_semantic_compiler_capabilities,
+    build_application_manifest,
+    build_implementation_binding,
+    build_semantic_graph,
+    semantic_capability_advertisement_gate,
+    validate_implementation_binding_against_graph,
+)
+from mozaiksai.core.semantics.binding import ImplementationBindingError
+
+DIGEST = "0" * 64
+PRE_APP_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", pre_app_scope_id="creation-1")
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="ws-1")
+OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-2")
+
+
+def _graph(scope=SCOPE):
+    nodes = [
+        SemanticNode(node_id="mozaiks.pages.home", kind=SemanticNodeKind.PAGE),
+        SemanticNode(node_id="mozaiks.capabilities.billing", kind=SemanticNodeKind.CAPABILITY),
+        SemanticNode(node_id="mozaiks.targets.default", kind=SemanticNodeKind.DEPLOYMENT_TARGET),
+        SemanticNode(node_id="mozaiks.events.paid", kind=SemanticNodeKind.EVENT),
+    ]
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.capabilities.billing",
+            target_node_id="mozaiks.events.paid",
+        )
+    ]
+    return build_semantic_graph(
+        graph_id="graph-1", version=1, scope=scope, nodes=nodes, edges=edges
+    )
+
+
+def _graph_ref(graph):
+    return SemanticGraphRef(
+        subject_id=graph.graph_id,
+        subject_version=graph.version,
+        content_digest=graph.graph_digest,
+        scope=graph.scope,
+    )
+
+
+def _binding(graph, **overrides):
+    fields = {
+        "binding_id": "binding-1",
+        "version": 1,
+        "scope": graph.scope,
+        "semantic_graph_ref": _graph_ref(graph),
+        "capability_pack_selections": (
+            CapabilityPackSelection(
+                requirement_node_id="mozaiks.capabilities.billing",
+                pack_id="mozaikspay",
+                pack_digest=DIGEST,
+            ),
+        ),
+        "renderer_selections": (
+            RendererSelection(
+                requirement_node_id="mozaiks.pages.home",
+                renderer_id="page_schema_renderer",
+                renderer_version="1.0.0",
+            ),
+        ),
+        "deployment_profile_selections": (
+            DeploymentProfileSelection(
+                requirement_node_id="mozaiks.targets.default",
+                profile_id="docker_compose",
+                profile_version="1",
+            ),
+        ),
+    }
+    fields.update(overrides)
+    return build_implementation_binding(**fields)
+
+
+def _manifest_fields(scope=PRE_APP_SCOPE, **overrides):
+    graph = _graph(scope=scope)
+    binding = _binding(graph)
+    fields = {
+        "manifest_id": "manifest-1",
+        "version": 1,
+        "scope": scope,
+        "mode": AppContextMode.GREENFIELD,
+        "app_id": None,
+        "semantic_graph_ref": _graph_ref(graph),
+        "implementation_binding_ref": ImplementationBindingRef(
+            subject_id=binding.binding_id,
+            subject_version=binding.version,
+            content_digest=binding.binding_digest,
+            scope=scope,
+        ),
+        "taxonomy_refs": (
+            TaxonomyNamespaceRef(
+                namespace_id="mozaiks.events", namespace_version=1, content_digest=DIGEST
+            ),
+        ),
+        "build_context_binding_ref": BuildContextBindingRef(
+            subject_id="build-context-1",
+            subject_version=1,
+            content_digest=DIGEST,
+            scope=scope,
+        ),
+        "artifact_revision_ref": None,
+        "compiler_version": "mozaiks.compiler.v1",
+        "renderer_registry_version": "mozaiks.app_layout.v1",
+    }
+    fields.update(overrides)
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# ApplicationManifest
+# ---------------------------------------------------------------------------
+
+
+def test_pre_app_manifest_requires_creation_scope_not_app_id() -> None:
+    manifest = build_application_manifest(**_manifest_fields())
+    assert manifest.app_id is None
+    assert manifest.scope.pre_app_scope_id == "creation-1"
+
+    no_creation_scope = ExecutionAccessScopeRef(tenant_id="tenant-1")
+    with pytest.raises(pydantic.ValidationError, match="pre_app_scope_id"):
+        build_application_manifest(**_manifest_fields(scope=no_creation_scope))
+
+
+def test_assigning_app_id_is_a_new_immutable_version() -> None:
+    pre = build_application_manifest(**_manifest_fields())
+    with pytest.raises(pydantic.ValidationError):
+        pre.app_id = "app-1"
+
+    assigned = build_application_manifest(**_manifest_fields(version=2, app_id="app-1"))
+    assert assigned.version == 2
+    assert assigned.app_id == "app-1"
+    assert assigned.scope == pre.scope
+    assert assigned.manifest_digest != pre.manifest_digest
+    assert pre.app_id is None
+
+
+@pytest.mark.parametrize("mode", list(AppContextMode))
+def test_manifest_supports_all_context_modes(mode: AppContextMode) -> None:
+    manifest = build_application_manifest(**_manifest_fields(mode=mode))
+    assert manifest.mode is mode
+
+
+def test_manifest_rejects_cross_scope_references() -> None:
+    fields = _manifest_fields()
+    foreign_graph = _graph(scope=OTHER_SCOPE)
+    fields["semantic_graph_ref"] = _graph_ref(foreign_graph)
+    with pytest.raises(pydantic.ValidationError, match="cross-scope"):
+        build_application_manifest(**fields)
+
+    fields = _manifest_fields()
+    fields["artifact_revision_ref"] = ArtifactRevisionRef(
+        subject_id="rev-1", subject_version=1, content_digest=DIGEST, scope=OTHER_SCOPE
+    )
+    with pytest.raises(pydantic.ValidationError, match="cross-scope"):
+        build_application_manifest(**fields)
+
+
+def test_manifest_rejects_unknown_fields_and_duplicate_taxonomy_pins() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        build_application_manifest(**_manifest_fields(), surprise=True)
+
+    duplicate = (
+        TaxonomyNamespaceRef(
+            namespace_id="mozaiks.events", namespace_version=1, content_digest=DIGEST
+        ),
+        TaxonomyNamespaceRef(
+            namespace_id="mozaiks.events", namespace_version=2, content_digest=DIGEST
+        ),
+    )
+    with pytest.raises(pydantic.ValidationError, match="duplicate pinned taxonomy"):
+        build_application_manifest(**_manifest_fields(taxonomy_refs=duplicate))
+
+    with pytest.raises(pydantic.ValidationError):
+        build_application_manifest(**_manifest_fields(taxonomy_refs=()))
+
+
+def test_manifest_digest_tamper_fails_closed() -> None:
+    manifest = build_application_manifest(**_manifest_fields())
+    payload = manifest.model_dump()
+    payload["manifest_digest"] = "0" * 64
+    with pytest.raises(pydantic.ValidationError, match="manifest_digest"):
+        ApplicationManifest(**payload)
+
+
+def test_manifest_references_do_not_duplicate_graph_content() -> None:
+    field_names = set(ApplicationManifest.model_fields)
+    assert field_names == {
+        "schema_version",
+        "manifest_id",
+        "version",
+        "scope",
+        "mode",
+        "app_id",
+        "semantic_graph_ref",
+        "implementation_binding_ref",
+        "taxonomy_refs",
+        "build_context_binding_ref",
+        "artifact_revision_ref",
+        "compiler_version",
+        "renderer_registry_version",
+        "manifest_digest",
+    }
+
+
+# ---------------------------------------------------------------------------
+# ImplementationBinding
+# ---------------------------------------------------------------------------
+
+
+def test_valid_binding_passes_graph_validation() -> None:
+    graph = _graph()
+    binding = _binding(graph)
+    validate_implementation_binding_against_graph(binding, graph)
+
+
+def test_binding_cannot_select_for_absent_nodes() -> None:
+    graph = _graph()
+    binding = _binding(
+        graph,
+        capability_pack_selections=(
+            CapabilityPackSelection(
+                requirement_node_id="mozaiks.capabilities.ghost",
+                pack_id="mozaikspay",
+                pack_digest=DIGEST,
+            ),
+        ),
+    )
+    with pytest.raises(ImplementationBindingError, match="cannot widen graph semantics"):
+        validate_implementation_binding_against_graph(binding, graph)
+
+
+def test_binding_cannot_select_against_wrong_node_kind() -> None:
+    graph = _graph()
+    binding = _binding(
+        graph,
+        renderer_selections=(
+            RendererSelection(
+                requirement_node_id="mozaiks.events.paid",
+                renderer_id="page_schema_renderer",
+                renderer_version="1.0.0",
+            ),
+        ),
+    )
+    with pytest.raises(ImplementationBindingError, match="allowed kinds"):
+        validate_implementation_binding_against_graph(binding, graph)
+
+
+def test_binding_has_no_fields_that_could_add_semantics() -> None:
+    from mozaiksai.core.semantics.binding import ImplementationBinding
+
+    assert set(ImplementationBinding.model_fields) == {
+        "schema_version",
+        "binding_id",
+        "version",
+        "scope",
+        "semantic_graph_ref",
+        "capability_pack_selections",
+        "renderer_selections",
+        "deployment_profile_selections",
+        "binding_digest",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        _binding(_graph(), pages=("mozaiks.pages.extra",))
+
+
+def test_binding_pin_must_match_graph_identity() -> None:
+    graph = _graph()
+    binding = _binding(graph)
+    other = build_semantic_graph(
+        graph_id="graph-1",
+        version=2,
+        scope=SCOPE,
+        nodes=list(graph.nodes),
+        edges=list(graph.edges),
+    )
+    with pytest.raises(ImplementationBindingError, match="pin"):
+        validate_implementation_binding_against_graph(binding, other)
+
+
+def test_binding_scope_must_match_graph_scope() -> None:
+    graph = _graph()
+    foreign_graph = _graph(scope=OTHER_SCOPE)
+    binding = _binding(foreign_graph)
+    with pytest.raises(ImplementationBindingError, match="scope"):
+        validate_implementation_binding_against_graph(binding, graph)
+
+
+def test_duplicate_selections_for_one_requirement_fail_closed() -> None:
+    graph = _graph()
+    with pytest.raises(pydantic.ValidationError, match="duplicate capability-pack"):
+        _binding(
+            graph,
+            capability_pack_selections=(
+                CapabilityPackSelection(
+                    requirement_node_id="mozaiks.capabilities.billing",
+                    pack_id="mozaikspay",
+                    pack_digest=DIGEST,
+                ),
+                CapabilityPackSelection(
+                    requirement_node_id="mozaiks.capabilities.billing",
+                    pack_id="other_pack",
+                    pack_digest=DIGEST,
+                ),
+            ),
+        )
+
+
+def test_binding_is_immutable_and_digest_tamper_fails() -> None:
+    graph = _graph()
+    binding = _binding(graph)
+    with pytest.raises(pydantic.ValidationError):
+        binding.version = 2
+    payload = binding.model_dump()
+    payload["binding_digest"] = "0" * 64
+    from mozaiksai.core.semantics.binding import ImplementationBinding
+
+    with pytest.raises(pydantic.ValidationError, match="binding_digest"):
+        ImplementationBinding(**payload)
+
+
+# ---------------------------------------------------------------------------
+# ADR 0006 capability interlock
+# ---------------------------------------------------------------------------
+
+
+def test_capability_identifiers_match_adr_0007() -> None:
+    assert SEMANTIC_TAXONOMY_CAPABILITY == "semantic_taxonomy_v1"
+    assert SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY == "semantic_reference_contracts_v1"
+
+
+def test_capabilities_are_not_advertised_and_never_partially() -> None:
+    advertised = advertised_semantic_compiler_capabilities()
+    assert advertised == ()
+    # Joint-or-none: the only legal non-empty answer is both identifiers.
+    assert set(advertised) in (
+        set(),
+        {SEMANTIC_TAXONOMY_CAPABILITY, SEMANTIC_REFERENCE_CONTRACTS_CAPABILITY},
+    )
+
+
+def test_advertisement_gate_names_the_advisory_mode_blocker() -> None:
+    gate = semantic_capability_advertisement_gate()
+    assert "advisory" in gate
+    assert "blocked" in gate

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -1,0 +1,317 @@
+"""Adversarial tests for the strict scoped/unscoped reference contracts."""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from mozaiksai.core.semantics import (
+    ApplicationManifestRef,
+    ArtifactRevisionRef,
+    BuildContextBindingRef,
+    ChildContractRef,
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    RefDocumentType,
+    ReferenceResolutionError,
+    RefinementPatchRef,
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraphRef,
+    SemanticNode,
+    SemanticNodeKind,
+    SemanticReferenceResolver,
+    TaxonomyNamespaceRef,
+    build_semantic_graph,
+)
+
+DIGEST = "0" * 64
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="ws-1")
+OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-2")
+
+SCOPED_REF_TYPES = [
+    ApplicationManifestRef,
+    SemanticGraphRef,
+    ImplementationBindingRef,
+    CompilationPlanRef,
+    BuildContextBindingRef,
+    RefinementPatchRef,
+    ArtifactRevisionRef,
+]
+
+
+def _ref(ref_type, **overrides):
+    fields = {
+        "subject_id": "subject-1",
+        "subject_version": 1,
+        "content_digest": DIGEST,
+        "scope": SCOPE,
+    }
+    fields.update(overrides)
+    return ref_type(**fields)
+
+
+@pytest.mark.parametrize("ref_type", SCOPED_REF_TYPES)
+def test_scoped_refs_pin_all_identity_fields(ref_type) -> None:
+    ref = _ref(ref_type)
+    assert ref.subject_version == 1
+    assert ref.content_digest == DIGEST
+    assert ref.scope == SCOPE
+    assert ref.ref_schema_version.startswith("mozaiks.")
+
+
+@pytest.mark.parametrize("ref_type", SCOPED_REF_TYPES)
+@pytest.mark.parametrize(
+    "missing", ["subject_id", "subject_version", "content_digest", "scope"]
+)
+def test_missing_immutable_identity_fields_fail_closed(ref_type, missing) -> None:
+    fields = {
+        "subject_id": "subject-1",
+        "subject_version": 1,
+        "content_digest": DIGEST,
+        "scope": SCOPE,
+    }
+    del fields[missing]
+    with pytest.raises(pydantic.ValidationError):
+        ref_type(**fields)
+
+
+@pytest.mark.parametrize("ref_type", SCOPED_REF_TYPES)
+def test_unknown_fields_fail_closed(ref_type) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        _ref(ref_type, surprise="value")
+
+
+@pytest.mark.parametrize("ref_type", SCOPED_REF_TYPES)
+def test_refs_are_immutable(ref_type) -> None:
+    ref = _ref(ref_type)
+    with pytest.raises(pydantic.ValidationError):
+        ref.subject_version = 2
+
+
+@pytest.mark.parametrize("alias", ["latest", "current", "head", "tip", "newest"])
+def test_mutable_alias_subject_ids_fail_closed(alias: str) -> None:
+    with pytest.raises(pydantic.ValidationError, match="mutable alias"):
+        _ref(SemanticGraphRef, subject_id=alias)
+
+
+@pytest.mark.parametrize("bad_version", ["latest", "1", 0, -1, 1.5, None])
+def test_non_immutable_versions_fail_closed(bad_version) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        _ref(SemanticGraphRef, subject_version=bad_version)
+
+
+@pytest.mark.parametrize("bad_digest", ["", "abc", "Z" * 64, "0" * 63, "0" * 65])
+def test_malformed_digests_fail_closed(bad_digest: str) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        _ref(SemanticGraphRef, content_digest=bad_digest)
+
+
+def test_taxonomy_namespace_ref_is_unscoped() -> None:
+    ref = TaxonomyNamespaceRef(
+        namespace_id="mozaiks.events", namespace_version=1, content_digest=DIGEST
+    )
+    assert not hasattr(ref, "scope")
+    with pytest.raises(pydantic.ValidationError):
+        TaxonomyNamespaceRef(
+            namespace_id="mozaiks.events",
+            namespace_version=1,
+            content_digest=DIGEST,
+            scope=SCOPE,
+        )
+
+
+def test_taxonomy_namespace_ref_rejects_alias_and_bad_version() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        TaxonomyNamespaceRef(namespace_id="latest", namespace_version=1, content_digest=DIGEST)
+    with pytest.raises(pydantic.ValidationError):
+        TaxonomyNamespaceRef(
+            namespace_id="mozaiks.events", namespace_version="latest", content_digest=DIGEST
+        )
+
+
+def test_child_contract_ref_pins_family_path_and_schema() -> None:
+    ref = ChildContractRef(
+        subject_id="module-users",
+        subject_version=3,
+        content_digest=DIGEST,
+        scope=SCOPE,
+        artifact_family="module_manifest",
+        canonical_relative_path="modules/users/module.yaml",
+        contract_schema_version="mozaiks.module.v1",
+    )
+    assert ref.artifact_family == "module_manifest"
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/abs/path.yaml",
+        "a\\b.yaml",
+        "C:/x.yaml",
+        "../escape.yaml",
+        "a/../b.yaml",
+        "a//b.yaml",
+        "a/./b.yaml",
+        "a/*.yaml",
+        "",
+    ],
+)
+def test_child_contract_ref_rejects_non_canonical_paths(bad_path: str) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        ChildContractRef(
+            subject_id="module-users",
+            subject_version=1,
+            content_digest=DIGEST,
+            scope=SCOPE,
+            artifact_family="module_manifest",
+            canonical_relative_path=bad_path,
+            contract_schema_version="mozaiks.module.v1",
+        )
+
+
+def test_scope_ref_requires_valid_identifiers() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        ExecutionAccessScopeRef(tenant_id="")
+    with pytest.raises(pydantic.ValidationError):
+        ExecutionAccessScopeRef(tenant_id="latest")
+    scope = ExecutionAccessScopeRef(tenant_id="t1", pre_app_scope_id="pre-1")
+    assert scope.pre_app_scope_id == "pre-1"
+
+
+# ---------------------------------------------------------------------------
+# Resolver behavior
+# ---------------------------------------------------------------------------
+
+
+def _graph(scope=SCOPE, version=1):
+    node = SemanticNode(node_id="mozaiks.pages.home", kind=SemanticNodeKind.PAGE)
+    event = SemanticNode(node_id="mozaiks.events.created", kind=SemanticNodeKind.EVENT)
+    edge = SemanticEdge(
+        kind=SemanticEdgeKind.EMITS,
+        source_node_id="mozaiks.pages.home",
+        target_node_id="mozaiks.events.created",
+    )
+    return build_semantic_graph(
+        graph_id="graph-1", version=version, scope=scope, nodes=[node, event], edges=[edge]
+    )
+
+
+def _graph_ref(graph, **overrides):
+    fields = {
+        "subject_id": graph.graph_id,
+        "subject_version": graph.version,
+        "content_digest": graph.graph_digest,
+        "scope": graph.scope,
+    }
+    fields.update(overrides)
+    return SemanticGraphRef(**fields)
+
+
+def test_resolver_returns_content_for_fully_pinned_ref() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    resolved = resolver.resolve(_graph_ref(graph), requesting_scope=SCOPE)
+    assert resolved is graph
+
+
+def test_resolver_rejects_unknown_version_without_fallback() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    with pytest.raises(ReferenceResolutionError, match="never fall back"):
+        resolver.resolve(
+            _graph_ref(graph, subject_version=2, content_digest=DIGEST),
+            requesting_scope=SCOPE,
+        )
+
+
+def test_resolver_rejects_digest_mismatch() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    with pytest.raises(ReferenceResolutionError, match="digest mismatch"):
+        resolver.resolve(_graph_ref(graph, content_digest=DIGEST), requesting_scope=SCOPE)
+
+
+def test_resolver_rejects_document_type_mismatch() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    wrong_type_ref = ApplicationManifestRef(
+        subject_id=graph.graph_id,
+        subject_version=graph.version,
+        content_digest=graph.graph_digest,
+        scope=SCOPE,
+    )
+    with pytest.raises(ReferenceResolutionError, match="document type mismatch"):
+        resolver.resolve(wrong_type_ref, requesting_scope=SCOPE)
+
+
+def test_resolver_rejects_cross_scope_access() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    with pytest.raises(ReferenceResolutionError, match="cross-scope"):
+        resolver.resolve(_graph_ref(graph), requesting_scope=OTHER_SCOPE)
+
+
+def test_resolver_rejects_ref_scope_that_does_not_own_subject() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    foreign_ref = _graph_ref(graph, scope=OTHER_SCOPE)
+    with pytest.raises(ReferenceResolutionError, match="scope"):
+        resolver.resolve(foreign_ref, requesting_scope=OTHER_SCOPE)
+
+
+def test_resolver_subjects_are_immutable() -> None:
+    resolver = SemanticReferenceResolver()
+    graph = _graph()
+    resolver.register_semantic_graph(graph)
+    with pytest.raises(ReferenceResolutionError, match="immutable"):
+        resolver.register_semantic_graph(graph)
+
+
+def test_resolver_has_no_bare_id_lookup_surface() -> None:
+    resolver = SemanticReferenceResolver()
+    public = [name for name in dir(resolver) if not name.startswith("_")]
+    assert set(public) == {
+        "register_semantic_graph",
+        "register_application_manifest",
+        "register_implementation_binding",
+        "register_taxonomy_namespace",
+        "register_opaque_subject",
+        "resolve",
+        "resolve_manifest_ref",
+        "resolve_taxonomy_namespace",
+    }
+
+
+def test_opaque_subjects_resolve_for_ref_only_kinds() -> None:
+    resolver = SemanticReferenceResolver()
+    resolver.register_opaque_subject(
+        kind=RefDocumentType.COMPILATION_PLAN,
+        subject_id="plan-1",
+        version=1,
+        digest=DIGEST,
+        scope=SCOPE,
+    )
+    ref = CompilationPlanRef(
+        subject_id="plan-1", subject_version=1, content_digest=DIGEST, scope=SCOPE
+    )
+    assert resolver.resolve(ref, requesting_scope=SCOPE) is None
+
+
+def test_content_bearing_kinds_cannot_register_opaque() -> None:
+    resolver = SemanticReferenceResolver()
+    with pytest.raises(ReferenceResolutionError, match="content-bearing"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.SEMANTIC_GRAPH,
+            subject_id="graph-1",
+            version=1,
+            digest=DIGEST,
+            scope=SCOPE,
+        )

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -345,8 +345,32 @@ def test_opaque_registration_validates_immutable_identity() -> None:
         )
 
 
-def test_child_contract_registration_requires_and_pins_typed_identity() -> None:
+def _child_ref(**overrides) -> ChildContractRef:
+    fields = {
+        "subject_id": "child-1",
+        "subject_version": 1,
+        "content_digest": DIGEST,
+        "scope": SCOPE,
+        "artifact_family": "module_manifest",
+        "canonical_relative_path": "modules/users/module.yaml",
+        "contract_schema_version": "mozaiks.module.v1",
+    }
+    fields.update(overrides)
+    return ChildContractRef(**fields)
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["artifact_family", "canonical_relative_path", "contract_schema_version"],
+)
+def test_child_contract_registration_requires_each_child_identity_field(missing: str) -> None:
     resolver = SemanticReferenceResolver()
+    fields = {
+        "artifact_family": "module_manifest",
+        "canonical_relative_path": "modules/users/module.yaml",
+        "contract_schema_version": "mozaiks.module.v1",
+    }
+    del fields[missing]
     with pytest.raises(pydantic.ValidationError):
         resolver.register_opaque_subject(
             kind=RefDocumentType.CHILD_CONTRACT,
@@ -354,8 +378,12 @@ def test_child_contract_registration_requires_and_pins_typed_identity() -> None:
             version=1,
             digest=DIGEST,
             scope=SCOPE,
+            **fields,
         )
 
+
+def test_child_contract_registration_and_matching_resolution_pin_typed_identity() -> None:
+    resolver = SemanticReferenceResolver()
     resolver.register_opaque_subject(
         kind=RefDocumentType.CHILD_CONTRACT,
         subject_id="child-1",
@@ -366,25 +394,113 @@ def test_child_contract_registration_requires_and_pins_typed_identity() -> None:
         canonical_relative_path="modules/users/module.yaml",
         contract_schema_version="mozaiks.module.v1",
     )
-    matching = ChildContractRef(
+    matching = _child_ref()
+    assert resolver.resolve(matching, requesting_scope=SCOPE) is None
+
+
+@pytest.mark.parametrize(
+    ("field", "substitute", "error"),
+    [
+        ("artifact_family", "page_schema", "typed reference identity mismatch"),
+        (
+            "canonical_relative_path",
+            "modules/admin/module.yaml",
+            "typed reference identity mismatch",
+        ),
+        ("contract_schema_version", "mozaiks.module.v2", "typed reference identity mismatch"),
+        ("subject_id", "child-2", "no subject"),
+        ("subject_version", 2, "never fall back"),
+        ("content_digest", "1" * 64, "digest mismatch"),
+        ("scope", OTHER_SCOPE, "scope mismatch"),
+    ],
+)
+def test_child_contract_substitution_of_each_identity_field_fails_closed(
+    field: str, substitute, error: str
+) -> None:
+    resolver = SemanticReferenceResolver()
+    resolver.register_opaque_subject(
+        kind=RefDocumentType.CHILD_CONTRACT,
         subject_id="child-1",
-        subject_version=1,
-        content_digest=DIGEST,
+        version=1,
+        digest=DIGEST,
         scope=SCOPE,
         artifact_family="module_manifest",
         canonical_relative_path="modules/users/module.yaml",
         contract_schema_version="mozaiks.module.v1",
     )
-    assert resolver.resolve(matching, requesting_scope=SCOPE) is None
 
-    wrong_path = matching.model_copy(
-        update={"canonical_relative_path": "modules/admin/module.yaml"}
+    substituted = _child_ref(**{field: substitute})
+    with pytest.raises(ReferenceResolutionError, match=error):
+        resolver.resolve(substituted, requesting_scope=substituted.scope)
+
+
+def test_child_contract_document_type_substitution_fails_closed() -> None:
+    resolver = SemanticReferenceResolver()
+    resolver.register_opaque_subject(
+        kind=RefDocumentType.CHILD_CONTRACT,
+        subject_id="child-1",
+        version=1,
+        digest=DIGEST,
+        scope=SCOPE,
+        artifact_family="module_manifest",
+        canonical_relative_path="modules/users/module.yaml",
+        contract_schema_version="mozaiks.module.v1",
     )
-    with pytest.raises(ReferenceResolutionError, match="typed reference identity mismatch"):
-        resolver.resolve(wrong_path, requesting_scope=SCOPE)
+    substituted = CompilationPlanRef(
+        subject_id="child-1", subject_version=1, content_digest=DIGEST, scope=SCOPE
+    )
+    with pytest.raises(ReferenceResolutionError, match="document type mismatch"):
+        resolver.resolve(substituted, requesting_scope=SCOPE)
 
 
-def test_non_child_registration_rejects_child_identity_fields() -> None:
+def test_conflicting_child_identity_cannot_reuse_registered_base_identity() -> None:
+    resolver = SemanticReferenceResolver()
+    registration = {
+        "kind": RefDocumentType.CHILD_CONTRACT,
+        "subject_id": "child-1",
+        "version": 1,
+        "digest": DIGEST,
+        "scope": SCOPE,
+        "artifact_family": "module_manifest",
+        "canonical_relative_path": "modules/users/module.yaml",
+        "contract_schema_version": "mozaiks.module.v1",
+    }
+    resolver.register_opaque_subject(**registration)
+    registration["artifact_family"] = "page_schema"
+    with pytest.raises(ReferenceResolutionError, match="immutable.*already registered"):
+        resolver.register_opaque_subject(**registration)
+
+
+def test_child_resolution_is_deterministic_and_does_not_mutate_inputs() -> None:
+    resolver = SemanticReferenceResolver()
+    scope_before = SCOPE.model_dump(mode="json")
+    resolver.register_opaque_subject(
+        kind=RefDocumentType.CHILD_CONTRACT,
+        subject_id="child-1",
+        version=1,
+        digest=DIGEST,
+        scope=SCOPE,
+        artifact_family="module_manifest",
+        canonical_relative_path="modules/users/module.yaml",
+        contract_schema_version="mozaiks.module.v1",
+    )
+    ref = _child_ref()
+    ref_before = ref.model_dump(mode="json")
+    assert resolver.resolve(ref, requesting_scope=SCOPE) is None
+    assert resolver.resolve(ref, requesting_scope=SCOPE) is None
+    assert ref.model_dump(mode="json") == ref_before
+    assert SCOPE.model_dump(mode="json") == scope_before
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("artifact_family", "module_manifest"),
+        ("canonical_relative_path", "modules/users/module.yaml"),
+        ("contract_schema_version", "mozaiks.module.v1"),
+    ],
+)
+def test_non_child_registration_rejects_child_identity_fields(field: str, value: str) -> None:
     resolver = SemanticReferenceResolver()
     with pytest.raises(ReferenceResolutionError, match="only for child contracts"):
         resolver.register_opaque_subject(
@@ -393,5 +509,5 @@ def test_non_child_registration_rejects_child_identity_fields() -> None:
             version=1,
             digest=DIGEST,
             scope=SCOPE,
-            artifact_family="module_manifest",
+            **{field: value},
         )

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -315,3 +315,83 @@ def test_content_bearing_kinds_cannot_register_opaque() -> None:
             digest=DIGEST,
             scope=SCOPE,
         )
+
+
+def test_opaque_registration_validates_immutable_identity() -> None:
+    resolver = SemanticReferenceResolver()
+    with pytest.raises(pydantic.ValidationError, match="mutable alias"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.COMPILATION_PLAN,
+            subject_id="latest",
+            version=1,
+            digest=DIGEST,
+            scope=SCOPE,
+        )
+    with pytest.raises(pydantic.ValidationError, match="greater than or equal to 1"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.COMPILATION_PLAN,
+            subject_id="plan-1",
+            version=0,
+            digest=DIGEST,
+            scope=SCOPE,
+        )
+    with pytest.raises(pydantic.ValidationError, match="lowercase hex"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.COMPILATION_PLAN,
+            subject_id="plan-1",
+            version=1,
+            digest="Z" * 64,
+            scope=SCOPE,
+        )
+
+
+def test_child_contract_registration_requires_and_pins_typed_identity() -> None:
+    resolver = SemanticReferenceResolver()
+    with pytest.raises(pydantic.ValidationError):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.CHILD_CONTRACT,
+            subject_id="child-1",
+            version=1,
+            digest=DIGEST,
+            scope=SCOPE,
+        )
+
+    resolver.register_opaque_subject(
+        kind=RefDocumentType.CHILD_CONTRACT,
+        subject_id="child-1",
+        version=1,
+        digest=DIGEST,
+        scope=SCOPE,
+        artifact_family="module_manifest",
+        canonical_relative_path="modules/users/module.yaml",
+        contract_schema_version="mozaiks.module.v1",
+    )
+    matching = ChildContractRef(
+        subject_id="child-1",
+        subject_version=1,
+        content_digest=DIGEST,
+        scope=SCOPE,
+        artifact_family="module_manifest",
+        canonical_relative_path="modules/users/module.yaml",
+        contract_schema_version="mozaiks.module.v1",
+    )
+    assert resolver.resolve(matching, requesting_scope=SCOPE) is None
+
+    wrong_path = matching.model_copy(
+        update={"canonical_relative_path": "modules/admin/module.yaml"}
+    )
+    with pytest.raises(ReferenceResolutionError, match="typed reference identity mismatch"):
+        resolver.resolve(wrong_path, requesting_scope=SCOPE)
+
+
+def test_non_child_registration_rejects_child_identity_fields() -> None:
+    resolver = SemanticReferenceResolver()
+    with pytest.raises(ReferenceResolutionError, match="only for child contracts"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.COMPILATION_PLAN,
+            subject_id="plan-1",
+            version=1,
+            digest=DIGEST,
+            scope=SCOPE,
+            artifact_family="module_manifest",
+        )


### PR DESCRIPTION
## Summary

Implements **ADR 0007 Slice 2 only**: the strict, immutable contract layer for `ApplicationManifest`, `SemanticGraph`, `ImplementationBinding`, and the full typed reference roster, with one canonical serialization/digest contract, deterministic node/edge identity, and fail-closed reference resolution and closure validation — all behind non-production/test seams. Base: `cb9e6b3b` (current `origin/main`, Slice 1 merged). No live models ran.

## Contracts introduced (`mozaiksai/core/semantics/`, new package)

| Contract | Schema version |
|---|---|
| Canonical serialization + digest | `mozaiks.canonical_json.v1` |
| `ExecutionAccessScopeRef` (tenant / workspace / pre-app creation scope) | `mozaiks.execution_access_scope_ref.v1` |
| `ApplicationManifestRef`, `SemanticGraphRef`, `ImplementationBindingRef`, `CompilationPlanRef`, `BuildContextBindingRef`, `RefinementPatchRef`, `ArtifactRevisionRef` | `mozaiks.<name>_ref.v1` each |
| Typed child-contract ref (family + canonical relative path + contract schema version + digest) | `mozaiks.child_contract_ref.v1` |
| `TaxonomyNamespaceRef` (unscoped: namespace id + version + digest) | `mozaiks.taxonomy_namespace_ref.v1` |
| `ApplicationManifest` | `mozaiks.app_manifest.v1` |
| `SemanticGraph` | `mozaiks.semantic_graph.v1` |
| `ImplementationBinding` | `mozaiks.implementation_binding.v1` |

**Test seams**: nothing outside `mozaiksai/core/semantics/` imports the package (verified by repo grep and by the fact that no production file changed). It takes no authority from the generator, runtime contracts, refinement system, or `AppBuildPlan`.

## Canonical serialization rules (one implementation, models cannot invent digests)

Sorted keys, `,`/`:` separators, all non-ASCII escaped (pure-ASCII bytes → platform-independent); mapping keys must be `str` (silent JSON key coercion rejected); values limited to `None`/`bool`/`str`/int64-range `int`/finite `float`/sequences/mappings — sets, bytes, datetimes, and arbitrary objects fail closed; NaN/±inf fail closed; `-0.0` normalizes to `0.0`; `bool` never conflates with `int`; sequences preserve order (schemas must pre-sort collections they declare unordered — the taxonomy/graph models do); every payload field participates in the digest, and exclusions must be schema-explicit; inputs are never mutated. Digest = SHA-256 hex over the ASCII bytes. Golden vectors (exact bytes + digests) committed in tests, including a subprocess-restart digest proof.

## Identity and resolution behavior

- **Node identity**: namespace-qualified dotted `node_id`, stable across graph versions, independent of list order.
- **Edge identity**: canonical digest of `{kind, source, target, discriminator}`; golden vector committed; duplicates and collisions fail closed; discriminators distinguish parallel edges.
- **References**: every scoped ref pins ref schema version, typed subject id, immutable integer version (so `"latest"` fails typing), content digest, and scope; alias identifiers (`latest`/`current`/`head`/…) are rejected as ids. Resolution verifies required fields, expected document type, exact version (no fallback), digest, ref-scope ownership, and requesting-scope equality — each proven to fail closed independently. The resolver's public surface has **no bare-id/path/family/current lookup** (asserted by test).

## Graph closure and scope enforcement

Dangling edge endpoints, dangling node references, and unresolvable taxonomy references fail closed (closure validates against the **Slice 1 `TaxonomyRegistry` authority** — no parallel registry). Extension nodes must sit inside granted namespace roots; the core root cannot be granted. Graph scope is embedded in the digest and must equal the manifest scope (mismatch is a validation error). Manifest/binding cross-scope references fail closed. Pre-app manifests require `scope.pre_app_scope_id` and `app_id=None`; assigning a real `app_id` requires a new manifest version (documents are frozen; mutation raises). The binding is structurally unable to add semantics (field-set asserted by test) and validation rejects selections for absent or wrong-kind requirement nodes.

## ADR 0006 capability interlock — NOT advertised, with the exact gate

`semantic_taxonomy_v1` and `semantic_reference_contracts_v1` are **not advertised** (neither, per the joint-or-none rule). ADR 0007's rollout table requires slices 1 and 2 to "both pass **outside advisory mode**" before joint advertisement. Slice 1 taxonomy validation currently runs only on the explicit advisory path (`taxonomy_advisory=True`); every production consumer defaults it off. Flipping production taxonomy enforcement is authority-cutover work owned by a later slice, so truthful joint advertisement is impossible today without activating later slices. `mozaiksai/core/semantics/capabilities.py` is the single authority: `advertised_semantic_compiler_capabilities()` returns `()` and `semantic_capability_advertisement_gate()` states this gate; tests pin both and the joint-or-none property. No `JourneyExecutionPort` or other ADR 0006 execution behavior was implemented.

## Decision: `AppContextVersion.semantic_graph_ref` sibling deferred

ADR 0007's Slice 2 component list is "manifest/graph/binding/reference contracts … **test-only seams**"; the sibling field on `AppContextVersion` is production model surface that nothing can populate until projection work (Slice 3+) exists. It is deferred with this rationale rather than added as dead metadata.

## Explicitly not implemented (per task exclusions)

Offline projection adapters; `CompilationPlan` derivation; renderer-registry extensions; generator authority cutover; graph persistence/publication CAS; `ArtifactRevision` content/promotion; `RefinementPatch` application; graph-based refinement; strict structured-output cutover; `AppBuildPlan` retirement; runtime-loader changes; entitlement-policy changes; live evaluation; migrations; the `mozaiksai.hosts.studio` import-time env side effect (tracked separately). No workflow steps, transitions, prompts, AG2 execution, generated-app formats, or runtime loading changed.

## Changed files (13, all additive except CHANGELOG)

`mozaiksai/core/semantics/{__init__,canonical,refs,graph,manifest,binding,resolver,capabilities}.py`; `tests/test_semantic_{canonical_serialization,reference_contracts,graph_contract,manifest_binding_contracts}.py`; `CHANGELOG.md` (Unreleased entry).

## Validation (local, no live models)

- **152 new adversarial contract tests** — all pass (golden vectors; subprocess digest stability; key-order independence; strict unknown-field rejection; immutability; stable node/edge identities; order-independent graph identity; duplicate/collision rejection; dangling-reference rejection; taxonomy closure; namespace isolation; wrong type/version/digest; missing identity fields; mutable aliases; pre-app scope; cross-tenant/cross-scope rejection; manifest/graph scope mismatch; binding-widening attempts; input immutability).
- Direct consumers: `test_semantic_taxonomy`, `test_app_context_models`, `test_app_context_store_helpers`, `test_workflow_context_authority_compile`, `test_production_readiness_gate`, `test_app_layout_registry` — **331 passed**.
- `ruff check .` clean; governance guardrails pass; source-hygiene scan 0 violations; `git diff --check` clean; DCO sign-off on the commit. Local mypy hits a pre-existing environment artifact (numpy 2.5 stubs vs the local Python 3.13 venv under the repo's `python_version=3.11` config — identical failure on untouched Slice 1 files); CI's lint job on real 3.11 is the authoritative mypy run.
- No MkDocs change (no docs files touched), so no strict docs build required.
- Full-suite evidence: GitHub's four test shards on this PR.

## Deferred to Slices 3–7

Offline projection adapters and archetype-corpus equivalence (3); derived `CompilationPlan` + renderer-registry extension (4); authority cutover, strict structured outputs, persistence unification, taxonomy-enforcement flip that unlocks joint capability advertisement (5); typed graph refinement (6); retirement and hygiene-guard extension (7).

Draft PR; auto-merge disabled; do not merge — requesting one independent exact-head review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
