### PR TITLE
feat(semantics): ADR 0007 Slice 3E — projection emits graph v2 + typed payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Projection emits graph v2 + typed payloads (ADR 0007 Slice 3E)**: the
+  offline source projection now produces `mozaiks.semantic_projection.v2` —
+  a Merkle-rooted `mozaiks.semantic_graph.v2` with one typed payload per node
+  and bijective payload closure validated at build. Former "not representable
+  by SemanticGraph v1" gap families become projected content: page/section
+  ordering as explicit dense positions, plan/limit/meter/product facts
+  (integer minor-unit prices, ISO-4217 currency), module/action/permission/
+  event descriptions, and endpoint trigger bindings. Content is never
+  invented — payload prose fields are now optional-truthful (`None` when the
+  source carries no such fact) while structural rules stay strict, and facts
+  owned by edges or taxonomy are never duplicated into payloads. Navigation
+  ordering, plan catalog ordering, intra-section binding composition, and
+  renderer file lists remain explicit typed gaps. The source/graph fact
+  equivalence proof now covers payload content digests, so projection honesty
+  extends to content, not just identity.
+
 - **Typed semantic payloads + Merkle-rooted graph v2 (ADR 0007 Slice 2E)**:
   every semantic node kind now has exactly one strict payload variant
   (`mozaiks.semantic_payload.v1` — titles/intent text, typed field shapes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ This project follows a practical pre-1.0 changelog format:
   ordering as explicit dense positions, plan/limit/meter/product facts
   (integer minor-unit prices, ISO-4217 currency), module/action/permission/
   event descriptions, and endpoint trigger bindings. Content is never
-  invented — payload prose fields are now optional-truthful (`None` when the
-  source carries no such fact) while structural rules stay strict, and facts
+  invented — payload content fields are required-nullable (`None` when the
+  source carries no such fact, omission is invalid), and absent collections
+  remain distinct from explicitly empty collections while structural rules
+  stay strict. Facts
   owned by edges or taxonomy are never duplicated into payloads. Navigation
   ordering, plan catalog ordering, intra-section binding composition, and
   renderer file lists remain explicit typed gaps. The source/graph fact

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -1,8 +1,11 @@
-"""ADR 0007 Slice 3 deterministic, offline-only source projection.
+"""ADR 0007 Slice 3E deterministic, offline-only source projection.
 
 Production generators, runtimes, hosts, workflows, Studio, and control-plane
 code must not import this module. It accepts current contract shapes, projects
-only graph-v1 facts, and reports every other source fact as typed coverage.
+graph-v2 identity plus typed payload content, and reports every other source
+fact as typed coverage. Content is never invented: a payload field is set only
+when the source carries that fact, and facts that edges or taxonomy already
+own are never duplicated into payloads.
 """
 
 from __future__ import annotations
@@ -19,12 +22,24 @@ from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.graph import (
     SemanticEdge,
     SemanticEdgeKind,
-    SemanticGraph,
+    SemanticGraphV2,
     SemanticNode,
     SemanticNodeKind,
+    SemanticNodeV2,
     TaxonomyReference,
-    build_semantic_graph,
-    validate_semantic_graph_taxonomy_closure,
+    build_semantic_graph_v2,
+    validate_semantic_graph_v2_taxonomy_closure,
+)
+from mozaiksai.core.semantics.payloads import (
+    PAYLOAD_MODEL_BY_KIND,
+    BillingPeriod,
+    PageSectionEntry,
+    PriceSpec,
+    SemanticPayloadBase,
+    TriggerKind,
+    build_semantic_payload,
+    semantic_payload_ref,
+    validate_semantic_graph_v2_payload_closure,
 )
 from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef, SemanticsModel
 from mozaiksai.core.taxonomy import (
@@ -33,8 +48,8 @@ from mozaiksai.core.taxonomy import (
     validate_identifier_grammar,
 )
 
-PROJECTION_SCHEMA_VERSION: Literal["mozaiks.semantic_projection.v1"] = (
-    "mozaiks.semantic_projection.v1"
+PROJECTION_SCHEMA_VERSION: Literal["mozaiks.semantic_projection.v2"] = (
+    "mozaiks.semantic_projection.v2"
 )
 
 
@@ -77,14 +92,17 @@ class ProjectionCoverage(SemanticsModel):
 
 
 class SemanticFactSet(SemanticsModel):
-    nodes: tuple[tuple[str, str, tuple[tuple[str, str], ...]], ...]
+    """Node facts carry (node_id, kind, taxonomy refs, payload content digest)."""
+
+    nodes: tuple[tuple[str, str, tuple[tuple[str, str], ...], str], ...]
     edges: tuple[tuple[str, str, str, str | None], ...]
 
 
 class ProjectionResult(SemanticsModel):
-    schema_version: Literal["mozaiks.semantic_projection.v1"] = PROJECTION_SCHEMA_VERSION
+    schema_version: Literal["mozaiks.semantic_projection.v2"] = PROJECTION_SCHEMA_VERSION
     source_digest: str
-    graph: SemanticGraph
+    graph: SemanticGraphV2
+    payloads: tuple[SemanticPayloadBase, ...]
     source_facts: SemanticFactSet
     represented_facts: SemanticFactSet
     gaps: tuple[ProjectionGap, ...]
@@ -468,6 +486,7 @@ class _Builder:
         ] = {}
         self.gaps: list[ProjectionGap] = []
         self.observations: dict[tuple[str, str, str], str] = {}
+        self.content: dict[str, dict[str, Any]] = {}
 
     def mark(
         self,
@@ -495,6 +514,63 @@ class _Builder:
         self.gaps.append(
             ProjectionGap(kind=kind, source_path=path, reason=reason, adr_slice=adr_slice)
         )
+
+    def content_field(self, node_id: str, field: str, value: Any, path: str) -> None:
+        """Record one typed payload content fact for a node, never inventing.
+
+        ``None`` records nothing (absent source content stays absent). The same
+        field stated twice with different values is a contradiction, not a
+        merge.
+        """
+        if value is None:
+            return
+        existing = self.content.setdefault(node_id, {})
+        if field in existing and existing[field] != value:
+            raise ProjectionError(
+                [
+                    ProjectionGap(
+                        kind=ProjectionGapKind.CONTRADICTORY,
+                        source_path=path,
+                        reason=f"conflicting payload content {field!r} for {node_id!r}",
+                    )
+                ]
+            )
+        existing[field] = value
+        self.mark(path, identity="typed semantic payload content field")
+
+    def build_payloads(self, version: int) -> dict[str, SemanticPayloadBase]:
+        """Build the typed payload for every projected node.
+
+        Every node gets exactly one payload of its kind; content fields hold
+        only what the source stated. Content that fails the payload contract is
+        a projection failure, not a silent drop.
+        """
+        payloads: dict[str, SemanticPayloadBase] = {}
+        for node_id, node in self.nodes.items():
+            model = PAYLOAD_MODEL_BY_KIND[node.kind]
+            fields = self.content.get(node_id, {})
+            try:
+                payloads[node_id] = build_semantic_payload(
+                    model,
+                    node_id=node_id,
+                    payload_version=version,
+                    scope=self.scope,
+                    **fields,
+                )
+            except (TypeError, ValueError) as exc:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=ProjectionGapKind.AMBIGUOUS,
+                            source_path="$",
+                            reason=(
+                                f"payload content for node {node_id!r} failed the "
+                                f"{model.__name__} contract: {exc}"
+                            ),
+                        )
+                    ]
+                ) from exc
+        return payloads
 
     def observe(self, concept: str, identity: Any, field: str, value: Any, path: str) -> None:
         if value is None:
@@ -697,8 +773,8 @@ class _Builder:
                     ProjectionGapKind.UNSUPPORTED,
                     f"{base}.surface_kind",
                     (
-                        f"surface_kind {kind!r} is current application semantics but "
-                        "SemanticGraph v1 cannot retain that realization classification"
+                        f"surface_kind {kind!r} is current application semantics but no typed "
+                        "payload field retains that realization classification"
                     ),
                     adr_slice=5,
                 )
@@ -764,7 +840,8 @@ class _Builder:
             self.gap(
                 ProjectionGapKind.UNSUPPORTED,
                 f"{root}.pages",
-                "ordered page/navigation semantics are not representable by SemanticGraph v1",
+                "page navigation ordering has no typed semantic payload field; "
+                "navigation modeling remains deferred",
                 adr_slice=5,
             )
         for i, raw in enumerate(pages):
@@ -782,7 +859,9 @@ class _Builder:
                 )
             path = f"{root}.pages[{i}].name" if item.get("name") else f"{root}.pages[{i}].route"
             self.observe("page", identity, "route", item.get("route"), f"{root}.pages[{i}].route")
-            self.node(SemanticNodeKind.PAGE, identity, path=path, group=f"{root}.pages")
+            page = self.node(SemanticNodeKind.PAGE, identity, path=path, group=f"{root}.pages")
+            self.content_field(page, "title", item.get("title"), f"{root}.pages[{i}].title")
+            self.content_field(page, "intent", item.get("purpose"), f"{root}.pages[{i}].purpose")
         for i, raw in enumerate(_as_list(plan.get("entities"))):
             item = _mapping(raw)
             if item.get("name"):
@@ -829,12 +908,20 @@ class _Builder:
                     if item.get("target_id")
                     else f"{root}.deployment_targets[{i}].deployment_profile"
                 )
-                self.node(
+                target = self.node(
                     SemanticNodeKind.DEPLOYMENT_TARGET,
                     identity,
                     path=path,
                     group=f"{root}.deployment_targets",
                 )
+                profile = item.get("deployment_profile")
+                if isinstance(profile, str) and re.fullmatch(r"[a-z][a-z0-9_]*", profile):
+                    self.content_field(
+                        target,
+                        "profile_id",
+                        profile,
+                        f"{root}.deployment_targets[{i}].deployment_profile",
+                    )
 
     def project_pages(self, pages: Any, root: str) -> None:
         for i, raw in enumerate(_as_list(pages)):
@@ -853,6 +940,8 @@ class _Builder:
             key = next(key for key in ("page_id", "name", "route") if item.get(key))
             self.observe("page", identity, "route", item.get("route"), f"{root}[{i}].route")
             page = self.node(SemanticNodeKind.PAGE, identity, path=f"{root}[{i}].{key}", group=root)
+            self.content_field(page, "title", item.get("title"), f"{root}[{i}].title")
+            self.content_field(page, "intent", item.get("description"), f"{root}[{i}].description")
             sections = _as_list(item.get("sections"))
             if item.get("schema_version") == "mozaiks.app_page.v1" and not sections:
                 raise ProjectionError(
@@ -864,13 +953,7 @@ class _Builder:
                         )
                     ]
                 )
-            if len(sections) > 1:
-                self.gap(
-                    ProjectionGapKind.UNSUPPORTED,
-                    f"{root}[{i}].sections",
-                    "ordered page-section semantics are not representable by SemanticGraph v1",
-                    adr_slice=5,
-                )
+            section_entries: list[PageSectionEntry] = []
             for j, raw_section in enumerate(sections):
                 section = _mapping(raw_section)
                 section_id = section.get("id") or section.get("section_id")
@@ -889,7 +972,28 @@ class _Builder:
                         path=f"{root}[{i}].sections[{j}].{key}",
                         group=f"{root}[{i}].sections",
                     )
+                    section_entries.append(
+                        PageSectionEntry(position=len(section_entries), section_node_id=child)
+                    )
+                    self.content_field(
+                        child,
+                        "title",
+                        section.get("title"),
+                        f"{root}[{i}].sections[{j}].title",
+                    )
+                    self.content_field(
+                        child,
+                        "intent",
+                        section.get("description"),
+                        f"{root}[{i}].sections[{j}].description",
+                    )
                 self._page_bindings(section, page, f"{root}[{i}].sections[{j}]")
+            if section_entries:
+                # The declared source order is the semantic order: it survives
+                # as explicit dense positions in the page payload.
+                self.content_field(
+                    page, "sections", tuple(section_entries), f"{root}[{i}].sections"
+                )
             auth = _mapping(_mapping(item.get("meta")).get("routeAuth"))
             if auth:
                 self._bind_action(
@@ -913,14 +1017,15 @@ class _Builder:
                         # _API_PATH_RE); only /api/modules/{module}/{action} names a
                         # declared module action. Other valid paths — the committed
                         # /api/notifications route, for one — are real bindings that
-                        # graph v1 has no node kind for, so they are typed gaps
+                        # no projected payload entry yet exists for, so they are typed gaps
                         # rather than a hard failure or an invented action target.
                         self.gap(
                             ProjectionGapKind.UNSUPPORTED,
                             child_path,
                             (
-                                "valid non-module page API binding has no SemanticGraph v1 "
-                                "target; only /api/modules/{module}/{action} names a declared action"
+                                "valid non-module page API binding is not yet projected into "
+                                "section payload entries; only /api/modules/{module}/{action} "
+                                "names a declared action"
                             ),
                             adr_slice=5,
                         )
@@ -1091,6 +1196,15 @@ class _Builder:
                 else f"{base}.module.id",
                 group=root,
             )
+            module_description = _mapping(manifest.get("module")).get("description")
+            self.content_field(
+                module,
+                "description",
+                module_description,
+                f"{base}.manifest.module.description"
+                if bundle.get("manifest")
+                else f"{base}.module.description",
+            )
             bundles.append((str(module_id), bundle, manifest, base))
             declarations = (
                 ("actions", "id", SemanticNodeKind.ACTION, True),
@@ -1113,6 +1227,12 @@ class _Builder:
                             path=f"{base}.manifest.{field}[{j}].{key}",
                             group=f"{base}.{field}",
                             taxonomy=taxonomy,
+                        )
+                        self.content_field(
+                            child,
+                            "description",
+                            _mapping(raw_item).get("description"),
+                            f"{base}.manifest.{field}[{j}].description",
                         )
                         self.edge(
                             SemanticEdgeKind.DECLARES,
@@ -1147,6 +1267,13 @@ class _Builder:
                             group=f"{base}.{companion}",
                             taxonomy=taxonomy,
                         )
+                        if "description" in PAYLOAD_MODEL_BY_KIND[kind].model_fields:
+                            self.content_field(
+                                child,
+                                "description",
+                                _mapping(raw_item).get("description"),
+                                f"{base}.{companion}.{list_key}[{j}].description",
+                            )
                         edge_kind = (
                             SemanticEdgeKind.EMITS
                             if kind is SemanticNodeKind.EVENT
@@ -1198,13 +1325,36 @@ class _Builder:
                             group=f"{base}.{companion}",
                         )
 
+    def _price_spec(self, item: dict[str, Any], period: BillingPeriod | None) -> PriceSpec | None:
+        """Map a source price mapping to a typed spec, never guessing.
+
+        Only integer minor units, a resolvable ISO-4217 code, and an explicit
+        billing period produce a spec; anything else stays deferred coverage.
+        """
+        price = _mapping(item.get("price"))
+        amount = price.get("amount_cents")
+        currency = str(price.get("currency") or "").strip().upper()
+        if not isinstance(amount, int) or isinstance(amount, bool) or not currency or period is None:
+            return None
+        try:
+            return PriceSpec(amount_minor_units=amount, currency=currency, period=period)
+        except ValueError:
+            return None
+
+    _CADENCE_PERIODS = {
+        "monthly": BillingPeriod.MONTHLY,
+        "yearly": BillingPeriod.YEARLY,
+        "one_time": BillingPeriod.ONE_TIME,
+    }
+
     def project_subscriptions(self, config: dict[str, Any], root: str) -> None:
         plans = _as_list(config.get("plans"))
         if len(plans) > 1:
             self.gap(
                 ProjectionGapKind.UNSUPPORTED,
                 f"{root}.plans",
-                "ordered plan presentation semantics are not representable by SemanticGraph v1",
+                "plan presentation ordering has no typed semantic payload field; "
+                "catalog ordering remains deferred",
                 adr_slice=5,
             )
         for i, raw_plan in enumerate(plans):
@@ -1226,6 +1376,7 @@ class _Builder:
                 path=f"{root}.plans[{i}].plan_id",
                 group=f"{root}.plans",
             )
+            self.content_field(plan, "title", item.get("label"), f"{root}.plans[{i}].label")
             for j, cap_id in enumerate(_as_list(item.get("capabilities"))):
                 cap = self.node(
                     SemanticNodeKind.CAPABILITY,
@@ -1250,12 +1401,27 @@ class _Builder:
                         path=f"{root}.plans[{i}].usage_limits[{j}].meter_id",
                         group=f"{root}.plans[{i}].usage_limits",
                     )
+                    self.content_field(
+                        meter,
+                        "unit",
+                        limit.get("unit"),
+                        f"{root}.plans[{i}].usage_limits[{j}].unit",
+                    )
                     limit_node = self.node(
                         SemanticNodeKind.LIMIT,
                         f"{plan_id}_{limit['meter_id']}",
                         path=f"{root}.plans[{i}].usage_limits[{j}].monthly_limit",
                         group=f"{root}.plans[{i}].usage_limits",
                     )
+                    monthly_limit = limit.get("monthly_limit")
+                    if isinstance(monthly_limit, int) and not isinstance(monthly_limit, bool):
+                        limit_path = f"{root}.plans[{i}].usage_limits[{j}].monthly_limit"
+                        self.content_field(limit_node, "limit_value", monthly_limit, limit_path)
+                        # The source field is monthly by declaration, so the
+                        # period is stated fact, not inference.
+                        self.content_field(
+                            limit_node, "period", BillingPeriod.MONTHLY, limit_path
+                        )
                     self.edge(
                         SemanticEdgeKind.GATES,
                         plan,
@@ -1276,14 +1442,34 @@ class _Builder:
             ("products", "product_id"),
         ):
             for i, raw_product in enumerate(_as_list(config.get(field))):
-                identity = _mapping(raw_product).get(id_key)
+                item = _mapping(raw_product)
+                identity = item.get(id_key)
                 if identity:
-                    self.node(
+                    product = self.node(
                         SemanticNodeKind.PRODUCT,
                         identity,
                         path=f"{root}.{field}[{i}].{id_key}",
                         group=f"{root}.{field}",
                     )
+                    self.content_field(
+                        product, "title", item.get("label"), f"{root}.{field}[{i}].label"
+                    )
+                    period: BillingPeriod | None
+                    if field == "top_up_products":
+                        # A token top-up is a one-time cash purchase by
+                        # contract definition (TokenTopUpPriceDef), so the
+                        # period is stated by the source contract itself.
+                        period = BillingPeriod.ONE_TIME
+                    else:
+                        cadence = str(
+                            item.get("cadence") or item.get("billing_mode") or ""
+                        ).strip()
+                        period = self._CADENCE_PERIODS.get(cadence)
+                    spec = self._price_spec(item, period)
+                    if spec is not None:
+                        self.content_field(
+                            product, "prices", (spec,), f"{root}.{field}[{i}].price"
+                        )
 
     def project_workflows(self, workflows: Any, root: str) -> None:
         items = (
@@ -1362,9 +1548,13 @@ class _Builder:
             self.gap(
                 ProjectionGapKind.UNSUPPORTED,
                 path,
-                "orchestrator.yaml contains workflow behavior beyond graph-v1 identity and trigger relationships",
+                "orchestrator.yaml contains workflow behavior beyond graph identity, "
+                "trigger relationships, and typed workflow payload content",
                 adr_slice=5,
             )
+            description = orchestration.get("description")
+            if isinstance(description, str):
+                self.content_field(workflow, "description", description, path)
             for raw_trigger in _as_list(orchestration.get("triggers")):
                 trigger_item = _mapping(raw_trigger)
                 identity = (
@@ -1378,6 +1568,20 @@ class _Builder:
                     path=path,
                     group=f"{base}.orchestrator.triggers",
                 )
+                # Event and capability trigger bindings are owned by CONSUMES/
+                # GATES edges; duplicating them into payload fields would give
+                # one fact two authorities. Endpoint bindings have no edge
+                # representation, so a well-formed route path is payload
+                # content.
+                endpoint = trigger_item.get("endpoint")
+                if (
+                    not trigger_item.get("event")
+                    and isinstance(endpoint, str)
+                    and endpoint.startswith("/")
+                    and " " not in endpoint
+                ):
+                    self.content_field(trigger, "trigger_kind", TriggerKind.ENDPOINT, path)
+                    self.content_field(trigger, "endpoint_path", endpoint, path)
                 self.edge(
                     SemanticEdgeKind.BINDS,
                     trigger,
@@ -1403,13 +1607,13 @@ class _Builder:
                     )
 
     def project_provenance(self, value: Any, root: str) -> None:
-        """Classify accepted provenance roots that carry no graph-v1 identity.
+        """Classify accepted provenance roots that carry no semantic-graph identity.
 
         ``build_context`` is declared pack provenance and ``workflows`` is
         recorded execution metadata on an AppBuildPlan envelope. Both are real
         parts of current recorded sources, so they are accepted rather than
         rejected as unknown roots — but neither declares application semantics
-        that SemanticGraph v1 can hold, so every leaf becomes an explicit typed
+        that the semantic graph can hold, so every leaf becomes an explicit typed
         gap instead of an invented node.
         """
         authority = _SOURCE_AUTHORITIES[root][2]
@@ -1417,7 +1621,7 @@ class _Builder:
             self.gap(
                 ProjectionGapKind.UNSUPPORTED,
                 leaf_path,
-                f"{authority} is not SemanticGraph v1 application semantics",
+                f"{authority} is not semantic-graph application semantics",
                 adr_slice=5,
             )
 
@@ -1466,7 +1670,7 @@ class _Builder:
                     None,
                     None,
                     None,
-                    "none; graph v1 cannot retain this complete fact",
+                    "none; the graph and payload contracts cannot retain this complete fact",
                 )
                 disposition, fully, reason, adr_slice = (
                     ProjectionDisposition.DEFERRED,
@@ -1502,18 +1706,18 @@ class _Builder:
                 )
             else:
                 node = edge = taxonomy = None
