### PR TITLE
docs: define Genesis Builds and Revision Runs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,6 +86,18 @@ Mozaiks is a **persistent intent-orchestration runtime**. It covers the full lif
 
 Most AI products treat each interaction as isolated. Mozaiks treats every interaction as part of a living system. Users do not move linearly — they revise, branch, change foundational assumptions, ask for local edits, and continue unfinished work. The system needs to know the difference between a small patch and a change that invalidates everything downstream.
 
+The product-facing application lifecycle has two run types:
+
+- **Genesis Build** — the first complete build journey for an app. It creates
+  the app's first canonical, validated artifact lineage.
+- **Revision Run** — any later change against that lineage. It loads current
+  artifact state, scopes the impact, stages a new version, and returns it for
+  review.
+
+The Refinement Engine is the internal continuity and routing layer that executes
+Revision Runs. A `core` Revision Run may re-enter at `ValueEngine`, but it does
+not become another Genesis Build unless the user creates a new app lineage.
+
 This means:
 - **Workflows are execution primitives**, not the top-level product abstraction
 - **Artifacts are durable, versioned state** — not disposable chat outputs
@@ -108,6 +120,8 @@ Customer-facing terminology follows a different layer:
 - `Studio` is an internal host/composition term
 - visible UX should prefer `Apps`, `Build`, `Operations`, `Integrations`, and
   `Admin`
+- app creation and evolution should use `Genesis Build` and `Revision Run`;
+  `refinement` remains the internal engine and contract term
 - `Hub`, `Studio` as a top-level product area, and `Adapters` should not be
   treated as long-term customer-facing IA
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Changed
 
+- **App lifecycle terminology now centers Genesis Builds and Revision Runs.**
+  Public docs use Genesis Build for an app's first canonical build journey and
+  Revision Run for every later change in that app lineage, while Refinement
+  Engine remains the internal routing and contract term.
+
 - **Importing `mozaiksai.hosts.studio` no longer mutates the process
   environment.** Repo-local Studio defaults (`PLATFORM_PATH`,
   `MOZAIKS_WORKFLOWS_PATH`) and OpenTelemetry configuration are now applied

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AI-native software products.
 
 It brings together three things that usually live in separate tools:
 
