### PR TITLE
docs: restore Refinement Run terminology

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,12 +90,12 @@ The product-facing application lifecycle has two run types:
 
 - **Genesis Build** — the first complete build journey for an app. It creates
   the app's first canonical, validated artifact lineage.
-- **Revision Run** — any later change against that lineage. It loads current
+- **Refinement Run** — any later change against that lineage. It loads current
   artifact state, scopes the impact, stages a new version, and returns it for
   review.
 
 The Refinement Engine is the internal continuity and routing layer that executes
-Revision Runs. A `core` Revision Run may re-enter at `ValueEngine`, but it does
+Refinement Runs. A `core` Refinement Run may re-enter at `ValueEngine`, but it does
 not become another Genesis Build unless the user creates a new app lineage.
 
 This means:
@@ -120,7 +120,7 @@ Customer-facing terminology follows a different layer:
 - `Studio` is an internal host/composition term
 - visible UX should prefer `Apps`, `Build`, `Operations`, `Integrations`, and
   `Admin`
-- app creation and evolution should use `Genesis Build` and `Revision Run`;
+- app creation and evolution should use `Genesis Build` and `Refinement Run`;
   `refinement` remains the internal engine and contract term
 - `Hub`, `Studio` as a top-level product area, and `Adapters` should not be
   treated as long-term customer-facing IA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Changed
 
-- **App lifecycle terminology now centers Genesis Builds and Revision Runs.**
+- **App lifecycle terminology now centers Genesis Builds and Refinement Runs.**
   Public docs use Genesis Build for an app's first canonical build journey and
-  Revision Run for every later change in that app lineage, while Refinement
+  Refinement Run for every later change in that app lineage, while Refinement
   Engine remains the internal routing and contract term.
 
 - **Importing `mozaiksai.hosts.studio` no longer mutates the process

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AI-native software products.
 
 It brings together three things that usually live in separate tools:
 