-                identity = "none; SemanticGraph v1 has no payload field for this fact"
+                identity = "none; no typed payload field is projected for this fact"
                 gap_kind = (
                     ProjectionGapKind.UNSUPPORTED
                     if leaf in _KNOWN_DEFERRED
                     else ProjectionGapKind.AMBIGUOUS
                 )
                 reason = (
-                    "source fact is not representable by Slice 2 identity-only nodes"
+                    "source fact is not yet projected into typed payload content"
                     if gap_kind is ProjectionGapKind.UNSUPPORTED
                     else (
                         "field is not in this projection's classified set; it is reported "
-                        "rather than projected, and carries no SemanticGraph v1 identity "
+                        "rather than projected, and carries no semantic-graph identity "
                         "until it is classified"
                     )
                 )
@@ -1555,7 +1759,7 @@ class _Builder:
                     source_symbol=symbol,
                     current_authority=authority,
                     disposition=ProjectionDisposition.DEFERRED,
-                    stable_identity_derivation="none; the source container carries ordering or compound semantics absent from graph v1",
+                    stable_identity_derivation="none; the source container carries ordering or compound semantics without a typed payload home",
                     scope_source="project_semantic_graph(scope=ExecutionAccessScopeRef)",
                     fully_representable=False,
                     absence_valid=value in (None, [], {}),