-- **Mozaiks Studio** for creating apps, continuing builds, and managing them.
+- **Mozaiks Studio** for creating apps, running revisions, and managing them.
 - **AI workflow orchestration powered by [AG2](https://github.com/ag2ai/ag2)** for planning, tool use, human
   review, and generation.
 - **Generated app files** with modules, pages, workflows, config, and brand
@@ -35,6 +35,21 @@ It brings together three things that usually live in separate tools:
 The goal is not to generate a throwaway demo. Mozaiks stages production-shaped
 artifacts, validates them against strict contracts, and keeps runtime concerns
 separate from builder workflows.
+
+## Genesis Builds and Revision Runs
+
+Every Mozaiks app begins with one **Genesis Build**: the first complete journey
+from product intent to a staged, validated app. It establishes the app's first
+canonical artifact lineage.
+
+Every later change is a **Revision Run**. Mozaiks starts from the app's current
+artifacts and history, determines what the request affects, and re-enters only
+the parts of the build needed to stage a safe new version for review. A small
+copy fix and a major product rethink are both Revision Runs; their scope and
+route are different, but neither discards the app's lineage.
+
+Internally, the Refinement Engine classifies and routes Revision Runs. Genesis
+Build and Revision Run are the product-facing lifecycle terms.
 
 ## Quickstart
 
@@ -97,21 +112,15 @@ This creates `.\mozaiks-workspace` and starts the local Studio.
 output, config, and launch scripts. It is not the app itself. The app is
 created later from inside Studio.
 
-### 5. Build your first app
+### 5. Start your Genesis Build
 
 Open `http://localhost:3000/apps` and click `Create App`, then describe what you
 want to build. The workflow walks you through the build steps and stages the
 generated artifacts for review. In-progress builds stay in **Apps**, so you can
 always pick up where you left off.
 
-This first creation is your app's **Genesis Build**: Mozaiks turns your
-plain-language idea into the first validated version of your app. After that,
-you do not start over when you want something changed. You simply describe the
-change, and Mozaiks handles it as a **Refinement Run** against the app you
-already have. It prepares the smallest safe change, validates it, and lets you
-review it before it becomes active.
-
-See [Build your first app, then keep improving it](https://docs.mozaiks.ai/getting-started/genesis-builds-and-refinement-runs/)
+After promotion, describe any later change to start a Revision Run against the
+app you already have. See [Genesis Builds and Revision Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-revision-runs/)
 for examples ranging from a typo fix to a major product rethink.
 
 ### Troubleshooting
@@ -125,7 +134,7 @@ MongoDB instance, and set an LLM API key before running builds.
 | Guide | What it covers |
 |---|---|
 | [Use Studio](https://docs.mozaiks.ai/studio/) | The workspace and app-dashboard pages |
-| [Build and Improve Your App](https://docs.mozaiks.ai/getting-started/genesis-builds-and-refinement-runs/) | Create the first version, then make safe changes without starting over |
+| [Genesis Builds and Revision Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-revision-runs/) | Create the first version, then make safe changes without starting over |
 | [Add a Workflow](https://docs.mozaiks.ai/guides/adding-workflows/01-overview/) | Extend an app with a custom AI workflow |
 | [Add a Module](https://docs.mozaiks.ai/guides/adding-modules/01-overview/) | Add a self-contained backend capability |
 | [Add a Page](https://docs.mozaiks.ai/guides/adding-pages/01-overview/) | Add new pages and routes to your app workspace |

--- a/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
+++ b/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
@@ -28,7 +28,10 @@ The implementation policy for deterministic generated contracts is
 * `AppBuildPlan` is the post-reasoning deterministic materialization boundary.
 * Validation remains deterministic.
 * Evaluation complements validation; it does not replace validation.
-* Refinement is part of the core application lifecycle.
+* A Genesis Build creates an app's first canonical artifact lineage; every
+  subsequent change in that lineage is a Revision Run.
+* The Refinement Engine is the internal routing and continuity layer for
+  Revision Runs; `refinement` remains the implementation and contract term.
 * Operator intelligence enters through public OSS seams.
 * Do not duplicate canonical owners.
 

--- a/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
+++ b/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
@@ -553,6 +553,14 @@ Once a canonical structured plan exists, downstream behavior should be as determ
 
 Generation and refinement are phases of the same canonical application lifecycle.
 
+The product-facing names for those phases are **Genesis Build** and **Revision
+Run**. A Genesis Build creates the first canonical artifact lineage for an app.
+Every later change against that lineage is a Revision Run, including a `core`
+change that re-enters at `ValueEngine`. A new Genesis Build starts only when a
+new app lineage is created. Internal architecture continues to use
+`generation`, `refinement`, and `Refinement Engine` for the mechanisms that
+execute those lifecycle phases.
+
 The current conceptual refinement flow is:
 
 ```text

--- a/docs/architecture/builder/end-to-end-build-lifecycle.md
+++ b/docs/architecture/builder/end-to-end-build-lifecycle.md
@@ -13,6 +13,16 @@ This document defines the canonical lifecycle across:
 
 Terminology note:
 
+- a **Genesis Build** is the first complete build journey for an app and
+  establishes its first canonical artifact lineage
+- a **Revision Run** is every later change against that lineage, whether the
+  change is classified as `patch`, `design`, `feature`, or `core`
+- the Refinement Engine is the internal system that classifies, scopes, and
+  routes Revision Runs; `refinement` remains an implementation and contract
+  term rather than the product-facing run name
+- resuming an unfinished Genesis Build does not create another Genesis Build,
+  and a `core` Revision Run remains a Revision Run unless it creates a new app
+  lineage
 - `Studio` is the browser product and `studio` is the host/composition name
 - `mozaiks studio` is the current public CLI command for opening Studio
 - customer-facing UX should prefer `Apps`, `Usage`, `Health`, and

--- a/docs/architecture/foundations/context-graph-and-code-intelligence.md
+++ b/docs/architecture/foundations/context-graph-and-code-intelligence.md
@@ -541,7 +541,7 @@ generated files directly. The target state is for those checks to be graph
 queries against the post-build `AppContextGraph`, making them:
 
 - domain-agnostic (any domain's generated files can be indexed and checked)
-- reusable across initial build and refinement runs
+- reusable across Genesis Builds and Revision Runs
 - available to Studio's inspection UX as annotated graph nodes
 
 This is tracked as open work below.

--- a/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
+++ b/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
@@ -183,7 +183,7 @@ effect of handler code.
 
 - `DesignDocs` owns the typed `data_contract`
 - `AppGenerator` stages `data/contract.json`
-- refinement runs may stage `data/migrations/{migration_id}.json`
+- Revision Runs may stage `data/migrations/{migration_id}.json`
 - generated module repos use `backend/schemas.py` for typed document shapes and
   `backend/repo.py` for persistence operations
 - the runtime injects `ctx.persistence` into module actions when `app_id` exists;

--- a/docs/architecture/workflows/refinement-engine.md
+++ b/docs/architecture/workflows/refinement-engine.md
@@ -15,9 +15,10 @@ handoffs.
 
 The goal is simple:
 
-- initial generation workflows create the first canonical shape
-- refinement workflows adjust that shape safely and quickly
-- the Refinement Engine decides when a change is small, scoped, design-only, or concept-breaking
+- a Genesis Build creates the first canonical shape
+- Revision Runs adjust that shape safely and quickly
+- the Refinement Engine decides when a Revision Run is small, scoped,
+  design-only, or concept-breaking
 
 The Refinement Engine uses `app/config/ai.json` for runtime startup,
 `app/config/refinement_policy.yaml` for refinement policy, and
@@ -45,21 +46,27 @@ outdated refinement paths.
 
 ## Core Decision
 
-Mozaiks must treat **initial generation** and **refinement** as separate modes.
+Mozaiks must treat **Genesis Build** and **Revision Run** as separate product
+lifecycle modes. Internal architecture continues to use `generation` for the
+Genesis Build path and `refinement` for the engine, routing, workers, and
+contracts that execute Revision Runs.
 
-Initial generation is the compiler path:
+A Genesis Build is the compiler path:
 
 1. `ValueEngine` defines canonical product intent
 2. `DesignDocs` defines frontend/backend/database/ui schema intent
 3. `AgentGenerator` and `AppGenerator` generate the first concrete artifacts
 
-Refinement is the edit path:
+A Revision Run is the edit path:
 
 1. load the latest persisted artifact version
 2. classify the requested change
 3. route to the smallest valid re-entry point
 4. run refinement agents against scoped files or scoped plans
 5. validate and persist a new artifact version
+
+A `core` Revision Run may restart from `ValueEngine`, but it remains part of the
+same app lineage. Only creating a new app lineage starts another Genesis Build.
 
 Do **not** re-run `AgentGenerator` or `AppGenerator` from the top for every tweak.
 Do **not** let E2B become the source of truth.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -102,8 +102,8 @@ at any time from the **Apps** page.
 
 The first complete run of this sequence is your app's **Genesis Build** — the
 build that establishes the app's first authoritative version. Every change
-after that is a **Refinement Run**. See
-[Genesis Builds and Refinement Runs](getting-started/genesis-builds-and-refinement-runs.md)
+after that is a **Revision Run**. See
+[Genesis Builds and Revision Runs](getting-started/genesis-builds-and-revision-runs.md)
 for how the two fit together.
 
 ## Generate and Promote

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,8 +103,8 @@ Studio in your browser at `http://localhost:3000`.
 In-progress builds stay in **Apps** so you can always pick up where you left off.
 
 This first build is your app's **Genesis Build**; after that, every change you
-ask for is a **Refinement Run** against the app you already have. See
-[Genesis Builds and Refinement Runs](getting-started/genesis-builds-and-refinement-runs.md).
+ask for is a **Revision Run** against the app you already have. See
+[Genesis Builds and Revision Runs](getting-started/genesis-builds-and-revision-runs.md).
 
 ## Code Context Infrastructure
 

--- a/docs/getting-started/genesis-builds-and-revision-runs.md
+++ b/docs/getting-started/genesis-builds-and-revision-runs.md
@@ -1,8 +1,8 @@
-# Genesis Builds and Refinement Runs
+# Genesis Builds and Revision Runs
 
 Every Mozaiks app begins with a **Genesis Build**, which transforms the
 builder's intent into the app's first canonical, validated artifact lineage.
-Every subsequent change happens through a **Refinement Run**, where Mozaiks
+Every subsequent change happens through a **Revision Run**, where Mozaiks
 understands the current app, chooses the smallest safe path for the requested
 change, stages and validates the result, and lets the builder review it before
 it becomes the new app state.
@@ -15,7 +15,7 @@ it to change.
 flowchart LR
     A([Idea]) --> B[Genesis Build]
     B --> C([First App Version])
-    C --> D[Refinement Run]
+    C --> D[Revision Run]
     D --> E([New App Version])
     E -.->|next change| D
 ```
@@ -51,12 +51,12 @@ change is measured against, and the start of your app's revision history.
 If you want to see the individual build workflows behind these stages, they are
 described in [The Build Sequence](../concepts.md#the-build-sequence).
 
-## Refinement Runs
+## Revision Runs
 
 Once your app exists, you never start over. Every change — from fixing a label
-to rethinking the whole product — is a **Refinement Run**.
+to rethinking the whole product — is a **Revision Run**.
 
-A Refinement Run always follows the same shape:
+A Revision Run always follows the same shape:
 
 1. Mozaiks loads what it knows about your app — its current artifacts, design
    intent, and history — rather than guessing from the request alone.
@@ -83,7 +83,7 @@ appropriate part of the Genesis Build — and only that part.
 
 ### Your app is always safe
 
-A Refinement Run never edits your live app in place:
+A Revision Run never edits your live app in place:
 
 - **The existing app is preserved.** The current version keeps running and
   remains untouched while changes are prepared.
@@ -107,7 +107,7 @@ A Refinement Run never edits your live app in place:
   weekly summaries." → Mozaiks plans an inspections capability, an AI workflow
   for the summaries, generates the app, and stages it for promotion.
 
-**Refinement Runs:**
+**Revision Runs:**
 
 - "The dashboard title says 'Ivoices' — fix the typo." → classified as a
   patch; one file is edited, validated, and staged for your approval.
@@ -125,12 +125,16 @@ A Refinement Run never edits your live app in place:
 
 The practical takeaway: treat your app as a living product. Ask for the change
 you actually want, at whatever size it is, and Mozaiks will scale the work to
-match. The Genesis Build happens once; everything after it is refinement of the
-same continuously evolving app.
+match. The Genesis Build happens once; everything after it is a Revision Run
+within the same continuously evolving app lineage.
 
 ## Going deeper
 
 For technical readers who want the machinery behind these concepts:
+
+Revision Run is the product-facing term. The architecture uses `refinement`
+for the internal engine, routing policy, workers, and contracts that execute a
+Revision Run.
 
 - [Refinement](../guides/platform-intelligence/03-refinement.md) — the builder-facing
   guide to change classes and opting an app into refinement

--- a/docs/guides/platform-intelligence/03-refinement.md
+++ b/docs/guides/platform-intelligence/03-refinement.md
@@ -9,7 +9,7 @@ the smallest safe next step.
 !!! tip "New to these concepts?"
     For the product-level introduction to how the first build and later changes
     fit together, start with
-    [Genesis Builds and Refinement Runs](../../getting-started/genesis-builds-and-refinement-runs.md).
+    [Genesis Builds and Revision Runs](../../getting-started/genesis-builds-and-revision-runs.md).
 
 ## The Four Change Classes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - getting-started.md
-      - Genesis Builds & Refinement Runs: getting-started/genesis-builds-and-refinement-runs.md
+      - Genesis Builds & Revision Runs: getting-started/genesis-builds-and-revision-runs.md
   - Key Concepts: concepts.md
 
   - Guides:


### PR DESCRIPTION
## Summary

- establish **Genesis Build** as the first canonical app-lineage build
- establish **Revision Run** as every subsequent change in that lineage
- keep **Refinement Engine** as the internal routing and contract term
- rename the getting-started guide and update all navigation and links
- document that core re-entry remains a Revision Run unless a new app lineage is created

## OSS Change Impact

- **Layer changed:** public and architecture documentation
- **Build workflow impact:** terminology only; no workflow sequence, transition, or entrypoint changes
- **Runtime/platform impact:** none
- **App workspace impact:** none
- **Docs updated:** README, getting-started/concepts, lifecycle/refinement architecture, MkDocs navigation, changelog
- **Compatibility risk:** documentation URL renamed pre-1.0; no runtime or persisted contract changes

## Tests run

- `ruff check .` — passed
- `python -m mkdocs build --strict` — passed
- stale terminology/path search — passed
- `git diff --check` — passed
- `pytest -q --no-cov` — 14,040 passed, 80 skipped, 18 failed in existing task-batch runtime tests because `TaskStarted` lacks `expires_at`; this branch changes only Markdown and `mkdocs.yml`
