### PR TITLE
test(cli): restore env leaked by serve.run() past delenv-absent monkeypatch

### DIFF
--- a/tests/test_cli_serve_log_level.py
+++ b/tests/test_cli_serve_log_level.py
@@ -42,11 +42,18 @@ def _run_serve_with_captured_log_level(tmp_path, monkeypatch, log_level_env: str
     else:
         monkeypatch.setenv("LOG_LEVEL", log_level_env)
 
-    # serve.run() sets PLATFORM_PATH and MOZAIKS_APP_WORKSPACE_PATH as side effects.
-    # Register them with monkeypatch so teardown restores the originals and prevents
-    # test-order-dependent failures in workspace-dependent tests downstream.
-    monkeypatch.delenv("PLATFORM_PATH", raising=False)
-    monkeypatch.delenv("MOZAIKS_APP_WORKSPACE_PATH", raising=False)
+    # serve.run() writes PLATFORM_PATH, MOZAIKS_APP_WORKSPACE_PATH, and (via
+    # setdefault) MOZAIKS_HOST into os.environ as side effects. A bare
+    # ``monkeypatch.delenv(name, raising=False)`` records NO restore entry when
+    # the key is already absent, so the values serve.run() writes afterwards
+    # survived teardown — leaking this test's tmp workspace into every later
+    # test in the process (a later Studio smoke test 500'd because
+    # MOZAIKS_APP_WORKSPACE_PATH still named this test's minimal bundle).
+    # Setting each key first forces monkeypatch to record a restore entry;
+    # undo then replays back to the original value or original absence.
+    for name in ("PLATFORM_PATH", "MOZAIKS_APP_WORKSPACE_PATH", "MOZAIKS_HOST"):
+        monkeypatch.setenv(name, "")
+        monkeypatch.delenv(name)
 
     captured: dict = {}
 


### PR DESCRIPTION
## Summary

One-file, test-only fix for a pre-existing env leak on `main` (`f6a8b34c`) that PR #421's re-sharding surfaced.

`tests/test_cli_serve_log_level.py` guards `serve.run()`'s env side effects with `monkeypatch.delenv(name, raising=False)` — which records **no restore entry when the key is already absent** (the PR #418 defect class; the file's own comment claims a restoration that never happens). So `PLATFORM_PATH` and `MOZAIKS_APP_WORKSPACE_PATH` written by `serve.run()` survive teardown, and `MOZAIKS_HOST` (written via `setdefault`) was never guarded at all.

**Reproduction on current main:**
```
pytest tests/test_cli_serve_log_level.py tests/test_studio_host_smoke.py
→ FAILED test_studio_endpoints_work_without_auth_user_id  (assert 500 == 200)
```
The leaked `MOZAIKS_APP_WORKSPACE_PATH` names this test's minimal tmp bundle (still on disk during the run), and the later Studio smoke test resolves it and 500s. Isolated empirically: setting only that key to an existing minimal bundle reproduces the failure.

Dormant on main solely because the two files sit in **different CI shards**; any change to the `tests/` file count re-shards the suite and can co-locate them — PR #421 did exactly that, which is how this surfaced. Found by delta-debug bisect over the 133 files preceding the victim in the re-sharded shard 1.

**Fix**: the #418 set-then-delete pattern (`setenv(name, "")` then `delenv(name)`) so undo replays to the original value or original absence, now covering `MOZAIKS_HOST` too.

**Validation**: polluter+victim pair green in both orders; the file alone green (3 passed); `ruff` clean; `git diff --check` clean; DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)