@@ -1568,14 +1772,20 @@ class _Builder:
         return tuple(sorted(rows, key=lambda row: row.source_path))
 
 
-def extract_semantic_facts(graph: SemanticGraph) -> SemanticFactSet:
-    """Extract represented facts independently from the built graph."""
+def extract_semantic_facts(graph: SemanticGraphV2) -> SemanticFactSet:
+    """Extract represented facts independently from the built graph.
+
+    The node fact tuple includes the pinned payload content digest, so the
+    source/graph equivalence proof covers projected content, not just
+    identity.
+    """
     return SemanticFactSet(
         nodes=tuple(
             (
                 node.node_id,
                 node.kind.value,
                 tuple((ref.category.value, ref.identifier) for ref in node.taxonomy_references),
+                node.payload_ref.content_digest,
             )
             for node in graph.nodes
         ),
@@ -1588,7 +1798,9 @@ def extract_semantic_facts(graph: SemanticGraph) -> SemanticFactSet:
     )
 
 
-def _source_facts(builder: _Builder) -> SemanticFactSet:
+def _source_facts(
+    builder: _Builder, payloads: Mapping[str, SemanticPayloadBase]
+) -> SemanticFactSet:
     """Extract source candidates before graph construction (non-circular proof side)."""
     return SemanticFactSet(
         nodes=tuple(
@@ -1597,6 +1809,7 @@ def _source_facts(builder: _Builder) -> SemanticFactSet:
                     node.node_id,
                     node.kind.value,
                     tuple((ref.category.value, ref.identifier) for ref in node.taxonomy_references),
+                    payloads[node.node_id].payload_digest,
                 )
                 for node in builder.nodes.values()
             )
