### PR TITLE
feat(semantics): ADR 0007 Slice 2E — typed payloads + Merkle-rooted graph v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ This project follows a practical pre-1.0 changelog format:
 - **Typed semantic payloads + Merkle-rooted graph v2 (ADR 0007 Slice 2E)**:
   every semantic node kind now has exactly one strict payload variant
   (`mozaiks.semantic_payload.v1` — titles/intent text, typed field shapes,
-  integer minor-unit prices, explicit dense-position ordering, taxonomy-
+  integer minor-unit prices with ISO-4217 codes, explicit dense-position ordering, taxonomy-
   validated event/capability ids, portable-path-validated paths; no untyped
   dicts), pinned into `mozaiks.semantic_graph.v2` nodes by a full-identity
   `SemanticPayloadRef` so the graph digest is a Merkle root — any payload byte
-  change re-roots the graph. The reference resolver registers payloads as
-  immutable content-bearing subjects and requires complete payload closure
-  before a v2 graph registers; there is no "current"/latest payload lookup.
+  change re-roots the graph. The reference resolver cold-validates payload and
+  graph model instances before mutation, registers payloads as immutable
+  content-bearing subjects, and requires complete payload closure before a v2
+  graph registers; there is no "current"/latest payload lookup. Semantic
+  payloads and the layout registry consume one shared leaf `StubKind` authority.
   Graph v1 is byte-for-byte unchanged (golden vectors), no production code
   consumes the new symbols, and no compiler capability is advertised.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Typed semantic payloads + Merkle-rooted graph v2 (ADR 0007 Slice 2E)**:
+  every semantic node kind now has exactly one strict payload variant
+  (`mozaiks.semantic_payload.v1` — titles/intent text, typed field shapes,
+  integer minor-unit prices, explicit dense-position ordering, taxonomy-
+  validated event/capability ids, portable-path-validated paths; no untyped
+  dicts), pinned into `mozaiks.semantic_graph.v2` nodes by a full-identity
+  `SemanticPayloadRef` so the graph digest is a Merkle root — any payload byte
+  change re-roots the graph. The reference resolver registers payloads as
+  immutable content-bearing subjects and requires complete payload closure
+  before a v2 graph registers; there is no "current"/latest payload lookup.
+  Graph v1 is byte-for-byte unchanged (golden vectors), no production code
+  consumes the new symbols, and no compiler capability is advertised.
+
 - **Portable path, registry v2, and deterministic archive substrate (ADR 0007
   Slice 4A)**: compiler-owned outputs now share one host-independent
   `mozaiks.portable_path.v1` profile (POSIX separators, NFC normalization,

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from mozaiksai.core.stub_kinds import StubKind
 from mozaiksai.core.workflow.assignment_kinds import AssignmentKind
 
 SCHEMA_VERSION: Literal["mozaiks.app_layout.v2"] = "mozaiks.app_layout.v2"
@@ -222,19 +223,6 @@ class ExtensionSlot(StrEnum):
     SERVICE_ADAPTER = "service_adapter"
     SERVICE_ROUTE = "service_route"
     BUILD_CONTEXT_PACK = "build_context_pack"
-
-
-class StubKind(StrEnum):
-    """Bounded customization stub kinds a family may reference.
-
-    Mirrors the contract-declared customization rule: Python stubs extend
-    backend/runtime-adjacent behavior; JS/TS stubs extend UI, admin, or
-    workflow-facing frontend behavior. A family with an empty tuple admits no
-    stubs at all.
-    """
-
-    PYTHON_BACKEND = "python_backend"
-    JS_FRONTEND = "js_frontend"
 
 
 class ArtifactFamily(LayoutModel):

--- a/mozaiksai/core/semantics/graph.py
+++ b/mozaiksai/core/semantics/graph.py
@@ -30,7 +30,9 @@ from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.refs import (
     MUTABLE_ALIASES,
     ExecutionAccessScopeRef,
+    SemanticPayloadRef,
     SemanticsModel,
+    validate_node_id_grammar,
 )
 from mozaiksai.core.taxonomy import (
     SemanticCategory,
@@ -39,11 +41,13 @@ from mozaiksai.core.taxonomy import (
 )
 
 SEMANTIC_GRAPH_SCHEMA_VERSION: Literal["mozaiks.semantic_graph.v1"] = "mozaiks.semantic_graph.v1"
+SEMANTIC_GRAPH_V2_SCHEMA_VERSION: Literal["mozaiks.semantic_graph.v2"] = (
+    "mozaiks.semantic_graph.v2"
+)
 
 #: Core namespace root; nodes outside it must sit inside a granted namespace.
 CORE_NODE_NAMESPACE_ROOT = "mozaiks"
 
-_NODE_ID = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$")
 _GRAPH_ID = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
 
@@ -105,15 +109,45 @@ class TaxonomyReference(SemanticsModel):
         return {"category": self.category.value, "identifier": self.identifier}
 
 
-def _validate_node_id(value: str) -> str:
+# The node-id grammar is shared contract state: graph v1/v2 nodes and
+# SemanticPayloadRef validate through the single helper in refs.py.
+_validate_node_id = validate_node_id_grammar
+
+
+def _normalize_taxonomy_references(
+    value: tuple[TaxonomyReference, ...],
+) -> tuple[TaxonomyReference, ...]:
+    ordered = tuple(sorted(value, key=lambda item: (item.category.value, item.identifier)))
+    identities = [(item.category, item.identifier) for item in ordered]
+    if len(identities) != len(set(identities)):
+        raise ValueError("duplicate taxonomy references on one node")
+    return ordered
+
+
+def _normalize_node_references(value: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(sorted(_validate_node_id(item) for item in value))
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("duplicate node references on one node")
+    return normalized
+
+
+def _validate_graph_id(value: str) -> str:
     text = str(value or "").strip()
-    if _NODE_ID.fullmatch(text) is None:
-        raise ValueError(
-            f"node_id must be a namespace-qualified lowercase dotted identifier, got {value!r}"
-        )
-    if text.split(".", 1)[0] in MUTABLE_ALIASES:
-        raise ValueError(f"node_id namespace must be immutable identity, got {text!r}")
+    if _GRAPH_ID.fullmatch(text) is None:
+        raise ValueError(f"graph_id must be a lowercase identifier, got {value!r}")
+    if text in MUTABLE_ALIASES:
+        raise ValueError(f"graph_id must be immutable identity, got {text!r}")
     return text
+
+
+def _normalize_namespace_grants(value: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(sorted({str(item or "").strip() for item in value}))
+    for item in normalized:
+        if re.fullmatch(r"[a-z][a-z0-9_]*", item) is None:
+            raise ValueError(f"namespace grant must be a lowercase root identifier, got {item!r}")
+        if item == CORE_NODE_NAMESPACE_ROOT:
+            raise ValueError("the core namespace root cannot be granted to extensions")
+    return normalized
 
 
 class SemanticNode(SemanticsModel):
@@ -132,19 +166,12 @@ class SemanticNode(SemanticsModel):
     def _taxonomy_references(
         cls, value: tuple[TaxonomyReference, ...]
     ) -> tuple[TaxonomyReference, ...]:
-        ordered = tuple(sorted(value, key=lambda item: (item.category.value, item.identifier)))
-        identities = [(item.category, item.identifier) for item in ordered]
-        if len(identities) != len(set(identities)):
-            raise ValueError("duplicate taxonomy references on one node")
-        return ordered
+        return _normalize_taxonomy_references(value)
 
     @field_validator("node_references")
     @classmethod
     def _node_references(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = tuple(sorted(_validate_node_id(item) for item in value))
-        if len(normalized) != len(set(normalized)):
-            raise ValueError("duplicate node references on one node")
-        return normalized
+        return _normalize_node_references(value)
 
     @property
     def namespace_root(self) -> str:
@@ -196,6 +223,47 @@ class SemanticEdge(SemanticsModel):
         return canonical_digest(self.identity_payload)
 
 
+def _validate_graph_structure(graph: SemanticGraph | SemanticGraphV2) -> None:
+    """Shared structural validation for graph v1 and v2 (identical rules)."""
+    node_ids = [node.node_id for node in graph.nodes]
+    if len(node_ids) != len(set(node_ids)):
+        duplicates = sorted({item for item in node_ids if node_ids.count(item) > 1})
+        raise ValueError(f"duplicate node identities: {duplicates}")
+    known = set(node_ids)
+
+    for node in graph.nodes:
+        root = node.namespace_root
+        if root != CORE_NODE_NAMESPACE_ROOT and root not in graph.namespace_grants:
+            raise ValueError(
+                f"node {node.node_id!r} is outside the core namespace and the "
+                f"granted namespaces {list(graph.namespace_grants)!r}"
+            )
+        for reference in node.node_references:
+            if reference not in known:
+                raise ValueError(
+                    f"node {node.node_id!r} references unknown node {reference!r}"
+                )
+
+    edge_identities: dict[str, SemanticEdge] = {}
+    for edge in graph.edges:
+        if edge.source_node_id not in known:
+            raise ValueError(
+                f"edge {edge.kind.value} has dangling source {edge.source_node_id!r}"
+            )
+        if edge.target_node_id not in known:
+            raise ValueError(
+                f"edge {edge.kind.value} has dangling target {edge.target_node_id!r}"
+            )
+        identity = edge.edge_identity
+        if identity in edge_identities:
+            raise ValueError(
+                f"duplicate edge identity for {edge.kind.value} "
+                f"{edge.source_node_id!r} -> {edge.target_node_id!r} "
+                f"(discriminator {edge.discriminator!r})"
+            )
+        edge_identities[identity] = edge
+
+
 class SemanticGraph(SemanticsModel):
     schema_version: Literal["mozaiks.semantic_graph.v1"] = SEMANTIC_GRAPH_SCHEMA_VERSION
     graph_id: str
@@ -209,23 +277,12 @@ class SemanticGraph(SemanticsModel):
     @field_validator("graph_id")
     @classmethod
     def _graph_id(cls, value: str) -> str:
-        text = str(value or "").strip()
-        if _GRAPH_ID.fullmatch(text) is None:
-            raise ValueError(f"graph_id must be a lowercase identifier, got {value!r}")
-        if text in MUTABLE_ALIASES:
-            raise ValueError(f"graph_id must be immutable identity, got {text!r}")
-        return text
+        return _validate_graph_id(value)
 
     @field_validator("namespace_grants")
     @classmethod
     def _grants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = tuple(sorted({str(item or "").strip() for item in value}))
-        for item in normalized:
-            if re.fullmatch(r"[a-z][a-z0-9_]*", item) is None:
-                raise ValueError(f"namespace grant must be a lowercase root identifier, got {item!r}")
-            if item == CORE_NODE_NAMESPACE_ROOT:
-                raise ValueError("the core namespace root cannot be granted to extensions")
-        return normalized
+        return _normalize_namespace_grants(value)
 
     @field_validator("nodes")
     @classmethod
@@ -239,44 +296,7 @@ class SemanticGraph(SemanticsModel):
 
     @model_validator(mode="after")
     def _validate_graph(self) -> SemanticGraph:
-        node_ids = [node.node_id for node in self.nodes]
-        if len(node_ids) != len(set(node_ids)):
-            duplicates = sorted({item for item in node_ids if node_ids.count(item) > 1})
-            raise ValueError(f"duplicate node identities: {duplicates}")
-        known = set(node_ids)
-
-        for node in self.nodes:
-            root = node.namespace_root
-            if root != CORE_NODE_NAMESPACE_ROOT and root not in self.namespace_grants:
-                raise ValueError(
-                    f"node {node.node_id!r} is outside the core namespace and the "
-                    f"granted namespaces {list(self.namespace_grants)!r}"
-                )
-            for reference in node.node_references:
-                if reference not in known:
-                    raise ValueError(
-                        f"node {node.node_id!r} references unknown node {reference!r}"
-                    )
-
-        edge_identities: dict[str, SemanticEdge] = {}
-        for edge in self.edges:
-            if edge.source_node_id not in known:
-                raise ValueError(
-                    f"edge {edge.kind.value} has dangling source {edge.source_node_id!r}"
-                )
-            if edge.target_node_id not in known:
-                raise ValueError(
-                    f"edge {edge.kind.value} has dangling target {edge.target_node_id!r}"
-                )
-            identity = edge.edge_identity
-            if identity in edge_identities:
-                raise ValueError(
-                    f"duplicate edge identity for {edge.kind.value} "
-                    f"{edge.source_node_id!r} -> {edge.target_node_id!r} "
-                    f"(discriminator {edge.discriminator!r})"
-                )
-            edge_identities[identity] = edge
-
+        _validate_graph_structure(self)
         expected = canonical_digest(self.canonical_payload(include_digest=False))
         if self.graph_digest != expected:
             raise ValueError("graph_digest does not match graph content")
@@ -349,16 +369,192 @@ def validate_semantic_graph_taxonomy_closure(
             registry.resolve(reference.category, reference.identifier)
 
 
+class SemanticNodeV2(SemanticsModel):
+    """Graph-v2 node: v1 identity plus a required pinned semantic payload.
+
+    Not a subclass of :class:`SemanticNode` — frozen models with distinct
+    identity payloads stay independent; both validate through the shared
+    module helpers so the grammars cannot diverge.
+    """
+
+    node_id: str
+    kind: SemanticNodeKind
+    taxonomy_references: tuple[TaxonomyReference, ...] = Field(default_factory=tuple)
+    node_references: tuple[str, ...] = Field(default_factory=tuple)
+    payload_ref: SemanticPayloadRef
+
+    @field_validator("node_id")
+    @classmethod
+    def _node_id(cls, value: str) -> str:
+        return _validate_node_id(value)
+
+    @field_validator("taxonomy_references")
+    @classmethod
+    def _taxonomy_references(
+        cls, value: tuple[TaxonomyReference, ...]
+    ) -> tuple[TaxonomyReference, ...]:
+        return _normalize_taxonomy_references(value)
+
+    @field_validator("node_references")
+    @classmethod
+    def _node_references(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _normalize_node_references(value)
+
+    @model_validator(mode="after")
+    def _payload_pin(self) -> SemanticNodeV2:
+        if self.payload_ref.node_id != self.node_id:
+            raise ValueError(
+                f"payload_ref pins node {self.payload_ref.node_id!r} but the node is "
+                f"{self.node_id!r}"
+            )
+        if self.payload_ref.payload_kind != self.kind.value:
+            raise ValueError(
+                f"payload_ref kind {self.payload_ref.payload_kind!r} does not match "
+                f"node kind {self.kind.value!r} on {self.node_id!r}"
+            )
+        return self
+
+    @property
+    def namespace_root(self) -> str:
+        return self.node_id.split(".", 1)[0]
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "kind": self.kind.value,
+            "taxonomy_references": [item.identity_payload for item in self.taxonomy_references],
+            "node_references": list(self.node_references),
+            "payload_ref": self.payload_ref.identity_payload,
+        }
+
+
+class SemanticGraphV2(SemanticsModel):
+    """Graph v2: every node pins its typed payload; ``graph_digest`` is the
+    Merkle root — any payload byte change flows payload digest → node identity
+    → graph digest."""
+
+    schema_version: Literal["mozaiks.semantic_graph.v2"] = SEMANTIC_GRAPH_V2_SCHEMA_VERSION
+    graph_id: str
+    version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    namespace_grants: tuple[str, ...] = Field(default_factory=tuple)
+    nodes: tuple[SemanticNodeV2, ...] = Field(min_length=1)
+    edges: tuple[SemanticEdge, ...] = Field(default_factory=tuple)
+    graph_digest: str = Field(min_length=64, max_length=64)
+
+    @field_validator("graph_id")
+    @classmethod
+    def _graph_id(cls, value: str) -> str:
+        return _validate_graph_id(value)
+
+    @field_validator("namespace_grants")
+    @classmethod
+    def _grants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _normalize_namespace_grants(value)
+
+    @field_validator("nodes")
+    @classmethod
+    def _nodes(cls, value: tuple[SemanticNodeV2, ...]) -> tuple[SemanticNodeV2, ...]:
+        return tuple(sorted(value, key=lambda item: item.node_id))
+
+    @field_validator("edges")
+    @classmethod
+    def _edges(cls, value: tuple[SemanticEdge, ...]) -> tuple[SemanticEdge, ...]:
+        return tuple(sorted(value, key=lambda item: item.edge_identity))
+
+    @model_validator(mode="after")
+    def _validate_graph(self) -> SemanticGraphV2:
+        _validate_graph_structure(self)
+        for node in self.nodes:
+            if node.payload_ref.scope != self.scope:
+                raise ValueError(
+                    f"payload_ref on {node.node_id!r} is pinned in a different scope "
+                    "than the graph"
+                )
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.graph_digest != expected:
+            raise ValueError("graph_digest does not match graph content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "graph_id": self.graph_id,
+            "version": self.version,
+            "scope": self.scope.model_dump(mode="json"),
+            "namespace_grants": list(self.namespace_grants),
+            "nodes": [node.identity_payload for node in self.nodes],
+            "edges": [edge.identity_payload for edge in self.edges],
+        }
+        if include_digest:
+            payload["graph_digest"] = self.graph_digest
+        return payload
+
+    def node(self, node_id: str) -> SemanticNodeV2:
+        for candidate in self.nodes:
+            if candidate.node_id == node_id:
+                return candidate
+        raise SemanticGraphError(f"unknown node {node_id!r}")
+
+
+def build_semantic_graph_v2(
+    *,
+    graph_id: str,
+    version: int,
+    scope: ExecutionAccessScopeRef,
+    nodes: tuple[SemanticNodeV2, ...] | list[SemanticNodeV2],
+    edges: tuple[SemanticEdge, ...] | list[SemanticEdge] = (),
+    namespace_grants: tuple[str, ...] | list[str] = (),
+) -> SemanticGraphV2:
+    """Construct a v2 graph with its Merkle-root digest computed canonically."""
+    ordered_nodes = tuple(sorted(tuple(nodes), key=lambda item: item.node_id))
+    ordered_edges = tuple(sorted(tuple(edges), key=lambda item: item.edge_identity))
+    ordered_grants = tuple(sorted({str(item).strip() for item in namespace_grants}))
+    payload = {
+        "schema_version": SEMANTIC_GRAPH_V2_SCHEMA_VERSION,
+        "graph_id": str(graph_id).strip(),
+        "version": version,
+        "scope": scope.model_dump(mode="json"),
+        "namespace_grants": list(ordered_grants),
+        "nodes": [node.identity_payload for node in ordered_nodes],
+        "edges": [edge.identity_payload for edge in ordered_edges],
+    }
+    return SemanticGraphV2(
+        graph_id=graph_id,
+        version=version,
+        scope=scope,
+        namespace_grants=ordered_grants,
+        nodes=ordered_nodes,
+        edges=ordered_edges,
+        graph_digest=canonical_digest(payload),
+    )
+
+
+def validate_semantic_graph_v2_taxonomy_closure(
+    graph: SemanticGraphV2, registry: TaxonomyRegistry
+) -> None:
+    """Fail closed unless every v2 taxonomy reference resolves in ``registry``."""
+    for node in graph.nodes:
+        for reference in node.taxonomy_references:
+            registry.resolve(reference.category, reference.identifier)
+
+
 __all__ = [
     "CORE_NODE_NAMESPACE_ROOT",
     "SEMANTIC_GRAPH_SCHEMA_VERSION",
+    "SEMANTIC_GRAPH_V2_SCHEMA_VERSION",
     "SemanticEdge",
     "SemanticEdgeKind",
     "SemanticGraph",
     "SemanticGraphError",
+    "SemanticGraphV2",
     "SemanticNode",
     "SemanticNodeKind",
+    "SemanticNodeV2",
     "TaxonomyReference",
     "build_semantic_graph",
+    "build_semantic_graph_v2",
     "validate_semantic_graph_taxonomy_closure",
+    "validate_semantic_graph_v2_taxonomy_closure",
 ]

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -38,6 +38,7 @@ from mozaiksai.core.semantics.refs import (
     _validate_digest,
     validate_node_id_grammar,
 )
+from mozaiksai.core.stub_kinds import StubKind
 from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_grammar
 
 SEMANTIC_PAYLOAD_SCHEMA_VERSION: Literal["mozaiks.semantic_payload.v1"] = (
@@ -47,7 +48,23 @@ SEMANTIC_PAYLOAD_SCHEMA_VERSION: Literal["mozaiks.semantic_payload.v1"] = (
 _MAX_TEXT_CHARS = 4000
 _FIELD_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
 _ENTRYPOINT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_CURRENCY = re.compile(r"^[A-Z]{3}$")
+# ISO 4217 Maintenance Agency List One (current currencies and funds),
+# captured for this schema version on 2026-08-29.  Shape validation alone is
+# insufficient: unassigned uppercase triples such as ``ZZZ`` fail closed.
+_ISO_4217_LIST_ONE_CODES = frozenset(
+    """
+    AED AFN ALL AMD AOA ARS AUD AWG AZN BAM BBD BDT BHD BIF BMD BND BOB BOV BRL
+    BSD BTN BWP BYN BZD CAD CDF CHE CHF CHW CLF CLP CNY COP COU CRC CUP CVE CZK
+    DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD
+    HNL HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD
+    KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRU MUR MVR MWK
+    MXN MXV MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR
+    RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SLE SOS SRD SSP STN SVC SYP SZL
+    THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD USN UYI UYU UYW UZS VED VES
+    VND VUV WST XAD XAF XAG XAU XBA XBB XBC XBD XCD XCG XDR XOF XPD XPF XPT
+    XSU XTS XUA XXX YER ZAR ZMW ZWG
+    """.split()
+)
 
 #: Validation-context key used exclusively by :func:`build_semantic_payload`
 #: to defer the digest check while computing the digest.  It is a validation
@@ -137,13 +154,6 @@ class DeploymentTargetKind(StrEnum):
     CONTAINER = "container"
     STATIC_SITE = "static_site"
     SERVERLESS = "serverless"
-
-
-#: Mirror of ``layout_registry.StubKind`` values.  The registry lives in the
-#: runtime layer and imports workflow modules, so the semantics contract layer
-#: mirrors the closed value set as a Literal instead of importing it; a test
-#: pins the two sets equal so they cannot drift.
-StubKindLiteral = Literal["python_backend", "js_frontend"]
 
 
 # ---------------------------------------------------------------------------
@@ -258,8 +268,8 @@ class PriceSpec(SemanticsModel):
     @classmethod
     def _currency(cls, value: str) -> str:
         text = str(value or "").strip()
-        if _CURRENCY.fullmatch(text) is None:
-            raise ValueError(f"currency must be a 3-letter uppercase code, got {value!r}")
+        if text not in _ISO_4217_LIST_ONE_CODES:
+            raise ValueError(f"currency must be a current ISO-4217 code, got {value!r}")
         return text
 
 
@@ -726,7 +736,7 @@ class DeploymentTargetPayload(SemanticPayloadBase):
 
 class StubDeclarationPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.STUB_DECLARATION] = SemanticNodeKind.STUB_DECLARATION
-    stub_kind: StubKindLiteral
+    stub_kind: StubKind
     path: str
     entrypoint: str
 
@@ -821,8 +831,20 @@ def validate_semantic_graph_v2_payload_closure(
     (node_id, kind, version, digest, scope); every supplied payload must be
     pinned.  Missing, mismatched, duplicate, and extra payloads fail closed.
     """
+    try:
+        verified_graph = SemanticGraphV2.model_validate(graph.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise SemanticPayloadError(f"semantic graph v2 failed cold validation: {exc}") from exc
+
     supplied: dict[tuple[str, int], SemanticPayloadBase] = {}
     for payload in payloads:
+        try:
+            verified_payload = parse_semantic_payload(payload.model_dump(mode="json"))
+        except (TypeError, ValueError) as exc:
+            raise SemanticPayloadError(
+                f"semantic payload failed cold validation: {exc}"
+            ) from exc
+        payload = verified_payload
         key = (payload.node_id, payload.payload_version)
         if key in supplied:
             raise SemanticPayloadError(
@@ -832,7 +854,7 @@ def validate_semantic_graph_v2_payload_closure(
         supplied[key] = payload
 
     pinned: set[tuple[str, int]] = set()
-    for node in graph.nodes:
+    for node in verified_graph.nodes:
         ref = node.payload_ref
         key = (ref.node_id, ref.payload_version)
         pinned.add(key)

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -1,0 +1,909 @@
+"""ADR 0007 Slice 2E typed semantic payload documents (``mozaiks.semantic_payload.v1``).
+
+Exactly one strict payload variant exists per :class:`SemanticNodeKind`; a
+graph-v2 node pins its payload by full identity through
+:class:`~mozaiksai.core.semantics.refs.SemanticPayloadRef`.  Payloads carry the
+content a node's identity cannot — titles, intent text, typed field shapes,
+prices, ordered entries — never a second copy of identity facts the node
+already owns, and never untyped ``dict[str, Any]`` escape hatches.
+
+Ordering rule: order-bearing collections (page sections, section entries) use
+explicit dense ``position`` integers, so canonical sorting cannot destroy
+source order; identity collections (fields, emits, hints) are sorted and
+deduplicated by key.  Prices are integer minor units — floats never carry
+money.  Event and capability identifiers validate through the Slice 1
+taxonomy grammar; portable paths validate through the Slice 4A profile.
+
+``payload_digest`` is the canonical digest (Slice 2 serializer — the only
+serializer) over the payload with the digest field excluded; every parse
+re-verifies it, so a tampered field or digest fails closed at validation.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import Field, TypeAdapter, ValidationInfo, field_validator, model_validator
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.graph import SemanticGraphV2, SemanticNodeKind
+from mozaiksai.core.semantics.portable_path import validate_portable_path
+from mozaiksai.core.semantics.refs import (
+    ExecutionAccessScopeRef,
+    SemanticPayloadRef,
+    SemanticsModel,
+    _validate_digest,
+    validate_node_id_grammar,
+)
+from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_grammar
+
+SEMANTIC_PAYLOAD_SCHEMA_VERSION: Literal["mozaiks.semantic_payload.v1"] = (
+    "mozaiks.semantic_payload.v1"
+)
+
+_MAX_TEXT_CHARS = 4000
+_FIELD_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+_ENTRYPOINT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CURRENCY = re.compile(r"^[A-Z]{3}$")
+
+#: Validation-context key used exclusively by :func:`build_semantic_payload`
+#: to defer the digest check while computing the digest.  It is a validation
+#: parameter, not document data — serialized payloads cannot smuggle it.
+_BUILDER_CONTEXT_KEY = "semantic_payload_builder"
+_PLACEHOLDER_DIGEST = "0" * 64
+
+
+class SemanticPayloadError(ValueError):
+    """Raised when a payload document violates the contract."""
+
+
+def _text(value: str, *, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty text")
+    if len(text) > _MAX_TEXT_CHARS:
+        raise ValueError(f"{field_name} exceeds {_MAX_TEXT_CHARS} characters")
+    return text
+
+
+def _field_name(value: str, *, field_name: str) -> str:
+    text = str(value or "").strip()
+    if _FIELD_NAME.fullmatch(text) is None:
+        raise ValueError(f"{field_name} must be a lowercase snake_case name, got {value!r}")
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabulary enums (structured-output-first: no freeform strings)
+# ---------------------------------------------------------------------------
+
+
+class FieldType(StrEnum):
+    """Closed field-type set for typed request/response/data shapes."""
+
+    STRING = "string"
+    TEXT = "text"
+    INTEGER = "integer"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+    REFERENCE = "reference"
+
+
+class SectionEntryKind(StrEnum):
+    TEXT = "text"
+    MODULE_BINDING = "module_binding"
+    ACTION_BINDING = "action_binding"
+    API_BINDING = "api_binding"
+
+
+class HttpMethod(StrEnum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
+
+class NotificationChannel(StrEnum):
+    IN_APP = "in_app"
+    EMAIL = "email"
+    SMS = "sms"
+    WEBHOOK = "webhook"
+
+
+class WorkflowStartupMode(StrEnum):
+    ON_DEMAND = "on_demand"
+    EVENT_DRIVEN = "event_driven"
+    SCHEDULED = "scheduled"
+
+
+class TriggerKind(StrEnum):
+    EVENT = "event"
+    ENDPOINT = "endpoint"
+    CAPABILITY = "capability"
+
+
+class BillingPeriod(StrEnum):
+    ONE_TIME = "one_time"
+    MONTHLY = "monthly"
+    YEARLY = "yearly"
+
+
+class DeploymentTargetKind(StrEnum):
+    CONTAINER = "container"
+    STATIC_SITE = "static_site"
+    SERVERLESS = "serverless"
+
+
+#: Mirror of ``layout_registry.StubKind`` values.  The registry lives in the
+#: runtime layer and imports workflow modules, so the semantics contract layer
+#: mirrors the closed value set as a Literal instead of importing it; a test
+#: pins the two sets equal so they cannot drift.
+StubKindLiteral = Literal["python_backend", "js_frontend"]
+
+
+# ---------------------------------------------------------------------------
+# Typed sub-shapes
+# ---------------------------------------------------------------------------
+
+
+class TypedFieldSpec(SemanticsModel):
+    """One typed field in a request/response/data/event shape."""
+
+    name: str
+    field_type: FieldType
+    required: bool
+
+    @field_validator("name")
+    @classmethod
+    def _name(cls, value: str) -> str:
+        return _field_name(value, field_name="name")
+
+
+class IndexSpec(SemanticsModel):
+    """One declared index over a data collection's fields."""
+
+    name: str
+    field_names: tuple[str, ...] = Field(min_length=1)
+    unique: bool
+
+    @field_validator("name")
+    @classmethod
+    def _name(cls, value: str) -> str:
+        return _field_name(value, field_name="name")
+
+    @field_validator("field_names")
+    @classmethod
+    def _field_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_field_name(item, field_name="field_names") for item in value)
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("duplicate field names in one index")
+        return normalized
+
+
+class PageSectionEntry(SemanticsModel):
+    """Ordered reference from a page to a section node."""
+
+    position: int = Field(ge=0, strict=True)
+    section_node_id: str
+
+    @field_validator("section_node_id")
+    @classmethod
+    def _section(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+
+class SectionContentEntry(SemanticsModel):
+    """One ordered entry inside a section: text or a typed binding."""
+
+    position: int = Field(ge=0, strict=True)
+    entry_kind: SectionEntryKind
+    text: str | None = None
+    target_node_id: str | None = None
+    api_method: HttpMethod | None = None
+    api_path: str | None = None
+
+    @field_validator("text")
+    @classmethod
+    def _text_value(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _text(value, field_name="text")
+
+    @field_validator("target_node_id")
+    @classmethod
+    def _target(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_node_id_grammar(value)
+
+    @field_validator("api_path")
+    @classmethod
+    def _api_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value or "").strip()
+        if not text.startswith("/") or " " in text:
+            raise ValueError(f"api_path must be an absolute route path, got {value!r}")
+        return text
+
+    @model_validator(mode="after")
+    def _shape(self) -> SectionContentEntry:
+        if self.entry_kind is SectionEntryKind.TEXT:
+            if self.text is None or self.target_node_id or self.api_method or self.api_path:
+                raise ValueError("text entries carry text and no binding fields")
+        elif self.entry_kind in (SectionEntryKind.MODULE_BINDING, SectionEntryKind.ACTION_BINDING):
+            if self.target_node_id is None or self.text or self.api_method or self.api_path:
+                raise ValueError(
+                    f"{self.entry_kind.value} entries carry target_node_id and nothing else"
+                )
+        else:  # API_BINDING
+            if self.api_method is None or self.api_path is None or self.text or self.target_node_id:
+                raise ValueError("api_binding entries carry api_method and api_path only")
+        return self
+
+
+class PriceSpec(SemanticsModel):
+    """One price point: integer minor units, ISO-4217 currency, billing period."""
+
+    amount_minor_units: int = Field(ge=0, strict=True)
+    currency: str
+    period: BillingPeriod
+
+    @field_validator("currency")
+    @classmethod
+    def _currency(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if _CURRENCY.fullmatch(text) is None:
+            raise ValueError(f"currency must be a 3-letter uppercase code, got {value!r}")
+        return text
+
+
+def _ordered_dense(entries: tuple, *, field_name: str) -> tuple:
+    """Enforce dense 0..n-1 explicit positions and order by them."""
+    positions = sorted(entry.position for entry in entries)
+    if positions != list(range(len(entries))):
+        raise ValueError(
+            f"{field_name} positions must be dense 0..{max(len(entries) - 1, 0)}, got {positions}"
+        )
+    return tuple(sorted(entries, key=lambda entry: entry.position))
+
+
+def _sorted_prices(value: tuple[PriceSpec, ...]) -> tuple[PriceSpec, ...]:
+    ordered = tuple(sorted(value, key=lambda item: (item.currency, item.period.value)))
+    keys = [(item.currency, item.period) for item in ordered]
+    if len(keys) != len(set(keys)):
+        raise ValueError("duplicate price for one (currency, period)")
+    return ordered
+
+
+def _sorted_event_ids(value: tuple[str, ...], *, field_name: str) -> tuple[str, ...]:
+    normalized = tuple(
+        sorted({validate_identifier_grammar(SemanticCategory.EVENT, item) for item in value})
+    )
+    if len(normalized) != len(value):
+        raise ValueError(f"duplicate event identifiers in {field_name}")
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Payload base + one strict variant per node kind
+# ---------------------------------------------------------------------------
+
+
+class SemanticPayloadBase(SemanticsModel):
+    """Shared identity/digest shape of every payload variant."""
+
+    payload_schema_version: Literal["mozaiks.semantic_payload.v1"] = (
+        SEMANTIC_PAYLOAD_SCHEMA_VERSION
+    )
+    node_id: str
+    payload_version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    payload_digest: str
+
+    @field_validator("node_id")
+    @classmethod
+    def _node_id(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("payload_digest")
+    @classmethod
+    def _digest_field(cls, value: str) -> str:
+        return _validate_digest(value, field_name="payload_digest")
+
+    @model_validator(mode="after")
+    def _verify_digest(self, info: ValidationInfo) -> SemanticPayloadBase:
+        if info.context is not None and info.context.get(_BUILDER_CONTEXT_KEY):
+            return self
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.payload_digest != expected:
+            raise ValueError("payload_digest does not match payload content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        """Canonical digest payload: every field participates except the digest."""
+        payload = self.model_dump(mode="json", exclude={"payload_digest"})
+        if include_digest:
+            payload["payload_digest"] = self.payload_digest
+        return payload
+
+
+class SurfacePayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.SURFACE] = SemanticNodeKind.SURFACE
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class PagePayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.PAGE] = SemanticNodeKind.PAGE
+    title: str
+    intent: str
+    layout_id: str | None = None
+    sections: tuple[PageSectionEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("title", "intent")
+    @classmethod
+    def _texts(cls, value: str, info: ValidationInfo) -> str:
+        return _text(value, field_name=str(info.field_name))
+
+    @field_validator("layout_id")
+    @classmethod
+    def _layout(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _field_name(value, field_name="layout_id")
+
+    @field_validator("sections")
+    @classmethod
+    def _sections(cls, value: tuple[PageSectionEntry, ...]) -> tuple[PageSectionEntry, ...]:
+        ordered = _ordered_dense(value, field_name="sections")
+        section_ids = [entry.section_node_id for entry in ordered]
+        if len(section_ids) != len(set(section_ids)):
+            raise ValueError("duplicate section references on one page")
+        return ordered
+
+
+class SectionPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.SECTION] = SemanticNodeKind.SECTION
+    title: str
+    intent: str
+    entries: tuple[SectionContentEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("title", "intent")
+    @classmethod
+    def _texts(cls, value: str, info: ValidationInfo) -> str:
+        return _text(value, field_name=str(info.field_name))
+
+    @field_validator("entries")
+    @classmethod
+    def _entries(cls, value: tuple[SectionContentEntry, ...]) -> tuple[SectionContentEntry, ...]:
+        return _ordered_dense(value, field_name="entries")
+
+
+class ModulePayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.MODULE] = SemanticNodeKind.MODULE
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class ActionPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.ACTION] = SemanticNodeKind.ACTION
+    description: str
+    request_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
+    response_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
+    emits: tuple[str, ...] = Field(default_factory=tuple)
+    entitlement_gate: str | None = None
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("request_fields", "response_fields")
+    @classmethod
+    def _fields(
+        cls, value: tuple[TypedFieldSpec, ...], info: ValidationInfo
+    ) -> tuple[TypedFieldSpec, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.name))
+        names = [item.name for item in ordered]
+        if len(names) != len(set(names)):
+            raise ValueError(f"duplicate field names in {info.field_name}")
+        return ordered
+
+    @field_validator("emits")
+    @classmethod
+    def _emits(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _sorted_event_ids(value, field_name="emits")
+
+    @field_validator("entitlement_gate")
+    @classmethod
+    def _gate(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_identifier_grammar(SemanticCategory.CAPABILITY, value)
+
+
+class CapabilityPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.CAPABILITY] = SemanticNodeKind.CAPABILITY
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class PermissionPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.PERMISSION] = SemanticNodeKind.PERMISSION
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class EventPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.EVENT] = SemanticNodeKind.EVENT
+    description: str
+    payload_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("payload_fields")
+    @classmethod
+    def _fields(cls, value: tuple[TypedFieldSpec, ...]) -> tuple[TypedFieldSpec, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.name))
+        names = [item.name for item in ordered]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate field names in payload_fields")
+        return ordered
+
+
+class ReactionPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.REACTION] = SemanticNodeKind.REACTION
+    description: str
+    consumed_event: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("consumed_event")
+    @classmethod
+    def _event(cls, value: str) -> str:
+        return validate_identifier_grammar(SemanticCategory.EVENT, value)
+
+
+class NotificationPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.NOTIFICATION] = SemanticNodeKind.NOTIFICATION
+    template_text: str
+    channel: NotificationChannel
+
+    @field_validator("template_text")
+    @classmethod
+    def _template(cls, value: str) -> str:
+        return _text(value, field_name="template_text")
+
+
+class DataCollectionPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.DATA_COLLECTION] = SemanticNodeKind.DATA_COLLECTION
+    description: str
+    fields: tuple[TypedFieldSpec, ...] = Field(min_length=1)
+    indexes: tuple[IndexSpec, ...] = Field(default_factory=tuple)
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("fields")
+    @classmethod
+    def _fields(cls, value: tuple[TypedFieldSpec, ...]) -> tuple[TypedFieldSpec, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.name))
+        names = [item.name for item in ordered]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate field names in fields")
+        return ordered
+
+    @field_validator("indexes")
+    @classmethod
+    def _indexes(cls, value: tuple[IndexSpec, ...]) -> tuple[IndexSpec, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.name))
+        names = [item.name for item in ordered]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate index names")
+        return ordered
+
+    @model_validator(mode="after")
+    def _index_closure(self) -> DataCollectionPayload:
+        declared = {field.name for field in self.fields}
+        for index in self.indexes:
+            for name in index.field_names:
+                if name not in declared:
+                    raise ValueError(f"index {index.name!r} references undeclared field {name!r}")
+        return self
+
+
+class DataAliasPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.DATA_ALIAS] = SemanticNodeKind.DATA_ALIAS
+    alias: str
+    collection: str
+    owner_node_id: str
+
+    @field_validator("alias", "collection")
+    @classmethod
+    def _names(cls, value: str, info: ValidationInfo) -> str:
+        return _field_name(value, field_name=str(info.field_name))
+
+    @field_validator("owner_node_id")
+    @classmethod
+    def _owner(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+
+class WorkflowPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.WORKFLOW] = SemanticNodeKind.WORKFLOW
+    description: str
+    startup_mode: WorkflowStartupMode
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class TriggerPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.TRIGGER] = SemanticNodeKind.TRIGGER
+    description: str
+    trigger_kind: TriggerKind
+    event_id: str | None = None
+    endpoint_path: str | None = None
+    capability_id: str | None = None
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("event_id")
+    @classmethod
+    def _event(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_identifier_grammar(SemanticCategory.EVENT, value)
+
+    @field_validator("endpoint_path")
+    @classmethod
+    def _endpoint(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value or "").strip()
+        if not text.startswith("/") or " " in text:
+            raise ValueError(f"endpoint_path must be an absolute route path, got {value!r}")
+        return text
+
+    @field_validator("capability_id")
+    @classmethod
+    def _capability(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_identifier_grammar(SemanticCategory.CAPABILITY, value)
+
+    @model_validator(mode="after")
+    def _binding(self) -> TriggerPayload:
+        bindings = {
+            TriggerKind.EVENT: (self.event_id, "event_id"),
+            TriggerKind.ENDPOINT: (self.endpoint_path, "endpoint_path"),
+            TriggerKind.CAPABILITY: (self.capability_id, "capability_id"),
+        }
+        required_value, required_name = bindings[self.trigger_kind]
+        if required_value is None:
+            raise ValueError(
+                f"trigger_kind {self.trigger_kind.value!r} requires {required_name}"
+            )
+        for kind, (value, name) in bindings.items():
+            if kind is not self.trigger_kind and value is not None:
+                raise ValueError(
+                    f"trigger_kind {self.trigger_kind.value!r} must not set {name}"
+                )
+        return self
+
+
+class PlanPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.PLAN] = SemanticNodeKind.PLAN
+    title: str
+    prices: tuple[PriceSpec, ...] = Field(min_length=1)
+    granted_capabilities: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("title")
+    @classmethod
+    def _title(cls, value: str) -> str:
+        return _text(value, field_name="title")
+
+    @field_validator("prices")
+    @classmethod
+    def _prices(cls, value: tuple[PriceSpec, ...]) -> tuple[PriceSpec, ...]:
+        return _sorted_prices(value)
+
+    @field_validator("granted_capabilities")
+    @classmethod
+    def _grants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(
+            sorted(
+                {
+                    validate_identifier_grammar(SemanticCategory.CAPABILITY, item)
+                    for item in value
+                }
+            )
+        )
+        if len(normalized) != len(value):
+            raise ValueError("duplicate capability identifiers in granted_capabilities")
+        return normalized
+
+
+class ProductPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.PRODUCT] = SemanticNodeKind.PRODUCT
+    title: str
+    description: str
+    prices: tuple[PriceSpec, ...] = Field(min_length=1)
+
+    @field_validator("title", "description")
+    @classmethod
+    def _texts(cls, value: str, info: ValidationInfo) -> str:
+        return _text(value, field_name=str(info.field_name))
+
+    @field_validator("prices")
+    @classmethod
+    def _prices(cls, value: tuple[PriceSpec, ...]) -> tuple[PriceSpec, ...]:
+        return _sorted_prices(value)
+
+
+class MeterPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.METER] = SemanticNodeKind.METER
+    description: str
+    unit: str
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+    @field_validator("unit")
+    @classmethod
+    def _unit(cls, value: str) -> str:
+        return _field_name(value, field_name="unit")
+
+
+class LimitPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.LIMIT] = SemanticNodeKind.LIMIT
+    description: str
+    limit_value: int = Field(ge=0, strict=True)
+    period: BillingPeriod | None = None
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str) -> str:
+        return _text(value, field_name="description")
+
+
+class DeploymentTargetPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.DEPLOYMENT_TARGET] = SemanticNodeKind.DEPLOYMENT_TARGET
+    target_kind: DeploymentTargetKind
+    profile_id: str
+    output_hints: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("profile_id")
+    @classmethod
+    def _profile(cls, value: str) -> str:
+        return _field_name(value, field_name="profile_id")
+
+    @field_validator("output_hints")
+    @classmethod
+    def _hints(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(sorted({validate_portable_path(item).text for item in value}))
+        if len(normalized) != len(value):
+            raise ValueError("duplicate portable output hints")
+        return normalized
+
+
+class StubDeclarationPayload(SemanticPayloadBase):
+    payload_kind: Literal[SemanticNodeKind.STUB_DECLARATION] = SemanticNodeKind.STUB_DECLARATION
+    stub_kind: StubKindLiteral
+    path: str
+    entrypoint: str
+
+    @field_validator("path")
+    @classmethod
+    def _path(cls, value: str) -> str:
+        return validate_portable_path(value).text
+
+    @field_validator("entrypoint")
+    @classmethod
+    def _entrypoint(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if _ENTRYPOINT.fullmatch(text) is None:
+            raise ValueError(f"entrypoint must be a bare symbol name, got {value!r}")
+        return text
+
+
+SemanticPayload = Annotated[
+    SurfacePayload | PagePayload | SectionPayload | ModulePayload | ActionPayload | CapabilityPayload | PermissionPayload | EventPayload | ReactionPayload | NotificationPayload | DataCollectionPayload | DataAliasPayload | WorkflowPayload | TriggerPayload | PlanPayload | ProductPayload | MeterPayload | LimitPayload | DeploymentTargetPayload | StubDeclarationPayload,
+    Field(discriminator="payload_kind"),
+]
+
+#: Exactly one variant per node kind; enum-completeness is test-enforced.
+PAYLOAD_MODEL_BY_KIND: dict[SemanticNodeKind, type[SemanticPayloadBase]] = {
+    SemanticNodeKind.SURFACE: SurfacePayload,
+    SemanticNodeKind.PAGE: PagePayload,
+    SemanticNodeKind.SECTION: SectionPayload,
+    SemanticNodeKind.MODULE: ModulePayload,
+    SemanticNodeKind.ACTION: ActionPayload,
+    SemanticNodeKind.CAPABILITY: CapabilityPayload,
+    SemanticNodeKind.PERMISSION: PermissionPayload,
+    SemanticNodeKind.EVENT: EventPayload,
+    SemanticNodeKind.REACTION: ReactionPayload,
+    SemanticNodeKind.NOTIFICATION: NotificationPayload,
+    SemanticNodeKind.DATA_COLLECTION: DataCollectionPayload,
+    SemanticNodeKind.DATA_ALIAS: DataAliasPayload,
+    SemanticNodeKind.WORKFLOW: WorkflowPayload,
+    SemanticNodeKind.TRIGGER: TriggerPayload,
+    SemanticNodeKind.PLAN: PlanPayload,
+    SemanticNodeKind.PRODUCT: ProductPayload,
+    SemanticNodeKind.METER: MeterPayload,
+    SemanticNodeKind.LIMIT: LimitPayload,
+    SemanticNodeKind.DEPLOYMENT_TARGET: DeploymentTargetPayload,
+    SemanticNodeKind.STUB_DECLARATION: StubDeclarationPayload,
+}
+
+_PAYLOAD_ADAPTER: TypeAdapter[SemanticPayloadBase] = TypeAdapter(SemanticPayload)
+
+
+def parse_semantic_payload(data: Any) -> SemanticPayloadBase:
+    """Parse and fully re-verify one payload document (discriminated union)."""
+    return _PAYLOAD_ADAPTER.validate_python(data)
+
+
+def build_semantic_payload(
+    model_cls: type[SemanticPayloadBase], /, **fields: Any
+) -> SemanticPayloadBase:
+    """Construct a payload with its canonical self-digest computed.
+
+    Validation runs twice: a builder-context pass normalizes every field, then
+    the definitive pass re-validates with the computed digest so the returned
+    document is exactly what a cold parse would accept.
+    """
+    probe = model_cls.model_validate(
+        {**fields, "payload_digest": _PLACEHOLDER_DIGEST},
+        context={_BUILDER_CONTEXT_KEY: True},
+    )
+    digest = canonical_digest(probe.canonical_payload(include_digest=False))
+    return model_cls.model_validate({**fields, "payload_digest": digest})
+
+
+def semantic_payload_ref(payload: SemanticPayloadBase) -> SemanticPayloadRef:
+    """The full-identity reference pinning ``payload`` into a graph-v2 node."""
+    kind = getattr(payload, "payload_kind", None)
+    if not isinstance(kind, SemanticNodeKind):
+        raise SemanticPayloadError("payload has no discriminant kind")
+    return SemanticPayloadRef(
+        node_id=payload.node_id,
+        payload_kind=kind.value,
+        payload_version=payload.payload_version,
+        content_digest=payload.payload_digest,
+        scope=payload.scope,
+    )
+
+
+def validate_semantic_graph_v2_payload_closure(
+    graph: SemanticGraphV2, payloads: Iterable[SemanticPayloadBase]
+) -> None:
+    """Bijective closure between a v2 graph's pins and the supplied payloads.
+
+    Every pinned reference must match exactly one supplied payload on
+    (node_id, kind, version, digest, scope); every supplied payload must be
+    pinned.  Missing, mismatched, duplicate, and extra payloads fail closed.
+    """
+    supplied: dict[tuple[str, int], SemanticPayloadBase] = {}
+    for payload in payloads:
+        key = (payload.node_id, payload.payload_version)
+        if key in supplied:
+            raise SemanticPayloadError(
+                f"duplicate payload supplied for node {payload.node_id!r} "
+                f"version {payload.payload_version}"
+            )
+        supplied[key] = payload
+
+    pinned: set[tuple[str, int]] = set()
+    for node in graph.nodes:
+        ref = node.payload_ref
+        key = (ref.node_id, ref.payload_version)
+        pinned.add(key)
+        candidate = supplied.get(key)
+        if candidate is None:
+            raise SemanticPayloadError(
+                f"graph pins payload for node {ref.node_id!r} version "
+                f"{ref.payload_version} but it was not supplied"
+            )
+        kind = getattr(candidate, "payload_kind", None)
+        if not isinstance(kind, SemanticNodeKind) or kind.value != ref.payload_kind:
+            raise SemanticPayloadError(
+                f"payload kind mismatch for node {ref.node_id!r}"
+            )
+        if candidate.payload_digest != ref.content_digest:
+            raise SemanticPayloadError(
+                f"payload digest mismatch for node {ref.node_id!r}"
+            )
+        if candidate.scope != ref.scope:
+            raise SemanticPayloadError(
+                f"payload scope mismatch for node {ref.node_id!r}"
+            )
+
+    extras = sorted(set(supplied) - pinned)
+    if extras:
+        raise SemanticPayloadError(
+            f"supplied payloads are not pinned by the graph: {extras}"
+        )
+
+
+__all__ = [
+    "PAYLOAD_MODEL_BY_KIND",
+    "SEMANTIC_PAYLOAD_SCHEMA_VERSION",
+    "ActionPayload",
+    "BillingPeriod",
+    "CapabilityPayload",
+    "DataAliasPayload",
+    "DataCollectionPayload",
+    "DeploymentTargetKind",
+    "DeploymentTargetPayload",
+    "EventPayload",
+    "FieldType",
+    "HttpMethod",
+    "IndexSpec",
+    "LimitPayload",
+    "MeterPayload",
+    "ModulePayload",
+    "NotificationChannel",
+    "NotificationPayload",
+    "PagePayload",
+    "PageSectionEntry",
+    "PermissionPayload",
+    "PlanPayload",
+    "PriceSpec",
+    "ProductPayload",
+    "ReactionPayload",
+    "SectionContentEntry",
+    "SectionEntryKind",
+    "SectionPayload",
+    "SemanticPayload",
+    "SemanticPayloadBase",
+    "SemanticPayloadError",
+    "StubDeclarationPayload",
+    "SurfacePayload",
+    "TriggerKind",
+    "TriggerPayload",
+    "TypedFieldSpec",
+    "WorkflowPayload",
+    "WorkflowStartupMode",
+    "build_semantic_payload",
+    "parse_semantic_payload",
+    "semantic_payload_ref",
+    "validate_semantic_graph_v2_payload_closure",
+]

--- a/mozaiksai/core/semantics/refs.py
+++ b/mozaiksai/core/semantics/refs.py
@@ -21,6 +21,7 @@ from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_gramma
 _HEX_DIGEST = re.compile(r"^[0-9a-f]{64}$")
 _IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _PATH_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_NODE_ID = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$")
 
 #: Mutable-alias identifiers that must never masquerade as immutable identity.
 MUTABLE_ALIASES = frozenset({"latest", "current", "head", "tip", "newest"})
@@ -52,6 +53,18 @@ def _validate_digest(value: str, *, field_name: str) -> str:
     return text
 
 
+def validate_node_id_grammar(value: str) -> str:
+    """Shared semantic-graph node-id grammar (used by graph v1/v2 and payload refs)."""
+    text = str(value or "").strip()
+    if _NODE_ID.fullmatch(text) is None:
+        raise ValueError(
+            f"node_id must be a namespace-qualified lowercase dotted identifier, got {value!r}"
+        )
+    if text.split(".", 1)[0] in MUTABLE_ALIASES:
+        raise ValueError(f"node_id namespace must be immutable identity, got {text!r}")
+    return text
+
+
 class RefDocumentType(StrEnum):
     """The document type a reference expects its subject to be."""
 
@@ -64,6 +77,7 @@ class RefDocumentType(StrEnum):
     ARTIFACT_REVISION = "artifact_revision"
     CHILD_CONTRACT = "child_contract"
     TAXONOMY_NAMESPACE = "taxonomy_namespace"
+    SEMANTIC_PAYLOAD = "semantic_payload"
 
 
 class ExecutionAccessScopeRef(SemanticsModel):
@@ -213,6 +227,58 @@ class ChildContractRef(_ScopedRef):
         return text
 
 
+class SemanticPayloadRef(SemanticsModel):
+    """Typed reference pinning one node's semantic payload by full identity.
+
+    Node ids are dotted, so this is a sibling of :class:`_ScopedRef` (whose
+    ``subject_id`` grammar has no namespace qualification), not a subclass.  It
+    still carries the complete identity quartet plus the payload kind: node id,
+    payload kind, immutable payload version, content digest, and owning scope.
+    Path independence is by construction — no storage locator field exists.
+    """
+
+    document_type: ClassVar[RefDocumentType] = RefDocumentType.SEMANTIC_PAYLOAD
+    ref_schema_version: Literal["mozaiks.semantic_payload_ref.v1"] = (
+        "mozaiks.semantic_payload_ref.v1"
+    )
+    node_id: str
+    payload_kind: str
+    payload_version: int = Field(ge=1, strict=True)
+    content_digest: str
+    scope: ExecutionAccessScopeRef
+
+    @field_validator("node_id")
+    @classmethod
+    def _node_id(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("payload_kind")
+    @classmethod
+    def _payload_kind(cls, value: str) -> str:
+        # Deferred import: graph.py imports this module at top level, so the
+        # closed node-kind set is resolved lazily rather than creating a cycle.
+        from mozaiksai.core.semantics.graph import SemanticNodeKind
+
+        try:
+            return SemanticNodeKind(str(value or "").strip()).value
+        except ValueError as exc:
+            raise ValueError(f"payload_kind must be a semantic node kind, got {value!r}") from exc
+
+    @field_validator("content_digest")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="content_digest")
+
+    @property
+    def identity_payload(self) -> dict[str, object]:
+        """Identity contribution pinned into a graph-v2 node (Merkle leaf)."""
+        return {
+            "payload_kind": self.payload_kind,
+            "payload_version": self.payload_version,
+            "content_digest": self.content_digest,
+        }
+
+
 class TaxonomyNamespaceRef(SemanticsModel):
     """Unscoped registry reference pinning namespace identifier, version, digest."""
 
@@ -252,7 +318,9 @@ __all__ = [
     "RefDocumentType",
     "RefinementPatchRef",
     "SemanticGraphRef",
+    "SemanticPayloadRef",
     "SemanticRefError",
     "SemanticsModel",
     "TaxonomyNamespaceRef",
+    "validate_node_id_grammar",
 ]

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -15,7 +15,7 @@ from typing import Any
 from mozaiksai.core.semantics.binding import ImplementationBinding
 from mozaiksai.core.semantics.graph import SemanticGraph, SemanticGraphV2
 from mozaiksai.core.semantics.manifest import ApplicationManifest
-from mozaiksai.core.semantics.payloads import SemanticPayloadBase
+from mozaiksai.core.semantics.payloads import SemanticPayloadBase, parse_semantic_payload
 from mozaiksai.core.semantics.refs import (
     ApplicationManifestRef,
     ArtifactRevisionRef,
@@ -114,14 +114,20 @@ class SemanticReferenceResolver:
         cross-scope reuse is impossible because resolution re-verifies the
         node binding and scope.
         """
+        try:
+            verified = parse_semantic_payload(payload.model_dump(mode="json"))
+        except (TypeError, ValueError) as exc:
+            raise ReferenceResolutionError(
+                f"semantic payload failed cold validation: {exc}"
+            ) from exc
         self._register(
             _Subject(
                 kind=RefDocumentType.SEMANTIC_PAYLOAD,
-                subject_id=payload.node_id,
-                version=payload.payload_version,
-                digest=payload.payload_digest,
-                scope=payload.scope,
-                content=payload,
+                subject_id=verified.node_id,
+                version=verified.payload_version,
+                digest=verified.payload_digest,
+                scope=verified.scope,
+                content=verified,
             )
         )
 
@@ -173,16 +179,22 @@ class SemanticReferenceResolver:
         there is no partial registration and no "current"/latest payload
         lookup anywhere; resolution is by full identity only.
         """
-        for node in graph.nodes:
-            self.resolve_semantic_payload(node.payload_ref, requesting_scope=graph.scope)
+        try:
+            verified = SemanticGraphV2.model_validate(graph.model_dump(mode="json"))
+        except (TypeError, ValueError) as exc:
+            raise ReferenceResolutionError(
+                f"semantic graph v2 failed cold validation: {exc}"
+            ) from exc
+        for node in verified.nodes:
+            self.resolve_semantic_payload(node.payload_ref, requesting_scope=verified.scope)
         self._register(
             _Subject(
                 kind=RefDocumentType.SEMANTIC_GRAPH,
-                subject_id=graph.graph_id,
-                version=graph.version,
-                digest=graph.graph_digest,
-                scope=graph.scope,
-                content=graph,
+                subject_id=verified.graph_id,
+                version=verified.version,
+                digest=verified.graph_digest,
+                scope=verified.scope,
+                content=verified,
             )
         )
 

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -13,8 +13,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from mozaiksai.core.semantics.binding import ImplementationBinding
-from mozaiksai.core.semantics.graph import SemanticGraph
+from mozaiksai.core.semantics.graph import SemanticGraph, SemanticGraphV2
 from mozaiksai.core.semantics.manifest import ApplicationManifest
+from mozaiksai.core.semantics.payloads import SemanticPayloadBase
 from mozaiksai.core.semantics.refs import (
     ApplicationManifestRef,
     ArtifactRevisionRef,
@@ -24,6 +25,7 @@ from mozaiksai.core.semantics.refs import (
     ExecutionAccessScopeRef,
     RefDocumentType,
     RefinementPatchRef,
+    SemanticPayloadRef,
     TaxonomyNamespaceRef,
     _ScopedRef,
 )
@@ -104,6 +106,86 @@ class SemanticReferenceResolver:
             )
         )
 
+    def register_semantic_payload(self, payload: SemanticPayloadBase) -> None:
+        """Register one typed payload as an immutable content-bearing subject.
+
+        Identity is (node_id, payload_version); re-registration fails closed.
+        Many graph versions may pin one registered payload; cross-node or
+        cross-scope reuse is impossible because resolution re-verifies the
+        node binding and scope.
+        """
+        self._register(
+            _Subject(
+                kind=RefDocumentType.SEMANTIC_PAYLOAD,
+                subject_id=payload.node_id,
+                version=payload.payload_version,
+                digest=payload.payload_digest,
+                scope=payload.scope,
+                content=payload,
+            )
+        )
+
+    def resolve_semantic_payload(
+        self, ref: SemanticPayloadRef, *, requesting_scope: ExecutionAccessScopeRef
+    ) -> SemanticPayloadBase:
+        """Verify document type, node binding, kind, version, digest, and scope."""
+        subject = self._subjects.get((ref.node_id, ref.payload_version))
+        if subject is None:
+            raise ReferenceResolutionError(
+                f"no semantic payload for node {ref.node_id!r} at immutable version "
+                f"{ref.payload_version}; refs never fall back to another version"
+            )
+        if subject.kind is not RefDocumentType.SEMANTIC_PAYLOAD:
+            raise ReferenceResolutionError(
+                f"document type mismatch: ref expects semantic_payload, "
+                f"stored subject is {subject.kind.value!r}"
+            )
+        if subject.digest != ref.content_digest:
+            raise ReferenceResolutionError(
+                f"content digest mismatch for payload of node {ref.node_id!r} "
+                f"version {ref.payload_version}"
+            )
+        if subject.scope != ref.scope:
+            raise ReferenceResolutionError(
+                f"scope mismatch: ref scope does not own payload of node {ref.node_id!r}"
+            )
+        if requesting_scope != subject.scope:
+            raise ReferenceResolutionError(
+                f"cross-scope access to payload of node {ref.node_id!r} fails closed"
+            )
+        payload = subject.content
+        if not isinstance(payload, SemanticPayloadBase):
+            raise ReferenceResolutionError(
+                f"subject for node {ref.node_id!r} did not resolve to a semantic payload"
+            )
+        kind = getattr(payload, "payload_kind", None)
+        if getattr(kind, "value", None) != ref.payload_kind:
+            raise ReferenceResolutionError(
+                f"payload kind mismatch for node {ref.node_id!r}: ref expects "
+                f"{ref.payload_kind!r}"
+            )
+        return payload
+
+    def register_semantic_graph_v2(self, graph: SemanticGraphV2) -> None:
+        """Register a v2 graph only after its complete payload closure resolves.
+
+        Every pinned payload reference must already resolve in this store —
+        there is no partial registration and no "current"/latest payload
+        lookup anywhere; resolution is by full identity only.
+        """
+        for node in graph.nodes:
+            self.resolve_semantic_payload(node.payload_ref, requesting_scope=graph.scope)
+        self._register(
+            _Subject(
+                kind=RefDocumentType.SEMANTIC_GRAPH,
+                subject_id=graph.graph_id,
+                version=graph.version,
+                digest=graph.graph_digest,
+                scope=graph.scope,
+                content=graph,
+            )
+        )
+
     def register_taxonomy_namespace(self, namespace: TaxonomyNamespace, digest: str) -> None:
         ref = TaxonomyNamespaceRef(
             namespace_id=namespace.namespace_id,
@@ -138,6 +220,7 @@ class SemanticReferenceResolver:
             RefDocumentType.APPLICATION_MANIFEST,
             RefDocumentType.IMPLEMENTATION_BINDING,
             RefDocumentType.TAXONOMY_NAMESPACE,
+            RefDocumentType.SEMANTIC_PAYLOAD,
         }:
             raise ReferenceResolutionError(
                 f"{kind.value} is content-bearing in this slice; register its document"

--- a/mozaiksai/core/stub_kinds.py
+++ b/mozaiksai/core/stub_kinds.py
@@ -1,0 +1,18 @@
+"""Shared leaf contract for bounded customization-stub kinds.
+
+The semantic compiler and application layout registry both consume this
+closed vocabulary.  Keeping it in a dependency-free leaf prevents either
+layer from becoming a second authority or importing the other subsystem.
+"""
+
+from enum import StrEnum
+
+
+class StubKind(StrEnum):
+    """Bounded customization stub kinds a family may reference."""
+
+    PYTHON_BACKEND = "python_backend"
+    JS_FRONTEND = "js_frontend"
+
+
+__all__ = ["StubKind"]

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -8,11 +8,11 @@ immutability, binding non-authority, and no capability advertisement.
 
 from __future__ import annotations
 
+import ast
 import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import get_args
 
 import pytest
 from pydantic import ValidationError
@@ -83,6 +83,7 @@ from mozaiksai.core.semantics.resolver import (
     ReferenceResolutionError,
     SemanticReferenceResolver,
 )
+from mozaiksai.core.stub_kinds import StubKind
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -369,11 +370,10 @@ def test_union_rejects_kind_content_mismatch() -> None:
         parse_semantic_payload(document)
 
 
-def test_stub_kind_literal_mirrors_layout_registry_enum() -> None:
-    from mozaiksai.core.runtime.app.layout_registry import StubKind
-    from mozaiksai.core.semantics.payloads import StubKindLiteral
+def test_stub_kind_has_one_shared_leaf_authority() -> None:
+    from mozaiksai.core.runtime.app.layout_registry import StubKind as LayoutStubKind
 
-    assert set(get_args(StubKindLiteral)) == {kind.value for kind in StubKind}
+    assert LayoutStubKind is StubKind
 
 
 # ---------------------------------------------------------------------------
@@ -499,6 +499,39 @@ def test_digest_tampering_fails_closed() -> None:
     with pytest.raises(ValidationError, match="payload_digest does not match"):
         parse_semantic_payload(document)
 
+
+def test_forged_frozen_model_copies_fail_cold_validation_before_registration() -> None:
+    graph, payloads = _corpus_graph()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    forged_page = page.model_copy(update={"title": "Forged"})
+    resolver = SemanticReferenceResolver()
+
+    with pytest.raises(ReferenceResolutionError, match="cold validation"):
+        resolver.register_semantic_payload(forged_page)
+    resolver.register_semantic_payload(page)  # failed registration did not mutate the store
+    for payload in payloads:
+        if payload is not page:
+            resolver.register_semantic_payload(payload)
+
+    forged_graph = graph.model_copy(update={"graph_digest": "f" * 64})
+    with pytest.raises(ReferenceResolutionError, match="cold validation"):
+        resolver.register_semantic_graph_v2(forged_graph)
+    resolver.register_semantic_graph_v2(graph)  # failed registration did not mutate the store
+
+
+def test_payload_closure_cold_validates_frozen_model_copies() -> None:
+    graph, payloads = _corpus_graph()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    forged_payloads = [
+        page.model_copy(update={"title": "Forged"}) if payload is page else payload
+        for payload in payloads
+    ]
+    with pytest.raises(SemanticPayloadError, match="payload failed cold validation"):
+        validate_semantic_graph_v2_payload_closure(graph, forged_payloads)
+
+    forged_graph = graph.model_copy(update={"graph_digest": "f" * 64})
+    with pytest.raises(SemanticPayloadError, match="graph v2 failed cold validation"):
+        validate_semantic_graph_v2_payload_closure(forged_graph, payloads)
 
 def test_duplicate_identity_fails_closed() -> None:
     resolver, graph, payloads = _registered_resolver()
@@ -740,6 +773,8 @@ def test_prices_are_integer_minor_units_never_floats() -> None:
         PriceSpec(amount_minor_units=19.99, currency="USD", period=BillingPeriod.MONTHLY)
     with pytest.raises(ValidationError, match="currency"):
         PriceSpec(amount_minor_units=1900, currency="usd", period=BillingPeriod.MONTHLY)
+    with pytest.raises(ValidationError, match="ISO-4217"):
+        PriceSpec(amount_minor_units=1900, currency="ZZZ", period=BillingPeriod.MONTHLY)
 
 
 def test_ordering_permutations_do_not_change_digests() -> None:
@@ -757,6 +792,41 @@ def test_ordering_permutations_do_not_change_digests() -> None:
     assert [entry.section_node_id for entry in permuted.sections] == [
         entry.section_node_id for entry in base.sections
     ]
+
+
+def test_meaningful_order_changes_identity_and_invalid_positions_fail_closed() -> None:
+    base = _corpus_payloads()[SemanticNodeKind.PAGE]
+    reordered = build_semantic_payload(
+        PagePayload,
+        node_id=base.node_id,
+        payload_version=base.payload_version,
+        scope=base.scope,
+        title=base.title,
+        intent=base.intent,
+        sections=tuple(
+            entry.model_copy(update={"position": 1 - entry.position})
+            for entry in base.sections
+        ),
+    )
+    assert reordered.payload_digest != base.payload_digest
+    assert [entry.section_node_id for entry in reordered.sections] == list(
+        reversed([entry.section_node_id for entry in base.sections])
+    )
+
+    for positions in ((0, 0), (0, 2), (-1, 0)):
+        with pytest.raises(ValidationError, match="position"):
+            build_semantic_payload(
+                PagePayload,
+                node_id=base.node_id,
+                payload_version=base.payload_version,
+                scope=base.scope,
+                title=base.title,
+                intent=base.intent,
+                sections=tuple(
+                    entry.model_copy(update={"position": position})
+                    for entry, position in zip(base.sections, positions, strict=True)
+                ),
+            )
 
 
 def test_payloads_and_v2_nodes_are_frozen() -> None:
@@ -807,22 +877,90 @@ def test_production_sources_do_not_import_payloads_or_v2_symbols() -> None:
         Path("mozaiksai/core/semantics/resolver.py"),
         Path("tests/test_semantic_payload_graph_v2.py"),
     }
-    markers = (
-        "semantics.payloads",
+    forbidden_modules = {"mozaiksai.core.semantics.payloads"}
+    forbidden_symbols = {
         "SemanticGraphV2",
         "SemanticNodeV2",
         "SemanticPayloadRef",
-        "semantic_payload",
-    )
-    roots = [ROOT / "mozaiksai", ROOT / "factory_app"]
-    for root in roots:
-        for path in root.rglob("*.py"):
-            relative = path.relative_to(ROOT)
-            if relative in excluded:
-                continue
-            text = path.read_text(encoding="utf-8")
-            if any(marker in text for marker in markers):
+        "parse_semantic_payload",
+        "register_semantic_payload",
+        "resolve_semantic_payload",
+        "semantic_payload_ref",
+        "validate_semantic_graph_v2_payload_closure",
+    }
+
+    def constant_string(node: ast.AST) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left = constant_string(node.left)
+            right = constant_string(node.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", "*.py", "*.pyi"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    for relative_text in tracked:
+        relative = Path(relative_text)
+        if relative in excluded or "tests" in relative.parts:
+            continue
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=relative_text)
+        except SyntaxError:
+            # Tracked generator templates may contain contract placeholders
+            # that become Python only after rendering.  They still receive a
+            # direct string-access scan rather than disappearing from proof.
+            if any(marker in source for marker in forbidden_modules | forbidden_symbols):
                 offenders.append(relative.as_posix())
+            continue
+        for node in ast.walk(tree):
+            resolved_string = constant_string(node)
+            if resolved_string in forbidden_modules | forbidden_symbols:
+                offenders.append(relative.as_posix())
+            if isinstance(node, ast.Import):
+                if any(alias.name in forbidden_modules for alias in node.names):
+                    offenders.append(relative.as_posix())
+            elif isinstance(node, ast.ImportFrom):
+                if node.module in forbidden_modules or any(
+                    alias.name == "*" or alias.name in forbidden_symbols
+                    for alias in node.names
+                    if node.module in {
+                        "mozaiksai.core.semantics",
+                        "mozaiksai.core.semantics.graph",
+                        "mozaiksai.core.semantics.refs",
+                        "mozaiksai.core.semantics.resolver",
+                    }
+                ):
+                    offenders.append(relative.as_posix())
+            elif isinstance(node, ast.Call) and node.args:
+                target = constant_string(node.args[0])
+                if target in forbidden_modules:
+                    offenders.append(relative.as_posix())
+            elif isinstance(node, ast.Attribute) and node.attr in forbidden_symbols:
+                offenders.append(relative.as_posix())
+            elif isinstance(node, ast.Name) and node.id in forbidden_symbols:
+                offenders.append(relative.as_posix())
+    declarative = subprocess.run(
+        ["git", "ls-files", "--", "*.json", "*.toml", "*.yaml", "*.yml"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    for relative_text in declarative:
+        relative = Path(relative_text)
+        if "tests" in relative.parts:
+            continue
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        if any(marker in source for marker in forbidden_modules | forbidden_symbols):
+            offenders.append(relative.as_posix())
     assert offenders == []
 
 

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -623,28 +623,43 @@ def test_forged_payload_axes_fail_cold_validation_atomically(construction: str) 
 
     invalid_sections = tuple(forge(entry, position=0) for entry in page.sections)
     cases = {
-        "stale digest": forge(page, title="Forged"),
-        "invalid field": forge(page, title=""),
-        "invalid ordering": forge(page, sections=invalid_sections),
-        "wrong kind": forge(page, payload_kind=SemanticNodeKind.MODULE),
-        "wrong node": forge(page, node_id="mozaiks.page.other"),
-        "wrong version": forge(page, payload_version=2),
-        "wrong scope": forge(page, scope=_OTHER_SCOPE),
+        "stale digest": (forge(page, title="Forged"), "payload_digest does not match"),
+        "invalid field": (forge(page, title=""), "title must be non-empty text"),
+        "invalid ordering": (
+            forge(page, sections=invalid_sections),
+            "sections positions must be dense",
+        ),
+        "wrong kind": (
+            forge(page, payload_kind=SemanticNodeKind.MODULE),
+            "Extra inputs are not permitted",
+        ),
+        "wrong node": (
+            forge(page, node_id="mozaiks.page.other"),
+            "payload_digest does not match",
+        ),
+        "wrong version": (
+            forge(page, payload_version=2),
+            "payload_digest does not match",
+        ),
+        "wrong scope": (
+            forge(page, scope=_OTHER_SCOPE),
+            "payload_digest does not match",
+        ),
     }
 
-    for label, forged_page in cases.items():
+    sentinel = next(payload for payload in payloads if payload is not page)
+    for label, (forged_page, match) in cases.items():
         resolver = SemanticReferenceResolver()
+        resolver.register_semantic_payload(sentinel)
         before = resolver._subjects.copy()
-        with pytest.raises(ReferenceResolutionError, match="cold validation"):
+        with pytest.raises(ReferenceResolutionError, match=match):
             resolver.register_semantic_payload(forged_page)
         assert resolver._subjects == before, label
-
-    resolver = SemanticReferenceResolver()
-    resolver.register_semantic_payload(page)
-    resolved = resolver.resolve_semantic_payload(
-        semantic_payload_ref(page), requesting_scope=page.scope
-    )
-    assert resolved.model_dump(mode="json") == page.model_dump(mode="json")
+        resolver.register_semantic_payload(page)
+        resolved = resolver.resolve_semantic_payload(
+            semantic_payload_ref(page), requesting_scope=page.scope
+        )
+        assert resolved.model_dump(mode="json") == page.model_dump(mode="json")
 
 
 @pytest.mark.parametrize("construction", ["model_copy", "model_construct"])
@@ -725,10 +740,16 @@ def test_payload_closure_cold_validates_payloads_graphs_and_nested_nodes(
 def test_duplicate_identity_fails_closed() -> None:
     resolver, graph, payloads = _registered_resolver()
     page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    before = resolver._subjects.copy()
     with pytest.raises(ReferenceResolutionError, match="immutable"):
         resolver.register_semantic_payload(page)
+    assert resolver._subjects == before
+
+    before = resolver._subjects.copy()
     with pytest.raises(ReferenceResolutionError, match="immutable"):
         resolver.register_semantic_graph_v2(graph)
+    assert resolver._subjects == before
+
     with pytest.raises(SemanticPayloadError, match="duplicate payload supplied"):
         validate_semantic_graph_v2_payload_closure(graph, [*payloads, page])
 

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -1,0 +1,832 @@
+"""ADR 0007 Slice 2E proof gate: typed payloads + Merkle-rooted graph v2.
+
+Adversarial matrix: kind closure, node/scope/type substitution, version
+drift, digest tampering, duplicate identity, Merkle-root chain, payload
+reuse, v1-shape rejection, partial closure, deterministic bytes,
+immutability, binding non-authority, and no capability advertisement.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import get_args
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.archive import (
+    ArchiveEntry,
+    archive_digest,
+    build_deterministic_archive,
+)
+from mozaiksai.core.semantics.binding import ImplementationBinding
+from mozaiksai.core.semantics.capabilities import advertised_semantic_compiler_capabilities
+from mozaiksai.core.semantics.graph import (
+    SEMANTIC_GRAPH_V2_SCHEMA_VERSION,
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraphV2,
+    SemanticNodeKind,
+    SemanticNodeV2,
+    build_semantic_graph,
+    build_semantic_graph_v2,
+)
+from mozaiksai.core.semantics.payloads import (
+    PAYLOAD_MODEL_BY_KIND,
+    ActionPayload,
+    BillingPeriod,
+    CapabilityPayload,
+    DataAliasPayload,
+    DataCollectionPayload,
+    DeploymentTargetKind,
+    DeploymentTargetPayload,
+    EventPayload,
+    FieldType,
+    IndexSpec,
+    LimitPayload,
+    MeterPayload,
+    ModulePayload,
+    NotificationChannel,
+    NotificationPayload,
+    PagePayload,
+    PageSectionEntry,
+    PermissionPayload,
+    PlanPayload,
+    PriceSpec,
+    ProductPayload,
+    ReactionPayload,
+    SectionContentEntry,
+    SectionEntryKind,
+    SectionPayload,
+    SemanticPayloadBase,
+    SemanticPayloadError,
+    StubDeclarationPayload,
+    SurfacePayload,
+    TriggerKind,
+    TriggerPayload,
+    TypedFieldSpec,
+    WorkflowPayload,
+    WorkflowStartupMode,
+    build_semantic_payload,
+    parse_semantic_payload,
+    semantic_payload_ref,
+    validate_semantic_graph_v2_payload_closure,
+)
+from mozaiksai.core.semantics.refs import (
+    ExecutionAccessScopeRef,
+    SemanticPayloadRef,
+)
+from mozaiksai.core.semantics.resolver import (
+    ReferenceResolutionError,
+    SemanticReferenceResolver,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
+_OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
+
+# Golden Merkle-root vector: pinned digests for the full-corpus v2 graph and
+# its archived fixture.  Independent of host, process, and input order.
+_GOLDEN_GRAPH_DIGEST = "a4eaa86709134dc5677a0b67b99e00a02b0cedfa4b45d39e37ade35f4f8b85f4"
+_GOLDEN_ARCHIVE_DIGEST = "sha256:53b569a6c62e9ae4c1ce0bed9b86cd2eed5a18147f5bdb531cd763c7bafff20b"
+
+
+def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str = "Home"):
+    """One payload of every kind, so kind closure is exercised end to end."""
+    field = TypedFieldSpec(name="name", field_type=FieldType.STRING, required=True)
+    return {
+        SemanticNodeKind.SURFACE: build_semantic_payload(
+            SurfacePayload,
+            node_id="mozaiks.surface.web",
+            payload_version=1,
+            scope=scope,
+            description="Primary web surface",
+        ),
+        SemanticNodeKind.PAGE: build_semantic_payload(
+            PagePayload,
+            node_id="mozaiks.page.home",
+            payload_version=1,
+            scope=scope,
+            title=home_title,
+            intent="Landing page",
+            sections=(
+                PageSectionEntry(position=1, section_node_id="mozaiks.section.pricing"),
+                PageSectionEntry(position=0, section_node_id="mozaiks.section.hero"),
+            ),
+        ),
+        SemanticNodeKind.SECTION: build_semantic_payload(
+            SectionPayload,
+            node_id="mozaiks.section.hero",
+            payload_version=1,
+            scope=scope,
+            title="Hero",
+            intent="Welcome banner",
+            entries=(
+                SectionContentEntry(
+                    position=0, entry_kind=SectionEntryKind.TEXT, text="Welcome"
+                ),
+                SectionContentEntry(
+                    position=1,
+                    entry_kind=SectionEntryKind.API_BINDING,
+                    api_method="GET",
+                    api_path="/api/status",
+                ),
+            ),
+        ),
+        SemanticNodeKind.MODULE: build_semantic_payload(
+            ModulePayload,
+            node_id="mozaiks.module.reports",
+            payload_version=1,
+            scope=scope,
+            description="Reporting module",
+        ),
+        SemanticNodeKind.ACTION: build_semantic_payload(
+            ActionPayload,
+            node_id="mozaiks.action.create_report",
+            payload_version=1,
+            scope=scope,
+            description="Create one report",
+            request_fields=(field,),
+            response_fields=(
+                TypedFieldSpec(name="report_id", field_type=FieldType.REFERENCE, required=True),
+            ),
+            emits=("reports.report_created",),
+            entitlement_gate="reports.premium",
+        ),
+        SemanticNodeKind.CAPABILITY: build_semantic_payload(
+            CapabilityPayload,
+            node_id="mozaiks.capability.reporting",
+            payload_version=1,
+            scope=scope,
+            description="Reporting capability",
+        ),
+        SemanticNodeKind.PERMISSION: build_semantic_payload(
+            PermissionPayload,
+            node_id="mozaiks.permission.report_admin",
+            payload_version=1,
+            scope=scope,
+            description="Administer reports",
+        ),
+        SemanticNodeKind.EVENT: build_semantic_payload(
+            EventPayload,
+            node_id="mozaiks.event.report_created",
+            payload_version=1,
+            scope=scope,
+            description="A report was created",
+            payload_fields=(field,),
+        ),
+        SemanticNodeKind.REACTION: build_semantic_payload(
+            ReactionPayload,
+            node_id="mozaiks.reaction.notify_owner",
+            payload_version=1,
+            scope=scope,
+            description="Notify the owner",
+            consumed_event="reports.report_created",
+        ),
+        SemanticNodeKind.NOTIFICATION: build_semantic_payload(
+            NotificationPayload,
+            node_id="mozaiks.notification.report_ready",
+            payload_version=1,
+            scope=scope,
+            template_text="Your report is ready",
+            channel=NotificationChannel.IN_APP,
+        ),
+        SemanticNodeKind.DATA_COLLECTION: build_semantic_payload(
+            DataCollectionPayload,
+            node_id="mozaiks.data.reports",
+            payload_version=1,
+            scope=scope,
+            description="Report documents",
+            fields=(
+                field,
+                TypedFieldSpec(name="created_at", field_type=FieldType.DATETIME, required=True),
+            ),
+            indexes=(IndexSpec(name="by_name", field_names=("name",), unique=False),),
+        ),
+        SemanticNodeKind.DATA_ALIAS: build_semantic_payload(
+            DataAliasPayload,
+            node_id="mozaiks.alias.reports",
+            payload_version=1,
+            scope=scope,
+            alias="reports",
+            collection="report_documents",
+            owner_node_id="mozaiks.module.reports",
+        ),
+        SemanticNodeKind.WORKFLOW: build_semantic_payload(
+            WorkflowPayload,
+            node_id="mozaiks.workflow.digest",
+            payload_version=1,
+            scope=scope,
+            description="Weekly digest workflow",
+            startup_mode=WorkflowStartupMode.EVENT_DRIVEN,
+        ),
+        SemanticNodeKind.TRIGGER: build_semantic_payload(
+            TriggerPayload,
+            node_id="mozaiks.trigger.on_report",
+            payload_version=1,
+            scope=scope,
+            description="Start on report creation",
+            trigger_kind=TriggerKind.EVENT,
+            event_id="reports.report_created",
+        ),
+        SemanticNodeKind.PLAN: build_semantic_payload(
+            PlanPayload,
+            node_id="mozaiks.plan.pro",
+            payload_version=1,
+            scope=scope,
+            title="Pro",
+            prices=(
+                PriceSpec(amount_minor_units=1900, currency="USD", period=BillingPeriod.MONTHLY),
+            ),
+            granted_capabilities=("reports.premium",),
+        ),
+        SemanticNodeKind.PRODUCT: build_semantic_payload(
+            ProductPayload,
+            node_id="mozaiks.product.addon",
+            payload_version=1,
+            scope=scope,
+            title="Add-on",
+            description="Extra seats",
+            prices=(
+                PriceSpec(amount_minor_units=500, currency="USD", period=BillingPeriod.ONE_TIME),
+            ),
+        ),
+        SemanticNodeKind.METER: build_semantic_payload(
+            MeterPayload,
+            node_id="mozaiks.meter.report_runs",
+            payload_version=1,
+            scope=scope,
+            description="Report executions",
+            unit="runs",
+        ),
+        SemanticNodeKind.LIMIT: build_semantic_payload(
+            LimitPayload,
+            node_id="mozaiks.limit.report_runs",
+            payload_version=1,
+            scope=scope,
+            description="Monthly run cap",
+            limit_value=100,
+            period=BillingPeriod.MONTHLY,
+        ),
+        SemanticNodeKind.DEPLOYMENT_TARGET: build_semantic_payload(
+            DeploymentTargetPayload,
+            node_id="mozaiks.deploy.container",
+            payload_version=1,
+            scope=scope,
+            target_kind=DeploymentTargetKind.CONTAINER,
+            profile_id="generic_container",
+            output_hints=("Dockerfile", "docker-compose.yml"),
+        ),
+        SemanticNodeKind.STUB_DECLARATION: build_semantic_payload(
+            StubDeclarationPayload,
+            node_id="mozaiks.stub.report_hook",
+            payload_version=1,
+            scope=scope,
+            stub_kind="python_backend",
+            path="modules/reports/backend/hooks.py",
+            entrypoint="on_report_created",
+        ),
+    }
+
+
+def _pricing_section(scope: ExecutionAccessScopeRef = _SCOPE) -> SectionPayload:
+    return build_semantic_payload(
+        SectionPayload,
+        node_id="mozaiks.section.pricing",
+        payload_version=1,
+        scope=scope,
+        title="Pricing",
+        intent="Plans overview",
+    )
+
+
+def _corpus_graph(
+    *, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str = "Home"
+) -> tuple[SemanticGraphV2, list[SemanticPayloadBase]]:
+    payloads = list(_corpus_payloads(scope=scope, home_title=home_title).values())
+    payloads.append(_pricing_section(scope))
+    nodes = [
+        SemanticNodeV2(
+            node_id=payload.node_id,
+            kind=payload.payload_kind,
+            payload_ref=semantic_payload_ref(payload),
+        )
+        for payload in payloads
+    ]
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.RENDERS,
+            source_node_id="mozaiks.page.home",
+            target_node_id="mozaiks.section.hero",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.action.create_report",
+            target_node_id="mozaiks.event.report_created",
+        ),
+    ]
+    graph = build_semantic_graph_v2(
+        graph_id="corpus-app",
+        version=1,
+        scope=scope,
+        nodes=nodes,
+        edges=edges,
+    )
+    return graph, payloads
+
+
+# ---------------------------------------------------------------------------
+# Kind closure
+# ---------------------------------------------------------------------------
+
+
+def test_every_node_kind_has_exactly_one_payload_variant() -> None:
+    assert set(PAYLOAD_MODEL_BY_KIND) == set(SemanticNodeKind)
+    models = list(PAYLOAD_MODEL_BY_KIND.values())
+    assert len(models) == len(set(models)), "one variant must not serve two kinds"
+    for kind, model in PAYLOAD_MODEL_BY_KIND.items():
+        assert model.model_fields["payload_kind"].default is kind
+
+
+@pytest.mark.parametrize("kind", list(SemanticNodeKind))
+def test_each_kind_round_trips_through_the_discriminated_union(
+    kind: SemanticNodeKind,
+) -> None:
+    payload = _corpus_payloads()[kind]
+    parsed = parse_semantic_payload(json.loads(json.dumps(payload.model_dump(mode="json"))))
+    assert type(parsed) is PAYLOAD_MODEL_BY_KIND[kind]
+    assert parsed == payload
+
+
+def test_union_rejects_kind_content_mismatch() -> None:
+    document = _corpus_payloads()[SemanticNodeKind.PAGE].model_dump(mode="json")
+    document["payload_kind"] = "module"  # page content under module discriminant
+    with pytest.raises(ValidationError):
+        parse_semantic_payload(document)
+
+
+def test_stub_kind_literal_mirrors_layout_registry_enum() -> None:
+    from mozaiksai.core.runtime.app.layout_registry import StubKind
+    from mozaiksai.core.semantics.payloads import StubKindLiteral
+
+    assert set(get_args(StubKindLiteral)) == {kind.value for kind in StubKind}
+
+
+# ---------------------------------------------------------------------------
+# Substitution, drift, tampering, duplicates
+# ---------------------------------------------------------------------------
+
+
+def _registered_resolver() -> tuple[SemanticReferenceResolver, SemanticGraphV2, list]:
+    graph, payloads = _corpus_graph()
+    resolver = SemanticReferenceResolver()
+    for payload in payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(graph)
+    return resolver, graph, payloads
+
+
+def test_node_substitution_fails_closed() -> None:
+    resolver, _graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    wrong_node = SemanticPayloadRef(
+        node_id="mozaiks.page.other",
+        payload_kind="page",
+        payload_version=page.payload_version,
+        content_digest=page.payload_digest,
+        scope=page.scope,
+    )
+    with pytest.raises(ReferenceResolutionError, match="no semantic payload"):
+        resolver.resolve_semantic_payload(wrong_node, requesting_scope=_SCOPE)
+    with pytest.raises(ValidationError, match="pins node"):
+        SemanticNodeV2(
+            node_id="mozaiks.page.home",
+            kind=SemanticNodeKind.PAGE,
+            payload_ref=wrong_node,
+        )
+
+
+def test_type_substitution_fails_closed() -> None:
+    resolver, _graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    wrong_kind = SemanticPayloadRef(
+        node_id=page.node_id,
+        payload_kind="module",
+        payload_version=page.payload_version,
+        content_digest=page.payload_digest,
+        scope=page.scope,
+    )
+    with pytest.raises(ReferenceResolutionError, match="kind mismatch"):
+        resolver.resolve_semantic_payload(wrong_kind, requesting_scope=_SCOPE)
+    with pytest.raises(ValidationError, match="does not match node kind"):
+        SemanticNodeV2(
+            node_id=page.node_id,
+            kind=SemanticNodeKind.MODULE,
+            payload_ref=semantic_payload_ref(page),
+        )
+
+
+def test_scope_substitution_fails_closed() -> None:
+    resolver, _graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    foreign = SemanticPayloadRef(
+        node_id=page.node_id,
+        payload_kind="page",
+        payload_version=page.payload_version,
+        content_digest=page.payload_digest,
+        scope=_OTHER_SCOPE,
+    )
+    with pytest.raises(ReferenceResolutionError, match="scope"):
+        resolver.resolve_semantic_payload(foreign, requesting_scope=_OTHER_SCOPE)
+    with pytest.raises(ReferenceResolutionError, match="cross-scope"):
+        resolver.resolve_semantic_payload(
+            semantic_payload_ref(page), requesting_scope=_OTHER_SCOPE
+        )
+    # A graph cannot even be constructed around a foreign-scope pin.
+    with pytest.raises(ValidationError, match="different scope"):
+        build_semantic_graph_v2(
+            graph_id="cross-scope",
+            version=1,
+            scope=_OTHER_SCOPE,
+            nodes=[
+                SemanticNodeV2(
+                    node_id=page.node_id,
+                    kind=SemanticNodeKind.PAGE,
+                    payload_ref=semantic_payload_ref(page),
+                )
+            ],
+        )
+
+
+def test_version_drift_fails_closed() -> None:
+    resolver, _graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    drifted = SemanticPayloadRef(
+        node_id=page.node_id,
+        payload_kind="page",
+        payload_version=2,
+        content_digest=page.payload_digest,
+        scope=page.scope,
+    )
+    with pytest.raises(ReferenceResolutionError, match="never fall back"):
+        resolver.resolve_semantic_payload(drifted, requesting_scope=_SCOPE)
+
+
+def test_digest_tampering_fails_closed() -> None:
+    resolver, _graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    tampered_ref = SemanticPayloadRef(
+        node_id=page.node_id,
+        payload_kind="page",
+        payload_version=page.payload_version,
+        content_digest="f" * 64,
+        scope=page.scope,
+    )
+    with pytest.raises(ReferenceResolutionError, match="digest mismatch"):
+        resolver.resolve_semantic_payload(tampered_ref, requesting_scope=_SCOPE)
+
+    document = page.model_dump(mode="json")
+    document["title"] = "Tampered"
+    with pytest.raises(ValidationError, match="payload_digest does not match"):
+        parse_semantic_payload(document)
+
+    document = page.model_dump(mode="json")
+    document["payload_digest"] = "f" * 64
+    with pytest.raises(ValidationError, match="payload_digest does not match"):
+        parse_semantic_payload(document)
+
+
+def test_duplicate_identity_fails_closed() -> None:
+    resolver, graph, payloads = _registered_resolver()
+    page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
+    with pytest.raises(ReferenceResolutionError, match="immutable"):
+        resolver.register_semantic_payload(page)
+    with pytest.raises(ReferenceResolutionError, match="immutable"):
+        resolver.register_semantic_graph_v2(graph)
+    with pytest.raises(SemanticPayloadError, match="duplicate payload supplied"):
+        validate_semantic_graph_v2_payload_closure(graph, [*payloads, page])
+
+
+# ---------------------------------------------------------------------------
+# Merkle root
+# ---------------------------------------------------------------------------
+
+
+def test_merkle_chain_payload_byte_change_reroots_the_graph() -> None:
+    graph, _payloads = _corpus_graph()
+    changed_graph, _changed = _corpus_graph(home_title="Home!")
+
+    original_page = graph.node("mozaiks.page.home")
+    changed_page = changed_graph.node("mozaiks.page.home")
+    # payload digest changes...
+    assert original_page.payload_ref.content_digest != changed_page.payload_ref.content_digest
+    # ...which changes the node identity payload...
+    assert original_page.identity_payload != changed_page.identity_payload
+    # ...which changes the graph digest (Merkle root).
+    assert graph.graph_digest != changed_graph.graph_digest
+    # Everything else about the two graphs is identical.
+    assert [n.node_id for n in graph.nodes] == [n.node_id for n in changed_graph.nodes]
+
+
+def test_stale_graph_digest_is_rejected() -> None:
+    graph, _payloads = _corpus_graph()
+    changed_graph, _changed = _corpus_graph(home_title="Home!")
+    stale = graph.model_dump(mode="json")
+    stale["nodes"] = changed_graph.model_dump(mode="json")["nodes"]
+    with pytest.raises(ValidationError, match="graph_digest does not match"):
+        SemanticGraphV2.model_validate(stale)
+
+
+def test_golden_merkle_root_pinned_and_stable_across_processes() -> None:
+    graph, payloads = _corpus_graph()
+    assert graph.graph_digest == _GOLDEN_GRAPH_DIGEST
+
+    fixture = build_deterministic_archive(
+        [
+            ArchiveEntry(
+                path=f"payloads/{payload.node_id}.json",
+                content=json.dumps(
+                    payload.canonical_payload(), sort_keys=True, ensure_ascii=True
+                ).encode("ascii"),
+            )
+            for payload in payloads
+        ]
+        + [
+            ArchiveEntry(
+                path="graph.json",
+                content=json.dumps(
+                    graph.canonical_payload(), sort_keys=True, ensure_ascii=True
+                ).encode("ascii"),
+            )
+        ]
+    )
+    assert archive_digest(fixture) == _GOLDEN_ARCHIVE_DIGEST
+
+    probe = (
+        "import json\n"
+        "from tests.test_semantic_payload_graph_v2 import _corpus_graph\n"
+        "graph, _payloads = _corpus_graph()\n"
+        "print(graph.graph_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == _GOLDEN_GRAPH_DIGEST
+
+
+def test_archive_identity_is_transport_evidence_not_semantics() -> None:
+    """Archiving the fixture differently must not perturb graph identity."""
+    graph, payloads = _corpus_graph()
+    alternate = build_deterministic_archive(
+        [
+            ArchiveEntry(
+                path="bundle.json",
+                content=json.dumps(
+                    [payload.canonical_payload() for payload in payloads],
+                    sort_keys=True,
+                    ensure_ascii=True,
+                ).encode("ascii"),
+            )
+        ]
+    )
+    assert archive_digest(alternate) != _GOLDEN_ARCHIVE_DIGEST
+    assert graph.graph_digest == _GOLDEN_GRAPH_DIGEST
+
+
+# ---------------------------------------------------------------------------
+# Payload reuse across graph versions
+# ---------------------------------------------------------------------------
+
+
+def test_payload_reuse_across_graph_versions_of_one_scope() -> None:
+    graph, payloads = _corpus_graph()
+    resolver = SemanticReferenceResolver()
+    for payload in payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(graph)
+
+    successor = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=2,
+        scope=graph.scope,
+        nodes=graph.nodes,
+        edges=graph.edges,
+        namespace_grants=graph.namespace_grants,
+    )
+    resolver.register_semantic_graph_v2(successor)  # same payloads, no re-registration
+    assert successor.graph_digest != graph.graph_digest  # version participates
+
+
+def test_partial_closure_fails_closed() -> None:
+    graph, payloads = _corpus_graph()
+    resolver = SemanticReferenceResolver()
+    for payload in payloads[:-1]:  # one pinned payload missing
+        resolver.register_semantic_payload(payload)
+    with pytest.raises(ReferenceResolutionError, match="no semantic payload"):
+        resolver.register_semantic_graph_v2(graph)
+
+    with pytest.raises(SemanticPayloadError, match="not supplied"):
+        validate_semantic_graph_v2_payload_closure(graph, payloads[:-1])
+
+    unpinned = build_semantic_payload(
+        SurfacePayload,
+        node_id="mozaiks.surface.extra",
+        payload_version=1,
+        scope=_SCOPE,
+        description="Not pinned by the graph",
+    )
+    with pytest.raises(SemanticPayloadError, match="not pinned"):
+        validate_semantic_graph_v2_payload_closure(graph, [*payloads, unpinned])
+
+
+# ---------------------------------------------------------------------------
+# V1 shapes, strictness, determinism, immutability
+# ---------------------------------------------------------------------------
+
+
+def test_v1_graph_document_is_rejected_by_v2_model() -> None:
+    scope = _SCOPE
+    from mozaiksai.core.semantics.graph import SemanticNode
+
+    v1 = build_semantic_graph(
+        graph_id="v1-doc",
+        version=1,
+        scope=scope,
+        nodes=[SemanticNode(node_id="mozaiks.page.home", kind=SemanticNodeKind.PAGE)],
+    )
+    with pytest.raises(ValidationError):
+        SemanticGraphV2.model_validate(v1.model_dump(mode="json"))
+    assert SEMANTIC_GRAPH_V2_SCHEMA_VERSION != v1.schema_version
+
+
+def test_unknown_fields_and_untyped_shapes_are_rejected() -> None:
+    page = _corpus_payloads()[SemanticNodeKind.PAGE]
+    document = page.model_dump(mode="json")
+    document["extra_blob"] = {"anything": 1}
+    with pytest.raises(ValidationError):
+        parse_semantic_payload(document)
+
+
+@pytest.mark.parametrize(
+    ("model", "fields", "match"),
+    [
+        (
+            PagePayload,
+            {
+                "title": "T",
+                "intent": "I",
+                "sections": (
+                    PageSectionEntry(position=0, section_node_id="mozaiks.section.a"),
+                    PageSectionEntry(position=2, section_node_id="mozaiks.section.b"),
+                ),
+            },
+            "dense",
+        ),
+        (
+            TriggerPayload,
+            {"description": "D", "trigger_kind": TriggerKind.EVENT},
+            "requires event_id",
+        ),
+        (
+            TriggerPayload,
+            {
+                "description": "D",
+                "trigger_kind": TriggerKind.EVENT,
+                "event_id": "reports.report_created",
+                "endpoint_path": "/api/x",
+            },
+            "must not set",
+        ),
+        (
+            DataCollectionPayload,
+            {
+                "description": "D",
+                "fields": (
+                    TypedFieldSpec(name="name", field_type=FieldType.STRING, required=True),
+                ),
+                "indexes": (IndexSpec(name="bad", field_names=("missing",), unique=False),),
+            },
+            "undeclared field",
+        ),
+        (
+            StubDeclarationPayload,
+            {
+                "stub_kind": "python_backend",
+                "path": "modules\\reports\\hook.py",
+                "entrypoint": "run",
+            },
+            "backslash",
+        ),
+    ],
+)
+def test_typed_variant_rules_fail_closed(model, fields, match) -> None:
+    with pytest.raises((ValidationError, ValueError), match=match):
+        build_semantic_payload(
+            model, node_id="mozaiks.subject.x", payload_version=1, scope=_SCOPE, **fields
+        )
+
+
+def test_prices_are_integer_minor_units_never_floats() -> None:
+    with pytest.raises(ValidationError):
+        PriceSpec(amount_minor_units=19.99, currency="USD", period=BillingPeriod.MONTHLY)
+    with pytest.raises(ValidationError, match="currency"):
+        PriceSpec(amount_minor_units=1900, currency="usd", period=BillingPeriod.MONTHLY)
+
+
+def test_ordering_permutations_do_not_change_digests() -> None:
+    base = _corpus_payloads()[SemanticNodeKind.PAGE]
+    permuted = build_semantic_payload(
+        PagePayload,
+        node_id=base.node_id,
+        payload_version=base.payload_version,
+        scope=base.scope,
+        title=base.title,
+        intent=base.intent,
+        sections=tuple(reversed(base.sections)),
+    )
+    assert permuted.payload_digest == base.payload_digest
+    assert [entry.section_node_id for entry in permuted.sections] == [
+        entry.section_node_id for entry in base.sections
+    ]
+
+
+def test_payloads_and_v2_nodes_are_frozen() -> None:
+    page = _corpus_payloads()[SemanticNodeKind.PAGE]
+    with pytest.raises(ValidationError):
+        page.title = "Mutated"
+    node = SemanticNodeV2(
+        node_id=page.node_id,
+        kind=SemanticNodeKind.PAGE,
+        payload_ref=semantic_payload_ref(page),
+    )
+    with pytest.raises(ValidationError):
+        node.node_id = "mozaiks.page.other"
+
+
+# ---------------------------------------------------------------------------
+# Authority boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_binding_cannot_author_or_perturb_payload_facts() -> None:
+    graph, _payloads = _corpus_graph()
+    assert "payload" not in " ".join(ImplementationBinding.model_fields)
+    binding_fields = set(ImplementationBinding.model_fields)
+    assert not any("payload" in name for name in binding_fields)
+    # Graph identity is computed before and without any binding: rebuilding
+    # the same graph yields the same digest regardless of binding existence.
+    rebuilt, _ = _corpus_graph()
+    assert rebuilt.graph_digest == graph.graph_digest
+
+
+def test_no_payload_field_accepts_a_child_contract_ref() -> None:
+    for model in PAYLOAD_MODEL_BY_KIND.values():
+        for name, field in model.model_fields.items():
+            assert "ChildContractRef" not in str(field.annotation), (model, name)
+
+
+def test_capability_advertisement_is_unchanged() -> None:
+    assert advertised_semantic_compiler_capabilities() == ()
+
+
+def test_production_sources_do_not_import_payloads_or_v2_symbols() -> None:
+    offenders: list[str] = []
+    excluded = {
+        Path("mozaiksai/core/semantics/payloads.py"),
+        Path("mozaiksai/core/semantics/graph.py"),
+        Path("mozaiksai/core/semantics/refs.py"),
+        Path("mozaiksai/core/semantics/resolver.py"),
+        Path("tests/test_semantic_payload_graph_v2.py"),
+    }
+    markers = (
+        "semantics.payloads",
+        "SemanticGraphV2",
+        "SemanticNodeV2",
+        "SemanticPayloadRef",
+        "semantic_payload",
+    )
+    roots = [ROOT / "mozaiksai", ROOT / "factory_app"]
+    for root in roots:
+        for path in root.rglob("*.py"):
+            relative = path.relative_to(ROOT)
+            if relative in excluded:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if any(marker in text for marker in markers):
+                offenders.append(relative.as_posix())
+    assert offenders == []
+
+
+def test_payload_modules_have_no_ag2_imports() -> None:
+    for name in ("payloads.py", "graph.py", "refs.py", "resolver.py"):
+        text = (ROOT / "mozaiksai/core/semantics" / name).read_text(encoding="utf-8")
+        assert "import ag2" not in text and "from ag2" not in text, name

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -87,6 +87,117 @@ from mozaiksai.core.stub_kinds import StubKind
 
 ROOT = Path(__file__).resolve().parents[1]
 
+_PRODUCTION_ROOTS = frozenset({"mozaiksai", "factory_app"})
+_SEMANTICS_OWNER_FILES = frozenset(
+    {
+        Path("mozaiksai/core/semantics/payloads.py"),
+        Path("mozaiksai/core/semantics/graph.py"),
+        Path("mozaiksai/core/semantics/refs.py"),
+        Path("mozaiksai/core/semantics/resolver.py"),
+    }
+)
+_FORBIDDEN_PRODUCTION_MODULES = frozenset({"mozaiksai.core.semantics.payloads"})
+_FORBIDDEN_PRODUCTION_SYMBOLS = frozenset(
+    {
+        "SemanticGraphV2",
+        "SemanticNodeV2",
+        "SemanticPayloadRef",
+        "parse_semantic_payload",
+        "register_semantic_payload",
+        "resolve_semantic_payload",
+        "semantic_payload_ref",
+        "validate_semantic_graph_v2_payload_closure",
+    }
+)
+_SEMANTICS_SYMBOL_MODULES = frozenset(
+    {
+        "mozaiksai.core.semantics",
+        "mozaiksai.core.semantics.graph",
+        "mozaiksai.core.semantics.refs",
+        "mozaiksai.core.semantics.resolver",
+    }
+)
+_DECLARATIVE_SUFFIXES = (
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".json.j2",
+    ".toml.j2",
+    ".yaml.j2",
+    ".yml.j2",
+)
+
+
+def _constant_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _constant_string(node.left)
+        right = _constant_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _contains_forbidden_production_reference(value: str) -> bool:
+    markers = _FORBIDDEN_PRODUCTION_MODULES | _FORBIDDEN_PRODUCTION_SYMBOLS
+    return any(marker in value for marker in markers)
+
+
+def _python_source_has_forbidden_production_reference(source: str, *, filename: str) -> bool:
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        # Tracked generator templates can contain placeholders that become
+        # Python only after rendering. They still receive a conservative raw
+        # reference scan instead of disappearing from the proof.
+        return _contains_forbidden_production_reference(source)
+
+    for node in ast.walk(tree):
+        resolved_string = _constant_string(node)
+        if resolved_string is not None and _contains_forbidden_production_reference(
+            resolved_string
+        ):
+            return True
+        if isinstance(node, ast.Import):
+            if any(alias.name in _FORBIDDEN_PRODUCTION_MODULES for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module in _FORBIDDEN_PRODUCTION_MODULES:
+                return True
+            if any(
+                alias.name in _FORBIDDEN_PRODUCTION_SYMBOLS
+                or (alias.name == "*" and node.module in _SEMANTICS_SYMBOL_MODULES)
+                for alias in node.names
+            ):
+                return True
+        elif isinstance(node, ast.Call) and node.args:
+            target = _constant_string(node.args[0])
+            if target is not None and _contains_forbidden_production_reference(target):
+                return True
+        elif isinstance(node, ast.Attribute) and node.attr in _FORBIDDEN_PRODUCTION_SYMBOLS:
+            return True
+        elif isinstance(node, ast.Name) and node.id in _FORBIDDEN_PRODUCTION_SYMBOLS:
+            return True
+    return False
+
+
+def _tracked_production_paths(*, suffixes: tuple[str, ...]) -> tuple[Path, ...]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--", "mozaiksai", "factory_app"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout.decode("utf-8").split("\0")
+    return tuple(
+        Path(relative)
+        for relative in tracked
+        if relative
+        and Path(relative).parts[0] in _PRODUCTION_ROOTS
+        and relative.endswith(suffixes)
+    )
+
 _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
@@ -500,38 +611,116 @@ def test_digest_tampering_fails_closed() -> None:
         parse_semantic_payload(document)
 
 
-def test_forged_frozen_model_copies_fail_cold_validation_before_registration() -> None:
-    graph, payloads = _corpus_graph()
+@pytest.mark.parametrize("construction", ["model_copy", "model_construct"])
+def test_forged_payload_axes_fail_cold_validation_atomically(construction: str) -> None:
+    _graph, payloads = _corpus_graph()
     page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
-    forged_page = page.model_copy(update={"title": "Forged"})
+
+    def forge(model, **updates):
+        if construction == "model_copy":
+            return model.model_copy(update=updates)
+        return type(model).model_construct(**{**model.__dict__, **updates})
+
+    invalid_sections = tuple(forge(entry, position=0) for entry in page.sections)
+    cases = {
+        "stale digest": forge(page, title="Forged"),
+        "invalid field": forge(page, title=""),
+        "invalid ordering": forge(page, sections=invalid_sections),
+        "wrong kind": forge(page, payload_kind=SemanticNodeKind.MODULE),
+        "wrong node": forge(page, node_id="mozaiks.page.other"),
+        "wrong version": forge(page, payload_version=2),
+        "wrong scope": forge(page, scope=_OTHER_SCOPE),
+    }
+
+    for label, forged_page in cases.items():
+        resolver = SemanticReferenceResolver()
+        before = resolver._subjects.copy()
+        with pytest.raises(ReferenceResolutionError, match="cold validation"):
+            resolver.register_semantic_payload(forged_page)
+        assert resolver._subjects == before, label
+
     resolver = SemanticReferenceResolver()
+    resolver.register_semantic_payload(page)
+    resolved = resolver.resolve_semantic_payload(
+        semantic_payload_ref(page), requesting_scope=page.scope
+    )
+    assert resolved.model_dump(mode="json") == page.model_dump(mode="json")
 
-    with pytest.raises(ReferenceResolutionError, match="cold validation"):
-        resolver.register_semantic_payload(forged_page)
-    resolver.register_semantic_payload(page)  # failed registration did not mutate the store
-    for payload in payloads:
-        if payload is not page:
+
+@pytest.mark.parametrize("construction", ["model_copy", "model_construct"])
+def test_forged_graph_axes_and_nested_nodes_fail_registration_atomically(
+    construction: str,
+) -> None:
+    graph, payloads = _corpus_graph()
+    page_node = graph.node("mozaiks.page.home")
+
+    def forge(model, **updates):
+        if construction == "model_copy":
+            return model.model_copy(update=updates)
+        return type(model).model_construct(**{**model.__dict__, **updates})
+
+    def replace_page_node(replacement):
+        return tuple(replacement if node.node_id == page_node.node_id else node for node in graph.nodes)
+
+    cases = {
+        "stale graph digest": forge(graph, graph_digest="f" * 64),
+        "wrong version": forge(graph, version=2),
+        "wrong scope": forge(graph, scope=_OTHER_SCOPE),
+        "wrong nested node": forge(
+            graph,
+            nodes=replace_page_node(forge(page_node, node_id="mozaiks.page.other")),
+        ),
+        "wrong nested kind": forge(
+            graph,
+            nodes=replace_page_node(forge(page_node, kind=SemanticNodeKind.MODULE)),
+        ),
+    }
+
+    for label, forged_graph in cases.items():
+        resolver = SemanticReferenceResolver()
+        for payload in payloads:
             resolver.register_semantic_payload(payload)
+        before = resolver._subjects.copy()
+        with pytest.raises(ReferenceResolutionError, match="cold validation"):
+            resolver.register_semantic_graph_v2(forged_graph)
+        assert resolver._subjects == before, label
 
-    forged_graph = graph.model_copy(update={"graph_digest": "f" * 64})
-    with pytest.raises(ReferenceResolutionError, match="cold validation"):
-        resolver.register_semantic_graph_v2(forged_graph)
-    resolver.register_semantic_graph_v2(graph)  # failed registration did not mutate the store
+    resolver = SemanticReferenceResolver()
+    for payload in payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(graph)
+    registered = resolver._subjects[(graph.graph_id, graph.version)].content
+    assert registered.model_dump(mode="json") == graph.model_dump(mode="json")
 
 
-def test_payload_closure_cold_validates_frozen_model_copies() -> None:
+@pytest.mark.parametrize("construction", ["model_copy", "model_construct"])
+def test_payload_closure_cold_validates_payloads_graphs_and_nested_nodes(
+    construction: str,
+) -> None:
     graph, payloads = _corpus_graph()
     page = next(p for p in payloads if p.node_id == "mozaiks.page.home")
-    forged_payloads = [
-        page.model_copy(update={"title": "Forged"}) if payload is page else payload
-        for payload in payloads
-    ]
+    page_node = graph.node(page.node_id)
+
+    def forge(model, **updates):
+        if construction == "model_copy":
+            return model.model_copy(update=updates)
+        return type(model).model_construct(**{**model.__dict__, **updates})
+
+    forged_payloads = [forge(page, title="Forged") if payload is page else payload for payload in payloads]
     with pytest.raises(SemanticPayloadError, match="payload failed cold validation"):
         validate_semantic_graph_v2_payload_closure(graph, forged_payloads)
 
-    forged_graph = graph.model_copy(update={"graph_digest": "f" * 64})
+    forged_graph = forge(graph, graph_digest="f" * 64)
     with pytest.raises(SemanticPayloadError, match="graph v2 failed cold validation"):
         validate_semantic_graph_v2_payload_closure(forged_graph, payloads)
+
+    forged_node = forge(page_node, node_id="mozaiks.page.other")
+    forged_nested_graph = forge(
+        graph,
+        nodes=tuple(forged_node if node.node_id == page.node_id else node for node in graph.nodes),
+    )
+    with pytest.raises(SemanticPayloadError, match="graph v2 failed cold validation"):
+        validate_semantic_graph_v2_payload_closure(forged_nested_graph, payloads)
 
 def test_duplicate_identity_fails_closed() -> None:
     resolver, graph, payloads = _registered_resolver()
@@ -664,8 +853,11 @@ def test_partial_closure_fails_closed() -> None:
     resolver = SemanticReferenceResolver()
     for payload in payloads[:-1]:  # one pinned payload missing
         resolver.register_semantic_payload(payload)
+    before = resolver._subjects.copy()
     with pytest.raises(ReferenceResolutionError, match="no semantic payload"):
         resolver.register_semantic_graph_v2(graph)
+    assert resolver._subjects == before
+    assert (graph.graph_id, graph.version) not in resolver._subjects
 
     with pytest.raises(SemanticPayloadError, match="not supplied"):
         validate_semantic_graph_v2_payload_closure(graph, payloads[:-1])
@@ -771,60 +963,164 @@ def test_typed_variant_rules_fail_closed(model, fields, match) -> None:
 def test_prices_are_integer_minor_units_never_floats() -> None:
     with pytest.raises(ValidationError):
         PriceSpec(amount_minor_units=19.99, currency="USD", period=BillingPeriod.MONTHLY)
-    with pytest.raises(ValidationError, match="currency"):
-        PriceSpec(amount_minor_units=1900, currency="usd", period=BillingPeriod.MONTHLY)
-    with pytest.raises(ValidationError, match="ISO-4217"):
-        PriceSpec(amount_minor_units=1900, currency="ZZZ", period=BillingPeriod.MONTHLY)
 
 
-def test_ordering_permutations_do_not_change_digests() -> None:
-    base = _corpus_payloads()[SemanticNodeKind.PAGE]
-    permuted = build_semantic_payload(
-        PagePayload,
-        node_id=base.node_id,
-        payload_version=base.payload_version,
-        scope=base.scope,
-        title=base.title,
-        intent=base.intent,
-        sections=tuple(reversed(base.sections)),
+@pytest.mark.parametrize("currency", ["XAD", "XAU", "XTS", "XXX"])
+def test_prices_accept_representative_iso_4217_list_one_special_codes(currency: str) -> None:
+    price = PriceSpec(
+        amount_minor_units=1900,
+        currency=currency,
+        period=BillingPeriod.MONTHLY,
     )
-    assert permuted.payload_digest == base.payload_digest
-    assert [entry.section_node_id for entry in permuted.sections] == [
-        entry.section_node_id for entry in base.sections
+    assert price.currency == currency
+
+
+@pytest.mark.parametrize("currency", ["usd", "US", "USDD", "US$", "ZZZ", "BGN", ""])
+def test_prices_reject_lowercase_malformed_unassigned_and_historic_codes(
+    currency: str,
+) -> None:
+    with pytest.raises(ValidationError, match="ISO-4217"):
+        PriceSpec(
+            amount_minor_units=1900,
+            currency=currency,
+            period=BillingPeriod.MONTHLY,
+        )
+
+
+def test_order_bearing_input_permutations_do_not_change_page_or_section_digests() -> None:
+    payloads = _corpus_payloads()
+    page = payloads[SemanticNodeKind.PAGE]
+    permuted_page = build_semantic_payload(
+        PagePayload,
+        node_id=page.node_id,
+        payload_version=page.payload_version,
+        scope=page.scope,
+        title=page.title,
+        intent=page.intent,
+        sections=tuple(reversed(page.sections)),
+    )
+    assert permuted_page.payload_digest == page.payload_digest
+    assert [entry.section_node_id for entry in permuted_page.sections] == [
+        entry.section_node_id for entry in page.sections
     ]
 
+    section = payloads[SemanticNodeKind.SECTION]
+    permuted_section = build_semantic_payload(
+        SectionPayload,
+        node_id=section.node_id,
+        payload_version=section.payload_version,
+        scope=section.scope,
+        title=section.title,
+        intent=section.intent,
+        entries=tuple(reversed(section.entries)),
+    )
+    assert permuted_section.payload_digest == section.payload_digest
+    assert permuted_section.entries == section.entries
 
-def test_meaningful_order_changes_identity_and_invalid_positions_fail_closed() -> None:
-    base = _corpus_payloads()[SemanticNodeKind.PAGE]
-    reordered = build_semantic_payload(
+
+def test_unordered_identity_collections_remain_permutation_stable() -> None:
+    action = _corpus_payloads()[SemanticNodeKind.ACTION]
+    fields = (
+        TypedFieldSpec(name="zeta", field_type=FieldType.STRING, required=False),
+        TypedFieldSpec(name="alpha", field_type=FieldType.INTEGER, required=True),
+    )
+    emits = ("reports.report_updated", "reports.report_created")
+    first = build_semantic_payload(
+        ActionPayload,
+        node_id=action.node_id,
+        payload_version=action.payload_version,
+        scope=action.scope,
+        description=action.description,
+        request_fields=fields,
+        response_fields=fields,
+        emits=emits,
+        entitlement_gate=action.entitlement_gate,
+    )
+    permuted = build_semantic_payload(
+        ActionPayload,
+        node_id=action.node_id,
+        payload_version=action.payload_version,
+        scope=action.scope,
+        description=action.description,
+        request_fields=tuple(reversed(fields)),
+        response_fields=tuple(reversed(fields)),
+        emits=tuple(reversed(emits)),
+        entitlement_gate=action.entitlement_gate,
+    )
+    assert permuted.payload_digest == first.payload_digest
+    assert permuted.request_fields == first.request_fields
+    assert permuted.response_fields == first.response_fields
+    assert permuted.emits == first.emits
+
+
+def test_meaningful_page_and_section_order_changes_identity() -> None:
+    payloads = _corpus_payloads()
+    page = payloads[SemanticNodeKind.PAGE]
+    reordered_page = build_semantic_payload(
         PagePayload,
-        node_id=base.node_id,
-        payload_version=base.payload_version,
-        scope=base.scope,
-        title=base.title,
-        intent=base.intent,
+        node_id=page.node_id,
+        payload_version=page.payload_version,
+        scope=page.scope,
+        title=page.title,
+        intent=page.intent,
         sections=tuple(
             entry.model_copy(update={"position": 1 - entry.position})
-            for entry in base.sections
+            for entry in page.sections
         ),
     )
-    assert reordered.payload_digest != base.payload_digest
-    assert [entry.section_node_id for entry in reordered.sections] == list(
-        reversed([entry.section_node_id for entry in base.sections])
+    assert reordered_page.payload_digest != page.payload_digest
+    assert [entry.section_node_id for entry in reordered_page.sections] == list(
+        reversed([entry.section_node_id for entry in page.sections])
     )
 
+    section = payloads[SemanticNodeKind.SECTION]
+    reordered_section = build_semantic_payload(
+        SectionPayload,
+        node_id=section.node_id,
+        payload_version=section.payload_version,
+        scope=section.scope,
+        title=section.title,
+        intent=section.intent,
+        entries=tuple(
+            entry.model_copy(update={"position": 1 - entry.position})
+            for entry in section.entries
+        ),
+    )
+    assert reordered_section.payload_digest != section.payload_digest
+    assert [entry.entry_kind for entry in reordered_section.entries] == list(
+        reversed([entry.entry_kind for entry in section.entries])
+    )
+
+
+def test_negative_duplicate_sparse_and_non_dense_positions_fail_closed() -> None:
+    payloads = _corpus_payloads()
+    page = payloads[SemanticNodeKind.PAGE]
+    section = payloads[SemanticNodeKind.SECTION]
     for positions in ((0, 0), (0, 2), (-1, 0)):
         with pytest.raises(ValidationError, match="position"):
             build_semantic_payload(
                 PagePayload,
-                node_id=base.node_id,
-                payload_version=base.payload_version,
-                scope=base.scope,
-                title=base.title,
-                intent=base.intent,
+                node_id=page.node_id,
+                payload_version=page.payload_version,
+                scope=page.scope,
+                title=page.title,
+                intent=page.intent,
                 sections=tuple(
                     entry.model_copy(update={"position": position})
-                    for entry, position in zip(base.sections, positions, strict=True)
+                    for entry, position in zip(page.sections, positions, strict=True)
+                ),
+            )
+        with pytest.raises(ValidationError, match="position"):
+            build_semantic_payload(
+                SectionPayload,
+                node_id=section.node_id,
+                payload_version=section.payload_version,
+                scope=section.scope,
+                title=section.title,
+                intent=section.intent,
+                entries=tuple(
+                    entry.model_copy(update={"position": position})
+                    for entry, position in zip(section.entries, positions, strict=True)
                 ),
             )
 
@@ -869,99 +1165,114 @@ def test_capability_advertisement_is_unchanged() -> None:
 
 
 def test_production_sources_do_not_import_payloads_or_v2_symbols() -> None:
-    offenders: list[str] = []
-    excluded = {
-        Path("mozaiksai/core/semantics/payloads.py"),
-        Path("mozaiksai/core/semantics/graph.py"),
-        Path("mozaiksai/core/semantics/refs.py"),
-        Path("mozaiksai/core/semantics/resolver.py"),
-        Path("tests/test_semantic_payload_graph_v2.py"),
-    }
-    forbidden_modules = {"mozaiksai.core.semantics.payloads"}
-    forbidden_symbols = {
-        "SemanticGraphV2",
-        "SemanticNodeV2",
-        "SemanticPayloadRef",
-        "parse_semantic_payload",
-        "register_semantic_payload",
-        "resolve_semantic_payload",
-        "semantic_payload_ref",
-        "validate_semantic_graph_v2_payload_closure",
-    }
+    python_paths = _tracked_production_paths(suffixes=(".py", ".pyi"))
+    declarative_paths = _tracked_production_paths(suffixes=_DECLARATIVE_SUFFIXES)
 
-    def constant_string(node: ast.AST) -> str | None:
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return node.value
-        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-            left = constant_string(node.left)
-            right = constant_string(node.right)
-            if left is not None and right is not None:
-                return left + right
-        return None
+    # The proof itself is non-vacuous across both production roots, rendered
+    # Python stubs, and declarative templates that can become loader input.
+    assert {path.parts[0] for path in python_paths} == _PRODUCTION_ROOTS
+    assert (
+        Path("factory_app/build_context/commerce/templates/modules/commerce/backend/handler.py")
+        in python_paths
+    )
+    assert (
+        Path(
+            "factory_app/build_context/operator_readiness/templates/config/"
+            "operator_readiness.yaml.j2"
+        )
+        in declarative_paths
+    )
 
-    tracked = subprocess.run(
-        ["git", "ls-files", "--", "*.py", "*.pyi"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.splitlines()
-    for relative_text in tracked:
-        relative = Path(relative_text)
-        if relative in excluded or "tests" in relative.parts:
+    offenders: set[str] = set()
+    for relative in python_paths:
+        if relative in _SEMANTICS_OWNER_FILES:
             continue
         source = (ROOT / relative).read_text(encoding="utf-8")
-        try:
-            tree = ast.parse(source, filename=relative_text)
-        except SyntaxError:
-            # Tracked generator templates may contain contract placeholders
-            # that become Python only after rendering.  They still receive a
-            # direct string-access scan rather than disappearing from proof.
-            if any(marker in source for marker in forbidden_modules | forbidden_symbols):
-                offenders.append(relative.as_posix())
-            continue
-        for node in ast.walk(tree):
-            resolved_string = constant_string(node)
-            if resolved_string in forbidden_modules | forbidden_symbols:
-                offenders.append(relative.as_posix())
-            if isinstance(node, ast.Import):
-                if any(alias.name in forbidden_modules for alias in node.names):
-                    offenders.append(relative.as_posix())
-            elif isinstance(node, ast.ImportFrom):
-                if node.module in forbidden_modules or any(
-                    alias.name == "*" or alias.name in forbidden_symbols
-                    for alias in node.names
-                    if node.module in {
-                        "mozaiksai.core.semantics",
-                        "mozaiksai.core.semantics.graph",
-                        "mozaiksai.core.semantics.refs",
-                        "mozaiksai.core.semantics.resolver",
-                    }
-                ):
-                    offenders.append(relative.as_posix())
-            elif isinstance(node, ast.Call) and node.args:
-                target = constant_string(node.args[0])
-                if target in forbidden_modules:
-                    offenders.append(relative.as_posix())
-            elif isinstance(node, ast.Attribute) and node.attr in forbidden_symbols:
-                offenders.append(relative.as_posix())
-            elif isinstance(node, ast.Name) and node.id in forbidden_symbols:
-                offenders.append(relative.as_posix())
-    declarative = subprocess.run(
-        ["git", "ls-files", "--", "*.json", "*.toml", "*.yaml", "*.yml"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.splitlines()
-    for relative_text in declarative:
-        relative = Path(relative_text)
-        if "tests" in relative.parts:
-            continue
+        if _python_source_has_forbidden_production_reference(
+            source, filename=relative.as_posix()
+        ):
+            offenders.add(relative.as_posix())
+
+    for relative in declarative_paths:
         source = (ROOT / relative).read_text(encoding="utf-8")
-        if any(marker in source for marker in forbidden_modules | forbidden_symbols):
-            offenders.append(relative.as_posix())
-    assert offenders == []
+        if _contains_forbidden_production_reference(source):
+            offenders.add(relative.as_posix())
+
+    assert sorted(offenders) == []
+
+
+@pytest.mark.parametrize(
+    ("reference_class", "filename", "source"),
+    [
+        (
+            "direct import",
+            "probe.py",
+            "from mozaiksai.core.semantics.graph import SemanticGraphV2\n",
+        ),
+        (
+            "direct module import",
+            "probe.py",
+            "import mozaiksai.core.semantics.payloads\n",
+        ),
+        (
+            "aliased import",
+            "probe.py",
+            "from mozaiksai.core.semantics.graph import SemanticGraphV2 as Graph\n",
+        ),
+        (
+            "dynamic import",
+            "probe.py",
+            "import importlib\nimportlib.import_module('mozaiksai.core.semantics.payloads')\n",
+        ),
+        (
+            "module-qualified access",
+            "probe.py",
+            "import mozaiksai.core.semantics.graph as graph\ngraph.SemanticGraphV2\n",
+        ),
+        (
+            "Python string reference",
+            "probe.py",
+            "entrypoint = 'mozaiksai.core.semantics.graph:SemanticGraphV2'\n",
+        ),
+        (
+            "unrendered Python stub",
+            "stub.py",
+            "{{ invalid_python }}\nSemanticPayloadRef\n",
+        ),
+        (
+            "JSON reference",
+            "probe.json",
+            '{"entrypoint":"mozaiksai.core.semantics.graph:SemanticGraphV2"}',
+        ),
+        (
+            "YAML reference",
+            "probe.yaml",
+            "entrypoint: mozaiksai.core.semantics.payloads:parse_semantic_payload\n",
+        ),
+        (
+            "declarative template reference",
+            "probe.yaml.j2",
+            "entrypoint: mozaiksai.core.semantics.graph:SemanticGraphV2\n",
+        ),
+        (
+            "TOML reference",
+            "probe.toml",
+            "entrypoint = 'mozaiksai.core.semantics.refs:SemanticPayloadRef'\n",
+        ),
+    ],
+)
+def test_production_hygiene_guard_mutation_probe_detects_every_reference_class(
+    reference_class: str,
+    filename: str,
+    source: str,
+) -> None:
+    if filename.endswith((".py", ".pyi")):
+        detected = _python_source_has_forbidden_production_reference(
+            source, filename=filename
+        )
+    else:
+        detected = _contains_forbidden_production_reference(source)
+    assert detected, reference_class
 
 
 def test_payload_modules_have_no_ag2_imports() -> None:

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -280,12 +280,15 @@ def test_resolver_has_no_bare_id_lookup_surface() -> None:
     public = [name for name in dir(resolver) if not name.startswith("_")]
     assert set(public) == {
         "register_semantic_graph",
+        "register_semantic_graph_v2",
+        "register_semantic_payload",
         "register_application_manifest",
         "register_implementation_binding",
         "register_taxonomy_namespace",
         "register_opaque_subject",
         "resolve",
         "resolve_manifest_ref",
+        "resolve_semantic_payload",
         "resolve_taxonomy_namespace",
     }
 


### PR DESCRIPTION
## Summary

Implements **ADR 0007 Slice 2E** per the settled slice sequence (#422, after Slice 4A merged in #435): **typed semantic payloads + Merkle-rooted graph v2**, entirely behind test seams. No production code consumes the new symbols, no capability is advertised, no cutover occurs, and no live models were run. Slices 3E/4B/4C/5 remain deliberately unimplemented.

Base: `56479d43` (main = the Slice 4A squash).

## What's in it

**`mozaiksai/core/semantics/payloads.py` (new)** — `mozaiks.semantic_payload.v1`: **exactly one strict variant per `SemanticNodeKind`** (all 20), each `extra=forbid`, frozen, and self-digested with the Slice 2 canonical serializer (the only serializer). Content categories per the ADR clarification: titles/intent text; ordered page/section entries with **explicit dense 0..n-1 positions** (order-bearing collections keep source order under canonical sorting; identity collections sort+dedup by key); typed field shapes (closed `FieldType` enum); **integer minor-unit prices** with ISO-4217 currency and closed billing periods — no floats carry money; taxonomy-grammar-validated event/capability ids (Slice 1 authority, no second grammar); portable-path-validated paths (Slice 4A profile); closed enums for channels, trigger kinds, startup modes, deployment targets. **No `dict[str, Any]` anywhere.** `StubDeclarationPayload` mirrors layout-registry `StubKind` values as a Literal (the registry lives in the runtime layer and imports workflow modules — importing it would invert layering; a test pins the two sets equal). Cross-field rules fail closed: trigger kind ↔ binding exclusivity, index fields ⊆ declared fields, section entry kind ↔ field shape.

**`refs.py`** — `RefDocumentType.SEMANTIC_PAYLOAD` + `SemanticPayloadRef`: full-identity pin (node_id, payload_kind, payload_version, content_digest, scope), path-independent by construction. Node ids are dotted, so it is a sibling of `_ScopedRef`, not a subclass; the node-id grammar moved to a single shared helper (`validate_node_id_grammar`) used by graph v1, v2, and the ref — v1 behavior byte-identical.

**`graph.py`** — `mozaiks.semantic_graph.v2`: `SemanticNodeV2` (v1 identity + required `payload_ref`, pin verified against node id and kind), `SemanticGraphV2` (v1 validators mirrored + per-node payload scope equality), `build_semantic_graph_v2`, v2 taxonomy closure. The node identity payload embeds `{payload_kind, payload_version, content_digest}` → **`graph_digest` is a Merkle root**: payload byte change → payload digest → node identity → graph digest, proven link by link. v1 validator bodies were extracted into shared module helpers with **zero digest change — all 170 existing Slice 2 contract tests (golden vectors included) pass unmodified**. No v1→v2 converter is shipped: 3E re-projects from sources; a converter would smuggle v1's payload-less shape into v2 as invented empty payloads.

**`resolver.py`** — `register_semantic_payload` (immutable content-bearing subject; duplicate registration fails), `resolve_semantic_payload` (verifies document type, node binding, kind, version, digest, scope — every substitution axis fails closed), `register_semantic_graph_v2` (**payload closure first**: every pinned ref must already resolve; no partial registration). There is no "current"/latest lookup anywhere — resolution is by full identity only.

**`payloads.validate_semantic_graph_v2_payload_closure`** — bijective closure: every pin matches exactly one supplied payload on (node_id, kind, version, digest, scope); every supplied payload is pinned; missing/mismatched/duplicate/extra fail closed with typed errors.

## Proof gate (tests/test_semantic_payload_graph_v2.py, 50 tests)

Kind closure (every kind ↔ exactly one variant, discriminated-union round-trip per kind, kind/content mismatch rejected, StubKind mirror pinned) · node/type/scope substitution and version drift each rejected at both the model and the resolver · digest tampering rejected at parse and at resolve · duplicate identity rejected at registration, in one graph, and in closure · **Merkle chain proven link by link** with pinned golden root `a4eaa867…` + cross-process subprocess proof + STORED-archive fixture digest (transport evidence only — archiving differently perturbs nothing) · stale graph digest rejected · payload reuse across graph versions accepted, partial closure rejected in both directions · v1 document rejected by the v2 model · unknown fields rejected · float prices rejected · ordering permutations digest-stable · frozen-model immutability · binding cannot author payload facts (no payload field; graph digest binding-independent) · no payload field accepts a `ChildContractRef` · advertised capability set still `()` · production-import hygiene scan (mozaiksai + factory_app) proves nothing outside the semantics seam references payloads/v2 symbols · no AG2 imports.

## Validation

New suite **50 passed** · all Slice 1–4A semantic suites + layout registry/validation + readiness gates green (semantics v1: 170 tests with golden vectors unmodified; the resolver-surface roster test extends by the three new full-identity methods — the only pre-existing test changed) · **full local suite 14,123 passed, 0 failed across the four exact CI shard partitions**, re-run locally after the re-shard caused by the new test file (the known hazard) — shards 3336/3648/3488/3651, no latent order-dependent pair woke · `ruff check .` clean · `mypy mozaiksai/core/semantics/` clean (12 files) · source-hygiene gate clean · `git diff --check` clean · DCO signed.

## Scope confirmation

Untouched: `offline_projection.py` (Slice 3), `capabilities.py`, `ChildContractRef` (its looser path validator is a recorded 4B/4C follow-up, not absorbed here), `manifest.py`, `binding.py`, portable-path/archive/layout-registry (4A surfaces), generators, `AppBuildPlan`, AG2 workflows, CI sharding, issues #426–#432, MatrAIx. No renderer, no `CompilationPlan` content, no agent loop, no model execution, no capability advertisement, no persistence promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
