### PR TITLE
fix(runtime): bound workflow trigger admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,12 @@ This project follows a practical pre-1.0 changelog format:
   `detail` envelope, so HTTP 402 responses reach the app's upgrade flow while
   flat object responses remain compatible. Declarative page rendering is
   unchanged.
+- **Module-event workflow triggers now fail closed instead of amplifying**:
+  each event/capability invocation is durably claimed before session creation,
+  concurrent replay is suppressed, workflow-trigger lineage carries bounded
+  depth and cycle ancestry, and Mongo-backed per-tenant admission limits reject
+  runaway unique events without affecting other tenants. Replay, cycle/depth,
+  rate, and persistence rejections emit distinct platform diagnostics.
 - **ADR 0007 Slice 0 closes proven generator and refinement defects**:
   generated app/workflow writers now use the canonical build-scoped staging
   roots, required artifact and DesignDocs persistence fails closed, lineage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,8 @@ This project follows a practical pre-1.0 changelog format:
   concurrent replay is suppressed, workflow-trigger lineage carries bounded
   depth and cycle ancestry, and Mongo-backed per-tenant admission limits reject
   runaway unique events without affecting other tenants. Replay, cycle/depth,
-  rate, and persistence rejections emit distinct platform diagnostics.
+  rate, rate-authority, and persistence rejections emit distinct platform
+  diagnostics.
 - **ADR 0007 Slice 0 closes proven generator and refinement defects**:
   generated app/workflow writers now use the canonical build-scoped staging
   roots, required artifact and DesignDocs persistence fails closed, lineage

--- a/docs/architecture/foundations/events-and-data/event-contracts.md
+++ b/docs/architecture/foundations/events-and-data/event-contracts.md
@@ -384,8 +384,11 @@ Current platform support:
   intent and emits `notification.created`.
 - `capability` targets are active. The platform host resolves
   `target.capability_id` against workflow `orchestrator.yaml` trigger
-  declarations, creates the routed workflow session, and emits
-  `platform.workflow_capability_started`.
+  declarations, admits the event/capability pair through durable replay,
+  ancestry/depth, and per-tenant rate guards, then creates the routed workflow
+  session and emits `platform.workflow_capability_started`. Rejected admissions
+  emit `platform.workflow_capability_trigger_rejected` without creating a
+  session or starting a workflow.
 - `handler` targets are active. `ModuleEventRouter` invokes
   `target.handler_method` on the module handler class and passes event payload
   fields as keyword arguments.

--- a/docs/architecture/foundations/events-and-data/event-system.md
+++ b/docs/architecture/foundations/events-and-data/event-system.md
@@ -107,7 +107,10 @@ Current implementation:
 - `mozaiksai/hosts/platform.py` indexes capability-triggered workflows from
   `workflows/*/orchestrator.yaml`, creates the routed chat session, and
   auto-starts background execution when transport is available.
-- Capability resolution emits `platform.workflow_capability_started`.
+- Admitted capability resolution emits `platform.workflow_capability_started`;
+  replay, cycle/depth, rate, or authority rejection emits
+  `platform.workflow_capability_trigger_rejected` without creating a session or
+  starting a workflow.
 - Handler targets route the event payload directly to a named module action
   method, enabling module-to-module event-driven calls without HTTP indirection.
 - Service adapter targets route the event payload to an app-owned

--- a/mozaiksai/core/adapters/http_app_backend.py
+++ b/mozaiksai/core/adapters/http_app_backend.py
@@ -139,7 +139,7 @@ class HttpAppBackendAdapter:
         try:
             from mozaiksai.core.events.unified_event_dispatcher import get_event_dispatcher
             dispatcher = get_event_dispatcher()
-            await dispatcher.dispatch(event_type, data)  # type: ignore[arg-type,call-arg]
+            await dispatcher.emit(event_type, data)
             logger.debug("Emitted event '%s'", event_type)
             return True
         except Exception as exc:

--- a/mozaiksai/core/runtime/composition/module_event_provenance.py
+++ b/mozaiksai/core/runtime/composition/module_event_provenance.py
@@ -6,8 +6,10 @@ These types explain where an event reaction came from. They are evidence for
 application/operator policy, not production authority.
 """
 
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from hashlib import sha256
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -189,6 +191,31 @@ def normalize_module_event_provenance(
         envelope_shape=envelope_shape,
         trust_shape=trust_shape,
     )
+
+
+def module_event_identity(
+    event_type: str,
+    envelope: dict[str, Any],
+    provenance: ModuleEventProvenance | None = None,
+) -> str:
+    """Return the canonical identity used by module-event admission ledgers."""
+
+    normalized = provenance or normalize_module_event_provenance(event_type, envelope)
+    if normalized.event_id:
+        return normalized.event_id
+    return sha256(
+        json.dumps(
+            {
+                "event_type": event_type,
+                "tenant_id": normalized.tenant_id,
+                "app_id": normalized.app_id,
+                "actor_id": normalized.actor_id,
+                "payload": envelope.get("payload", envelope),
+            },
+            sort_keys=True,
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 def normalize_module_reaction_provenance(reaction: dict[str, Any]) -> ModuleReactionProvenance:

--- a/mozaiksai/core/runtime/composition/module_event_router.py
+++ b/mozaiksai/core/runtime/composition/module_event_router.py
@@ -13,13 +13,11 @@ This keeps module event meaning above the runtime kernel.
 
 import importlib
 import inspect
-import json
 import re
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import replace
 from datetime import UTC, datetime
-from hashlib import sha256
 from typing import Any
 from uuid import uuid4
 
@@ -30,6 +28,7 @@ from mozaiksai.core.runtime.composition.module_event_provenance import (
     ModuleReactionAudit,
     ModuleReactionProvenance,
     build_module_reaction_audit,
+    module_event_identity,
     normalize_module_event_provenance,
     normalize_module_reaction_provenance,
 )
@@ -551,21 +550,11 @@ class ModuleEventRouter:
             return None
         reaction_id = str(reaction.get("id") or "").strip()
         module_id = str(reaction.get("module_id") or "").strip()
-        event_identity = str(event_provenance.event_id or "").strip()
-        if not event_identity:
-            event_identity = sha256(
-                json.dumps(
-                    {
-                        "event_type": event_type,
-                        "tenant_id": event_provenance.tenant_id,
-                        "app_id": event_provenance.app_id,
-                        "actor_id": event_provenance.actor_id,
-                        "payload": envelope.get("payload", envelope),
-                    },
-                    sort_keys=True,
-                    default=str,
-                ).encode("utf-8")
-            ).hexdigest()
+        event_identity = module_event_identity(
+            event_type,
+            envelope,
+            event_provenance,
+        )
         return (module_id, reaction_id, event_type, declared, event_identity)
 
     async def _durable_complete(

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -55,6 +55,9 @@ from mozaiksai.core.runtime.composition.schema_validation import (
     normalize_nullable_schema,
     validate_json_schema,
 )
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_KEY,
+)
 from mozaiksai.core.runtime.persistence import MongoPersistenceContext
 
 logger = get_workflow_logger("module_executor")
@@ -750,6 +753,13 @@ class ModuleExecutor:
             }
             if request.user_id:
                 envelope["actor"] = {"type": "user", "id": request.user_id}
+            trigger_trace = (
+                request.provenance.metadata.get(WORKFLOW_TRIGGER_TRACE_KEY)
+                if request.provenance is not None
+                else None
+            )
+            if isinstance(trigger_trace, dict):
+                envelope[WORKFLOW_TRIGGER_TRACE_KEY] = dict(trigger_trace)
 
             result = self._event_emitter(event_type_text, envelope)  # type: ignore[misc]
             if inspect.isawaitable(result):

--- a/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
+++ b/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
@@ -1,0 +1,344 @@
+"""Fail-closed admission guard for module-event workflow triggers.
+
+This is platform-owned event-to-run admission policy.  It composes the
+existing durable reaction claim store with the existing ``limits`` rate-limit
+library; it does not queue, schedule, or execute workflows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Literal, Protocol
+
+from mozaiksai.core.runtime.composition.module_event_provenance import (
+    module_event_identity,
+)
+from mozaiksai.core.runtime.composition.reaction_idempotency_store import (
+    ReactionIdempotencyStore,
+)
+
+WORKFLOW_TRIGGER_TRACE_KEY = "_mozaiks_workflow_trigger"
+WORKFLOW_TRIGGER_TRACE_HEADER = "X-Mozaiks-Workflow-Trigger"
+_DEFAULT_MAX_DEPTH = 8
+_DEFAULT_RATE_PER_MINUTE = 10
+
+TriggerDecisionReason = Literal[
+    "allowed",
+    "replay",
+    "cycle",
+    "depth",
+    "rate",
+    "persistence",
+]
+
+
+class WorkflowTriggerRateLimiter(Protocol):
+    async def ensure_ready(self) -> None: ...
+
+    async def hit(self, tenant_key: str) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowTriggerDecision:
+    allowed: bool
+    reason: TriggerDecisionReason
+    invocation_id: str
+    event_identity: str
+    depth: int
+    trace: dict[str, Any] | None = None
+    detail: str | None = None
+
+
+class MongoWorkflowTriggerRateLimiter:
+    """Distributed per-tenant moving-window limiter backed by existing Mongo."""
+
+    def __init__(
+        self,
+        mongo_uri: str,
+        *,
+        database_name: str | None = None,
+        requests_per_minute: int | None = None,
+    ) -> None:
+        from limits import parse
+        from limits.storage import MongoDBStorage
+        from limits.strategies import MovingWindowRateLimiter
+
+        rpm = requests_per_minute or _positive_env_int(
+            "WORKFLOW_TRIGGER_RATE_LIMIT_PER_MINUTE",
+            _DEFAULT_RATE_PER_MINUTE,
+        )
+        db_name = (
+            database_name or os.getenv("MOZAIKS_APP_DATABASE_NAME") or "mozaiks_apps"
+        ).strip()
+        self._storage = MongoDBStorage(
+            mongo_uri,
+            database_name=db_name,
+            counter_collection_name="_mz_workflow_trigger_rate_counters",
+            window_collection_name="_mz_workflow_trigger_rate_windows",
+        )
+        self._limiter = MovingWindowRateLimiter(self._storage)
+        self._limit = parse(f"{rpm}/minute")
+
+    async def ensure_ready(self) -> None:
+        ready = await asyncio.to_thread(self._storage.check)
+        if not ready:
+            raise RuntimeError("workflow trigger rate-limit storage is unavailable")
+
+    async def hit(self, tenant_key: str) -> bool:
+        return bool(
+            await asyncio.to_thread(
+                self._limiter.hit,
+                self._limit,
+                tenant_key,
+                "workflow_capability_trigger",
+            )
+        )
+
+
+class WorkflowTriggerGuard:
+    """Atomically admit one bounded workflow trigger invocation."""
+
+    def __init__(
+        self,
+        *,
+        claim_store: ReactionIdempotencyStore | None,
+        rate_limiter: WorkflowTriggerRateLimiter | None,
+        max_depth: int | None = None,
+    ) -> None:
+        self._claim_store = claim_store
+        self._rate_limiter = rate_limiter
+        self._max_depth = max_depth or _positive_env_int(
+            "WORKFLOW_TRIGGER_MAX_DEPTH",
+            _DEFAULT_MAX_DEPTH,
+        )
+        self._ready = False
+        self._ready_lock = asyncio.Lock()
+
+    async def authorize(
+        self,
+        *,
+        capability_id: str,
+        source_event: dict[str, Any],
+        app_id: str,
+        tenant_id: str | None,
+        workspace_id: str | None,
+    ) -> WorkflowTriggerDecision:
+        event_identity = workflow_trigger_event_identity(source_event)
+        invocation_id = workflow_trigger_invocation_id(event_identity, capability_id)
+        trace_result = _next_trace(
+            source_event=source_event,
+            capability_id=capability_id,
+            event_identity=event_identity,
+            invocation_id=invocation_id,
+            max_depth=self._max_depth,
+        )
+        if isinstance(trace_result, WorkflowTriggerDecision):
+            return trace_result
+        depth, trace = trace_result
+
+        if self._claim_store is None or self._rate_limiter is None:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="persistence",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail="durable trigger claim or rate-limit authority is unavailable",
+            )
+
+        try:
+            await self._ensure_ready()
+            key = f"workflow_trigger:{invocation_id}"
+            claim = await self._claim_store.claim(
+                app_id=app_id,
+                tenant_id=tenant_id,
+                workspace_id=workspace_id,
+                idempotency_key_str=key,
+                max_attempts=1,
+            )
+            if not claim.claimed or not claim.claim_token:
+                return WorkflowTriggerDecision(
+                    allowed=False,
+                    reason="replay",
+                    invocation_id=invocation_id,
+                    event_identity=event_identity,
+                    depth=depth,
+                    trace=trace,
+                    detail="invocation identity is already claimed or completed",
+                )
+
+            # Persist the terminal claim before spawning.  This deliberately
+            # chooses at-most-once admission: a crash after this point may lose
+            # the invocation, but can never amplify it on replay.
+            completed = await self._claim_store.complete(
+                app_id=app_id,
+                tenant_id=tenant_id,
+                workspace_id=workspace_id,
+                idempotency_key_str=key,
+                claim_token=claim.claim_token,
+            )
+            if not completed:
+                raise RuntimeError("workflow trigger claim could not be finalized")
+
+            tenant_key = ":".join([app_id, tenant_id or app_id, workspace_id or ""])
+            if not await self._rate_limiter.hit(tenant_key):
+                return WorkflowTriggerDecision(
+                    allowed=False,
+                    reason="rate",
+                    invocation_id=invocation_id,
+                    event_identity=event_identity,
+                    depth=depth,
+                    trace=trace,
+                    detail="per-tenant workflow trigger rate limit exceeded",
+                )
+        except Exception as exc:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="persistence",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail=f"{type(exc).__name__}: trigger authority failed",
+            )
+
+        return WorkflowTriggerDecision(
+            allowed=True,
+            reason="allowed",
+            invocation_id=invocation_id,
+            event_identity=event_identity,
+            depth=depth,
+            trace=trace,
+        )
+
+    async def _ensure_ready(self) -> None:
+        if self._ready:
+            return
+        async with self._ready_lock:
+            if self._ready:
+                return
+            if self._claim_store is None or self._rate_limiter is None:
+                raise RuntimeError("workflow trigger authority is unavailable")
+            await self._claim_store.ensure_indexes()
+            await self._rate_limiter.ensure_ready()
+            self._ready = True
+
+
+def workflow_trigger_event_identity(source_event: dict[str, Any]) -> str:
+    event_type = str(source_event.get("type") or "").strip()
+    identity = module_event_identity(event_type, source_event)
+    return (
+        identity
+        if source_event.get("id") or source_event.get("event_id")
+        else f"derived_{identity}"
+    )
+
+
+def workflow_trigger_invocation_id(event_identity: str, capability_id: str) -> str:
+    digest = sha256(f"{event_identity}\x00{capability_id.strip()}".encode()).hexdigest()
+    return f"wti_{digest}"
+
+
+def _next_trace(
+    *,
+    source_event: dict[str, Any],
+    capability_id: str,
+    event_identity: str,
+    invocation_id: str,
+    max_depth: int,
+) -> tuple[int, dict[str, Any]] | WorkflowTriggerDecision:
+    raw = source_event.get(WORKFLOW_TRIGGER_TRACE_KEY)
+    if raw is None and isinstance(source_event.get("payload"), dict):
+        raw = source_event["payload"].get(WORKFLOW_TRIGGER_TRACE_KEY)
+    if raw is None:
+        parent_depth = 0
+        capabilities: list[str] = []
+        invocations: list[str] = []
+        root_event_id = event_identity
+    elif isinstance(raw, dict):
+        parent_depth_raw = raw.get("depth")
+        capabilities_raw = raw.get("capability_ids")
+        invocations_raw = raw.get("invocation_ids")
+        root_event_id = str(raw.get("root_event_id") or event_identity)
+        if (
+            not isinstance(parent_depth_raw, int)
+            or parent_depth_raw < 0
+            or not isinstance(capabilities_raw, list)
+            or not all(isinstance(item, str) and item for item in capabilities_raw)
+            or not isinstance(invocations_raw, list)
+            or not all(isinstance(item, str) and item for item in invocations_raw)
+            or parent_depth_raw != len(capabilities_raw)
+            or len(invocations_raw) != len(capabilities_raw)
+        ):
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="depth",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=max_depth + 1,
+                detail="workflow trigger lineage is malformed",
+            )
+        parent_depth = parent_depth_raw
+        capabilities = list(capabilities_raw)
+        invocations = list(invocations_raw)
+    else:
+        return WorkflowTriggerDecision(
+            allowed=False,
+            reason="depth",
+            invocation_id=invocation_id,
+            event_identity=event_identity,
+            depth=max_depth + 1,
+            detail="workflow trigger lineage is malformed",
+        )
+
+    next_depth = parent_depth + 1
+    if capability_id in capabilities:
+        return WorkflowTriggerDecision(
+            allowed=False,
+            reason="cycle",
+            invocation_id=invocation_id,
+            event_identity=event_identity,
+            depth=next_depth,
+            detail="capability already exists in the trigger ancestry",
+        )
+    if next_depth > max_depth:
+        return WorkflowTriggerDecision(
+            allowed=False,
+            reason="depth",
+            invocation_id=invocation_id,
+            event_identity=event_identity,
+            depth=next_depth,
+            detail=f"workflow trigger depth exceeds {max_depth}",
+        )
+
+    trace = {
+        "root_event_id": root_event_id,
+        "depth": next_depth,
+        "capability_ids": [*capabilities, capability_id],
+        "invocation_ids": [*invocations, invocation_id],
+    }
+    return next_depth, trace
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    try:
+        value = int((os.getenv(name) or str(default)).strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+__all__ = [
+    "MongoWorkflowTriggerRateLimiter",
+    "WORKFLOW_TRIGGER_TRACE_HEADER",
+    "WORKFLOW_TRIGGER_TRACE_KEY",
+    "WorkflowTriggerDecision",
+    "WorkflowTriggerGuard",
+    "WorkflowTriggerRateLimiter",
+    "workflow_trigger_event_identity",
+    "workflow_trigger_invocation_id",
+]

--- a/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
+++ b/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
@@ -144,7 +144,7 @@ class WorkflowTriggerGuard:
             return trace_result
         depth, trace = trace_result
 
-        if self._claim_store is None or self._rate_limiter is None:
+        if self._claim_store is None:
             return WorkflowTriggerDecision(
                 allowed=False,
                 reason="persistence",
@@ -152,7 +152,17 @@ class WorkflowTriggerGuard:
                 event_identity=event_identity,
                 depth=depth,
                 trace=trace,
-                detail="durable trigger claim or rate-limit authority is unavailable",
+                detail="durable trigger claim authority is unavailable",
+            )
+        if self._rate_limiter is None:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="rate_authority",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail="rate-limit authority is unavailable",
             )
 
         try:
@@ -221,7 +231,12 @@ class WorkflowTriggerGuard:
                 detail=f"{type(exc).__name__}: durable trigger claim failed",
             )
 
-        tenant_key = sha256(f"{app_id}\x00{tenant_id or app_id}".encode()).hexdigest()
+        rate_scope = (
+            f"tenant\x00{tenant_id}"
+            if tenant_id
+            else f"app\x00{app_id}"
+        )
+        tenant_key = sha256(rate_scope.encode()).hexdigest()
         try:
             rate_allowed = await self._rate_limiter.hit(tenant_key)
         except Exception as exc:
@@ -260,8 +275,12 @@ class WorkflowTriggerGuard:
         async with self._ready_lock:
             if self._ready:
                 return
-            if self._claim_store is None or self._rate_limiter is None:
-                raise RuntimeError("workflow trigger authority is unavailable")
+            if self._claim_store is None:
+                raise RuntimeError("durable trigger claim authority is unavailable")
+            if self._rate_limiter is None:
+                raise _WorkflowTriggerRateAuthorityError(
+                    "rate-limit authority is unavailable"
+                )
             await self._claim_store.ensure_indexes()
             try:
                 await self._rate_limiter.ensure_ready()

--- a/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
+++ b/mozaiksai/core/runtime/composition/workflow_trigger_guard.py
@@ -31,6 +31,7 @@ TriggerDecisionReason = Literal[
     "cycle",
     "depth",
     "rate",
+    "rate_authority",
     "persistence",
 ]
 
@@ -39,6 +40,10 @@ class WorkflowTriggerRateLimiter(Protocol):
     async def ensure_ready(self) -> None: ...
 
     async def hit(self, tenant_key: str) -> bool: ...