@@ -1736,7 +1949,7 @@ def project_semantic_graph(
     for provenance_root in sorted(_PROVENANCE_ROOTS & set(plain)):
         builder.project_provenance(plain[provenance_root], provenance_root)
     if not builder.nodes:
-        # Distinguish "this input carries only graph-v1-unrepresentable
+        # Distinguish "this input carries only unrepresentable
         # provenance" from "this input declares nothing at all". Reporting the
         # former as a missing semantic identity misnames the cause.
         provenance_only = bool(_PROVENANCE_ROOTS & set(plain)) and not (
@@ -1749,7 +1962,7 @@ def project_semantic_graph(
                         kind=ProjectionGapKind.UNSUPPORTED,
                         source_path=root,
                         reason=(
-                            f"{_SOURCE_AUTHORITIES[root][2]} carries no SemanticGraph v1 "
+                            f"{_SOURCE_AUTHORITIES[root][2]} carries no semantic-graph "
                             "identity; it is accepted and classified as typed gaps but "
                             "cannot by itself produce a graph"
                         ),
@@ -1768,15 +1981,30 @@ def project_semantic_graph(
             ]
         )
     builder.resolve_edges()
-    graph = build_semantic_graph(
+    payloads = builder.build_payloads(version)
+    nodes_v2 = [
+        SemanticNodeV2(
+            node_id=node.node_id,
+            kind=node.kind,
+            taxonomy_references=node.taxonomy_references,
+            node_references=node.node_references,
+            payload_ref=semantic_payload_ref(payloads[node.node_id]),
+        )
+        for node in builder.nodes.values()
+    ]
+    graph = build_semantic_graph_v2(
         graph_id=graph_id,
         version=version,
         scope=scope,
-        nodes=list(builder.nodes.values()),
+        nodes=nodes_v2,
         edges=list(builder.edges.values()),
     )
-    validate_semantic_graph_taxonomy_closure(graph, builder.registry)
-    source_facts, represented_facts = _source_facts(builder), extract_semantic_facts(graph)
+    validate_semantic_graph_v2_taxonomy_closure(graph, builder.registry)
+    validate_semantic_graph_v2_payload_closure(graph, payloads.values())
+    source_facts, represented_facts = (
+        _source_facts(builder, payloads),
+        extract_semantic_facts(graph),
+    )
     if source_facts != represented_facts:
         raise ProjectionError(
             [
@@ -1794,6 +2022,9 @@ def project_semantic_graph(
     return ProjectionResult(
         source_digest=canonical_digest(plain),
         graph=graph,
+        payloads=tuple(
+            sorted(payloads.values(), key=lambda payload: payload.node_id)
+        ),
         source_facts=source_facts,
         represented_facts=represented_facts,
         gaps=gaps,

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping, Sequence
 from enum import StrEnum
-from typing import Any, Literal
+from types import NoneType
+from typing import Any, Literal, get_args
 
 import yaml
 from pydantic import Field
@@ -548,7 +549,12 @@ class _Builder:
         payloads: dict[str, SemanticPayloadBase] = {}
         for node_id, node in self.nodes.items():
             model = PAYLOAD_MODEL_BY_KIND[node.kind]
-            fields = self.content.get(node_id, {})
+            fields = {
+                field_name: None
+                for field_name, field in model.model_fields.items()
+                if field.is_required() and NoneType in get_args(field.annotation)
+            }
+            fields.update(self.content.get(node_id, {}))
             try:
                 payloads[node_id] = build_semantic_payload(
                     model,

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -345,24 +345,28 @@ class SemanticPayloadBase(SemanticsModel):
 
 class SurfacePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.SURFACE] = SemanticNodeKind.SURFACE
-    description: str
+    description: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class PagePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PAGE] = SemanticNodeKind.PAGE
-    title: str
-    intent: str
+    title: str | None = None
+    intent: str | None = None
     layout_id: str | None = None
     sections: tuple[PageSectionEntry, ...] = Field(default_factory=tuple)
 
     @field_validator("title", "intent")
     @classmethod
-    def _texts(cls, value: str, info: ValidationInfo) -> str:
+    def _texts(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name=str(info.field_name))
 
     @field_validator("layout_id")
@@ -384,13 +388,15 @@ class PagePayload(SemanticPayloadBase):
 
 class SectionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.SECTION] = SemanticNodeKind.SECTION
-    title: str
-    intent: str
+    title: str | None = None
+    intent: str | None = None
     entries: tuple[SectionContentEntry, ...] = Field(default_factory=tuple)
 
     @field_validator("title", "intent")
     @classmethod
-    def _texts(cls, value: str, info: ValidationInfo) -> str:
+    def _texts(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name=str(info.field_name))
 
     @field_validator("entries")
@@ -401,17 +407,19 @@ class SectionPayload(SemanticPayloadBase):
 
 class ModulePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.MODULE] = SemanticNodeKind.MODULE
-    description: str
+    description: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class ActionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.ACTION] = SemanticNodeKind.ACTION
-    description: str
+    description: str | None = None
     request_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     response_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     emits: tuple[str, ...] = Field(default_factory=tuple)
@@ -419,7 +427,9 @@ class ActionPayload(SemanticPayloadBase):
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("request_fields", "response_fields")
@@ -448,32 +458,38 @@ class ActionPayload(SemanticPayloadBase):
 
 class CapabilityPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.CAPABILITY] = SemanticNodeKind.CAPABILITY
-    description: str
+    description: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class PermissionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PERMISSION] = SemanticNodeKind.PERMISSION
-    description: str
+    description: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class EventPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.EVENT] = SemanticNodeKind.EVENT
-    description: str
+    description: str | None = None
     payload_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("payload_fields")
@@ -488,40 +504,48 @@ class EventPayload(SemanticPayloadBase):
 
 class ReactionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.REACTION] = SemanticNodeKind.REACTION
-    description: str
-    consumed_event: str
+    description: str | None = None
+    consumed_event: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("consumed_event")
     @classmethod
-    def _event(cls, value: str) -> str:
+    def _event(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return validate_identifier_grammar(SemanticCategory.EVENT, value)
 
 
 class NotificationPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.NOTIFICATION] = SemanticNodeKind.NOTIFICATION
-    template_text: str
-    channel: NotificationChannel
+    template_text: str | None = None
+    channel: NotificationChannel | None = None
 
     @field_validator("template_text")
     @classmethod
-    def _template(cls, value: str) -> str:
+    def _template(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="template_text")
 
 
 class DataCollectionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DATA_COLLECTION] = SemanticNodeKind.DATA_COLLECTION
-    description: str
-    fields: tuple[TypedFieldSpec, ...] = Field(min_length=1)
+    description: str | None = None
+    fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     indexes: tuple[IndexSpec, ...] = Field(default_factory=tuple)
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("fields")
@@ -554,43 +578,51 @@ class DataCollectionPayload(SemanticPayloadBase):
 
 class DataAliasPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DATA_ALIAS] = SemanticNodeKind.DATA_ALIAS
-    alias: str
-    collection: str
-    owner_node_id: str
+    alias: str | None = None
+    collection: str | None = None
+    owner_node_id: str | None = None
 
     @field_validator("alias", "collection")
     @classmethod
-    def _names(cls, value: str, info: ValidationInfo) -> str:
+    def _names(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
         return _field_name(value, field_name=str(info.field_name))
 
     @field_validator("owner_node_id")
     @classmethod
-    def _owner(cls, value: str) -> str:
+    def _owner(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return validate_node_id_grammar(value)
 
 
 class WorkflowPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.WORKFLOW] = SemanticNodeKind.WORKFLOW
-    description: str
-    startup_mode: WorkflowStartupMode
+    description: str | None = None
+    startup_mode: WorkflowStartupMode | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class TriggerPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.TRIGGER] = SemanticNodeKind.TRIGGER
-    description: str
-    trigger_kind: TriggerKind
+    description: str | None = None
+    trigger_kind: TriggerKind | None = None
     event_id: str | None = None
     endpoint_path: str | None = None
     capability_id: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("event_id")