-- **Mozaiks Studio** for creating apps, running revisions, and managing them.
+- **Mozaiks Studio** for creating apps, continuing builds, and managing them.
 - **AI workflow orchestration powered by [AG2](https://github.com/ag2ai/ag2)** for planning, tool use, human
   review, and generation.
 - **Generated app files** with modules, pages, workflows, config, and brand
@@ -36,20 +36,20 @@ The goal is not to generate a throwaway demo. Mozaiks stages production-shaped
 artifacts, validates them against strict contracts, and keeps runtime concerns
 separate from builder workflows.
 
-## Genesis Builds and Revision Runs
+## Genesis Builds and Refinement Runs
 
 Every Mozaiks app begins with one **Genesis Build**: the first complete journey
 from product intent to a staged, validated app. It establishes the app's first
 canonical artifact lineage.
 
-Every later change is a **Revision Run**. Mozaiks starts from the app's current
+Every later change is a **Refinement Run**. Mozaiks starts from the app's current
 artifacts and history, determines what the request affects, and re-enters only
 the parts of the build needed to stage a safe new version for review. A small
-copy fix and a major product rethink are both Revision Runs; their scope and
+copy fix and a major product rethink are both Refinement Runs; their scope and
 route are different, but neither discards the app's lineage.
 
-Internally, the Refinement Engine classifies and routes Revision Runs. Genesis
-Build and Revision Run are the product-facing lifecycle terms.
+Internally, the Refinement Engine classifies and routes Refinement Runs. Genesis
+Build and Refinement Run are the product-facing lifecycle terms.
 
 ## Quickstart
 
@@ -119,8 +119,8 @@ want to build. The workflow walks you through the build steps and stages the
 generated artifacts for review. In-progress builds stay in **Apps**, so you can
 always pick up where you left off.
 
-After promotion, describe any later change to start a Revision Run against the
-app you already have. See [Genesis Builds and Revision Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-revision-runs/)
+After promotion, describe any later change to start a Refinement Run against the
+app you already have. See [Genesis Builds and Refinement Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-refinement-runs/)
 for examples ranging from a typo fix to a major product rethink.
 
 ### Troubleshooting
@@ -134,7 +134,7 @@ MongoDB instance, and set an LLM API key before running builds.
 | Guide | What it covers |
 |---|---|
 | [Use Studio](https://docs.mozaiks.ai/studio/) | The workspace and app-dashboard pages |
-| [Genesis Builds and Revision Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-revision-runs/) | Create the first version, then make safe changes without starting over |
+| [Genesis Builds and Refinement Runs](https://docs.mozaiks.ai/getting-started/genesis-builds-and-refinement-runs/) | Create the first version, then make safe changes without starting over |
 | [Add a Workflow](https://docs.mozaiks.ai/guides/adding-workflows/01-overview/) | Extend an app with a custom AI workflow |
 | [Add a Module](https://docs.mozaiks.ai/guides/adding-modules/01-overview/) | Add a self-contained backend capability |
 | [Add a Page](https://docs.mozaiks.ai/guides/adding-pages/01-overview/) | Add new pages and routes to your app workspace |

--- a/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
+++ b/docs/architecture/ARCHITECTURE_QUICK_REFERENCE.md
@@ -29,9 +29,9 @@ The implementation policy for deterministic generated contracts is
 * Validation remains deterministic.
 * Evaluation complements validation; it does not replace validation.
 * A Genesis Build creates an app's first canonical artifact lineage; every
-  subsequent change in that lineage is a Revision Run.
+  subsequent change in that lineage is a Refinement Run.
 * The Refinement Engine is the internal routing and continuity layer for
-  Revision Runs; `refinement` remains the implementation and contract term.
+  Refinement Runs; `refinement` remains the implementation and contract term.
 * Operator intelligence enters through public OSS seams.
 * Do not duplicate canonical owners.
 

--- a/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
+++ b/docs/architecture/MOZAIKS_OSS_SOFTWARE_DESIGN.md
@@ -553,9 +553,9 @@ Once a canonical structured plan exists, downstream behavior should be as determ
 
 Generation and refinement are phases of the same canonical application lifecycle.
 
-The product-facing names for those phases are **Genesis Build** and **Revision
+The product-facing names for those phases are **Genesis Build** and **Refinement
 Run**. A Genesis Build creates the first canonical artifact lineage for an app.
-Every later change against that lineage is a Revision Run, including a `core`
+Every later change against that lineage is a Refinement Run, including a `core`
 change that re-enters at `ValueEngine`. A new Genesis Build starts only when a
 new app lineage is created. Internal architecture continues to use
 `generation`, `refinement`, and `Refinement Engine` for the mechanisms that

--- a/docs/architecture/builder/end-to-end-build-lifecycle.md
+++ b/docs/architecture/builder/end-to-end-build-lifecycle.md
@@ -15,13 +15,13 @@ Terminology note:
 
 - a **Genesis Build** is the first complete build journey for an app and
   establishes its first canonical artifact lineage
-- a **Revision Run** is every later change against that lineage, whether the
+- a **Refinement Run** is every later change against that lineage, whether the
   change is classified as `patch`, `design`, `feature`, or `core`
 - the Refinement Engine is the internal system that classifies, scopes, and
-  routes Revision Runs; `refinement` remains an implementation and contract
+  routes Refinement Runs; `refinement` remains an implementation and contract
   term rather than the product-facing run name
 - resuming an unfinished Genesis Build does not create another Genesis Build,
-  and a `core` Revision Run remains a Revision Run unless it creates a new app
+  and a `core` Refinement Run remains a Refinement Run unless it creates a new app
   lineage
 - `Studio` is the browser product and `studio` is the host/composition name
 - `mozaiks studio` is the current public CLI command for opening Studio

--- a/docs/architecture/foundations/context-graph-and-code-intelligence.md
+++ b/docs/architecture/foundations/context-graph-and-code-intelligence.md
@@ -541,7 +541,7 @@ generated files directly. The target state is for those checks to be graph
 queries against the post-build `AppContextGraph`, making them:
 
 - domain-agnostic (any domain's generated files can be indexed and checked)
-- reusable across Genesis Builds and Revision Runs
+- reusable across Genesis Builds and Refinement Runs
 - available to Studio's inspection UX as annotated graph nodes
 
 This is tracked as open work below.

--- a/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
+++ b/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
@@ -183,7 +183,7 @@ effect of handler code.
 
 - `DesignDocs` owns the typed `data_contract`
 - `AppGenerator` stages `data/contract.json`
-- Revision Runs may stage `data/migrations/{migration_id}.json`
+- Refinement Runs may stage `data/migrations/{migration_id}.json`
 - generated module repos use `backend/schemas.py` for typed document shapes and
   `backend/repo.py` for persistence operations
 - the runtime injects `ctx.persistence` into module actions when `app_id` exists;

--- a/docs/architecture/workflows/refinement-engine.md
+++ b/docs/architecture/workflows/refinement-engine.md
@@ -16,8 +16,8 @@ handoffs.
 The goal is simple:
 
 - a Genesis Build creates the first canonical shape
-- Revision Runs adjust that shape safely and quickly
-- the Refinement Engine decides when a Revision Run is small, scoped,
+- Refinement Runs adjust that shape safely and quickly
+- the Refinement Engine decides when a Refinement Run is small, scoped,
   design-only, or concept-breaking
 
 The Refinement Engine uses `app/config/ai.json` for runtime startup,
@@ -46,10 +46,10 @@ outdated refinement paths.
 
 ## Core Decision
 
-Mozaiks must treat **Genesis Build** and **Revision Run** as separate product
+Mozaiks must treat **Genesis Build** and **Refinement Run** as separate product
 lifecycle modes. Internal architecture continues to use `generation` for the
 Genesis Build path and `refinement` for the engine, routing, workers, and
-contracts that execute Revision Runs.
+contracts that execute Refinement Runs.
 
 A Genesis Build is the compiler path:
 
@@ -57,7 +57,7 @@ A Genesis Build is the compiler path:
 2. `DesignDocs` defines frontend/backend/database/ui schema intent
 3. `AgentGenerator` and `AppGenerator` generate the first concrete artifacts
 
-A Revision Run is the edit path:
+A Refinement Run is the edit path:
 
 1. load the latest persisted artifact version
 2. classify the requested change
@@ -65,7 +65,7 @@ A Revision Run is the edit path:
 4. run refinement agents against scoped files or scoped plans
 5. validate and persist a new artifact version
 
-A `core` Revision Run may restart from `ValueEngine`, but it remains part of the
+A `core` Refinement Run may restart from `ValueEngine`, but it remains part of the
 same app lineage. Only creating a new app lineage starts another Genesis Build.
 
 Do **not** re-run `AgentGenerator` or `AppGenerator` from the top for every tweak.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -102,8 +102,8 @@ at any time from the **Apps** page.
 
 The first complete run of this sequence is your app's **Genesis Build** — the
 build that establishes the app's first authoritative version. Every change
-after that is a **Revision Run**. See
-[Genesis Builds and Revision Runs](getting-started/genesis-builds-and-revision-runs.md)
+after that is a **Refinement Run**. See
+[Genesis Builds and Refinement Runs](getting-started/genesis-builds-and-refinement-runs.md)
 for how the two fit together.
 
 ## Generate and Promote

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,8 +103,8 @@ Studio in your browser at `http://localhost:3000`.
 In-progress builds stay in **Apps** so you can always pick up where you left off.
 
 This first build is your app's **Genesis Build**; after that, every change you
-ask for is a **Revision Run** against the app you already have. See
-[Genesis Builds and Revision Runs](getting-started/genesis-builds-and-revision-runs.md).
+ask for is a **Refinement Run** against the app you already have. See
+[Genesis Builds and Refinement Runs](getting-started/genesis-builds-and-refinement-runs.md).
 
 ## Code Context Infrastructure
 

--- a/docs/getting-started/genesis-builds-and-refinement-runs.md
+++ b/docs/getting-started/genesis-builds-and-refinement-runs.md
@@ -1,8 +1,8 @@
-# Genesis Builds and Revision Runs
+# Genesis Builds and Refinement Runs
 
 Every Mozaiks app begins with a **Genesis Build**, which transforms the
 builder's intent into the app's first canonical, validated artifact lineage.
-Every subsequent change happens through a **Revision Run**, where Mozaiks
+Every subsequent change happens through a **Refinement Run**, where Mozaiks
 understands the current app, chooses the smallest safe path for the requested
 change, stages and validates the result, and lets the builder review it before
 it becomes the new app state.
@@ -15,7 +15,7 @@ it to change.
 flowchart LR
     A([Idea]) --> B[Genesis Build]
     B --> C([First App Version])
-    C --> D[Revision Run]
+    C --> D[Refinement Run]
     D --> E([New App Version])
     E -.->|next change| D
 ```
@@ -51,12 +51,12 @@ change is measured against, and the start of your app's revision history.
 If you want to see the individual build workflows behind these stages, they are
 described in [The Build Sequence](../concepts.md#the-build-sequence).
 
-## Revision Runs
+## Refinement Runs
 
 Once your app exists, you never start over. Every change — from fixing a label
-to rethinking the whole product — is a **Revision Run**.
+to rethinking the whole product — is a **Refinement Run**.
 
-A Revision Run always follows the same shape:
+A Refinement Run always follows the same shape:
 
 1. Mozaiks loads what it knows about your app — its current artifacts, design
    intent, and history — rather than guessing from the request alone.
@@ -83,7 +83,7 @@ appropriate part of the Genesis Build — and only that part.
 
 ### Your app is always safe
 
-A Revision Run never edits your live app in place:
+A Refinement Run never edits your live app in place:
 
 - **The existing app is preserved.** The current version keeps running and
   remains untouched while changes are prepared.
@@ -107,7 +107,7 @@ A Revision Run never edits your live app in place:
   weekly summaries." → Mozaiks plans an inspections capability, an AI workflow
   for the summaries, generates the app, and stages it for promotion.
 
-**Revision Runs:**
+**Refinement Runs:**
 
 - "The dashboard title says 'Ivoices' — fix the typo." → classified as a
   patch; one file is edited, validated, and staged for your approval.
@@ -125,16 +125,16 @@ A Revision Run never edits your live app in place:
 
 The practical takeaway: treat your app as a living product. Ask for the change
 you actually want, at whatever size it is, and Mozaiks will scale the work to
-match. The Genesis Build happens once; everything after it is a Revision Run
+match. The Genesis Build happens once; everything after it is a Refinement Run
 within the same continuously evolving app lineage.
 
 ## Going deeper
 
 For technical readers who want the machinery behind these concepts:
 
-Revision Run is the product-facing term. The architecture uses `refinement`
-for the internal engine, routing policy, workers, and contracts that execute a
-Revision Run.
+Refinement Run is the lifecycle term for every subsequent change. The
+Refinement Engine is the internal system whose routing policy, workers, and
+contracts execute each Refinement Run.
 
 - [Refinement](../guides/platform-intelligence/03-refinement.md) — the builder-facing
   guide to change classes and opting an app into refinement

--- a/docs/guides/platform-intelligence/03-refinement.md
+++ b/docs/guides/platform-intelligence/03-refinement.md
@@ -9,7 +9,7 @@ the smallest safe next step.
 !!! tip "New to these concepts?"
     For the product-level introduction to how the first build and later changes
     fit together, start with
-    [Genesis Builds and Revision Runs](../../getting-started/genesis-builds-and-revision-runs.md).
+    [Genesis Builds and Refinement Runs](../../getting-started/genesis-builds-and-refinement-runs.md).
 
 ## The Four Change Classes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - getting-started.md
-      - Genesis Builds & Revision Runs: getting-started/genesis-builds-and-revision-runs.md
+      - Genesis Builds & Refinement Runs: getting-started/genesis-builds-and-refinement-runs.md
   - Key Concepts: concepts.md
 
   - Guides:


### PR DESCRIPTION
## Summary

- restore **Refinement Run** as the canonical term for every post-Genesis change
- rename the lifecycle guide back to `genesis-builds-and-refinement-runs.md`
- update MkDocs navigation and internal documentation links
- preserve the lifecycle explanations introduced by #437

## Scope

Documentation and navigation only. No runtime contracts, persisted run types, ADRs, workflow behavior, Slice 3E, PR #438, or issue #426 are changed.

## Validation

- `python -m mkdocs build --strict`
- canonical path and stale-link scan
- source hygiene scan
- `python -m pytest -q tests/test_getting_started_docs.py tests/test_user_facing_docs_language.py tests/test_guide_overview_docs_language.py --no-cov` (12 passed)
- `git diff --check`

Auto-merge is intentionally disabled.