### PR TITLE
feat(semantics): ADR 0007 Slice 3 offline projection adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Offline semantic projection comparison (ADR 0007 Slice 3)**: deterministic,
+  input-immutable adapters can now project existing AppGenerator, DesignDocs,
+  subscription, module, workflow, deployment, recorded-artifact, build-context,
+  and ownership evidence into candidate `SemanticGraph` documents for offline
+  corpus comparison. A machine-readable coverage report classifies every source
+  leaf as projected, deliberately non-semantic, or deferred and returns typed
+  gaps for unsupported facts. Production generators, hosts, loaders, Studio,
+  workflows, control-plane code, capability advertisement, and runtime authority
+  remain unchanged.
+
 - **Semantic-compiler contract layer (ADR 0007 Slice 2)**: strict, immutable,
   content-digested contracts for `ApplicationManifest`
   (`mozaiks.app_manifest.v1`), `SemanticGraph` (`mozaiks.semantic_graph.v1`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,14 @@ This project follows a practical pre-1.0 changelog format:
 ### Added
 
 - **Offline semantic projection comparison (ADR 0007 Slice 3)**: deterministic,
-  input-immutable adapters can now project existing AppGenerator, DesignDocs,
-  subscription, module, workflow, deployment, recorded-artifact, build-context,
-  and ownership evidence into candidate `SemanticGraph` documents for offline
-  corpus comparison. A machine-readable coverage report classifies every source
-  leaf as projected, deliberately non-semantic, or deferred and returns typed
-  gaps for unsupported facts. Production generators, hosts, loaders, Studio,
-  workflows, control-plane code, capability advertisement, and runtime authority
-  remain unchanged.
+  input-immutable adapters accept current AppGenerator, DesignDocs,
+  subscription, module, page/route, AgentGenerator bundle, deployment,
+  recorded-AppBuildPlan, build-context, and AppContext ownership shapes. They
+  project only graph-v1 facts and report every other source fact through typed,
+  machine-readable coverage and gaps; unresolved action, event, capability,
+  scope, and ownership references fail closed instead of creating graph facts.
+  Production generators, hosts, loaders, Studio, workflows, control-plane code,
+  capability advertisement, and runtime authority remain unchanged.
 
 - **Semantic-compiler contract layer (ADR 0007 Slice 2)**: strict, immutable,
   content-digested contracts for `ApplicationManifest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ This project follows a practical pre-1.0 changelog format:
   they declare no graph-v1 identity and cannot by themselves produce a graph.
   Page bindings outside `/api/modules/{module}/{action}` are retained as typed
   gaps rather than invented action targets, so any valid AppPageSchema api path
-  projects. Projection requires an explicitly pinned Slice 1
+  projects. Surface realization kinds that graph v1 cannot retain are likewise
+  precise typed gaps rather than falsely reported as represented, and custom
+  route identities retain their current AppSchema producer paths. Projection
+  requires an explicitly pinned Slice 1
   `TaxonomyRegistry`, which keeps the call free of runtime, workflow, and
   workflow-catalog side effects. Production generators, hosts, loaders, Studio,
   workflows, control-plane code, capability advertisement, and runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,20 @@ This project follows a practical pre-1.0 changelog format:
 - **Offline semantic projection comparison (ADR 0007 Slice 3)**: deterministic,
   input-immutable adapters accept current AppGenerator, DesignDocs,
   subscription, module, page/route, AgentGenerator bundle, deployment,
-  recorded-AppBuildPlan, build-context, and AppContext ownership shapes. They
-  project only graph-v1 facts and report every other source fact through typed,
+  recorded-AppBuildPlan, and AppContext ownership shapes. They project only
+  graph-v1 facts and report every other source fact through typed,
   machine-readable coverage and gaps; unresolved action, event, capability,
-  scope, and ownership references fail closed instead of creating graph facts.
-  Production generators, hosts, loaders, Studio, workflows, control-plane code,
-  capability advertisement, and runtime authority remain unchanged.
+  scope, and ownership references fail closed instead of creating graph facts,
+  as do duplicate canonical root aliases. Build-context and recorded workflow
+  envelopes are accepted as provenance and classified entirely as typed gaps —
+  they declare no graph-v1 identity and cannot by themselves produce a graph.
+  Page bindings outside `/api/modules/{module}/{action}` are retained as typed
+  gaps rather than invented action targets, so any valid AppPageSchema api path
+  projects. Projection requires an explicitly pinned Slice 1
+  `TaxonomyRegistry`, which keeps the call free of runtime, workflow, and
+  workflow-catalog side effects. Production generators, hosts, loaders, Studio,
+  workflows, control-plane code, capability advertisement, and runtime
+  authority remain unchanged.
 
 - **Semantic-compiler contract layer (ADR 0007 Slice 2)**: strict, immutable,
   content-digested contracts for `ApplicationManifest`

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -332,6 +332,17 @@ _KNOWN_DEFERRED = frozenset(
     }
 )
 _PROVENANCE_ROOTS = frozenset({"build_context", "workflows"})
+_SURFACE_KINDS = frozenset(
+    {
+        "module",
+        "workflow",
+        "app_policy",
+        "refinement",
+        "external_integration",
+        "ui_only",
+    }
+)
+_GRAPH_V1_SURFACE_KINDS = frozenset({"module", "workflow"})
 _SLUG = re.compile(r"[^a-z0-9_]+")
 _MODULE_ENDPOINT = re.compile(r"^/api/modules/([^/]+)/([^/]+)$")
 # Mirrors AppPageSchema's _API_PATH_RE (mozaiksai/core/runtime/app/page_schema.py).
@@ -639,15 +650,33 @@ class _Builder:
                 group=f"{root}.surface_map.surfaces",
             )
             kind = str(item.get("surface_kind") or "")
+            if not kind:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{base}.surface_kind",
+                            reason="surface_kind is required by the current producer contract",
+                        )
+                    ]
+                )
+            if kind not in _SURFACE_KINDS:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.UNSUPPORTED,
+                            source_path=f"{base}.surface_kind",
+                            reason=(
+                                f"surface_kind {kind!r} is not in the current producer "
+                                f"taxonomy {sorted(_SURFACE_KINDS)!r}"
+                            ),
+                        )
+                    ]
+                )
             self.observe(
                 "surface", sid, "surface_kind", item.get("surface_kind"), f"{base}.surface_kind"
             )
             self.observe("surface", sid, "owner", item.get("owner"), f"{base}.owner")
-            self.mark(
-                f"{base}.surface_kind",
-                node=SemanticNodeKind.SURFACE,
-                identity="surface classification; graph-v1 payload deferred",
-            )
             owner: str | None = None
             if kind == "module":
                 owner = self.node(
@@ -662,6 +691,16 @@ class _Builder:
                     sid,
                     path=f"{base}.surface_kind",
                     group=f"{root}.surface_workflows",
+                )
+            elif kind not in _GRAPH_V1_SURFACE_KINDS:
+                self.gap(
+                    ProjectionGapKind.UNSUPPORTED,
+                    f"{base}.surface_kind",
+                    (
+                        f"surface_kind {kind!r} is current application semantics but "
+                        "SemanticGraph v1 cannot retain that realization classification"
+                    ),
+                    adr_slice=5,
                 )
             if owner:
                 self.edge(
@@ -924,16 +963,32 @@ class _Builder:
         )
 
     def project_route_manifest(self, manifest: dict[str, Any], root: str) -> None:
-        entries = manifest.get("pages", manifest.get("route_manifest", []))
+        present_keys = [key for key in ("pages", "route_manifest") if key in manifest]
+        if len(present_keys) > 1:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=root,
+                        reason=(
+                            "route manifest contains both runtime 'pages' and AppSchema "
+                            "'route_manifest' entry collections"
+                        ),
+                    )
+                ]
+            )
+        entries_key = present_keys[0] if present_keys else "pages"
+        entries = manifest.get(entries_key, [])
         for i, raw in enumerate(_as_list(entries)):
             item = _mapping(raw)
+            base = f"{root}.{entries_key}[{i}]"
             identity = item.get("id") or item.get("path")
             if not identity:
                 raise ProjectionError(
                     [
                         ProjectionGap(
                             kind=ProjectionGapKind.MISSING,
-                            source_path=f"{root}.pages[{i}]",
+                            source_path=base,
                             reason="route identity is required",
                         )
                     ]
@@ -942,8 +997,8 @@ class _Builder:
             page = self.node(
                 SemanticNodeKind.PAGE,
                 identity,
-                path=f"{root}.pages[{i}].{key}",
-                group=f"{root}.pages",
+                path=f"{base}.{key}",
+                group=f"{root}.{entries_key}",
             )
             auth = _mapping(_mapping(item.get("meta")).get("routeAuth"))
             if auth:
@@ -951,7 +1006,7 @@ class _Builder:
                     page,
                     auth.get("module"),
                     auth.get("action"),
-                    f"{root}.pages[{i}].meta.routeAuth",
+                    f"{base}.meta.routeAuth",
                 )
 
     def project_data_contract(self, contract: dict[str, Any], root: str) -> None:

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -30,7 +30,6 @@ from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef, SemanticsMode
 from mozaiksai.core.taxonomy import (
     SemanticCategory,
     TaxonomyRegistry,
-    default_taxonomy_registry,
     validate_identifier_grammar,
 )
 
@@ -332,8 +331,11 @@ _KNOWN_DEFERRED = frozenset(
         "ui_layout",
     }
 )
+_PROVENANCE_ROOTS = frozenset({"build_context", "workflows"})
 _SLUG = re.compile(r"[^a-z0-9_]+")
 _MODULE_ENDPOINT = re.compile(r"^/api/modules/([^/]+)/([^/]+)$")
+# Mirrors AppPageSchema's _API_PATH_RE (mozaiksai/core/runtime/app/page_schema.py).
+_PAGE_API_PATH = re.compile(r"^/api/[A-Za-z0-9_./-]+$")
 _PATH_TOKEN = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
 
 
@@ -865,17 +867,37 @@ class _Builder:
                     and child.startswith("/api/")
                 ):
                     match = _MODULE_ENDPOINT.fullmatch(child)
-                    if match is None:
+                    if match is not None:
+                        self._bind_action(page, match.group(1), match.group(2), child_path)
+                    elif _PAGE_API_PATH.fullmatch(child):
+                        # AppPageSchema permits any /api/... path (page_schema.py
+                        # _API_PATH_RE); only /api/modules/{module}/{action} names a
+                        # declared module action. Other valid paths — the committed
+                        # /api/notifications route, for one — are real bindings that
+                        # graph v1 has no node kind for, so they are typed gaps
+                        # rather than a hard failure or an invented action target.
+                        self.gap(
+                            ProjectionGapKind.UNSUPPORTED,
+                            child_path,
+                            (
+                                "valid non-module page API binding has no SemanticGraph v1 "
+                                "target; only /api/modules/{module}/{action} names a declared action"
+                            ),
+                            adr_slice=5,
+                        )
+                    else:
                         raise ProjectionError(
                             [
                                 ProjectionGap(
                                     kind=ProjectionGapKind.AMBIGUOUS,
                                     source_path=child_path,
-                                    reason="API binding is not /api/modules/{module}/{action}",
+                                    reason=(
+                                        "API binding is not a valid AppPageSchema api path "
+                                        "(^/api/[A-Za-z0-9_./-]+$)"
+                                    ),
                                 )
                             ]
                         )
-                    self._bind_action(page, match.group(1), match.group(2), child_path)
                 else:
                     self._page_bindings(child, page, child_path)
         elif isinstance(value, list):
@@ -1325,6 +1347,25 @@ class _Builder:
                         group=f"{base}.orchestrator.triggers",
                     )
 
+    def project_provenance(self, value: Any, root: str) -> None:
+        """Classify accepted provenance roots that carry no graph-v1 identity.
+
+        ``build_context`` is declared pack provenance and ``workflows`` is
+        recorded execution metadata on an AppBuildPlan envelope. Both are real
+        parts of current recorded sources, so they are accepted rather than
+        rejected as unknown roots — but neither declares application semantics
+        that SemanticGraph v1 can hold, so every leaf becomes an explicit typed
+        gap instead of an invented node.
+        """
+        authority = _SOURCE_AUTHORITIES[root][2]
+        for leaf_path, _leaf in _iter_leaves(value, root):
+            self.gap(
+                ProjectionGapKind.UNSUPPORTED,
+                leaf_path,
+                f"{authority} is not SemanticGraph v1 application semantics",
+                adr_slice=5,
+            )
+
     def project_ownership(self, evidence: dict[str, Any], root: str) -> None:
         mode = str(evidence.get("mode") or "greenfield")
         boundaries = _as_list(evidence.get("ownership_boundaries"))
@@ -1415,7 +1456,11 @@ class _Builder:
                 reason = (
                     "source fact is not representable by Slice 2 identity-only nodes"
                     if gap_kind is ProjectionGapKind.UNSUPPORTED
-                    else "unclassified source field may be producer drift or a typo; projection refuses to guess"
+                    else (
+                        "field is not in this projection's classified set; it is reported "
+                        "rather than projected, and carries no SemanticGraph v1 identity "
+                        "until it is classified"
+                    )
                 )
                 disposition, fully, adr_slice = ProjectionDisposition.DEFERRED, False, 5
                 gap = ProjectionGap(kind=gap_kind, source_path=path, reason=reason, adr_slice=5)
@@ -1511,9 +1556,18 @@ def project_semantic_graph(
     graph_id: str,
     version: int,
     scope: ExecutionAccessScopeRef,
-    taxonomy_registry: TaxonomyRegistry | None = None,
+    taxonomy_registry: TaxonomyRegistry,
 ) -> ProjectionResult:
-    """Project current contracts without mutation, writes, network, models, or authority."""
+    """Project current contracts without mutation, writes, network, models, or authority.
+
+    ``taxonomy_registry`` is required and must be a pinned Slice 1 registry.
+    Constructing a default here would call ``default_taxonomy_registry()``,
+    which lazily imports the runtime layout registry and transport event
+    contract at call time — that pulls the workflow manager in, which reads
+    the workflow catalog from disk. An offline projection cannot own that side
+    effect, and Slice 1 remains the only taxonomy authority, so the caller
+    supplies the registry it has pinned.
+    """
     plain = _plain(source)
     if not isinstance(plain, dict) or not plain:
         raise ProjectionError(
@@ -1538,7 +1592,27 @@ def project_semantic_graph(
                 for root in unknown
             ]
         )
-    builder = _Builder(plain, scope, taxonomy_registry or default_taxonomy_registry())
+    duplicate_aliases = sorted(
+        f"{alias}/{canonical}"
+        for alias, canonical in _ROOT_ALIASES.items()
+        if alias in plain and canonical in plain
+    )
+    if duplicate_aliases:
+        raise ProjectionError(
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.CONTRADICTORY,
+                    source_path=pair.split("/", 1)[0],
+                    reason=(
+                        f"both {pair.split('/')[0]!r} and its canonical name "
+                        f"{pair.split('/')[1]!r} are present; one envelope would be "
+                        "silently ignored, so duplicate roots fail closed"
+                    ),
+                )
+                for pair in duplicate_aliases
+            ]
+        )
+    builder = _Builder(plain, scope, taxonomy_registry)
     for source_name, raw_scope in sorted(_mapping(plain.get("source_scopes")).items()):
         source_scope = ExecutionAccessScopeRef.model_validate(raw_scope)
         path = f"source_scopes.{source_name}"
@@ -1604,7 +1678,31 @@ def project_semantic_graph(
         builder.project_ownership(_mapping(plain["app_context"]), "app_context")
     if _mapping(plain.get("ownership_evidence")):
         builder.project_ownership(_mapping(plain["ownership_evidence"]), "ownership_evidence")
+    for provenance_root in sorted(_PROVENANCE_ROOTS & set(plain)):
+        builder.project_provenance(plain[provenance_root], provenance_root)
     if not builder.nodes:
+        # Distinguish "this input carries only graph-v1-unrepresentable
+        # provenance" from "this input declares nothing at all". Reporting the
+        # former as a missing semantic identity misnames the cause.
+        provenance_only = bool(_PROVENANCE_ROOTS & set(plain)) and not (
+            set(plain) - _PROVENANCE_ROOTS - {"source_scopes"}
+        )
+        if provenance_only:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.UNSUPPORTED,
+                        source_path=root,
+                        reason=(
+                            f"{_SOURCE_AUTHORITIES[root][2]} carries no SemanticGraph v1 "
+                            "identity; it is accepted and classified as typed gaps but "
+                            "cannot by itself produce a graph"
+                        ),
+                        adr_slice=5,
+                    )
+                    for root in sorted(_PROVENANCE_ROOTS & set(plain))
+                ]
+            )
         raise ProjectionError(
             [
                 ProjectionGap(

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -1,9 +1,8 @@
-"""Deterministic, offline-only projection of current build artifacts.
+"""ADR 0007 Slice 3 deterministic, offline-only source projection.
 
-This module is ADR 0007 Slice 3 comparison infrastructure.  Production
-generators, hosts, loaders, workflows, Studio, and control-plane code must not
-import it.  It projects only facts representable by ``SemanticGraph`` v1 and
-reports every other source leaf through a typed coverage/gap record.
+Production generators, runtimes, hosts, workflows, Studio, and control-plane
+code must not import this module. It accepts current contract shapes, projects
+only graph-v1 facts, and reports every other source fact as typed coverage.
 """
 
 from __future__ import annotations
@@ -13,6 +12,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from enum import StrEnum
 from typing import Any, Literal
 
+import yaml
 from pydantic import Field
 
 from mozaiksai.core.semantics.canonical import canonical_digest
@@ -27,7 +27,12 @@ from mozaiksai.core.semantics.graph import (
     validate_semantic_graph_taxonomy_closure,
 )
 from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef, SemanticsModel
-from mozaiksai.core.taxonomy import SemanticCategory, TaxonomyRegistry, default_taxonomy_registry
+from mozaiksai.core.taxonomy import (
+    SemanticCategory,
+    TaxonomyRegistry,
+    default_taxonomy_registry,
+    validate_identifier_grammar,
+)
 
 PROJECTION_SCHEMA_VERSION: Literal["mozaiks.semantic_projection.v1"] = (
     "mozaiks.semantic_projection.v1"
@@ -73,7 +78,7 @@ class ProjectionCoverage(SemanticsModel):
 
 
 class SemanticFactSet(SemanticsModel):
-    nodes: tuple[tuple[str, str], ...]
+    nodes: tuple[tuple[str, str, tuple[tuple[str, str], ...]], ...]
     edges: tuple[tuple[str, str, str, str | None], ...]
 
 
@@ -81,6 +86,7 @@ class ProjectionResult(SemanticsModel):
     schema_version: Literal["mozaiks.semantic_projection.v1"] = PROJECTION_SCHEMA_VERSION
     source_digest: str
     graph: SemanticGraph
+    source_facts: SemanticFactSet
     represented_facts: SemanticFactSet
     gaps: tuple[ProjectionGap, ...]
     coverage: tuple[ProjectionCoverage, ...]
@@ -90,7 +96,9 @@ class ProjectionError(ValueError):
     """Fail-closed projection error retaining deterministic typed gaps."""
 
     def __init__(self, gaps: Iterable[ProjectionGap]):
-        self.gaps = tuple(sorted(gaps, key=lambda gap: (gap.source_path, gap.kind.value, gap.reason)))
+        self.gaps = tuple(
+            sorted(gaps, key=lambda gap: (gap.source_path, gap.kind.value, gap.reason))
+        )
         super().__init__("; ".join(f"{gap.source_path}: {gap.reason}" for gap in self.gaps))
 
 
@@ -98,79 +106,235 @@ _SOURCE_AUTHORITIES: dict[str, tuple[str, str, str]] = {
     "app_build_plan": (
         "factory_app/workflows/AppGenerator/structured_outputs.yaml",
         "AppBuildPlan",
-        "AppGenerator agent-authored operational plan",
+        "AppGenerator operational plan",
     ),
     "app_schema": (
         "factory_app/workflows/AppGenerator/structured_outputs.yaml",
         "AppSchemaOutput",
-        "AppGenerator schema-stage output",
+        "AppGenerator schema output",
     ),
     "design_docs": (
         "factory_app/workflows/DesignDocs/structured_outputs.yaml",
         "DesignDocsBundle",
-        "DesignDocs stage output",
+        "DesignDocs output",
     ),
     "subscription_contract": (
         "factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml",
         "SubscriptionContractOutput",
-        "SubscriptionContractDesigner stage output",
+        "subscription design output",
     ),
     "modules": (
         "mozaiksai/core/runtime/app/module_loader.py",
         "ModuleLoader",
-        "runtime module child contracts",
+        "runtime module contracts",
+    ),
+    "pages": (
+        "mozaiksai/core/runtime/app/page_schema.py",
+        "AppPageSchema",
+        "runtime page contract",
+    ),
+    "route_manifest": (
+        "mozaiksai/core/runtime/app/loader.py",
+        "AppLoader",
+        "runtime route manifest",
     ),
     "subscriptions": (
         "mozaiksai/core/runtime/app/subscriptions_loader.py",
         "SubscriptionsConfig",
-        "runtime subscription child contract",
+        "runtime subscription contract",
     ),
     "agent_workflows": (
         "factory_app/workflows/AgentGenerator/structured_outputs.yaml",
         "WorkflowBundleBuilderOutput",
-        "AgentGenerator workflow bundle output",
+        "AgentGenerator bundle output",
     ),
-    "recorded_artifacts": (
-        "mozaiksai/core/runtime/app/loader.py",
-        "AppLoader",
-        "recorded generated-app artifact bundle",
+    "app_context": (
+        "mozaiksai/core/app_context/models.py",
+        "AppContextVersion",
+        "observed ownership evidence",
     ),
     "ownership_evidence": (
         "mozaiksai/core/app_context/models.py",
-        "OwnershipBoundary",
-        "observed brownfield/hybrid ownership evidence",
+        "AppContextVersion.ownership_boundaries",
+        "observed ownership evidence",
     ),
     "build_context": (
         "mozaiksai/core/session/build_context_schema.py",
-        "BuildContextRegistry",
+        "validate_pack_context",
         "declared build-context provenance",
+    ),
+    "workflows": (
+        "tests/fixtures/appplan_persistent_projects_output.json",
+        "recorded fixture envelope",
+        "recorded AppBuildPlan execution metadata; not an AppBuildPlan field",
     ),
     "source_scopes": (
         "mozaiksai/core/semantics/offline_projection.py",
         "project_semantic_graph",
-        "offline projection composition envelope",
+        "offline composition envelope",
     ),
 }
-
-_NON_SEMANTIC_NAMES = frozenset(
+_ROOT_ALIASES = {
+    "AppBuildPlan": "app_build_plan",
+    "AppSchemaOutput": "app_schema",
+    "DesignDocsBundle": "design_docs",
+    "SubscriptionContractOutput": "subscription_contract",
+}
+_SUPPORTED_ROOTS = frozenset(_SOURCE_AUTHORITIES) | frozenset(_ROOT_ALIASES)
+_NON_SEMANTIC = frozenset({"agent_message"})
+_KNOWN_DEFERRED = frozenset(
     {
-        "agent_message",
+        "acceptance_criteria",
+        "access",
+        "action_id",
+        "active",
+        "add_on_id",
+        "agent_backend_required",
+        "allowed_operations",
+        "amount",
+        "amount_cents",
+        "app_id",
+        "app_kind",
+        "app_name",
+        "artifact_version_id",
+        "assets",
+        "auth_strategy",
+        "billing_mode",
+        "brand_direction",
+        "brand_intent",
+        "capability_groups",
+        "capability_pack_id",
+        "cadence",
+        "collection",
+        "component",
+        "config",
+        "config_hint",
+        "content",
+        "context_id",
+        "context_variables",
+        "contract_required",
+        "currency",
+        "dependencies",
         "description",
+        "display",
+        "emits",
+        "endpoint",
+        "entities",
+        "fields",
+        "filename",
+        "frontend_markdown",
+        "frontend_scope",
+        "generation_order",
+        "handler",
+        "handler_method",
+        "href",
+        "initial_agent",
+        "initial_message",
+        "indexes",
+        "intent",
+        "kind",
         "label",
+        "layout",
+        "lifecycle",
+        "max_turns",
+        "metering_declarations",
+        "method",
+        "mode",
+        "module_contract_updates",
+        "monthly_limit",
+        "navigation_model",
         "notes",
+        "order",
+        "orchestration_pattern",
+        "owner",
+        "owner_module",
+        "ownership",
+        "ownership_boundaries",
+        "page_surface_requirements",
+        "pages",
+        "path",
+        "path_or_artifact",
+        "pattern_id",
+        "pattern_name",
+        "placement",
+        "plan_design_rationale",
+        "policies",
+        "price",
+        "pricing_catalog",
+        "primitive",
+        "profile_layout",
+        "projections",
         "purpose",
         "rationale",
+        "readiness_profile",
+        "ref_schema_version",
+        "required",
+        "revenue_model",
+        "roles",
+        "route",
+        "schema_version",
+        "scope",
+        "search_by",
+        "section_id_hint",
+        "sections",
+        "service_scope",
+        "shell_preset_hint",
+        "source",
+        "source_capability_packs",
+        "source_ref",
+        "subscriber_intents",
         "summary",
+        "surface_kind",
+        "target",
+        "target_kind",
+        "theme_config_patch",
+        "theme_preferences",
         "title",
-        "frontend_markdown",
-        "backend_markdown",
-        "database_markdown",
-        "acceptance_criteria",
-        "initial_message",
-        "generation_order",
+        "token_amount",
+        "trigger",
+        "triggers",
+        "type",
+        "unit",
+        "value",
+        "value_type",
+        "version",
+        "workflow_capability_ids",
+        "workflow_contract_updates",
+        "workflow_startup_mode",
+        "workflow_triggers",
+        "write_mode",
+        "appearance_hint",
+        "brand_keywords",
+        "depends_on",
+        "entity_name",
+        "execution_target",
+        "experience_goals",
+        "field",
+        "implementation_mode",
+        "keys",
+        "migration_id",
+        "module_id",
+        "monetization_provider",
+        "name",
+        "operations",
+        "owned_paths",
+        "pack_type",
+        "page_type_hint",
+        "primary_actions",
+        "primary_entities",
+        "primary_pages",
+        "sections_hint",
+        "style_summary",
+        "surface_id",
+        "task_id",
+        "task_type",
+        "title_hint",
+        "ui_layout",
     }
 )
 _SLUG = re.compile(r"[^a-z0-9_]+")
+_MODULE_ENDPOINT = re.compile(r"^/api/modules/([^/]+)/([^/]+)$")
+_PATH_TOKEN = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
 
 
 def _plain(value: Any) -> Any:
@@ -187,7 +351,13 @@ def _slug(value: Any) -> str:
     text = _SLUG.sub("_", str(value or "").strip().lower()).strip("_")
     if not text:
         raise ProjectionError(
-            [ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="identity", reason="stable identity is empty")]
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.MISSING,
+                    source_path="identity",
+                    reason="stable identity is empty",
+                )
+            ]
         )
     return text
 
@@ -222,24 +392,69 @@ def _iter_leaves(value: Any, path: str) -> Iterable[tuple[str, Any]]:
 
 def _source_metadata(path: str) -> tuple[str, str, str]:
     root = path.split(".", 1)[0].split("[", 1)[0]
-    root = {
-        "AppBuildPlan": "app_build_plan",
-        "AppSchemaOutput": "app_schema",
-        "DesignDocsBundle": "design_docs",
-        "SubscriptionContractOutput": "subscription_contract",
-    }.get(root, root)
-    return _SOURCE_AUTHORITIES.get(root, ("unknown", "unknown", "unclassified input"))
+    return _SOURCE_AUTHORITIES[_ROOT_ALIASES.get(root, root)]
+
+
+def _value_at_path(source: Any, path: str) -> Any:
+    value = source
+    for name, index in _PATH_TOKEN.findall(path):
+        value = value[int(index)] if index else value[name]
+    return value
+
+
+def _canonicalize_unordered(source: dict[str, Any]) -> None:
+    """Normalize collections whose current contracts define identity, not order."""
+
+    for root in ("app_build_plan", "AppBuildPlan", "design_docs", "DesignDocsBundle"):
+        value = _mapping(source.get(root))
+        surfaces = _mapping(value.get("surface_map")).get("surfaces")
+        if isinstance(surfaces, list):
+            surfaces.sort(key=lambda item: str(_mapping(item).get("surface_id") or ""))
+    modules = source.get("modules")
+    if not isinstance(modules, list):
+        return
+    modules.sort(
+        key=lambda raw: str(
+            _mapping(
+                _mapping(raw).get("manifest")
+                or _mapping(raw).get("module_manifest")
+                or _mapping(raw)
+            )
+            .get("module", {})
+            .get("id", "")
+        )
+    )
+    for raw in modules:
+        bundle = _mapping(raw)
+        manifest = _mapping(bundle.get("manifest") or bundle.get("module_manifest") or bundle)
+        for field, key in (
+            ("actions", "id"),
+            ("capabilities", "capability_id"),
+            ("permissions", "id"),
+        ):
+            values = manifest.get(field)
+            if isinstance(values, list):
+                values.sort(key=lambda item: str(_mapping(item).get(key) or ""))
 
 
 class _Builder:
-    def __init__(self, source: dict[str, Any], scope: ExecutionAccessScopeRef, registry: TaxonomyRegistry):
+    def __init__(
+        self, source: dict[str, Any], scope: ExecutionAccessScopeRef, registry: TaxonomyRegistry
+    ):
         self.source = source
         self.scope = scope
         self.registry = registry
         self.nodes: dict[str, SemanticNode] = {}
         self.edges: dict[tuple[str, str, str, str | None], SemanticEdge] = {}
-        self.projected_paths: dict[str, tuple[SemanticNodeKind | None, SemanticEdgeKind | None, SemanticCategory | None, str]] = {}
+        self.node_groups: set[tuple[str, str]] = set()
+        self.edge_groups: set[tuple[str, tuple[str, str, str, str | None]]] = set()
+        self.pending: list[tuple[SemanticEdgeKind, str, str, str, str | None, str]] = []
+        self.projected: dict[
+            str,
+            tuple[SemanticNodeKind | None, SemanticEdgeKind | None, SemanticCategory | None, str],
+        ] = {}
         self.gaps: list[ProjectionGap] = []
+        self.observations: dict[tuple[str, str, str], str] = {}
 
     def mark(
         self,
@@ -250,292 +465,967 @@ class _Builder:
         taxonomy: SemanticCategory | None = None,
         identity: str,
     ) -> None:
-        self.projected_paths[path] = (node, edge, taxonomy, identity)
+        prior = self.projected.get(path)
+        if prior is None:
+            self.projected[path] = (node, edge, taxonomy, identity)
+        else:
+            self.projected[path] = (
+                prior[0] or node,
+                prior[1] or edge,
+                prior[2] or taxonomy,
+                prior[3] if identity in prior[3] else f"{prior[3]}; {identity}",
+            )
 
-    def add_node(
+    def gap(
+        self, kind: ProjectionGapKind, path: str, reason: str, *, adr_slice: int | None = None
+    ) -> None:
+        self.gaps.append(
+            ProjectionGap(kind=kind, source_path=path, reason=reason, adr_slice=adr_slice)
+        )
+
+    def observe(self, concept: str, identity: Any, field: str, value: Any, path: str) -> None:
+        if value is None:
+            return
+        key = (concept, str(identity), field)
+        digest = canonical_digest(value)
+        prior = self.observations.get(key)
+        if prior is not None and prior != digest:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=path,
+                        reason=f"conflicting {concept} {field} facts for {identity!r}",
+                    )
+                ]
+            )
+        self.observations[key] = digest
+
+    def node(
         self,
         kind: SemanticNodeKind,
         identity: Any,
         *,
         path: str,
+        group: str,
         taxonomy: tuple[SemanticCategory, str] | None = None,
     ) -> str:
         node_id = _node_id(kind, identity)
-        tax_refs: tuple[TaxonomyReference, ...] = ()
-        if taxonomy is not None:
+        if (group, node_id) in self.node_groups:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=path,
+                        reason=f"duplicate semantic identity {node_id!r} in {group}",
+                    )
+                ]
+            )
+        self.node_groups.add((group, node_id))
+        refs: tuple[TaxonomyReference, ...] = ()
+        if taxonomy:
             category, identifier = taxonomy
+            try:
+                validate_identifier_grammar(category, identifier)
+            except Exception as exc:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.UNSUPPORTED,
+                            source_path=path,
+                            reason=f"invalid {category.value} taxonomy identifier {identifier!r}: {exc}",
+                        )
+                    ]
+                ) from exc
             try:
                 self.registry.resolve(category, identifier)
             except Exception as exc:
                 raise ProjectionError(
-                    [ProjectionGap(kind=ProjectionGapKind.UNSUPPORTED, source_path=path, reason=f"unknown {category.value} taxonomy identifier {identifier!r}: {exc}")]
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=path,
+                            reason=(
+                                f"valid {category.value} identifier {identifier!r} is absent "
+                                "from the pinned taxonomy registry; a declared namespace entry is required"
+                            ),
+                        )
+                    ]
                 ) from exc
-            tax_refs = (TaxonomyReference(category=category, identifier=identifier),)
-        candidate = SemanticNode(node_id=node_id, kind=kind, taxonomy_references=tax_refs)
-        existing = self.nodes.get(node_id)
-        if existing is not None and existing != candidate:
+            refs = (TaxonomyReference(category=category, identifier=identifier),)
+        candidate = SemanticNode(node_id=node_id, kind=kind, taxonomy_references=refs)
+        if node_id in self.nodes and self.nodes[node_id] != candidate:
             raise ProjectionError(
-                [ProjectionGap(kind=ProjectionGapKind.CONTRADICTORY, source_path=path, reason=f"conflicting facts reuse node identity {node_id!r}")]
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=path,
+                        reason=f"conflicting facts reuse node identity {node_id!r}",
+                    )
+                ]
             )
         self.nodes[node_id] = candidate
-        self.mark(path, node=kind, taxonomy=taxonomy[0] if taxonomy else None, identity="kind + canonical source identifier")
+        self.mark(
+            path,
+            node=kind,
+            taxonomy=taxonomy[0] if taxonomy else None,
+            identity="node kind + canonical source identifier",
+        )
         return node_id
 
-    def add_edge(self, kind: SemanticEdgeKind, source: str, target: str, *, path: str, discriminator: str | None = None) -> None:
-        key = (kind.value, source, target, discriminator)
-        self.edges[key] = SemanticEdge(kind=kind, source_node_id=source, target_node_id=target, discriminator=discriminator)
-        self.mark(path, edge=kind, identity="edge kind + stable source/target identities + discriminator")
+    def edge(
+        self,
+        kind: SemanticEdgeKind,
+        source: str,
+        target: str,
+        *,
+        path: str,
+        group: str,
+        discriminator: str | None = None,
+    ) -> None:
+        self.pending.append((kind, source, target, path, discriminator, group))
+        self.mark(path, edge=kind, identity="edge kind + stable declared endpoints + discriminator")
 
-    def module(self, module_id: Any, path: str) -> str:
-        return self.add_node(SemanticNodeKind.MODULE, module_id, path=path)
+    def resolve_edges(self) -> None:
+        for kind, source, target, path, discriminator, group in self.pending:
+            missing = [node_id for node_id in (source, target) if node_id not in self.nodes]
+            if missing:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=path,
+                            reason=f"reference does not resolve to a declared semantic node: {missing}",
+                        )
+                    ]
+                )
+            key = (kind.value, source, target, discriminator)
+            if (group, key) in self.edge_groups:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.CONTRADICTORY,
+                            source_path=path,
+                            reason=f"duplicate semantic relationship {key!r} in {group}",
+                        )
+                    ]
+                )
+            self.edge_groups.add((group, key))
+            self.edges[key] = SemanticEdge(
+                kind=kind, source_node_id=source, target_node_id=target, discriminator=discriminator
+            )
 
     def project_plan(self, plan: dict[str, Any], root: str) -> None:
         surfaces = _as_list(_mapping(plan.get("surface_map")).get("surfaces"))
-        for i, surface in enumerate(surfaces):
-            item = _mapping(surface)
-            base = f"{root}.surface_map.surfaces[{i}]"
+        for i, raw in enumerate(surfaces):
+            item, base = _mapping(raw), f"{root}.surface_map.surfaces[{i}]"
             sid = item.get("surface_id")
             if not sid:
-                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{base}.surface_id", reason="surface identity is required")])
-            module = self.module(sid, f"{base}.surface_id")
-            self.mark(f"{base}.surface_kind", node=SemanticNodeKind.MODULE, identity="surface kind selects graph node kind")
-            self.mark(f"{base}.owner", node=SemanticNodeKind.MODULE, identity="ownership is preserved by scoped module identity")
-            for j, action in enumerate(_as_list(item.get("owned_mutations"))):
-                action_node = self.add_node(SemanticNodeKind.ACTION, f"{sid}_{action}", path=f"{base}.owned_mutations[{j}]")
-                self.add_edge(SemanticEdgeKind.DECLARES, module, action_node, path=f"{base}.owned_mutations[{j}]")
-            for j, event in enumerate(_as_list(item.get("events_emitted"))):
-                event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{base}.events_emitted[{j}]", taxonomy=(SemanticCategory.EVENT, str(event)))
-                self.add_edge(SemanticEdgeKind.EMITS, module, event_node, path=f"{base}.events_emitted[{j}]")
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{base}.surface_id",
+                            reason="surface identity is required",
+                        )
+                    ]
+                )
+            surface = self.node(
+                SemanticNodeKind.SURFACE,
+                sid,
+                path=f"{base}.surface_id",
+                group=f"{root}.surface_map.surfaces",
+            )
+            kind = str(item.get("surface_kind") or "")
+            self.observe(
+                "surface", sid, "surface_kind", item.get("surface_kind"), f"{base}.surface_kind"
+            )
+            self.observe("surface", sid, "owner", item.get("owner"), f"{base}.owner")
+            self.mark(
+                f"{base}.surface_kind",
+                node=SemanticNodeKind.SURFACE,
+                identity="surface classification; graph-v1 payload deferred",
+            )
+            owner: str | None = None
+            if kind == "module":
+                owner = self.node(
+                    SemanticNodeKind.MODULE,
+                    sid,
+                    path=f"{base}.surface_kind",
+                    group=f"{root}.surface_modules",
+                )
+            elif kind == "workflow":
+                owner = self.node(
+                    SemanticNodeKind.WORKFLOW,
+                    sid,
+                    path=f"{base}.surface_kind",
+                    group=f"{root}.surface_workflows",
+                )
+            if owner:
+                self.edge(
+                    SemanticEdgeKind.OWNS,
+                    surface,
+                    owner,
+                    path=f"{base}.surface_kind",
+                    group=f"{root}.surface_ownership",
+                )
+            for j, action_id in enumerate(_as_list(item.get("owned_mutations"))):
+                if owner is None or kind != "module":
+                    raise ProjectionError(
+                        [
+                            ProjectionGap(
+                                kind=ProjectionGapKind.CONTRADICTORY,
+                                source_path=f"{base}.owned_mutations[{j}]",
+                                reason="only module surfaces can declare module actions",
+                            )
+                        ]
+                    )
+                action = self.node(
+                    SemanticNodeKind.ACTION,
+                    f"{sid}_{action_id}",
+                    path=f"{base}.owned_mutations[{j}]",
+                    group=f"{base}.owned_mutations",
+                )
+                self.edge(
+                    SemanticEdgeKind.DECLARES,
+                    owner,
+                    action,
+                    path=f"{base}.owned_mutations[{j}]",
+                    group=f"{base}.owned_mutations",
+                )
+            for j, event_type in enumerate(_as_list(item.get("events_emitted"))):
+                event = self.node(
+                    SemanticNodeKind.EVENT,
+                    event_type,
+                    path=f"{base}.events_emitted[{j}]",
+                    group=f"{base}.events_emitted",
+                    taxonomy=(SemanticCategory.EVENT, str(event_type)),
+                )
+                self.edge(
+                    SemanticEdgeKind.EMITS,
+                    owner or surface,
+                    event,
+                    path=f"{base}.events_emitted[{j}]",
+                    group=f"{base}.events_emitted",
+                )
+        for i, raw in enumerate(surfaces):
+            item, base = _mapping(raw), f"{root}.surface_map.surfaces[{i}]"
             for j, dependency in enumerate(_as_list(item.get("dependencies"))):
-                target = self.module(dependency, f"{base}.dependencies[{j}]")
-                self.add_edge(SemanticEdgeKind.DEPENDS_ON, module, target, path=f"{base}.dependencies[{j}]")
-
-        for i, page in enumerate(_as_list(plan.get("pages"))):
-            item = _mapping(page)
+                self.edge(
+                    SemanticEdgeKind.DEPENDS_ON,
+                    _node_id(SemanticNodeKind.SURFACE, item.get("surface_id")),
+                    _node_id(SemanticNodeKind.SURFACE, dependency),
+                    path=f"{base}.dependencies[{j}]",
+                    group=f"{base}.dependencies",
+                )
+        pages = _as_list(plan.get("pages"))
+        if len(pages) > 1:
+            self.gap(
+                ProjectionGapKind.UNSUPPORTED,
+                f"{root}.pages",
+                "ordered page/navigation semantics are not representable by SemanticGraph v1",
+                adr_slice=5,
+            )
+        for i, raw in enumerate(pages):
+            item = _mapping(raw)
             identity = item.get("name") or item.get("route")
-            if identity:
-                self.add_node(SemanticNodeKind.PAGE, identity, path=f"{root}.pages[{i}].name")
-                if "route" in item:
-                    self.mark(f"{root}.pages[{i}].route", node=SemanticNodeKind.PAGE, identity="page name is stable; route is deferred payload")
-
-        for i, entity in enumerate(_as_list(plan.get("entities"))):
-            item = _mapping(entity)
-            identity = item.get("name")
-            if identity:
-                self.add_node(SemanticNodeKind.DATA_COLLECTION, identity, path=f"{root}.entities[{i}].name")
-
-        for i, pack in enumerate(_as_list(plan.get("capability_packs"))):
-            item = _mapping(pack)
-            pack_id = item.get("capability_pack_id")
-            if pack_id:
-                cap = self.add_node(SemanticNodeKind.CAPABILITY, pack_id, path=f"{root}.capability_packs[{i}].capability_pack_id")
-                surface_id = item.get("surface_id")
-                if surface_id:
-                    module = self.module(surface_id, f"{root}.capability_packs[{i}].surface_id")
-                    self.add_edge(SemanticEdgeKind.DEPENDS_ON, module, cap, path=f"{root}.capability_packs[{i}].capability_pack_id")
-
-        for i, flow in enumerate(_as_list(plan.get("event_flows"))):
-            item = _mapping(flow)
-            event = item.get("event_type")
-            producer = item.get("producer_pack_id")
-            if event and producer:
-                event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}.event_flows[{i}].event_type", taxonomy=(SemanticCategory.EVENT, str(event)))
-                producer_node = self.module(producer, f"{root}.event_flows[{i}].producer_pack_id")
-                self.add_edge(SemanticEdgeKind.EMITS, producer_node, event_node, path=f"{root}.event_flows[{i}].event_type")
-
-        for i, touchpoint in enumerate(_as_list(plan.get("workflow_touchpoints"))):
-            item = _mapping(touchpoint)
-            workflow_id = item.get("workflow_id")
-            if workflow_id:
-                workflow = self.add_node(SemanticNodeKind.WORKFLOW, workflow_id, path=f"{root}.workflow_touchpoints[{i}].workflow_id")
-                page_name = item.get("page_name")
-                if page_name:
-                    page = self.add_node(SemanticNodeKind.PAGE, page_name, path=f"{root}.workflow_touchpoints[{i}].page_name")
-                    self.add_edge(SemanticEdgeKind.BINDS, page, workflow, path=f"{root}.workflow_touchpoints[{i}].workflow_id")
-
+            if not identity:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}.pages[{i}]",
+                            reason="page identity is required",
+                        )
+                    ]
+                )
+            path = f"{root}.pages[{i}].name" if item.get("name") else f"{root}.pages[{i}].route"
+            self.observe("page", identity, "route", item.get("route"), f"{root}.pages[{i}].route")
+            self.node(SemanticNodeKind.PAGE, identity, path=path, group=f"{root}.pages")
+        for i, raw in enumerate(_as_list(plan.get("entities"))):
+            item = _mapping(raw)
+            if item.get("name"):
+                self.node(
+                    SemanticNodeKind.DATA_COLLECTION,
+                    item["name"],
+                    path=f"{root}.entities[{i}].name",
+                    group=f"{root}.entities",
+                )
+        for i, raw in enumerate(_as_list(plan.get("event_flows"))):
+            item = _mapping(raw)
+            if item.get("event_type") and item.get("producer_pack_id"):
+                event = self.node(
+                    SemanticNodeKind.EVENT,
+                    item["event_type"],
+                    path=f"{root}.event_flows[{i}].event_type",
+                    group=f"{root}.event_flows",
+                    taxonomy=(SemanticCategory.EVENT, str(item["event_type"])),
+                )
+                self.edge(
+                    SemanticEdgeKind.EMITS,
+                    _node_id(SemanticNodeKind.MODULE, item["producer_pack_id"]),
+                    event,
+                    path=f"{root}.event_flows[{i}].producer_pack_id",
+                    group=f"{root}.event_flows",
+                )
+        for i, raw in enumerate(_as_list(plan.get("workflow_touchpoints"))):
+            item = _mapping(raw)
+            if item.get("workflow_id") and item.get("page_name"):
+                self.edge(
+                    SemanticEdgeKind.BINDS,
+                    _node_id(SemanticNodeKind.PAGE, item["page_name"]),
+                    _node_id(SemanticNodeKind.WORKFLOW, item["workflow_id"]),
+                    path=f"{root}.workflow_touchpoints[{i}].workflow_id",
+                    group=f"{root}.workflow_touchpoints",
+                )
         self.project_data_contract(_mapping(plan.get("data_contract")), f"{root}.data_contract")
-        for i, target in enumerate(_as_list(plan.get("deployment_targets"))):
-            item = _mapping(target)
+        for i, raw in enumerate(_as_list(plan.get("deployment_targets"))):
+            item = _mapping(raw)
             identity = item.get("target_id") or item.get("deployment_profile")
             if identity:
-                self.add_node(SemanticNodeKind.DEPLOYMENT_TARGET, identity, path=f"{root}.deployment_targets[{i}].target_id")
+                path = (
+                    f"{root}.deployment_targets[{i}].target_id"
+                    if item.get("target_id")
+                    else f"{root}.deployment_targets[{i}].deployment_profile"
+                )
+                self.node(
+                    SemanticNodeKind.DEPLOYMENT_TARGET,
+                    identity,
+                    path=path,
+                    group=f"{root}.deployment_targets",
+                )
 
-    def project_schema(self, schema: dict[str, Any], root: str) -> None:
-        for i, page in enumerate(_as_list(schema.get("pages"))):
-            item = _mapping(page)
+    def project_pages(self, pages: Any, root: str) -> None:
+        for i, raw in enumerate(_as_list(pages)):
+            item = _mapping(raw)
             identity = item.get("page_id") or item.get("name") or item.get("route")
             if not identity:
-                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}.pages[{i}]", reason="page identity is required")])
-            page_node = self.add_node(SemanticNodeKind.PAGE, identity, path=f"{root}.pages[{i}].name")
-            for j, section in enumerate(_as_list(item.get("sections"))):
-                section_item = _mapping(section)
-                section_id = section_item.get("id") or section_item.get("section_id")
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}[{i}]",
+                            reason="page identity is required",
+                        )
+                    ]
+                )
+            key = next(key for key in ("page_id", "name", "route") if item.get(key))
+            self.observe("page", identity, "route", item.get("route"), f"{root}[{i}].route")
+            page = self.node(SemanticNodeKind.PAGE, identity, path=f"{root}[{i}].{key}", group=root)
+            sections = _as_list(item.get("sections"))
+            if item.get("schema_version") == "mozaiks.app_page.v1" and not sections:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}[{i}].sections",
+                            reason="runtime AppPageSchema requires at least one section",
+                        )
+                    ]
+                )
+            if len(sections) > 1:
+                self.gap(
+                    ProjectionGapKind.UNSUPPORTED,
+                    f"{root}[{i}].sections",
+                    "ordered page-section semantics are not representable by SemanticGraph v1",
+                    adr_slice=5,
+                )
+            for j, raw_section in enumerate(sections):
+                section = _mapping(raw_section)
+                section_id = section.get("id") or section.get("section_id")
                 if section_id:
-                    section_node = self.add_node(SemanticNodeKind.SECTION, f"{identity}_{section_id}", path=f"{root}.pages[{i}].sections[{j}].id")
-                    self.add_edge(SemanticEdgeKind.RENDERS, page_node, section_node, path=f"{root}.pages[{i}].sections[{j}].id")
-                self._project_page_actions(section_item, page_node, f"{root}.pages[{i}].sections[{j}]")
-        self.project_data_contract(_mapping(schema.get("data_contract")), f"{root}.data_contract")
+                    key = "id" if section.get("id") else "section_id"
+                    child = self.node(
+                        SemanticNodeKind.SECTION,
+                        f"{identity}_{section_id}",
+                        path=f"{root}[{i}].sections[{j}].{key}",
+                        group=f"{root}[{i}].sections",
+                    )
+                    self.edge(
+                        SemanticEdgeKind.RENDERS,
+                        page,
+                        child,
+                        path=f"{root}[{i}].sections[{j}].{key}",
+                        group=f"{root}[{i}].sections",
+                    )
+                self._page_bindings(section, page, f"{root}[{i}].sections[{j}]")
+            auth = _mapping(_mapping(item.get("meta")).get("routeAuth"))
+            if auth:
+                self._bind_action(
+                    page, auth.get("module"), auth.get("action"), f"{root}[{i}].meta.routeAuth"
+                )
 
-    def _project_page_actions(self, value: Any, page_node: str, path: str) -> None:
+    def _page_bindings(self, value: Any, page: str, path: str) -> None:
         if isinstance(value, Mapping):
             for key, child in value.items():
                 child_path = f"{path}.{key}"
-                if key in {"api_endpoint", "endpoint"} and isinstance(child, str) and "/" in child:
-                    parts = [part for part in child.strip("/").split("/") if part]
-                    if len(parts) >= 2:
-                        module_id, action_id = parts[-2], parts[-1]
-                        module = self.module(module_id, child_path)
-                        action = self.add_node(SemanticNodeKind.ACTION, f"{module_id}_{action_id}", path=child_path)
-                        self.add_edge(SemanticEdgeKind.DECLARES, module, action, path=child_path)
-                        self.add_edge(SemanticEdgeKind.BINDS, page_node, action, path=child_path)
+                if (
+                    key in {"api_endpoint", "href"}
+                    and isinstance(child, str)
+                    and child.startswith("/api/")
+                ):
+                    match = _MODULE_ENDPOINT.fullmatch(child)
+                    if match is None:
+                        raise ProjectionError(
+                            [
+                                ProjectionGap(
+                                    kind=ProjectionGapKind.AMBIGUOUS,
+                                    source_path=child_path,
+                                    reason="API binding is not /api/modules/{module}/{action}",
+                                )
+                            ]
+                        )
+                    self._bind_action(page, match.group(1), match.group(2), child_path)
                 else:
-                    self._project_page_actions(child, page_node, child_path)
+                    self._page_bindings(child, page, child_path)
         elif isinstance(value, list):
             for index, child in enumerate(value):
-                self._project_page_actions(child, page_node, f"{path}[{index}]")
+                self._page_bindings(child, page, f"{path}[{index}]")
+
+    def _bind_action(self, page: str, module_id: Any, action_id: Any, path: str) -> None:
+        if not module_id or not action_id:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.MISSING,
+                        source_path=path,
+                        reason="page binding requires module and action",
+                    )
+                ]
+            )
+        self.edge(
+            SemanticEdgeKind.BINDS,
+            page,
+            _node_id(SemanticNodeKind.ACTION, f"{module_id}_{action_id}"),
+            path=path,
+            group=path,
+        )
+
+    def project_route_manifest(self, manifest: dict[str, Any], root: str) -> None:
+        entries = manifest.get("pages", manifest.get("route_manifest", []))
+        for i, raw in enumerate(_as_list(entries)):
+            item = _mapping(raw)
+            identity = item.get("id") or item.get("path")
+            if not identity:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}.pages[{i}]",
+                            reason="route identity is required",
+                        )
+                    ]
+                )
+            key = "id" if item.get("id") else "path"
+            page = self.node(
+                SemanticNodeKind.PAGE,
+                identity,
+                path=f"{root}.pages[{i}].{key}",
+                group=f"{root}.pages",
+            )
+            auth = _mapping(_mapping(item.get("meta")).get("routeAuth"))
+            if auth:
+                self._bind_action(
+                    page,
+                    auth.get("module"),
+                    auth.get("action"),
+                    f"{root}.pages[{i}].meta.routeAuth",
+                )
 
     def project_data_contract(self, contract: dict[str, Any], root: str) -> None:
-        for i, surface in enumerate(_as_list(contract.get("surfaces"))):
-            item = _mapping(surface)
-            owner_id = item.get("surface_id")
-            owner = self.module(owner_id, f"{root}.surfaces[{i}].surface_id") if owner_id else None
-            for j, collection in enumerate(_as_list(item.get("collections"))):
-                collection_item = _mapping(collection)
-                name = collection_item.get("name") or collection_item.get("entity_name")
+        for i, raw_surface in enumerate(_as_list(contract.get("surfaces"))):
+            surface = _mapping(raw_surface)
+            owner_id = surface.get("surface_id")
+            owner = None
+            if owner_id and surface.get("surface_kind") == "module":
+                owner = self.node(
+                    SemanticNodeKind.MODULE,
+                    owner_id,
+                    path=f"{root}.surfaces[{i}].surface_id",
+                    group=f"{root}.surface_owners",
+                )
+            for j, raw_collection in enumerate(_as_list(surface.get("collections"))):
+                item = _mapping(raw_collection)
+                name = item.get("name") or item.get("entity_name")
                 if name:
-                    collection_node = self.add_node(SemanticNodeKind.DATA_COLLECTION, f"{owner_id}_{name}", path=f"{root}.surfaces[{i}].collections[{j}].name")
+                    collection = self.node(
+                        SemanticNodeKind.DATA_COLLECTION,
+                        f"{owner_id}_{name}" if owner_id else name,
+                        path=f"{root}.surfaces[{i}].collections[{j}].name",
+                        group=f"{root}.surfaces[{i}].collections",
+                    )
                     if owner:
-                        self.add_edge(SemanticEdgeKind.OWNS, owner, collection_node, path=f"{root}.surfaces[{i}].collections[{j}].name")
-        for i, alias in enumerate(_as_list(contract.get("aliases"))):
-            item = _mapping(alias)
-            alias_id = item.get("alias")
-            collection = item.get("collection")
-            if alias_id:
-                alias_node = self.add_node(SemanticNodeKind.DATA_ALIAS, alias_id, path=f"{root}.aliases[{i}].alias")
-                if collection:
-                    target = self.add_node(SemanticNodeKind.DATA_COLLECTION, f"{item.get('owner_module', 'app')}_{collection}", path=f"{root}.aliases[{i}].collection")
-                    self.add_edge(SemanticEdgeKind.BINDS, alias_node, target, path=f"{root}.aliases[{i}].collection")
+                        self.edge(
+                            SemanticEdgeKind.OWNS,
+                            owner,
+                            collection,
+                            path=f"{root}.surfaces[{i}].collections[{j}].name",
+                            group=f"{root}.surfaces[{i}].collections",
+                        )
+        for i, raw_alias in enumerate(_as_list(contract.get("aliases"))):
+            item = _mapping(raw_alias)
+            if item.get("alias"):
+                alias = self.node(
+                    SemanticNodeKind.DATA_ALIAS,
+                    item["alias"],
+                    path=f"{root}.aliases[{i}].alias",
+                    group=f"{root}.aliases",
+                )
+                if item.get("collection"):
+                    identity = (
+                        f"{item.get('owner_module')}_{item['collection']}"
+                        if item.get("owner_module")
+                        else item["collection"]
+                    )
+                    self.edge(
+                        SemanticEdgeKind.BINDS,
+                        alias,
+                        _node_id(SemanticNodeKind.DATA_COLLECTION, identity),
+                        path=f"{root}.aliases[{i}].collection",
+                        group=f"{root}.aliases",
+                    )
 
     def project_modules(self, modules: Any, root: str) -> None:
-        values = list(modules.values()) if isinstance(modules, Mapping) else _as_list(modules)
-        for i, raw in enumerate(values):
+        items = (
+            [(f"{root}.{key}", modules[key]) for key in sorted(modules)]
+            if isinstance(modules, Mapping)
+            else [(f"{root}[{index}]", raw) for index, raw in enumerate(_as_list(modules))]
+        )
+        bundles: list[tuple[str, dict[str, Any], dict[str, Any], str]] = []
+        for base, raw in items:
             bundle = _mapping(raw)
             manifest = _mapping(bundle.get("manifest") or bundle.get("module_manifest") or bundle)
-            identity = _mapping(manifest.get("module"))
-            module_id = identity.get("id") or manifest.get("module_id")
+            module_id = _mapping(manifest.get("module")).get("id") or manifest.get("module_id")
             if not module_id:
-                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}[{i}]", reason="module id is required")])
-            module = self.module(module_id, f"{root}[{i}].manifest.module.id")
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=base,
+                            reason="module id is required",
+                        )
+                    ]
+                )
+            module = self.node(
+                SemanticNodeKind.MODULE,
+                module_id,
+                path=f"{base}.manifest.module.id"
+                if bundle.get("manifest")
+                else f"{base}.module.id",
+                group=root,
+            )
+            bundles.append((str(module_id), bundle, manifest, base))
+            declarations = (
+                ("actions", "id", SemanticNodeKind.ACTION, True),
+                ("capabilities", "capability_id", SemanticNodeKind.CAPABILITY, False),
+                ("permissions", "id", SemanticNodeKind.PERMISSION, True),
+            )
+            for field, key, kind, module_qualified in declarations:
+                for j, raw_item in enumerate(_as_list(manifest.get(field))):
+                    value = _mapping(raw_item).get(key)
+                    if value:
+                        taxonomy = (
+                            (SemanticCategory.CAPABILITY, str(value))
+                            if kind is SemanticNodeKind.CAPABILITY
+                            else None
+                        )
+                        identity = f"{module_id}_{value}" if module_qualified else str(value)
+                        child = self.node(
+                            kind,
+                            identity,
+                            path=f"{base}.manifest.{field}[{j}].{key}",
+                            group=f"{base}.{field}",
+                            taxonomy=taxonomy,
+                        )
+                        self.edge(
+                            SemanticEdgeKind.DECLARES,
+                            module,
+                            child,
+                            path=f"{base}.manifest.{field}[{j}].{key}",
+                            group=f"{base}.{field}",
+                        )
+            companions = (
+                ("events", "events", "type", SemanticNodeKind.EVENT),
+                ("reactions", "reactions", "id", SemanticNodeKind.REACTION),
+                ("notifications", "notifications", "id", SemanticNodeKind.NOTIFICATION),
+            )
+            for companion, list_key, id_key, kind in companions:
+                for j, raw_item in enumerate(
+                    _as_list(_mapping(bundle.get(companion)).get(list_key))
+                ):
+                    value = _mapping(raw_item).get(id_key)
+                    if value:
+                        identity = (
+                            value if kind is SemanticNodeKind.EVENT else f"{module_id}_{value}"
+                        )
+                        taxonomy = (
+                            (SemanticCategory.EVENT, str(value))
+                            if kind is SemanticNodeKind.EVENT
+                            else None
+                        )
+                        child = self.node(
+                            kind,
+                            identity,
+                            path=f"{base}.{companion}.{list_key}[{j}].{id_key}",
+                            group=f"{base}.{companion}",
+                            taxonomy=taxonomy,
+                        )
+                        edge_kind = (
+                            SemanticEdgeKind.EMITS
+                            if kind is SemanticNodeKind.EVENT
+                            else SemanticEdgeKind.DECLARES
+                        )
+                        self.edge(
+                            edge_kind,
+                            module,
+                            child,
+                            path=f"{base}.{companion}.{list_key}[{j}].{id_key}",
+                            group=f"{base}.{companion}",
+                        )
+        for module_id, bundle, manifest, base in bundles:
             for j, raw_action in enumerate(_as_list(manifest.get("actions"))):
-                action_item = _mapping(raw_action)
-                action_id = action_item.get("id")
-                if action_id:
-                    action = self.add_node(SemanticNodeKind.ACTION, f"{module_id}_{action_id}", path=f"{root}[{i}].manifest.actions[{j}].id")
-                    self.add_edge(SemanticEdgeKind.DECLARES, module, action, path=f"{root}[{i}].manifest.actions[{j}].id")
-                    for k, event in enumerate(_as_list(action_item.get("emits"))):
-                        event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].manifest.actions[{j}].emits[{k}]", taxonomy=(SemanticCategory.EVENT, str(event)))
-                        self.add_edge(SemanticEdgeKind.EMITS, action, event_node, path=f"{root}[{i}].manifest.actions[{j}].emits[{k}]")
-                    gate = action_item.get("entitlement_gate")
-                    if gate:
-                        cap = self.add_node(SemanticNodeKind.CAPABILITY, gate, path=f"{root}[{i}].manifest.actions[{j}].entitlement_gate", taxonomy=(SemanticCategory.CAPABILITY, str(gate)))
-                        self.add_edge(SemanticEdgeKind.GATES, cap, action, path=f"{root}[{i}].manifest.actions[{j}].entitlement_gate")
-            for j, raw_cap in enumerate(_as_list(manifest.get("capabilities"))):
-                cap_item = _mapping(raw_cap)
-                cap_id = cap_item.get("capability_id")
-                if cap_id:
-                    cap = self.add_node(SemanticNodeKind.CAPABILITY, cap_id, path=f"{root}[{i}].manifest.capabilities[{j}].capability_id", taxonomy=(SemanticCategory.CAPABILITY, str(cap_id)))
-                    self.add_edge(SemanticEdgeKind.DECLARES, module, cap, path=f"{root}[{i}].manifest.capabilities[{j}].capability_id")
-            events = _mapping(bundle.get("events"))
-            for j, raw_event in enumerate(_as_list(events.get("events"))):
-                event = _mapping(raw_event).get("type")
-                if event:
-                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].events.events[{j}].type", taxonomy=(SemanticCategory.EVENT, str(event)))
-                    self.add_edge(SemanticEdgeKind.EMITS, module, event_node, path=f"{root}[{i}].events.events[{j}].type")
-            reactions = _mapping(bundle.get("reactions"))
-            for j, raw_reaction in enumerate(_as_list(reactions.get("reactions"))):
-                reaction_item = _mapping(raw_reaction)
-                reaction_id = reaction_item.get("id")
-                event = reaction_item.get("event_type")
-                if reaction_id and event:
-                    reaction = self.add_node(SemanticNodeKind.REACTION, f"{module_id}_{reaction_id}", path=f"{root}[{i}].reactions.reactions[{j}].id")
-                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].reactions.reactions[{j}].event_type", taxonomy=(SemanticCategory.EVENT, str(event)))
-                    self.add_edge(SemanticEdgeKind.CONSUMES, reaction, event_node, path=f"{root}[{i}].reactions.reactions[{j}].event_type")
-                    self.add_edge(SemanticEdgeKind.DECLARES, module, reaction, path=f"{root}[{i}].reactions.reactions[{j}].id")
+                item = _mapping(raw_action)
+                action = _node_id(SemanticNodeKind.ACTION, f"{module_id}_{item.get('id')}")
+                for k, event_type in enumerate(_as_list(item.get("emits"))):
+                    self.edge(
+                        SemanticEdgeKind.EMITS,
+                        action,
+                        _node_id(SemanticNodeKind.EVENT, event_type),
+                        path=f"{base}.manifest.actions[{j}].emits[{k}]",
+                        group=f"{base}.actions[{j}].emits",
+                    )
+                if item.get("entitlement_gate"):
+                    self.edge(
+                        SemanticEdgeKind.GATES,
+                        _node_id(SemanticNodeKind.CAPABILITY, item["entitlement_gate"]),
+                        action,
+                        path=f"{base}.manifest.actions[{j}].entitlement_gate",
+                        group=f"{base}.actions[{j}].gate",
+                    )
+            for companion, kind in (
+                ("reactions", SemanticNodeKind.REACTION),
+                ("notifications", SemanticNodeKind.NOTIFICATION),
+            ):
+                for j, raw_item in enumerate(
+                    _as_list(_mapping(bundle.get(companion)).get(companion))
+                ):
+                    item = _mapping(raw_item)
+                    event_type = item.get("event_type") or item.get("on")
+                    if item.get("id") and event_type:
+                        source = _node_id(kind, f"{module_id}_{item['id']}")
+                        self.edge(
+                            SemanticEdgeKind.CONSUMES,
+                            source,
+                            _node_id(SemanticNodeKind.EVENT, event_type),
+                            path=f"{base}.{companion}.{companion}[{j}].event_type",
+                            group=f"{base}.{companion}",
+                        )
 
     def project_subscriptions(self, config: dict[str, Any], root: str) -> None:
-        for i, raw_plan in enumerate(_as_list(config.get("plans"))):
+        plans = _as_list(config.get("plans"))
+        if len(plans) > 1:
+            self.gap(
+                ProjectionGapKind.UNSUPPORTED,
+                f"{root}.plans",
+                "ordered plan presentation semantics are not representable by SemanticGraph v1",
+                adr_slice=5,
+            )
+        for i, raw_plan in enumerate(plans):
             item = _mapping(raw_plan)
             plan_id = item.get("plan_id")
             if not plan_id:
-                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}.plans[{i}].plan_id", reason="subscription plan id is required")])
-            plan = self.add_node(SemanticNodeKind.PLAN, plan_id, path=f"{root}.plans[{i}].plan_id")
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}.plans[{i}].plan_id",
+                            reason="subscription plan id is required",
+                        )
+                    ]
+                )
+            plan = self.node(
+                SemanticNodeKind.PLAN,
+                plan_id,
+                path=f"{root}.plans[{i}].plan_id",
+                group=f"{root}.plans",
+            )
             for j, cap_id in enumerate(_as_list(item.get("capabilities"))):
-                cap = self.add_node(SemanticNodeKind.CAPABILITY, cap_id, path=f"{root}.plans[{i}].capabilities[{j}]", taxonomy=(SemanticCategory.CAPABILITY, str(cap_id)))
-                self.add_edge(SemanticEdgeKind.GATES, plan, cap, path=f"{root}.plans[{i}].capabilities[{j}]")
+                cap = self.node(
+                    SemanticNodeKind.CAPABILITY,
+                    cap_id,
+                    path=f"{root}.plans[{i}].capabilities[{j}]",
+                    group=f"{root}.plans[{i}].capabilities",
+                    taxonomy=(SemanticCategory.CAPABILITY, str(cap_id)),
+                )
+                self.edge(
+                    SemanticEdgeKind.GATES,
+                    plan,
+                    cap,
+                    path=f"{root}.plans[{i}].capabilities[{j}]",
+                    group=f"{root}.plans[{i}].capabilities",
+                )
             for j, raw_limit in enumerate(_as_list(item.get("usage_limits"))):
-                limit_item = _mapping(raw_limit)
-                meter_id = limit_item.get("meter_id")
-                if meter_id:
-                    meter = self.add_node(SemanticNodeKind.METER, meter_id, path=f"{root}.plans[{i}].usage_limits[{j}].meter_id")
-                    limit = self.add_node(SemanticNodeKind.LIMIT, f"{plan_id}_{meter_id}", path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit")
-                    self.add_edge(SemanticEdgeKind.GATES, plan, limit, path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit")
-                    self.add_edge(SemanticEdgeKind.BINDS, limit, meter, path=f"{root}.plans[{i}].usage_limits[{j}].meter_id")
-        for key, id_key in (("top_up_products", "product_id"), ("add_on_products", "add_on_id")):
-            for i, raw_product in enumerate(_as_list(config.get(key))):
-                product_id = _mapping(raw_product).get(id_key)
-                if product_id:
-                    self.add_node(SemanticNodeKind.PRODUCT, product_id, path=f"{root}.{key}[{i}].{id_key}")
+                limit = _mapping(raw_limit)
+                if limit.get("meter_id"):
+                    meter = self.node(
+                        SemanticNodeKind.METER,
+                        limit["meter_id"],
+                        path=f"{root}.plans[{i}].usage_limits[{j}].meter_id",
+                        group=f"{root}.plans[{i}].usage_limits",
+                    )
+                    limit_node = self.node(
+                        SemanticNodeKind.LIMIT,
+                        f"{plan_id}_{limit['meter_id']}",
+                        path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit",
+                        group=f"{root}.plans[{i}].usage_limits",
+                    )
+                    self.edge(
+                        SemanticEdgeKind.GATES,
+                        plan,
+                        limit_node,
+                        path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit",
+                        group=f"{root}.plans[{i}].usage_limits",
+                    )
+                    self.edge(
+                        SemanticEdgeKind.BINDS,
+                        limit_node,
+                        meter,
+                        path=f"{root}.plans[{i}].usage_limits[{j}].meter_id",
+                        group=f"{root}.plans[{i}].usage_limits",
+                    )
+        for field, id_key in (
+            ("top_up_products", "product_id"),
+            ("add_on_products", "add_on_id"),
+            ("products", "product_id"),
+        ):
+            for i, raw_product in enumerate(_as_list(config.get(field))):
+                identity = _mapping(raw_product).get(id_key)
+                if identity:
+                    self.node(
+                        SemanticNodeKind.PRODUCT,
+                        identity,
+                        path=f"{root}.{field}[{i}].{id_key}",
+                        group=f"{root}.{field}",
+                    )
 
     def project_workflows(self, workflows: Any, root: str) -> None:
-        values = list(workflows.values()) if isinstance(workflows, Mapping) else _as_list(workflows)
-        for i, raw in enumerate(values):
+        items = (
+            [(f"{root}.{key}", value) for key, value in sorted(workflows.items()) if key != "_meta"]
+            if isinstance(workflows, Mapping)
+            else [(f"{root}[{index}]", raw) for index, raw in enumerate(_as_list(workflows))]
+        )
+        for base, raw in items:
             item = _mapping(raw)
-            name = item.get("workflow_name") or item.get("name")
+            name = item.get("workflow_name")
             if not name:
-                continue
-            workflow = self.add_node(SemanticNodeKind.WORKFLOW, name, path=f"{root}[{i}].workflow_name")
-            for j, raw_trigger in enumerate(_as_list(item.get("triggers"))):
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{base}.workflow_name",
+                            reason="WorkflowBundleBuilderOutput requires workflow_name",
+                        )
+                    ]
+                )
+            workflow = self.node(
+                SemanticNodeKind.WORKFLOW, name, path=f"{base}.workflow_name", group=root
+            )
+            files = _as_list(item.get("files"))
+            if len(files) > 1:
+                self.gap(
+                    ProjectionGapKind.UNSUPPORTED,
+                    f"{base}.files",
+                    "ordered renderer file list is a Slice 4 execution concern",
+                    adr_slice=4,
+                )
+            orchestrators = [
+                (j, _mapping(raw_file))
+                for j, raw_file in enumerate(files)
+                if _mapping(raw_file).get("filename") == "orchestrator.yaml"
+            ]
+            if len(orchestrators) != 1:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{base}.files",
+                            reason="WorkflowBundleBuilderOutput must contain exactly one orchestrator.yaml",
+                        )
+                    ]
+                )
+            file_index, file = orchestrators[0]
+            path = f"{base}.files[{file_index}].content"
+            try:
+                orchestration = _mapping(yaml.safe_load(str(file.get("content") or "")))
+            except yaml.YAMLError as exc:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.AMBIGUOUS,
+                            source_path=path,
+                            reason=f"orchestrator.yaml is invalid YAML: {exc}",
+                        )
+                    ]
+                ) from exc
+            if orchestration.get("workflow_name") != name:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.CONTRADICTORY,
+                            source_path=path,
+                            reason="bundle workflow_name disagrees with orchestrator.yaml",
+                        )
+                    ]
+                )
+            self.mark(
+                path,
+                node=SemanticNodeKind.WORKFLOW,
+                identity="parsed current orchestrator.yaml identity and triggers",
+            )
+            self.gap(
+                ProjectionGapKind.UNSUPPORTED,
+                path,
+                "orchestrator.yaml contains workflow behavior beyond graph-v1 identity and trigger relationships",
+                adr_slice=5,
+            )
+            for raw_trigger in _as_list(orchestration.get("triggers")):
                 trigger_item = _mapping(raw_trigger)
-                identity = trigger_item.get("event") or trigger_item.get("endpoint") or f"{name}_{j}"
-                trigger = self.add_node(SemanticNodeKind.TRIGGER, identity, path=f"{root}[{i}].triggers[{j}]")
-                self.add_edge(SemanticEdgeKind.BINDS, trigger, workflow, path=f"{root}[{i}].triggers[{j}]")
-                event = trigger_item.get("event")
-                if event:
-                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].triggers[{j}].event", taxonomy=(SemanticCategory.EVENT, str(event)))
-                    self.add_edge(SemanticEdgeKind.CONSUMES, trigger, event_node, path=f"{root}[{i}].triggers[{j}].event")
+                identity = (
+                    trigger_item.get("event")
+                    or trigger_item.get("endpoint")
+                    or f"{name}_{canonical_digest(trigger_item)[:12]}"
+                )
+                trigger = self.node(
+                    SemanticNodeKind.TRIGGER,
+                    identity,
+                    path=path,
+                    group=f"{base}.orchestrator.triggers",
+                )
+                self.edge(
+                    SemanticEdgeKind.BINDS,
+                    trigger,
+                    workflow,
+                    path=path,
+                    group=f"{base}.orchestrator.triggers",
+                )
+                if trigger_item.get("event"):
+                    self.edge(
+                        SemanticEdgeKind.CONSUMES,
+                        trigger,
+                        _node_id(SemanticNodeKind.EVENT, trigger_item["event"]),
+                        path=path,
+                        group=f"{base}.orchestrator.triggers",
+                    )
+                if trigger_item.get("capability_id"):
+                    self.edge(
+                        SemanticEdgeKind.GATES,
+                        _node_id(SemanticNodeKind.CAPABILITY, trigger_item["capability_id"]),
+                        trigger,
+                        path=path,
+                        group=f"{base}.orchestrator.triggers",
+                    )
+
+    def project_ownership(self, evidence: dict[str, Any], root: str) -> None:
+        mode = str(evidence.get("mode") or "greenfield")
+        boundaries = _as_list(evidence.get("ownership_boundaries"))
+        if mode in {"brownfield", "hybrid"} and not boundaries:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.MISSING,
+                        source_path=f"{root}.ownership_boundaries",
+                        reason=f"{mode} projection requires AppContextVersion ownership boundaries",
+                    )
+                ]
+            )
+        for i, raw in enumerate(boundaries):
+            item = _mapping(raw)
+            if not item.get("path_or_artifact") or not item.get("ownership"):
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=f"{root}.ownership_boundaries[{i}]",
+                            reason="ownership boundary requires path_or_artifact and ownership",
+                        )
+                    ]
+                )
 
     def coverage(self) -> tuple[ProjectionCoverage, ...]:
         rows: list[ProjectionCoverage] = []
+        gap_by_path = {
+            gap.source_path: gap
+            for gap in sorted(
+                self.gaps, key=lambda item: (item.source_path, item.kind.value, item.reason)
+            )
+        }
         for path, value in _iter_leaves(self.source, ""):
-            source_file, source_symbol, authority = _source_metadata(path)
-            projected = self.projected_paths.get(path)
-            leaf_name = re.split(r"[.\[]", path)[-1].rstrip("]0123456789")
-            if projected:
+            source_file, symbol, authority = _source_metadata(path)
+            projected = self.projected.get(path)
+            names = [name for name, _index in _PATH_TOKEN.findall(path) if name]
+            leaf = names[-1] if names else ""
+            gap = gap_by_path.get(path)
+            if gap:
+                node, edge, taxonomy, identity = projected or (
+                    None,
+                    None,
+                    None,
+                    "none; graph v1 cannot retain this complete fact",
+                )
+                disposition, fully, reason, adr_slice = (
+                    ProjectionDisposition.DEFERRED,
+                    False,
+                    gap.reason,
+                    gap.adr_slice,
+                )
+            elif projected:
                 node, edge, taxonomy, identity = projected
-                disposition = ProjectionDisposition.PROJECTED
-                fully = leaf_name in {"id", "name", "type", "event", "event_type", "capability_id", "plan_id", "target_id", "workflow_id", "surface_id", "monthly_limit", "api_endpoint", "endpoint"}
-                reason = "represented in graph identity, taxonomy reference, or edge closure"
-                adr_slice = None if fully else 5
-            elif leaf_name in _NON_SEMANTIC_NAMES:
+                disposition, fully, reason, adr_slice = (
+                    ProjectionDisposition.PROJECTED,
+                    True,
+                    "source-derived fact is represented by graph identity, taxonomy, or relationship",
+                    None,
+                )
+            elif leaf in _NON_SEMANTIC:
                 node = edge = taxonomy = None
-                identity = "excluded from SemanticGraph v1 identity by declared non-semantic classification"
-                disposition = ProjectionDisposition.DELIBERATELY_NON_SEMANTIC
-                fully = True
-                reason = "human-readable or execution-planning metadata is not graph semantics"
-                adr_slice = None
+                identity = "excluded status narration"
+                disposition, fully, reason, adr_slice = (
+                    ProjectionDisposition.DELIBERATELY_NON_SEMANTIC,
+                    True,
+                    "agent status narration is not application semantics",
+                    None,
+                )
+            elif value in (None, [], {}):
+                node = edge = taxonomy = None
+                identity = "explicit absence contributes no positive semantic fact"
+                disposition, fully, reason, adr_slice = (
+                    ProjectionDisposition.DELIBERATELY_NON_SEMANTIC,
+                    True,
+                    "empty or null optional input is intentionally absent",
+                    None,
+                )
             else:
                 node = edge = taxonomy = None
                 identity = "none; SemanticGraph v1 has no payload field for this fact"
-                disposition = ProjectionDisposition.DEFERRED
-                fully = False
-                reason = "source fact is not representable by Slice 2 identity-only nodes"
-                adr_slice = 5
-                self.gaps.append(ProjectionGap(kind=ProjectionGapKind.UNSUPPORTED, source_path=path, reason=reason, adr_slice=5))
+                gap_kind = (
+                    ProjectionGapKind.UNSUPPORTED
+                    if leaf in _KNOWN_DEFERRED
+                    else ProjectionGapKind.AMBIGUOUS
+                )
+                reason = (
+                    "source fact is not representable by Slice 2 identity-only nodes"
+                    if gap_kind is ProjectionGapKind.UNSUPPORTED
+                    else "unclassified source field may be producer drift or a typo; projection refuses to guess"
+                )
+                disposition, fully, adr_slice = ProjectionDisposition.DEFERRED, False, 5
+                gap = ProjectionGap(kind=gap_kind, source_path=path, reason=reason, adr_slice=5)
+                self.gaps.append(gap)
+                gap_by_path[path] = gap
             rows.append(
                 ProjectionCoverage(
                     source_path=path,
                     source_file=source_file,
-                    source_symbol=source_symbol,
+                    source_symbol=symbol,
                     current_authority=authority,
                     disposition=disposition,
                     target_node_kind=node,
@@ -545,22 +1435,73 @@ class _Builder:
                     scope_source="project_semantic_graph(scope=ExecutionAccessScopeRef)",
                     fully_representable=fully,
                     absence_valid=value in (None, [], {}),
-                    failure_policy="fail closed when required/contradictory/ambiguous; report typed gap when unsupported",
+                    failure_policy="fail closed for missing/contradictory/ambiguous; typed gap for unsupported",
                     adr_slice=adr_slice,
                     reason=reason,
                 )
             )
+        covered = {row.source_path for row in rows}
+        for gap in sorted(
+            self.gaps, key=lambda item: (item.source_path, item.kind.value, item.reason)
+        ):
+            if gap.source_path in covered:
+                continue
+            value = _value_at_path(self.source, gap.source_path)
+            source_file, symbol, authority = _source_metadata(gap.source_path)
+            rows.append(
+                ProjectionCoverage(
+                    source_path=gap.source_path,
+                    source_file=source_file,
+                    source_symbol=symbol,
+                    current_authority=authority,
+                    disposition=ProjectionDisposition.DEFERRED,
+                    stable_identity_derivation="none; the source container carries ordering or compound semantics absent from graph v1",
+                    scope_source="project_semantic_graph(scope=ExecutionAccessScopeRef)",
+                    fully_representable=False,
+                    absence_valid=value in (None, [], {}),
+                    failure_policy="typed deferred gap for unsupported container semantics",
+                    adr_slice=gap.adr_slice,
+                    reason=gap.reason,
+                )
+            )
+            covered.add(gap.source_path)
         return tuple(sorted(rows, key=lambda row: row.source_path))
 
 
 def extract_semantic_facts(graph: SemanticGraph) -> SemanticFactSet:
-    """Return exactly the graph-v1 facts used by Slice 3 equivalence."""
+    """Extract represented facts independently from the built graph."""
     return SemanticFactSet(
-        nodes=tuple((node.node_id, node.kind.value) for node in graph.nodes),
-        edges=tuple(
-            (edge.kind.value, edge.source_node_id, edge.target_node_id, edge.discriminator)
-            for edge in graph.edges
+        nodes=tuple(
+            (
+                node.node_id,
+                node.kind.value,
+                tuple((ref.category.value, ref.identifier) for ref in node.taxonomy_references),
+            )
+            for node in graph.nodes
         ),
+        edges=tuple(
+            sorted(
+                (edge.kind.value, edge.source_node_id, edge.target_node_id, edge.discriminator)
+                for edge in graph.edges
+            )
+        ),
+    )
+
+
+def _source_facts(builder: _Builder) -> SemanticFactSet:
+    """Extract source candidates before graph construction (non-circular proof side)."""
+    return SemanticFactSet(
+        nodes=tuple(
+            sorted(
+                (
+                    node.node_id,
+                    node.kind.value,
+                    tuple((ref.category.value, ref.identifier) for ref in node.taxonomy_references),
+                )
+                for node in builder.nodes.values()
+            )
+        ),
+        edges=tuple(sorted(builder.edges)),
     )
 
 
@@ -572,13 +1513,32 @@ def project_semantic_graph(
     scope: ExecutionAccessScopeRef,
     taxonomy_registry: TaxonomyRegistry | None = None,
 ) -> ProjectionResult:
-    """Project current outputs without I/O, mutation, defaults, or side effects."""
+    """Project current contracts without mutation, writes, network, models, or authority."""
     plain = _plain(source)
     if not isinstance(plain, dict) or not plain:
-        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="$", reason="projection source must be a non-empty mapping")])
-    registry = taxonomy_registry or default_taxonomy_registry()
-    builder = _Builder(plain, scope, registry)
-
+        raise ProjectionError(
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.MISSING,
+                    source_path="$",
+                    reason="projection source must be a non-empty mapping",
+                )
+            ]
+        )
+    _canonicalize_unordered(plain)
+    unknown = sorted(set(plain) - _SUPPORTED_ROOTS)
+    if unknown:
+        raise ProjectionError(
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.UNSUPPORTED,
+                    source_path=root,
+                    reason="unknown projection source root; current producer names fail closed",
+                )
+                for root in unknown
+            ]
+        )
+    builder = _Builder(plain, scope, taxonomy_registry or default_taxonomy_registry())
     for source_name, raw_scope in sorted(_mapping(plain.get("source_scopes")).items()):
         source_scope = ExecutionAccessScopeRef.model_validate(raw_scope)
         path = f"source_scopes.{source_name}"
@@ -592,54 +1552,69 @@ def project_semantic_graph(
                     )
                 ]
             )
-        for leaf_path, _value in _iter_leaves(raw_scope, path):
-            builder.mark(
-                leaf_path,
-                identity="exact ExecutionAccessScopeRef equality across every source",
-            )
-
+        for leaf_path, _ in _iter_leaves(raw_scope, path):
+            builder.mark(leaf_path, identity="exact ExecutionAccessScopeRef equality")
     plan = _mapping(plain.get("app_build_plan") or plain.get("AppBuildPlan"))
     if plan:
-        root = "app_build_plan" if "app_build_plan" in plain else "AppBuildPlan"
-        builder.project_plan(plan, root)
+        builder.project_plan(
+            plan, "app_build_plan" if "app_build_plan" in plain else "AppBuildPlan"
+        )
     schema = _mapping(plain.get("app_schema") or plain.get("AppSchemaOutput"))
     if schema:
         root = "app_schema" if "app_schema" in plain else "AppSchemaOutput"
-        builder.project_schema(schema, root)
+        builder.project_pages(schema.get("pages", []), f"{root}.pages")
+        builder.project_data_contract(
+            _mapping(schema.get("data_contract")), f"{root}.data_contract"
+        )
+        if _mapping(schema.get("custom_route_bundle")):
+            builder.project_route_manifest(
+                _mapping(schema["custom_route_bundle"]), f"{root}.custom_route_bundle"
+            )
     design = _mapping(plain.get("design_docs") or plain.get("DesignDocsBundle"))
     if design:
         root = "design_docs" if "design_docs" in plain else "DesignDocsBundle"
-        builder.project_plan({"surface_map": design.get("surface_map"), "data_contract": design.get("data_contract"), "pages": _mapping(design.get("experience_spec")).get("pages", [])}, root)
-    subscription_output = _mapping(plain.get("subscription_contract") or plain.get("SubscriptionContractOutput"))
-    if subscription_output:
-        root = "subscription_contract" if "subscription_contract" in plain else "SubscriptionContractOutput"
-        builder.project_subscriptions(_mapping(subscription_output.get("subscription_config_file")), f"{root}.subscription_config_file")
-    builder.project_modules(plain.get("modules", []), "modules")
-    builder.project_subscriptions(_mapping(plain.get("subscriptions")), "subscriptions")
-    builder.project_workflows(plain.get("agent_workflows", []), "agent_workflows")
-    recorded = _mapping(plain.get("recorded_artifacts"))
-    if recorded:
-        builder.project_modules(recorded.get("modules", []), "recorded_artifacts.modules")
-        builder.project_schema(
-            {"pages": recorded.get("pages", []), "data_contract": recorded.get("data_contract")},
-            "recorded_artifacts",
+        builder.project_plan(
+            {
+                "surface_map": design.get("surface_map"),
+                "data_contract": design.get("data_contract"),
+                "pages": _mapping(design.get("experience_spec")).get("pages", []),
+            },
+            root,
+        )
+    subscription = _mapping(
+        plain.get("subscription_contract") or plain.get("SubscriptionContractOutput")
+    )
+    if subscription:
+        root = (
+            "subscription_contract"
+            if "subscription_contract" in plain
+            else "SubscriptionContractOutput"
         )
         builder.project_subscriptions(
-            _mapping(recorded.get("subscriptions")), "recorded_artifacts.subscriptions"
+            _mapping(subscription.get("subscription_config_file")),
+            f"{root}.subscription_config_file",
         )
-        builder.project_workflows(
-            recorded.get("workflows", []), "recorded_artifacts.workflows"
-        )
-
-    ownership = _mapping(plain.get("ownership_evidence"))
-    mode = str(ownership.get("mode") or "greenfield")
-    if mode in {"brownfield", "hybrid"} and not _as_list(ownership.get("owned_surfaces")):
-        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="ownership_evidence.owned_surfaces", reason=f"{mode} projection requires explicit owned surfaces")])
-    for i, surface_id in enumerate(_as_list(ownership.get("owned_surfaces"))):
-        builder.module(surface_id, f"ownership_evidence.owned_surfaces[{i}]")
-
+    builder.project_modules(plain.get("modules", []), "modules")
+    builder.project_pages(plain.get("pages", []), "pages")
+    if _mapping(plain.get("route_manifest")):
+        builder.project_route_manifest(_mapping(plain["route_manifest"]), "route_manifest")
+    builder.project_subscriptions(_mapping(plain.get("subscriptions")), "subscriptions")
+    builder.project_workflows(plain.get("agent_workflows", []), "agent_workflows")
+    if _mapping(plain.get("app_context")):
+        builder.project_ownership(_mapping(plain["app_context"]), "app_context")
+    if _mapping(plain.get("ownership_evidence")):
+        builder.project_ownership(_mapping(plain["ownership_evidence"]), "ownership_evidence")
     if not builder.nodes:
-        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="$", reason="source contains no representable semantic identity")])
+        raise ProjectionError(
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.MISSING,
+                    source_path="$",
+                    reason="source contains no representable semantic identity",
+                )
+            ]
+        )
+    builder.resolve_edges()
     graph = build_semantic_graph(
         graph_id=graph_id,
         version=version,
@@ -647,13 +1622,27 @@ def project_semantic_graph(
         nodes=list(builder.nodes.values()),
         edges=list(builder.edges.values()),
     )
-    validate_semantic_graph_taxonomy_closure(graph, registry)
+    validate_semantic_graph_taxonomy_closure(graph, builder.registry)
+    source_facts, represented_facts = _source_facts(builder), extract_semantic_facts(graph)
+    if source_facts != represented_facts:
+        raise ProjectionError(
+            [
+                ProjectionGap(
+                    kind=ProjectionGapKind.CONTRADICTORY,
+                    source_path="$",
+                    reason="source-derived and graph-represented facts diverge",
+                )
+            ]
+        )
     coverage = builder.coverage()
-    gaps = tuple(sorted(set(builder.gaps), key=lambda gap: (gap.source_path, gap.reason)))
+    gaps = tuple(
+        sorted(set(builder.gaps), key=lambda gap: (gap.source_path, gap.kind.value, gap.reason))
+    )
     return ProjectionResult(
         source_digest=canonical_digest(plain),
         graph=graph,
-        represented_facts=extract_semantic_facts(graph),
+        source_facts=source_facts,
+        represented_facts=represented_facts,
         gaps=gaps,
         coverage=coverage,
     )

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -1,0 +1,673 @@
+"""Deterministic, offline-only projection of current build artifacts.
+
+This module is ADR 0007 Slice 3 comparison infrastructure.  Production
+generators, hosts, loaders, workflows, Studio, and control-plane code must not
+import it.  It projects only facts representable by ``SemanticGraph`` v1 and
+reports every other source leaf through a typed coverage/gap record.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import Field
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraph,
+    SemanticNode,
+    SemanticNodeKind,
+    TaxonomyReference,
+    build_semantic_graph,
+    validate_semantic_graph_taxonomy_closure,
+)
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef, SemanticsModel
+from mozaiksai.core.taxonomy import SemanticCategory, TaxonomyRegistry, default_taxonomy_registry
+
+PROJECTION_SCHEMA_VERSION: Literal["mozaiks.semantic_projection.v1"] = (
+    "mozaiks.semantic_projection.v1"
+)
+
+
+class ProjectionGapKind(StrEnum):
+    MISSING = "missing"
+    CONTRADICTORY = "contradictory"
+    UNSUPPORTED = "unsupported"
+    AMBIGUOUS = "ambiguous"
+
+
+class ProjectionDisposition(StrEnum):
+    PROJECTED = "projected"
+    DELIBERATELY_NON_SEMANTIC = "deliberately_non_semantic"
+    DEFERRED = "deferred"
+
+
+class ProjectionGap(SemanticsModel):
+    kind: ProjectionGapKind
+    source_path: str
+    reason: str
+    adr_slice: int | None = Field(default=None, ge=4, le=7)
+
+
+class ProjectionCoverage(SemanticsModel):
+    source_path: str
+    source_file: str
+    source_symbol: str
+    current_authority: str
+    disposition: ProjectionDisposition
+    target_node_kind: SemanticNodeKind | None = None
+    target_edge_kind: SemanticEdgeKind | None = None
+    taxonomy_category: SemanticCategory | None = None
+    stable_identity_derivation: str
+    scope_source: str
+    fully_representable: bool
+    absence_valid: bool
+    failure_policy: str
+    adr_slice: int | None = Field(default=None, ge=4, le=7)
+    reason: str
+
+
+class SemanticFactSet(SemanticsModel):
+    nodes: tuple[tuple[str, str], ...]
+    edges: tuple[tuple[str, str, str, str | None], ...]
+
+
+class ProjectionResult(SemanticsModel):
+    schema_version: Literal["mozaiks.semantic_projection.v1"] = PROJECTION_SCHEMA_VERSION
+    source_digest: str
+    graph: SemanticGraph
+    represented_facts: SemanticFactSet
+    gaps: tuple[ProjectionGap, ...]
+    coverage: tuple[ProjectionCoverage, ...]
+
+
+class ProjectionError(ValueError):
+    """Fail-closed projection error retaining deterministic typed gaps."""
+
+    def __init__(self, gaps: Iterable[ProjectionGap]):
+        self.gaps = tuple(sorted(gaps, key=lambda gap: (gap.source_path, gap.kind.value, gap.reason)))
+        super().__init__("; ".join(f"{gap.source_path}: {gap.reason}" for gap in self.gaps))
+
+
+_SOURCE_AUTHORITIES: dict[str, tuple[str, str, str]] = {
+    "app_build_plan": (
+        "factory_app/workflows/AppGenerator/structured_outputs.yaml",
+        "AppBuildPlan",
+        "AppGenerator agent-authored operational plan",
+    ),
+    "app_schema": (
+        "factory_app/workflows/AppGenerator/structured_outputs.yaml",
+        "AppSchemaOutput",
+        "AppGenerator schema-stage output",
+    ),
+    "design_docs": (
+        "factory_app/workflows/DesignDocs/structured_outputs.yaml",
+        "DesignDocsBundle",
+        "DesignDocs stage output",
+    ),
+    "subscription_contract": (
+        "factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml",
+        "SubscriptionContractOutput",
+        "SubscriptionContractDesigner stage output",
+    ),
+    "modules": (
+        "mozaiksai/core/runtime/app/module_loader.py",
+        "ModuleLoader",
+        "runtime module child contracts",
+    ),
+    "subscriptions": (
+        "mozaiksai/core/runtime/app/subscriptions_loader.py",
+        "SubscriptionsConfig",
+        "runtime subscription child contract",
+    ),
+    "agent_workflows": (
+        "factory_app/workflows/AgentGenerator/structured_outputs.yaml",
+        "WorkflowBundleBuilderOutput",
+        "AgentGenerator workflow bundle output",
+    ),
+    "recorded_artifacts": (
+        "mozaiksai/core/runtime/app/loader.py",
+        "AppLoader",
+        "recorded generated-app artifact bundle",
+    ),
+    "ownership_evidence": (
+        "mozaiksai/core/app_context/models.py",
+        "OwnershipBoundary",
+        "observed brownfield/hybrid ownership evidence",
+    ),
+    "build_context": (
+        "mozaiksai/core/session/build_context_schema.py",
+        "BuildContextRegistry",
+        "declared build-context provenance",
+    ),
+    "source_scopes": (
+        "mozaiksai/core/semantics/offline_projection.py",
+        "project_semantic_graph",
+        "offline projection composition envelope",
+    ),
+}
+
+_NON_SEMANTIC_NAMES = frozenset(
+    {
+        "agent_message",
+        "description",
+        "label",
+        "notes",
+        "purpose",
+        "rationale",
+        "summary",
+        "title",
+        "frontend_markdown",
+        "backend_markdown",
+        "database_markdown",
+        "acceptance_criteria",
+        "initial_message",
+        "generation_order",
+    }
+)
+_SLUG = re.compile(r"[^a-z0-9_]+")
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return _plain(value.model_dump(mode="json"))
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_plain(item) for item in value]
+    return value
+
+
+def _slug(value: Any) -> str:
+    text = _SLUG.sub("_", str(value or "").strip().lower()).strip("_")
+    if not text:
+        raise ProjectionError(
+            [ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="identity", reason="stable identity is empty")]
+        )
+    return text
+
+
+def _node_id(kind: SemanticNodeKind, identity: Any) -> str:
+    text = str(identity or "").strip()
+    return f"mozaiks.{kind.value}.{_slug(text)}_{canonical_digest(text)[:12]}"
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _iter_leaves(value: Any, path: str) -> Iterable[tuple[str, Any]]:
+    if isinstance(value, Mapping):
+        if not value:
+            yield path, value
+        for key in sorted(value):
+            yield from _iter_leaves(value[key], f"{path}.{key}" if path else str(key))
+    elif isinstance(value, list):
+        if not value:
+            yield path, value
+        for index, item in enumerate(value):
+            yield from _iter_leaves(item, f"{path}[{index}]")
+    else:
+        yield path, value
+
+
+def _source_metadata(path: str) -> tuple[str, str, str]:
+    root = path.split(".", 1)[0].split("[", 1)[0]
+    root = {
+        "AppBuildPlan": "app_build_plan",
+        "AppSchemaOutput": "app_schema",
+        "DesignDocsBundle": "design_docs",
+        "SubscriptionContractOutput": "subscription_contract",
+    }.get(root, root)
+    return _SOURCE_AUTHORITIES.get(root, ("unknown", "unknown", "unclassified input"))
+
+
+class _Builder:
+    def __init__(self, source: dict[str, Any], scope: ExecutionAccessScopeRef, registry: TaxonomyRegistry):
+        self.source = source
+        self.scope = scope
+        self.registry = registry
+        self.nodes: dict[str, SemanticNode] = {}
+        self.edges: dict[tuple[str, str, str, str | None], SemanticEdge] = {}
+        self.projected_paths: dict[str, tuple[SemanticNodeKind | None, SemanticEdgeKind | None, SemanticCategory | None, str]] = {}
+        self.gaps: list[ProjectionGap] = []
+
+    def mark(
+        self,
+        path: str,
+        *,
+        node: SemanticNodeKind | None = None,
+        edge: SemanticEdgeKind | None = None,
+        taxonomy: SemanticCategory | None = None,
+        identity: str,
+    ) -> None:
+        self.projected_paths[path] = (node, edge, taxonomy, identity)
+
+    def add_node(
+        self,
+        kind: SemanticNodeKind,
+        identity: Any,
+        *,
+        path: str,
+        taxonomy: tuple[SemanticCategory, str] | None = None,
+    ) -> str:
+        node_id = _node_id(kind, identity)
+        tax_refs: tuple[TaxonomyReference, ...] = ()
+        if taxonomy is not None:
+            category, identifier = taxonomy
+            try:
+                self.registry.resolve(category, identifier)
+            except Exception as exc:
+                raise ProjectionError(
+                    [ProjectionGap(kind=ProjectionGapKind.UNSUPPORTED, source_path=path, reason=f"unknown {category.value} taxonomy identifier {identifier!r}: {exc}")]
+                ) from exc
+            tax_refs = (TaxonomyReference(category=category, identifier=identifier),)
+        candidate = SemanticNode(node_id=node_id, kind=kind, taxonomy_references=tax_refs)
+        existing = self.nodes.get(node_id)
+        if existing is not None and existing != candidate:
+            raise ProjectionError(
+                [ProjectionGap(kind=ProjectionGapKind.CONTRADICTORY, source_path=path, reason=f"conflicting facts reuse node identity {node_id!r}")]
+            )
+        self.nodes[node_id] = candidate
+        self.mark(path, node=kind, taxonomy=taxonomy[0] if taxonomy else None, identity="kind + canonical source identifier")
+        return node_id
+
+    def add_edge(self, kind: SemanticEdgeKind, source: str, target: str, *, path: str, discriminator: str | None = None) -> None:
+        key = (kind.value, source, target, discriminator)
+        self.edges[key] = SemanticEdge(kind=kind, source_node_id=source, target_node_id=target, discriminator=discriminator)
+        self.mark(path, edge=kind, identity="edge kind + stable source/target identities + discriminator")
+
+    def module(self, module_id: Any, path: str) -> str:
+        return self.add_node(SemanticNodeKind.MODULE, module_id, path=path)
+
+    def project_plan(self, plan: dict[str, Any], root: str) -> None:
+        surfaces = _as_list(_mapping(plan.get("surface_map")).get("surfaces"))
+        for i, surface in enumerate(surfaces):
+            item = _mapping(surface)
+            base = f"{root}.surface_map.surfaces[{i}]"
+            sid = item.get("surface_id")
+            if not sid:
+                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{base}.surface_id", reason="surface identity is required")])
+            module = self.module(sid, f"{base}.surface_id")
+            self.mark(f"{base}.surface_kind", node=SemanticNodeKind.MODULE, identity="surface kind selects graph node kind")
+            self.mark(f"{base}.owner", node=SemanticNodeKind.MODULE, identity="ownership is preserved by scoped module identity")
+            for j, action in enumerate(_as_list(item.get("owned_mutations"))):
+                action_node = self.add_node(SemanticNodeKind.ACTION, f"{sid}_{action}", path=f"{base}.owned_mutations[{j}]")
+                self.add_edge(SemanticEdgeKind.DECLARES, module, action_node, path=f"{base}.owned_mutations[{j}]")
+            for j, event in enumerate(_as_list(item.get("events_emitted"))):
+                event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{base}.events_emitted[{j}]", taxonomy=(SemanticCategory.EVENT, str(event)))
+                self.add_edge(SemanticEdgeKind.EMITS, module, event_node, path=f"{base}.events_emitted[{j}]")
+            for j, dependency in enumerate(_as_list(item.get("dependencies"))):
+                target = self.module(dependency, f"{base}.dependencies[{j}]")
+                self.add_edge(SemanticEdgeKind.DEPENDS_ON, module, target, path=f"{base}.dependencies[{j}]")
+
+        for i, page in enumerate(_as_list(plan.get("pages"))):
+            item = _mapping(page)
+            identity = item.get("name") or item.get("route")
+            if identity:
+                self.add_node(SemanticNodeKind.PAGE, identity, path=f"{root}.pages[{i}].name")
+                if "route" in item:
+                    self.mark(f"{root}.pages[{i}].route", node=SemanticNodeKind.PAGE, identity="page name is stable; route is deferred payload")
+
+        for i, entity in enumerate(_as_list(plan.get("entities"))):
+            item = _mapping(entity)
+            identity = item.get("name")
+            if identity:
+                self.add_node(SemanticNodeKind.DATA_COLLECTION, identity, path=f"{root}.entities[{i}].name")
+
+        for i, pack in enumerate(_as_list(plan.get("capability_packs"))):
+            item = _mapping(pack)
+            pack_id = item.get("capability_pack_id")
+            if pack_id:
+                cap = self.add_node(SemanticNodeKind.CAPABILITY, pack_id, path=f"{root}.capability_packs[{i}].capability_pack_id")
+                surface_id = item.get("surface_id")
+                if surface_id:
+                    module = self.module(surface_id, f"{root}.capability_packs[{i}].surface_id")
+                    self.add_edge(SemanticEdgeKind.DEPENDS_ON, module, cap, path=f"{root}.capability_packs[{i}].capability_pack_id")
+
+        for i, flow in enumerate(_as_list(plan.get("event_flows"))):
+            item = _mapping(flow)
+            event = item.get("event_type")
+            producer = item.get("producer_pack_id")
+            if event and producer:
+                event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}.event_flows[{i}].event_type", taxonomy=(SemanticCategory.EVENT, str(event)))
+                producer_node = self.module(producer, f"{root}.event_flows[{i}].producer_pack_id")
+                self.add_edge(SemanticEdgeKind.EMITS, producer_node, event_node, path=f"{root}.event_flows[{i}].event_type")
+
+        for i, touchpoint in enumerate(_as_list(plan.get("workflow_touchpoints"))):
+            item = _mapping(touchpoint)
+            workflow_id = item.get("workflow_id")
+            if workflow_id:
+                workflow = self.add_node(SemanticNodeKind.WORKFLOW, workflow_id, path=f"{root}.workflow_touchpoints[{i}].workflow_id")
+                page_name = item.get("page_name")
+                if page_name:
+                    page = self.add_node(SemanticNodeKind.PAGE, page_name, path=f"{root}.workflow_touchpoints[{i}].page_name")
+                    self.add_edge(SemanticEdgeKind.BINDS, page, workflow, path=f"{root}.workflow_touchpoints[{i}].workflow_id")
+
+        self.project_data_contract(_mapping(plan.get("data_contract")), f"{root}.data_contract")
+        for i, target in enumerate(_as_list(plan.get("deployment_targets"))):
+            item = _mapping(target)
+            identity = item.get("target_id") or item.get("deployment_profile")
+            if identity:
+                self.add_node(SemanticNodeKind.DEPLOYMENT_TARGET, identity, path=f"{root}.deployment_targets[{i}].target_id")
+
+    def project_schema(self, schema: dict[str, Any], root: str) -> None:
+        for i, page in enumerate(_as_list(schema.get("pages"))):
+            item = _mapping(page)
+            identity = item.get("page_id") or item.get("name") or item.get("route")
+            if not identity:
+                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}.pages[{i}]", reason="page identity is required")])
+            page_node = self.add_node(SemanticNodeKind.PAGE, identity, path=f"{root}.pages[{i}].name")
+            for j, section in enumerate(_as_list(item.get("sections"))):
+                section_item = _mapping(section)
+                section_id = section_item.get("id") or section_item.get("section_id")
+                if section_id:
+                    section_node = self.add_node(SemanticNodeKind.SECTION, f"{identity}_{section_id}", path=f"{root}.pages[{i}].sections[{j}].id")
+                    self.add_edge(SemanticEdgeKind.RENDERS, page_node, section_node, path=f"{root}.pages[{i}].sections[{j}].id")
+                self._project_page_actions(section_item, page_node, f"{root}.pages[{i}].sections[{j}]")
+        self.project_data_contract(_mapping(schema.get("data_contract")), f"{root}.data_contract")
+
+    def _project_page_actions(self, value: Any, page_node: str, path: str) -> None:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                child_path = f"{path}.{key}"
+                if key in {"api_endpoint", "endpoint"} and isinstance(child, str) and "/" in child:
+                    parts = [part for part in child.strip("/").split("/") if part]
+                    if len(parts) >= 2:
+                        module_id, action_id = parts[-2], parts[-1]
+                        module = self.module(module_id, child_path)
+                        action = self.add_node(SemanticNodeKind.ACTION, f"{module_id}_{action_id}", path=child_path)
+                        self.add_edge(SemanticEdgeKind.DECLARES, module, action, path=child_path)
+                        self.add_edge(SemanticEdgeKind.BINDS, page_node, action, path=child_path)
+                else:
+                    self._project_page_actions(child, page_node, child_path)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._project_page_actions(child, page_node, f"{path}[{index}]")
+
+    def project_data_contract(self, contract: dict[str, Any], root: str) -> None:
+        for i, surface in enumerate(_as_list(contract.get("surfaces"))):
+            item = _mapping(surface)
+            owner_id = item.get("surface_id")
+            owner = self.module(owner_id, f"{root}.surfaces[{i}].surface_id") if owner_id else None
+            for j, collection in enumerate(_as_list(item.get("collections"))):
+                collection_item = _mapping(collection)
+                name = collection_item.get("name") or collection_item.get("entity_name")
+                if name:
+                    collection_node = self.add_node(SemanticNodeKind.DATA_COLLECTION, f"{owner_id}_{name}", path=f"{root}.surfaces[{i}].collections[{j}].name")
+                    if owner:
+                        self.add_edge(SemanticEdgeKind.OWNS, owner, collection_node, path=f"{root}.surfaces[{i}].collections[{j}].name")
+        for i, alias in enumerate(_as_list(contract.get("aliases"))):
+            item = _mapping(alias)
+            alias_id = item.get("alias")
+            collection = item.get("collection")
+            if alias_id:
+                alias_node = self.add_node(SemanticNodeKind.DATA_ALIAS, alias_id, path=f"{root}.aliases[{i}].alias")
+                if collection:
+                    target = self.add_node(SemanticNodeKind.DATA_COLLECTION, f"{item.get('owner_module', 'app')}_{collection}", path=f"{root}.aliases[{i}].collection")
+                    self.add_edge(SemanticEdgeKind.BINDS, alias_node, target, path=f"{root}.aliases[{i}].collection")
+
+    def project_modules(self, modules: Any, root: str) -> None:
+        values = list(modules.values()) if isinstance(modules, Mapping) else _as_list(modules)
+        for i, raw in enumerate(values):
+            bundle = _mapping(raw)
+            manifest = _mapping(bundle.get("manifest") or bundle.get("module_manifest") or bundle)
+            identity = _mapping(manifest.get("module"))
+            module_id = identity.get("id") or manifest.get("module_id")
+            if not module_id:
+                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}[{i}]", reason="module id is required")])
+            module = self.module(module_id, f"{root}[{i}].manifest.module.id")
+            for j, raw_action in enumerate(_as_list(manifest.get("actions"))):
+                action_item = _mapping(raw_action)
+                action_id = action_item.get("id")
+                if action_id:
+                    action = self.add_node(SemanticNodeKind.ACTION, f"{module_id}_{action_id}", path=f"{root}[{i}].manifest.actions[{j}].id")
+                    self.add_edge(SemanticEdgeKind.DECLARES, module, action, path=f"{root}[{i}].manifest.actions[{j}].id")
+                    for k, event in enumerate(_as_list(action_item.get("emits"))):
+                        event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].manifest.actions[{j}].emits[{k}]", taxonomy=(SemanticCategory.EVENT, str(event)))
+                        self.add_edge(SemanticEdgeKind.EMITS, action, event_node, path=f"{root}[{i}].manifest.actions[{j}].emits[{k}]")
+                    gate = action_item.get("entitlement_gate")
+                    if gate:
+                        cap = self.add_node(SemanticNodeKind.CAPABILITY, gate, path=f"{root}[{i}].manifest.actions[{j}].entitlement_gate", taxonomy=(SemanticCategory.CAPABILITY, str(gate)))
+                        self.add_edge(SemanticEdgeKind.GATES, cap, action, path=f"{root}[{i}].manifest.actions[{j}].entitlement_gate")
+            for j, raw_cap in enumerate(_as_list(manifest.get("capabilities"))):
+                cap_item = _mapping(raw_cap)
+                cap_id = cap_item.get("capability_id")
+                if cap_id:
+                    cap = self.add_node(SemanticNodeKind.CAPABILITY, cap_id, path=f"{root}[{i}].manifest.capabilities[{j}].capability_id", taxonomy=(SemanticCategory.CAPABILITY, str(cap_id)))
+                    self.add_edge(SemanticEdgeKind.DECLARES, module, cap, path=f"{root}[{i}].manifest.capabilities[{j}].capability_id")
+            events = _mapping(bundle.get("events"))
+            for j, raw_event in enumerate(_as_list(events.get("events"))):
+                event = _mapping(raw_event).get("type")
+                if event:
+                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].events.events[{j}].type", taxonomy=(SemanticCategory.EVENT, str(event)))
+                    self.add_edge(SemanticEdgeKind.EMITS, module, event_node, path=f"{root}[{i}].events.events[{j}].type")
+            reactions = _mapping(bundle.get("reactions"))
+            for j, raw_reaction in enumerate(_as_list(reactions.get("reactions"))):
+                reaction_item = _mapping(raw_reaction)
+                reaction_id = reaction_item.get("id")
+                event = reaction_item.get("event_type")
+                if reaction_id and event:
+                    reaction = self.add_node(SemanticNodeKind.REACTION, f"{module_id}_{reaction_id}", path=f"{root}[{i}].reactions.reactions[{j}].id")
+                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].reactions.reactions[{j}].event_type", taxonomy=(SemanticCategory.EVENT, str(event)))
+                    self.add_edge(SemanticEdgeKind.CONSUMES, reaction, event_node, path=f"{root}[{i}].reactions.reactions[{j}].event_type")
+                    self.add_edge(SemanticEdgeKind.DECLARES, module, reaction, path=f"{root}[{i}].reactions.reactions[{j}].id")
+
+    def project_subscriptions(self, config: dict[str, Any], root: str) -> None:
+        for i, raw_plan in enumerate(_as_list(config.get("plans"))):
+            item = _mapping(raw_plan)
+            plan_id = item.get("plan_id")
+            if not plan_id:
+                raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path=f"{root}.plans[{i}].plan_id", reason="subscription plan id is required")])
+            plan = self.add_node(SemanticNodeKind.PLAN, plan_id, path=f"{root}.plans[{i}].plan_id")
+            for j, cap_id in enumerate(_as_list(item.get("capabilities"))):
+                cap = self.add_node(SemanticNodeKind.CAPABILITY, cap_id, path=f"{root}.plans[{i}].capabilities[{j}]", taxonomy=(SemanticCategory.CAPABILITY, str(cap_id)))
+                self.add_edge(SemanticEdgeKind.GATES, plan, cap, path=f"{root}.plans[{i}].capabilities[{j}]")
+            for j, raw_limit in enumerate(_as_list(item.get("usage_limits"))):
+                limit_item = _mapping(raw_limit)
+                meter_id = limit_item.get("meter_id")
+                if meter_id:
+                    meter = self.add_node(SemanticNodeKind.METER, meter_id, path=f"{root}.plans[{i}].usage_limits[{j}].meter_id")
+                    limit = self.add_node(SemanticNodeKind.LIMIT, f"{plan_id}_{meter_id}", path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit")
+                    self.add_edge(SemanticEdgeKind.GATES, plan, limit, path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit")
+                    self.add_edge(SemanticEdgeKind.BINDS, limit, meter, path=f"{root}.plans[{i}].usage_limits[{j}].meter_id")
+        for key, id_key in (("top_up_products", "product_id"), ("add_on_products", "add_on_id")):
+            for i, raw_product in enumerate(_as_list(config.get(key))):
+                product_id = _mapping(raw_product).get(id_key)
+                if product_id:
+                    self.add_node(SemanticNodeKind.PRODUCT, product_id, path=f"{root}.{key}[{i}].{id_key}")
+
+    def project_workflows(self, workflows: Any, root: str) -> None:
+        values = list(workflows.values()) if isinstance(workflows, Mapping) else _as_list(workflows)
+        for i, raw in enumerate(values):
+            item = _mapping(raw)
+            name = item.get("workflow_name") or item.get("name")
+            if not name:
+                continue
+            workflow = self.add_node(SemanticNodeKind.WORKFLOW, name, path=f"{root}[{i}].workflow_name")
+            for j, raw_trigger in enumerate(_as_list(item.get("triggers"))):
+                trigger_item = _mapping(raw_trigger)
+                identity = trigger_item.get("event") or trigger_item.get("endpoint") or f"{name}_{j}"
+                trigger = self.add_node(SemanticNodeKind.TRIGGER, identity, path=f"{root}[{i}].triggers[{j}]")
+                self.add_edge(SemanticEdgeKind.BINDS, trigger, workflow, path=f"{root}[{i}].triggers[{j}]")
+                event = trigger_item.get("event")
+                if event:
+                    event_node = self.add_node(SemanticNodeKind.EVENT, event, path=f"{root}[{i}].triggers[{j}].event", taxonomy=(SemanticCategory.EVENT, str(event)))
+                    self.add_edge(SemanticEdgeKind.CONSUMES, trigger, event_node, path=f"{root}[{i}].triggers[{j}].event")
+
+    def coverage(self) -> tuple[ProjectionCoverage, ...]:
+        rows: list[ProjectionCoverage] = []
+        for path, value in _iter_leaves(self.source, ""):
+            source_file, source_symbol, authority = _source_metadata(path)
+            projected = self.projected_paths.get(path)
+            leaf_name = re.split(r"[.\[]", path)[-1].rstrip("]0123456789")
+            if projected:
+                node, edge, taxonomy, identity = projected
+                disposition = ProjectionDisposition.PROJECTED
+                fully = leaf_name in {"id", "name", "type", "event", "event_type", "capability_id", "plan_id", "target_id", "workflow_id", "surface_id", "monthly_limit", "api_endpoint", "endpoint"}
+                reason = "represented in graph identity, taxonomy reference, or edge closure"
+                adr_slice = None if fully else 5
+            elif leaf_name in _NON_SEMANTIC_NAMES:
+                node = edge = taxonomy = None
+                identity = "excluded from SemanticGraph v1 identity by declared non-semantic classification"
+                disposition = ProjectionDisposition.DELIBERATELY_NON_SEMANTIC
+                fully = True
+                reason = "human-readable or execution-planning metadata is not graph semantics"
+                adr_slice = None
+            else:
+                node = edge = taxonomy = None
+                identity = "none; SemanticGraph v1 has no payload field for this fact"
+                disposition = ProjectionDisposition.DEFERRED
+                fully = False
+                reason = "source fact is not representable by Slice 2 identity-only nodes"
+                adr_slice = 5
+                self.gaps.append(ProjectionGap(kind=ProjectionGapKind.UNSUPPORTED, source_path=path, reason=reason, adr_slice=5))
+            rows.append(
+                ProjectionCoverage(
+                    source_path=path,
+                    source_file=source_file,
+                    source_symbol=source_symbol,
+                    current_authority=authority,
+                    disposition=disposition,
+                    target_node_kind=node,
+                    target_edge_kind=edge,
+                    taxonomy_category=taxonomy,
+                    stable_identity_derivation=identity,
+                    scope_source="project_semantic_graph(scope=ExecutionAccessScopeRef)",
+                    fully_representable=fully,
+                    absence_valid=value in (None, [], {}),
+                    failure_policy="fail closed when required/contradictory/ambiguous; report typed gap when unsupported",
+                    adr_slice=adr_slice,
+                    reason=reason,
+                )
+            )
+        return tuple(sorted(rows, key=lambda row: row.source_path))
+
+
+def extract_semantic_facts(graph: SemanticGraph) -> SemanticFactSet:
+    """Return exactly the graph-v1 facts used by Slice 3 equivalence."""
+    return SemanticFactSet(
+        nodes=tuple((node.node_id, node.kind.value) for node in graph.nodes),
+        edges=tuple(
+            (edge.kind.value, edge.source_node_id, edge.target_node_id, edge.discriminator)
+            for edge in graph.edges
+        ),
+    )
+
+
+def project_semantic_graph(
+    source: Mapping[str, Any],
+    *,
+    graph_id: str,
+    version: int,
+    scope: ExecutionAccessScopeRef,
+    taxonomy_registry: TaxonomyRegistry | None = None,
+) -> ProjectionResult:
+    """Project current outputs without I/O, mutation, defaults, or side effects."""
+    plain = _plain(source)
+    if not isinstance(plain, dict) or not plain:
+        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="$", reason="projection source must be a non-empty mapping")])
+    registry = taxonomy_registry or default_taxonomy_registry()
+    builder = _Builder(plain, scope, registry)
+
+    for source_name, raw_scope in sorted(_mapping(plain.get("source_scopes")).items()):
+        source_scope = ExecutionAccessScopeRef.model_validate(raw_scope)
+        path = f"source_scopes.{source_name}"
+        if source_scope != scope:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=path,
+                        reason="cross-tenant/workspace source composition fails closed",
+                    )
+                ]
+            )
+        for leaf_path, _value in _iter_leaves(raw_scope, path):
+            builder.mark(
+                leaf_path,
+                identity="exact ExecutionAccessScopeRef equality across every source",
+            )
+
+    plan = _mapping(plain.get("app_build_plan") or plain.get("AppBuildPlan"))
+    if plan:
+        root = "app_build_plan" if "app_build_plan" in plain else "AppBuildPlan"
+        builder.project_plan(plan, root)
+    schema = _mapping(plain.get("app_schema") or plain.get("AppSchemaOutput"))
+    if schema:
+        root = "app_schema" if "app_schema" in plain else "AppSchemaOutput"
+        builder.project_schema(schema, root)
+    design = _mapping(plain.get("design_docs") or plain.get("DesignDocsBundle"))
+    if design:
+        root = "design_docs" if "design_docs" in plain else "DesignDocsBundle"
+        builder.project_plan({"surface_map": design.get("surface_map"), "data_contract": design.get("data_contract"), "pages": _mapping(design.get("experience_spec")).get("pages", [])}, root)
+    subscription_output = _mapping(plain.get("subscription_contract") or plain.get("SubscriptionContractOutput"))
+    if subscription_output:
+        root = "subscription_contract" if "subscription_contract" in plain else "SubscriptionContractOutput"
+        builder.project_subscriptions(_mapping(subscription_output.get("subscription_config_file")), f"{root}.subscription_config_file")
+    builder.project_modules(plain.get("modules", []), "modules")
+    builder.project_subscriptions(_mapping(plain.get("subscriptions")), "subscriptions")
+    builder.project_workflows(plain.get("agent_workflows", []), "agent_workflows")
+    recorded = _mapping(plain.get("recorded_artifacts"))
+    if recorded:
+        builder.project_modules(recorded.get("modules", []), "recorded_artifacts.modules")
+        builder.project_schema(
+            {"pages": recorded.get("pages", []), "data_contract": recorded.get("data_contract")},
+            "recorded_artifacts",
+        )
+        builder.project_subscriptions(
+            _mapping(recorded.get("subscriptions")), "recorded_artifacts.subscriptions"
+        )
+        builder.project_workflows(
+            recorded.get("workflows", []), "recorded_artifacts.workflows"
+        )
+
+    ownership = _mapping(plain.get("ownership_evidence"))
+    mode = str(ownership.get("mode") or "greenfield")
+    if mode in {"brownfield", "hybrid"} and not _as_list(ownership.get("owned_surfaces")):
+        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="ownership_evidence.owned_surfaces", reason=f"{mode} projection requires explicit owned surfaces")])
+    for i, surface_id in enumerate(_as_list(ownership.get("owned_surfaces"))):
+        builder.module(surface_id, f"ownership_evidence.owned_surfaces[{i}]")
+
+    if not builder.nodes:
+        raise ProjectionError([ProjectionGap(kind=ProjectionGapKind.MISSING, source_path="$", reason="source contains no representable semantic identity")])
+    graph = build_semantic_graph(
+        graph_id=graph_id,
+        version=version,
+        scope=scope,
+        nodes=list(builder.nodes.values()),
+        edges=list(builder.edges.values()),
+    )
+    validate_semantic_graph_taxonomy_closure(graph, registry)
+    coverage = builder.coverage()
+    gaps = tuple(sorted(set(builder.gaps), key=lambda gap: (gap.source_path, gap.reason)))
+    return ProjectionResult(
+        source_digest=canonical_digest(plain),
+        graph=graph,
+        represented_facts=extract_semantic_facts(graph),
+        gaps=gaps,
+        coverage=coverage,
+    )
+
+
+__all__ = [
+    "PROJECTION_SCHEMA_VERSION",
+    "ProjectionCoverage",
+    "ProjectionDisposition",
+    "ProjectionError",
+    "ProjectionGap",
+    "ProjectionGapKind",
+    "ProjectionResult",
+    "SemanticFactSet",
+    "extract_semantic_facts",
+    "project_semantic_graph",
+]

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import builtins
 import copy
 import json
-import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -32,9 +31,52 @@ from mozaiksai.core.semantics.offline_projection import (
 )
 from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
 from mozaiksai.core.session.build_context_schema import validate_pack_context
+from mozaiksai.core.taxonomy import (
+    NamespaceKind,
+    SemanticCategory,
+    TaxonomyEntry,
+    TaxonomyNamespace,
+    build_taxonomy_registry,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="workspace-1")
+
+
+def _pinned_registry():
+    """Build the corpus taxonomy from Slice 1 primitives only.
+
+    ``default_taxonomy_registry()`` lazily imports the runtime layout registry
+    and the transport event contract, which drags in the workflow manager and
+    a workflow-catalog read. Projection must not own that, so callers pin a
+    registry; ``build_taxonomy_registry`` itself performs no imports, which is
+    what makes the cold-cache purity proof below meaningful.
+    """
+    return build_taxonomy_registry(
+        [
+            TaxonomyNamespace(
+                namespace_id="slice3.corpus",
+                version=1,
+                kind=NamespaceKind.EXTENSION,
+                grants=("domain", "reports"),
+                entries=(
+                    TaxonomyEntry(
+                        identifier="domain.reports.generated", category=SemanticCategory.EVENT
+                    ),
+                    # Declared by the committed DesignDocs bundle fixture.
+                    TaxonomyEntry(
+                        identifier="domain.users.user_created", category=SemanticCategory.EVENT
+                    ),
+                    TaxonomyEntry(
+                        identifier="reports.export", category=SemanticCategory.CAPABILITY
+                    ),
+                    TaxonomyEntry(
+                        identifier="reports.view", category=SemanticCategory.CAPABILITY
+                    ),
+                ),
+            )
+        ]
+    )
 
 
 def _corpus_source() -> dict:
@@ -287,9 +329,13 @@ triggers:
     }
 
 
-def _project(source: dict | None = None, *, scope: ExecutionAccessScopeRef = SCOPE):
+def _project(source: dict | None = None, *, scope: ExecutionAccessScopeRef = SCOPE, registry=None):
     return project_semantic_graph(
-        source or _corpus_source(), graph_id="slice-3-corpus", version=1, scope=scope
+        source or _corpus_source(),
+        graph_id="slice-3-corpus",
+        version=1,
+        scope=scope,
+        taxonomy_registry=registry or _pinned_registry(),
     )
 
 
@@ -511,7 +557,10 @@ def test_recorded_appbuildplan_unknown_semantics_are_not_silently_omitted() -> N
         )
     )
     with pytest.raises(ProjectionError) as exc_info:
-        project_semantic_graph(recorded, graph_id="recorded-projects", version=1, scope=SCOPE)
+        project_semantic_graph(
+            recorded, graph_id="recorded-projects", version=1, scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
+        )
     assert exc_info.value.gaps[0].kind is ProjectionGapKind.MISSING
     assert "domain.projects" in exc_info.value.gaps[0].reason
 
@@ -522,7 +571,10 @@ def test_existing_recorded_saas_fixture_projects_with_explicit_gaps() -> None:
             encoding="utf-8"
         )
     )
-    result = project_semantic_graph(recorded, graph_id="recorded-saas", version=1, scope=SCOPE)
+    result = project_semantic_graph(
+        recorded, graph_id="recorded-saas", version=1, scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
     assert result.graph.nodes
     assert result.gaps
     assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in result.gaps)
@@ -668,6 +720,7 @@ triggers:
         graph_id="current-contracts",
         version=1,
         scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
     )
     assert result.source_facts == extract_semantic_facts(result.graph)
     assert any(gap.source_path == "agent_workflows[0].files" for gap in result.gaps)
@@ -680,6 +733,7 @@ triggers:
         graph_id="current-contracts",
         version=1,
         scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
     )
     assert mapped_result.graph.graph_digest == result.graph.graph_digest
     assert all(row.source_file != "unknown" for row in mapped_result.coverage)
@@ -740,6 +794,7 @@ def test_committed_design_docs_subscription_build_context_and_route_sources() ->
         graph_id="recorded-design-docs",
         version=1,
         scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
     )
     assert design_result.graph.nodes
     assert design_result.source_facts == design_result.represented_facts
@@ -750,6 +805,7 @@ def test_committed_design_docs_subscription_build_context_and_route_sources() ->
             graph_id="recorded-subscription",
             version=1,
             scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
         )
     assert exc_info.value.gaps[0].kind is ProjectionGapKind.MISSING
     assert "reports.generate" in exc_info.value.gaps[0].reason
@@ -773,6 +829,7 @@ def test_committed_design_docs_subscription_build_context_and_route_sources() ->
         graph_id="recorded-route-manifest",
         version=1,
         scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
     )
     assert {node.kind for node in route_result.graph.nodes} == {SemanticNodeKind.PAGE}
 
@@ -852,7 +909,8 @@ def test_unclassified_field_is_ambiguous_instead_of_generic_deferred() -> None:
     result = _project(source)
     gap = next(gap for gap in result.gaps if gap.source_path.endswith("capabilty_id"))
     assert gap.kind is ProjectionGapKind.AMBIGUOUS
-    assert "typo" in gap.reason
+    assert "not in this projection's classified set" in gap.reason
+    assert "typo" not in gap.reason
 
 
 def test_pre_app_scope_and_unowned_evidence_never_fabricate_identity_or_control() -> None:
@@ -883,23 +941,123 @@ def test_semantic_descriptions_pricing_and_data_shapes_are_typed_gaps() -> None:
     assert gap_paths == deferred
 
 
-def test_projection_has_no_process_or_external_side_effects(monkeypatch) -> None:
-    cwd = Path.cwd()
-    environment = dict(os.environ)
-    modules = set(sys.modules)
-    monkeypatch.setattr("socket.socket.connect", lambda *_args, **_kwargs: pytest.fail("network"))
-    monkeypatch.setattr(builtins, "open", lambda *_args, **_kwargs: pytest.fail("filesystem open"))
-    monkeypatch.setattr(
-        Path, "write_text", lambda *_args, **_kwargs: pytest.fail("filesystem write")
+_COLD_PURITY_PROBE = r'''
+import builtins, copy, json, os, socket, sys
+from pathlib import Path
+
+# Import ONLY the projection seam and Slice 1 primitives. Importing the runtime
+# model helpers this file uses elsewhere would warm the very modules this probe
+# exists to detect, which is what made the previous in-process assertion vacuous.
+from mozaiksai.core.semantics.offline_projection import project_semantic_graph
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+from mozaiksai.core.taxonomy import (
+    NamespaceKind, SemanticCategory, TaxonomyEntry, TaxonomyNamespace, build_taxonomy_registry,
+)
+
+scope = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="workspace-1")
+registry = build_taxonomy_registry([
+    TaxonomyNamespace(
+        namespace_id="slice3.cold", version=1, kind=NamespaceKind.EXTENSION,
+        grants=("reports",),
+        entries=(
+            TaxonomyEntry(identifier="reports.export", category=SemanticCategory.CAPABILITY),
+        ),
     )
-    monkeypatch.setattr(
-        Path, "write_bytes", lambda *_args, **_kwargs: pytest.fail("filesystem write")
+])
+source = {
+    "modules": [
+        {
+            "manifest": {
+                "module": {"id": "reports"},
+                "actions": [{"id": "export_report", "entitlement_gate": "reports.export"}],
+                "capabilities": [{"capability_id": "reports.export"}],
+            }
+        }
+    ]
+}
+guarded = copy.deepcopy(source)
+
+failures = []
+def _boom(kind):
+    def _fail(*_a, **_k):
+        failures.append(kind)
+        raise AssertionError(kind)
+    return _fail
+
+# Guard every prohibited effect for the duration of the call itself.
+builtins.open = _boom("filesystem read/write")
+Path.open = _boom("filesystem read/write")
+Path.read_text = _boom("filesystem read")
+Path.read_bytes = _boom("filesystem read")
+Path.write_text = _boom("filesystem write")
+Path.write_bytes = _boom("filesystem write")
+Path.mkdir = _boom("filesystem write")
+os.chdir = _boom("cwd mutation")
+socket.socket.connect = _boom("network")
+socket.getaddrinfo = _boom("network")
+
+cwd, environment, modules = os.getcwd(), dict(os.environ), set(sys.modules)
+result = project_semantic_graph(
+    source, graph_id="cold", version=1, scope=scope, taxonomy_registry=registry
+)
+added = sorted(set(sys.modules) - modules)
+
+print(json.dumps({
+    "failures": failures,
+    "modules_added": added,
+    "cwd_changed": os.getcwd() != cwd,
+    "env_changed": dict(os.environ) != environment,
+    "input_mutated": source != guarded,
+    "node_count": len(result.graph.nodes),
+}))
+'''
+
+
+def test_projection_has_no_process_or_external_side_effects() -> None:
+    """Prove the projection seam is pure in a cold interpreter.
+
+    This runs in a fresh subprocess that imports only the projection seam and
+    Slice 1 primitives. The previous in-process form asserted
+    ``set(sys.modules) == modules`` after 22 earlier tests in this file had
+    already warmed the cache, so it asserted nothing where it passed and failed
+    outright when run alone. Nothing is imported here to make the measurement
+    succeed — a cold cache is the point.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", _COLD_PURITY_PROBE],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
     )
-    monkeypatch.setattr(os, "chdir", lambda *_args, **_kwargs: pytest.fail("cwd mutation"))
-    _project()
-    assert Path.cwd() == cwd
-    assert dict(os.environ) == environment
-    assert set(sys.modules) == modules
+    assert completed.returncode == 0, f"{completed.stdout}\n{completed.stderr}"
+    report = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert report["failures"] == [], report
+    assert report["cwd_changed"] is False
+    assert report["env_changed"] is False
+    assert report["input_mutated"] is False
+    assert report["node_count"] > 0
+    # No runtime, workflow, persistence, control-plane, host, or model modules
+    # may be pulled in by projecting.
+    forbidden = [
+        name
+        for name in report["modules_added"]
+        if any(
+            token in name
+            for token in (
+                "runtime",
+                "workflow",
+                "persistence",
+                "control_plane",
+                "hosts",
+                "ag2",
+                "openai",
+                "httpx",
+            )
+        )
+    ]
+    assert forbidden == [], f"projection imported prohibited modules: {forbidden}"
 
 
 def test_production_sources_do_not_import_offline_projection() -> None:
@@ -919,3 +1077,147 @@ def test_production_sources_do_not_import_offline_projection() -> None:
             if "offline_projection" in path.read_text(encoding="utf-8"):
                 offenders.append(relative.as_posix())
     assert offenders == []
+
+
+def test_provenance_roots_are_classified_not_falsely_reported_as_empty() -> None:
+    """build_context and workflows are accepted, classified, and honestly diagnosed.
+
+    Both are real parts of current recorded sources but carry no SemanticGraph
+    v1 identity. Previously they were listed as supported roots with no
+    projector, so a source containing only one of them failed with "source
+    contains no representable semantic identity" — which names the wrong cause.
+    """
+    build_context = yaml.safe_load(
+        (ROOT / "factory_app/build_context/AppGenerator/context.yaml").read_text(encoding="utf-8")
+    )
+    for root, payload in (
+        ("build_context", build_context),
+        ("workflows", [{"workflow_name": "report_builder", "status": "completed"}]),
+    ):
+        with pytest.raises(ProjectionError) as exc_info:
+            project_semantic_graph(
+                {root: payload},
+                graph_id=f"provenance-{root}",
+                version=1,
+                scope=SCOPE,
+                taxonomy_registry=_pinned_registry(),
+            )
+        gaps = exc_info.value.gaps
+        assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in gaps), gaps
+        assert all(gap.source_path == root for gap in gaps), gaps
+        assert "no SemanticGraph v1 identity" in gaps[0].reason
+        assert "no representable semantic identity" not in gaps[0].reason
+
+    # Alongside real semantic roots they contribute typed gaps, never nodes.
+    source = _corpus_source()
+    source["workflows"] = [{"workflow_name": "report_builder", "status": "completed"}]
+    result = _project(source)
+    workflow_gaps = [gap for gap in result.gaps if gap.source_path.startswith("workflows")]
+    assert workflow_gaps
+    assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in workflow_gaps)
+
+
+def test_committed_notifications_page_projects_with_explicit_non_module_binding_gap() -> None:
+    """The committed first-party page must project, not hard-fail.
+
+    AppPageSchema permits any /api/... path; only /api/modules/{module}/{action}
+    names a declared action. /api/notifications is valid and real, so it becomes
+    a typed gap rather than an error or an invented action target.
+    """
+    page = yaml.safe_load(
+        (ROOT / "factory_app/app/ui/pages/notifications.yaml").read_text(encoding="utf-8")
+    )
+    result = project_semantic_graph(
+        {"pages": [page]},
+        graph_id="committed-notifications",
+        version=1,
+        scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
+    assert any(node.kind is SemanticNodeKind.PAGE for node in result.graph.nodes)
+    binding_gaps = [
+        gap
+        for gap in result.gaps
+        if gap.source_path.endswith("api_endpoint")
+        and "non-module page API binding" in gap.reason
+    ]
+    assert binding_gaps, [gap.reason for gap in result.gaps]
+    assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in binding_gaps)
+    assert not any(node.kind is SemanticNodeKind.ACTION for node in result.graph.nodes)
+
+
+def test_invalid_api_path_still_fails_closed() -> None:
+    page = {
+        "name": "Broken",
+        "route": "/broken",
+        "sections": [
+            {"id": "s", "primitive": "Card", "config": {"api_endpoint": "/api/has spaces"}}
+        ],
+    }
+    with pytest.raises(ProjectionError) as exc_info:
+        project_semantic_graph(
+            {"pages": [page]},
+            graph_id="invalid-api",
+            version=1,
+            scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
+        )
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.AMBIGUOUS
+    assert "valid AppPageSchema api path" in exc_info.value.gaps[0].reason
+
+
+def test_duplicate_canonical_root_aliases_fail_closed() -> None:
+    """Supplying both an alias and its canonical name must not silently drop one."""
+    source = _corpus_source()
+    diverging = copy.deepcopy(source["app_build_plan"])
+    diverging["surface_map"]["surfaces"][0]["surface_id"] = "totally_different_surface"
+    source["AppBuildPlan"] = diverging
+    with pytest.raises(ProjectionError) as exc_info:
+        _project(source)
+    gap = exc_info.value.gaps[0]
+    assert gap.kind is ProjectionGapKind.CONTRADICTORY
+    assert "silently ignored" in gap.reason
+
+
+def test_entitlement_gate_requires_declared_capability_input_closure() -> None:
+    """Reproduce and pin the module-only entitlement coupling.
+
+    The committed OSS pattern grants an action's entitlement_gate capability
+    from subscriptions.yaml rather than the module's own capabilities[]. Alone,
+    the module cannot close that reference — projection returns a precise typed
+    missing-reference naming the entitlement_gate path, and never invents the
+    capability. Supplying the subscription catalog closes it.
+    """
+    module = {
+        "manifest": {
+            "module": {"id": "reports"},
+            "actions": [{"id": "export_report", "entitlement_gate": "reports.export"}],
+        }
+    }
+    with pytest.raises(ProjectionError) as exc_info:
+        project_semantic_graph(
+            {"modules": [module]},
+            graph_id="entitlement-open",
+            version=1,
+            scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
+        )
+    gap = exc_info.value.gaps[0]
+    assert gap.kind is ProjectionGapKind.MISSING
+    assert gap.source_path.endswith("entitlement_gate")
+    assert "does not resolve to a declared semantic node" in gap.reason
+
+    closed = project_semantic_graph(
+        {
+            "modules": [module],
+            "subscriptions": {
+                "plans": [{"plan_id": "pro", "capabilities": ["reports.export"]}]
+            },
+        },
+        graph_id="entitlement-closed",
+        version=1,
+        scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
+    assert any(node.kind is SemanticNodeKind.CAPABILITY for node in closed.graph.nodes)
+    assert any(edge.kind is SemanticEdgeKind.GATES for edge in closed.graph.edges)

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -785,6 +785,35 @@ def test_projection_field_access_is_pinned_to_current_structured_outputs() -> No
     assert "triggers" in agent["OrchestrationConfigOutput"]["fields"]
 
 
+def test_appschema_custom_route_identity_uses_current_producer_path() -> None:
+    result = project_semantic_graph(
+        {
+            "app_schema": {
+                "custom_route_bundle": {
+                    "route_manifest": [
+                        {
+                            "id": "checkout_success",
+                            "path": "/checkout/success",
+                            "component": "CheckoutSuccessPage",
+                        }
+                    ],
+                    "page_files": [],
+                }
+            }
+        },
+        graph_id="custom-route",
+        version=1,
+        scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
+    path = "app_schema.custom_route_bundle.route_manifest[0].id"
+    row = next(row for row in result.coverage if row.source_path == path)
+    assert row.disposition is ProjectionDisposition.PROJECTED
+    assert row.target_node_kind is SemanticNodeKind.PAGE
+    assert row.fully_representable is True
+    assert not any(gap.source_path == path for gap in result.gaps)
+
+
 def test_committed_design_docs_subscription_build_context_and_route_sources() -> None:
     from tests.test_design_docs_bundle_persistence import _bundle
     from tests.test_subscription_contract_designer import _sample_contract
@@ -939,6 +968,70 @@ def test_semantic_descriptions_pricing_and_data_shapes_are_typed_gaps() -> None:
         if row.disposition is ProjectionDisposition.DEFERRED
     }
     assert gap_paths == deferred
+
+
+@pytest.mark.parametrize(
+    "surface_kind",
+    ["app_policy", "refinement", "external_integration", "ui_only"],
+)
+def test_non_graph_v1_surface_kinds_are_precise_typed_gaps(surface_kind: str) -> None:
+    result = project_semantic_graph(
+        {
+            "app_build_plan": {
+                "surface_map": {
+                    "surfaces": [
+                        {
+                            "surface_id": "special_surface",
+                            "surface_kind": surface_kind,
+                            "owner": "app",
+                        }
+                    ]
+                }
+            }
+        },
+        graph_id=f"surface-{surface_kind}",
+        version=1,
+        scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
+    path = "app_build_plan.surface_map.surfaces[0].surface_kind"
+    gap = next(gap for gap in result.gaps if gap.source_path == path)
+    row = next(row for row in result.coverage if row.source_path == path)
+    assert gap.kind is ProjectionGapKind.UNSUPPORTED
+    assert surface_kind in gap.reason
+    assert "cannot retain" in gap.reason
+    assert row.disposition is ProjectionDisposition.DEFERRED
+    assert row.fully_representable is False
+    assert not any(
+        node.kind in {SemanticNodeKind.MODULE, SemanticNodeKind.WORKFLOW}
+        for node in result.graph.nodes
+    )
+
+
+@pytest.mark.parametrize(
+    ("surface", "expected_kind"),
+    [
+        ({"surface_id": "missing"}, ProjectionGapKind.MISSING),
+        (
+            {"surface_id": "invented", "surface_kind": "invented_kind"},
+            ProjectionGapKind.UNSUPPORTED,
+        ),
+    ],
+)
+def test_missing_or_unknown_surface_kind_fails_closed(
+    surface: dict[str, str], expected_kind: ProjectionGapKind
+) -> None:
+    with pytest.raises(ProjectionError) as exc_info:
+        project_semantic_graph(
+            {"app_build_plan": {"surface_map": {"surfaces": [surface]}}},
+            graph_id="invalid-surface-kind",
+            version=1,
+            scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
+        )
+    gap = exc_info.value.gaps[0]
+    assert gap.kind is expected_kind
+    assert gap.source_path.endswith("surface_kind")
 
 
 _COLD_PURITY_PROBE = r'''

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -1,0 +1,470 @@
+"""ADR 0007 Slice 3 offline projection and archetype-corpus proof."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.semantics.canonical import canonical_json
+from mozaiksai.core.semantics.graph import SemanticEdgeKind, SemanticNodeKind
+from mozaiksai.core.semantics.offline_projection import (
+    ProjectionDisposition,
+    ProjectionError,
+    ProjectionGapKind,
+    extract_semantic_facts,
+    project_semantic_graph,
+)
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+
+ROOT = Path(__file__).resolve().parents[1]
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="workspace-1")
+
+
+def _corpus_source() -> dict:
+    return {
+        "source_scopes": {
+            "app_generator": SCOPE.model_dump(mode="json"),
+            "agent_generator": SCOPE.model_dump(mode="json"),
+        },
+        "app_build_plan": {
+            "agent_message": "Deterministic corpus plan",
+            "pages": [
+                {"name": "Reports", "route": "/reports"},
+                {"name": "Billing", "route": "/billing"},
+            ],
+            "surface_map": {
+                "surfaces": [
+                    {
+                        "surface_id": "reports",
+                        "surface_kind": "module",
+                        "owner": "app",
+                        "owned_mutations": ["export_report", "view_report"],
+                        "events_emitted": ["domain.reports.generated"],
+                        "dependencies": [],
+                    },
+                    {
+                        "surface_id": "billing",
+                        "surface_kind": "module",
+                        "owner": "app",
+                        "owned_mutations": [],
+                        "events_emitted": [],
+                        "dependencies": ["reports"],
+                    },
+                ]
+            },
+            "capability_packs": [
+                {
+                    "capability_pack_id": "reporting_pack",
+                    "surface_id": "reports",
+                    "label": "Reporting",
+                }
+            ],
+            "event_flows": [
+                {
+                    "event_type": "domain.reports.generated",
+                    "producer_pack_id": "reports",
+                    "subscriber_intents": ["notify"],
+                }
+            ],
+            "workflow_touchpoints": [
+                {
+                    "page_name": "Reports",
+                    "workflow_id": "report_builder",
+                    "action_id": "launch",
+                    "placement": "page",
+                }
+            ],
+            "data_contract": {
+                "version": "1",
+                "surfaces": [
+                    {
+                        "surface_id": "reports",
+                        "surface_kind": "module",
+                        "collections": [
+                            {
+                                "name": "reports",
+                                "scope": "app",
+                                "fields": [{"name": "status", "type": "string"}],
+                            }
+                        ],
+                    }
+                ],
+                "aliases": [
+                    {
+                        "alias": "reports.current",
+                        "collection": "reports",
+                        "owner_module": "reports",
+                    }
+                ],
+            },
+            "deployment_targets": [
+                {
+                    "target_id": "local_container",
+                    "target_kind": "container",
+                    "deployment_profile": "local",
+                }
+            ],
+            "generation_order": ["modules", "pages"],
+        },
+        "app_schema": {
+            "pages": [
+                {
+                    "name": "Reports",
+                    "route": "/reports",
+                    "sections": [
+                        {
+                            "id": "report_table",
+                            "primitive": "DataTable",
+                            "config": {
+                                "actions": [
+                                    {
+                                        "id": "export",
+                                        "api_endpoint": "/api/modules/reports/export_report",
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                }
+            ],
+            "theme_config_patch": {"theme": {"mode": "dark"}},
+        },
+        "design_docs": {
+            "agent_message": "Design corpus",
+            "experience_spec": {
+                "navigation_model": "sidebar",
+                "pages": [{"name": "Reports", "route": "/reports", "sections": []}],
+            },
+            "surface_map": {
+                "surfaces": [
+                    {
+                        "surface_id": "reports",
+                        "surface_kind": "module",
+                        "owner": "app",
+                        "owned_mutations": [],
+                        "events_emitted": [],
+                        "dependencies": [],
+                    }
+                ]
+            },
+        },
+        "modules": [
+            {
+                "manifest": {
+                    "schema_version": "mozaiks.module.v1",
+                    "module": {"id": "reports", "display_name": "Reports"},
+                    "actions": [
+                        {
+                            "id": "export_report",
+                            "emits": ["domain.reports.generated"],
+                            "entitlement_gate": "reports.export",
+                        },
+                        {"id": "view_report", "entitlement_gate": "reports.view"},
+                    ],
+                    "capabilities": [
+                        {"capability_id": "reports.export"},
+                        {"capability_id": "reports.view"},
+                    ],
+                },
+                "events": {"events": [{"type": "domain.reports.generated"}]},
+                "reactions": {
+                    "reactions": [
+                        {
+                            "id": "notify_report_ready",
+                            "event_type": "domain.reports.generated",
+                        }
+                    ]
+                },
+            }
+        ],
+        "subscriptions": {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "plans": [
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["reports.export", "reports.view"],
+                    "usage_limits": [
+                        {
+                            "meter_id": "report_exports",
+                            "monthly_limit": 100,
+                            "unit": "exports",
+                        }
+                    ],
+                }
+            ],
+            "top_up_products": [
+                {"product_id": "extra_exports", "label": "Extra exports", "token_amount": 100}
+            ],
+        },
+        "subscription_contract": {
+            "contract_required": True,
+            "rationale": "Reports are metered",
+            "subscription_config_file": {
+                "schema_version": "mozaiks.subscriptions.v1",
+                "plans": [
+                    {
+                        "plan_id": "pro",
+                        "label": "Pro",
+                        "capabilities": ["reports.view"],
+                        "usage_limits": [],
+                    }
+                ],
+            },
+        },
+        "agent_workflows": [
+            {
+                "workflow_name": "report_builder",
+                "description": "Build reports",
+                "triggers": [
+                    {
+                        "type": "event",
+                        "event": "domain.reports.generated",
+                        "description": "Resume after generation",
+                    }
+                ],
+            }
+        ],
+        "ownership_evidence": {
+            "mode": "hybrid",
+            "owned_surfaces": ["reports", "billing"],
+            "unowned_paths": ["existing/admin.py"],
+        },
+        "build_context": {
+            "context_id": "AppGenerator",
+            "assets": [{"path": "file_contracts.yaml", "kind": "contract"}],
+        },
+        "recorded_artifacts": {
+            "modules": [
+                {
+                    "manifest": {
+                        "module": {"id": "audit"},
+                        "actions": [{"id": "list_entries"}],
+                        "capabilities": [],
+                    }
+                }
+            ],
+            "pages": [
+                {
+                    "name": "Audit",
+                    "route": "/audit",
+                    "sections": [
+                        {
+                            "id": "entries",
+                            "config": {"api_endpoint": "/api/modules/audit/list_entries"},
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def _project(source: dict | None = None, *, scope: ExecutionAccessScopeRef = SCOPE):
+    return project_semantic_graph(
+        source or _corpus_source(), graph_id="slice-3-corpus", version=1, scope=scope
+    )
+
+
+def test_archetype_corpus_projects_complete_relationship_spine() -> None:
+    result = _project()
+    kinds = {node.kind for node in result.graph.nodes}
+    assert {
+        SemanticNodeKind.MODULE,
+        SemanticNodeKind.PAGE,
+        SemanticNodeKind.SECTION,
+        SemanticNodeKind.ACTION,
+        SemanticNodeKind.CAPABILITY,
+        SemanticNodeKind.EVENT,
+        SemanticNodeKind.REACTION,
+        SemanticNodeKind.DATA_COLLECTION,
+        SemanticNodeKind.DATA_ALIAS,
+        SemanticNodeKind.WORKFLOW,
+        SemanticNodeKind.TRIGGER,
+        SemanticNodeKind.PLAN,
+        SemanticNodeKind.PRODUCT,
+        SemanticNodeKind.METER,
+        SemanticNodeKind.LIMIT,
+        SemanticNodeKind.DEPLOYMENT_TARGET,
+    } <= kinds
+    edge_kinds = {edge.kind for edge in result.graph.edges}
+    assert {
+        SemanticEdgeKind.DECLARES,
+        SemanticEdgeKind.EMITS,
+        SemanticEdgeKind.CONSUMES,
+        SemanticEdgeKind.RENDERS,
+        SemanticEdgeKind.BINDS,
+        SemanticEdgeKind.DEPENDS_ON,
+        SemanticEdgeKind.GATES,
+        SemanticEdgeKind.OWNS,
+    } <= edge_kinds
+    assert extract_semantic_facts(result.graph) == result.represented_facts
+
+
+def test_projection_is_byte_identical_order_independent_and_input_immutable() -> None:
+    source = _corpus_source()
+    before = copy.deepcopy(source)
+    first = _project(source)
+    reordered = copy.deepcopy(source)
+    reordered["app_build_plan"]["pages"].reverse()
+    reordered["app_build_plan"]["surface_map"]["surfaces"].reverse()
+    reordered["modules"][0]["manifest"]["actions"].reverse()
+    reordered = dict(reversed(list(reordered.items())))
+    second = _project(reordered)
+    third = _project(source)
+    assert source == before
+    assert first.graph.graph_digest == second.graph.graph_digest == third.graph.graph_digest
+    assert canonical_json(first.graph.canonical_payload()).encode("ascii") == canonical_json(
+        second.graph.canonical_payload()
+    ).encode("ascii")
+    assert first.represented_facts == second.represented_facts
+
+
+def test_machine_readable_coverage_classifies_every_source_leaf() -> None:
+    source = _corpus_source()
+    result = _project(source)
+    leaf_paths = {path for path, _ in _walk_leaves(source)}
+    coverage_paths = {row.source_path for row in result.coverage}
+    assert coverage_paths == leaf_paths
+    assert {row.disposition for row in result.coverage} == {
+        ProjectionDisposition.PROJECTED,
+        ProjectionDisposition.DELIBERATELY_NON_SEMANTIC,
+        ProjectionDisposition.DEFERRED,
+    }
+    deferred = {row.source_path for row in result.coverage if row.disposition is ProjectionDisposition.DEFERRED}
+    assert deferred == {gap.source_path for gap in result.gaps}
+    assert json.loads(result.model_dump_json())["schema_version"] == "mozaiks.semantic_projection.v1"
+
+
+def _walk_leaves(value, path=""):
+    if isinstance(value, dict):
+        if not value:
+            yield path, value
+        for key in sorted(value):
+            yield from _walk_leaves(value[key], f"{path}.{key}" if path else key)
+    elif isinstance(value, list):
+        if not value:
+            yield path, value
+        for index, item in enumerate(value):
+            yield from _walk_leaves(item, f"{path}[{index}]")
+    else:
+        yield path, value
+
+
+@pytest.mark.parametrize("field", ["event", "capability"])
+def test_unknown_taxonomy_references_fail_closed(field: str) -> None:
+    source = _corpus_source()
+    if field == "event":
+        source["modules"][0]["events"]["events"][0]["type"] = "domain.unknown.created"
+    else:
+        source["modules"][0]["manifest"]["capabilities"][0]["capability_id"] = "unknown.capability"
+    with pytest.raises(ProjectionError, match="unknown .* taxonomy identifier"):
+        _project(source)
+
+
+def test_recorded_appbuildplan_unknown_semantics_are_not_silently_omitted() -> None:
+    recorded = json.loads(
+        (ROOT / "tests/fixtures/appplan_persistent_projects_output.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    with pytest.raises(ProjectionError) as exc_info:
+        project_semantic_graph(recorded, graph_id="recorded-projects", version=1, scope=SCOPE)
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED
+    assert "domain.projects" in exc_info.value.gaps[0].reason
+
+
+def test_existing_recorded_saas_fixture_projects_with_explicit_gaps() -> None:
+    recorded = json.loads(
+        (ROOT / "tests/fixtures/appplan_saas_entitlement_dispatch_output.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    result = project_semantic_graph(
+        recorded, graph_id="recorded-saas", version=1, scope=SCOPE
+    )
+    assert result.graph.nodes
+    assert result.gaps
+    assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in result.gaps)
+    assert all(row.source_file != "unknown" for row in result.coverage)
+
+
+def test_incomplete_required_and_contradictory_duplicate_inputs_fail_closed() -> None:
+    missing = {"modules": [{"manifest": {"actions": []}}]}
+    with pytest.raises(ProjectionError, match="module id is required"):
+        _project(missing)
+
+    contradictory = _corpus_source()
+    contradictory["app_build_plan"]["capability_packs"][0]["capability_pack_id"] = (
+        "reports.export"
+    )
+    with pytest.raises(ProjectionError, match="conflicting facts reuse node identity"):
+        _project(contradictory)
+
+
+@pytest.mark.parametrize(
+    "foreign_scope",
+    [
+        ExecutionAccessScopeRef(tenant_id="tenant-2", workspace_id="workspace-1"),
+        ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="workspace-2"),
+    ],
+)
+def test_cross_tenant_or_workspace_composition_fails_closed(foreign_scope) -> None:
+    source = _corpus_source()
+    source["source_scopes"]["agent_generator"] = foreign_scope.model_dump(mode="json")
+    with pytest.raises(ProjectionError, match="cross-tenant/workspace"):
+        _project(source)
+
+
+def test_brownfield_and_hybrid_require_ownership_evidence() -> None:
+    source = _corpus_source()
+    source["ownership_evidence"]["owned_surfaces"] = []
+    with pytest.raises(ProjectionError, match="requires explicit owned surfaces"):
+        _project(source)
+
+
+def test_projection_has_no_process_or_external_side_effects(monkeypatch) -> None:
+    cwd = Path.cwd()
+    environment = dict(os.environ)
+    modules = set(sys.modules)
+    monkeypatch.setattr("socket.socket.connect", lambda *_args, **_kwargs: pytest.fail("network"))
+    _project()
+    assert Path.cwd() == cwd
+    assert dict(os.environ) == environment
+    assert set(sys.modules) == modules
+
+
+def test_production_sources_do_not_import_offline_projection() -> None:
+    offenders: list[str] = []
+    excluded = {
+        Path("mozaiksai/core/semantics/offline_projection.py"),
+        Path("tests/test_semantic_offline_projection.py"),
+    }
+    roots = [ROOT / "mozaiksai", ROOT / "factory_app"]
+    for root in roots:
+        for path in root.rglob("*.py"):
+            relative = path.relative_to(ROOT)
+            if relative in excluded:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
+            except SyntaxError:
+                # Build-context Python templates contain unresolved {{placeholders}}.
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module == (
+                    "mozaiksai.core.semantics.offline_projection"
+                ):
+                    offenders.append(relative.as_posix())
+                if isinstance(node, ast.Import) and any(
+                    alias.name == "mozaiksai.core.semantics.offline_projection"
+                    for alias in node.names
+                ):
+                    offenders.append(relative.as_posix())
+    assert offenders == []

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
-import ast
+import builtins
 import copy
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
-from mozaiksai.core.semantics.canonical import canonical_json
+from mozaiksai.core.app_context.models import AppContextVersion, OwnershipBoundary
+from mozaiksai.core.runtime.app.module_loader import (
+    ModuleDefinition,
+    ModuleEventsManifest,
+    ModuleReactionsManifest,
+)
+from mozaiksai.core.runtime.app.page_schema import AppPageSchema
+from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
+from mozaiksai.core.semantics.canonical import canonical_digest, canonical_json
 from mozaiksai.core.semantics.graph import SemanticEdgeKind, SemanticNodeKind
 from mozaiksai.core.semantics.offline_projection import (
     ProjectionDisposition,
@@ -21,6 +31,7 @@ from mozaiksai.core.semantics.offline_projection import (
     project_semantic_graph,
 )
 from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+from mozaiksai.core.session.build_context_schema import validate_pack_context
 
 ROOT = Path(__file__).resolve().parents[1]
 SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-1", workspace_id="workspace-1")
@@ -167,6 +178,7 @@ def _corpus_source() -> dict:
                         },
                         {"id": "view_report", "entitlement_gate": "reports.view"},
                     ],
+                    "permissions": [{"id": "reports.read", "description": "Read reports"}],
                     "capabilities": [
                         {"capability_id": "reports.export"},
                         {"capability_id": "reports.view"},
@@ -178,6 +190,16 @@ def _corpus_source() -> dict:
                         {
                             "id": "notify_report_ready",
                             "event_type": "domain.reports.generated",
+                        }
+                    ]
+                },
+                "notifications": {
+                    "notifications": [
+                        {
+                            "id": "report_ready",
+                            "event_type": "domain.reports.generated",
+                            "title": "Report ready",
+                            "body": "Your report is ready.",
                         }
                     ]
                 },
@@ -221,47 +243,46 @@ def _corpus_source() -> dict:
         "agent_workflows": [
             {
                 "workflow_name": "report_builder",
-                "description": "Build reports",
-                "triggers": [
+                "agent_message": "Generated.",
+                "pattern_id": 1,
+                "pattern_name": "Pipeline",
+                "files": [
                     {
-                        "type": "event",
-                        "event": "domain.reports.generated",
-                        "description": "Resume after generation",
+                        "filename": "orchestrator.yaml",
+                        "content": """workflow_name: report_builder
+max_turns: 4
+human_in_the_loop: false
+workflow_startup_mode: BackendOnly
+orchestration_pattern: ag2_network
+initial_agent: ReportAgent
+initial_message: Build reports.
+triggers:
+  - type: event
+    event: domain.reports.generated
+    description: Resume after generation
+""",
                     }
                 ],
             }
         ],
         "ownership_evidence": {
             "mode": "hybrid",
-            "owned_surfaces": ["reports", "billing"],
-            "unowned_paths": ["existing/admin.py"],
+            "ownership_boundaries": [
+                {
+                    "path_or_artifact": "app/modules/reports",
+                    "ownership": "generated_overlay",
+                    "source_ref": "source-1",
+                },
+                {
+                    "path_or_artifact": "existing/admin.py",
+                    "ownership": "external_system",
+                    "source_ref": "source-1",
+                },
+            ],
         },
         "build_context": {
             "context_id": "AppGenerator",
             "assets": [{"path": "file_contracts.yaml", "kind": "contract"}],
-        },
-        "recorded_artifacts": {
-            "modules": [
-                {
-                    "manifest": {
-                        "module": {"id": "audit"},
-                        "actions": [{"id": "list_entries"}],
-                        "capabilities": [],
-                    }
-                }
-            ],
-            "pages": [
-                {
-                    "name": "Audit",
-                    "route": "/audit",
-                    "sections": [
-                        {
-                            "id": "entries",
-                            "config": {"api_endpoint": "/api/modules/audit/list_entries"},
-                        }
-                    ],
-                }
-            ],
         },
     }
 
@@ -276,13 +297,16 @@ def test_archetype_corpus_projects_complete_relationship_spine() -> None:
     result = _project()
     kinds = {node.kind for node in result.graph.nodes}
     assert {
+        SemanticNodeKind.SURFACE,
         SemanticNodeKind.MODULE,
         SemanticNodeKind.PAGE,
         SemanticNodeKind.SECTION,
         SemanticNodeKind.ACTION,
         SemanticNodeKind.CAPABILITY,
+        SemanticNodeKind.PERMISSION,
         SemanticNodeKind.EVENT,
         SemanticNodeKind.REACTION,
+        SemanticNodeKind.NOTIFICATION,
         SemanticNodeKind.DATA_COLLECTION,
         SemanticNodeKind.DATA_ALIAS,
         SemanticNodeKind.WORKFLOW,
@@ -304,7 +328,79 @@ def test_archetype_corpus_projects_complete_relationship_spine() -> None:
         SemanticEdgeKind.GATES,
         SemanticEdgeKind.OWNS,
     } <= edge_kinds
+    assert result.source_facts == result.represented_facts
     assert extract_semantic_facts(result.graph) == result.represented_facts
+
+
+def test_independent_source_expectations_equal_every_graph_fact() -> None:
+    result = _project()
+
+    def node_id(kind: str, identity: str) -> str:
+        slug = re.sub(r"[^a-z0-9_]+", "_", identity.strip().lower()).strip("_")
+        return f"mozaiks.{kind}.{slug}_{canonical_digest(identity)[:12]}"
+
+    specs = {
+        "surface_reports": ("surface", "reports", ()),
+        "surface_billing": ("surface", "billing", ()),
+        "module_reports": ("module", "reports", ()),
+        "module_billing": ("module", "billing", ()),
+        "export": ("action", "reports_export_report", ()),
+        "view": ("action", "reports_view_report", ()),
+        "page_reports": ("page", "Reports", ()),
+        "page_billing": ("page", "Billing", ()),
+        "section": ("section", "Reports_report_table", ()),
+        "event": ("event", "domain.reports.generated", (("event", "domain.reports.generated"),)),
+        "cap_export": ("capability", "reports.export", (("capability", "reports.export"),)),
+        "cap_view": ("capability", "reports.view", (("capability", "reports.view"),)),
+        "permission": ("permission", "reports_reports.read", ()),
+        "reaction": ("reaction", "reports_notify_report_ready", ()),
+        "notification": ("notification", "reports_report_ready", ()),
+        "collection": ("data_collection", "reports_reports", ()),
+        "alias": ("data_alias", "reports.current", ()),
+        "workflow": ("workflow", "report_builder", ()),
+        "trigger": ("trigger", "domain.reports.generated", ()),
+        "plan": ("plan", "pro", ()),
+        "product": ("product", "extra_exports", ()),
+        "meter": ("meter", "report_exports", ()),
+        "limit": ("limit", "pro_report_exports", ()),
+        "deployment": ("deployment_target", "local_container", ()),
+    }
+    ids = {key: node_id(kind, identity) for key, (kind, identity, _refs) in specs.items()}
+    expected_nodes = {(ids[key], kind, refs) for key, (kind, _identity, refs) in specs.items()}
+    expected_edges = {
+        (kind, ids[source], ids[target], None)
+        for kind, source, target in {
+            ("owns", "surface_reports", "module_reports"),
+            ("owns", "surface_billing", "module_billing"),
+            ("depends_on", "surface_billing", "surface_reports"),
+            ("declares", "module_reports", "export"),
+            ("declares", "module_reports", "view"),
+            ("declares", "module_reports", "cap_export"),
+            ("declares", "module_reports", "cap_view"),
+            ("declares", "module_reports", "permission"),
+            ("declares", "module_reports", "reaction"),
+            ("declares", "module_reports", "notification"),
+            ("emits", "module_reports", "event"),
+            ("emits", "export", "event"),
+            ("consumes", "reaction", "event"),
+            ("consumes", "notification", "event"),
+            ("consumes", "trigger", "event"),
+            ("gates", "cap_export", "export"),
+            ("gates", "cap_view", "view"),
+            ("gates", "plan", "cap_export"),
+            ("gates", "plan", "cap_view"),
+            ("gates", "plan", "limit"),
+            ("binds", "page_reports", "export"),
+            ("binds", "page_reports", "workflow"),
+            ("binds", "trigger", "workflow"),
+            ("binds", "alias", "collection"),
+            ("binds", "limit", "meter"),
+            ("owns", "module_reports", "collection"),
+            ("renders", "page_reports", "section"),
+        }
+    }
+    assert set(result.represented_facts.nodes) == expected_nodes
+    assert set(result.represented_facts.edges) == expected_edges
 
 
 def test_projection_is_byte_identical_order_independent_and_input_immutable() -> None:
@@ -324,22 +420,43 @@ def test_projection_is_byte_identical_order_independent_and_input_immutable() ->
         second.graph.canonical_payload()
     ).encode("ascii")
     assert first.represented_facts == second.represented_facts
+    assert first.coverage == second.coverage
+    assert first.gaps == second.gaps
+    assert any(gap.source_path == "app_build_plan.pages" for gap in first.gaps)
 
 
 def test_machine_readable_coverage_classifies_every_source_leaf() -> None:
     source = _corpus_source()
     result = _project(source)
-    leaf_paths = {path for path, _ in _walk_leaves(source)}
+    canonical_source = copy.deepcopy(source)
+    canonical_source["app_build_plan"]["surface_map"]["surfaces"].sort(
+        key=lambda item: item["surface_id"]
+    )
+    canonical_source["modules"].sort(key=lambda item: item["manifest"]["module"]["id"])
+    for module in canonical_source["modules"]:
+        module["manifest"]["actions"].sort(key=lambda item: item["id"])
+        module["manifest"]["capabilities"].sort(key=lambda item: item["capability_id"])
+        module["manifest"]["permissions"].sort(key=lambda item: item["id"])
+    leaf_paths = {path for path, _ in _walk_leaves(canonical_source)}
     coverage_paths = {row.source_path for row in result.coverage}
-    assert coverage_paths == leaf_paths
+    assert leaf_paths <= coverage_paths
+    assert len(result.coverage) == len(coverage_paths)
     assert {row.disposition for row in result.coverage} == {
         ProjectionDisposition.PROJECTED,
         ProjectionDisposition.DELIBERATELY_NON_SEMANTIC,
         ProjectionDisposition.DEFERRED,
     }
-    deferred = {row.source_path for row in result.coverage if row.disposition is ProjectionDisposition.DEFERRED}
+    deferred = {
+        row.source_path
+        for row in result.coverage
+        if row.disposition is ProjectionDisposition.DEFERRED
+    }
     assert deferred == {gap.source_path for gap in result.gaps}
-    assert json.loads(result.model_dump_json())["schema_version"] == "mozaiks.semantic_projection.v1"
+    for path in coverage_paths:
+        _lookup_path(canonical_source, path)
+    assert (
+        json.loads(result.model_dump_json())["schema_version"] == "mozaiks.semantic_projection.v1"
+    )
 
 
 def _walk_leaves(value, path=""):
@@ -357,6 +474,14 @@ def _walk_leaves(value, path=""):
         yield path, value
 
 
+def _lookup_path(value, path):
+    import re
+
+    for name, index in re.findall(r"([^.\[\]]+)|\[(\d+)\]", path):
+        value = value[int(index)] if index else value[name]
+    return value
+
+
 @pytest.mark.parametrize("field", ["event", "capability"])
 def test_unknown_taxonomy_references_fail_closed(field: str) -> None:
     source = _corpus_source()
@@ -364,8 +489,19 @@ def test_unknown_taxonomy_references_fail_closed(field: str) -> None:
         source["modules"][0]["events"]["events"][0]["type"] = "domain.unknown.created"
     else:
         source["modules"][0]["manifest"]["capabilities"][0]["capability_id"] = "unknown.capability"
-    with pytest.raises(ProjectionError, match="unknown .* taxonomy identifier"):
+    with pytest.raises(
+        ProjectionError, match="absent from the pinned taxonomy registry"
+    ) as exc_info:
         _project(source)
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.MISSING
+
+
+def test_invalid_taxonomy_grammar_is_distinct_from_missing_registry_entry() -> None:
+    source = _corpus_source()
+    source["modules"][0]["manifest"]["capabilities"][0]["capability_id"] = "INVALID CAPABILITY"
+    with pytest.raises(ProjectionError, match="invalid capability taxonomy identifier") as exc_info:
+        _project(source)
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED
 
 
 def test_recorded_appbuildplan_unknown_semantics_are_not_silently_omitted() -> None:
@@ -376,7 +512,7 @@ def test_recorded_appbuildplan_unknown_semantics_are_not_silently_omitted() -> N
     )
     with pytest.raises(ProjectionError) as exc_info:
         project_semantic_graph(recorded, graph_id="recorded-projects", version=1, scope=SCOPE)
-    assert exc_info.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.MISSING
     assert "domain.projects" in exc_info.value.gaps[0].reason
 
 
@@ -386,13 +522,259 @@ def test_existing_recorded_saas_fixture_projects_with_explicit_gaps() -> None:
             encoding="utf-8"
         )
     )
-    result = project_semantic_graph(
-        recorded, graph_id="recorded-saas", version=1, scope=SCOPE
-    )
+    result = project_semantic_graph(recorded, graph_id="recorded-saas", version=1, scope=SCOPE)
     assert result.graph.nodes
     assert result.gaps
     assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in result.gaps)
     assert all(row.source_file != "unknown" for row in result.coverage)
+
+
+def test_current_runtime_models_and_agentgenerator_bundle_shape_project() -> None:
+    module = ModuleDefinition.model_validate(
+        {
+            "schema_version": "mozaiks.module.v1",
+            "module": {"id": "reports", "handler": "backend.handler:Handler"},
+            "actions": [
+                {
+                    "id": "export_report",
+                    "description": "Export a report.",
+                    "handler_method": "export_report",
+                    "emits": ["domain.reports.generated"],
+                    "entitlement_gate": "reports.export",
+                }
+            ],
+            "capabilities": [
+                {
+                    "capability_id": "reports.export",
+                    "kind": "action",
+                    "target": "export_report",
+                    "title": "Export reports",
+                }
+            ],
+        }
+    )
+    events = ModuleEventsManifest.model_validate(
+        {
+            "events": [
+                {
+                    "type": "domain.reports.generated",
+                    "version": 1,
+                    "producer": "reports",
+                }
+            ]
+        }
+    )
+    reactions = ModuleReactionsManifest.model_validate(
+        {
+            "reactions": [
+                {
+                    "id": "index_report",
+                    "event_type": "domain.reports.generated",
+                    "target": {"kind": "handler", "handler_method": "index_report"},
+                }
+            ]
+        }
+    )
+    page = AppPageSchema.model_validate(
+        {
+            "schema_version": "mozaiks.app_page.v1",
+            "name": "Reports",
+            "route": "/reports",
+            "title": "Reports",
+            "page_type": "record_list",
+            "layout": "full-width",
+            "sections": [
+                {
+                    "id": "header",
+                    "primitive": "PageHeader",
+                    "config": {
+                        "title": "Reports",
+                        "actions": [
+                            {
+                                "id": "export",
+                                "label": "Export",
+                                "action_type": "submit",
+                                "href": "/api/modules/reports/export_report",
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    subscriptions = SubscriptionsConfig.model_validate(
+        {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "Reports plans",
+            "default_plan_id": "pro",
+            "plans": [
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["reports.export"],
+                    "usage_limits": [
+                        {"meter_id": "report_exports", "unit": "requests", "monthly_limit": 100}
+                    ],
+                }
+            ],
+        }
+    )
+    app_context = AppContextVersion(
+        context_version_id="context-1",
+        app_id="reports-app",
+        mode="hybrid",
+        ownership_boundaries=[
+            OwnershipBoundary(
+                path_or_artifact="app/modules/reports",
+                ownership="generated_overlay",
+                allowed_operations=["generate_overlay"],
+            )
+        ],
+    )
+    workflow_bundle = {
+        "workflow_name": "report_builder",
+        "agent_message": "Generated.",
+        "pattern_id": 1,
+        "pattern_name": "Pipeline",
+        "files": [
+            {
+                "filename": "orchestrator.yaml",
+                "content": """workflow_name: report_builder
+max_turns: 4
+human_in_the_loop: false
+workflow_startup_mode: BackendOnly
+orchestration_pattern: ag2_network
+initial_agent: ReportAgent
+initial_message: Build reports.
+triggers:
+  - type: event
+    event: domain.reports.generated
+    capability_id: reports.export
+""",
+            },
+            {"filename": "agents.yaml", "content": "agents: []\n"},
+        ],
+    }
+    module_bundle = {"manifest": module, "events": events, "reactions": reactions}
+    source = {
+        "modules": [module_bundle],
+        "pages": [page],
+        "subscriptions": subscriptions,
+        "agent_workflows": [workflow_bundle],
+        "app_context": app_context,
+    }
+    result = project_semantic_graph(
+        source,
+        graph_id="current-contracts",
+        version=1,
+        scope=SCOPE,
+    )
+    assert result.source_facts == extract_semantic_facts(result.graph)
+    assert any(gap.source_path == "agent_workflows[0].files" for gap in result.gaps)
+    assert any(gap.source_path.endswith("ownership_boundaries[0].ownership") for gap in result.gaps)
+    mapped = dict(source)
+    mapped["modules"] = {"reports": module_bundle}
+    mapped["agent_workflows"] = {"report_builder": workflow_bundle, "_meta": {"count": 1}}
+    mapped_result = project_semantic_graph(
+        mapped,
+        graph_id="current-contracts",
+        version=1,
+        scope=SCOPE,
+    )
+    assert mapped_result.graph.graph_digest == result.graph.graph_digest
+    assert all(row.source_file != "unknown" for row in mapped_result.coverage)
+
+
+def test_projection_field_access_is_pinned_to_current_structured_outputs() -> None:
+    app = yaml.safe_load(
+        (ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["models"]
+    assert {
+        "surface_map",
+        "pages",
+        "entities",
+        "event_flows",
+        "workflow_touchpoints",
+        "data_contract",
+        "deployment_targets",
+    } <= set(app["AppBuildPlan"]["fields"])
+    assert {"pages", "data_contract", "custom_route_bundle"} <= set(
+        app["AppSchemaOutput"]["fields"]
+    )
+
+    design = yaml.safe_load(
+        (ROOT / "factory_app/workflows/DesignDocs/structured_outputs.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["models"]["DesignDocsBundle"]["fields"]
+    assert {"experience_spec", "surface_map", "data_contract"} <= set(design)
+
+    subscription = yaml.safe_load(
+        (
+            ROOT / "factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml"
+        ).read_text(encoding="utf-8")
+    )["models"]["SubscriptionContractOutput"]["fields"]
+    assert "subscription_config_file" in subscription
+
+    agent = yaml.safe_load(
+        (ROOT / "factory_app/workflows/AgentGenerator/structured_outputs.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["models"]
+    assert set(agent["WorkflowBundleBuilderOutput"]["fields"]) >= {
+        "workflow_name",
+        "files",
+    }
+    assert "triggers" not in agent["WorkflowBundleBuilderOutput"]["fields"]
+    assert "triggers" in agent["OrchestrationConfigOutput"]["fields"]
+
+
+def test_committed_design_docs_subscription_build_context_and_route_sources() -> None:
+    from tests.test_design_docs_bundle_persistence import _bundle
+    from tests.test_subscription_contract_designer import _sample_contract
+
+    design_result = project_semantic_graph(
+        {"DesignDocsBundle": _bundle()},
+        graph_id="recorded-design-docs",
+        version=1,
+        scope=SCOPE,
+    )
+    assert design_result.graph.nodes
+    assert design_result.source_facts == design_result.represented_facts
+
+    with pytest.raises(ProjectionError) as exc_info:
+        project_semantic_graph(
+            {"SubscriptionContractOutput": _sample_contract()},
+            graph_id="recorded-subscription",
+            version=1,
+            scope=SCOPE,
+        )
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.MISSING
+    assert "reports.generate" in exc_info.value.gaps[0].reason
+
+    build_context = yaml.safe_load(
+        (ROOT / "factory_app/build_context/AppGenerator/context.yaml").read_text(encoding="utf-8")
+    )
+    assert validate_pack_context(build_context).valid
+    source = _corpus_source()
+    source["build_context"] = build_context
+    context_result = _project(source)
+    assert any(gap.source_path.startswith("build_context.assets") for gap in context_result.gaps)
+
+    route_manifest = json.loads(
+        (
+            ROOT / "tests/fixtures/community_packs/greetings/templates/ui/route_manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    route_result = project_semantic_graph(
+        {"route_manifest": route_manifest},
+        graph_id="recorded-route-manifest",
+        version=1,
+        scope=SCOPE,
+    )
+    assert {node.kind for node in route_result.graph.nodes} == {SemanticNodeKind.PAGE}
 
 
 def test_incomplete_required_and_contradictory_duplicate_inputs_fail_closed() -> None:
@@ -400,12 +782,19 @@ def test_incomplete_required_and_contradictory_duplicate_inputs_fail_closed() ->
     with pytest.raises(ProjectionError, match="module id is required"):
         _project(missing)
 
-    contradictory = _corpus_source()
-    contradictory["app_build_plan"]["capability_packs"][0]["capability_pack_id"] = (
-        "reports.export"
+    duplicate = _corpus_source()
+    duplicate["app_build_plan"]["pages"].append(
+        copy.deepcopy(duplicate["app_build_plan"]["pages"][0])
     )
-    with pytest.raises(ProjectionError, match="conflicting facts reuse node identity"):
-        _project(contradictory)
+    with pytest.raises(ProjectionError, match="duplicate semantic identity"):
+        _project(duplicate)
+
+    conflicting = _corpus_source()
+    conflicting["app_schema"]["pages"][0]["route"] = "/different-reports"
+    with pytest.raises(ProjectionError) as exc_info:
+        _project(conflicting)
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.CONTRADICTORY
+    assert "conflicting page route" in exc_info.value.gaps[0].reason
 
 
 @pytest.mark.parametrize(
@@ -424,9 +813,74 @@ def test_cross_tenant_or_workspace_composition_fails_closed(foreign_scope) -> No
 
 def test_brownfield_and_hybrid_require_ownership_evidence() -> None:
     source = _corpus_source()
-    source["ownership_evidence"]["owned_surfaces"] = []
-    with pytest.raises(ProjectionError, match="requires explicit owned surfaces"):
+    source["ownership_evidence"]["ownership_boundaries"] = []
+    with pytest.raises(ProjectionError, match="requires AppContextVersion ownership boundaries"):
         _project(source)
+
+
+def test_closure_does_not_invent_page_actions_events_or_capabilities() -> None:
+    source = _corpus_source()
+    source["modules"][0]["manifest"]["actions"] = []
+    source["app_build_plan"]["surface_map"]["surfaces"][0]["owned_mutations"] = []
+    with pytest.raises(ProjectionError, match="does not resolve to a declared semantic node"):
+        _project(source)
+
+    source = _corpus_source()
+    source["modules"][0]["events"]["events"] = []
+    source["modules"][0]["manifest"]["actions"][0]["emits"] = []
+    source["app_build_plan"]["surface_map"]["surfaces"][0]["events_emitted"] = []
+    source["app_build_plan"]["event_flows"] = []
+    with pytest.raises(ProjectionError, match="does not resolve to a declared semantic node"):
+        _project(source)
+
+    source = _corpus_source()
+    source["modules"][0]["manifest"]["capabilities"] = []
+    source["subscriptions"]["plans"][0]["capabilities"] = []
+    source["subscription_contract"]["subscription_config_file"]["plans"][0]["capabilities"] = []
+    with pytest.raises(ProjectionError, match="does not resolve to a declared semantic node"):
+        _project(source)
+
+
+def test_unknown_root_and_synthetic_slice3_envelopes_fail_closed() -> None:
+    with pytest.raises(ProjectionError) as exc_info:
+        _project({"recorded_artifacts": {"pages": []}, "pages": [{"name": "Home"}]})
+    assert exc_info.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED
+
+
+def test_unclassified_field_is_ambiguous_instead_of_generic_deferred() -> None:
+    source = {"pages": [{"name": "Home", "capabilty_id": "typo.value"}]}
+    result = _project(source)
+    gap = next(gap for gap in result.gaps if gap.source_path.endswith("capabilty_id"))
+    assert gap.kind is ProjectionGapKind.AMBIGUOUS
+    assert "typo" in gap.reason
+
+
+def test_pre_app_scope_and_unowned_evidence_never_fabricate_identity_or_control() -> None:
+    pre_app = ExecutionAccessScopeRef(tenant_id="tenant-1", pre_app_scope_id="creation-1")
+    source = _corpus_source()
+    source["source_scopes"] = {"app_generator": pre_app.model_dump(mode="json")}
+    first = _project(source, scope=pre_app)
+    source["ownership_evidence"]["ownership_boundaries"][1]["path_or_artifact"] = (
+        "unrelated/system/root"
+    )
+    second = _project(source, scope=pre_app)
+    assert first.graph.scope == pre_app
+    assert "app_id" not in first.graph.scope.model_dump(mode="json")
+    assert first.graph.graph_digest == second.graph.graph_digest
+
+
+def test_semantic_descriptions_pricing_and_data_shapes_are_typed_gaps() -> None:
+    result = _project()
+    gap_paths = {gap.source_path for gap in result.gaps}
+    assert "subscription_contract.rationale" in gap_paths
+    assert "app_build_plan.data_contract.surfaces[0].collections[0].fields[0].type" in gap_paths
+    assert "subscriptions.plans[0].usage_limits[0].monthly_limit" not in gap_paths
+    deferred = {
+        row.source_path
+        for row in result.coverage
+        if row.disposition is ProjectionDisposition.DEFERRED
+    }
+    assert gap_paths == deferred
 
 
 def test_projection_has_no_process_or_external_side_effects(monkeypatch) -> None:
@@ -434,6 +888,14 @@ def test_projection_has_no_process_or_external_side_effects(monkeypatch) -> None
     environment = dict(os.environ)
     modules = set(sys.modules)
     monkeypatch.setattr("socket.socket.connect", lambda *_args, **_kwargs: pytest.fail("network"))
+    monkeypatch.setattr(builtins, "open", lambda *_args, **_kwargs: pytest.fail("filesystem open"))
+    monkeypatch.setattr(
+        Path, "write_text", lambda *_args, **_kwargs: pytest.fail("filesystem write")
+    )
+    monkeypatch.setattr(
+        Path, "write_bytes", lambda *_args, **_kwargs: pytest.fail("filesystem write")
+    )
+    monkeypatch.setattr(os, "chdir", lambda *_args, **_kwargs: pytest.fail("cwd mutation"))
     _project()
     assert Path.cwd() == cwd
     assert dict(os.environ) == environment
@@ -452,19 +914,8 @@ def test_production_sources_do_not_import_offline_projection() -> None:
             relative = path.relative_to(ROOT)
             if relative in excluded:
                 continue
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
-            except SyntaxError:
-                # Build-context Python templates contain unresolved {{placeholders}}.
-                continue
-            for node in ast.walk(tree):
-                if isinstance(node, ast.ImportFrom) and node.module == (
-                    "mozaiksai.core.semantics.offline_projection"
-                ):
-                    offenders.append(relative.as_posix())
-                if isinstance(node, ast.Import) and any(
-                    alias.name == "mozaiksai.core.semantics.offline_projection"
-                    for alias in node.names
-                ):
-                    offenders.append(relative.as_posix())
+            # Text scanning intentionally catches direct/aliased/relative imports,
+            # package re-exports, importlib/__import__ strings, and loader strings.
+            if "offline_projection" in path.read_text(encoding="utf-8"):
+                offenders.append(relative.as_posix())
     assert offenders == []


### PR DESCRIPTION
## Summary

Implements ADR 0007 Slice 3 as offline, fail-closed comparison infrastructure only.

An independent review of the original exact head `a0e46d25892b6fdc3b0f01ec0c932612b57078aa` found material defects. Commit `c016092719f4397f5c8b009d566d9104bbb84306` corrects them without widening Slice 3 authority.

- accepts current AppGenerator/AppSchemaOutput, DesignDocs, subscription, module/page/route, AgentGenerator workflow-bundle, deployment, recorded-AppBuildPlan, build-context, and AppContext ownership shapes
- parses AgentGenerator `files[]` and its `orchestrator.yaml` triggers instead of an invented top-level trigger shape
- consumes `AppContextVersion.ownership_boundaries`; ownership evidence never fabricates graph authority
- projects only facts supported by SemanticGraph v1 and records unrepresentable application semantics as typed gaps
- requires action, event, capability, scope, and ownership references to resolve rather than inventing closure nodes
- rejects duplicate identities, contradictory observations, unknown source roots, and obsolete synthetic envelopes
- distinguishes invalid taxonomy grammar from valid-but-unpinned namespace entries
- independently derives source facts before graph construction and represented facts from the graph, then requires exact equality
- classifies every canonical source leaf exactly once and keeps coverage/gap paths aligned

## Review corrections

The original implementation used stale or invented producer shapes, allowed graph construction to supply missing reference targets, coalesced duplicate semantic identities, used circular fact-equivalence proof, and treated application-semantic payloads as nonsemantic. It also had incomplete import-side-effect guards and could misclassify valid unpinned taxonomy references. These defects are corrected in the current head.

## Validation

- focused Slice 3 suite: 23 passed
- Slice 1-3 semantic contract suite: 274 passed
- affected producer/consumer suite: 504 passed
- golden/materialization suite: 300 passed, 8 skipped
- production-readiness gate (quick, frontend skipped): 750 passed, 4 skipped; source hygiene passed
- `ruff check .`
- `git diff --check` (clean; checkout line-ending warnings only)
- DCO sign-off present
- GitHub exact-head CI: lint, frontend, visual regression, packaging, dependency audit, infrastructure build, DCO, security scans, and shards 0/2/3 pass
- GitHub shard 1 remains blocked by the known PR #420 host/process leak on the initial run and one failed-job rerun: `test_workspace_app_intelligence_acceptance` receives the temporary root created by `test_serve_normalizes_uppercase_log_level`; 3,482 other tests in that shard pass

No live models were used.

## Boundaries

No production generator, renderer, runtime host, loader, workflow, Studio, control-plane, persistence, promotion, refinement, ArtifactRevision, RefinementPatch, CompilationPlan, or ADR 0006 execution authority imports or invokes this offline module. No deployment, network, persistence, or live-model operation is introduced.

Exact base: `359c3e06b157c897c5d9f7a2717e4d48b688bb53`
Original independently reviewed head: `a0e46d25892b6fdc3b0f01ec0c932612b57078aa`
Corrected head: `c016092719f4397f5c8b009d566d9104bbb84306`

Keep draft and unmerged. Because the independent reviewer authored a material correction, this head requires a short independent follow-up review after PR #420 is resolved/rebased as applicable.

---

## Independent Stage A review + corrective delta (`c0160927` → `69783c0c`)

Reviewed at exact head `c0160927` by an agent that did not author the original slice, then rebased onto `f6a8b34c` (PR #420's squash + #387) and corrected. The rebase was conflict-free and both Slice 3 files were byte-identical to the reviewed head before any corrective edit.

### Findings and disposition

| # | Finding | Severity | Disposition |
|---|---|---|---|
| 1 | Purity test order-dependent and vacuous | High | **Fixed** |
| 2 | Purity property fails on a cold module cache | High | **Fixed** |
| 3 | `build_context`/`workflows` advertised with no projector | Medium | **Fixed** |
| 4 | Projection narrower than the page-schema API-path contract | Medium | **Fixed** |
| 5 | Duplicate root aliases don't fail closed | Low | **Fixed** |
| 6 | Real contract fields labelled "producer drift or a typo" | Low–Med | **Fixed** |
| 7 | Entitlement-gate module-only coupling | Low | **Reproduced, pinned by test** |
| — | "Generated apps' `domain.*` events can never be projected" | — | **Refuted, not a defect** |

### 1 + 2 — cold-cache purity

`project_semantic_graph()` defaulted its registry to `default_taxonomy_registry()`, which lazily imports the runtime layout registry and transport event contract **at call time**; that pulls in the workflow manager, which reads the workflow catalog from disk. Measured: **116 modules** added by one call, including 20 × `core.workflow.*`, `runtime.app.*`, and `ag2`.

The registry is now a **required pinned Slice 1 input**. Slice 1 stays the only taxonomy authority — no second registry, no copied entries, no eager-import or pre-warm workaround, and `mozaiksai/core/taxonomy.py` is untouched.

The old proof was itself broken: it failed run alone and its `sys.modules` assertion was vacuous in the passing run, because 22 earlier tests in the file had warmed the cache (CI shards by file, so it never surfaced). It is replaced by a **cold-subprocess proof** importing only the projection seam and Slice 1 primitives, guarding filesystem reads/writes, network, cwd and env mutation, asserting no prohibited module import and no input mutation.

```
alone:                    1 passed
first, then whole file:  28 passed
whole file:              28 passed
fresh cold subprocess:    1 passed
```

### 3 — truthful supported-root scope

`build_context` and `workflows` sat in `_SUPPORTED_ROOTS` with no projector, so a source containing only one failed with *"source contains no representable semantic identity"* — the wrong cause. Both are real provenance in recorded sources (`workflows` is documented in-file as *recorded AppBuildPlan execution metadata; not an AppBuildPlan field*) that declare no graph-v1 identity. Every leaf is now an explicit typed `UNSUPPORTED` gap, and a provenance-only source fails with an accurate diagnostic naming the root. No nodes are invented.

### 4 — full page-schema API-path contract

`AppPageSchema` permits any `/api/...` path (`page_schema.py:34` `_API_PATH_RE`); only `/api/modules/{module}/{action}` names a declared action. Projection hard-failed on everything else, so the committed `factory_app/app/ui/pages/notifications.yaml` (`/api/notifications`) could not be projected. Valid non-module bindings are now typed gaps; invalid paths still fail closed; no action or module target is invented. The committed page is tested directly.

### 5–7

Duplicate canonical root aliases now fail closed (`CONTRADICTORY`) instead of using one envelope and reporting the other as ~97 gaps. The unclassified-field diagnostic no longer calls genuine current contract fields "producer drift or a typo". The entitlement-gate coupling was reproduced: it already returns a precise typed missing-reference naming the `entitlement_gate` path and never invents the capability — both the open case and the closure with `subscriptions` are now covered by test.

### Validation

Slice 1–3 semantic suites + production-readiness + hygiene **329 passed**; producer/direct-consumer (AppGenerator materialization, DesignDocs, subscription contract, page schema, AgentGenerator brownfield) **46 passed**; build-context and workflow producer suites **645 passed**; Slice 3 file **28 passed**. `ruff check .` clean; `mypy mozaiksai/core/semantics/` clean (9 files, `--python-version 3.12` locally for NumPy stubs); `git diff --check` clean; DCO signed on all commits; exactly three files changed.

No later-slice behavior, production authority, capability advertisement, ADR 0006 execution, entitlement-policy change, or live model is involved.


---

## CI diagnosis at `69783c0c` and rebase to `36eb35fb`

The first run at `69783c0c` failed only shard 1, on `tests/test_studio_host_smoke.py::test_studio_endpoints_work_without_auth_user_id` (`assert 500 == 200`) — not a Slice 3 test. Delta-debug bisect over the 133 preceding files isolated a single polluter: `tests/test_cli_serve_log_level.py`.

**Pre-existing on main, proven both ways**: the pair fails identically on `f6a8b34c`, and it is dormant there only because the two files sit in different CI shards. Adding the Slice 3 test file re-shards the suite (`test_studio_host_smoke.py` moves shard 0 → shard 1), co-locating the pair. Mechanism: the polluter guards `serve.run()`'s env writes with `monkeypatch.delenv(name, raising=False)` on absent keys — the PR #418 delenv-absent defect — so `MOZAIKS_APP_WORKSPACE_PATH` leaks pointing at its tmp bundle, and the Studio smoke test then resolves that workspace and 500s. Verified empirically by reproducing the failure with only that key leaked.

Fixed at the source in **PR #423** (one test file, #418 set-then-delete pattern, now also guarding `MOZAIKS_HOST`), merged as `4d880e36`. This PR is rebased onto that main; the two Slice 3 code files remain **byte-identical** to the reviewed corrective delta at `69783c0c`, and the polluter+victim pair plus the Slice 3 file pass together locally (40 passed).