@@ -624,6 +656,13 @@ class TriggerPayload(SemanticPayloadBase):
             TriggerKind.ENDPOINT: (self.endpoint_path, "endpoint_path"),
             TriggerKind.CAPABILITY: (self.capability_id, "capability_id"),
         }
+        if self.trigger_kind is None:
+            set_names = [name for value, name in bindings.values() if value is not None]
+            if set_names:
+                raise ValueError(
+                    f"trigger bindings {set_names} require an explicit trigger_kind"
+                )
+            return self
         required_value, required_name = bindings[self.trigger_kind]
         if required_value is None:
             raise ValueError(
@@ -639,13 +678,15 @@ class TriggerPayload(SemanticPayloadBase):
 
 class PlanPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PLAN] = SemanticNodeKind.PLAN
-    title: str
-    prices: tuple[PriceSpec, ...] = Field(min_length=1)
+    title: str | None = None
+    prices: tuple[PriceSpec, ...] = Field(default_factory=tuple)
     granted_capabilities: tuple[str, ...] = Field(default_factory=tuple)
 
     @field_validator("title")
     @classmethod
-    def _title(cls, value: str) -> str:
+    def _title(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="title")
 
     @field_validator("prices")
@@ -671,13 +712,15 @@ class PlanPayload(SemanticPayloadBase):
 
 class ProductPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PRODUCT] = SemanticNodeKind.PRODUCT
-    title: str
-    description: str
-    prices: tuple[PriceSpec, ...] = Field(min_length=1)
+    title: str | None = None
+    description: str | None = None
+    prices: tuple[PriceSpec, ...] = Field(default_factory=tuple)
 
     @field_validator("title", "description")
     @classmethod
-    def _texts(cls, value: str, info: ValidationInfo) -> str:
+    def _texts(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name=str(info.field_name))
 
     @field_validator("prices")
@@ -688,41 +731,49 @@ class ProductPayload(SemanticPayloadBase):
 
 class MeterPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.METER] = SemanticNodeKind.METER
-    description: str
-    unit: str
+    description: str | None = None
+    unit: str | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
     @field_validator("unit")
     @classmethod
-    def _unit(cls, value: str) -> str:
+    def _unit(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _field_name(value, field_name="unit")
 
 
 class LimitPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.LIMIT] = SemanticNodeKind.LIMIT
-    description: str
-    limit_value: int = Field(ge=0, strict=True)
+    description: str | None = None
+    limit_value: int | None = Field(default=None, ge=0, strict=True)
     period: BillingPeriod | None = None
 
     @field_validator("description")
     @classmethod
-    def _description(cls, value: str) -> str:
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _text(value, field_name="description")
 
 
 class DeploymentTargetPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DEPLOYMENT_TARGET] = SemanticNodeKind.DEPLOYMENT_TARGET
-    target_kind: DeploymentTargetKind
-    profile_id: str
+    target_kind: DeploymentTargetKind | None = None
+    profile_id: str | None = None
     output_hints: tuple[str, ...] = Field(default_factory=tuple)
 
     @field_validator("profile_id")
     @classmethod
-    def _profile(cls, value: str) -> str:
+    def _profile(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _field_name(value, field_name="profile_id")
 
     @field_validator("output_hints")

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -345,7 +345,7 @@ class SemanticPayloadBase(SemanticsModel):
 
 class SurfacePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.SURFACE] = SemanticNodeKind.SURFACE
-    description: str | None = None
+    description: str | None
 
     @field_validator("description")
     @classmethod
@@ -357,8 +357,8 @@ class SurfacePayload(SemanticPayloadBase):
 
 class PagePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PAGE] = SemanticNodeKind.PAGE
-    title: str | None = None
-    intent: str | None = None
+    title: str | None
+    intent: str | None
     layout_id: str | None = None
     sections: tuple[PageSectionEntry, ...] = Field(default_factory=tuple)
 
@@ -388,8 +388,8 @@ class PagePayload(SemanticPayloadBase):
 
 class SectionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.SECTION] = SemanticNodeKind.SECTION
-    title: str | None = None
-    intent: str | None = None
+    title: str | None
+    intent: str | None
     entries: tuple[SectionContentEntry, ...] = Field(default_factory=tuple)
 
     @field_validator("title", "intent")
@@ -407,7 +407,7 @@ class SectionPayload(SemanticPayloadBase):
 
 class ModulePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.MODULE] = SemanticNodeKind.MODULE
-    description: str | None = None
+    description: str | None
 
     @field_validator("description")
     @classmethod
@@ -419,7 +419,7 @@ class ModulePayload(SemanticPayloadBase):
 
 class ActionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.ACTION] = SemanticNodeKind.ACTION
-    description: str | None = None
+    description: str | None
     request_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     response_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     emits: tuple[str, ...] = Field(default_factory=tuple)
@@ -458,7 +458,7 @@ class ActionPayload(SemanticPayloadBase):
 
 class CapabilityPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.CAPABILITY] = SemanticNodeKind.CAPABILITY
-    description: str | None = None
+    description: str | None
 
     @field_validator("description")
     @classmethod
@@ -470,7 +470,7 @@ class CapabilityPayload(SemanticPayloadBase):
 
 class PermissionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PERMISSION] = SemanticNodeKind.PERMISSION
-    description: str | None = None
+    description: str | None
 
     @field_validator("description")
     @classmethod
@@ -482,7 +482,7 @@ class PermissionPayload(SemanticPayloadBase):
 
 class EventPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.EVENT] = SemanticNodeKind.EVENT
-    description: str | None = None
+    description: str | None
     payload_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
 
     @field_validator("description")
@@ -504,8 +504,8 @@ class EventPayload(SemanticPayloadBase):
 
 class ReactionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.REACTION] = SemanticNodeKind.REACTION
-    description: str | None = None
-    consumed_event: str | None = None
+    description: str | None
+    consumed_event: str | None
 
     @field_validator("description")
     @classmethod
@@ -524,8 +524,8 @@ class ReactionPayload(SemanticPayloadBase):
 
 class NotificationPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.NOTIFICATION] = SemanticNodeKind.NOTIFICATION
-    template_text: str | None = None
-    channel: NotificationChannel | None = None
+    template_text: str | None
+    channel: NotificationChannel | None
 
     @field_validator("template_text")
     @classmethod
@@ -537,8 +537,8 @@ class NotificationPayload(SemanticPayloadBase):
 
 class DataCollectionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DATA_COLLECTION] = SemanticNodeKind.DATA_COLLECTION
-    description: str | None = None
-    fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
+    description: str | None
+    fields: tuple[TypedFieldSpec, ...] | None
     indexes: tuple[IndexSpec, ...] = Field(default_factory=tuple)
 
     @field_validator("description")
@@ -550,7 +550,11 @@ class DataCollectionPayload(SemanticPayloadBase):
 
     @field_validator("fields")
     @classmethod
-    def _fields(cls, value: tuple[TypedFieldSpec, ...]) -> tuple[TypedFieldSpec, ...]:
+    def _fields(
+        cls, value: tuple[TypedFieldSpec, ...] | None
+    ) -> tuple[TypedFieldSpec, ...] | None:
+        if value is None:
+            return None
         ordered = tuple(sorted(value, key=lambda item: item.name))
         names = [item.name for item in ordered]
         if len(names) != len(set(names)):
@@ -568,7 +572,7 @@ class DataCollectionPayload(SemanticPayloadBase):
 
     @model_validator(mode="after")
     def _index_closure(self) -> DataCollectionPayload:
-        declared = {field.name for field in self.fields}
+        declared = {field.name for field in self.fields or ()}
         for index in self.indexes:
             for name in index.field_names:
                 if name not in declared:
@@ -578,9 +582,9 @@ class DataCollectionPayload(SemanticPayloadBase):
 
 class DataAliasPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DATA_ALIAS] = SemanticNodeKind.DATA_ALIAS
-    alias: str | None = None
-    collection: str | None = None
-    owner_node_id: str | None = None
+    alias: str | None
+    collection: str | None
+    owner_node_id: str | None
 
     @field_validator("alias", "collection")
     @classmethod