+
+
+class _WorkflowTriggerRateAuthorityError(RuntimeError):
+    """Raised when the distributed rate authority cannot be verified."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,6 +157,28 @@ class WorkflowTriggerGuard:
 
         try:
             await self._ensure_ready()
+        except _WorkflowTriggerRateAuthorityError as exc:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="rate_authority",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail=f"{type(exc.__cause__ or exc).__name__}: rate authority failed",
+            )
+        except Exception as exc:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="persistence",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail=f"{type(exc).__name__}: durable trigger claim failed",
+            )
+
+        try:
             key = f"workflow_trigger:{invocation_id}"
             claim = await self._claim_store.claim(
                 app_id=app_id,
@@ -183,18 +210,6 @@ class WorkflowTriggerGuard:
             )
             if not completed:
                 raise RuntimeError("workflow trigger claim could not be finalized")
-
-            tenant_key = ":".join([app_id, tenant_id or app_id, workspace_id or ""])
-            if not await self._rate_limiter.hit(tenant_key):
-                return WorkflowTriggerDecision(
-                    allowed=False,
-                    reason="rate",
-                    invocation_id=invocation_id,
-                    event_identity=event_identity,
-                    depth=depth,
-                    trace=trace,
-                    detail="per-tenant workflow trigger rate limit exceeded",
-                )
         except Exception as exc:
             return WorkflowTriggerDecision(
                 allowed=False,
@@ -203,7 +218,31 @@ class WorkflowTriggerGuard:
                 event_identity=event_identity,
                 depth=depth,
                 trace=trace,
-                detail=f"{type(exc).__name__}: trigger authority failed",
+                detail=f"{type(exc).__name__}: durable trigger claim failed",
+            )
+
+        tenant_key = sha256(f"{app_id}\x00{tenant_id or app_id}".encode()).hexdigest()
+        try:
+            rate_allowed = await self._rate_limiter.hit(tenant_key)
+        except Exception as exc:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="rate_authority",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail=f"{type(exc).__name__}: rate authority failed",
+            )
+        if not rate_allowed:
+            return WorkflowTriggerDecision(
+                allowed=False,
+                reason="rate",
+                invocation_id=invocation_id,
+                event_identity=event_identity,
+                depth=depth,
+                trace=trace,
+                detail="per-tenant workflow trigger rate limit exceeded",
             )
 
         return WorkflowTriggerDecision(
@@ -224,7 +263,10 @@ class WorkflowTriggerGuard:
             if self._claim_store is None or self._rate_limiter is None:
                 raise RuntimeError("workflow trigger authority is unavailable")
             await self._claim_store.ensure_indexes()
-            await self._rate_limiter.ensure_ready()
+            try:
+                await self._rate_limiter.ensure_ready()
+            except Exception as exc:
+                raise _WorkflowTriggerRateAuthorityError from exc
             self._ready = True
 
 
@@ -296,6 +338,12 @@ def _next_trace(
         )
 
     next_depth = parent_depth + 1
+    current_trace = {
+        "root_event_id": root_event_id,
+        "depth": parent_depth,
+        "capability_ids": list(capabilities),
+        "invocation_ids": list(invocations),
+    }
     if capability_id in capabilities:
         return WorkflowTriggerDecision(
             allowed=False,
@@ -303,6 +351,7 @@ def _next_trace(
             invocation_id=invocation_id,
             event_identity=event_identity,
             depth=next_depth,
+            trace=current_trace,
             detail="capability already exists in the trigger ancestry",
         )
     if next_depth > max_depth:
@@ -312,6 +361,7 @@ def _next_trace(
             invocation_id=invocation_id,
             event_identity=event_identity,
             depth=next_depth,
+            trace=current_trace,
             detail=f"workflow trigger depth exceeds {max_depth}",
         )
 

--- a/mozaiksai/core/taxonomy.py
+++ b/mozaiksai/core/taxonomy.py
@@ -294,6 +294,7 @@ _CORE_EVENTS = (
     "notification.count_changed",
     "notification.created",
     "platform.workflow_capability_started",
+    "platform.workflow_capability_trigger_rejected",
     "user.input.submit",
     "workflow.completed",
     "chat.tool_call_complete",

--- a/mozaiksai/core/workflow/app_backend_tools.py
+++ b/mozaiksai/core/workflow/app_backend_tools.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 from typing import Any
+from uuid import uuid4
+
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_HEADER,
+    WORKFLOW_TRIGGER_TRACE_KEY,
+)
 
 logger = logging.getLogger("mozaiksai.app_backend_tools")
 
@@ -45,9 +52,24 @@ async def backend_request(
 
         ctx = context_variables or {}
         token = ctx.get("auth_token")
+        headers: dict[str, str] | None = None
+        trigger_trace = ctx.get(WORKFLOW_TRIGGER_TRACE_KEY)
+        if isinstance(trigger_trace, dict):
+            headers = {
+                WORKFLOW_TRIGGER_TRACE_HEADER: json.dumps(
+                    trigger_trace,
+                    separators=(",", ":"),
+                )
+            }
 
         backend = get_app_backend()
-        result = await backend.request(method, path, json_body=payload, user_token=token)
+        result = await backend.request(
+            method,
+            path,
+            json_body=payload,
+            headers=headers,
+            user_token=token,
+        )
 
         if result.success:
             return json.dumps({"status": "success", "data": result.data})
@@ -76,7 +98,32 @@ async def emit_event(
         from mozaiksai.core.adapters.http_app_backend import get_app_backend
 
         ctx = context_variables or {}
-        data = {**(event_data or {}), "app_id": ctx.get("app_id", ""), "user_id": ctx.get("user_id", "")}
+        tenant = {"app_id": ctx.get("app_id", "")}
+        if ctx.get("tenant_id"):
+            tenant["tenant_id"] = ctx["tenant_id"]
+        if ctx.get("workspace_id"):
+            tenant["workspace_id"] = ctx["workspace_id"]
+        data: dict[str, Any] = {
+            "id": f"evt_{uuid4().hex}",
+            "type": event_type,
+            "version": 1,
+            "occurred_at": datetime.now(UTC).isoformat(),
+            "source": {
+                "layer": "workflow",
+                "workflow_id": ctx.get("workflow_id") or ctx.get("workflow_name"),
+                "chat_id": ctx.get("chat_id"),
+            },
+            "tenant": tenant,
+            "payload": dict(event_data or {}),
+            "visibility": "internal",
+        }
+        if ctx.get("user_id"):
+            data["actor"] = {"type": "user", "id": ctx["user_id"]}
+        if ctx.get("correlation_id"):
+            data["correlation"] = {"correlation_id": ctx["correlation_id"]}
+        trigger_trace = ctx.get(WORKFLOW_TRIGGER_TRACE_KEY)
+        if isinstance(trigger_trace, dict):
+            data[WORKFLOW_TRIGGER_TRACE_KEY] = dict(trigger_trace)
 
         backend = get_app_backend()
         ok = await backend.emit(event_type, data)

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -2989,6 +2989,7 @@ async def _invoke_workflow_capability(
             "status": {
                 "replay": "replay_suppressed",
                 "rate": "rate_limited",
+                "rate_authority": "failed_closed",
                 "persistence": "failed_closed",
             }.get(decision.reason, "rejected"),
             "reason": decision.reason,
@@ -3033,6 +3034,8 @@ async def _invoke_workflow_capability(
                 "payload": result,
                 "visibility": "internal",
             }
+            if isinstance(decision.trace, dict):
+                diagnostic[WORKFLOW_TRIGGER_TRACE_KEY] = dict(decision.trace)
             await _maybe_await(
                 event_emitter(
                     "platform.workflow_capability_trigger_rejected",
@@ -3103,6 +3106,7 @@ async def _invoke_workflow_capability(
             "correlation": source_event.get("correlation") if isinstance(source_event.get("correlation"), dict) else {},
             "payload": {**result, "source_event_id": source_event.get("id")},
             "visibility": "internal",
+            WORKFLOW_TRIGGER_TRACE_KEY: dict(decision.trace or {}),
         }
         await _maybe_await(event_emitter("platform.workflow_capability_started", event))
     return result

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -65,6 +65,11 @@ from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
 from mozaiksai.core.runtime.composition.reaction_idempotency_store import (
     ReactionIdempotencyStore,
 )
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_KEY,
+    MongoWorkflowTriggerRateLimiter,
+    WorkflowTriggerGuard,
+)
 from mozaiksai.core.runtime.persistence import (
     DatabaseStartupPolicyError,
     apply_data_migrations,
@@ -346,6 +351,14 @@ async def _platform_startup() -> None:
             workflow_capability_routes = _load_workflow_capability_routes(app_root)
             app.state.workflow_capability_routes = workflow_capability_routes
 
+            mongo_uri = str(os.getenv("MONGO_URI") or os.getenv("MONGODB_URI") or "").strip()
+            _reaction_idempotency_store = ReactionIdempotencyStore() if mongo_uri else None
+            workflow_trigger_guard = WorkflowTriggerGuard(
+                claim_store=_reaction_idempotency_store,
+                rate_limiter=(MongoWorkflowTriggerRateLimiter(mongo_uri) if mongo_uri else None),
+            )
+            app.state.workflow_trigger_guard = workflow_trigger_guard
+
             async def invoke_capability(
                 capability_id: str,
                 source_event: dict[str, Any],
@@ -357,11 +370,9 @@ async def _platform_startup() -> None:
                     subscription=subscription,
                     routes=workflow_capability_routes,
                     event_emitter=dispatcher.emit,
+                    trigger_guard=workflow_trigger_guard,
                 )
 
-            _reaction_idempotency_store: ReactionIdempotencyStore | None = None
-            if os.getenv("MONGO_URI") or os.getenv("MONGODB_URI"):
-                _reaction_idempotency_store = ReactionIdempotencyStore()
             module_event_router = ModuleEventRouter(
                 load_result.modules,
                 event_emitter=dispatcher.emit,
@@ -2932,6 +2943,7 @@ async def _invoke_workflow_capability(
     routes: dict[str, list[dict[str, Any]]],
     event_emitter: Callable[[str, dict[str, Any]], Any] | None = None,
     create_session: Callable[..., Any] | None = None,
+    trigger_guard: WorkflowTriggerGuard | None = None,
     auto_start: bool = True,
 )-> dict[str, Any]:
     route = _select_workflow_capability_route(
@@ -2955,13 +2967,87 @@ async def _invoke_workflow_capability(
     tenant = source_event.get("tenant") if isinstance(source_event.get("tenant"), dict) else {}
     actor = source_event.get("actor") if isinstance(source_event.get("actor"), dict) else {}
     app_id = str(tenant.get("app_id") or source_event.get("app_id") or "default")
+    tenant_id = str(tenant.get("tenant_id") or source_event.get("tenant_id") or "").strip() or None
+    workspace_id = (
+        str(tenant.get("workspace_id") or source_event.get("workspace_id") or "").strip() or None
+    )
     user_id = str(actor.get("id") or source_event.get("user_id") or "system")
+    if trigger_guard is None:
+        trigger_guard = WorkflowTriggerGuard(
+            claim_store=None,
+            rate_limiter=None,
+        )
+    decision = await trigger_guard.authorize(
+        capability_id=capability_id,
+        source_event=source_event,
+        app_id=app_id,
+        tenant_id=tenant_id,
+        workspace_id=workspace_id,
+    )
+    if not decision.allowed:
+        result = {
+            "status": {
+                "replay": "replay_suppressed",
+                "rate": "rate_limited",
+                "persistence": "failed_closed",
+            }.get(decision.reason, "rejected"),
+            "reason": decision.reason,
+            "detail": decision.detail,
+            "capability_id": capability_id,
+            "workflow_id": workflow_id,
+            "event_type": source_event.get("type"),
+            "source_event_id": source_event.get("id") or source_event.get("event_id"),
+            "invocation_id": decision.invocation_id,
+            "trigger_depth": decision.depth,
+            "app_id": app_id,
+            "tenant_id": tenant_id,
+            "workspace_id": workspace_id,
+        }
+        logger.warning(
+            "WORKFLOW_CAPABILITY_TRIGGER_REJECTED: reason=%s invocation=%s "
+            "capability=%s event=%s app=%s tenant=%s",
+            decision.reason,
+            decision.invocation_id,
+            capability_id,
+            source_event.get("type"),
+            app_id,
+            tenant_id,
+        )
+        if event_emitter is not None:
+            diagnostic = {
+                "id": f"evt_{uuid4().hex}",
+                "type": "platform.workflow_capability_trigger_rejected",
+                "version": 1,
+                "occurred_at": datetime.now(UTC).isoformat(),
+                "source": {
+                    "layer": "platform",
+                    "capability_id": capability_id,
+                    "workflow_id": workflow_id,
+                },
+                "tenant": tenant,
+                "correlation": (
+                    source_event.get("correlation")
+                    if isinstance(source_event.get("correlation"), dict)
+                    else {}
+                ),
+                "payload": result,
+                "visibility": "internal",
+            }
+            await _maybe_await(
+                event_emitter(
+                    "platform.workflow_capability_trigger_rejected",
+                    diagnostic,
+                )
+            )
+        return result
+
     context_seed = _build_workflow_trigger_context(
         capability_id=capability_id,
         source_event=source_event,
         trigger=route.get("trigger") if isinstance(route.get("trigger"), dict) else {},
     )
     context_variables = validate_context_for_workflow(workflow_id, context_seed)
+    context_variables[WORKFLOW_TRIGGER_TRACE_KEY] = decision.trace
     trigger_meta = {
         "trigger_source": "module_event",
         "event_type": source_event.get("type"),
@@ -2970,6 +3056,8 @@ async def _invoke_workflow_capability(
         "workflow_id": workflow_id,
         "subscription_id": subscription.get("id"),
         "module_id": subscription.get("module_id"),
+        "invocation_id": decision.invocation_id,
+        "trigger_depth": decision.depth,
     }
     session_creator = create_session or create_routed_chat_session
     chat_id = await _maybe_await(
@@ -2998,6 +3086,8 @@ async def _invoke_workflow_capability(
         "chat_id": str(chat_id),
         "app_id": app_id,
         "user_id": user_id,
+        "invocation_id": decision.invocation_id,
+        "trigger_depth": decision.depth,
         "started": started,
         "websocket_url": f"/ws/{workflow_id}/{app_id}/{chat_id}/{user_id}",
     }

--- a/mozaiksai/hosts/routers/modules.py
+++ b/mozaiksai/hosts/routers/modules.py
@@ -6,6 +6,7 @@ Routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import Any, cast
@@ -24,6 +25,10 @@ from mozaiksai.core.runtime.composition.module_authority import (
 )
 from mozaiksai.core.runtime.composition.module_executor import ModuleRequest
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_HEADER,
+    WORKFLOW_TRIGGER_TRACE_KEY,
+)
 
 router = APIRouter(tags=["modules"])
 logger = logging.getLogger(__name__)
@@ -50,6 +55,21 @@ def _extract_bearer_token(request: Request) -> str | None:
     if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip() or None
     return auth_header.strip() or None
+
+
+def _workflow_trigger_trace(request: Request) -> dict[str, Any] | None:
+    raw = str(request.headers.get(WORKFLOW_TRIGGER_TRACE_HEADER) or "").strip()
+    if not raw:
+        return None
+    if len(raw) > 4096:
+        raise HTTPException(status_code=400, detail="Workflow trigger trace header is too large.")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Workflow trigger trace header is invalid.") from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="Workflow trigger trace header is invalid.")
+    return parsed
 
 
 def _module_action_api_surface(request: Request, module_name: str, action_name: str) -> str | None:
@@ -346,6 +366,11 @@ async def _execute_module_action(
         provenance=ModuleDispatchProvenance(
             surface="http_module_dispatch",
             correlation_id=str(correlation_id) if correlation_id else None,
+            metadata=(
+                {WORKFLOW_TRIGGER_TRACE_KEY: trigger_trace}
+                if (trigger_trace := _workflow_trigger_trace(request)) is not None
+                else {}
+            ),
         ),
     )
 

--- a/tests/test_app_backend_tools.py
+++ b/tests/test_app_backend_tools.py
@@ -88,6 +88,41 @@ async def test_backend_request_success_path(monkeypatch):
     assert parsed["data"]["ok"] is True
 
 
+@pytest.mark.asyncio
+async def test_backend_request_propagates_workflow_trigger_lineage(monkeypatch):
+    import mozaiksai.core.adapters.http_app_backend as _http_mod
+    from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+        WORKFLOW_TRIGGER_TRACE_HEADER,
+        WORKFLOW_TRIGGER_TRACE_KEY,
+    )
+    from mozaiksai.core.workflow import app_backend_tools
+
+    captured = {}
+
+    class _CapturingBackend(_HealthyBackend):
+        async def request(self, method, path, **kwargs):
+            captured.update(kwargs)
+            return await super().request(method, path, **kwargs)
+
+    monkeypatch.setattr(_http_mod, "get_app_backend", lambda: _CapturingBackend())
+    trace = {
+        "root_event_id": "evt-root",
+        "depth": 1,
+        "capability_ids": ["tasks.review"],
+        "invocation_ids": ["wti-parent"],
+    }
+
+    result = await app_backend_tools.backend_request(
+        "POST",
+        "/api/modules/tasks/complete",
+        payload={"task_id": "task-1"},
+        context_variables={WORKFLOW_TRIGGER_TRACE_KEY: trace},
+    )
+
+    assert json.loads(result)["status"] == "success"
+    assert json.loads(captured["headers"][WORKFLOW_TRIGGER_TRACE_HEADER]) == trace
+
+
 # ---------------------------------------------------------------------------
 # emit_event
 # ---------------------------------------------------------------------------
@@ -121,6 +156,57 @@ async def test_emit_event_success_path(monkeypatch):
 
     assert parsed["status"] == "emitted"
     assert parsed["event_type"] == "listing.saved"
+
+
+@pytest.mark.asyncio
+async def test_emit_event_propagates_canonical_trigger_lineage(monkeypatch):
+    import mozaiksai.core.adapters.http_app_backend as _http_mod
+    from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+        WORKFLOW_TRIGGER_TRACE_KEY,
+    )
+    from mozaiksai.core.workflow import app_backend_tools
+
+    captured = {}
+
+    class _CapturingBackend(_HealthyBackend):
+        async def emit(self, event_type, data):
+            captured["event_type"] = event_type
+            captured["data"] = data
+            return True
+
+    monkeypatch.setattr(_http_mod, "get_app_backend", lambda: _CapturingBackend())
+    trace = {
+        "root_event_id": "evt-root",
+        "depth": 1,
+        "capability_ids": ["tasks.review"],
+        "invocation_ids": ["wti-parent"],
+    }
+    result = await app_backend_tools.emit_event(
+        "domain.tasks.reviewed",
+        {"task_id": "task-1"},
+        context_variables={
+            "app_id": "app-1",
+            "tenant_id": "tenant-1",
+            "workspace_id": "workspace-1",
+            "user_id": "user-1",
+            "workflow_id": "ReviewWorkflow",
+            "chat_id": "chat-1",
+            WORKFLOW_TRIGGER_TRACE_KEY: trace,
+        },
+    )
+
+    assert json.loads(result)["status"] == "emitted"
+    envelope = captured["data"]
+    assert captured["event_type"] == "domain.tasks.reviewed"
+    assert envelope["id"].startswith("evt_")
+    assert envelope["type"] == "domain.tasks.reviewed"
+    assert envelope["payload"] == {"task_id": "task-1"}
+    assert envelope["tenant"] == {
+        "app_id": "app-1",
+        "tenant_id": "tenant-1",
+        "workspace_id": "workspace-1",
+    }
+    assert envelope[WORKFLOW_TRIGGER_TRACE_KEY] == trace
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_module_executor_dispatch.py
+++ b/tests/test_module_executor_dispatch.py
@@ -12,11 +12,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from mozaiksai.core.ports.entitlement import EntitlementResult
-from mozaiksai.core.runtime.composition.module_authority import ModuleDispatchAuthority
+from mozaiksai.core.runtime.composition.module_authority import (
+    ModuleDispatchAuthority,
+    ModuleDispatchProvenance,
+)
 from mozaiksai.core.runtime.composition.module_executor import (
     ModuleExecutor,
     ModuleRequest,
     _validate_schema,
+)
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_KEY,
 )
 from tests.module_authority_test_helpers import enforce_authority, trusted_framework_authority
 
@@ -57,6 +63,7 @@ def _request(
     tenant_id: str | None = None,
     workspace_id: str | None = None,
     authority: ModuleDispatchAuthority | None = None,
+    provenance: ModuleDispatchProvenance | None = None,
 ) -> ModuleRequest:
     return ModuleRequest(
         module=module,
@@ -67,6 +74,7 @@ def _request(
         tenant_id=tenant_id,
         workspace_id=workspace_id,
         authority=authority if authority is not None else trusted_framework_authority(),
+        provenance=provenance,
     )
 
 
@@ -472,6 +480,39 @@ class TestEventEmitterEnvelope:
         req = _request(action="do_action", user_id=None)
         await ex.execute(req)
         assert "actor" not in emitted[0]
+
+    @pytest.mark.asyncio
+    async def test_event_emitter_preserves_workflow_trigger_lineage(self):
+        emitted: list[dict] = []
+
+        async def fake_emitter(_event_type: str, envelope: dict) -> None:
+            emitted.append(envelope)
+
+        ex = ModuleExecutor(event_emitter=fake_emitter)
+
+        class _EmittingHandler:
+            async def do_action(self, ctx) -> dict:
+                await ctx.emit("tasks.completed", {"task_id": "task-1"})
+                return {}
+
+        trace = {
+            "root_event_id": "evt-root",
+            "depth": 1,
+            "capability_ids": ["tasks.review"],
+            "invocation_ids": ["wti-parent"],
+        }
+        ex.register("contacts", _EmittingHandler())
+        await ex.execute(
+            _request(
+                action="do_action",
+                provenance=ModuleDispatchProvenance(
+                    surface="http_module_dispatch",
+                    metadata={WORKFLOW_TRIGGER_TRACE_KEY: trace},
+                ),
+            )
+        )
+
+        assert emitted[0][WORKFLOW_TRIGGER_TRACE_KEY] == trace
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_module_router_context_overrides.py
+++ b/tests/test_module_router_context_overrides.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from mozaiksai.core.runtime.composition.module_executor import ModuleResult
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_HEADER,
+)
 from mozaiksai.hosts.routers import modules as module_router
 
 
@@ -16,6 +20,20 @@ class _FakeModuleExecutor:
     async def execute(self, request, context=None):
         self.requests.append(request)
         return ModuleResult(success=True, data={"ok": True, "user_id": request.user_id})
+
+
+def test_workflow_trigger_trace_header_decodes_into_runtime_metadata() -> None:
+    trace = {
+        "root_event_id": "evt-root",
+        "depth": 1,
+        "capability_ids": ["tasks.review"],
+        "invocation_ids": ["wti-parent"],
+    }
+    request = SimpleNamespace(
+        headers={WORKFLOW_TRIGGER_TRACE_HEADER: json.dumps(trace)},
+    )
+
+    assert module_router._workflow_trigger_trace(request) == trace
 
 
 @pytest.mark.asyncio

--- a/tests/test_port_defaults_oss.py
+++ b/tests/test_port_defaults_oss.py
@@ -97,13 +97,20 @@ def test_http_app_backend_adapter_satisfies_protocol() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_app_backend_emit_returns_bool_without_raising() -> None:
-    """emit() must never raise — it falls back to False when no dispatcher."""
+async def test_http_app_backend_emit_reaches_registered_event_listeners(monkeypatch) -> None:
     from mozaiksai.core.adapters.http_app_backend import HttpAppBackendAdapter
+    from mozaiksai.core.events import unified_event_dispatcher
+    from mozaiksai.core.events.unified_event_dispatcher import UnifiedEventDispatcher
 
+    dispatcher = UnifiedEventDispatcher(taxonomy_advisory=True)
+    emitted = []
+    event_type = "platform.workflow_capability_started"
+    dispatcher.register_handler(event_type, emitted.append)
+    monkeypatch.setattr(unified_event_dispatcher, "get_event_dispatcher", lambda: dispatcher)
     adapter = HttpAppBackendAdapter(base_url="http://localhost:9999")
-    result = await adapter.emit("test.event", {"key": "value"})
-    assert isinstance(result, bool)
+    result = await adapter.emit(event_type, {"key": "value"})
+    assert result is True
+    assert emitted == [{"key": "value"}]
 
 
 def test_backend_response_defaults() -> None:

--- a/tests/test_studio_host_smoke.py
+++ b/tests/test_studio_host_smoke.py
@@ -280,6 +280,10 @@ triggers:
 
 @pytest.mark.asyncio
 async def test_platform_host_invokes_capability_route_into_workflow_session():
+    from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+        WORKFLOW_TRIGGER_TRACE_KEY,
+        WorkflowTriggerDecision,
+    )
     from mozaiksai.hosts import platform as platform_app
 
     created: list[dict] = []
@@ -291,6 +295,22 @@ async def test_platform_host_invokes_capability_route_into_workflow_session():
 
     async def fake_emit(event_type: str, payload: dict) -> None:
         emitted.append((event_type, payload))
+
+    class _AllowingGuard:
+        async def authorize(self, **_kwargs):
+            return WorkflowTriggerDecision(
+                allowed=True,
+                reason="allowed",
+                invocation_id="wti_test",
+                event_identity="evt_1",
+                depth=1,
+                trace={
+                    "root_event_id": "evt_1",
+                    "depth": 1,
+                    "capability_ids": ["tasks.review"],
+                    "invocation_ids": ["wti_test"],
+                },
+            )
 
     result = await platform_app._invoke_workflow_capability(
         capability_id="tasks.review",
@@ -319,6 +339,7 @@ async def test_platform_host_invokes_capability_route_into_workflow_session():
         },
         event_emitter=fake_emit,
         create_session=fake_create_session,
+        trigger_guard=_AllowingGuard(),
         auto_start=False,
     )
 
@@ -329,6 +350,8 @@ async def test_platform_host_invokes_capability_route_into_workflow_session():
         "chat_id": "chat_capability_1",
         "app_id": "app_1",
         "user_id": "user_1",
+        "invocation_id": "wti_test",
+        "trigger_depth": 1,
         "started": False,
         "websocket_url": "/ws/ReviewWorkflow/app_1/chat_capability_1/user_1",
     }
@@ -337,6 +360,7 @@ async def test_platform_host_invokes_capability_route_into_workflow_session():
     assert created[0]["user_id"] == "user_1"
     assert created[0]["context_variables"]["triggered_capability_id"] == "tasks.review"
     assert created[0]["context_variables"]["task_id"] == "task_1"
+    assert created[0]["context_variables"][WORKFLOW_TRIGGER_TRACE_KEY]["depth"] == 1
     assert created[0]["trigger_meta"] == {
         "trigger_source": "module_event",
         "event_type": "domain.tasks.task_created",
@@ -345,6 +369,8 @@ async def test_platform_host_invokes_capability_route_into_workflow_session():
         "workflow_id": "ReviewWorkflow",
         "subscription_id": "task_created_react",
         "module_id": "tasks",
+        "invocation_id": "wti_test",
+        "trigger_depth": 1,
     }
     assert emitted[0][0] == "platform.workflow_capability_started"
     assert emitted[0][1]["payload"]["chat_id"] == "chat_capability_1"

--- a/tests/test_workflow_trigger_guard.py
+++ b/tests/test_workflow_trigger_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -54,15 +55,31 @@ class _AtomicClaimStore:
 
 
 class _TenantRateLimiter:
-    def __init__(self, limit: int = 100) -> None:
+    def __init__(
+        self,
+        limit: int = 100,
+        *,
+        fail_ready: bool = False,
+        fail_hit: bool = False,
+        cancel_hit: bool = False,
+    ) -> None:
         self.limit = limit
         self.hits: dict[str, int] = defaultdict(int)
         self._lock = asyncio.Lock()
+        self.fail_ready = fail_ready
+        self.fail_hit = fail_hit
+        self.cancel_hit = cancel_hit
 
     async def ensure_ready(self) -> None:
+        if self.fail_ready:
+            raise ConnectionError("rate database unavailable")
         return None
 
     async def hit(self, tenant_key: str) -> bool:
+        if self.cancel_hit:
+            raise asyncio.CancelledError
+        if self.fail_hit:
+            raise ConnectionError("rate database unavailable")
         async with self._lock:
             self.hits[tenant_key] += 1
             return self.hits[tenant_key] <= self.limit
@@ -103,10 +120,23 @@ def _routes() -> dict[str, list[dict[str, Any]]]:
     }
 
 
-def _guard(*, rate_limit: int = 100, fail_ready: bool = False, max_depth: int = 8):
+def _guard(
+    *,
+    rate_limit: int = 100,
+    fail_ready: bool = False,
+    fail_rate_ready: bool = False,
+    fail_rate_hit: bool = False,
+    cancel_rate_hit: bool = False,
+    max_depth: int = 8,
+):
     return WorkflowTriggerGuard(
         claim_store=_AtomicClaimStore(fail_ready=fail_ready),  # type: ignore[arg-type]
-        rate_limiter=_TenantRateLimiter(rate_limit),
+        rate_limiter=_TenantRateLimiter(
+            rate_limit,
+            fail_ready=fail_rate_ready,
+            fail_hit=fail_rate_hit,
+            cancel_hit=cancel_rate_hit,
+        ),
         max_depth=max_depth,
     )
 
@@ -164,6 +194,8 @@ async def test_concurrent_double_delivery_spawns_exactly_one_workflow() -> None:
         "platform.workflow_capability_started",
         "platform.workflow_capability_trigger_rejected",
     }
+    for _event_type, payload in emitted:
+        assert payload[WORKFLOW_TRIGGER_TRACE_KEY]["capability_ids"] == ["tasks.review"]
 
 
 @pytest.mark.asyncio
@@ -256,6 +288,127 @@ async def test_rate_limit_is_tenant_scoped() -> None:
     assert tenant_a_first.allowed is True
     assert tenant_a_second.reason == "rate"
     assert tenant_b_first.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_shared_across_one_tenants_workspaces() -> None:
+    guard = _guard(rate_limit=1)
+
+    first = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event("evt-workspace-1", tenant_id="tenant-a"),
+        app_id="app-1",
+        tenant_id="tenant-a",
+        workspace_id="workspace-1",
+    )
+    second = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event("evt-workspace-2", tenant_id="tenant-a"),
+        app_id="app-1",
+        tenant_id="tenant-a",
+        workspace_id="workspace-2",
+    )
+
+    assert first.allowed is True
+    assert second.reason == "rate"
+
+
+@pytest.mark.asyncio
+async def test_rate_scope_encoding_cannot_collide_across_app_and_tenant_boundaries() -> None:
+    guard = _guard(rate_limit=1)
+
+    first = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event("evt-scope-1", app_id="app:a", tenant_id="b"),
+        app_id="app:a",
+        tenant_id="b",
+        workspace_id=None,
+    )
+    second = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event("evt-scope-2", app_id="app", tenant_id="a:b"),
+        app_id="app",
+        tenant_id="a:b",
+        workspace_id=None,
+    )
+
+    assert first.allowed is True
+    assert second.allowed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["ready", "hit"])
+async def test_rate_authority_failure_fails_closed_before_spawn(failure: str) -> None:
+    from mozaiksai.hosts import platform
+
+    created = 0
+
+    async def create_session(**_kwargs: Any) -> str:
+        nonlocal created
+        created += 1
+        return "must-not-exist"
+
+    result = await platform._invoke_workflow_capability(
+        capability_id="tasks.review",
+        source_event=_event(f"evt-rate-{failure}"),
+        subscription={"id": "reaction-1", "module_id": "tasks"},
+        routes=_routes(),
+        create_session=create_session,
+        trigger_guard=_guard(
+            fail_rate_ready=failure == "ready",
+            fail_rate_hit=failure == "hit",
+        ),
+        auto_start=False,
+    )
+
+    assert result["status"] == "failed_closed"
+    assert result["reason"] == "rate_authority"
+    assert result["detail"] == "ConnectionError: rate authority failed"
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_without_mutating_the_source_event() -> None:
+    event = _event("evt-cancel")
+    original = deepcopy(event)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _guard(cancel_rate_hit=True).authorize(
+            capability_id="tasks.review",
+            source_event=event,
+            app_id="app-1",
+            tenant_id="tenant-1",
+            workspace_id=None,
+        )
+
+    assert event == original
+
+
+@pytest.mark.asyncio
+async def test_rejection_diagnostic_uses_registered_taxonomy_and_preserves_lineage() -> None:
+    from mozaiksai.core.events.unified_event_dispatcher import UnifiedEventDispatcher
+    from mozaiksai.hosts import platform
+
+    dispatcher = UnifiedEventDispatcher()
+    emitted: list[dict[str, Any]] = []
+    dispatcher.register_handler(
+        "platform.workflow_capability_trigger_rejected",
+        emitted.append,
+    )
+
+    result = await platform._invoke_workflow_capability(
+        capability_id="tasks.review",
+        source_event=_event("evt-rate-diagnostic"),
+        subscription={"id": "reaction-1", "module_id": "tasks"},
+        routes=_routes(),
+        event_emitter=dispatcher.emit,
+        trigger_guard=_guard(rate_limit=0),
+        auto_start=False,
+    )
+
+    assert result["reason"] == "rate"
+    assert len(emitted) == 1
+    assert emitted[0][WORKFLOW_TRIGGER_TRACE_KEY]["capability_ids"] == ["tasks.review"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_trigger_guard.py
+++ b/tests/test_workflow_trigger_guard.py
@@ -314,6 +314,29 @@ async def test_rate_limit_is_shared_across_one_tenants_workspaces() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rate_limit_is_shared_across_one_tenants_apps() -> None:
+    guard = _guard(rate_limit=1)
+
+    first = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event("evt-app-1", app_id="app-1", tenant_id="tenant-a"),
+        app_id="app-1",
+        tenant_id="tenant-a",
+        workspace_id=None,
+    )
+    second = await guard.authorize(
+        capability_id="tasks.publish",
+        source_event=_event("evt-app-2", app_id="app-2", tenant_id="tenant-a"),
+        app_id="app-2",
+        tenant_id="tenant-a",
+        workspace_id=None,
+    )
+
+    assert first.allowed is True
+    assert second.reason == "rate"
+
+
+@pytest.mark.asyncio
 async def test_rate_scope_encoding_cannot_collide_across_app_and_tenant_boundaries() -> None:
     guard = _guard(rate_limit=1)
 
@@ -334,6 +357,64 @@ async def test_rate_scope_encoding_cannot_collide_across_app_and_tenant_boundari
 
     assert first.allowed is True
     assert second.allowed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("missing_authority", "expected_reason", "expected_detail"),
+    [
+        (
+            "claim",
+            "persistence",
+            "durable trigger claim authority is unavailable",
+        ),
+        (
+            "rate",
+            "rate_authority",
+            "rate-limit authority is unavailable",
+        ),
+    ],
+)
+async def test_missing_authorities_fail_closed_with_distinct_diagnostics(
+    missing_authority: str,
+    expected_reason: str,
+    expected_detail: str,
+) -> None:
+    from mozaiksai.hosts import platform
+
+    claim_store = None if missing_authority == "claim" else _AtomicClaimStore()
+    rate_limiter = None if missing_authority == "rate" else _TenantRateLimiter()
+    created = 0
+    emitted: list[tuple[str, dict[str, Any]]] = []
+
+    async def create_session(**_kwargs: Any) -> str:
+        nonlocal created
+        created += 1
+        return "must-not-exist"
+
+    async def emit(event_type: str, payload: dict[str, Any]) -> None:
+        emitted.append((event_type, payload))
+
+    result = await platform._invoke_workflow_capability(
+        capability_id="tasks.review",
+        source_event=_event(f"evt-missing-{missing_authority}"),
+        subscription={"id": "reaction-1", "module_id": "tasks"},
+        routes=_routes(),
+        event_emitter=emit,
+        create_session=create_session,
+        trigger_guard=WorkflowTriggerGuard(
+            claim_store=claim_store,
+            rate_limiter=rate_limiter,
+        ),
+        auto_start=False,
+    )
+
+    assert result["status"] == "failed_closed"
+    assert result["reason"] == expected_reason
+    assert result["detail"] == expected_detail
+    assert created == 0
+    assert emitted[0][0] == "platform.workflow_capability_trigger_rejected"
+    assert emitted[0][1]["payload"]["reason"] == expected_reason
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_trigger_guard.py
+++ b/tests/test_workflow_trigger_guard.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.runtime.composition.reaction_idempotency_store import LeaseClaim
+from mozaiksai.core.runtime.composition.workflow_trigger_guard import (
+    WORKFLOW_TRIGGER_TRACE_KEY,
+    WorkflowTriggerGuard,
+    workflow_trigger_event_identity,
+    workflow_trigger_invocation_id,
+)
+
+
+class _AtomicClaimStore:
+    def __init__(self, *, fail_ready: bool = False) -> None:
+        self._lock = asyncio.Lock()
+        self._records: dict[tuple[str, str, str, str], str] = {}
+        self.fail_ready = fail_ready
+
+    async def ensure_indexes(self) -> None:
+        if self.fail_ready:
+            raise ConnectionError("claim database unavailable")
+
+    async def claim(self, **kwargs: Any) -> LeaseClaim:
+        key = (
+            kwargs["app_id"],
+            kwargs.get("tenant_id") or "",
+            kwargs.get("workspace_id") or "",
+            kwargs["idempotency_key_str"],
+        )
+        async with self._lock:
+            if key in self._records:
+                return LeaseClaim(claimed=False)
+            token = f"claim-{len(self._records) + 1}"
+            self._records[key] = token
+            return LeaseClaim(claimed=True, claim_token=token, attempt_count=1)
+
+    async def complete(self, **kwargs: Any) -> bool:
+        key = (
+            kwargs["app_id"],
+            kwargs.get("tenant_id") or "",
+            kwargs.get("workspace_id") or "",
+            kwargs["idempotency_key_str"],
+        )
+        async with self._lock:
+            if self._records.get(key) != kwargs["claim_token"]:
+                return False
+            self._records[key] = "completed"
+            return True
+
+
+class _TenantRateLimiter:
+    def __init__(self, limit: int = 100) -> None:
+        self.limit = limit
+        self.hits: dict[str, int] = defaultdict(int)
+        self._lock = asyncio.Lock()
+
+    async def ensure_ready(self) -> None:
+        return None
+
+    async def hit(self, tenant_key: str) -> bool:
+        async with self._lock:
+            self.hits[tenant_key] += 1
+            return self.hits[tenant_key] <= self.limit
+
+
+def _event(
+    event_id: str,
+    *,
+    app_id: str = "app-1",
+    tenant_id: str = "tenant-1",
+    trace: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "id": event_id,
+        "type": "domain.tasks.created",
+        "tenant": {"app_id": app_id, "tenant_id": tenant_id},
+        "actor": {"type": "user", "id": "user-1"},
+        "payload": {"task_id": event_id},
+    }
+    if trace is not None:
+        event[WORKFLOW_TRIGGER_TRACE_KEY] = trace
+    return event
+
+
+def _routes() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "tasks.review": [
+            {
+                "workflow_id": "ReviewWorkflow",
+                "event_type": "domain.tasks.created",
+                "trigger": {
+                    "type": "event",
+                    "event": "domain.tasks.created",
+                    "capability_id": "tasks.review",
+                },
+            }
+        ]
+    }
+
+
+def _guard(*, rate_limit: int = 100, fail_ready: bool = False, max_depth: int = 8):
+    return WorkflowTriggerGuard(
+        claim_store=_AtomicClaimStore(fail_ready=fail_ready),  # type: ignore[arg-type]
+        rate_limiter=_TenantRateLimiter(rate_limit),
+        max_depth=max_depth,
+    )
+
+
+def test_invocation_identity_uses_event_and_capability_authority() -> None:
+    event = _event("evt-1")
+    event_identity = workflow_trigger_event_identity(event)
+    assert event_identity == "evt-1"
+    first = workflow_trigger_invocation_id(event_identity, "tasks.review")
+    assert first == workflow_trigger_invocation_id(event_identity, "tasks.review")
+    assert first != workflow_trigger_invocation_id(event_identity, "tasks.publish")
+    derived = workflow_trigger_event_identity(
+        {"type": "domain.tasks.created", "payload": {"task_id": "task-1"}}
+    )
+    assert derived.startswith("derived_")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_double_delivery_spawns_exactly_one_workflow() -> None:
+    from mozaiksai.hosts import platform
+
+    guard = _guard()
+    created: list[dict[str, Any]] = []
+    emitted: list[tuple[str, dict[str, Any]]] = []
+
+    async def create_session(**kwargs: Any) -> str:
+        created.append(kwargs)
+        await asyncio.sleep(0)
+        return "chat-1"
+
+    async def emit(event_type: str, payload: dict[str, Any]) -> None:
+        emitted.append((event_type, payload))
+
+    async def invoke() -> dict[str, Any]:
+        return await platform._invoke_workflow_capability(
+            capability_id="tasks.review",
+            source_event=_event("evt-concurrent"),
+            subscription={"id": "reaction-1", "module_id": "tasks"},
+            routes=_routes(),
+            event_emitter=emit,
+            create_session=create_session,
+            trigger_guard=guard,
+            auto_start=False,
+        )
+
+    results = await asyncio.gather(invoke(), invoke())
+    assert sorted(result["status"] for result in results) == [
+        "created",
+        "replay_suppressed",
+    ]
+    assert len(created) == 1
+    assert created[0]["context_variables"][WORKFLOW_TRIGGER_TRACE_KEY]["depth"] == 1
+    assert created[0]["trigger_meta"]["trigger_depth"] == 1
+    assert {event_type for event_type, _payload in emitted} == {
+        "platform.workflow_capability_started",
+        "platform.workflow_capability_trigger_rejected",
+    }
+
+
+@pytest.mark.asyncio
+async def test_self_and_multi_capability_cycles_terminate() -> None:
+    guard = _guard()
+    self_cycle = await guard.authorize(
+        capability_id="tasks.review",
+        source_event=_event(
+            "evt-self",
+            trace={
+                "root_event_id": "root",
+                "depth": 1,
+                "capability_ids": ["tasks.review"],
+                "invocation_ids": ["wti-parent"],
+            },
+        ),
+        app_id="app-1",
+        tenant_id="tenant-1",
+        workspace_id=None,
+    )
+    multi_cycle = await guard.authorize(
+        capability_id="capability.a",
+        source_event=_event(
+            "evt-multi",
+            trace={
+                "root_event_id": "root",
+                "depth": 2,
+                "capability_ids": ["capability.a", "capability.b"],
+                "invocation_ids": ["wti-a", "wti-b"],
+            },
+        ),
+        app_id="app-1",
+        tenant_id="tenant-1",
+        workspace_id=None,
+    )
+    assert self_cycle.reason == "cycle"
+    assert multi_cycle.reason == "cycle"
+    assert self_cycle.allowed is multi_cycle.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_trigger_depth_is_bounded_and_propagated() -> None:
+    guard = _guard(max_depth=2)
+    allowed = await guard.authorize(
+        capability_id="capability.b",
+        source_event=_event(
+            "evt-depth-2",
+            trace={
+                "root_event_id": "root",
+                "depth": 1,
+                "capability_ids": ["capability.a"],
+                "invocation_ids": ["wti-a"],
+            },
+        ),
+        app_id="app-1",
+        tenant_id="tenant-1",
+        workspace_id=None,
+    )
+    rejected = await guard.authorize(
+        capability_id="capability.c",
+        source_event=_event("evt-depth-3", trace=allowed.trace),
+        app_id="app-1",
+        tenant_id="tenant-1",
+        workspace_id=None,
+    )
+    assert allowed.allowed is True
+    assert allowed.depth == 2
+    assert allowed.trace is not None
+    assert rejected.allowed is False
+    assert rejected.reason == "depth"
+    assert rejected.depth == 3
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_tenant_scoped() -> None:
+    guard = _guard(rate_limit=1)
+
+    async def authorize(event_id: str, tenant_id: str):
+        return await guard.authorize(
+            capability_id="tasks.review",
+            source_event=_event(event_id, tenant_id=tenant_id),
+            app_id="app-1",
+            tenant_id=tenant_id,
+            workspace_id=None,
+        )
+
+    tenant_a_first = await authorize("evt-a-1", "tenant-a")
+    tenant_a_second = await authorize("evt-a-2", "tenant-a")
+    tenant_b_first = await authorize("evt-b-1", "tenant-b")
+    assert tenant_a_first.allowed is True
+    assert tenant_a_second.reason == "rate"
+    assert tenant_b_first.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_fails_closed_before_spawn() -> None:
+    from mozaiksai.hosts import platform
+
+    created = 0
+
+    async def create_session(**_kwargs: Any) -> str:
+        nonlocal created
+        created += 1
+        return "must-not-exist"
+
+    result = await platform._invoke_workflow_capability(
+        capability_id="tasks.review",
+        source_event=_event("evt-persistence"),
+        subscription={"id": "reaction-1", "module_id": "tasks"},
+        routes=_routes(),
+        create_session=create_session,
+        trigger_guard=_guard(fail_ready=True),
+        auto_start=False,
+    )
+    assert result["status"] == "failed_closed"
+    assert result["reason"] == "persistence"
+    assert created == 0


### PR DESCRIPTION
Closes #425.

## Summary
- add platform-owned, fail-closed admission for module-event -> workflow-capability triggers
- derive canonical invocation identity from existing module-event identity plus capability ID and atomically persist a terminal claim before session creation
- propagate bounded capability/invocation ancestry across workflow event emission and workflow -> module-action -> module-event paths
- enforce a Mongo-backed per-tenant moving-window limit with distinct replay, cycle/depth, rate, and persistence diagnostics
- preserve one valid unique one-hop trigger as exactly one workflow session/run

## Architecture impact
- Platform composition owns event-to-run admission; AG2 continues to own workflow execution mechanics.
- Reuses the existing ReactionIdempotencyStore, module-event provenance identity, and `limits` moving-window implementation.
- Does not wire MongoWorkflowQueue or add scheduling, locking, cancellation, orphan adoption, token reservation, filesystem atomicity, workflow rewrites, or ADR 0007 Slice 4+ contracts.
- Mongo/claim authority is mandatory for automatic trigger admission; absence or failure rejects before session creation.

## Tests
- `python -m pytest -q --no-cov tests/test_workflow_trigger_guard.py tests/test_studio_host_smoke.py tests/test_app_backend_tools.py tests/test_module_executor_dispatch.py tests/test_module_event_router.py tests/test_durable_reaction_idempotency.py tests/test_module_router_context_overrides.py` (168 passed, 2 skipped)
- final boundary-focused set after the last assertion (72 passed, 2 skipped)
- `python scripts/production_readiness_gate.py` (passed: 1,075 tests, coverage gate, source hygiene, frontend production build)
- `python -m pytest -q --no-cov` (13,940 passed, 80 skipped)
- `python -m ruff check .`
- source hygiene scan
- touched-source mypy (`--follow-imports=skip`; existing no-any-return in modules router excluded from the final scoped claim)
- `git diff --check`

## Review state
Draft only. Auto-merge must remain disabled. Requires an independent exact-head review before readiness or merge. No live models were run.