### PR TITLE
fix(runtime): distributed same-chat exclusion (issue #426 sub-slice A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **Distributed same-chat exclusion is now enforced (issue #426, sub-slice A)**:
+  the MongoDB chat lock at
+  `mozaiksai/core/runtime/persistence/distributed_lock.py` — previously dead
+  code with zero call sites — is rebuilt as a renewable chat execution lease
+  and wired into every production start/resume/restart path (the
+  `handle_user_input_from_api` funnel: HTTP input, WebSocket start/switch
+  handlers, host auto-start, journey spawns, and live paused-run
+  continuation). At most one runtime instance can execute a mutable run for a
+  given `(app_id, chat_id)` at a time; distinct chats and tenants proceed
+  independently, and read-only paths (history replay, reconnect) take no
+  lock. The lease is renewed for the length of the protected operation,
+  released at a durably persisted terminal or human-waiting boundary
+  (including on exceptions and cancellation), and a stale holder can never
+  delete a successor's lease. After confirmed lease loss (failed or
+  unprovable renewal), further durable session/WAL writes for that chat are
+  refused in-process. Operating modes are explicit: `required`
+  (fail-closed distributed exclusion whenever database persistence is
+  enabled; acquisition also fails closed if the unique lock index cannot be
+  verified, instead of degrading to a cosmetic lock) and `local` (explicit
+  single-process serialization only), overridable via
+  `MOZAIKS_CHAT_LOCK_MODE`. Contention, unavailable authority, renewal loss,
+  and release failure each emit distinct diagnostics (`CHAT_LOCK_BUSY`,
+  `CHAT_LOCK_AUTHORITY_UNAVAILABLE`, `CHAT_LOCK_RENEWAL_LOST`,
+  `CHAT_LOCK_RELEASE_FAILED`). Lock documents now live in the same system
+  database as the chat state they protect. One residual window remains
+  documented and out of this slice: storage-level fencing tokens for a
+  single in-flight write by a holder stalled past its TTL.
+
 ### Added
 
 - **Typed semantic payloads + Merkle-rooted graph v2 (ADR 0007 Slice 2E)**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,14 @@ This project follows a practical pre-1.0 changelog format:
   released at a durably persisted terminal or human-waiting boundary
   (including on exceptions and cancellation), and a stale holder can never
   delete a successor's lease. After confirmed lease loss (failed or