@@ -599,8 +603,8 @@ class DataAliasPayload(SemanticPayloadBase):
 
 class WorkflowPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.WORKFLOW] = SemanticNodeKind.WORKFLOW
-    description: str | None = None
-    startup_mode: WorkflowStartupMode | None = None
+    description: str | None
+    startup_mode: WorkflowStartupMode | None
 
     @field_validator("description")
     @classmethod
@@ -612,8 +616,8 @@ class WorkflowPayload(SemanticPayloadBase):
 
 class TriggerPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.TRIGGER] = SemanticNodeKind.TRIGGER
-    description: str | None = None
-    trigger_kind: TriggerKind | None = None
+    description: str | None
+    trigger_kind: TriggerKind | None
     event_id: str | None = None
     endpoint_path: str | None = None
     capability_id: str | None = None
@@ -678,8 +682,8 @@ class TriggerPayload(SemanticPayloadBase):
 
 class PlanPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PLAN] = SemanticNodeKind.PLAN
-    title: str | None = None
-    prices: tuple[PriceSpec, ...] = Field(default_factory=tuple)
+    title: str | None
+    prices: tuple[PriceSpec, ...] | None
     granted_capabilities: tuple[str, ...] = Field(default_factory=tuple)
 
     @field_validator("title")
@@ -691,7 +695,9 @@ class PlanPayload(SemanticPayloadBase):
 
     @field_validator("prices")
     @classmethod
-    def _prices(cls, value: tuple[PriceSpec, ...]) -> tuple[PriceSpec, ...]:
+    def _prices(cls, value: tuple[PriceSpec, ...] | None) -> tuple[PriceSpec, ...] | None:
+        if value is None:
+            return None
         return _sorted_prices(value)
 
     @field_validator("granted_capabilities")
@@ -712,9 +718,9 @@ class PlanPayload(SemanticPayloadBase):
 
 class ProductPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PRODUCT] = SemanticNodeKind.PRODUCT
-    title: str | None = None
-    description: str | None = None
-    prices: tuple[PriceSpec, ...] = Field(default_factory=tuple)
+    title: str | None
+    description: str | None
+    prices: tuple[PriceSpec, ...] | None
 
     @field_validator("title", "description")
     @classmethod
@@ -725,14 +731,16 @@ class ProductPayload(SemanticPayloadBase):
 
     @field_validator("prices")
     @classmethod
-    def _prices(cls, value: tuple[PriceSpec, ...]) -> tuple[PriceSpec, ...]:
+    def _prices(cls, value: tuple[PriceSpec, ...] | None) -> tuple[PriceSpec, ...] | None:
+        if value is None:
+            return None
         return _sorted_prices(value)
 
 
 class MeterPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.METER] = SemanticNodeKind.METER
-    description: str | None = None
-    unit: str | None = None
+    description: str | None
+    unit: str | None
 
     @field_validator("description")
     @classmethod
@@ -751,8 +759,8 @@ class MeterPayload(SemanticPayloadBase):
 
 class LimitPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.LIMIT] = SemanticNodeKind.LIMIT
-    description: str | None = None
-    limit_value: int | None = Field(default=None, ge=0, strict=True)
+    description: str | None
+    limit_value: int | None = Field(ge=0, strict=True)
     period: BillingPeriod | None = None
 
     @field_validator("description")
@@ -765,8 +773,8 @@ class LimitPayload(SemanticPayloadBase):
 
 class DeploymentTargetPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.DEPLOYMENT_TARGET] = SemanticNodeKind.DEPLOYMENT_TARGET
-    target_kind: DeploymentTargetKind | None = None
-    profile_id: str | None = None
+    target_kind: DeploymentTargetKind | None
+    profile_id: str | None
     output_hints: tuple[str, ...] = Field(default_factory=tuple)
 
     @field_validator("profile_id")

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -761,7 +761,7 @@ class LimitPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.LIMIT] = SemanticNodeKind.LIMIT
     description: str | None
     limit_value: int | None = Field(ge=0, strict=True)
-    period: BillingPeriod | None = None
+    period: BillingPeriod | None
 
     @field_validator("description")
     @classmethod

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -445,7 +445,11 @@ def test_independent_source_expectations_equal_every_graph_fact() -> None:
             ("renders", "page_reports", "section"),
         }
     }
-    assert set(result.represented_facts.nodes) == expected_nodes
+    identity_facts = {(nid, kind, refs) for nid, kind, refs, _digest in result.represented_facts.nodes}
+    assert identity_facts == expected_nodes
+    payload_digest_by_node = {payload.node_id: payload.payload_digest for payload in result.payloads}
+    for nid, _kind, _refs, digest in result.represented_facts.nodes:
+        assert digest == payload_digest_by_node[nid]
     assert set(result.represented_facts.edges) == expected_edges
 
 
@@ -501,7 +505,7 @@ def test_machine_readable_coverage_classifies_every_source_leaf() -> None:
     for path in coverage_paths:
         _lookup_path(canonical_source, path)
     assert (
-        json.loads(result.model_dump_json())["schema_version"] == "mozaiks.semantic_projection.v1"
+        json.loads(result.model_dump_json())["schema_version"] == "mozaiks.semantic_projection.v2"
     )
 
 
@@ -999,7 +1003,7 @@ def test_non_graph_v1_surface_kinds_are_precise_typed_gaps(surface_kind: str) ->
     row = next(row for row in result.coverage if row.source_path == path)
     assert gap.kind is ProjectionGapKind.UNSUPPORTED
     assert surface_kind in gap.reason
-    assert "cannot retain" in gap.reason
+    assert "no typed payload field retains" in gap.reason
     assert row.disposition is ProjectionDisposition.DEFERRED
     assert row.fully_representable is False
     assert not any(
@@ -1198,7 +1202,7 @@ def test_provenance_roots_are_classified_not_falsely_reported_as_empty() -> None
         gaps = exc_info.value.gaps
         assert all(gap.kind is ProjectionGapKind.UNSUPPORTED for gap in gaps), gaps
         assert all(gap.source_path == root for gap in gaps), gaps
-        assert "no SemanticGraph v1 identity" in gaps[0].reason
+        assert "no semantic-graph identity" in gaps[0].reason
         assert "no representable semantic identity" not in gaps[0].reason
 
     # Alongside real semantic roots they contribute typed gaps, never nodes.
@@ -1314,3 +1318,165 @@ def test_entitlement_gate_requires_declared_capability_input_closure() -> None:
     )
     assert any(node.kind is SemanticNodeKind.CAPABILITY for node in closed.graph.nodes)
     assert any(edge.kind is SemanticEdgeKind.GATES for edge in closed.graph.edges)
