### PR TITLE
fix(hosts): make host imports process-inert; apply Studio defaults at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Changed
+
+- **Importing `mozaiksai.hosts.studio` no longer mutates the process
+  environment.** Repo-local Studio defaults (`PLATFORM_PATH`,
+  `MOZAIKS_WORKFLOWS_PATH`) and OpenTelemetry configuration are now applied
+  exactly once at server startup — before runtime/platform startup resolves
+  app and workflow roots — instead of at module import time. The
+  `uvicorn mozaiksai.hosts.studio:app` entrypoint, `mozaiks serve`, and
+  app-local host composition are unchanged; caller-provided environment
+  values keep precedence, and embedders that only import the host module no
+  longer see their environment rewritten.
+
 ### Added
 
 - **Semantic-compiler contract layer (ADR 0007 Slice 2)**: strict, immutable,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,16 @@ This project follows a practical pre-1.0 changelog format:
 - **Importing `mozaiksai.hosts.studio` no longer mutates the process
   environment.** Repo-local Studio defaults (`PLATFORM_PATH`,
   `MOZAIKS_WORKFLOWS_PATH`) and OpenTelemetry configuration are now applied
-  exactly once at server startup — before runtime/platform startup resolves
-  app and workflow roots — instead of at module import time. The
-  `uvicorn mozaiksai.hosts.studio:app` entrypoint, `mozaiks serve`, and
-  app-local host composition are unchanged; caller-provided environment
-  values keep precedence, and embedders that only import the host module no
-  longer see their environment rewritten.
+  exactly once at server startup — before runtime and platform startup run —
+  instead of at module import time. Because the global workflow catalog is
+  built when `mozaiksai.core.workflow.workflow_manager` is imported, Studio
+  startup now also rebinds that catalog to the workflow root its defaults
+  select, so `mozaiks serve <workspace> --host studio` still serves the shared
+  factory workflow catalog rather than the workspace's own `workflows/` root.
+  The `uvicorn mozaiksai.hosts.studio:app` entrypoint, `mozaiks serve`, and
+  app-local host composition keep their existing behavior; caller-provided
+  environment values keep precedence, and embedders that only import the host
+  module no longer see their environment rewritten.
 
 ### Added
 

--- a/docs/architecture/hosts/host-composition-contract.md
+++ b/docs/architecture/hosts/host-composition-contract.md
@@ -8,15 +8,24 @@ The supported pattern is:
 ```python
 from importlib import import_module
 
-# Configure workspace environment before importing the Studio host.
+# Configure workspace environment before starting the composed server.
 studio_app = import_module("mozaiksai.hosts.studio")
 app = studio_app.app
 
 # App-local hosts may register product-specific routes on `app`.
 ```
 
-The app-local host must configure workspace paths before importing
-`mozaiksai.hosts.studio`:
+Importing `mozaiksai.hosts.studio` is environment-inert: it composes routes on
+the shared host app but does not mutate `os.environ`, `sys.path`, or the
+working directory. Repo-local defaults (`PLATFORM_PATH`,
+`MOZAIKS_WORKFLOWS_PATH`) are applied exactly once at server startup, before
+runtime and platform startup resolve app/workflow roots, by the Studio host's
+registered bootstrap (`mozaiksai.hosts.bootstrap.configure_repo_host_defaults`).
+Caller-provided environment values always keep precedence over those defaults.
+
+The app-local host must configure workspace paths before the composed server
+starts (setting them before importing `mozaiksai.hosts.studio` remains
+supported and sufficient):
 
 - `MOZAIKS_APP_WORKSPACE_PATH`
 - `PLATFORM_PATH`

--- a/docs/architecture/hosts/host-composition-contract.md
+++ b/docs/architecture/hosts/host-composition-contract.md
@@ -19,13 +19,21 @@ Importing `mozaiksai.hosts.studio` is environment-inert: it composes routes on
 the shared host app but does not mutate `os.environ`, `sys.path`, or the
 working directory. Repo-local defaults (`PLATFORM_PATH`,
 `MOZAIKS_WORKFLOWS_PATH`) are applied exactly once at server startup, before
-runtime and platform startup resolve app/workflow roots, by the Studio host's
-registered bootstrap (`mozaiksai.hosts.bootstrap.configure_repo_host_defaults`).
-Caller-provided environment values always keep precedence over those defaults.
+runtime and platform startup run, by the Studio host's registered bootstrap
+(`mozaiksai.hosts.bootstrap.configure_repo_host_defaults`). Caller-provided
+environment values always keep precedence over those defaults.
+
+One component is not covered by that ordering: the global workflow catalog in
+`mozaiksai.core.workflow.workflow_manager` is built when that module is
+imported, binding whichever workflow root the environment named at the time.
+Studio startup therefore also rebinds the catalog to the root its defaults
+selected (`align_workflow_catalog_with_host_config`), which is a no-op when
+the two already agree.
 
 The app-local host must configure workspace paths before the composed server
-starts (setting them before importing `mozaiksai.hosts.studio` remains
-supported and sufficient):
+starts. Setting them before importing `mozaiksai.hosts.studio` is still the
+recommended pattern — it makes the import-time catalog agree with the startup
+configuration, so no rebind is needed:
 
 - `MOZAIKS_APP_WORKSPACE_PATH`
 - `PLATFORM_PATH`

--- a/mozaiksai/hosts/bootstrap.py
+++ b/mozaiksai/hosts/bootstrap.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncIterator, Mapping
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
 _BOOTSTRAP_STATE_ATTR = "mozaiks_repo_host_bootstrap_hosts"
+_otel_configured = False
 
 
 def _resolve_app_bundle_dir(path_value: str | os.PathLike[str]) -> Path:
@@ -89,6 +90,23 @@ def resolve_repo_host_defaults(
     return updates
 
 
+def _configure_otel_once() -> None:
+    """Configure OpenTelemetry at most once per process.
+
+    ``configure_otel_from_env`` builds a fresh ``TracerProvider`` (and a
+    ``BatchSpanProcessor`` worker thread) on every call, while
+    ``trace.set_tracer_provider`` refuses to replace an installed provider. It
+    used to run once, at host import; the guard keeps that once-per-process
+    behavior now that bootstrap can run on each ASGI startup (``--reload``, or
+    a test that starts the app more than once).
+    """
+    global _otel_configured
+    if _otel_configured:
+        return
+    _otel_configured = True
+    configure_otel_from_env()
+
+
 def configure_repo_host_defaults(host: str) -> None:
     """Apply default app/workflow paths for a real Studio or platform startup.
 
@@ -103,39 +121,98 @@ def configure_repo_host_defaults(host: str) -> None:
     if normalized_host not in {"platform", "studio"}:
         return
 
-    configure_otel_from_env()
+    _configure_otel_once()
     os.environ.update(resolve_repo_host_defaults(normalized_host))
+
+
+def align_workflow_catalog_with_host_config() -> None:
+    """Rebind the global workflow catalog to the root host startup selected.
+
+    ``mozaiksai.core.workflow.workflow_manager`` constructs its global manager
+    at module import, binding whichever workflow root the environment named at
+    that moment. Host startup — not import order — is the authority on that
+    root, so when the two disagree the catalog is rebuilt against the resolved
+    root. The rebuild preserves manager object identity, so modules that
+    imported the manager by value keep working. When the roots already agree
+    (the repo-local and correctly pre-configured cases) this is a no-op.
+
+    Studio is the case that needs it: its defaults prefer the shared factory
+    workflow root, while bare root resolution prefers an app workspace's own
+    ``workflows/``. Without this, ``mozaiks serve <workspace> --host studio``
+    would bind Studio to the workspace's (usually empty) workflow root and lose
+    the entire factory build catalog.
+    """
+    from mozaiksai.core.workflow.paths import resolve_workflows_root
+    from mozaiksai.core.workflow.workflow_manager import initialize_workflows, workflow_manager
+
+    resolved_root = resolve_workflows_root()
+    current_root = getattr(workflow_manager, "workflows_base_path", None)
+    if current_root is not None and Path(str(current_root)) == resolved_root:
+        return
+    initialize_workflows(str(resolved_root))
+
+
+@contextmanager
+def _workflow_catalog_bound_to_host_config() -> Iterator[None]:
+    """Bind the workflow catalog to the host's root for the life of the server.
+
+    The binding is released on shutdown so it lasts exactly as long as the
+    running server does. A process that starts a host, stops it, and starts
+    another (``--reload``, or a test that drives more than one app) then gets
+    the same catalog it would have had on a fresh start, instead of inheriting
+    whichever root the previous server selected.
+    """
+    from mozaiksai.core.workflow import workflow_manager as workflow_manager_module
+
+    manager = workflow_manager_module.workflow_manager
+    catalog_snapshot = dict(manager.__dict__)
+    align_workflow_catalog_with_host_config()
+    if manager.__dict__ == catalog_snapshot:
+        yield
+        return
+    try:
+        yield
+    finally:
+        manager.__dict__.clear()
+        manager.__dict__.update(catalog_snapshot)
+        workflow_manager_module.UnifiedWorkflowManager._instance = manager
+        workflow_manager_module._unified_workflow_manager = manager
+        workflow_manager_module.workflow_manager = manager
 
 
 def register_repo_host_bootstrap(target_app: FastAPI, host: str) -> None:
     """Arrange for ``configure_repo_host_defaults(host)`` to run at server startup.
 
     Wraps the app's composed lifespan so the repo defaults are applied before
-    any lower-layer startup (runtime, platform) resolves app or workflow roots.
-    Importing a host module stays free of environment mutation; only actually
-    starting the server applies defaults. Registration is idempotent per
-    (app, host) so module reloads do not stack duplicate bootstrap layers.
+    any lower-layer startup (runtime, platform) runs, then rebinds the global
+    workflow catalog to the root those defaults selected. Importing a host
+    module stays free of environment mutation; only actually starting the
+    server applies defaults. Registration is idempotent per (app, host) so
+    module reloads do not stack duplicate bootstrap layers.
     """
+    normalized_host = str(host or "").strip().lower()
     registered_hosts = getattr(target_app.state, _BOOTSTRAP_STATE_ATTR, None)
     if registered_hosts is None:
         registered_hosts = set()
         setattr(target_app.state, _BOOTSTRAP_STATE_ATTR, registered_hosts)
-    if host in registered_hosts:
+    if normalized_host in registered_hosts:
         return
-    registered_hosts.add(host)
+    registered_hosts.add(normalized_host)
 
     existing_lifespan = target_app.router.lifespan_context
 
     @asynccontextmanager
     async def _bootstrap_lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
-        configure_repo_host_defaults(host)
-        async with existing_lifespan(app_instance):
-            yield
+        configure_repo_host_defaults(normalized_host)
+        with _workflow_catalog_bound_to_host_config():
+            async with existing_lifespan(app_instance):
+                yield
 
     target_app.router.lifespan_context = _bootstrap_lifespan
 
 
 __all__ = [
+    "align_workflow_catalog_with_host_config",
     "configure_repo_host_defaults",
     "register_repo_host_bootstrap",
     "resolve_repo_host_defaults",

--- a/mozaiksai/hosts/bootstrap.py
+++ b/mozaiksai/hosts/bootstrap.py
@@ -99,12 +99,16 @@ def _configure_otel_once() -> None:
     used to run once, at host import; the guard keeps that once-per-process
     behavior now that bootstrap can run on each ASGI startup (``--reload``, or
     a test that starts the app more than once).
+
+    The flag is set only after configuration returns, so a call that raises
+    leaves observability un-configured and retryable on the next startup
+    instead of permanently marking it done.
     """
     global _otel_configured
     if _otel_configured:
         return
-    _otel_configured = True
     configure_otel_from_env()
+    _otel_configured = True
 
 
 def configure_repo_host_defaults(host: str) -> None:

--- a/mozaiksai/hosts/bootstrap.py
+++ b/mozaiksai/hosts/bootstrap.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import os
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from mozaiksai.core.observability import configure_otel_from_env
 from mozaiksai.core.workflow.paths import candidate_app_workflows_roots
 from mozaiksai.resources import resolve_factory_app_root, resolve_factory_workflows_root
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+_BOOTSTRAP_STATE_ATTR = "mozaiks_repo_host_bootstrap_hosts"
 
 
 def _resolve_app_bundle_dir(path_value: str | os.PathLike[str]) -> Path:
@@ -26,55 +34,109 @@ def _resolve_app_bundle_dir(path_value: str | os.PathLike[str]) -> Path:
     return candidate
 
 
-def configure_repo_host_defaults(host: str) -> None:
-    """Apply default app/workflow paths for Studio and platform hosts.
+def resolve_repo_host_defaults(
+    host: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Compute the default app/workflow env entries for a Studio or platform host.
 
-    The active app workspace comes from PLATFORM_PATH or
-    MOZAIKS_APP_WORKSPACE_PATH when provided. In a repo-local dogfood checkout,
-    fall back to the first-party factory_app/app bundle so Studio/platform hosts
-    have a real app root for shell config, routes, and branding. Shared factory
-    workflows come from the packaged factory_app bundle when that package is
-    installed.
+    Pure computation over ``environ`` (``os.environ`` when omitted): returns the
+    entries a real host startup applies, without mutating anything. The active
+    app workspace comes from PLATFORM_PATH or MOZAIKS_APP_WORKSPACE_PATH when
+    provided; caller-provided values keep precedence and are only normalized to
+    the resolved app bundle directory. In a repo-local dogfood checkout the
+    fallback is the first-party factory_app/app bundle so Studio/platform hosts
+    have a real app root for shell config, routes, and branding.
 
-    A running host should resolve its workflow root through MOZAIKS_WORKFLOWS_PATH
-    or through the host-specific app/factory defaults below.
+    Factory bundle discovery goes through ``mozaiksai.resources`` and therefore
+    consults ``MOZAIKS_FACTORY_APP_PATH`` from the process environment.
     """
+    env: Mapping[str, str] = os.environ if environ is None else environ
     normalized_host = str(host or "").strip().lower()
     if normalized_host not in {"platform", "studio"}:
-        return
+        return {}
 
-    configure_otel_from_env()
+    updates: dict[str, str] = {}
 
-    external_workspace_root = str(os.getenv("MOZAIKS_APP_WORKSPACE_PATH") or "").strip()
-    platform_path = str(os.getenv("PLATFORM_PATH") or "").strip()
+    external_workspace_root = str(env.get("MOZAIKS_APP_WORKSPACE_PATH") or "").strip()
+    platform_path = str(env.get("PLATFORM_PATH") or "").strip()
 
     if platform_path:
-        os.environ["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(platform_path))
+        updates["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(platform_path))
     elif external_workspace_root:
-        os.environ["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(external_workspace_root))
+        updates["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(external_workspace_root))
     else:
         factory_app_root = resolve_factory_app_root()
         if factory_app_root is not None:
-            os.environ["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(factory_app_root))
+            updates["PLATFORM_PATH"] = str(_resolve_app_bundle_dir(factory_app_root))
 
-    single_root = str(os.getenv("MOZAIKS_WORKFLOWS_PATH") or "").strip()
+    single_root = str(env.get("MOZAIKS_WORKFLOWS_PATH") or "").strip()
     if single_root:
-        return
+        return updates
 
-    platform_path = str(os.getenv("PLATFORM_PATH") or "").strip()
-    app_root = _resolve_app_bundle_dir(platform_path) if platform_path else None
+    effective_platform_path = str(updates.get("PLATFORM_PATH") or "").strip()
+    app_root = _resolve_app_bundle_dir(effective_platform_path) if effective_platform_path else None
     app_workflow_roots = candidate_app_workflows_roots(app_root) if app_root else ()
     app_workflows_root = next((root for root in app_workflow_roots if root.is_dir()), None)
     factory_workflows_root = resolve_factory_workflows_root()
 
     if normalized_host == "studio":
         selected_root: Path | None = factory_workflows_root or app_workflows_root
-        if selected_root is not None:
-            os.environ["MOZAIKS_WORKFLOWS_PATH"] = str(selected_root)
     else:
         selected_root = app_workflows_root if (app_workflows_root is not None and app_workflows_root.is_dir()) else factory_workflows_root
-        if selected_root is not None:
-            os.environ["MOZAIKS_WORKFLOWS_PATH"] = str(selected_root)
+    if selected_root is not None:
+        updates["MOZAIKS_WORKFLOWS_PATH"] = str(selected_root)
+    return updates
 
 
-__all__ = ["configure_repo_host_defaults"]
+def configure_repo_host_defaults(host: str) -> None:
+    """Apply default app/workflow paths for a real Studio or platform startup.
+
+    This is the explicit process-bootstrap step: it writes the resolved
+    defaults into ``os.environ`` and configures OpenTelemetry from env. Call it
+    from actual host startup (``register_repo_host_bootstrap``), the CLI, or a
+    script entrypoint — never at module import time. Re-running it is
+    idempotent: values already present keep precedence and resolved defaults
+    are stable for an unchanged environment.
+    """
+    normalized_host = str(host or "").strip().lower()
+    if normalized_host not in {"platform", "studio"}:
+        return
+
+    configure_otel_from_env()
+    os.environ.update(resolve_repo_host_defaults(normalized_host))
+
+
+def register_repo_host_bootstrap(target_app: FastAPI, host: str) -> None:
+    """Arrange for ``configure_repo_host_defaults(host)`` to run at server startup.
+
+    Wraps the app's composed lifespan so the repo defaults are applied before
+    any lower-layer startup (runtime, platform) resolves app or workflow roots.
+    Importing a host module stays free of environment mutation; only actually
+    starting the server applies defaults. Registration is idempotent per
+    (app, host) so module reloads do not stack duplicate bootstrap layers.
+    """
+    registered_hosts = getattr(target_app.state, _BOOTSTRAP_STATE_ATTR, None)
+    if registered_hosts is None:
+        registered_hosts = set()
+        setattr(target_app.state, _BOOTSTRAP_STATE_ATTR, registered_hosts)
+    if host in registered_hosts:
+        return
+    registered_hosts.add(host)
+
+    existing_lifespan = target_app.router.lifespan_context
+
+    @asynccontextmanager
+    async def _bootstrap_lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
+        configure_repo_host_defaults(host)
+        async with existing_lifespan(app_instance):
+            yield
+
+    target_app.router.lifespan_context = _bootstrap_lifespan
+
+
+__all__ = [
+    "configure_repo_host_defaults",
+    "register_repo_host_bootstrap",
+    "resolve_repo_host_defaults",
+]

--- a/mozaiksai/hosts/bootstrap.py
+++ b/mozaiksai/hosts/bootstrap.py
@@ -161,6 +161,12 @@ def _workflow_catalog_bound_to_host_config() -> Iterator[None]:
     another (``--reload``, or a test that drives more than one app) then gets
     the same catalog it would have had on a fresh start, instead of inheriting
     whichever root the previous server selected.
+
+    Snapshotting and restoring the manager's own state is sufficient:
+    ``initialize_workflows`` rebuilds the catalog into the existing manager
+    object rather than replacing it, precisely so modules that imported the
+    manager by value keep a live reference. The module globals therefore still
+    point at this same object afterwards and need no rebinding.
     """
     from mozaiksai.core.workflow import workflow_manager as workflow_manager_module
 
@@ -175,9 +181,6 @@ def _workflow_catalog_bound_to_host_config() -> Iterator[None]:
     finally:
         manager.__dict__.clear()
         manager.__dict__.update(catalog_snapshot)
-        workflow_manager_module.UnifiedWorkflowManager._instance = manager
-        workflow_manager_module._unified_workflow_manager = manager
-        workflow_manager_module.workflow_manager = manager
 
 
 def register_repo_host_bootstrap(target_app: FastAPI, host: str) -> None:

--- a/mozaiksai/hosts/studio.py
+++ b/mozaiksai/hosts/studio.py
@@ -20,10 +20,6 @@ from fastapi import BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field, ValidationError
 
 from factory_app.app.modules.app_registry.backend.service import AppRegistryService
-from mozaiksai.hosts.bootstrap import configure_repo_host_defaults
-
-configure_repo_host_defaults("studio")
-
 from logs.logging_config import get_workflow_logger
 from mozaiksai.control_plane import (
     AcceptedStagedAppBundleBuildRecordError,
@@ -113,6 +109,7 @@ from mozaiksai.core.workflow.generator_support.connector_service import (
 )
 from mozaiksai.core.workflow.paths import candidate_app_workflows_roots
 from mozaiksai.hosts import platform as platform_app
+from mozaiksai.hosts.bootstrap import register_repo_host_bootstrap
 from mozaiksai.hosts.platform import (
     build_shell_config,
     resolve_app_root,
@@ -120,6 +117,7 @@ from mozaiksai.hosts.platform import (
 from mozaiksai.hosts.routers.sandbox import router as _sandbox_router
 
 app = platform_app.app
+register_repo_host_bootstrap(app, "studio")
 app.include_router(_sandbox_router)
 logger = get_workflow_logger("studio_app")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,18 @@ from pathlib import Path
 
 import pytest
 
-_REPO_FACTORY_APP_BUNDLE = Path(__file__).resolve().parents[1] / "factory_app" / "app"
+
+def _repo_factory_app_bundle() -> Path:
+    """The first-party factory app bundle, honoring MOZAIKS_FACTORY_APP_PATH.
+
+    The host resolves the factory root through ``mozaiksai.resources``, which
+    consults that env var; matching it here keeps tests and host agreeing about
+    the active workspace in relocated or installed-package checkouts.
+    """
+    override = os.environ.get("MOZAIKS_FACTORY_APP_PATH", "").strip()
+    if override:
+        return (Path(override) / "app").resolve()
+    return (Path(__file__).resolve().parents[1] / "factory_app" / "app").resolve()
 
 
 def _resolve_active_app_root() -> Path | None:
@@ -43,8 +54,9 @@ def _resolve_active_app_root() -> Path | None:
         if (candidate / "app.json").exists():
             return candidate.resolve()
 
-    if (_REPO_FACTORY_APP_BUNDLE / "app.json").exists():
-        return _REPO_FACTORY_APP_BUNDLE.resolve()
+    factory_bundle = _repo_factory_app_bundle()
+    if (factory_bundle / "app.json").exists():
+        return factory_bundle
 
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 """Shared test fixtures and helpers.
 
-Tests that require an active app workspace (PLATFORM_PATH or
-MOZAIKS_APP_WORKSPACE_PATH) are skipped automatically when neither env var
-is set.  This allows the framework CI to run without a bundled product app.
+Tests that require an active app workspace resolve it explicitly:
+``PLATFORM_PATH`` or ``MOZAIKS_APP_WORKSPACE_PATH`` win when set, and the
+repo's first-party ``factory_app/app`` bundle is the deterministic fallback in
+a repo checkout. The fallback keeps the resolution order-independent — it must
+never depend on whether an earlier test happened to import a host module.
+Only when neither an env var nor the repo bundle resolves (framework CI
+without a bundled app) are workspace-dependent tests skipped.
 
-To run workspace-dependent tests locally:
+To run workspace-dependent tests against another workspace locally:
 
     MOZAIKS_APP_WORKSPACE_PATH=/path/to/mozaiks-app pytest
 """
@@ -15,9 +19,11 @@ from pathlib import Path
 
 import pytest
 
+_REPO_FACTORY_APP_BUNDLE = Path(__file__).resolve().parents[1] / "factory_app" / "app"
+
 
 def _resolve_active_app_root() -> Path | None:
-    """Return the active app root from env vars, or None if not configured."""
+    """Return the active app root: env vars first, then the repo factory bundle."""
     platform_path = os.environ.get("PLATFORM_PATH", "").strip()
     if platform_path:
         candidate = Path(platform_path)
@@ -36,6 +42,9 @@ def _resolve_active_app_root() -> Path | None:
             return nested.resolve()
         if (candidate / "app.json").exists():
             return candidate.resolve()
+
+    if (_REPO_FACTORY_APP_BUNDLE / "app.json").exists():
+        return _REPO_FACTORY_APP_BUNDLE.resolve()
 
     return None
 

--- a/tests/import_utils.py
+++ b/tests/import_utils.py
@@ -47,6 +47,7 @@ def import_module_directly(module_name: str):
         sys.modules[parent_name] = pkg
         fabricated_parents.append(parent_name)
 
+    loaded = False
     try:
         spec = importlib.util.spec_from_file_location(module_name, file_path)
         if spec is None or spec.loader is None:
@@ -54,15 +55,53 @@ def import_module_directly(module_name: str):
         mod = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = mod
         spec.loader.exec_module(mod)
+        loaded = True
     finally:
-        # Drop only the stubs this call created, deepest first. The loaded
-        # module keeps its own globals, so it stays usable afterwards.
-        for parent_name in reversed(fabricated_parents):
-            if type(sys.modules.get(parent_name)).__name__ == "module" and not getattr(
-                sys.modules.get(parent_name), "__file__", None
-            ):
-                sys.modules.pop(parent_name, None)
+        # A module whose body raised is half-initialized; leaving it cached
+        # would hand that broken object to the next importer.
+        if not loaded:
+            sys.modules.pop(module_name, None)
+        _upgrade_fabricated_parents(fabricated_parents)
     return mod
+
+
+def _upgrade_fabricated_parents(fabricated_parents: list[str]) -> None:
+    """Replace each stub this call created with the real package.
+
+    Deleting the stubs instead would orphan every real submodule that was
+    imported through them: the submodule stays in ``sys.modules`` but a later
+    real import of the parent builds a fresh module object without that
+    attribute, so ``monkeypatch.setattr("pkg.sub.name", ...)`` fails. Leaving
+    the stubs in place is what poisoned later imports in the first place (a
+    stub never runs the real ``__init__``, so
+    ``from mozaiksai.core.events import get_event_dispatcher`` raised "unknown
+    location"). Upgrading gives both: real parents with their real contents,
+    and submodules still reachable by dotted path.
+
+    Shallowest first, so each real import binds to an already-real parent. A
+    parent that cannot be imported keeps its stub, leaving behavior no worse
+    than before.
+    """
+    for parent_name in fabricated_parents:
+        stub = sys.modules.get(parent_name)
+        if stub is None or getattr(stub, "__file__", None):
+            continue
+        del sys.modules[parent_name]
+        try:
+            real_parent = importlib.import_module(parent_name)
+        except Exception:
+            sys.modules[parent_name] = stub
+            continue
+        # Re-attach submodules that were bound onto the stub during the load
+        # and that the real package does not import itself.
+        prefix = f"{parent_name}."
+        for name, module in list(sys.modules.items()):
+            if not name.startswith(prefix):
+                continue
+            child = name[len(prefix):]
+            if "." in child or getattr(real_parent, child, None) is not None:
+                continue
+            setattr(real_parent, child, module)
 
 
 def active_app_root() -> Path:
@@ -91,9 +130,14 @@ def active_app_root() -> Path:
         if (candidate / "app.json").exists():
             return candidate.resolve()
 
-    repo_factory_bundle = Path(__file__).resolve().parents[1] / "factory_app" / "app"
+    factory_override = os.environ.get("MOZAIKS_FACTORY_APP_PATH", "").strip()
+    repo_factory_bundle = (
+        (Path(factory_override) / "app")
+        if factory_override
+        else (Path(__file__).resolve().parents[1] / "factory_app" / "app")
+    ).resolve()
     if (repo_factory_bundle / "app.json").exists():
-        return repo_factory_bundle.resolve()
+        return repo_factory_bundle
 
     pytest.skip(
         "No active app workspace configured. "

--- a/tests/import_utils.py
+++ b/tests/import_utils.py
@@ -45,7 +45,12 @@ def import_module_directly(module_name: str):
 
 
 def active_app_root() -> Path:
-    """Return the active app workspace root. Skips the calling test if not configured."""
+    """Return the active app workspace root. Skips the calling test if not configured.
+
+    Env vars win when set; the repo's first-party ``factory_app/app`` bundle is
+    the deterministic fallback so resolution never depends on whether an
+    earlier test imported a host module.
+    """
     platform_path = os.environ.get("PLATFORM_PATH", "").strip()
     if platform_path:
         candidate = Path(platform_path)
@@ -64,6 +69,10 @@ def active_app_root() -> Path:
             return nested.resolve()
         if (candidate / "app.json").exists():
             return candidate.resolve()
+
+    repo_factory_bundle = Path(__file__).resolve().parents[1] / "factory_app" / "app"
+    if (repo_factory_bundle / "app.json").exists():
+        return repo_factory_bundle.resolve()
 
     pytest.skip(
         "No active app workspace configured. "

--- a/tests/import_utils.py
+++ b/tests/import_utils.py
@@ -9,7 +9,17 @@ import pytest
 
 
 def import_module_directly(module_name: str):
-    """Import a leaf module by path without executing heavy parent __init__ files."""
+    """Import a leaf module by path without executing heavy parent __init__ files.
+
+    Parent packages are fabricated only for the duration of the load and then
+    removed again. A fabricated parent never executes its real ``__init__.py``,
+    so leaving one cached in ``sys.modules`` would poison every later real
+    import of that package: ``from mozaiksai.core.events import
+    get_event_dispatcher`` then fails with "cannot import name ... (unknown
+    location)" because the cached stub has no such attribute. Removing exactly
+    the entries this call added keeps the helper non-polluting and makes the
+    result independent of which test ran first.
+    """
     if module_name in sys.modules:
         return sys.modules[module_name]
 
@@ -21,6 +31,7 @@ def import_module_directly(module_name: str):
     if not os.path.exists(file_path):
         raise ImportError(f"Cannot find module file for {module_name}")
 
+    fabricated_parents: list[str] = []
     for i in range(1, len(parts)):
         parent_name = ".".join(parts[:i])
         if parent_name in sys.modules:
@@ -34,13 +45,23 @@ def import_module_directly(module_name: str):
         pkg.__path__ = [parent_path]
         pkg.__package__ = parent_name
         sys.modules[parent_name] = pkg
+        fabricated_parents.append(parent_name)
 
-    spec = importlib.util.spec_from_file_location(module_name, file_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Unable to load module spec for {module_name}")
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = mod
-    spec.loader.exec_module(mod)
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Unable to load module spec for {module_name}")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = mod
+        spec.loader.exec_module(mod)
+    finally:
+        # Drop only the stubs this call created, deepest first. The loaded
+        # module keeps its own globals, so it stays usable afterwards.
+        for parent_name in reversed(fabricated_parents):
+            if type(sys.modules.get(parent_name)).__name__ == "module" and not getattr(
+                sys.modules.get(parent_name), "__file__", None
+            ):
+                sys.modules.pop(parent_name, None)
     return mod
 
 

--- a/tests/test_app_validation_strategy.py
+++ b/tests/test_app_validation_strategy.py
@@ -28,11 +28,23 @@ def _clean_factory_app_syspath():
 
     yield
 
-    # Remove only workflow-namespace modules added during the test to avoid cross-test pollution.
-    # Do NOT remove mozaiksai.* modules — other tests in the suite depend on them staying cached.
+    # Remove only workflow-namespace modules ADDED during the test to avoid
+    # cross-test pollution, including the top-level "workflows"/"factory_app"
+    # package entries themselves — leaving a top-level package cached with a
+    # __path__ resolved through the temporary sys.path entry would let later
+    # tests import through it after the path is removed. Never delete entries
+    # that existed before the test (that breaks dotted-path monkeypatch in
+    # other files), and do NOT remove mozaiksai.* modules — other tests in the
+    # suite depend on them staying cached.
     added_keys = [
         k for k in sys.modules
-        if k not in before and (k.startswith("workflows.") or k.startswith("factory_app."))
+        if k not in before
+        and (
+            k == "workflows"
+            or k == "factory_app"
+            or k.startswith("workflows.")
+            or k.startswith("factory_app.")
+        )
     ]
     for k in added_keys:
         del sys.modules[k]

--- a/tests/test_factory_studio_auth_fetch.py
+++ b/tests/test_factory_studio_auth_fetch.py
@@ -144,6 +144,12 @@ def test_studio_apps_endpoint_rejects_missing_bearer_and_accepts_authenticated_u
     get_auth_adapter(force_provider="none")
     register_adapter("studio-test", _TestStudioAuthAdapter)
 
+    from tests.import_utils import active_app_root
+
+    # Importing the Studio host is environment-inert; bind the workspace
+    # explicitly instead of relying on an import-time side effect.
+    monkeypatch.setenv("PLATFORM_PATH", str(active_app_root()))
+
     from mozaiksai.hosts import studio as studio_app
 
     monkeypatch.setattr(studio_app, "_get_app_registry_service", lambda: _AppRegistryService())

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -987,9 +987,36 @@ def test_generated_monetized_saas_bundle_boots_and_serves_mozaikspay_runtime_sur
         assert request["headers"]["Authorization"] == "Bearer mzk_test_generated_saas"
 
 
+@pytest.fixture
+def _restore_global_workflow_catalog():
+    """Restore the process-global workflow catalog after a test reinitializes it.
+
+    ``initialize_workflows(root)`` rebuilds the singleton in place — it mutates
+    the existing manager's ``__dict__`` so callers holding a reference see the
+    new catalog. Without this restore, a test that points the catalog at a
+    temporary workspace leaves every later test in the process seeing only that
+    workspace's workflows (``KeyError: 'ValueEngine'`` in the workflow catalog
+    contract tests).
+    """
+    from mozaiksai.core.workflow import workflow_manager as workflow_manager_module
+
+    manager = workflow_manager_module.workflow_manager
+    catalog_snapshot = dict(manager.__dict__)
+    instance = workflow_manager_module.UnifiedWorkflowManager._instance
+    try:
+        yield
+    finally:
+        manager.__dict__.clear()
+        manager.__dict__.update(catalog_snapshot)
+        workflow_manager_module.UnifiedWorkflowManager._instance = instance
+        workflow_manager_module._unified_workflow_manager = manager
+        workflow_manager_module.workflow_manager = manager
+
+
 def test_generated_workflow_agent_bundle_loads_catalog_and_starts_runtime_session(
     tmp_path,
     monkeypatch,
+    _restore_global_workflow_catalog,
 ) -> None:
     files = _generated_workflow_agent_files()
     assert scan_functional_generated_app(files) == []

--- a/tests/test_host_import_isolation.py
+++ b/tests/test_host_import_isolation.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -333,6 +334,57 @@ def test_real_studio_boot_binds_factory_workflow_catalog_for_external_workspace(
         "the startup workflow-catalog binding outlived the server; it must be "
         "released on shutdown so one host's root cannot leak into the next"
     )
+
+
+def test_failed_otel_configuration_stays_retryable_then_settles() -> None:
+    """A raising OTel configuration must not mark observability as configured.
+
+    ``_configure_otel_once`` guards against rebuilding a ``TracerProvider`` on
+    every ASGI startup. Setting its flag before the call would make a single
+    transient failure (an exporter that is not up yet) permanent for the life
+    of the process: the next startup would skip configuration and the host
+    would run silently untraced with no retry.
+
+    The monkeypatch context is exited inside the test so the restoration of
+    both patched attributes is asserted here rather than assumed — this test
+    mutates a module-global flag, and leaking it would disable or force OTel
+    configuration for every later test in the process.
+    """
+    attempts: list[str] = []
+    original_configure = host_bootstrap.configure_otel_from_env
+    original_flag = host_bootstrap._otel_configured
+
+    def _flaky_configure() -> bool:
+        attempts.append("call")
+        if len(attempts) == 1:
+            raise RuntimeError("otel exporter unavailable")
+        return True
+
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(host_bootstrap, "_otel_configured", False)
+        patcher.setattr(host_bootstrap, "configure_otel_from_env", _flaky_configure)
+
+        # 1. the first attempt raises, and leaves the flag false
+        with pytest.raises(RuntimeError, match="otel exporter unavailable"):
+            host_bootstrap._configure_otel_once()
+        assert host_bootstrap._otel_configured is False, (
+            "a failed configuration marked OTel configured, so no later startup can retry"
+        )
+        assert attempts == ["call"]
+
+        # 2. a later startup retries and succeeds
+        host_bootstrap._configure_otel_once()
+        assert host_bootstrap._otel_configured is True
+        assert attempts == ["call", "call"]
+
+        # 3. further startups are no-ops
+        host_bootstrap._configure_otel_once()
+        host_bootstrap._configure_otel_once()
+        assert attempts == ["call", "call"], "OTel was reconfigured after it had succeeded"
+
+    # 4. nothing leaks out of the test
+    assert host_bootstrap.configure_otel_from_env is original_configure
+    assert host_bootstrap._otel_configured is original_flag
 
 
 def test_registered_bootstrap_runs_before_inner_lifespans(monkeypatch, tmp_path) -> None:

--- a/tests/test_host_import_isolation.py
+++ b/tests/test_host_import_isolation.py
@@ -57,21 +57,18 @@ def _delenv_restoring(monkeypatch, name: str) -> None:
     monkeypatch.delenv(name)
 
 
-def _dotenv_preload() -> dict[str, str]:
-    """Values ``load_dotenv()`` (import side effect of mozaiksai.core.core_config)
-    would add, pre-injected so the subprocess env diff isolates host behavior."""
-    env_file = REPO_ROOT / ".env"
-    if not env_file.exists():
-        return {}
-    from dotenv import dotenv_values
-
-    return {k: v for k, v in dotenv_values(env_file).items() if v is not None}
-
-
 _IMPORT_PROBE = r"""
 import json
 import os
 import sys
+
+# Import the module whose import side effect is load_dotenv() FIRST, so the
+# snapshot below isolates what importing the host itself does. Compensating for
+# dotenv by pre-seeding the child environment instead would make this test
+# vacuous for any developer whose .env pins PLATFORM_PATH or
+# MOZAIKS_WORKFLOWS_PATH: the host's writes would land on identical values and
+# the diff would stay clean even with the import-time bootstrap restored.
+import mozaiksai.core.core_config  # noqa: F401
 
 before_env = dict(os.environ)
 before_path = list(sys.path)
@@ -97,19 +94,27 @@ report = {
     "bootstrap_hosts": sorted(
         getattr(mozaiksai.hosts.studio.app.state, "mozaiks_repo_host_bootstrap_hosts", ())
     ),
+    "platform_path_after": os.environ.get("PLATFORM_PATH"),
 }
 print(json.dumps(report))
 """
 
 
-def _run_import_probe(extra_env: dict[str, str] | None = None) -> dict:
+def _clean_child_env(extra_env: dict[str, str] | None = None) -> dict[str, str]:
     env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
-    # Pre-inject the local .env values (including any host-path keys it holds)
-    # so the subprocess's own load_dotenv() import side effect becomes a no-op
-    # and the before/after diff isolates host-import behavior.
-    env.update(_dotenv_preload())
+    # pytest-cov's subprocess hook is driven by COV_CORE_* rather than by the
+    # outer run's --no-cov, so an inherited value makes every nested
+    # interpreter drop a stray .coverage.* file into the repo root that the
+    # shard's own coverage run would then combine.
+    for key in [k for k in env if k.startswith("COV_CORE_")]:
+        env.pop(key, None)
     if extra_env:
         env.update(extra_env)
+    return env
+
+
+def _run_import_probe(extra_env: dict[str, str] | None = None) -> dict:
+    env = _clean_child_env(extra_env)
     result = subprocess.run(
         [sys.executable, "-c", _IMPORT_PROBE],
         cwd=str(REPO_ROOT),
@@ -144,6 +149,13 @@ def test_studio_import_registers_startup_bootstrap_without_running_it() -> None:
 
 
 def test_caller_env_survives_studio_import_unchanged(tmp_path) -> None:
+    """A caller's own PLATFORM_PATH must come back out of the import verbatim.
+
+    ``PLATFORM_PATH`` is deliberately set to the *workspace root* rather than
+    the bundle directory: the bootstrap normalizes that to ``<workspace>/app``,
+    so this asserts a value the import-time bootstrap would visibly rewrite.
+    That keeps the check meaningful no matter what the developer's .env holds.
+    """
     workspace = tmp_path / "caller-workspace"
     app_root = workspace / "app"
     app_root.mkdir(parents=True)
@@ -152,6 +164,10 @@ def test_caller_env_survives_studio_import_unchanged(tmp_path) -> None:
     report = _run_import_probe({"PLATFORM_PATH": str(workspace)})
     assert report["env_added"] == [], report
     assert report["env_changed"] == [], report
+    assert report["platform_path_after"] == str(workspace), (
+        "the Studio import rewrote the caller's PLATFORM_PATH to the resolved "
+        f"bundle dir: {report['platform_path_after']}"
+    )
 
 
 def test_resolve_repo_host_defaults_is_pure_and_reads_provided_environ(tmp_path) -> None:
@@ -236,6 +252,89 @@ def test_configure_repo_host_defaults_is_idempotent(monkeypatch, tmp_path) -> No
     assert Path(first_pass["PLATFORM_PATH"]) == app_root.resolve()
 
 
+_REAL_STUDIO_BOOT_PROBE = r"""
+import json
+from fastapi.testclient import TestClient
+
+import mozaiksai.hosts.studio as studio
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+at_import = sorted(workflow_manager.get_all_workflow_names())
+with TestClient(studio.app):
+    after_first = sorted(workflow_manager.get_all_workflow_names())
+after_shutdown = sorted(workflow_manager.get_all_workflow_names())
+with TestClient(studio.app):
+    after_second = sorted(workflow_manager.get_all_workflow_names())
+
+print(json.dumps({
+    "at_import": at_import,
+    "after_first": after_first,
+    "after_shutdown": after_shutdown,
+    "after_second": after_second,
+}))
+"""
+
+
+def test_real_studio_boot_binds_factory_workflow_catalog_for_external_workspace(tmp_path) -> None:
+    """Booting the real Studio app must still load the factory workflow catalog.
+
+    ``mozaiksai.core.workflow.workflow_manager`` builds its global catalog at
+    module import, from whatever workflow root the environment named then.
+    Studio's defaults deliberately prefer the shared factory workflow root,
+    while bare root resolution prefers an app workspace's own ``workflows/``.
+    So for ``mozaiks serve <workspace> --host studio`` the import-time catalog
+    binds the (usually empty) workspace root, and only the startup bootstrap
+    can rebind it to the factory catalog.
+
+    This drives the real ASGI startup of the real Studio app rather than a
+    probe, because the defect this guards against is invisible to any test
+    that stubs the host or strips the workspace environment.
+    """
+    workspace = tmp_path / "external-workspace"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (workspace / "workflows").mkdir()
+    (app_root / "app.json").write_text('{"appName": "External"}', encoding="utf-8")
+
+    env = _clean_child_env(
+        {
+            "PLATFORM_PATH": str(app_root),
+            "MOZAIKS_APP_WORKSPACE_PATH": str(app_root),
+            "AUTH_ENABLED": "false",
+            "RATE_LIMIT_ENABLED": "false",
+            "MOZAIKS_DATABASE_STARTUP_POLICY": "best_effort",
+            "ENV": "test",
+        }
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", _REAL_STUDIO_BOOT_PROBE],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    report = json.loads(result.stdout.strip().splitlines()[-1])
+
+    assert "AppGenerator" not in report["at_import"], (
+        "importing the Studio host resolved the factory catalog at import time — "
+        "the import is supposed to be inert"
+    )
+    assert "AppGenerator" in report["after_first"], (
+        "real Studio startup did not bind the factory workflow catalog; "
+        f"catalog was {report['after_first']}"
+    )
+    assert report["after_second"] == report["after_first"], (
+        "repeated Studio startup changed the workflow catalog"
+    )
+    assert report["after_shutdown"] == report["at_import"], (
+        "the startup workflow-catalog binding outlived the server; it must be "
+        "released on shutdown so one host's root cannot leak into the next"
+    )
+
+
 def test_registered_bootstrap_runs_before_inner_lifespans(monkeypatch, tmp_path) -> None:
     """The host bootstrap must apply defaults before runtime/platform startup."""
     from mozaiksai.hosts.runtime import register_app_lifespan
@@ -293,6 +392,9 @@ def test_register_repo_host_bootstrap_is_idempotent_per_host(monkeypatch, tmp_pa
     probe_app = FastAPI()
     register_repo_host_bootstrap(probe_app, "studio")
     register_repo_host_bootstrap(probe_app, "studio")
+    # Host names are normalized downstream, so registration must dedupe on the
+    # normalized name too — otherwise "Studio" stacks a second bootstrap layer.
+    register_repo_host_bootstrap(probe_app, "Studio")
 
     with TestClient(probe_app):
         pass

--- a/tests/test_host_import_isolation.py
+++ b/tests/test_host_import_isolation.py
@@ -1,0 +1,323 @@
+"""Host modules must be import-inert; only real startup applies repo defaults.
+
+Importing ``mozaiksai.hosts.studio`` (or platform/runtime) previously ran
+``configure_repo_host_defaults("studio")`` at module import time, writing
+``PLATFORM_PATH`` and ``MOZAIKS_WORKFLOWS_PATH`` into ``os.environ``. That made
+test outcomes depend on import order: any test that imported a host module
+silently reconfigured the active app workspace for every later test in the
+process. These tests pin the corrected contract:
+
+- a plain host import leaves the process environment byte-identical and does
+  not touch ``sys.path``, the working directory, or pre-existing
+  ``sys.modules`` entries;
+- explicit startup (the registered host bootstrap lifespan) still applies the
+  repo defaults before lower-layer startup resolves app/workflow roots;
+- caller-provided environment values keep precedence;
+- repeated initialization is idempotent;
+- isolated environments do not leak one workspace into another.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mozaiksai.hosts import bootstrap as host_bootstrap
+from mozaiksai.hosts.bootstrap import (
+    configure_repo_host_defaults,
+    register_repo_host_bootstrap,
+    resolve_repo_host_defaults,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_HOST_ENV_KEYS = (
+    "PLATFORM_PATH",
+    "MOZAIKS_WORKFLOWS_PATH",
+    "MOZAIKS_APP_WORKSPACE_PATH",
+    "MOZAIKS_FACTORY_APP_PATH",
+)
+
+
+def _delenv_restoring(monkeypatch, name: str) -> None:
+    """Delete ``name`` and guarantee restoration even when it was absent.
+
+    ``monkeypatch.delenv(name, raising=False)`` records nothing for an absent
+    key, so a value written afterwards by production bootstrap code would leak
+    past teardown (the defect fixed in PR #418). Setting the key first forces
+    monkeypatch to record a restore entry.
+    """
+    monkeypatch.setenv(name, "")
+    monkeypatch.delenv(name)
+
+
+def _dotenv_preload() -> dict[str, str]:
+    """Values ``load_dotenv()`` (import side effect of mozaiksai.core.core_config)
+    would add, pre-injected so the subprocess env diff isolates host behavior."""
+    env_file = REPO_ROOT / ".env"
+    if not env_file.exists():
+        return {}
+    from dotenv import dotenv_values
+
+    return {k: v for k, v in dotenv_values(env_file).items() if v is not None}
+
+
+_IMPORT_PROBE = r"""
+import json
+import os
+import sys
+
+before_env = dict(os.environ)
+before_path = list(sys.path)
+before_cwd = os.getcwd()
+before_modules = dict(sys.modules)
+
+import mozaiksai.hosts.studio  # noqa: F401
+
+after_env = dict(os.environ)
+report = {
+    "env_added": sorted(set(after_env) - set(before_env)),
+    "env_removed": sorted(set(before_env) - set(after_env)),
+    "env_changed": sorted(
+        k for k in set(before_env) & set(after_env) if before_env[k] != after_env[k]
+    ),
+    "sys_path_changed": sys.path != before_path,
+    "cwd_changed": os.getcwd() != before_cwd,
+    "modules_replaced": sorted(
+        name
+        for name, module in before_modules.items()
+        if sys.modules.get(name) is not module
+    ),
+    "bootstrap_hosts": sorted(
+        getattr(mozaiksai.hosts.studio.app.state, "mozaiks_repo_host_bootstrap_hosts", ())
+    ),
+}
+print(json.dumps(report))
+"""
+
+
+def _run_import_probe(extra_env: dict[str, str] | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
+    # Pre-inject the local .env values (including any host-path keys it holds)
+    # so the subprocess's own load_dotenv() import side effect becomes a no-op
+    # and the before/after diff isolates host-import behavior.
+    env.update(_dotenv_preload())
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PROBE],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_plain_studio_import_leaves_process_state_byte_identical() -> None:
+    """A plain host import must not mutate env, sys.path, cwd, or loaded modules.
+
+    Runs in a subprocess so the assertion covers the true first import of the
+    host stack in a clean interpreter, on both Windows and Linux env semantics.
+    """
+    report = _run_import_probe()
+
+    assert report["env_added"] == [], report
+    assert report["env_removed"] == [], report
+    assert report["env_changed"] == [], report
+    assert report["sys_path_changed"] is False
+    assert report["cwd_changed"] is False
+    assert report["modules_replaced"] == [], report
+
+
+def test_studio_import_registers_startup_bootstrap_without_running_it() -> None:
+    report = _run_import_probe()
+    assert report["bootstrap_hosts"] == ["studio"]
+
+
+def test_caller_env_survives_studio_import_unchanged(tmp_path) -> None:
+    workspace = tmp_path / "caller-workspace"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text('{"appName": "Caller App"}', encoding="utf-8")
+
+    report = _run_import_probe({"PLATFORM_PATH": str(workspace)})
+    assert report["env_added"] == [], report
+    assert report["env_changed"] == [], report
+
+
+def test_resolve_repo_host_defaults_is_pure_and_reads_provided_environ(tmp_path) -> None:
+    workspace = tmp_path / "workspace-a"
+    app_root = workspace / "app"
+    workflows = workspace / "workflows"
+    app_root.mkdir(parents=True)
+    workflows.mkdir()
+    (app_root / "app.json").write_text('{"appName": "A"}', encoding="utf-8")
+
+    env_before = dict(os.environ)
+    updates = resolve_repo_host_defaults(
+        "platform",
+        environ={"MOZAIKS_APP_WORKSPACE_PATH": str(workspace)},
+    )
+
+    assert dict(os.environ) == env_before, "resolve_repo_host_defaults mutated os.environ"
+    assert Path(updates["PLATFORM_PATH"]) == app_root.resolve()
+    assert Path(updates["MOZAIKS_WORKFLOWS_PATH"]) == workflows.resolve()
+
+
+def test_resolve_repo_host_defaults_caller_overrides_win(tmp_path) -> None:
+    workspace = tmp_path / "workspace-b"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text('{"appName": "B"}', encoding="utf-8")
+    explicit_workflows = tmp_path / "explicit-workflows"
+    explicit_workflows.mkdir()
+
+    updates = resolve_repo_host_defaults(
+        "studio",
+        environ={
+            "PLATFORM_PATH": str(workspace),
+            "MOZAIKS_WORKFLOWS_PATH": str(explicit_workflows),
+        },
+    )
+
+    assert Path(updates["PLATFORM_PATH"]) == app_root.resolve()
+    assert "MOZAIKS_WORKFLOWS_PATH" not in updates, (
+        "an explicit MOZAIKS_WORKFLOWS_PATH must never be overridden by defaults"
+    )
+
+
+def test_resolve_repo_host_defaults_isolated_workspaces_do_not_leak(tmp_path) -> None:
+    def _make_workspace(name: str) -> Path:
+        workspace = tmp_path / name
+        app_root = workspace / "app"
+        app_root.mkdir(parents=True)
+        (workspace / "workflows").mkdir()
+        (app_root / "app.json").write_text(f'{{"appName": "{name}"}}', encoding="utf-8")
+        return workspace
+
+    workspace_a = _make_workspace("workspace-a")
+    workspace_b = _make_workspace("workspace-b")
+
+    updates_a = resolve_repo_host_defaults("platform", environ={"PLATFORM_PATH": str(workspace_a)})
+    updates_b = resolve_repo_host_defaults("platform", environ={"PLATFORM_PATH": str(workspace_b)})
+
+    assert Path(updates_a["PLATFORM_PATH"]) == (workspace_a / "app").resolve()
+    assert Path(updates_b["PLATFORM_PATH"]) == (workspace_b / "app").resolve()
+    assert Path(updates_a["MOZAIKS_WORKFLOWS_PATH"]) == (workspace_a / "workflows").resolve()
+    assert Path(updates_b["MOZAIKS_WORKFLOWS_PATH"]) == (workspace_b / "workflows").resolve()
+
+
+def test_configure_repo_host_defaults_is_idempotent(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace-idempotent"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (workspace / "workflows").mkdir()
+    (app_root / "app.json").write_text('{"appName": "Idempotent"}', encoding="utf-8")
+
+    monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace))
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
+
+    configure_repo_host_defaults("platform")
+    first_pass = {key: os.environ.get(key) for key in _HOST_ENV_KEYS}
+    configure_repo_host_defaults("platform")
+    second_pass = {key: os.environ.get(key) for key in _HOST_ENV_KEYS}
+
+    assert first_pass == second_pass
+    assert Path(first_pass["PLATFORM_PATH"]) == app_root.resolve()
+
+
+def test_registered_bootstrap_runs_before_inner_lifespans(monkeypatch, tmp_path) -> None:
+    """The host bootstrap must apply defaults before runtime/platform startup."""
+    from mozaiksai.hosts.runtime import register_app_lifespan
+
+    workspace = tmp_path / "workspace-lifespan"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (workspace / "workflows").mkdir()
+    (app_root / "app.json").write_text('{"appName": "Lifespan"}', encoding="utf-8")
+
+    monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace))
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
+
+    seen_at_inner_startup: dict[str, str | None] = {}
+    probe_app = FastAPI()
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _inner_lifespan(_: FastAPI):
+        seen_at_inner_startup["PLATFORM_PATH"] = os.environ.get("PLATFORM_PATH")
+        seen_at_inner_startup["MOZAIKS_WORKFLOWS_PATH"] = os.environ.get("MOZAIKS_WORKFLOWS_PATH")
+        yield
+
+    register_app_lifespan(probe_app, _inner_lifespan)
+    register_repo_host_bootstrap(probe_app, "platform")
+
+    with TestClient(probe_app):
+        pass
+
+    assert seen_at_inner_startup["PLATFORM_PATH"] is not None
+    assert Path(seen_at_inner_startup["PLATFORM_PATH"]) == app_root.resolve()
+    assert seen_at_inner_startup["MOZAIKS_WORKFLOWS_PATH"] is not None
+    assert Path(seen_at_inner_startup["MOZAIKS_WORKFLOWS_PATH"]) == (workspace / "workflows").resolve()
+
+
+def test_register_repo_host_bootstrap_is_idempotent_per_host(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace-once"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text('{"appName": "Once"}', encoding="utf-8")
+
+    monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace))
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        host_bootstrap,
+        "configure_repo_host_defaults",
+        lambda host: calls.append(host),
+    )
+
+    probe_app = FastAPI()
+    register_repo_host_bootstrap(probe_app, "studio")
+    register_repo_host_bootstrap(probe_app, "studio")
+
+    with TestClient(probe_app):
+        pass
+
+    assert calls == ["studio"], "duplicate registration must not stack bootstrap layers"
+
+
+def test_repeated_startup_of_bootstrapped_app_is_deterministic(monkeypatch, tmp_path) -> None:
+    workspace = tmp_path / "workspace-repeat"
+    app_root = workspace / "app"
+    app_root.mkdir(parents=True)
+    (workspace / "workflows").mkdir()
+    (app_root / "app.json").write_text('{"appName": "Repeat"}', encoding="utf-8")
+
+    monkeypatch.setenv("MOZAIKS_APP_WORKSPACE_PATH", str(workspace))
+    _delenv_restoring(monkeypatch, "PLATFORM_PATH")
+    _delenv_restoring(monkeypatch, "MOZAIKS_WORKFLOWS_PATH")
+
+    probe_app = FastAPI()
+    register_repo_host_bootstrap(probe_app, "platform")
+
+    with TestClient(probe_app):
+        first = {key: os.environ.get(key) for key in _HOST_ENV_KEYS}
+    with TestClient(probe_app):
+        second = {key: os.environ.get(key) for key in _HOST_ENV_KEYS}
+
+    assert first == second
+    assert Path(first["PLATFORM_PATH"]) == app_root.resolve()

--- a/tests/test_refinement_staged_patch_e2e.py
+++ b/tests/test_refinement_staged_patch_e2e.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import zipfile
 from pathlib import Path
 
@@ -277,7 +276,6 @@ def _studio_app(monkeypatch):
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
     from mozaiksai.hosts import studio as studio_app
 
     return studio_app

--- a/tests/test_studio_app_context_operator_api.py
+++ b/tests/test_studio_app_context_operator_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import sys
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -35,7 +34,6 @@ def _studio_app(monkeypatch):
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
     from mozaiksai.hosts import studio as studio_app
 
     monkeypatch.setattr(studio_app, "get_artifact_store", lambda: object())

--- a/tests/test_studio_artifact_restore.py
+++ b/tests/test_studio_artifact_restore.py
@@ -4,7 +4,6 @@ import asyncio
 import inspect
 import json
 import stat
-import sys
 import zipfile
 from pathlib import Path
 
@@ -164,7 +163,6 @@ def _studio_app(monkeypatch):
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
     from mozaiksai.hosts import studio as studio_app
 
     return studio_app

--- a/tests/test_studio_host_smoke.py
+++ b/tests/test_studio_host_smoke.py
@@ -4,7 +4,12 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_studio_shell_config_injects_studio_routes():
+async def test_studio_shell_config_injects_studio_routes(monkeypatch):
+    from tests.import_utils import active_app_root
+
+    # Importing the Studio host is environment-inert; bind the workspace
+    # explicitly instead of relying on an import-time side effect.
+    monkeypatch.setenv("PLATFORM_PATH", str(active_app_root()))
     from mozaiksai.hosts import studio as studio_app
 
     shell_config = await studio_app.get_studio_shell_config()
@@ -89,6 +94,11 @@ def test_studio_endpoints_work_without_auth_user_id(monkeypatch):
 
     from mozaiksai.core.auth import reset_auth_adapter
     from mozaiksai.hosts import studio as studio_app
+    from tests.import_utils import active_app_root
+
+    # Importing the Studio host is environment-inert; bind the workspace
+    # explicitly instead of relying on an import-time side effect.
+    monkeypatch.setenv("PLATFORM_PATH", str(active_app_root()))
 
     class _ArtifactStore:
         async def list_build_records(self, **_kwargs):

--- a/tests/test_studio_workflow_trigger.py
+++ b/tests/test_studio_workflow_trigger.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -145,8 +144,6 @@ def test_studio_trigger_endpoint_accepts_refinement_trigger_payload(monkeypatch)
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     captured_prepare: dict = {}
@@ -435,8 +432,6 @@ def test_studio_trigger_endpoint_rejects_removed_top_level_refinement_fields(mon
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     client = TestClient(studio_app.app)
@@ -461,8 +456,6 @@ def test_studio_trigger_endpoint_rejects_refinement_when_control_plane_disabled(
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     monkeypatch.setattr(
@@ -501,8 +494,6 @@ def test_studio_trigger_endpoint_can_short_circuit_to_coding_worker(monkeypatch)
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     persisted_changes: list[dict] = []
@@ -689,8 +680,6 @@ def test_studio_trigger_endpoint_can_auto_scope_before_coding_worker(monkeypatch
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     persisted_changes: list[dict] = []
@@ -828,8 +817,6 @@ def test_studio_trigger_endpoint_can_confirm_proposed_multi_file_scope(monkeypat
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     persisted_changes: list[dict] = []
@@ -1012,8 +999,6 @@ def test_studio_trigger_endpoint_returns_core_harness_decision_before_launch(mon
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     async def fail_prepare(**kwargs):  # noqa: ANN003
@@ -1105,8 +1090,6 @@ def test_studio_trigger_endpoint_reuses_prelaunch_revision_intent_on_confirm(mon
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     persisted_state = {
@@ -1283,8 +1266,6 @@ def test_app_review_revision_trigger_preserves_staged_bundle_context(monkeypatch
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     staged_bundle_path = "C:/Repos/BlocUnitedRepo/mozaiks/generated/apps/app_1/build_1/app"
@@ -1525,8 +1506,6 @@ def test_studio_artifact_bundle_endpoint_returns_workbench_payload(monkeypatch, 
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(tmp_path, lifecycle_status=ArtifactLifecycleStatus.DRAFT)
@@ -1554,8 +1533,6 @@ def test_studio_artifact_review_endpoint_returns_diff_and_session_context(monkey
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(tmp_path, lifecycle_status=ArtifactLifecycleStatus.DRAFT)
@@ -1590,8 +1567,6 @@ def test_studio_artifact_review_marks_skipped_validation_as_override_required(mo
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(
@@ -1620,8 +1595,6 @@ def test_studio_artifact_accept_endpoint_marks_current_and_updates_session(monke
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(tmp_path, lifecycle_status=ArtifactLifecycleStatus.DRAFT)
@@ -1644,8 +1617,6 @@ def test_studio_artifact_reject_endpoint_archives_and_updates_session(monkeypatc
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(tmp_path, lifecycle_status=ArtifactLifecycleStatus.DRAFT)
@@ -1668,8 +1639,6 @@ def test_studio_artifact_promote_endpoint_restores_bundle_and_updates_session(mo
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     store = _build_review_store(tmp_path, lifecycle_status=ArtifactLifecycleStatus.CURRENT)
@@ -1722,8 +1691,6 @@ def test_studio_trigger_endpoint_invokes_surface_regeneration_for_feature_change
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
     reset_auth_adapter()
-    sys.modules.pop("factory_app", None)
-
     from mozaiksai.hosts import studio as studio_app
 
     _plan = ContractSurfacePlan(

--- a/tests/test_suite_order_independence.py
+++ b/tests/test_suite_order_independence.py
@@ -113,6 +113,54 @@ def test_workspace_gated_tests_run_without_a_prior_host_import() -> None:
     )
 
 
+def test_import_module_directly_leaves_no_fabricated_parent_stubs() -> None:
+    """The direct-import helper must not poison later real package imports.
+
+    Fabricated parent packages never execute their real ``__init__.py``. One
+    left in ``sys.modules`` made a later ``from mozaiksai.core.events import
+    get_event_dispatcher`` fail with "cannot import name ... (unknown
+    location)", degrading platform startup for any test that ran afterwards.
+    """
+    probe = (
+        "import sys\n"
+        "sys.path.insert(0, 'tests')\n"
+        "from import_utils import import_module_directly\n"
+        "mod = import_module_directly('mozaiksai.core.events.auto_tool_handler')\n"
+        "assert mod is not None\n"
+        "from mozaiksai.core.events import get_event_dispatcher\n"
+        "assert callable(get_event_dispatcher)\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "OK" in result.stdout
+
+
+def test_global_workflow_catalog_survives_a_workspace_scoped_reinitialization() -> None:
+    """A test that repoints the workflow catalog must restore it afterwards.
+
+    ``initialize_workflows(tmp_root)`` rebuilds the singleton in place, so
+    without a restore every later test in the process saw only the temporary
+    workspace's workflows.
+    """
+    result = _run_pytest(
+        [
+            "tests/test_generated_app_functional_acceptance.py",
+            "tests/test_workflow_catalog_contract.py",
+        ]
+    )
+    assert result.returncode == 0, (
+        "the global workflow catalog leaked out of a workspace-scoped "
+        f"reinitialization:\n{result.stdout}\n{result.stderr}"
+    )
+
+
 def test_workspace_resolution_identical_before_and_after_host_import() -> None:
     """The resolved workspace root must not change when a host import precedes it."""
     probe = (

--- a/tests/test_suite_order_independence.py
+++ b/tests/test_suite_order_independence.py
@@ -1,0 +1,141 @@
+"""Regression proofs that historical test-order hazards stay fixed.
+
+Two order hazards existed on main before this suite was added:
+
+1. ``import mozaiksai.hosts.studio`` wrote ``PLATFORM_PATH`` and
+   ``MOZAIKS_WORKFLOWS_PATH`` into ``os.environ`` at import time, so
+   workspace-gated tests ran or skipped depending on whether an earlier test
+   in the same process had imported the Studio host.
+2. Studio tests called ``sys.modules.pop("factory_app", None)`` before
+   importing the host. When those tests ran before
+   ``tests/test_check_workspace_integrations_tool.py`` (the inversion of the
+   alphabetical shard order), the pop broke that file's dotted-path
+   ``monkeypatch.setattr("factory_app....")`` calls.
+
+Each proof runs pytest in a subprocess with a CI-like environment (no
+``PLATFORM_PATH`` / ``MOZAIKS_WORKFLOWS_PATH`` / ``MOZAIKS_APP_WORKSPACE_PATH``)
+so the result is what a reordered CI shard would see, on both Windows and
+Linux environment semantics. These are deliberately heavier than unit tests;
+they are the executable form of the order-independence contract.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_HOST_ENV_KEYS = (
+    "PLATFORM_PATH",
+    "MOZAIKS_WORKFLOWS_PATH",
+    "MOZAIKS_APP_WORKSPACE_PATH",
+    "MOZAIKS_FACTORY_APP_PATH",
+)
+
+_POLLUTER_TEST = (
+    "tests/test_studio_workflow_trigger.py"
+    "::test_studio_trigger_endpoint_accepts_refinement_trigger_payload"
+)
+_DOTTED_PATCH_VICTIM = "tests/test_check_workspace_integrations_tool.py"
+_WORKSPACE_GATED_VICTIM = "tests/test_config_consolidation.py"
+
+
+def _run_pytest(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
+    env.setdefault("ENV", "test")
+    env.setdefault("AUTH_ENABLED", "false")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            *args,
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def _summary_line(result: subprocess.CompletedProcess[str]) -> str:
+    lines = [line for line in result.stdout.strip().splitlines() if line.strip()]
+    return lines[-1] if lines else result.stdout
+
+
+def test_dotted_path_monkeypatch_survives_studio_import_in_either_order() -> None:
+    """The historical polluter/victim pair passes in both file orders."""
+    historical = _run_pytest([_DOTTED_PATCH_VICTIM, _POLLUTER_TEST])
+    assert historical.returncode == 0, (
+        f"historical order failed:\n{historical.stdout}\n{historical.stderr}"
+    )
+
+    inverted = _run_pytest([_POLLUTER_TEST, _DOTTED_PATCH_VICTIM])
+    assert inverted.returncode == 0, (
+        f"inverted order failed (dotted-path monkeypatch broke after a Studio "
+        f"host import):\n{inverted.stdout}\n{inverted.stderr}"
+    )
+
+
+def test_dotted_path_monkeypatch_pair_passes_repeatedly_in_inverted_order() -> None:
+    """The previously failing order stays green across repeated runs."""
+    for attempt in range(2):
+        result = _run_pytest([_POLLUTER_TEST, _DOTTED_PATCH_VICTIM])
+        assert result.returncode == 0, (
+            f"inverted order failed on repeat run {attempt + 1}:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+
+def test_workspace_gated_tests_run_without_a_prior_host_import() -> None:
+    """Workspace-gated tests must not skip just because no host was imported.
+
+    On main, ``tests/test_config_consolidation.py`` alone skipped its 30
+    workspace-gated tests, but ran all of them whenever any earlier test
+    imported ``mozaiksai.hosts.studio``. Resolution is now explicit and
+    order-independent, so a run with no prior host import must produce zero
+    skips.
+    """
+    result = _run_pytest([_WORKSPACE_GATED_VICTIM])
+    summary = _summary_line(result)
+    assert result.returncode == 0, f"victim run failed:\n{result.stdout}\n{result.stderr}"
+    assert "skipped" not in summary, (
+        f"workspace-gated tests skipped without a prior host import — "
+        f"resolution is order-dependent again: {summary}"
+    )
+
+
+def test_workspace_resolution_identical_before_and_after_host_import() -> None:
+    """The resolved workspace root must not change when a host import precedes it."""
+    probe = (
+        "import json, sys\n"
+        "sys.path.insert(0, 'tests')\n"
+        "from conftest import _resolve_active_app_root\n"
+        "before = _resolve_active_app_root()\n"
+        "import mozaiksai.hosts.studio  # noqa: F401\n"
+        "after = _resolve_active_app_root()\n"
+        "print(json.dumps({'before': str(before), 'after': str(after)}))\n"
+    )
+    env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=True,
+    )
+    import json
+
+    report = json.loads(result.stdout.strip().splitlines()[-1])
+    assert report["before"] == report["after"], report
+    assert report["before"].endswith("app"), report

--- a/tests/test_suite_order_independence.py
+++ b/tests/test_suite_order_independence.py
@@ -43,8 +43,19 @@ _DOTTED_PATCH_VICTIM = "tests/test_check_workspace_integrations_tool.py"
 _WORKSPACE_GATED_VICTIM = "tests/test_config_consolidation.py"
 
 
-def _run_pytest(args: list[str]) -> subprocess.CompletedProcess[str]:
+def _child_env() -> dict[str, str]:
     env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
+    # pytest-cov's subprocess hook is driven by COV_CORE_* rather than by the
+    # outer run's --no-cov, so an inherited value makes every nested
+    # interpreter drop a stray .coverage.* file into the repo root that the
+    # shard's own coverage run would then combine.
+    for key in [k for k in env if k.startswith("COV_CORE_")]:
+        env.pop(key, None)
+    return env
+
+
+def _run_pytest(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = _child_env()
     env.setdefault("ENV", "test")
     env.setdefault("AUTH_ENABLED", "false")
     return subprocess.run(
@@ -104,12 +115,15 @@ def test_workspace_gated_tests_run_without_a_prior_host_import() -> None:
     order-independent, so a run with no prior host import must produce zero
     skips.
     """
-    result = _run_pytest([_WORKSPACE_GATED_VICTIM])
-    summary = _summary_line(result)
+    result = _run_pytest(["-rs", _WORKSPACE_GATED_VICTIM])
     assert result.returncode == 0, f"victim run failed:\n{result.stdout}\n{result.stderr}"
-    assert "skipped" not in summary, (
-        f"workspace-gated tests skipped without a prior host import — "
-        f"resolution is order-dependent again: {summary}"
+    # Assert on the specific skip reason rather than the presence of any skip:
+    # these files also carry legitimate content guards ("Product-specific
+    # HomePage.jsx not present ..."), and a new one of those must not read as
+    # this regression.
+    assert "No active app workspace configured" not in result.stdout, (
+        "workspace-gated tests skipped for lack of a configured workspace without "
+        f"a prior host import — resolution is order-dependent again:\n{result.stdout}"
     )
 
 
@@ -166,13 +180,17 @@ def test_workspace_resolution_identical_before_and_after_host_import() -> None:
     probe = (
         "import json, sys\n"
         "sys.path.insert(0, 'tests')\n"
+        # Run the load_dotenv() import side effect before the first snapshot,
+        # so a developer .env that pins PLATFORM_PATH cannot masquerade as the
+        # host import changing the resolution.
+        "import mozaiksai.core.core_config  # noqa: F401\n"
         "from conftest import _resolve_active_app_root\n"
         "before = _resolve_active_app_root()\n"
         "import mozaiksai.hosts.studio  # noqa: F401\n"
         "after = _resolve_active_app_root()\n"
         "print(json.dumps({'before': str(before), 'after': str(after)}))\n"
     )
-    env = {k: v for k, v in os.environ.items() if k not in _HOST_ENV_KEYS}
+    env = _child_env()
     result = subprocess.run(
         [sys.executable, "-c", probe],
         cwd=str(REPO_ROOT),


### PR DESCRIPTION
## Summary

Eliminates the process-global import and test-order hazards around `mozaiksai/hosts` without changing normal Studio, platform, CLI, or ASGI behavior.

**Base**: `359c3e06` (main, includes merged #419 — rebased cleanly, disjoint). Work started from `cb9e6b3b`; every defect below was reproduced against that exact main before fixing.

## Defects reproduced against main `cb9e6b3b`

1. **Import-time env mutation**: a plain `import mozaiksai.hosts.studio` in a clean interpreter added `PLATFORM_PATH` and `MOZAIKS_WORKFLOWS_PATH` to `os.environ` (via the module-scope `configure_repo_host_defaults("studio")` call).
2. **Order decides skip/run**: `pytest tests/test_config_consolidation.py` alone → 21 passed, **30 skipped**; the same file after one studio-importing test → **all 52 run**. Whether workspace-gated tests executed depended on whether any earlier test had imported the Studio host.
3. **`sys.modules.pop("factory_app")` polluter/victim**: `tests/test_check_workspace_integrations_tool.py` + `tests/test_studio_workflow_trigger.py` passed in alphabetical order (27 passed) and **failed in inverted order** (2 failed — both dotted-path `monkeypatch.setattr("factory_app....")` tests). 19 copies of the pop existed across 4 studio test files, none with a matching real polluter (provenance traced; cargo-culted from `552142f8`).

## Design

- `mozaiksai/hosts/bootstrap.py` now has three explicit seams:
  - `resolve_repo_host_defaults(host, environ=None)` — **pure** computation of the default env entries over a caller-provided mapping (tests get isolated settings; no mutation).
  - `configure_repo_host_defaults(host)` — the explicit process bootstrap (unchanged semantics: caller env precedence, PLATFORM_PATH normalization, OTel from env). Idempotent.
  - `register_repo_host_bootstrap(app, host)` — wraps the composed lifespan **outermost**, so defaults apply exactly once at real server startup, *before* runtime/platform startup resolves app/workflow roots. Idempotent per (app, host), so module reloads don't stack layers.
- `mozaiksai/hosts/studio.py` registers the bootstrap instead of running it at import. `uvicorn mozaiksai.hosts.studio:app`, `mozaiks serve` (which sets the env itself pre-uvicorn), and app-local host composition (`app = studio_app.app`) are unchanged. No test-only behavior in production startup.
- Test workspace resolution (`tests/conftest.py`, `tests/import_utils.py`) now falls back **explicitly** to the repo `factory_app/app` bundle — the same workspace the accidental import side effect used to select — so the ~30 workspace-gated tests run deterministically in CI instead of depending on import order. Env vars still win.
- All 19 pops removed. `tests/test_app_validation_strategy.py`'s autouse fixture (the one real `factory_app`-namespace mutator) now also removes the **top-level** `workflows`/`factory_app` entries *it itself adds* — never pre-existing entries. Three studio tests that leaned on the import-time env write now bind `PLATFORM_PATH` explicitly.

## Regression proofs added

- `tests/test_host_import_isolation.py` (10 tests): byte-identical env across a plain studio import in a clean subprocess (local `.env` neutralized by pre-injection; works on Windows and Linux env semantics); `sys.path`/cwd/pre-existing `sys.modules` untouched; bootstrap registered but not run at import; caller env survives import; pure resolver doesn't touch `os.environ`; caller overrides win; isolated workspaces don't leak; `configure` idempotent; bootstrap runs **before** inner lifespans; repeated startup deterministic; duplicate registration doesn't stack.
- `tests/test_suite_order_independence.py` (4 tests): the historical polluter/victim pair passes in **both** orders and **repeatedly** in the previously-failing order; workspace-gated tests produce **zero skips** with no prior host import; resolved workspace root identical before/after a host import.
- PR #418's `_delenv_restoring` correction and tests preserved and reused.

## Validation (local, Windows; Linux via the 4 CI shards)

- Focused affected batch (30 files incl. all studio/host/workspace victims): **315 passed, 16 skipped, 0 failed** — identical batch on main: 2 failed (main's own order hazard manifested), 299 passed, same 16 legit skips.
- Both polluter/victim pairs in both orders: green. Acceptance files with `os.environ["MOZAIKS_WORKFLOWS_PATH"]` reads: 9 passed unchanged (their runner sets env itself).
- Production-readiness + hygiene set (`test_production_readiness_gate`, `test_runtime_readiness`, `test_materialized_bundle_production_runtime`, `test_oss_prompt_hygiene`, `test_quickstart_workspace_hygiene`): 52 passed.
- `ruff check .` clean · `git diff --check` clean · strict MkDocs build clean (doc updated) · DCO signed.

## Scope confirmation

Untouched: PR #419 / `mozaiksai/core/semantics/` / semantic tests, ADRs, taxonomy behavior, CI sharding (`scripts/ci/split_tests.py` unmodified — its order-preservation rationale still stands for other latent stubbing patterns), generated-app contracts, workflow sequences, entitlement behavior. No live models were run.

## OSS Change Impact

- **Layer changed**: framework capability (host composition) + test suite hygiene; universal substrate untouched except the hosts bootstrap module itself.
- **Build workflow impact**: none.
- **Runtime/platform impact**: startup applies the same defaults at the same effective point (before any root resolution); import becomes side-effect free.
- **App workspace impact**: none; composition contract doc updated to state the startup-time guarantee.
- **Tests run**: listed above.
- **Docs updated**: `docs/architecture/hosts/host-composition-contract.md`, `CHANGELOG.md` (Unreleased/Changed).
- **Compatibility risk**: embedders that imported the studio module purely for the env side effect (no server startup) would no longer see env set — no such consumer exists in-repo; the smoke script calls the bootstrap explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit `3afa4f26` — two latent hazards surfaced by the new shard split

The first CI run failed shards 1 and 3. Both failures reproduced locally, and neither was a regression from the host change — but both had to be fixed at the source before this can land.

**Why they appeared now**: adding two test files shifts the round-robin indices in `scripts/ci/split_tests.py`, so every subsequent file's index moves and files reorder within shards. That script's docstring warns that relative order is load-bearing. Each polluter/victim pair was verified to **fail on main (`359c3e06`)** as an isolated pair, so the defects predate this branch; main's full shards passed only because the old ordering kept them dormant.

| Shard | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | `KeyError: 'ValueEngine'` in `test_workflow_catalog_contract.py` | `initialize_workflows(tmp)` rebuilds the global workflow manager **in place** and was never restored, so later tests saw only the temp workspace's workflows | `test_generated_app_functional_acceptance.py` restores the global catalog via a fixture |
| 3 | `cannot import name 'get_event_dispatcher' from 'mozaiksai.core.events' (unknown location)` → degraded platform startup | `import_module_directly` fabricated parent packages that never execute their real `__init__.py` and left them cached in `sys.modules`, poisoning later real imports of that package | the helper now removes exactly the stubs it created, deepest first |

Reordering, skipping, or withholding the regression files was not an option (and is ruled out by the task); both are the same process-global pollution class this branch targets.

**Proofs added** to the existing `tests/test_suite_order_independence.py` (kept in that file so shard composition does not shift again): the direct-import helper leaves no fabricated parent behind, and the global catalog survives a workspace-scoped reinitialization. That file now holds 6 passing proofs.

**Local verification after the fix**: all four CI shards green — shard 0 `3200 passed / 9 skipped`, shard 1 `3349 / 6`, shard 2 `3552 / 36`, shard 3 `3843 / 28` — **13,944 passed, 0 failed**. Both previously failing pairs pass. `ruff check .` clean, `git diff --check` clean.


---

## Follow-up commit `3b38477f` — independent review found a production regression

Two independent reviews ran against exact head `3afa4f26`. One found a **real production bug in the first commit**, which is now fixed. Every finding below was reproduced before being acted on.

### Critical: Studio lost its factory workflow catalog (14 → 0)

`mozaiks serve <workspace> --host studio` bound Studio to the workspace's own (usually empty) `workflows/` root instead of the shared factory catalog — losing `AppGenerator`, `AgentGenerator`, `ValueEngine`, and the rest of the build surface.

```
BRANCH: COUNT 0    ENV_WF (empty)
MAIN:   COUNT 14   ['AgentGenerator', 'AppGenerator', 'AppReview', ...]
```

**Cause.** The global catalog in `mozaiksai.core.workflow.workflow_manager` is constructed **at module import**, from whichever workflow root the environment names at that instant. The deleted `configure_repo_host_defaults("studio")` call sat deliberately *above* studio.py's heavy import block to seed `MOZAIKS_WORKFLOWS_PATH` first. Moving it to startup was too late for a component frozen at import. This is the one requirement in the brief the first commit did not meet: *configuration must be established before a component that needs it is constructed*.

Only Studio is affected: its defaults prefer the shared **factory** root while bare resolution prefers an **app workspace's** own `workflows/`, and `mozaiks init` scaffolds that directory in every workspace. `--host platform` never registered a bootstrap and is unchanged.

**Why CI missed it.** `test_host_bootstrap.py` asserts exactly this contract but calls the bootstrap *function* directly rather than booting the host — the `verification-priority.md` failure mode where the proof certifies the wrapper, not the seam.

**Fix.** Startup binds the catalog to the root its defaults selected, **scoped to the lifespan**: acquired at startup, released at shutdown. Scoping matters in both directions — an unscoped binding regressed shard 1 by leaking one test's workflow root into later tests, and releasing it makes repeated startup deterministic. The rebuild preserves manager object identity, and is a no-op when the roots already agree.

### Also fixed from review

| Finding | Fix |
|---|---|
| My `import_module_directly` stub-deletion orphaned real submodules, breaking `monkeypatch.setattr("mozaiksai.resources.X")` (verified A/B vs merge base) | Upgrade each fabricated stub to the real package instead of deleting it; keeps dotted-path resolution *and* fixes the stale-stub `unknown location` failure |
| Import-inertness proof was **vacuous** when `.env` pins the host keys — passed even with the bug reintroduced | Probes now import `mozaiksai.core.core_config` (whose side effect is `load_dotenv`) *before* snapshotting, instead of pre-seeding `.env` |
| Caller-env test could not distinguish a no-op write | Asserts an exact unnormalized `PLATFORM_PATH` the bootstrap would visibly rewrite |
| OTel rebuilt a `TracerProvider` + worker thread on every ASGI startup | Configured once per process again |
| Registration deduped on the raw host name | Dedupes on the normalized name |
| Nested pytest runs inherited `COV_CORE_*` (which pytest-cov honors over `--no-cov`), scattering `.coverage.*` into the repo root | Stripped from nested env; verified 0 stray files |
| `assert "skipped" not in summary` would false-positive on any new content guard | Matches the specific skip reason |
| Test resolvers ignored `MOZAIKS_FACTORY_APP_PATH` while the host honors it | Both now honor it |
| A module whose body raised stayed cached half-initialized | Removed on failure |

### New proof

Drives the **real Studio ASGI app** against an external workspace and asserts the factory catalog is bound at startup, unchanged across restarts, and released on shutdown. Confirmed non-vacuous — it fails with the fix disabled.

### Accepted, not fixed

Startup writes `PLATFORM_PATH`/`MOZAIKS_WORKFLOWS_PATH` into `os.environ` unrestored. That is required behavior — those vars are how every downstream module resolves roots, and the brief specifies startup must apply them exactly once. It is strictly narrower than main, where the write happened at import.

### Verification

All four CI shards green locally — **13,945 passed, 0 failed** (shard 0 `3200/9 skipped`, 1 `3350/6`, 2 `3552/36`, 3 `3843/28`). `ruff check .` clean, `git diff --check` clean, strict MkDocs build clean, no stray coverage files. CHANGELOG and the host-composition doc corrected — they previously overclaimed that `mozaiks serve` was unaffected.


---

## Deferred follow-up findings (NOT addressed in this PR)

Both surfaced during the independent exact-head review. Neither is a regression from this PR, and both are recorded here so they are not lost.

### 1. The startup bootstrap binds a host *name* to a shared app object — MEDIUM

`mozaiksai/hosts/studio.py` registers the bootstrap on `platform_app.app`, and `studio.app IS platform.app`. So booting the **platform** host in a process that has imported Studio runs the **Studio** bootstrap, and platform gets the shared factory workflow root instead of the workspace's own `workflows/` — contrary to `CLAUDE.md` ("app/product hosts prefer the workspace root's `workflows/`"). Reproduced: with `PLATFORM_PATH=<ws>/app` and no `MOZAIKS_WORKFLOWS_PATH`, `with TestClient(platform.app)` binds `factory_app/workflows` (14 workflows). The catalog is released on shutdown; `MOZAIKS_WORKFLOWS_PATH` is not.

**Not a regression** — on `main` the same env was pinned at Studio *import*, so the coupling predates this PR; this PR relocates it to startup. No OSS entrypoint reaches it today (`mozaiks serve --host platform` does not import Studio). It matters for the documented app-local composition pattern in `docs/architecture/hosts/host-composition-contract.md`, where a hosted product host composing on top of Studio would silently serve Studio's factory catalog.

**Fix direction:** key the bootstrap on the host actually being booted rather than on which module was imported first. Out of scope here because it changes shared host-binding behavior.

### 2. Pre-existing module-registry leak between in-process platform boots — separate issue

`pytest tests/test_platform_module_dispatch.py tests/test_continuous_deterministic_materialization.py` fails with `404 MODULE_NOT_FOUND: reports` immediately after `MODULE_REGISTERED: reports`.

Ruled out as caused by this PR two independent ways: it reproduces with **no Studio import in the process** (so no bootstrap fires), and it still reproduces with this PR's `_upgrade_fabricated_parents` neutralized back to `main`'s behavior. It is a module-registry leak across in-process platform boots that this PR's order-independence suite does not cover. Warrants its own issue.

### Minor, also deferred

- The startup env write (`PLATFORM_PATH` / `MOZAIKS_WORKFLOWS_PATH`) is not rolled back on shutdown while the workflow-catalog binding is — converges deterministically across restarts, but the asymmetry is undocumented.
- `initialize_workflows` copies the rebuilt manager's empty `_handlers`/`_handler_metadata`, so a startup rebind would discard anything registered by an import-time `@register_workflow`. `register_workflow`/`get_handler` have zero call sites outside `workflow_manager.py`, so nothing is affected today.
- `resolve_repo_host_defaults("platform")` / `register_repo_host_bootstrap(app, "platform")` has no production caller (true on `main` too); exercised only by tests.

---

## Final independent exact-head review (Codex)

Reviewed exact head `29e083fac306457760b62626e5ad33482a043538` independently against original merge base `359c3e06b157c897c5d9f7a2717e4d48b688bb53` and current main `453bec7372f71811666581f336860a04ea1d5fc1`.

Disposition: **clean to squash-merge**.

Evidence:
- Complete changed-file and commit review found no material defect or scope drift.
- Current-main advancement only deletes `mozaiksai/core/ports/ssl_provider.py`; it is disjoint and the effective merge tree is clean.
- Host imports are process-inert; Studio startup applies defaults before dependent lifespans.
- A real external-workspace Studio startup bound exactly 14 factory workflows, restored the prior catalog on shutdown, repeated identically, and preserved `workflow_manager`, `get_workflow_manager()`, `_unified_workflow_manager`, and `UnifiedWorkflowManager._instance` object identity.
- `import_module_directly` upgrades fabricated parents without orphaning submodules; a forced module-body failure left no failed leaf cached.
- `.env`-aware import probes are non-vacuous; nested pytest strips `COV_CORE_*`; no `.coverage*` artifacts or process-state leaks remained.
- OTel regression covers failed-call guard state, retry, success, later no-op, and test-state restoration.
- No added `Any`, cast, typing/mypy suppression, skip, flaky retry, sleep, ordering workaround, or behavioral masking. Added `noqa` markers are only deliberate `F401` import probes.
- Production entrypoints remain correct: direct Uvicorn, `mozaiks serve`, Studio launcher, and live workflow smoke bootstrap.
- Focused local validation: 76 passed / 2 legitimate skips; all changed direct-consumer tests: 115 passed; `ruff check .` and `git diff --check` clean; manual 14-workflow and failed-import-cache probes clean.
- The requested mypy command reports one error in untouched `acp_coding_provider.py`; the file has the identical blob on merge base, PR head, and current main, and the same error reproduces on the merge base. This is a pre-existing local AG2 signature/stub mismatch, not introduced or masked here. Exact-head CI lint passed.
- Exact-head DCO, all four test shards, aggregate test, lint, secret scan, dependency audit, frontend, package, infra-build, visual regression, and GitGuardian checks passed.
- Deferred shared `studio.app is platform.app` host-binding ambiguity and pre-existing `MODULE_NOT_FOUND: reports` leak are recorded above and remain correctly out of scope.
- PR #421 was not modified. No live models or workflows ran.