-  unprovable renewal), further durable session/WAL writes for that chat are
-  refused in-process. Operating modes are explicit: `required`
+  unprovable renewal), the protected execution is cancelled and further
+  durable session, workflow UI, AG2 stream, and AG2 Network knowledge/WAL
+  writes for that chat are refused in-process. A still-running local holder
+  cannot be hidden by a same-process successor. Operating modes are explicit: `required`
   (fail-closed distributed exclusion whenever database persistence is
-  enabled; acquisition also fails closed if the unique lock index cannot be
-  verified, instead of degrading to a cosmetic lock) and `local` (explicit
+  enabled; index or acquisition-authority failures remain distinct from
+  ordinary contention and fail closed instead of degrading to a cosmetic
+  lock) and `local` (explicit
   single-process serialization only), overridable via
   `MOZAIKS_CHAT_LOCK_MODE`. Contention, unavailable authority, renewal loss,
   and release failure each emit distinct diagnostics (`CHAT_LOCK_BUSY`,

--- a/mozaiksai/core/adapters/ag2_knowledge_store.py
+++ b/mozaiksai/core/adapters/ag2_knowledge_store.py
@@ -18,6 +18,7 @@ from pymongo import ReturnDocument
 from mozaiksai.core.core_config import get_mongo_client
 from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE, RuntimeCollections
 from mozaiksai.core.multitenant import build_app_scope_filter, coalesce_app_id, dual_write_app_scope
+from mozaiksai.core.runtime.persistence.distributed_lock import assert_chat_mutable
 
 
 def _normalize_path(path: str) -> str:
@@ -53,6 +54,7 @@ class MongoAG2KnowledgeStore:
         return None if doc is None else str(doc.get("content") or "")
 
     async def write(self, path: str, content: str) -> None:
+        assert_chat_mutable(app_id=self._app_id, chat_id=self._chat_id)
         normalized = _normalize_path(path)
         now = datetime.now(UTC)
         await (await self._coll()).update_one(
@@ -89,6 +91,7 @@ class MongoAG2KnowledgeStore:
         return sorted(children)
 
     async def delete(self, path: str) -> None:
+        assert_chat_mutable(app_id=self._app_id, chat_id=self._chat_id)
         normalized = _normalize_path(path)
         query = self._scope_filter()
         query["$or"] = [
@@ -108,6 +111,7 @@ class MongoAG2KnowledgeStore:
 
     async def append(self, path: str, content: str) -> int:
         """Atomically append UTF-8 content and return its prior byte offset."""
+        assert_chat_mutable(app_id=self._app_id, chat_id=self._chat_id)
         normalized = _normalize_path(path)
         now = datetime.now(UTC)
         prior = await (await self._coll()).find_one_and_update(

--- a/mozaiksai/core/adapters/ag2_orchestration.py
+++ b/mozaiksai/core/adapters/ag2_orchestration.py
@@ -57,6 +57,7 @@ from mozaiksai.core.ports.orchestration import (
     RunResult,
     RunStatus,
 )
+from mozaiksai.core.runtime.persistence.distributed_lock import assert_chat_mutable
 
 logger = get_core_logger("ag2_orchestration_adapter")
 
@@ -311,6 +312,9 @@ class AG2OrchestrationAdapter:
         """
         if not request.injected_context:
             return
+        # Guard before the try: a lease-loss refusal must abort the resume,
+        # never degrade into the warning path below.
+        assert_chat_mutable(app_id=request.app_id, chat_id=request.chat_id)
         try:
             from mozaiksai.core.data.persistence import AG2PersistenceManager
             from mozaiksai.core.multitenant import build_app_scope_filter

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -340,6 +340,7 @@ class AG2PersistenceManager:
         and persisted to the ChatSessions document under "cache_seed" for visibility and reuse.
         """
         resolved_app_id = coalesce_app_id(app_id=app_id)
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         coll = await self._coll()
         # Include app_id in the filter for defense-in-depth tenant isolation.
         _seed_filter: dict = {"_id": chat_id}
@@ -401,6 +402,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             # Scope the duplicate check to this app to maintain tenant isolation.

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -32,6 +32,7 @@ from pymongo import ReturnDocument, UpdateOne
 from logs.logging_config import get_workflow_logger
 from mozaiksai.core.core_config import get_mongo_client
 from mozaiksai.core.multitenant import build_app_scope_filter, coalesce_app_id, dual_write_app_scope
+from mozaiksai.core.runtime.persistence.distributed_lock import assert_chat_mutable
 from mozaiksai.core.workflow.outputs.runtime_validation import normalize_json_candidate_text
 
 from ..models import WorkflowStatus, WorkflowUIState
@@ -573,6 +574,7 @@ class AG2PersistenceManager:
 
         if not isinstance(variables, dict) or not variables:
             return
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
 
         from mozaiksai.core.workflow.context.authority import ContextAuthorityError
 
@@ -728,6 +730,9 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        # Raise (not swallow) on confirmed lease loss: a stale holder must not
+        # write terminal state over a successor's run.
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             now = datetime.now(UTC)
@@ -983,6 +988,7 @@ class AG2PersistenceManager:
         text = str(content or "").strip()
         if not text:
             return
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
 
         merged_metadata = dict(metadata or {})
         if agent_name:
@@ -1020,6 +1026,7 @@ class AG2PersistenceManager:
         text = str(content or "").strip()
         if not text:
             return
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
 
         event = TextInput(text)
         if metadata:
@@ -1705,6 +1712,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             await coll.update_one(

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -789,6 +789,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             now = datetime.now(UTC)
@@ -1544,6 +1545,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             history = await self.load_run_history(chat_id=chat_id, app_id=str(resolved_app_id))
             last_assistant_idx = None
@@ -1601,6 +1603,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             now = datetime.now(UTC).isoformat()
@@ -1671,6 +1674,7 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
             await coll.update_one(

--- a/mozaiksai/core/runtime/persistence/distributed_lock.py
+++ b/mozaiksai/core/runtime/persistence/distributed_lock.py
@@ -32,10 +32,10 @@
 #
 # Known residual window (documented, not fenced in this slice): a holder that
 # stalls past its TTL without a failed renewal can have at most one in-flight
-# write land after a successor acquires. Confirmed lease loss (failed or
-# unprovable renewal) stops all further guarded durable writes via
-# assert_chat_mutable(). Storage-level fencing tokens are a later sub-slice
-# of issue #426.
+# write land after a successor acquires. Confirmed lease loss cancels the
+# protected execution and stops all further guarded durable writes via
+# assert_chat_mutable(). Storage-level fencing tokens are a later sub-slice of
+# issue #426.
 #
 # Configuration (env vars):
 #   MOZAIKS_CHAT_LOCK_MODE         — "required" | "local" explicit override
@@ -54,6 +54,8 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any
 from uuid import uuid4
+
+from pymongo.errors import DuplicateKeyError
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.multitenant.app_ids import normalize_app_id
@@ -294,45 +296,42 @@ async def _try_acquire(collection: Any, resource: str, holder_id: str, ttl_secon
     """Attempt a single atomic lock acquisition. Returns True on success."""
     now = datetime.now(UTC)
     expires_at = now + timedelta(seconds=ttl_seconds)
-    try:
-        # Steal an expired lease, or re-assert one this holder already owns.
-        result = await collection.find_one_and_update(
-            {
-                "resource": resource,
-                "$or": [
-                    {"expires_at": {"$lt": now}},
-                    {"holder_id": holder_id},
-                ],
-            },
-            {
-                "$set": {
-                    "resource": resource,
-                    "holder_id": holder_id,
-                    "expires_at": expires_at,
-                    "acquired_at": now.isoformat(),
-                }
-            },
-            upsert=False,
-            return_document=True,
-        )
-        if result is not None:
-            return True
-
-        # No expired lease exists — try a clean insert; the unique index on
-        # `resource` makes exactly one concurrent inserter win.
-        try:
-            await collection.insert_one({
+    # Steal an expired lease, or re-assert one this holder already owns.
+    result = await collection.find_one_and_update(
+        {
+            "resource": resource,
+            "$or": [
+                {"expires_at": {"$lt": now}},
+                {"holder_id": holder_id},
+            ],
+        },
+        {
+            "$set": {
                 "resource": resource,
                 "holder_id": holder_id,
                 "expires_at": expires_at,
                 "acquired_at": now.isoformat(),
-            })
-            return True
-        except Exception:
-            # DuplicateKeyError or similar — lease is held by another owner.
-            return False
-    except Exception as exc:
-        logger.debug("Lock acquisition attempt failed resource=%s: %s", resource, exc)
+            }
+        },
+        upsert=False,
+        return_document=True,
+    )
+    if result is not None:
+        return True
+
+    # No expired lease exists — try a clean insert; the unique index on
+    # `resource` makes exactly one concurrent inserter win. Only a proven
+    # uniqueness race is contention; authority failures must use the distinct
+    # unavailable diagnostic.
+    try:
+        await collection.insert_one({
+            "resource": resource,
+            "holder_id": holder_id,
+            "expires_at": expires_at,
+            "acquired_at": now.isoformat(),
+        })
+        return True
+    except DuplicateKeyError:
         return False
 
 
@@ -364,6 +363,7 @@ class ChatLease:
         self._ttl_seconds = ttl_seconds
         self._expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
         self._lost = False
+        self._owner_task: asyncio.Task[Any] | None = None
         self._renew_task: asyncio.Task[None] | None = None
 
     @property
@@ -374,11 +374,14 @@ class ChatLease:
         if not self._lost:
             self._lost = True
             logger.error(
-                "CHAT_LOCK_RENEWAL_LOST resource=%s holder=%s: %s — durable writes for this chat are now refused in this process",
+                "CHAT_LOCK_RENEWAL_LOST resource=%s holder=%s: %s — cancelling protected execution and refusing durable writes",
                 self.resource,
                 self.holder_id,
                 reason,
             )
+            owner = self._owner_task
+            if owner is not None and not owner.done():
+                owner.cancel(f"chat execution lease lost: {self.resource}")
 
     async def _renew_once(self) -> None:
         """Extend the lease; mark lost when ownership can no longer be proven."""
@@ -419,6 +422,7 @@ class ChatLease:
 
     def start_renewal(self) -> None:
         if self._collection is not None and self._renew_task is None:
+            self._owner_task = asyncio.current_task()
             self._renew_task = asyncio.create_task(
                 self._renew_loop(), name=f"chat-lease-renew:{self.resource}"
             )
@@ -557,12 +561,28 @@ async def chat_execution_lease(
 
     await _verify_acquisition_indexes(collection)
 
+    # Never replace a still-running holder in the process registry. Mongo
+    # remains the cross-process authority, while this check closes the local
+    # expiry/takeover window in which a successor could otherwise hide the
+    # stale holder's lost state from assert_chat_mutable().
+    if resource in _process_leases:
+        logger.warning("CHAT_LOCK_BUSY resource=%s mode=required local_holder=true", resource)
+        raise LockAcquisitionError(resource)
+
     effective_holder = holder_id or _default_holder_id()
     ttl = _ttl()
 
     acquired = False
     for attempt in range(max_retries + 1):
-        acquired = await _try_acquire(collection, resource, effective_holder, ttl)
+        try:
+            acquired = await _try_acquire(collection, resource, effective_holder, ttl)
+        except Exception as exc:
+            logger.error(
+                "CHAT_LOCK_AUTHORITY_UNAVAILABLE resource=%s during acquisition: %s",
+                resource,
+                exc,
+            )
+            raise ChatLockAuthorityUnavailableError(resource, str(exc)) from exc
         if acquired:
             break
         if attempt < max_retries:
@@ -587,7 +607,17 @@ async def chat_execution_lease(
     lease.start_renewal()
     logger.debug("LOCK_ACQUIRED resource=%s holder=%s", resource, effective_holder)
     try:
-        yield lease
+        try:
+            yield lease
+        except asyncio.CancelledError as exc:
+            if lease.lost:
+                raise ChatLeaseLostError(resource) from exc
+            raise
+        if lease.lost:
+            # The protected operation may have consumed cancellation as part
+            # of its own shutdown protocol. Never let that turn confirmed
+            # lease loss into an apparent successful run.
+            raise ChatLeaseLostError(resource)
     finally:
         if _process_leases.get(resource) is lease:
             _process_leases.pop(resource, None)

--- a/mozaiksai/core/runtime/persistence/distributed_lock.py
+++ b/mozaiksai/core/runtime/persistence/distributed_lock.py
@@ -1,39 +1,80 @@
 # ==============================================================================
 # FILE: mozaiksai/core/runtime/persistence/distributed_lock.py
-# DESCRIPTION: MongoDB-backed distributed lock for chat session state mutations.
-#              Prevents two runtime instances from resuming the same chat
-#              simultaneously, which would corrupt session state.
+# DESCRIPTION: MongoDB-backed distributed chat execution lease.
+#              Guarantees at most one runtime instance executes a mutable
+#              start/resume/restart for a given (app_id, chat_id) at a time,
+#              so two instances cannot interleave session writes and WAL
+#              sequence allocation for the same chat.
 #
-# Pattern: findOneAndUpdate with upsert on (resource_key).
-#   Acquire: insert a lock document with an expiry.
-#   Release: delete the lock document by _id + holder.
-#   Expire:  TTL index on expires_at automatically cleans orphaned locks.
+# Lease semantics (same idiom as core/workflow/queue.py):
+#   Acquire: atomic insert / steal-expired findOneAndUpdate on a unique
+#            (resource) index. Exactly one holder wins.
+#   Renew:   a background task extends expires_at while the protected
+#            operation runs; renewal failure marks the lease LOST.
+#   Release: delete by (resource, holder_id) — a stale holder can never
+#            delete a successor's lease.
+#   Expire:  TTL index on expires_at cleans up leases from crashed holders.
+#
+# Operating modes (explicit, resolved once at host startup):
+#   required — the Mongo lock authority must be reachable; acquisition fails
+#              closed (ChatLockAuthorityUnavailableError) before any session
+#              or WAL mutation when it is not. This is the only mode that
+#              provides cross-instance exclusion.
+#   local    — process-local asyncio locks. Single-process boundary only;
+#              never distributed safety. Used when database persistence is
+#              disabled (no Mongo configured) and in unconfigured embedded /
+#              test processes.
+#
+# Hosts call configure_chat_lock() during startup; it resolves `required`
+# whenever database persistence is enabled for the process. An unconfigured
+# process (unit tests, embedded transports that never run host startup)
+# stays in local mode unless MOZAIKS_CHAT_LOCK_MODE overrides it.
+#
+# Known residual window (documented, not fenced in this slice): a holder that
+# stalls past its TTL without a failed renewal can have at most one in-flight
+# write land after a successor acquires. Confirmed lease loss (failed or
+# unprovable renewal) stops all further guarded durable writes via
+# assert_chat_mutable(). Storage-level fencing tokens are a later sub-slice
+# of issue #426.
 #
 # Configuration (env vars):
-#   DISTRIBUTED_LOCK_TTL_SECONDS   — lock TTL in seconds (default 60)
-#   DISTRIBUTED_LOCK_RETRY_DELAY   — retry interval on contention in seconds (default 0.2)
-#   DISTRIBUTED_LOCK_MAX_RETRIES   — max acquisition retries (default 15 = 3s total)
+#   MOZAIKS_CHAT_LOCK_MODE         — "required" | "local" explicit override
+#   DISTRIBUTED_LOCK_TTL_SECONDS   — lease TTL in seconds (default 60)
+#   DISTRIBUTED_LOCK_RETRY_DELAY   — retry interval on contention (default 0.2)
+#   DISTRIBUTED_LOCK_MAX_RETRIES   — max acquisition retries (default 15 = 3s)
 # ==============================================================================
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
+import socket
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from typing import Any
 from uuid import uuid4
 
 from logs.logging_config import get_core_logger
+from mozaiksai.core.multitenant.app_ids import normalize_app_id
 
 logger = get_core_logger("distributed_lock")
 
 _LOCK_COLLECTION = "distributed_locks"
-_LOCK_DB = os.getenv("MOZAIKS_APP_DATABASE_NAME", "mozaiks_apps")
+
+CHAT_LOCK_MODE_ENV = "MOZAIKS_CHAT_LOCK_MODE"
+
+_RELEASE_TIMEOUT_SECONDS = 5.0
+
+
+class ChatLockMode(StrEnum):
+    REQUIRED = "required"
+    LOCAL = "local"
 
 
 def _ttl() -> int:
     try:
-        return int(os.getenv("DISTRIBUTED_LOCK_TTL_SECONDS", "60").strip())
+        return max(2, int(os.getenv("DISTRIBUTED_LOCK_TTL_SECONDS", "60").strip()))
     except (ValueError, AttributeError):
         return 60
 
@@ -52,31 +93,140 @@ def _max_retries() -> int:
         return 15
 
 
-class LockAcquisitionError(Exception):
-    """Raised when a distributed lock cannot be acquired within the retry budget."""
+class ChatLockError(Exception):
+    """Base class for chat execution lease failures."""
+
+
+class LockAcquisitionError(ChatLockError):
+    """The resource is held by another owner and stayed held for the retry budget."""
 
     def __init__(self, resource: str) -> None:
         super().__init__(f"Could not acquire lock for resource '{resource}' within retry budget")
         self.resource = resource
 
 
+class ChatLockAuthorityUnavailableError(ChatLockError):
+    """The Mongo lock authority is unreachable while mode is `required`.
+
+    Raised before any session/WAL mutation — callers must fail closed.
+    """
+
+    def __init__(self, resource: str, cause: str = "") -> None:
+        detail = f": {cause}" if cause else ""
+        super().__init__(f"Chat lock authority unavailable for resource '{resource}'{detail}")
+        self.resource = resource
+
+
+class ChatLeaseLostError(ChatLockError):
+    """This process's lease for the chat was lost; durable writes are refused."""
+
+    def __init__(self, resource: str) -> None:
+        super().__init__(
+            f"Chat execution lease lost for resource '{resource}'; refusing further durable writes"
+        )
+        self.resource = resource
+
+
+def chat_lock_resource(app_id: Any, chat_id: str) -> str:
+    """Canonical tenant-scoped lock identity for a chat.
+
+    Scope comes from the same normalization authority as Mongo app-scope
+    filters, so identical chat ids under different tenants never collide.
+    """
+    scope = normalize_app_id(app_id) or "__invalid__"
+    return f"chat:{scope}:{chat_id}"
+
+
+# ------------------------------------------------------------------------------
+# Mode configuration
+# ------------------------------------------------------------------------------
+
+_configured_mode: ChatLockMode | None = None
+
+
+def _env_mode_override() -> ChatLockMode | None:
+    raw = (os.getenv(CHAT_LOCK_MODE_ENV) or "").strip().lower()
+    if not raw:
+        return None
+    if raw in (ChatLockMode.REQUIRED, ChatLockMode.LOCAL):
+        return ChatLockMode(raw)
+    logger.warning("Invalid %s=%r; ignoring override", CHAT_LOCK_MODE_ENV, raw)
+    return None
+
+
+def configure_chat_lock(mode: ChatLockMode | str | None = None) -> ChatLockMode:
+    """Resolve and pin the chat lock operating mode. Called at host startup.
+
+    Resolution order: explicit ``mode`` argument, ``MOZAIKS_CHAT_LOCK_MODE``,
+    then ``required`` when database persistence is enabled for this process
+    (the multi-instance posture), else ``local``.
+    """
+    global _configured_mode
+    resolved: ChatLockMode | None = ChatLockMode(mode) if mode else _env_mode_override()
+    if resolved is None:
+        from mozaiksai.core.runtime.persistence.startup_policy import (
+            database_persistence_is_enabled,
+            get_database_startup_policy,
+        )
+
+        policy = get_database_startup_policy()
+        resolved = (
+            ChatLockMode.REQUIRED
+            if database_persistence_is_enabled(policy)
+            else ChatLockMode.LOCAL
+        )
+    _configured_mode = resolved
+    logger.info("Chat lock mode configured: %s", resolved)
+    return resolved
+
+
+def get_chat_lock_mode() -> ChatLockMode:
+    """Current operating mode.
+
+    Unconfigured processes (no host startup ran) default to ``local`` unless
+    the env override says otherwise — local mode is a truthful description of
+    a process that never entered the host lifecycle, not distributed safety.
+    """
+    if _configured_mode is not None:
+        return _configured_mode
+    return _env_mode_override() or ChatLockMode.LOCAL
+
+
+def reset_chat_lock_state() -> None:
+    """Test hook: clear configured mode, lease registry, and local locks."""
+    global _configured_mode, _acquisition_indexes_verified
+    _configured_mode = None
+    _acquisition_indexes_verified = False
+    _process_leases.clear()
+    _local_locks.clear()
+
+
+# ------------------------------------------------------------------------------
+# Mongo authority
+# ------------------------------------------------------------------------------
+
 def _get_lock_collection() -> Any | None:
     try:
         from mozaiksai.core.core_config import get_mongo_client
+
+        # Lazy import: persistence_manager imports this module at load time,
+        # so a top-level namespaces import would be circular.
+        from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE
+
         client = get_mongo_client()
         if client is None:
             return None
-        return client[_LOCK_DB][_LOCK_COLLECTION]
+        return client[SYSTEM_DATABASE][_LOCK_COLLECTION]
     except Exception as exc:
         logger.debug("Lock collection unavailable: %s", exc)
         return None
 
 
 async def ensure_lock_indexes() -> None:
-    """Create TTL index on expires_at — call once at startup.
+    """Create TTL + unique resource indexes — call once at startup.
 
-    The TTL index auto-cleans orphaned locks after their expiry,
-    preventing lock starvation if a holder crashes.
+    The TTL index auto-cleans leases from crashed holders after expiry,
+    preventing lock starvation.
     """
     collection = _get_lock_collection()
     if collection is None:
@@ -99,18 +249,59 @@ async def ensure_lock_indexes() -> None:
         logger.warning("Could not ensure lock indexes: %s", exc)
 
 
-async def _try_acquire(collection: Any, resource: str, holder_id: str, ttl_seconds: int) -> bool:
-    """Attempt a single lock acquisition. Returns True on success."""
-    expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
-    now = datetime.now(UTC)
+_acquisition_indexes_verified = False
+
+
+def _is_unique_resource_index(spec: dict[str, Any]) -> bool:
+    if not spec.get("unique"):
+        return False
+    key = spec.get("key")
+    pairs = list(key.items()) if hasattr(key, "items") else list(key or [])
+    return [(str(field), int(direction)) for field, direction in pairs] == [("resource", 1)]
+
+
+async def _verify_acquisition_indexes(collection: Any) -> None:
+    """Ensure the unique resource index exists before the first acquisition.
+
+    The unique index is the atomicity backstop of the insert-based acquire:
+    without it two holders can insert duplicate lease documents and both
+    believe they own the chat. Index creation failures are therefore not a
+    warning here — required mode fails closed.
+    """
+    global _acquisition_indexes_verified
+    if _acquisition_indexes_verified:
+        return
     try:
-        # Upsert: insert new lock if none exists OR the existing one is expired.
+        await collection.create_index(
+            [("resource", 1)],
+            unique=True,
+            name="lock_resource_unique_idx",
+            background=True,
+        )
+        index_info = await collection.index_information()
+    except Exception as exc:
+        raise ChatLockAuthorityUnavailableError(
+            "*", f"could not ensure unique lock index: {exc}"
+        ) from exc
+    if not any(_is_unique_resource_index(spec) for spec in index_info.values()):
+        raise ChatLockAuthorityUnavailableError(
+            "*", "unique lock index missing after creation attempt"
+        )
+    _acquisition_indexes_verified = True
+
+
+async def _try_acquire(collection: Any, resource: str, holder_id: str, ttl_seconds: int) -> bool:
+    """Attempt a single atomic lock acquisition. Returns True on success."""
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    try:
+        # Steal an expired lease, or re-assert one this holder already owns.
         result = await collection.find_one_and_update(
             {
                 "resource": resource,
                 "$or": [
-                    {"expires_at": {"$lt": now}},   # expired lock — can steal
-                    {"holder_id": holder_id},         # same holder re-acquiring
+                    {"expires_at": {"$lt": now}},
+                    {"holder_id": holder_id},
                 ],
             },
             {
@@ -127,7 +318,8 @@ async def _try_acquire(collection: Any, resource: str, holder_id: str, ttl_secon
         if result is not None:
             return True
 
-        # No expired lock exists — try a clean insert.
+        # No expired lease exists — try a clean insert; the unique index on
+        # `resource` makes exactly one concurrent inserter win.
         try:
             await collection.insert_one({
                 "resource": resource,
@@ -137,44 +329,236 @@ async def _try_acquire(collection: Any, resource: str, holder_id: str, ttl_secon
             })
             return True
         except Exception:
-            # DuplicateKeyError or similar — lock is held by another.
+            # DuplicateKeyError or similar — lease is held by another owner.
             return False
     except Exception as exc:
         logger.debug("Lock acquisition attempt failed resource=%s: %s", resource, exc)
         return False
 
 
-async def _release(collection: Any, resource: str, holder_id: str) -> None:
-    """Release a lock held by this holder."""
-    try:
-        await collection.delete_one({"resource": resource, "holder_id": holder_id})
-    except Exception as exc:
-        logger.warning("Lock release failed resource=%s holder=%s: %s", resource, holder_id, exc)
+# ------------------------------------------------------------------------------
+# Lease handle + process registry
+# ------------------------------------------------------------------------------
 
+class ChatLease:
+    """Handle for one held chat execution lease.
+
+    ``lost`` flips to True on confirmed lease loss (renewal found the lease
+    gone, owned by a successor, or unprovable past its TTL). Guarded durable
+    writes consult it through assert_chat_mutable().
+    """
+
+    def __init__(
+        self,
+        *,
+        resource: str,
+        holder_id: str,
+        mode: ChatLockMode,
+        collection: Any | None,
+        ttl_seconds: int,
+    ) -> None:
+        self.resource = resource
+        self.holder_id = holder_id
+        self.mode = mode
+        self._collection = collection
+        self._ttl_seconds = ttl_seconds
+        self._expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+        self._lost = False
+        self._renew_task: asyncio.Task[None] | None = None
+
+    @property
+    def lost(self) -> bool:
+        return self._lost
+
+    def _mark_lost(self, reason: str) -> None:
+        if not self._lost:
+            self._lost = True
+            logger.error(
+                "CHAT_LOCK_RENEWAL_LOST resource=%s holder=%s: %s — durable writes for this chat are now refused in this process",
+                self.resource,
+                self.holder_id,
+                reason,
+            )
+
+    async def _renew_once(self) -> None:
+        """Extend the lease; mark lost when ownership can no longer be proven."""
+        if self._collection is None or self._lost:
+            return
+        now = datetime.now(UTC)
+        new_expiry = now + timedelta(seconds=self._ttl_seconds)
+        try:
+            result = await self._collection.find_one_and_update(
+                {"resource": self.resource, "holder_id": self.holder_id},
+                {"$set": {"expires_at": new_expiry, "renewed_at": now.isoformat()}},
+                upsert=False,
+                return_document=True,
+            )
+        except Exception as exc:
+            # Transient authority failure: ownership is unprovable. Only a
+            # lease that has actually passed its TTL may have been stolen.
+            if datetime.now(UTC) >= self._expires_at:
+                self._mark_lost(f"renewal unreachable past TTL ({exc})")
+            else:
+                logger.warning(
+                    "CHAT_LOCK_RENEWAL_RETRY resource=%s holder=%s: %s",
+                    self.resource,
+                    self.holder_id,
+                    exc,
+                )
+            return
+        if result is None:
+            self._mark_lost("lease document missing or owned by a successor")
+            return
+        self._expires_at = new_expiry
+
+    async def _renew_loop(self) -> None:
+        interval = max(self._ttl_seconds / 3.0, 1.0)
+        while not self._lost:
+            await asyncio.sleep(interval)
+            await self._renew_once()
+
+    def start_renewal(self) -> None:
+        if self._collection is not None and self._renew_task is None:
+            self._renew_task = asyncio.create_task(
+                self._renew_loop(), name=f"chat-lease-renew:{self.resource}"
+            )
+
+    async def stop_renewal(self) -> None:
+        task = self._renew_task
+        self._renew_task = None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    async def release(self) -> None:
+        """Delete this holder's lease document. Never touches a successor's.
+
+        The (resource, holder_id) filter means a stale holder's release
+        matches nothing once a successor owns the resource.
+        """
+        if self._collection is None:
+            return
+        try:
+            await self._collection.delete_one(
+                {"resource": self.resource, "holder_id": self.holder_id}
+            )
+        except Exception as exc:
+            logger.warning(
+                "CHAT_LOCK_RELEASE_FAILED resource=%s holder=%s: %s — the TTL index reclaims the lease at expiry",
+                self.resource,
+                self.holder_id,
+                exc,
+            )
+
+
+# Leases currently held by this process, keyed by resource. Consulted by
+# assert_chat_mutable() at durable chat write seams.
+_process_leases: dict[str, ChatLease] = {}
+
+
+def assert_chat_mutable(*, app_id: Any, chat_id: str) -> None:
+    """Refuse durable chat writes after confirmed lease loss.
+
+    No-op when this process holds no lease for the chat (read paths, local
+    mode, and processes outside the host lifecycle keep current behavior).
+    """
+    lease = _process_leases.get(chat_lock_resource(app_id, chat_id))
+    if lease is not None and lease.lost:
+        raise ChatLeaseLostError(lease.resource)
+
+
+# ------------------------------------------------------------------------------
+# Local (single-process) mode
+# ------------------------------------------------------------------------------
+
+class _LocalLockEntry:
+    __slots__ = ("lock", "refs")
+
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.refs = 0
+
+
+_local_locks: dict[str, _LocalLockEntry] = {}
+
+
+def _default_holder_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid4().hex}"
+
+
+# ------------------------------------------------------------------------------
+# Acquisition context manager
+# ------------------------------------------------------------------------------
 
 @asynccontextmanager
-async def distributed_lock(resource: str, *, holder_id: str | None = None):
-    """Async context manager that acquires and releases a distributed lock.
+async def chat_execution_lease(
+    *,
+    app_id: Any,
+    chat_id: str,
+    holder_id: str | None = None,
+):
+    """Hold the exclusive execution lease for one chat across the protected op.
 
     Usage:
-        async with distributed_lock(f"chat:{chat_id}"):
-            # Only one instance can resume this chat at a time
+        async with chat_execution_lease(app_id=app_id, chat_id=chat_id):
+            # only one instance may run a mutable start/resume for this chat
             ...
 
-    Raises LockAcquisitionError if the lock cannot be acquired.
-    Falls through silently if MongoDB is unavailable (degraded mode).
+    Raises:
+        LockAcquisitionError                — another owner holds the lease (busy).
+        ChatLockAuthorityUnavailableError   — mode is `required` and the Mongo
+                                              lock authority is unreachable;
+                                              callers must fail closed before
+                                              any session/WAL mutation.
     """
-    collection = _get_lock_collection()
-    if collection is None:
-        # MongoDB unavailable — run without distributed lock (degraded mode).
-        logger.warning("DISTRIBUTED_LOCK_DEGRADED resource=%s — MongoDB unavailable, proceeding without lock", resource)
-        yield
-        return
-
-    effective_holder = holder_id or str(uuid4())
-    ttl = _ttl()
+    resource = chat_lock_resource(app_id, chat_id)
+    mode = get_chat_lock_mode()
     delay = _retry_delay()
     max_retries = _max_retries()
+
+    if mode is ChatLockMode.LOCAL:
+        entry = _local_locks.setdefault(resource, _LocalLockEntry())
+        entry.refs += 1
+        try:
+            budget = delay * max_retries if delay * max_retries > 0 else 0.001
+            try:
+                await asyncio.wait_for(entry.lock.acquire(), timeout=budget)
+            except TimeoutError:
+                logger.warning("CHAT_LOCK_BUSY resource=%s mode=local", resource)
+                raise LockAcquisitionError(resource) from None
+            lease = ChatLease(
+                resource=resource,
+                holder_id=holder_id or _default_holder_id(),
+                mode=mode,
+                collection=None,
+                ttl_seconds=_ttl(),
+            )
+            _process_leases[resource] = lease
+            try:
+                yield lease
+            finally:
+                if _process_leases.get(resource) is lease:
+                    _process_leases.pop(resource, None)
+                entry.lock.release()
+        finally:
+            entry.refs -= 1
+            if entry.refs <= 0 and not entry.lock.locked():
+                _local_locks.pop(resource, None)
+        return
+
+    collection = _get_lock_collection()
+    if collection is None:
+        logger.error(
+            "CHAT_LOCK_AUTHORITY_UNAVAILABLE resource=%s — refusing execution before session/WAL mutation",
+            resource,
+        )
+        raise ChatLockAuthorityUnavailableError(resource, "MongoDB lock collection unavailable")
+
+    await _verify_acquisition_indexes(collection)
+
+    effective_holder = holder_id or _default_holder_id()
+    ttl = _ttl()
 
     acquired = False
     for attempt in range(max_retries + 1):
@@ -189,18 +573,53 @@ async def distributed_lock(resource: str, *, holder_id: str | None = None):
             await asyncio.sleep(delay)
 
     if not acquired:
+        logger.warning("CHAT_LOCK_BUSY resource=%s holder=%s", resource, effective_holder)
         raise LockAcquisitionError(resource)
 
+    lease = ChatLease(
+        resource=resource,
+        holder_id=effective_holder,
+        mode=mode,
+        collection=collection,
+        ttl_seconds=ttl,
+    )
+    _process_leases[resource] = lease
+    lease.start_renewal()
     logger.debug("LOCK_ACQUIRED resource=%s holder=%s", resource, effective_holder)
     try:
-        yield
+        yield lease
     finally:
-        await _release(collection, resource, effective_holder)
+        if _process_leases.get(resource) is lease:
+            _process_leases.pop(resource, None)
+        await lease.stop_renewal()
+        # Bounded, cancellation-safe release: the delete keeps running in its
+        # own task even if the surrounding task is being cancelled.
+        release_task = asyncio.create_task(lease.release())
+        try:
+            await asyncio.wait_for(asyncio.shield(release_task), timeout=_RELEASE_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.CancelledError):
+            # TTL expiry reclaims the lease if the detached delete also fails.
+            logger.warning(
+                "CHAT_LOCK_RELEASE_FAILED resource=%s holder=%s: release interrupted; TTL will reclaim",
+                resource,
+                effective_holder,
+            )
         logger.debug("LOCK_RELEASED resource=%s holder=%s", resource, effective_holder)
 
 
 __all__ = [
+    "CHAT_LOCK_MODE_ENV",
+    "ChatLease",
+    "ChatLeaseLostError",
+    "ChatLockAuthorityUnavailableError",
+    "ChatLockError",
+    "ChatLockMode",
     "LockAcquisitionError",
-    "distributed_lock",
+    "assert_chat_mutable",
+    "chat_execution_lease",
+    "chat_lock_resource",
+    "configure_chat_lock",
     "ensure_lock_indexes",
+    "get_chat_lock_mode",
+    "reset_chat_lock_state",
 ]

--- a/mozaiksai/core/runtime/persistence/distributed_lock.py
+++ b/mozaiksai/core/runtime/persistence/distributed_lock.py
@@ -255,8 +255,8 @@ _acquisition_indexes_verified = False
 def _is_unique_resource_index(spec: dict[str, Any]) -> bool:
     if not spec.get("unique"):
         return False
-    key = spec.get("key")
-    pairs = list(key.items()) if hasattr(key, "items") else list(key or [])
+    key = spec.get("key") or []
+    pairs = list(key.items()) if hasattr(key, "items") else list(key)
     return [(str(field), int(direction)) for field, direction in pairs] == [("resource", 1)]
 
 

--- a/mozaiksai/core/transport/workflow_bridge.py
+++ b/mozaiksai/core/transport/workflow_bridge.py
@@ -23,6 +23,12 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from mozaiksai.core.runtime.composition.extensions import get_workflow_lifecycle_hooks
+from mozaiksai.core.runtime.persistence.distributed_lock import (
+    ChatLockAuthorityUnavailableError,
+    LockAcquisitionError,
+    chat_execution_lease,
+    chat_lock_resource,
+)
 from mozaiksai.core.transport.session_registry import session_registry
 
 if TYPE_CHECKING:
@@ -259,14 +265,26 @@ class WorkflowBridgeMixin:
             if callable(get_live_run):
                 live_run = get_live_run(chat_id)
             if live_run is not None and isinstance(message, str) and message.strip():
-                return await self._continue_live_ag2_workflow_run(
-                    live_run=live_run,
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    workflow_name=workflow_name,
-                    message=message,
-                    app_id=app_id,
-                )
+                # Continuing a paused run restarts mutable execution: it needs
+                # the same chat execution lease as a fresh start/resume.
+                try:
+                    async with chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                        return await self._continue_live_ag2_workflow_run(
+                            live_run=live_run,
+                            chat_id=chat_id,
+                            user_id=user_id,
+                            workflow_name=workflow_name,
+                            message=message,
+                            app_id=app_id,
+                        )
+                except LockAcquisitionError as lock_err:
+                    if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                        raise
+                    return await self._reject_chat_locked(chat_id=chat_id, busy=True)
+                except ChatLockAuthorityUnavailableError as lock_err:
+                    if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                        raise
+                    return await self._reject_chat_locked(chat_id=chat_id, busy=False)
 
             if has_active_session and active_callbacks:
                 # Route to existing AG2 session via WebSocket callback mechanism
@@ -317,140 +335,31 @@ class WorkflowBridgeMixin:
             logger.debug("[SMART_ROUTING] Starting new workflow for chat %s", chat_id)
             starting_new_workflow = True
 
-            from mozaiksai.core.adapters.ag2_orchestration import get_ag2_adapter
-            from mozaiksai.core.ports.orchestration import ResumeRequest, RunRequest
-
-            if message or is_resume_request:
-                try:
-                    pm = self._get_or_create_persistence_manager()
-                    pending = await pm.get_pending_input_request(
-                        chat_id=chat_id,
-                        app_id=app_id,
-                    )
-                    if pending:
-                        await pm.clear_pending_input_request(
-                            chat_id=chat_id,
-                            app_id=app_id,
-                        )
-                        logger.debug(
-                            "[SMART_ROUTING] Cleared persisted pending input request %s before launching workflow for chat %s",
-                            pending.get("request_id"),
-                            chat_id,
-                        )
-                except Exception as clear_err:
-                    logger.debug(
-                        "[SMART_ROUTING] Failed clearing persisted pending input request for %s: %s", chat_id, clear_err)
-
-            # Only persist and echo user message when starting NEW workflows
-            # For existing sessions, the message goes directly to AG2 via callback
-            if message:
-                try:
-                    await self._apply_user_text_context_updates(
-                        chat_id=chat_id,
-                        workflow_name=workflow_name,
-                        app_id=app_id,
-                        user_input=message,
-                    )
-                except Exception as trigger_err:
-                    logger.debug("[SMART_ROUTING] user_text trigger update skipped for new run %s: %s", chat_id, trigger_err)
-                try:
-                    pm = self._get_or_create_persistence_manager()
-                    append_user_message = getattr(pm, "append_run_user_message", None)
-                    if append_user_message is not None:
-                        await append_user_message(
-                            chat_id=chat_id,
-                            app_id=app_id,
-                            content=str(message or ""),
-                            metadata={"source": "workflow_user", "user_id": user_id},
-                        )
-                    await self.process_incoming_user_message(
+            # Same-chat distributed exclusion: hold the chat execution lease
+            # for the entire mutable start/resume. adapter.run()/.resume()
+            # return exactly at a durably persisted terminal or human-waiting
+            # boundary, so releasing on context exit lands on that boundary.
+            try:
+                async with chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                    return await self._launch_workflow_run_locked(
                         chat_id=chat_id,
                         user_id=user_id,
-                        content=message,
-                        source='http'
+                        workflow_name=workflow_name,
+                        message=message,
+                        app_id=app_id,
+                        initial_agent_name_override=initial_agent_name_override,
+                        is_resume_request=is_resume_request,
+                        emit_execution_started=_emit_execution_started,
+                        emit_execution_completed=_emit_execution_completed,
                     )
-                except Exception as persist_err:
-                    logger.debug("Early persistence of user message failed (non-fatal): %s", persist_err)
-
-            # Build lifecycle reporting (best-effort; non-blocking).
-            if _emit_execution_started is not None:
-                try:
-                    _t = asyncio.create_task(
-                        _emit_execution_started(
-                            app_id=app_id,
-                            execution_id=chat_id,
-                            chat_id=chat_id,
-                            user_id=user_id,
-                            workflow_name=workflow_name,
-                        )
-                    )
-                    _t.add_done_callback(
-                        lambda t: logger.debug("EXECUTION_STARTED_EMIT_FAILED chat=%s: %s", chat_id, t.exception())
-                        if not t.cancelled() and t.exception() is not None
-                        else None
-                    )
-                except Exception as _ev_exc:
-                    logger.debug("EXECUTION_STARTED_EMIT_TASK_FAILED chat=%s: %s", chat_id, _ev_exc)
-
-            # Launch orchestration via OrchestrationPort (engine-agnostic).
-            # A missing message plus an explicit initial-agent override means the
-            # caller is resuming an existing chat, not starting a fresh run.
-            adapter = get_ag2_adapter()
-            if is_resume_request:
-                run_result = await adapter.resume(ResumeRequest(
-                    workflow_name=workflow_name,
-                    app_id=app_id,
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    resume_agent=initial_agent_name_override,
-                ))
-            else:
-                run_result = await adapter.run(RunRequest(
-                    workflow_name=workflow_name,
-                    app_id=app_id,
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    initial_message=None,  # already persisted & sent upstream
-                    initial_agent_name_override=initial_agent_name_override,
-                ))
-
-            run_status = getattr(run_result, "status", None)
-            run_status_value = str(getattr(run_status, "value", run_status or "completed"))
-
-            if _emit_execution_completed is not None and run_status_value == "completed":
-                try:
-                    _t = asyncio.create_task(
-                        _emit_execution_completed(
-                            app_id=app_id,
-                            execution_id=chat_id,
-                            chat_id=chat_id,
-                            user_id=user_id,
-                            workflow_name=workflow_name,
-                        )
-                    )
-                    _t.add_done_callback(
-                        lambda t: logger.debug("EXECUTION_COMPLETED_EMIT_FAILED chat=%s: %s", chat_id, t.exception())
-                        if not t.cancelled() and t.exception() is not None
-                        else None
-                    )
-                except Exception as _ev_exc:
-                    logger.debug("EXECUTION_COMPLETED_EMIT_TASK_FAILED chat=%s: %s", chat_id, _ev_exc)
-
-            await self._emit_synthetic_run_complete_if_needed(
-                chat_id=chat_id,
-                workflow_name=workflow_name,
-                run_status_value=run_status_value,
-            )
-
-            route = "workflow_resume" if is_resume_request else "new_workflow"
-            message_text = "Workflow resumed successfully." if is_resume_request else "Workflow started successfully."
-            return {
-                "status": "success",
-                "chat_id": chat_id,
-                "message": message_text,
-                "route": route,
-                "run_status": run_status_value,
-            }
+            except LockAcquisitionError as lock_err:
+                if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                    raise
+                return await self._reject_chat_locked(chat_id=chat_id, busy=True)
+            except ChatLockAuthorityUnavailableError as lock_err:
+                if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                    raise
+                return await self._reject_chat_locked(chat_id=chat_id, busy=False)
 
         except Exception as e:
             # Surface token denial before the generic failure path so the UI
@@ -518,6 +427,193 @@ class WorkflowBridgeMixin:
                 chat_id=chat_id
             )
             return {"status": "error", "chat_id": chat_id, "message": "Workflow execution failed"}
+
+    async def _reject_chat_locked(self, *, chat_id: str, busy: bool) -> dict[str, Any]:
+        """Fail closed before any session/WAL mutation with a distinct diagnostic."""
+        if busy:
+            logger.warning(
+                "CHAT_LOCK_BUSY chat=%s — another execution holds this chat's lease", chat_id
+            )
+            await self.send_error(
+                error_message="This chat is already executing elsewhere. Please retry shortly.",
+                error_code="CHAT_LOCK_BUSY",
+                chat_id=chat_id,
+            )
+            return {
+                "status": "busy",
+                "chat_id": chat_id,
+                "message": "Chat is locked by another execution.",
+                "route": "chat_lock_busy",
+            }
+        logger.error(
+            "CHAT_LOCK_AUTHORITY_UNAVAILABLE chat=%s — refusing execution before session/WAL mutation",
+            chat_id,
+        )
+        await self.send_error(
+            error_message="Chat execution is temporarily unavailable. Please retry shortly.",
+            error_code="CHAT_LOCK_UNAVAILABLE",
+            chat_id=chat_id,
+        )
+        return {
+            "status": "error",
+            "chat_id": chat_id,
+            "message": "Chat lock authority unavailable.",
+            "route": "chat_lock_unavailable",
+        }
+
+    async def _launch_workflow_run_locked(
+        self,
+        *,
+        chat_id: str,
+        user_id: str | None,
+        workflow_name: str,
+        message: str | None,
+        app_id: str,
+        initial_agent_name_override: str | None,
+        is_resume_request: bool,
+        emit_execution_started: Any,
+        emit_execution_completed: Any,
+    ) -> dict[str, Any]:
+        """Start or resume a workflow run for a chat.
+
+        The caller must hold the chat execution lease for this
+        (app_id, chat_id); every durable session/WAL mutation of the
+        start/resume path happens inside this method.
+        """
+        from mozaiksai.core.adapters.ag2_orchestration import get_ag2_adapter
+        from mozaiksai.core.ports.orchestration import ResumeRequest, RunRequest
+
+        if message or is_resume_request:
+            try:
+                pm = self._get_or_create_persistence_manager()
+                pending = await pm.get_pending_input_request(
+                    chat_id=chat_id,
+                    app_id=app_id,
+                )
+                if pending:
+                    await pm.clear_pending_input_request(
+                        chat_id=chat_id,
+                        app_id=app_id,
+                    )
+                    logger.debug(
+                        "[SMART_ROUTING] Cleared persisted pending input request %s before launching workflow for chat %s",
+                        pending.get("request_id"),
+                        chat_id,
+                    )
+            except Exception as clear_err:
+                logger.debug(
+                    "[SMART_ROUTING] Failed clearing persisted pending input request for %s: %s", chat_id, clear_err)
+
+        # Only persist and echo user message when starting NEW workflows
+        # For existing sessions, the message goes directly to AG2 via callback
+        if message:
+            try:
+                await self._apply_user_text_context_updates(
+                    chat_id=chat_id,
+                    workflow_name=workflow_name,
+                    app_id=app_id,
+                    user_input=message,
+                )
+            except Exception as trigger_err:
+                logger.debug("[SMART_ROUTING] user_text trigger update skipped for new run %s: %s", chat_id, trigger_err)
+            try:
+                pm = self._get_or_create_persistence_manager()
+                append_user_message = getattr(pm, "append_run_user_message", None)
+                if append_user_message is not None:
+                    await append_user_message(
+                        chat_id=chat_id,
+                        app_id=app_id,
+                        content=str(message or ""),
+                        metadata={"source": "workflow_user", "user_id": user_id},
+                    )
+                await self.process_incoming_user_message(
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    content=message,
+                    source='http'
+                )
+            except Exception as persist_err:
+                logger.debug("Early persistence of user message failed (non-fatal): %s", persist_err)
+
+        # Build lifecycle reporting (best-effort; non-blocking).
+        if emit_execution_started is not None:
+            try:
+                _t = asyncio.create_task(
+                    emit_execution_started(
+                        app_id=app_id,
+                        execution_id=chat_id,
+                        chat_id=chat_id,
+                        user_id=user_id,
+                        workflow_name=workflow_name,
+                    )
+                )
+                _t.add_done_callback(
+                    lambda t: logger.debug("EXECUTION_STARTED_EMIT_FAILED chat=%s: %s", chat_id, t.exception())
+                    if not t.cancelled() and t.exception() is not None
+                    else None
+                )
+            except Exception as _ev_exc:
+                logger.debug("EXECUTION_STARTED_EMIT_TASK_FAILED chat=%s: %s", chat_id, _ev_exc)
+
+        # Launch orchestration via OrchestrationPort (engine-agnostic).
+        # A missing message plus an explicit initial-agent override means the
+        # caller is resuming an existing chat, not starting a fresh run.
+        adapter = get_ag2_adapter()
+        if is_resume_request:
+            run_result = await adapter.resume(ResumeRequest(
+                workflow_name=workflow_name,
+                app_id=app_id,
+                chat_id=chat_id,
+                user_id=user_id,
+                resume_agent=initial_agent_name_override,
+            ))
+        else:
+            run_result = await adapter.run(RunRequest(
+                workflow_name=workflow_name,
+                app_id=app_id,
+                chat_id=chat_id,
+                user_id=user_id,
+                initial_message=None,  # already persisted & sent upstream
+                initial_agent_name_override=initial_agent_name_override,
+            ))
+
+        run_status = getattr(run_result, "status", None)
+        run_status_value = str(getattr(run_status, "value", run_status or "completed"))
+
+        if emit_execution_completed is not None and run_status_value == "completed":
+            try:
+                _t = asyncio.create_task(
+                    emit_execution_completed(
+                        app_id=app_id,
+                        execution_id=chat_id,
+                        chat_id=chat_id,
+                        user_id=user_id,
+                        workflow_name=workflow_name,
+                    )
+                )
+                _t.add_done_callback(
+                    lambda t: logger.debug("EXECUTION_COMPLETED_EMIT_FAILED chat=%s: %s", chat_id, t.exception())
+                    if not t.cancelled() and t.exception() is not None
+                    else None
+                )
+            except Exception as _ev_exc:
+                logger.debug("EXECUTION_COMPLETED_EMIT_TASK_FAILED chat=%s: %s", chat_id, _ev_exc)
+
+        await self._emit_synthetic_run_complete_if_needed(
+            chat_id=chat_id,
+            workflow_name=workflow_name,
+            run_status_value=run_status_value,
+        )
+
+        route = "workflow_resume" if is_resume_request else "new_workflow"
+        message_text = "Workflow resumed successfully." if is_resume_request else "Workflow started successfully."
+        return {
+            "status": "success",
+            "chat_id": chat_id,
+            "message": message_text,
+            "route": route,
+            "run_status": run_status_value,
+        }
 
     async def _continue_live_ag2_workflow_run(
         self,

--- a/mozaiksai/core/transport/workflow_bridge.py
+++ b/mozaiksai/core/transport/workflow_bridge.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from mozaiksai.core.runtime.composition.extensions import get_workflow_lifecycle_hooks
 from mozaiksai.core.runtime.persistence.distributed_lock import (
+    ChatLeaseLostError,
     ChatLockAuthorityUnavailableError,
     LockAcquisitionError,
     chat_execution_lease,
@@ -285,6 +286,10 @@ class WorkflowBridgeMixin:
                     if lock_err.resource != chat_lock_resource(app_id, chat_id):
                         raise
                     return await self._reject_chat_locked(chat_id=chat_id, busy=False)
+                except ChatLeaseLostError as lock_err:
+                    if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                        raise
+                    return await self._reject_chat_lease_lost(chat_id=chat_id)
 
             if has_active_session and active_callbacks:
                 # Route to existing AG2 session via WebSocket callback mechanism
@@ -360,6 +365,10 @@ class WorkflowBridgeMixin:
                 if lock_err.resource != chat_lock_resource(app_id, chat_id):
                     raise
                 return await self._reject_chat_locked(chat_id=chat_id, busy=False)
+            except ChatLeaseLostError as lock_err:
+                if lock_err.resource != chat_lock_resource(app_id, chat_id):
+                    raise
+                return await self._reject_chat_lease_lost(chat_id=chat_id)
 
         except Exception as e:
             # Surface token denial before the generic failure path so the UI
@@ -459,6 +468,21 @@ class WorkflowBridgeMixin:
             "chat_id": chat_id,
             "message": "Chat lock authority unavailable.",
             "route": "chat_lock_unavailable",
+        }
+
+    async def _reject_chat_lease_lost(self, *, chat_id: str) -> dict[str, Any]:
+        """Report a run aborted after its distributed lease was lost."""
+        logger.error("CHAT_LOCK_RENEWAL_LOST chat=%s — protected execution aborted", chat_id)
+        await self.send_error(
+            error_message="Chat execution ownership was lost. Please retry shortly.",
+            error_code="CHAT_LOCK_LOST",
+            chat_id=chat_id,
+        )
+        return {
+            "status": "error",
+            "chat_id": chat_id,
+            "message": "Chat execution lease lost.",
+            "route": "chat_lock_lost",
         }
 
     async def _launch_workflow_run_locked(

--- a/mozaiksai/hosts/runtime.py
+++ b/mozaiksai/hosts/runtime.py
@@ -51,7 +51,10 @@ from mozaiksai.core.events.unified_event_dispatcher import get_event_dispatcher
 from mozaiksai.core.multitenant import build_app_scope_filter
 from mozaiksai.core.ports.event_bus import get_event_bus
 from mozaiksai.core.runtime.persistence.artifact_version import ensure_artifact_version_indexes
-from mozaiksai.core.runtime.persistence.distributed_lock import ensure_lock_indexes
+from mozaiksai.core.runtime.persistence.distributed_lock import (
+    configure_chat_lock,
+    ensure_lock_indexes,
+)
 from mozaiksai.core.runtime.persistence.startup_policy import get_database_startup_policy
 from mozaiksai.core.startup.validation import run_startup_checks
 from mozaiksai.core.transport.handlers.workflow_handlers import _background_task_failure_callback
@@ -360,6 +363,11 @@ async def _runtime_startup() -> None:
         ensure_idempotency_indexes(),
         ensure_artifact_version_indexes(),
     )
+
+    # Pin the chat execution lock mode for this host process: `required`
+    # (fail-closed distributed exclusion) whenever database persistence is
+    # enabled, `local` (explicit single-process boundary) otherwise.
+    configure_chat_lock()
 
     # Connect distributed cache (Redis) — falls back to in-memory silently.
     await get_redis_cache().connect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,20 @@ def app_root() -> Path:
     """Pytest fixture: active app workspace root. Skips if not configured."""
     return active_app_root()
 
+
+@pytest.fixture(autouse=True)
+def _isolate_chat_lock_state():
+    """Reset the chat execution lock's process-level state before each test.
+
+    The lock module keeps process-global state (configured mode, held local
+    locks, the lease registry). A test that runs host startup pins `required`
+    mode, and an abandoned background task can leave a local lock held for a
+    reused chat id — either would silently change the behavior of every later
+    test. Entering each test with clean lock state keeps tests
+    order-independent.
+    """
+    from mozaiksai.core.runtime.persistence.distributed_lock import reset_chat_lock_state
+
+    reset_chat_lock_state()
+    yield
+

--- a/tests/test_ag2_knowledge_store.py
+++ b/tests/test_ag2_knowledge_store.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from mozaiksai.core.adapters.ag2_knowledge_store import MongoAG2KnowledgeStore
+from mozaiksai.core.runtime.persistence import distributed_lock as dl
 
 
 class _Cursor:
@@ -109,3 +110,37 @@ async def test_mongo_ag2_knowledge_store_returns_noop_subscription() -> None:
 
     subscription = await store.on_change("/channels", lambda _path: None)
     await subscription.close()
+
+
+@pytest.mark.asyncio
+async def test_mongo_ag2_knowledge_store_refuses_mutation_after_lease_loss() -> None:
+    resource = dl.chat_lock_resource("app-1", "chat-1")
+    lease = dl.ChatLease(
+        resource=resource,
+        holder_id="stale-holder",
+        mode=dl.ChatLockMode.REQUIRED,
+        collection=None,
+        ttl_seconds=60,
+    )
+    lease._mark_lost("test")
+    dl._process_leases[resource] = lease
+    collection = _Collection()
+    store = MongoAG2KnowledgeStore(
+        app_id="app-1",
+        chat_id="chat-1",
+        collection=collection,
+    )
+
+    try:
+        for operation in (
+            store.write("/hub/state", "state"),
+            store.append("/channels/wal", "entry"),
+            store.delete("/hub"),
+        ):
+            with pytest.raises(dl.ChatLeaseLostError):
+                await operation
+        assert collection.update_calls == []
+        assert collection.append_calls == []
+        assert collection.delete_calls == []
+    finally:
+        dl.reset_chat_lock_state()

--- a/tests/test_chat_execution_lease.py
+++ b/tests/test_chat_execution_lease.py
@@ -1,0 +1,375 @@
+"""Unit tests for the chat execution lease (distributed same-chat exclusion).
+
+Covers mode resolution, canonical lock identity, local-mode serialization,
+fail-closed behavior when the lock authority is unavailable, the lease-loss
+write guard, and the workflow-bridge rejection paths.
+
+Cross-instance exclusion against real MongoDB is proven separately in
+tests/test_chat_execution_lease_real_mongo.py.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from mozaiksai.core.runtime.persistence import distributed_lock as dl
+from tests.import_utils import import_module_directly
+
+_bridge_mod = import_module_directly("mozaiksai.core.transport.workflow_bridge")
+_ag2_mod = import_module_directly("mozaiksai.core.adapters.ag2_orchestration")
+
+WorkflowBridgeMixin = _bridge_mod.WorkflowBridgeMixin
+
+
+@pytest.fixture(autouse=True)
+def _clean_lock_state(monkeypatch):
+    monkeypatch.delenv(dl.CHAT_LOCK_MODE_ENV, raising=False)
+    dl.reset_chat_lock_state()
+    yield
+    dl.reset_chat_lock_state()
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution — the single-process boundary is explicit and testable
+# ---------------------------------------------------------------------------
+
+def test_unconfigured_process_defaults_to_local_mode() -> None:
+    assert dl.get_chat_lock_mode() is dl.ChatLockMode.LOCAL
+
+
+def test_env_override_selects_required_mode(monkeypatch) -> None:
+    monkeypatch.setenv(dl.CHAT_LOCK_MODE_ENV, "required")
+    assert dl.get_chat_lock_mode() is dl.ChatLockMode.REQUIRED
+
+
+def test_configure_resolves_required_when_database_persistence_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("MONGO_URI", "mongodb://example.invalid:27017")
+    assert dl.configure_chat_lock() is dl.ChatLockMode.REQUIRED
+    assert dl.get_chat_lock_mode() is dl.ChatLockMode.REQUIRED
+
+
+def test_configure_resolves_local_without_database_persistence(monkeypatch) -> None:
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL", "ENV", "ENVIRONMENT"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    assert dl.configure_chat_lock() is dl.ChatLockMode.LOCAL
+
+
+def test_production_environment_configures_required_mode(monkeypatch) -> None:
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ENV", "production")
+    assert dl.configure_chat_lock() is dl.ChatLockMode.REQUIRED
+
+
+# ---------------------------------------------------------------------------
+# Canonical lock identity — tenant-scoped, server-owned normalization
+# ---------------------------------------------------------------------------
+
+def test_chat_lock_resource_is_tenant_scoped() -> None:
+    assert dl.chat_lock_resource("app-1", "chat-9") == "chat:app-1:chat-9"
+    assert dl.chat_lock_resource("app-2", "chat-9") != dl.chat_lock_resource("app-1", "chat-9")
+
+
+def test_chat_lock_resource_normalizes_invalid_app_ids() -> None:
+    assert dl.chat_lock_resource(None, "chat-9") == "chat:__invalid__:chat-9"
+    assert dl.chat_lock_resource("  ", "chat-9") == "chat:__invalid__:chat-9"
+    assert dl.chat_lock_resource(" app-1 ", "chat-9") == "chat:app-1:chat-9"
+
+
+# ---------------------------------------------------------------------------
+# Local mode — explicit single-process serialization, not distributed safety
+# ---------------------------------------------------------------------------
+
+async def test_local_mode_serializes_same_chat() -> None:
+    order: list[str] = []
+
+    async def hold(tag: str, delay: float) -> None:
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-1"):
+            order.append(f"{tag}:enter")
+            await asyncio.sleep(delay)
+            order.append(f"{tag}:exit")
+
+    await asyncio.gather(hold("a", 0.05), hold("b", 0.0))
+    # Whoever entered first must exit before the other enters.
+    assert order[0].endswith(":enter") and order[1] == order[0].replace(":enter", ":exit")
+
+
+async def test_local_mode_rejects_busy_after_budget(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "1")
+    monkeypatch.setenv("DISTRIBUTED_LOCK_RETRY_DELAY", "0.01")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder() -> None:
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-busy"):
+            entered.set()
+            await release.wait()
+
+    task = asyncio.create_task(holder())
+    await entered.wait()
+    with pytest.raises(dl.LockAcquisitionError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-busy"):
+            pass
+    release.set()
+    await task
+
+
+async def test_local_mode_allows_distinct_chats_and_tenants_concurrently() -> None:
+    async def enter(app_id: str, chat_id: str, gate: asyncio.Event) -> None:
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+            await gate.wait()
+
+    gate = asyncio.Event()
+    tasks = [
+        asyncio.create_task(enter("app-1", "chat-1", gate)),
+        asyncio.create_task(enter("app-1", "chat-2", gate)),
+        asyncio.create_task(enter("app-2", "chat-1", gate)),
+    ]
+    # All three must be inside their lease simultaneously.
+    await asyncio.sleep(0.1)
+    assert all(not t.done() for t in tasks)
+    gate.set()
+    await asyncio.gather(*tasks)
+
+
+async def test_local_mode_releases_on_exception() -> None:
+    with pytest.raises(RuntimeError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-exc"):
+            raise RuntimeError("boom")
+    # Lease is free again.
+    async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-exc"):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Required mode — fail closed when the authority is unavailable
+# ---------------------------------------------------------------------------
+
+async def test_required_mode_fails_closed_when_authority_unavailable(monkeypatch) -> None:
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: None)
+    with pytest.raises(dl.ChatLockAuthorityUnavailableError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-1"):
+            pytest.fail("must not enter the protected section without a lease")
+
+
+class _IndexlessCollection:
+    """The unique index cannot be created — exclusion is unprovable."""
+
+    async def create_index(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("index creation refused")
+
+    async def index_information(self):
+        return {}
+
+
+async def test_required_mode_fails_closed_without_unique_index(monkeypatch) -> None:
+    """Without the unique resource index the insert-based acquire is not
+    atomic (two holders can both insert), so acquisition must fail closed
+    rather than degrade to a cosmetic lock."""
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: _IndexlessCollection())
+    with pytest.raises(dl.ChatLockAuthorityUnavailableError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-1"):
+            pytest.fail("must not enter the protected section without index-backed atomicity")
+
+
+# ---------------------------------------------------------------------------
+# Lease-loss write guard
+# ---------------------------------------------------------------------------
+
+def _register_lease(resource: str, *, lost: bool) -> dl.ChatLease:
+    lease = dl.ChatLease(
+        resource=resource,
+        holder_id="holder-1",
+        mode=dl.ChatLockMode.REQUIRED,
+        collection=None,
+        ttl_seconds=60,
+    )
+    if lost:
+        lease._mark_lost("test")
+    dl._process_leases[resource] = lease
+    return lease
+
+
+def test_assert_chat_mutable_noop_without_registered_lease() -> None:
+    dl.assert_chat_mutable(app_id="app-1", chat_id="chat-1")
+
+
+def test_assert_chat_mutable_noop_while_lease_held() -> None:
+    _register_lease(dl.chat_lock_resource("app-1", "chat-1"), lost=False)
+    dl.assert_chat_mutable(app_id="app-1", chat_id="chat-1")
+
+
+def test_assert_chat_mutable_raises_after_confirmed_lease_loss() -> None:
+    _register_lease(dl.chat_lock_resource("app-1", "chat-1"), lost=True)
+    with pytest.raises(dl.ChatLeaseLostError):
+        dl.assert_chat_mutable(app_id="app-1", chat_id="chat-1")
+    # Other chats stay unaffected.
+    dl.assert_chat_mutable(app_id="app-1", chat_id="chat-2")
+    dl.assert_chat_mutable(app_id="app-2", chat_id="chat-1")
+
+
+class _FakeRenewCollection:
+    """find_one_and_update returns None — the lease is gone or stolen."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def find_one_and_update(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        self.calls += 1
+        return None
+
+
+async def test_renewal_miss_marks_lease_lost() -> None:
+    lease = dl.ChatLease(
+        resource="chat:app-1:chat-1",
+        holder_id="holder-1",
+        mode=dl.ChatLockMode.REQUIRED,
+        collection=_FakeRenewCollection(),
+        ttl_seconds=60,
+    )
+    assert not lease.lost
+    await lease._renew_once()
+    assert lease.lost
+
+
+# ---------------------------------------------------------------------------
+# Workflow bridge rejection paths — no mutation on busy / unavailable
+# ---------------------------------------------------------------------------
+
+class _FakePersistenceManager:
+    def __init__(self) -> None:
+        self.pending_lookups: list[dict[str, str]] = []
+        self.pending_clears: list[dict[str, str]] = []
+        self.run_user_messages: list[dict[str, object]] = []
+
+    async def get_pending_input_request(self, **kwargs):  # noqa: ANN003
+        self.pending_lookups.append(kwargs)
+        return None
+
+    async def clear_pending_input_request(self, **kwargs):  # noqa: ANN003
+        self.pending_clears.append(kwargs)
+
+    async def append_run_user_message(self, **kwargs):  # noqa: ANN003
+        self.run_user_messages.append(kwargs)
+
+
+class _FakeAdapter:
+    def __init__(self, delay: float = 0.0) -> None:
+        self.delay = delay
+        self.run_requests: list[object] = []
+        self.resume_requests: list[object] = []
+
+    async def run(self, request):  # noqa: ANN001
+        self.run_requests.append(request)
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return SimpleNamespace(status=SimpleNamespace(value="completed"))
+
+    async def resume(self, request):  # noqa: ANN001
+        self.resume_requests.append(request)
+        return SimpleNamespace(status=SimpleNamespace(value="completed"))
+
+
+class _DummyTransport(WorkflowBridgeMixin):
+    def __init__(self, persistence_manager: _FakePersistenceManager) -> None:
+        self._input_request_registries = {}
+        self._workflow_spawn_semaphore = None
+        self._background_tasks = {}
+        self.connections = {}
+        self._derived_context_managers = {}
+        self._persistence_manager = persistence_manager
+        self.persisted_messages: list[dict[str, str | None]] = []
+        self.errors: list[dict[str, object]] = []
+        self._live_ag2_workflow_runs: dict[str, object] = {}
+
+    def _get_or_create_persistence_manager(self):
+        return self._persistence_manager
+
+    async def process_incoming_user_message(self, **kwargs) -> None:  # noqa: ANN003
+        self.persisted_messages.append(kwargs)
+
+    async def send_error(
+        self,
+        error_message: str,
+        error_code: str,
+        chat_id: str,
+        extra_data: dict | None = None,
+    ) -> None:
+        self.errors.append({"error_code": error_code, "chat_id": chat_id})
+
+    async def send_event_to_ui(self, event, chat_id=None) -> None:  # noqa: ANN001
+        pass
+
+    async def _apply_user_text_context_updates(self, **kwargs):  # noqa: ANN003
+        return {}
+
+    def get_live_ag2_workflow_run(self, chat_id: str):
+        return self._live_ag2_workflow_runs.get(chat_id)
+
+
+async def test_bridge_busy_loser_performs_no_mutation(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "1")
+    monkeypatch.setenv("DISTRIBUTED_LOCK_RETRY_DELAY", "0.01")
+    monkeypatch.setattr(_bridge_mod, "get_workflow_lifecycle_hooks", lambda _name: {})
+
+    winner_pm, loser_pm = _FakePersistenceManager(), _FakePersistenceManager()
+    winner, loser = _DummyTransport(winner_pm), _DummyTransport(loser_pm)
+    adapter = _FakeAdapter(delay=0.3)
+    monkeypatch.setattr(_ag2_mod, "get_ag2_adapter", lambda: adapter)
+
+    winner_task = asyncio.create_task(
+        winner.handle_user_input_from_api(
+            chat_id="chat-1", user_id="u1", workflow_name="AppGenerator",
+            message="go", app_id="app-1",
+        )
+    )
+    await asyncio.sleep(0.05)  # winner is inside the lease, adapter running
+    loser_result = await loser.handle_user_input_from_api(
+        chat_id="chat-1", user_id="u2", workflow_name="AppGenerator",
+        message="me too", app_id="app-1",
+    )
+    winner_result = await winner_task
+
+    assert winner_result["status"] == "success"
+    assert loser_result["status"] == "busy"
+    assert loser_result["route"] == "chat_lock_busy"
+    assert loser.errors == [{"error_code": "CHAT_LOCK_BUSY", "chat_id": "chat-1"}]
+    # The loser performed no session, workflow, or WAL mutation.
+    assert loser_pm.pending_lookups == []
+    assert loser_pm.pending_clears == []
+    assert loser_pm.run_user_messages == []
+    assert loser.persisted_messages == []
+    assert len(adapter.run_requests) == 1
+
+
+async def test_bridge_fails_closed_when_authority_unavailable(monkeypatch) -> None:
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: None)
+    monkeypatch.setattr(_bridge_mod, "get_workflow_lifecycle_hooks", lambda _name: {})
+
+    pm = _FakePersistenceManager()
+    transport = _DummyTransport(pm)
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(_ag2_mod, "get_ag2_adapter", lambda: adapter)
+
+    result = await transport.handle_user_input_from_api(
+        chat_id="chat-1", user_id="u1", workflow_name="AppGenerator",
+        message="go", app_id="app-1",
+    )
+
+    assert result["status"] == "error"
+    assert result["route"] == "chat_lock_unavailable"
+    assert transport.errors == [{"error_code": "CHAT_LOCK_UNAVAILABLE", "chat_id": "chat-1"}]
+    # Rejected before any session/WAL mutation or orchestration launch.
+    assert pm.pending_lookups == []
+    assert pm.pending_clears == []
+    assert pm.run_user_messages == []
+    assert transport.persisted_messages == []
+    assert adapter.run_requests == []
+    assert adapter.resume_requests == []

--- a/tests/test_chat_execution_lease.py
+++ b/tests/test_chat_execution_lease.py
@@ -10,6 +10,7 @@ tests/test_chat_execution_lease_real_mongo.py.
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -178,6 +179,25 @@ async def test_required_mode_fails_closed_without_unique_index(monkeypatch) -> N
             pytest.fail("must not enter the protected section without index-backed atomicity")
 
 
+class _UnavailableAcquireCollection:
+    async def find_one_and_update(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("lock authority disconnected during acquire")
+
+
+async def test_required_mode_distinguishes_authority_failure_from_contention(monkeypatch) -> None:
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "0")
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: _UnavailableAcquireCollection())
+
+    async def _verified(_collection) -> None:  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(dl, "_verify_acquisition_indexes", _verified)
+    with pytest.raises(dl.ChatLockAuthorityUnavailableError, match="disconnected during acquire"):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-1"):
+            pytest.fail("must not report an authority outage as lock contention")
+
+
 # ---------------------------------------------------------------------------
 # Lease-loss write guard
 # ---------------------------------------------------------------------------
@@ -236,6 +256,75 @@ async def test_renewal_miss_marks_lease_lost() -> None:
     assert not lease.lost
     await lease._renew_once()
     assert lease.lost
+
+
+async def test_confirmed_renewal_loss_cancels_protected_owner() -> None:
+    lease = dl.ChatLease(
+        resource="chat:app-1:chat-1",
+        holder_id="holder-1",
+        mode=dl.ChatLockMode.REQUIRED,
+        collection=_FakeRenewCollection(),
+        ttl_seconds=60,
+    )
+
+    async def _protected_execution() -> None:
+        lease._owner_task = asyncio.current_task()
+        await asyncio.create_task(lease._renew_once())
+        await asyncio.sleep(0)
+        pytest.fail("execution continued after confirmed lease loss")
+
+    with pytest.raises(asyncio.CancelledError):
+        await _protected_execution()
+    assert lease.lost
+
+
+async def test_same_process_successor_cannot_hide_existing_holder(monkeypatch) -> None:
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    resource = dl.chat_lock_resource("app-1", "chat-1")
+    incumbent = _register_lease(resource, lost=False)
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: object())
+
+    async def _verified(_collection) -> None:  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(dl, "_verify_acquisition_indexes", _verified)
+    with pytest.raises(dl.LockAcquisitionError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-1"):
+            pytest.fail("a same-process successor must not replace the incumbent registry entry")
+    assert dl._process_leases[resource] is incumbent
+
+
+async def test_confirmed_loss_guards_all_session_ui_mutation_seams(monkeypatch) -> None:
+    from mozaiksai.core.data.persistence.persistence_manager import AG2PersistenceManager
+
+    _register_lease(dl.chat_lock_resource("app-1", "chat-1"), lost=True)
+    manager = AG2PersistenceManager()
+
+    async def _unexpected_collection_access():
+        pytest.fail("guard must reject before reaching Mongo")
+
+    monkeypatch.setattr(manager, "_coll", _unexpected_collection_access)
+    calls = (
+        manager.update_last_artifact(
+            chat_id="chat-1", app_id="app-1", artifact={"tool_name": "test"}
+        ),
+        manager.attach_tool_call_metadata(
+            chat_id="chat-1", app_id="app-1", event_id="event-1", metadata={}
+        ),
+        manager.update_tool_call_state(
+            chat_id="chat-1", app_id="app-1", event_id="event-1", status="completed"
+        ),
+        manager.save_pending_input_request(
+            chat_id="chat-1",
+            app_id="app-1",
+            request_id="request-1",
+            agent="agent",
+            prompt="prompt",
+        ),
+    )
+    for call in calls:
+        with pytest.raises(dl.ChatLeaseLostError):
+            await call
 
 
 # ---------------------------------------------------------------------------
@@ -373,3 +462,32 @@ async def test_bridge_fails_closed_when_authority_unavailable(monkeypatch) -> No
     assert transport.persisted_messages == []
     assert adapter.run_requests == []
     assert adapter.resume_requests == []
+
+
+async def test_bridge_reports_confirmed_lease_loss_as_aborted_run(monkeypatch) -> None:
+    resource = dl.chat_lock_resource("app-1", "chat-1")
+
+    @asynccontextmanager
+    async def _lost_after_execution(**_kwargs):  # noqa: ANN003
+        yield SimpleNamespace(lost=False)
+        raise dl.ChatLeaseLostError(resource)
+
+    monkeypatch.setattr(_bridge_mod, "chat_execution_lease", _lost_after_execution)
+    monkeypatch.setattr(_bridge_mod, "get_workflow_lifecycle_hooks", lambda _name: {})
+    pm = _FakePersistenceManager()
+    transport = _DummyTransport(pm)
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(_ag2_mod, "get_ag2_adapter", lambda: adapter)
+
+    result = await transport.handle_user_input_from_api(
+        chat_id="chat-1",
+        user_id="u1",
+        workflow_name="AppGenerator",
+        message="go",
+        app_id="app-1",
+    )
+
+    assert result["status"] == "error"
+    assert result["route"] == "chat_lock_lost"
+    assert transport.errors == [{"error_code": "CHAT_LOCK_LOST", "chat_id": "chat-1"}]
+    assert len(adapter.run_requests) == 1

--- a/tests/test_chat_execution_lease.py
+++ b/tests/test_chat_execution_lease.py
@@ -491,3 +491,77 @@ async def test_bridge_reports_confirmed_lease_loss_as_aborted_run(monkeypatch) -
     assert result["route"] == "chat_lock_lost"
     assert transport.errors == [{"error_code": "CHAT_LOCK_LOST", "chat_id": "chat-1"}]
     assert len(adapter.run_requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# Correction round 2 — consumed-cancellation loss and newly guarded seams
+# ---------------------------------------------------------------------------
+
+class _FakeAuthorityCollection:
+    """Acquisition succeeds by clean insert; every renewal finds the lease gone."""
+
+    async def find_one_and_update(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return None
+
+    async def insert_one(self, document):  # noqa: ANN001
+        return object()
+
+    async def delete_one(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return object()
+
+
+async def test_consumed_cancellation_after_loss_still_fails_the_real_lease(monkeypatch) -> None:
+    """AG2-style shutdown may consume the loss cancellation; the real context
+    manager must still refuse to report success."""
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    monkeypatch.setattr(dl, "_get_lock_collection", lambda: _FakeAuthorityCollection())
+    monkeypatch.setattr(dl, "_acquisition_indexes_verified", True)
+
+    consumed = False
+    with pytest.raises(dl.ChatLeaseLostError):
+        async with dl.chat_execution_lease(app_id="app-1", chat_id="chat-consumed") as lease:
+            try:
+                await lease._renew_once()  # confirmed loss cancels this owner task
+                await asyncio.sleep(30)
+                pytest.fail("execution continued after confirmed lease loss")
+            except asyncio.CancelledError:
+                consumed = True  # the protected op swallowed its cancellation
+    assert consumed
+    assert dl._process_leases == {}
+
+
+async def test_confirmed_loss_guards_session_creation_and_cache_seed(monkeypatch) -> None:
+    from mozaiksai.core.data.persistence.persistence_manager import AG2PersistenceManager
+
+    _register_lease(dl.chat_lock_resource("app-1", "chat-1"), lost=True)
+    manager = AG2PersistenceManager()
+
+    async def _unexpected_collection_access():
+        pytest.fail("guard must reject before reaching Mongo")
+
+    monkeypatch.setattr(manager, "_coll", _unexpected_collection_access)
+    with pytest.raises(dl.ChatLeaseLostError):
+        await manager.create_chat_session(
+            chat_id="chat-1", app_id="app-1", workflow_name="wf", user_id="user"
+        )
+    with pytest.raises(dl.ChatLeaseLostError):
+        await manager.get_or_assign_cache_seed(chat_id="chat-1", app_id="app-1")
+
+
+async def test_confirmed_loss_guards_injected_context_before_resume() -> None:
+    from mozaiksai.core.adapters.ag2_orchestration import AG2OrchestrationAdapter
+    from mozaiksai.core.ports.orchestration import ResumeRequest
+
+    _register_lease(dl.chat_lock_resource("app-1", "chat-1"), lost=True)
+    adapter = AG2OrchestrationAdapter.__new__(AG2OrchestrationAdapter)
+    request = ResumeRequest(
+        workflow_name="wf",
+        app_id="app-1",
+        chat_id="chat-1",
+        user_id="user",
+        injected_context={"key": "value"},
+    )
+    # The guard sits before the persistence import/warning path: loss must
+    # abort the resume, never degrade into the logged-warning branch.
+    with pytest.raises(dl.ChatLeaseLostError):
+        await adapter._inject_context_before_resume(request)

--- a/tests/test_chat_execution_lease_real_mongo.py
+++ b/tests/test_chat_execution_lease_real_mongo.py
@@ -315,13 +315,16 @@ async def test_stale_owner_cannot_release_successor_lease() -> None:
 # 7. Confirmed lease loss refuses further durable session/WAL writes
 # ---------------------------------------------------------------------------
 
-async def test_lease_loss_blocks_durable_writes(monkeypatch) -> None:
+async def test_lease_loss_cancels_protected_execution(monkeypatch) -> None:
     monkeypatch.setenv("DISTRIBUTED_LOCK_TTL_SECONDS", "2")
     from mozaiksai.core.data.persistence.persistence_manager import AG2PersistenceManager
 
     app_id, chat_id = _ids()
     resource = dl.chat_lock_resource(app_id, chat_id)
     pm = AG2PersistenceManager()
+    captured_lease: dl.ChatLease | None = None
+    version_healthy: int | None = None
+    continued_after_loss = False
 
     try:
         await pm.create_chat_session(
@@ -329,42 +332,31 @@ async def test_lease_loss_blocks_durable_writes(monkeypatch) -> None:
         )
         version_before = await pm.get_session_version(chat_id, app_id)
 
-        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id) as lease:
-            # Writes are allowed while the lease is healthy.
-            await pm.append_run_user_message(
-                chat_id=chat_id, app_id=app_id, content="healthy write"
-            )
-            assert len(await pm.load_run_history(chat_id=chat_id, app_id=app_id)) == 1
-            await pm.clear_pending_input_request(chat_id=chat_id, app_id=app_id)
-            version_healthy = await pm.get_session_version(chat_id, app_id)
-            assert version_healthy == (version_before or 0) + 1
-
-            # Simulate a successor stealing the lease: the doc disappears.
-            collection = dl._get_lock_collection()
-            await collection.delete_many({"resource": resource})
-            for _ in range(80):  # renewal tick (~1s) confirms the loss
-                if lease.lost:
-                    break
-                await asyncio.sleep(0.1)
-            assert lease.lost
-
-            with pytest.raises(dl.ChatLeaseLostError):
-                await pm.persist_context_variables(
-                    chat_id=chat_id, app_id=app_id,
-                    variables={"step": "two"}, workflow_name="AppGenerator",
-                )
-            with pytest.raises(dl.ChatLeaseLostError):
+        async def _protected_execution() -> None:
+            nonlocal captured_lease, continued_after_loss, version_healthy
+            async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id) as lease:
+                captured_lease = lease
+                # Writes are allowed while the lease is healthy.
                 await pm.append_run_user_message(
-                    chat_id=chat_id, app_id=app_id, content="stale write"
+                    chat_id=chat_id, app_id=app_id, content="healthy write"
                 )
-            with pytest.raises(dl.ChatLeaseLostError):
-                await pm.append_run_assistant_message(
-                    chat_id=chat_id, app_id=app_id, content="stale write"
-                )
-            with pytest.raises(dl.ChatLeaseLostError):
+                assert len(await pm.load_run_history(chat_id=chat_id, app_id=app_id)) == 1
                 await pm.clear_pending_input_request(chat_id=chat_id, app_id=app_id)
+                version_healthy = await pm.get_session_version(chat_id, app_id)
+                assert version_healthy == (version_before or 0) + 1
 
-        # No durable write landed after the confirmed loss.
+                # Simulate expiry/takeover. The renewal task must cancel this
+                # protected owner rather than merely setting a diagnostic bit.
+                collection = dl._get_lock_collection()
+                await collection.delete_many({"resource": resource})
+                await asyncio.Event().wait()
+                continued_after_loss = True
+
+        with pytest.raises(dl.ChatLeaseLostError):
+            await asyncio.wait_for(_protected_execution(), timeout=10)
+
+        assert captured_lease is not None and captured_lease.lost
+        assert not continued_after_loss
         assert await pm.get_session_version(chat_id, app_id) == version_healthy
         history = await pm.load_run_history(chat_id=chat_id, app_id=app_id)
         assert len(history) == 1

--- a/tests/test_chat_execution_lease_real_mongo.py
+++ b/tests/test_chat_execution_lease_real_mongo.py
@@ -432,3 +432,23 @@ async def test_cancellation_releases_lease() -> None:
         assert await collection.find_one({"resource": resource}) is None
     finally:
         await _cleanup_resource(resource)
+
+
+async def test_real_driver_outage_is_unavailable_not_busy(monkeypatch) -> None:
+    """A real driver error against an unreachable authority must surface as
+    ChatLockAuthorityUnavailableError — never as normal lock contention."""
+    from pymongo import AsyncMongoClient
+
+    dead_client: AsyncMongoClient = AsyncMongoClient(
+        "mongodb://127.0.0.1:1/", serverSelectionTimeoutMS=200, connectTimeoutMS=200
+    )
+    try:
+        collection = dead_client["mozaiksai_outage_probe"]["distributed_locks"]
+        monkeypatch.setattr(dl, "_get_lock_collection", lambda: collection)
+        monkeypatch.setattr(dl, "_acquisition_indexes_verified", True)
+        dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+        with pytest.raises(dl.ChatLockAuthorityUnavailableError):
+            async with dl.chat_execution_lease(app_id="app-outage", chat_id="chat-outage"):
+                pytest.fail("acquisition must fail closed when the authority is unreachable")
+    finally:
+        await dead_client.close()

--- a/tests/test_chat_execution_lease_real_mongo.py
+++ b/tests/test_chat_execution_lease_real_mongo.py
@@ -1,0 +1,442 @@
+"""Adversarial integration proofs for distributed same-chat exclusion.
+
+These tests run against a real MongoDB (the CI `mongo:7` service, or any
+server reachable through MONGO_URI) and prove the cross-instance properties
+that in-memory objects cannot: atomic acquisition under contention, renewal,
+stale-owner safety, lease-loss write refusal, and true cross-process
+exclusion via a subprocess holder.
+
+Skipped when no reachable MongoDB is configured.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from mozaiksai.core.core_config import close_mongo_client
+from mozaiksai.core.runtime.persistence import distributed_lock as dl
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _mongo_uri() -> str | None:
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        value = (os.getenv(name) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _mongo_reachable() -> bool:
+    uri = _mongo_uri()
+    if not uri:
+        return False
+    try:
+        from pymongo import MongoClient
+
+        MongoClient(uri, serverSelectionTimeoutMS=2000).admin.command("ping")
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _mongo_reachable(),
+    reason="requires a reachable MongoDB via MONGO_URI (provided by the CI mongo service)",
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_mode_with_fresh_client(monkeypatch):
+    """Bind the Mongo client to this test's event loop and pin required mode."""
+    monkeypatch.setenv("MONGO_URI", _mongo_uri() or "")
+    close_mongo_client()
+    dl.reset_chat_lock_state()
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    yield
+    dl.reset_chat_lock_state()
+    close_mongo_client()
+
+
+def _ids() -> tuple[str, str]:
+    tag = uuid4().hex[:10]
+    return f"app-{tag}", f"chat-{tag}"
+
+
+async def _cleanup_resource(resource: str) -> None:
+    collection = dl._get_lock_collection()
+    if collection is not None:
+        await collection.delete_many({"resource": resource})
+
+
+# ---------------------------------------------------------------------------
+# 1. Atomic acquisition: many racers, exactly one owner
+# ---------------------------------------------------------------------------
+
+async def test_concurrent_racers_produce_exactly_one_owner(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "0")
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+
+    gate = asyncio.Event()
+    outcomes: list[str] = []
+
+    async def racer(tag: str) -> None:
+        try:
+            async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                outcomes.append(f"owner:{tag}")
+                await gate.wait()
+        except dl.LockAcquisitionError:
+            outcomes.append(f"busy:{tag}")
+
+    async def _wait_for_settled() -> None:
+        # One owner inside the lease, every other racer rejected as busy.
+        while not (
+            sum(o.startswith("owner:") for o in outcomes) == 1
+            and sum(o.startswith("busy:") for o in outcomes) == 7
+        ):
+            assert sum(o.startswith("owner:") for o in outcomes) <= 1, outcomes
+            await asyncio.sleep(0.01)
+
+    try:
+        tasks = [asyncio.create_task(racer(str(i))) for i in range(8)]
+        await asyncio.wait_for(_wait_for_settled(), timeout=30)
+        gate.set()
+        await asyncio.gather(*tasks)
+        assert sum(o.startswith("owner:") for o in outcomes) == 1, outcomes
+    finally:
+        gate.set()
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 2. Bridge-level race: the loser performs no session/workflow/WAL mutation
+# ---------------------------------------------------------------------------
+
+async def test_bridge_race_on_real_lock_loser_mutates_nothing(monkeypatch) -> None:
+    from tests.test_chat_execution_lease import (
+        _ag2_mod,
+        _bridge_mod,
+        _DummyTransport,
+        _FakeAdapter,
+        _FakePersistenceManager,
+    )
+
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "0")
+    monkeypatch.setattr(_bridge_mod, "get_workflow_lifecycle_hooks", lambda _name: {})
+
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+    winner_pm, loser_pm = _FakePersistenceManager(), _FakePersistenceManager()
+    winner, loser = _DummyTransport(winner_pm), _DummyTransport(loser_pm)
+    adapter = _FakeAdapter(delay=0.6)
+    monkeypatch.setattr(_ag2_mod, "get_ag2_adapter", lambda: adapter)
+
+    try:
+        winner_task = asyncio.create_task(
+            winner.handle_user_input_from_api(
+                chat_id=chat_id, user_id="u1", workflow_name="AppGenerator",
+                message="go", app_id=app_id,
+            )
+        )
+        # Wait until the winner holds the real Mongo lease.
+        collection = dl._get_lock_collection()
+        assert collection is not None
+        for _ in range(200):
+            if await collection.find_one({"resource": resource}):
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("winner never acquired the Mongo lease")
+
+        loser_result = await loser.handle_user_input_from_api(
+            chat_id=chat_id, user_id="u2", workflow_name="AppGenerator",
+            message="me too", app_id=app_id,
+        )
+        winner_result = await winner_task
+
+        assert winner_result["status"] == "success"
+        assert loser_result["status"] == "busy"
+        assert loser_pm.pending_lookups == []
+        assert loser_pm.pending_clears == []
+        assert loser_pm.run_user_messages == []
+        assert loser.persisted_messages == []
+        assert len(adapter.run_requests) == 1
+        # Release landed at the terminal boundary: the lease doc is gone.
+        assert await collection.find_one({"resource": resource}) is None
+    finally:
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 3. Cross-process exclusion: a subprocess holder blocks this process
+# ---------------------------------------------------------------------------
+
+_SUBPROCESS_HOLDER = """
+import asyncio, sys
+
+from mozaiksai.core.runtime.persistence import distributed_lock as dl
+
+async def main():
+    dl.configure_chat_lock(dl.ChatLockMode.REQUIRED)
+    async with dl.chat_execution_lease(
+        app_id=sys.argv[1], chat_id=sys.argv[2], holder_id="subprocess-holder"
+    ):
+        print("ACQUIRED", flush=True)
+        await asyncio.sleep(float(sys.argv[3]))
+    print("RELEASED", flush=True)
+
+asyncio.run(main())
+"""
+
+
+async def test_cross_process_holder_excludes_this_process(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "0")
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable, "-c", _SUBPROCESS_HOLDER, app_id, chat_id, "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(_REPO_ROOT),
+        env=env,
+    )
+    try:
+        line = await asyncio.wait_for(proc.stdout.readline(), timeout=120)
+        assert line.strip() == b"ACQUIRED", (
+            line,
+            (await proc.stderr.read())[:2000],
+        )
+        with pytest.raises(dl.LockAcquisitionError):
+            async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                pytest.fail("second process must not acquire a held lease")
+        # A different chat under the same tenant is unaffected by the holder.
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=f"{chat_id}-other"):
+            pass
+    finally:
+        proc.kill()
+        await proc.wait()
+        await _cleanup_resource(resource)
+        await _cleanup_resource(dl.chat_lock_resource(app_id, f"{chat_id}-other"))
+
+
+# ---------------------------------------------------------------------------
+# 4. Independence: distinct chats and distinct tenants proceed concurrently
+# ---------------------------------------------------------------------------
+
+async def test_distinct_chats_and_tenants_hold_leases_concurrently() -> None:
+    app_id, chat_id = _ids()
+    other_app = f"{app_id}-b"
+    resources = [
+        dl.chat_lock_resource(app_id, chat_id),
+        dl.chat_lock_resource(app_id, f"{chat_id}-2"),
+        dl.chat_lock_resource(other_app, chat_id),
+    ]
+    try:
+        async with (
+            dl.chat_execution_lease(app_id=app_id, chat_id=chat_id),
+            dl.chat_execution_lease(app_id=app_id, chat_id=f"{chat_id}-2"),
+            dl.chat_execution_lease(app_id=other_app, chat_id=chat_id),
+        ):
+            collection = dl._get_lock_collection()
+            held = [await collection.find_one({"resource": r}) for r in resources]
+            assert all(doc is not None for doc in held)
+            # Same chat id under different tenants produced distinct leases.
+            assert held[0]["resource"] != held[2]["resource"]
+    finally:
+        for r in resources:
+            await _cleanup_resource(r)
+
+
+# ---------------------------------------------------------------------------
+# 5. Renewal preserves ownership across an operation longer than the TTL
+# ---------------------------------------------------------------------------
+
+async def test_renewal_preserves_ownership_beyond_ttl(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_TTL_SECONDS", "2")
+    monkeypatch.setenv("DISTRIBUTED_LOCK_MAX_RETRIES", "0")
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+
+    try:
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id) as lease:
+            # Hold well past the 2s TTL; renewal must keep the lease alive.
+            for _ in range(3):
+                await asyncio.sleep(1.5)
+                with pytest.raises(dl.LockAcquisitionError):
+                    async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                        pytest.fail("contender must not steal a renewed lease")
+            assert not lease.lost
+    finally:
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 6. A stale owner can never release a successor's lease
+# ---------------------------------------------------------------------------
+
+async def test_stale_owner_cannot_release_successor_lease() -> None:
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+    collection = dl._get_lock_collection()
+    assert collection is not None
+
+    try:
+        assert await dl._try_acquire(collection, resource, "holder-old", 1)
+        await asyncio.sleep(1.1)  # let the old lease expire
+        assert await dl._try_acquire(collection, resource, "holder-new", 60)
+
+        stale = dl.ChatLease(
+            resource=resource,
+            holder_id="holder-old",
+            mode=dl.ChatLockMode.REQUIRED,
+            collection=collection,
+            ttl_seconds=60,
+        )
+        await stale.release()
+
+        doc = await collection.find_one({"resource": resource})
+        assert doc is not None, "successor's lease must survive a stale release"
+        assert doc["holder_id"] == "holder-new"
+    finally:
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 7. Confirmed lease loss refuses further durable session/WAL writes
+# ---------------------------------------------------------------------------
+
+async def test_lease_loss_blocks_durable_writes(monkeypatch) -> None:
+    monkeypatch.setenv("DISTRIBUTED_LOCK_TTL_SECONDS", "2")
+    from mozaiksai.core.data.persistence.persistence_manager import AG2PersistenceManager
+
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+    pm = AG2PersistenceManager()
+
+    try:
+        await pm.create_chat_session(
+            chat_id=chat_id, app_id=app_id, workflow_name="AppGenerator", user_id="u1"
+        )
+        version_before = await pm.get_session_version(chat_id, app_id)
+
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id) as lease:
+            # Writes are allowed while the lease is healthy.
+            await pm.append_run_user_message(
+                chat_id=chat_id, app_id=app_id, content="healthy write"
+            )
+            assert len(await pm.load_run_history(chat_id=chat_id, app_id=app_id)) == 1
+            await pm.clear_pending_input_request(chat_id=chat_id, app_id=app_id)
+            version_healthy = await pm.get_session_version(chat_id, app_id)
+            assert version_healthy == (version_before or 0) + 1
+
+            # Simulate a successor stealing the lease: the doc disappears.
+            collection = dl._get_lock_collection()
+            await collection.delete_many({"resource": resource})
+            for _ in range(80):  # renewal tick (~1s) confirms the loss
+                if lease.lost:
+                    break
+                await asyncio.sleep(0.1)
+            assert lease.lost
+
+            with pytest.raises(dl.ChatLeaseLostError):
+                await pm.persist_context_variables(
+                    chat_id=chat_id, app_id=app_id,
+                    variables={"step": "two"}, workflow_name="AppGenerator",
+                )
+            with pytest.raises(dl.ChatLeaseLostError):
+                await pm.append_run_user_message(
+                    chat_id=chat_id, app_id=app_id, content="stale write"
+                )
+            with pytest.raises(dl.ChatLeaseLostError):
+                await pm.append_run_assistant_message(
+                    chat_id=chat_id, app_id=app_id, content="stale write"
+                )
+            with pytest.raises(dl.ChatLeaseLostError):
+                await pm.clear_pending_input_request(chat_id=chat_id, app_id=app_id)
+
+        # No durable write landed after the confirmed loss.
+        assert await pm.get_session_version(chat_id, app_id) == version_healthy
+        history = await pm.load_run_history(chat_id=chat_id, app_id=app_id)
+        assert len(history) == 1
+    finally:
+        coll = await pm._coll()
+        await coll.delete_one({"_id": chat_id})
+        from mozaiksai.core.core_config import get_mongo_client
+        from mozaiksai.core.data.persistence.namespaces import (
+            SYSTEM_DATABASE,
+            RuntimeCollections,
+        )
+
+        client = get_mongo_client()
+        await client[SYSTEM_DATABASE][RuntimeCollections.AG2_STREAM_EVENTS].delete_many(
+            {"app_id": app_id}
+        )
+        await client[SYSTEM_DATABASE][RuntimeCollections.AG2_STREAM_HEADS].delete_many(
+            {"app_id": app_id}
+        )
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 8. Exceptions inside the protected section release the lease
+# ---------------------------------------------------------------------------
+
+async def test_exception_inside_lease_releases_lock() -> None:
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+    collection = dl._get_lock_collection()
+    assert collection is not None
+
+    try:
+        with pytest.raises(RuntimeError):
+            async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+                assert await collection.find_one({"resource": resource}) is not None
+                raise RuntimeError("boom")
+        assert await collection.find_one({"resource": resource}) is None
+        # Immediately re-acquirable.
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+            pass
+    finally:
+        await _cleanup_resource(resource)
+
+
+# ---------------------------------------------------------------------------
+# 9. Cancellation of the protected task still releases the lease
+# ---------------------------------------------------------------------------
+
+async def test_cancellation_releases_lease() -> None:
+    app_id, chat_id = _ids()
+    resource = dl.chat_lock_resource(app_id, chat_id)
+    collection = dl._get_lock_collection()
+    assert collection is not None
+    entered = asyncio.Event()
+
+    async def holder() -> None:
+        async with dl.chat_execution_lease(app_id=app_id, chat_id=chat_id):
+            entered.set()
+            await asyncio.sleep(60)
+
+    task = asyncio.create_task(holder())
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=30)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The detached release completes shortly after cancellation.
+        for _ in range(100):
+            if await collection.find_one({"resource": resource}) is None:
+                break
+            await asyncio.sleep(0.05)
+        assert await collection.find_one({"resource": resource}) is None
+    finally:
+        await _cleanup_resource(resource)


### PR DESCRIPTION
## Issue #426 — sub-slice A: production distributed same-chat exclusion

**This PR implements only the first bounded execution-fabric repair from #426 (the dead distributed chat lock). It does NOT close #426.** The durable queue wiring, cancellation endpoints, orphan reconciliation, run-scoped teardown, `_live_ag2_workflow_runs` retirement, and storage-level fencing tokens remain later sub-slices.

### Phase 1 — proven boundary (inventory before editing)

- Verified the issue's claim at base `56479d43`: `distributed_lock(...)` had **zero call sites** — only index creation at startup and comments claiming it was the exclusion boundary.
- Every production start/resume/restart path funnels through `WorkflowBridgeMixin.handle_user_input_from_api`: the HTTP input route, WS `start_workflow`/`switch_workflow`/batch handlers (via `_run_workflow_background`), both hosts' auto-start, journey auto-advance spawns, and live paused-run continuation. `adapter.run()`/`.resume()` return exactly at a durably persisted terminal or human-waiting boundary (pause registers the live run; `mark_chat_completed` runs in the orchestration `finally`), which makes lease release on context exit land on the required boundary.
- Trusted identity: `app_id` is the tenant scope (no separate tenant_id exists in the data plane) and reaches the funnel from server-owned auth/connection metadata; lock scope is never derived from client event payload fields.
- During test development a live defect in the old primitive surfaced: without the unique `resource` index, two holders could both insert lease documents and both believe they owned the chat — and `ensure_lock_indexes()` only *warned* on failure. Acquisition now verifies the unique-index backstop and fails closed instead of degrading to a cosmetic lock.

### Phase 2 — what changed

- **`distributed_lock.py` rebuilt as a renewable chat execution lease** (same lease/ownership idiom as `MongoWorkflowQueue`): atomic insert / steal-expired acquire on the unique `resource` index, background renewal at TTL/3, holder-scoped release (`delete_one({resource, holder_id})` — a stale holder can never delete a successor's lease), bounded cancellation-safe release, and confirmed-loss detection (`renewal found the lease gone/stolen, or unprovable past TTL`).
- **Wired at the funnel**: `handle_user_input_from_api` acquires `chat:{app_id}:{chat_id}` around the start-new/resume branch (before the first session/WAL mutation) and around live paused-run continuation. The feed-input-to-active-in-process-session branch takes no new lease — the run task blocked inside `adapter.run()` already holds it. Read-only paths (replay, reconnect) take no lock.
- **Lease-loss write guard**: `assert_chat_mutable()` consulted by the durable chat write seams (`append_run_user_message`, `append_run_assistant_message`, `persist_context_variables`, `mark_chat_completed`, `clear_pending_input_request`). After confirmed loss, further durable writes for that chat raise `ChatLeaseLostError`. Paths with no registered lease keep current behavior.
- **Explicit operating modes**, pinned by `configure_chat_lock()` in `_runtime_startup` (shared by runtime/platform/studio hosts): `required` whenever database persistence is enabled — Mongo-unavailable or index-unverifiable **fails closed before any mutation**; `local` (process-local asyncio locks) only when database persistence is disabled or in processes that never enter the host lifecycle — explicitly a single-process boundary, never presented as distributed safety. `MOZAIKS_CHAT_LOCK_MODE` overrides.
- **Distinct diagnostics**: `CHAT_LOCK_BUSY`, `CHAT_LOCK_AUTHORITY_UNAVAILABLE`, `CHAT_LOCK_RENEWAL_LOST`, `CHAT_LOCK_RELEASE_FAILED`; busy/unavailable surface to the UI as `CHAT_LOCK_BUSY` / `CHAT_LOCK_UNAVAILABLE` error codes.
- Lock documents moved from the app database to `SYSTEM_DATABASE` ("mozaiksai"), the database holding the chat state they protect (the collection was dead code; no migration needed).
- AG2 workflow execution and WAL formats untouched.

### Honest limits (documented, deliberate)

- **Residual window**: a holder that stalls past its TTL without a failed renewal can have at most one in-flight write land after a successor acquires. Closing it requires storage-level fencing tokens on every session/WAL write — a later #426 sub-slice. Everything after a *confirmed* loss is refused.
- Cross-instance input forwarding is out of scope: a second instance receiving input for a chat actively running elsewhere reports `CHAT_LOCK_BUSY` rather than forwarding.
- The unscoped `find_one({"_id": target_chat_id})` hydration in `handle_switch_workflow` (client-supplied target, no app/user scope filter) is a pre-existing identity seam noted during inventory — not touched here, worth its own issue.

### Adversarial proof (all against real MongoDB; CI's `mongo:7` service, skipped when unreachable)

`tests/test_chat_execution_lease_real_mongo.py` (9 tests):
1. 8 concurrent racers → exactly one owner, 7 busy.
2. Bridge-level race on the real lock → loser performs zero session/workflow/WAL mutation; winner's lease doc gone at the terminal boundary.
3. **True cross-process exclusion**: a subprocess holds the lease; this process cannot acquire; a different chat under the same tenant is unaffected.
4. Distinct chats and distinct tenants (same chat id) hold leases concurrently.
5. Renewal preserves ownership across an operation 2–3× the TTL; contender never steals.
6. A stale owner's release cannot delete a successor's lease.
7. Confirmed lease loss → all guarded durable writes raise; session version and WAL length unchanged (real `AG2PersistenceManager`).
8. Exception inside the lease releases it; immediately re-acquirable.
9. Cancellation of the protected task still releases the lease.

`tests/test_chat_execution_lease.py` (19 unit tests): mode resolution (local default / env override / persistence-enabled → required / production env → required), canonical tenant-scoped resource identity, local-mode serialization + busy + independence + exception release, fail-closed on unavailable authority and on unverifiable unique index, lease-loss guard semantics, renewal-miss loss detection, and bridge busy/unavailable rejection with zero mutation and no adapter launch.

Existing single-process behavior: all pre-existing bridge/handler/replay tests pass unchanged.

### Validation

- `ruff check .` clean; `git diff --check` clean; DCO signed off.
- Focused: `tests/test_chat_execution_lease.py` (19 passed), `tests/test_chat_execution_lease_real_mongo.py` (9 passed against mongo:7), `tests/test_workflow_bridge.py`, `tests/test_workflow_switch_handler.py`, `tests/test_transport_input_handlers.py` (14 passed).
- Full repository suite (with `MONGO_URI` pointing at a local `mongo:7`, mirroring CI): **14101 passed, 79 skipped, 0 failed** in 7m51s.
- The first full-suite run exposed an order dependency: the lock module's process-global state (pinned mode, held local locks, lease registry) leaked across tests, making 6 pre-existing `test_workflow_bridge.py` tests fail and causing 12 flaky reruns. Fixed with an autouse conftest fixture that resets lock state before each test; the rerun was green with zero reruns.

### OSS change impact

- **Layer changed**: runtime (transport bridge, persistence guard seams, lock primitive, host startup).
- **Build workflow impact**: none (no factory workflow/contract changes).
- **Runtime/platform impact**: mutable chat execution is now serialized per (app_id, chat_id) across instances; busy/unavailable are new explicit rejection outcomes on the input funnel.
- **App workspace impact**: none (no generated-app contract changes).
- **Docs updated**: CHANGELOG Unreleased entry (this PR); module header documents modes and the residual window.
- **Compatibility risk**: low — local mode preserves single-process behavior; required mode only engages where Mongo persistence is already mandatory.

Coordination: base `56479d43` (current origin/main); no overlap with PR #436 (Slice 2E semantic-contract files untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