+
+
+# ---------------------------------------------------------------------------
+# Slice 3E: typed payload content projection over graph v2
+# ---------------------------------------------------------------------------
+
+
+def _payload_for(result, kind: SemanticNodeKind, identity_fragment: str):
+    matches = [
+        payload
+        for payload in result.payloads
+        if payload.payload_kind is kind and identity_fragment in payload.node_id
+    ]
+    assert len(matches) == 1, (kind, identity_fragment, [p.node_id for p in result.payloads])
+    return matches[0]
+
+
+def test_projection_emits_v2_graph_with_bijective_payload_closure() -> None:
+    from mozaiksai.core.semantics.payloads import validate_semantic_graph_v2_payload_closure
+    from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+
+    result = _project()
+    assert result.schema_version == "mozaiks.semantic_projection.v2"
+    assert result.graph.schema_version == "mozaiks.semantic_graph.v2"
+    assert {payload.node_id for payload in result.payloads} == {
+        node.node_id for node in result.graph.nodes
+    }
+    validate_semantic_graph_v2_payload_closure(result.graph, result.payloads)
+    resolver = SemanticReferenceResolver()
+    for payload in result.payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(result.graph)
+    for node in result.graph.nodes:
+        resolved = resolver.resolve_semantic_payload(
+            node.payload_ref, requesting_scope=result.graph.scope
+        )
+        assert resolved.payload_digest == node.payload_ref.content_digest
+
+
+def test_section_ordering_is_projected_as_dense_positions() -> None:
+    source = _corpus_source()
+    page = source["app_schema"]["pages"][0]
+    page["sections"] = [
+        {"id": "hero", "primitive": "Hero"},
+        {"id": "report_table", "primitive": "DataTable"},
+        {"id": "footer", "primitive": "Footer"},
+    ]
+    result = _project(source)
+    page_payload = _payload_for(result, SemanticNodeKind.PAGE, "reports")
+    ordered = [entry.section_node_id for entry in page_payload.sections]
+    assert [entry.position for entry in page_payload.sections] == [0, 1, 2]
+    assert [fragment.split(".")[2].rsplit("_", 1)[0] for fragment in ordered] == [
+        "reports_hero",
+        "reports_report_table",
+        "reports_footer",
+    ]
+    # The former "ordered page-section semantics" gap is gone: sections are
+    # projected content now, not a deferred container.
+    assert not any(
+        "page-section" in gap.reason for gap in result.gaps
+    )
+
+    # Reversing the declared section order is a SEMANTIC change: payload and
+    # graph digests must both move (ordering is content, not serialization).
+    reversed_source = _corpus_source()
+    reversed_source["app_schema"]["pages"][0]["sections"] = list(reversed(page["sections"]))
+    reversed_result = _project(reversed_source)
+    reversed_page = _payload_for(reversed_result, SemanticNodeKind.PAGE, "reports")
+    assert reversed_page.payload_digest != page_payload.payload_digest
+    assert reversed_result.graph.graph_digest != result.graph.graph_digest
+
+
+def test_plan_limit_meter_and_product_content_is_projected() -> None:
+    result = _project()
+    plan = _payload_for(result, SemanticNodeKind.PLAN, "pro")
+    assert plan.title == "Pro"
+    limit = _payload_for(result, SemanticNodeKind.LIMIT, "pro_report_exports")
+    assert limit.limit_value == 100
+    assert limit.period is not None and limit.period.value == "monthly"
+    meter = _payload_for(result, SemanticNodeKind.METER, "report_exports")
+    assert meter.unit == "exports"
+    product = _payload_for(result, SemanticNodeKind.PRODUCT, "extra_exports")
+    assert product.title == "Extra exports"
+    assert product.prices == ()  # corpus declares no price: nothing invented
+
+
+def test_prices_project_as_integer_minor_units_with_iso_currency() -> None:
+    source = _corpus_source()
+    source["subscriptions"]["top_up_products"][0]["price"] = {
+        "amount_cents": 500,
+        "currency": "usd",
+        "display": "$5",
+    }
+    result = _project(source)
+    product = _payload_for(result, SemanticNodeKind.PRODUCT, "extra_exports")
+    assert len(product.prices) == 1
+    spec = product.prices[0]
+    assert spec.amount_minor_units == 500
+    assert spec.currency == "USD"
+    assert spec.period.value == "one_time"
+
+
+def test_descriptions_are_projected_but_never_invented() -> None:
+    result = _project()
+    permission = _payload_for(result, SemanticNodeKind.PERMISSION, "reports_reports_read")
+    assert permission.description == "Read reports"
+    module = _payload_for(result, SemanticNodeKind.MODULE, "reports")
+    assert module.description is None  # corpus module declares none
+
+
+def test_residual_gaps_are_typed_and_never_claim_v1_limits() -> None:
+    result = _project()
+    reasons = [gap.reason for gap in result.gaps]
+    assert any("navigation ordering has no typed semantic payload field" in r for r in reasons)
+    assert any(
+        "beyond graph identity, trigger relationships, and typed workflow payload content" in r
+        for r in reasons
+    )
+    for text in reasons + [row.reason for row in result.coverage] + [
+        row.stable_identity_derivation for row in result.coverage
+    ]:
+        assert "SemanticGraph v1" not in text and "graph v1" not in text, text
+
+
+def test_payload_byte_change_reroots_the_projected_graph() -> None:
+    baseline = _project()
+    changed_source = _corpus_source()
+    changed_source["modules"][0]["manifest"]["permissions"][0]["description"] = "Read all reports"
+    changed = _project(changed_source)
+    base_perm = _payload_for(baseline, SemanticNodeKind.PERMISSION, "reports_reports_read")
+    changed_perm = _payload_for(changed, SemanticNodeKind.PERMISSION, "reports_reports_read")
+    assert base_perm.payload_digest != changed_perm.payload_digest
+    assert baseline.graph.graph_digest != changed.graph.graph_digest
+    # Untouched nodes keep identical payload digests: the re-root is exactly
+    # the Merkle chain, not a wholesale rebuild difference.
+    base_plan = _payload_for(baseline, SemanticNodeKind.PLAN, "pro")
+    changed_plan = _payload_for(changed, SemanticNodeKind.PLAN, "pro")
+    assert base_plan.payload_digest == changed_plan.payload_digest
+
+
+def test_endpoint_trigger_binding_is_payload_content() -> None:
+    source = _corpus_source()
+    content = source["agent_workflows"][0]["files"][0]["content"]
+    source["agent_workflows"][0]["files"][0]["content"] = content + (
+        "  - type: endpoint\n"
+        "    endpoint: /api/hooks/report\n"
+    )
+    result = _project(source)
+    trigger = _payload_for(result, SemanticNodeKind.TRIGGER, "api_hooks_report")
+    assert trigger.trigger_kind is not None and trigger.trigger_kind.value == "endpoint"
+    assert trigger.endpoint_path == "/api/hooks/report"
+    # Event triggers keep their binding in CONSUMES edges only — the payload
+    # never duplicates an edge-owned fact.
+    event_trigger = _payload_for(result, SemanticNodeKind.TRIGGER, "domain_reports_generated")
+    assert event_trigger.trigger_kind is None and event_trigger.event_id is None
+
+
+def test_conflicting_payload_content_fails_closed() -> None:
+    source = _corpus_source()
+    source["subscription_contract"]["subscription_config_file"]["plans"][0]["label"] = "Premium"
+    with pytest.raises(ProjectionError, match="conflicting payload content"):
+        _project(source)

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -1401,7 +1401,7 @@ def test_plan_limit_meter_and_product_content_is_projected() -> None:
     assert meter.unit == "exports"
     product = _payload_for(result, SemanticNodeKind.PRODUCT, "extra_exports")
     assert product.title == "Extra exports"
-    assert product.prices == ()  # corpus declares no price: nothing invented
+    assert product.prices is None  # corpus declares no price: absence stays explicit
 
 
 def test_prices_project_as_integer_minor_units_with_iso_currency() -> None:

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -497,7 +497,7 @@ def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
         PlanPayload: ("title", "prices"),
         ProductPayload: ("title", "description", "prices"),
         MeterPayload: ("description", "unit"),
-        LimitPayload: ("description", "limit_value"),
+        LimitPayload: ("description", "limit_value", "period"),
         DeploymentTargetPayload: ("target_kind", "profile_id"),
     }
     for model, field_names in required_nullable.items():

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -94,6 +94,10 @@ _SEMANTICS_OWNER_FILES = frozenset(
         Path("mozaiksai/core/semantics/graph.py"),
         Path("mozaiksai/core/semantics/refs.py"),
         Path("mozaiksai/core/semantics/resolver.py"),
+        # Slice 3E: the offline projection emits graph v2 + typed payloads.
+        # It stays outside production imports itself (proven by the Slice 3
+        # hygiene test scanning for offline_projection references).
+        Path("mozaiksai/core/semantics/offline_projection.py"),
     }
 )
 _FORBIDDEN_PRODUCTION_MODULES = frozenset({"mozaiksai.core.semantics.payloads"})

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -478,6 +478,66 @@ def test_each_kind_round_trips_through_the_discriminated_union(
     assert parsed == payload
 
 
+def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
+    required_nullable = {
+        SurfacePayload: ("description",),
+        PagePayload: ("title", "intent"),
+        SectionPayload: ("title", "intent"),
+        ModulePayload: ("description",),
+        ActionPayload: ("description",),
+        CapabilityPayload: ("description",),
+        PermissionPayload: ("description",),
+        EventPayload: ("description",),
+        ReactionPayload: ("description", "consumed_event"),
+        NotificationPayload: ("template_text", "channel"),
+        DataCollectionPayload: ("description", "fields"),
+        DataAliasPayload: ("alias", "collection", "owner_node_id"),
+        WorkflowPayload: ("description", "startup_mode"),
+        TriggerPayload: ("description", "trigger_kind"),
+        PlanPayload: ("title", "prices"),
+        ProductPayload: ("title", "description", "prices"),
+        MeterPayload: ("description", "unit"),
+        LimitPayload: ("description", "limit_value"),
+        DeploymentTargetPayload: ("target_kind", "profile_id"),
+    }
+    for model, field_names in required_nullable.items():
+        for field_name in field_names:
+            field = model.model_fields[field_name]
+            assert field.is_required(), f"{model.__name__}.{field_name} must reject omission"
+
+    common = {
+        "node_id": "mozaiks.product.unpriced_addon",
+        "payload_version": 1,
+        "scope": _SCOPE,
+        "title": "Unpriced add-on",
+        "description": None,
+    }
+    with pytest.raises(ValidationError, match="prices"):
+        build_semantic_payload(ProductPayload, **common)
+
+    absent = build_semantic_payload(ProductPayload, prices=None, **common)
+    empty = build_semantic_payload(ProductPayload, prices=(), **common)
+    assert absent.prices is None
+    assert empty.prices == ()
+    assert absent.payload_digest != empty.payload_digest
+
+    with pytest.raises(ValidationError, match="description"):
+        build_semantic_payload(
+            ModulePayload,
+            node_id="mozaiks.module.incomplete",
+            payload_version=1,
+            scope=_SCOPE,
+        )
+    explicit_absence = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.explicit_absence",
+        payload_version=1,
+        scope=_SCOPE,
+        description=None,
+    )
+    assert explicit_absence.description is None
+
+
 def test_union_rejects_kind_content_mismatch() -> None:
     document = _corpus_payloads()[SemanticNodeKind.PAGE].model_dump(mode="json")
     document["payload_kind"] = "module"  # page content under module discriminant


### PR DESCRIPTION
## Summary

Implements **ADR 0007 Slice 3E** per the settled sequence (after Slice 2E merged in #436): the offline source projection now emits **`mozaiks.semantic_projection.v2`** — a Merkle-rooted graph v2 with one typed payload per node and **bijective payload closure validated at build**. Bounded strictly to source reprojection: no 4B/4C/Slice 5, no capability advertisement (`capabilities.py` untouched, still advertises `()`), no production cutover (the Slice 3 hygiene test still proves nothing in production imports the projector), no AG2 workflow changes, no MatrAIx, no live models.

Integration base: `4208dbe8` (the verified PR #438 squash on `main`; the Slice 3E semantic delta remains independent of that runtime change). Built against the **merged** Slice 2E surface including the final review corrections (StubKind in `core/stub_kinds.py`, ISO-4217 List One currency membership, cold-revalidation on registration/closure).

## Corrected required-nullable absence contract

Source-permitted absence is **required-nullable**, never omission-defaulted: the field key must be present, omission fails validation, and explicit `None` means **the source contains no fact**. For absence-bearing collections such as data fields and prices, `None` remains distinct from an explicitly empty collection; `None`, empty, and populated forms have different canonical bytes and digests. Empty strings and malformed non-null values fail closed.

`LimitPayload.period` is now required-nullable as well, closing the final unconditional projector-recorded content field that could previously be omitted. The projector explicitly supplies `None` for unrecorded required-nullable fields. Its introspection is bounded to fields that are both required and nullable, so it cannot conceal a newly added structurally required non-null field. Conditional trigger binding slots remain omission-defaulted only where `trigger_kind` validation requires the active binding, and structural collection accumulators retain explicit empty defaults where absence is not a distinct source fact.

An AST/model inventory covers every projector `content_field()` name, all 20 payload variants, and their JSON Schemas: JSON Schema `required` sets agree exactly with Pydantic `is_required()`. All merged Slice 2E payloads already supplied their fields explicitly, so their golden canonical bytes and Merkle vectors remain unchanged.
## What the projection now projects (former "not representable by v1" families)

| Former gap | Now |
|---|---|
| ordered page-section semantics | `PagePayload.sections` — declared source order as explicit dense positions; **reversing source sections re-roots the graph** (ordering is semantic), while canonicalized identity collections stay order-independent |
| page/section/module/action/permission/capability/event/reaction prose | `title`/`intent`/`description` captured only when stated; `None` otherwise (proven: corpus module without description projects `description=None`) |
| plan/limit/meter/product commerce facts | `PlanPayload.title` ← `label`; `LimitPayload.limit_value`/`period` ← `monthly_limit` (monthly by declaration); `MeterPayload.unit`; `ProductPayload.title` + `prices` as integer minor units with uppercased ISO codes and explicit periods (top-ups are one-time by contract definition; unmapped cadence projects nothing) |
| endpoint trigger bindings | `TriggerPayload.trigger_kind=ENDPOINT` + `endpoint_path` (event triggers stay CONSUMES-edge-only — no fact gets two authorities) |
| deployment profile | `DeploymentTargetPayload.profile_id` |

**Still explicit typed gaps, reworded truthfully** (no reason may claim a v1 limitation over a v2 emission — asserted by test over every gap/coverage string): page **navigation** ordering, plan **catalog** ordering, intra-section binding composition (non-module API bindings), orchestrator behavior beyond identity/triggers/payload content, renderer file lists (4B/4C), provenance roots, surface realization classification.

## Mechanics

- `ProjectionResult`: `schema_version` v2, `graph: SemanticGraphV2`, `payloads: tuple[SemanticPayloadBase, ...]`; assembly runs v2 taxonomy closure **and** `validate_semantic_graph_v2_payload_closure` (which cold-revalidates, per the 2E review pattern). No v1 emission remains — replace, don't layer.
- `_Builder.content_field()`: records content only when the source states it; the same field stated twice with different values is a fail-closed contradiction (proven: conflicting plan labels across `subscriptions` and `subscription_contract` raise).
- `_Builder.build_payloads()`: every node gets exactly one payload of its kind via `build_semantic_payload`; it supplies explicit `None` only for unrecorded fields that are both required and nullable, while any missing required non-null field remains a projection failure. Content that fails the payload contract is never silently dropped.
- `SemanticFactSet` node facts gain the **payload content digest**, so the source/graph equivalence proof now covers projected content, not just identity.
- The 2E production-hygiene scan's semantics-seam roster gains `offline_projection.py` (it consumes payloads/v2 legitimately; its own non-importability is separately proven).

## Proof gate

New/extended in `tests/test_semantic_offline_projection.py` (44 total, 9 new): v2 emission + bijective closure + full resolver round-trip · dense-position ordering fidelity with the semantic-vs-serialization ordering distinction · plan/limit/meter/product content · integer-minor-unit price projection with ISO uppercasing · projected-but-never-invented descriptions · residual-gap honesty (typed, narrowed, zero v1-claim strings anywhere) · **payload byte change re-roots the projected graph while untouched payload digests hold** (Merkle chain through projection) · endpoint-vs-event trigger authority split · conflicting content fails closed. Existing determinism, purity (cold-subprocess), input-immutability, coverage-classification, and provenance tests all pass on the v2 emission.

## Validation

The independent reviewed head `1c5297cc…` passed its focused semantic and exact-head CI gates. After rebasing onto `4208dbe8`, the focused payload/graph/resolver/projection battery is **232 passed**; `ruff check .`, source hygiene, `git diff --check`, and DCO are clean. The normal local scoped mypy invocation reaches only the same unrelated installed-ACP `elicitation_policy` mismatch reproduced on `main`; the exact-head CI clean-environment mypy gate passed. All four non-changelog implementation/test files remain byte-for-byte identical to reviewed head `1c5297cc…`. No new test file was added, so CI sharding is not re-partitioned by this PR.

## Scope confirmation

Untouched by the Slice 3E delta: later issue #426 work, `capabilities.py`, `manifest.py`, `binding.py`, `refs.py`/`graph.py`/`resolver.py`/`stub_kinds.py` (the 2E graph/ref/resolver contracts are consumed unchanged; `payloads.py` carries only the required-nullable absence correction), portable-path/archive/layout-registry, generators, `AppBuildPlan`, AG2 workflows, CI sharding, MatrAIx. PR #438 is present only through the rebased `main` history and routine changelog integration. No renderer, no `CompilationPlan`, no cutover, no advertisement, no live models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
