### PR TITLE
fix(runtime): resume durable AG2 network channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,10 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Continue Build now resumes the durable AG2 Network channel**: runtime
+  continuation reopens the chat-scoped AG2 KnowledgeStore, hydrates the Hub
+  WAL and transition state, and reattaches existing agent and human identities
+  instead of projecting transcript messages into a new Network channel.
 - **Generated custom-route clients now recognize real entitlement denials**:
   module-action and workflow-start failures unwrap FastAPI's structured
   `detail` envelope, so HTTP 402 responses reach the app's upgrade flow while

--- a/mozaiksai/core/adapters/ag2_knowledge_store.py
+++ b/mozaiksai/core/adapters/ag2_knowledge_store.py
@@ -1,0 +1,183 @@
+"""Tenant-scoped Mongo implementation of AG2's KnowledgeStore protocol.
+
+AG2 owns Network persistence semantics and Hub hydration. This adapter only
+maps AG2's virtual file paths onto Mozaiks' canonical runtime database because
+AG2 does not currently ship a Mongo KnowledgeStore.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from ag2.knowledge import NoopChangeSubscription
+from pymongo import ReturnDocument
+
+from mozaiksai.core.core_config import get_mongo_client
+from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE, RuntimeCollections
+from mozaiksai.core.multitenant import build_app_scope_filter, coalesce_app_id, dual_write_app_scope
+
+
+def _normalize_path(path: str) -> str:
+    value = "/" + str(path or "").strip().lstrip("/")
+    return value.rstrip("/") or "/"
+
+
+class MongoAG2KnowledgeStore:
+    """Persist one AG2 Network namespace for one app workflow chat."""
+
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        chat_id: str,
+        collection: Any | None = None,
+    ) -> None:
+        resolved_app_id = str(coalesce_app_id(app_id=app_id) or "").strip()
+        resolved_chat_id = str(chat_id or "").strip()
+        if not resolved_app_id:
+            raise ValueError("app_id is required")
+        if not resolved_chat_id:
+            raise ValueError("chat_id is required")
+        self._app_id = resolved_app_id
+        self._chat_id = resolved_chat_id
+        self._collection = collection
+        self._client: Any | None = None
+        self._lock = asyncio.Lock()
+        self._indexes_ready = False
+
+    async def read(self, path: str) -> str | None:
+        doc = await (await self._coll()).find_one(self._filter(_normalize_path(path)))
+        return None if doc is None else str(doc.get("content") or "")
+
+    async def write(self, path: str, content: str) -> None:
+        normalized = _normalize_path(path)
+        now = datetime.now(UTC)
+        await (await self._coll()).update_one(
+            self._filter(normalized),
+            {
+                "$set": dual_write_app_scope(
+                    {
+                        "app_id": self._app_id,
+                        "chat_id": self._chat_id,
+                        "path": normalized,
+                        "content": str(content),
+                        "updated_at": now,
+                    },
+                    self._app_id,
+                ),
+                "$setOnInsert": {"created_at": now},
+            },
+            upsert=True,
+        )
+
+    async def list(self, path: str = "/") -> list[str]:
+        normalized = _normalize_path(path)
+        prefix = normalized.rstrip("/") + "/"
+        query = self._scope_filter()
+        query["path"] = {"$regex": f"^{re.escape(prefix)}"}
+        cursor = (await self._coll()).find(query, {"path": 1})
+        docs = await cursor.to_list(length=100_000)
+        children: set[str] = set()
+        for doc in docs:
+            remainder = str(doc.get("path") or "")[len(prefix) :]
+            if not remainder:
+                continue
+            children.add(remainder.split("/", 1)[0] + ("/" if "/" in remainder else ""))
+        return sorted(children)
+
+    async def delete(self, path: str) -> None:
+        normalized = _normalize_path(path)
+        query = self._scope_filter()
+        query["$or"] = [
+            {"path": normalized},
+            {"path": {"$regex": f"^{re.escape(normalized.rstrip('/') + '/')}"}},
+        ]
+        await (await self._coll()).delete_many(query)
+
+    async def exists(self, path: str) -> bool:
+        normalized = _normalize_path(path)
+        query = self._scope_filter()
+        query["$or"] = [
+            {"path": normalized},
+            {"path": {"$regex": f"^{re.escape(normalized.rstrip('/') + '/')}"}},
+        ]
+        return await (await self._coll()).find_one(query, {"_id": 1}) is not None
+
+    async def append(self, path: str, content: str) -> int:
+        """Atomically append UTF-8 content and return its prior byte offset."""
+        normalized = _normalize_path(path)
+        now = datetime.now(UTC)
+        prior = await (await self._coll()).find_one_and_update(
+            self._filter(normalized),
+            [
+                {
+                    "$set": dual_write_app_scope(
+                        {
+                            "app_id": self._app_id,
+                            "chat_id": self._chat_id,
+                            "path": normalized,
+                            "content": {
+                                "$concat": [
+                                    {"$ifNull": ["$content", ""]},
+                                    str(content),
+                                ]
+                            },
+                            "created_at": {"$ifNull": ["$created_at", now]},
+                            "updated_at": now,
+                        },
+                        self._app_id,
+                    )
+                }
+            ],
+            upsert=True,
+            return_document=ReturnDocument.BEFORE,
+        )
+        return len(str((prior or {}).get("content") or "").encode("utf-8"))
+
+    async def read_range(self, path: str, start: int, end: int | None = None) -> str:
+        content = await self.read(path)
+        if content is None:
+            return ""
+        data = content.encode("utf-8")
+        stop = len(data) if end is None else min(end, len(data))
+        if start >= stop:
+            return ""
+        return data[start:stop].decode("utf-8", errors="strict")
+
+    async def on_change(self, path: str, callback: Any) -> NoopChangeSubscription:
+        _ = path, callback
+        return NoopChangeSubscription()
+
+    def _scope_filter(self) -> dict[str, Any]:
+        return {
+            "chat_id": self._chat_id,
+            **build_app_scope_filter(self._app_id),
+        }
+
+    def _filter(self, path: str) -> dict[str, Any]:
+        return {"path": path, **self._scope_filter()}
+
+    async def _coll(self) -> Any:
+        if self._collection is None:
+            async with self._lock:
+                if self._client is None:
+                    self._client = get_mongo_client()
+                self._collection = self._client[SYSTEM_DATABASE][
+                    RuntimeCollections.AG2_NETWORK_KNOWLEDGE
+                ]
+        if not self._indexes_ready:
+            create_index = getattr(self._collection, "create_index", None)
+            if callable(create_index):
+                await create_index(
+                    [("app_id", 1), ("chat_id", 1), ("path", 1)],
+                    name="ag2_network_app_chat_path",
+                    unique=True,
+                )
+            self._indexes_ready = True
+        return self._collection
+
+
+__all__ = ["MongoAG2KnowledgeStore"]

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +24,11 @@ from ag2.network import (
     EV_PACKET,
     EV_TEXT,
     AgentTarget,
+    ChannelState,
     Envelope,
     Hub,
     HubClient,
+    HumanClient,
     LocalLink,
     Passport,
     Resume,
@@ -137,6 +139,41 @@ def _authorized_context_updates(
     return safe
 
 
+async def _attach_human_client(
+    *,
+    hub: Hub,
+    hub_client: HubClient,
+    name: str,
+) -> HumanClient:
+    """Reconnect AG2's durable human identity to a freshly opened Hub client.
+
+    AG2 exposes ``HubClient.attach`` for Agents but has no public human-client
+    counterpart yet. Keep this compatibility seam localized until AG2 adds it.
+    """
+    attach_human = getattr(hub_client, "attach_human", None)
+    if callable(attach_human):
+        return cast(HumanClient, await attach_human(name))
+
+    agent_id = hub.find_agent_id(name)
+    if agent_id is None:
+        raise RuntimeError(f"AG2 human identity {name!r} was not hydrated")
+    client_link = await hub_client._ensure_connected_async()  # noqa: SLF001
+    passport = await hub.get_agent(agent_id)
+    resume = await hub.get_resume(agent_id)
+    rule = await hub.get_rule(agent_id)
+    hub.bind_endpoint(client_link.endpoint_id, agent_id)
+    hub_client._cache_passport(passport)  # noqa: SLF001
+    human = HumanClient(
+        passport=passport,
+        resume=resume,
+        rule=rule,
+        hub=hub,
+        hub_client=hub_client,
+    )
+    hub_client._clients[agent_id] = human  # type: ignore[assignment]  # noqa: SLF001
+    return human
+
+
 @dataclass(slots=True)
 class AG2NetworkRunnerRequest:
     """Already-loaded workflow execution inputs for the AG2 Network runner."""
@@ -147,7 +184,7 @@ class AG2NetworkRunnerRequest:
     agents: Mapping[str, Any]
     transition_rules: Sequence[Mapping[str, Any]]
     initial_agent_name: str
-    initial_message: str
+    initial_message: str | None
     context_variables: Mapping[str, Any] = field(default_factory=dict)
     structured_registry: Mapping[str, Any] = field(default_factory=dict)
     max_turns: int | None = None
@@ -160,7 +197,8 @@ class AG2NetworkRunnerRequest:
     # ---------------------------------------------------------------------------
     # Accepts an AG2-native KnowledgeStore instance (ag2.knowledge.KnowledgeStore
     # protocol). When None the runner creates a fresh MemoryKnowledgeStore per
-    # Hub — the safe default for local development and test isolation.
+    # Hub — the safe default for direct local/test use. The runtime adapter
+    # supplies the chat-scoped Mongo implementation for durable continuation.
     #
     # Lifecycle notes:
     #   - One Hub is created per workflow run (or per live session, kept alive for
@@ -182,6 +220,8 @@ class AG2NetworkRunnerRequest:
     #     tenant or platform data; AG2 memory/knowledge controls are engine-level,
     #     not Mozaiks-level authority.
     knowledge_store: KnowledgeStore | None = None
+    resume_existing_only: bool = False
+    resume_context_updates: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -240,12 +280,37 @@ class AG2NetworkRunner:
         keep_live_run = False
 
         try:
+            active_channels = [
+                metadata
+                for metadata in await hub.list_channels(state=ChannelState.ACTIVE)
+                if str((getattr(metadata, "labels", {}) or {}).get("workflow_name") or "")
+                in {"", request.workflow_name}
+            ]
+            if len(active_channels) > 1:
+                raise RuntimeError("multiple_active_ag2_network_channels")
+            existing_channel = active_channels[0] if active_channels else None
+            if request.resume_existing_only and existing_channel is None:
+                return AG2NetworkRunnerResult(
+                    status=RunStatus.FAILED,
+                    workflow_name=request.workflow_name,
+                    chat_id=request.chat_id,
+                    app_id=request.app_id,
+                    error="ag2_network_channel_not_found",
+                )
+
             initiator_hc = HubClient(link, hub=hub)
             hub_clients.append(initiator_hc)
-            initiator = await initiator_hc.register_human(
-                Passport(name=_INITIATOR_NAME),
-                resume=Resume(claimed_capabilities=["workflow_start"]),
-            )
+            if hub.find_agent_id(_INITIATOR_NAME) is None:
+                initiator = await initiator_hc.register_human(
+                    Passport(name=_INITIATOR_NAME),
+                    resume=Resume(claimed_capabilities=["workflow_start"]),
+                )
+            else:
+                initiator = await _attach_human_client(
+                    hub=hub,
+                    hub_client=initiator_hc,
+                    name=_INITIATOR_NAME,
+                )
 
             agent_clients = {}
             agent_id_by_name: dict[str, str] = {
@@ -258,10 +323,11 @@ class AG2NetworkRunner:
                     continue
                 hub_client = HubClient(link, hub=hub)
                 hub_clients.append(hub_client)
-                client = await hub_client.register(
+                client = await hub_client.attach(
                     agent,
-                    Passport(name=name),
-                    Resume(claimed_capabilities=[name]),
+                    name,
+                    passport=Passport(name=name),
+                    resume=Resume(claimed_capabilities=[name]),
                     attach_plugin=request.attach_network_plugin,
                 )
                 _install_context_update_handler(
@@ -277,33 +343,33 @@ class AG2NetworkRunner:
             if initial_agent_name not in agent_clients:
                 raise ValueError(f"initial agent {initial_agent_name!r} did not register")
 
-            graph = self._compile_graph_with_initiator(
-                transition_rules=request.transition_rules,
-                initial_agent_name=initial_agent_name,
-                agent_id_by_name=agent_id_by_name,
-                max_turns=request.max_turns,
-                context_authority_policy=request.context_authority_policy,
-            )
-
-            safe_context_vars = _json_safe_dict(request.context_variables)
-
-            channel = await initiator.open(
-                type="workflow",
-                target=[client.agent_id for client in agent_clients.values()],
-                knobs={
-                    "graph": graph.to_dict(),
-                    "context_vars": safe_context_vars,
-                },
-            )
+            channel: Any
+            if existing_channel is None:
+                graph = self._compile_graph_with_initiator(
+                    transition_rules=request.transition_rules,
+                    initial_agent_name=initial_agent_name,
+                    agent_id_by_name=agent_id_by_name,
+                    max_turns=request.max_turns,
+                    context_authority_policy=request.context_authority_policy,
+                )
+                channel = await initiator.open(
+                    type="workflow",
+                    target=[client.agent_id for client in agent_clients.values()],
+                    knobs={
+                        "graph": graph.to_dict(),
+                        "context_vars": _json_safe_dict(request.context_variables),
+                    },
+                    labels={"workflow_name": request.workflow_name},
+                )
+            else:
+                channel = existing_channel
             channel_id = channel.channel_id
-            await channel.send(
-                request.initial_message or ".",
-                audience=[agent_clients[initial_agent_name].agent_id],
-            )
-            failure_task = asyncio.create_task(
-                turn_failure_listener.wait_for_failure(channel.channel_id)
-            )
-
+            if existing_channel is None:
+                await initiator.send(
+                    channel.channel_id,
+                    request.initial_message or ".",
+                    audience=[agent_clients[initial_agent_name].agent_id],
+                )
             def _agent_names() -> dict[str, str]:
                 return {
                     initiator.agent_id: "user",
@@ -352,6 +418,38 @@ class AG2NetworkRunner:
                     error=error,
                 )
 
+            if existing_channel is not None:
+                live_run = _AG2LiveWorkflowRun(
+                    workflow_name=request.workflow_name,
+                    chat_id=request.chat_id,
+                    app_id=request.app_id,
+                    hub=hub,
+                    hub_clients=tuple(hub_clients),
+                    initiator=initiator,
+                    channel_id=channel.channel_id,
+                    turn_failure_listener=turn_failure_listener,
+                    snapshot_result=_snapshot_result,
+                    close_timeout_seconds=float(request.close_timeout_seconds or 120.0),
+                    context_authority_policy=request.context_authority_policy,
+                )
+                keep_live_run = True
+                if request.initial_message:
+                    return await live_run.continue_with_user_message(
+                        request.initial_message,
+                        context_updates=request.resume_context_updates,
+                    )
+                if request.resume_context_updates:
+                    await live_run.apply_context_updates(request.resume_context_updates)
+                result = await _snapshot_result(
+                    status=RunStatus.PAUSED,
+                    close_reason="awaiting_user_input",
+                )
+                result.live_run = live_run
+                return result
+
+            failure_task = asyncio.create_task(
+                turn_failure_listener.wait_for_failure(channel.channel_id)
+            )
             loop = asyncio.get_running_loop()
             deadline = loop.time() + float(request.close_timeout_seconds or 120.0)
 
@@ -430,7 +528,7 @@ class AG2NetworkRunner:
                         hub=hub,
                         hub_clients=tuple(hub_clients),
                         initiator=initiator,
-                        channel=channel,
+                        channel_id=channel.channel_id,
                         turn_failure_listener=turn_failure_listener,
                         snapshot_result=_snapshot_result,
                         close_timeout_seconds=float(request.close_timeout_seconds or 120.0),
@@ -546,7 +644,7 @@ class _AG2LiveWorkflowRun:
         hub: Any,
         hub_clients: Sequence[Any],
         initiator: Any,
-        channel: Any,
+        channel_id: str,
         turn_failure_listener: _TurnFailureListener,
         snapshot_result: Callable[..., Awaitable[AG2NetworkRunnerResult]],
         close_timeout_seconds: float,
@@ -555,11 +653,10 @@ class _AG2LiveWorkflowRun:
         self.workflow_name = workflow_name
         self.chat_id = chat_id
         self.app_id = app_id
-        self.channel_id = str(channel.channel_id)
+        self.channel_id = str(channel_id)
         self._hub = hub
         self._hub_clients = tuple(hub_clients)
         self._initiator = initiator
-        self._channel = channel
         self._turn_failure_listener = turn_failure_listener
         self._snapshot_result: Callable[..., Awaitable[AG2NetworkRunnerResult]] = snapshot_result
         self._close_timeout_seconds = close_timeout_seconds
@@ -593,18 +690,13 @@ class _AG2LiveWorkflowRun:
             }
 
             if context_updates:
-                safe_updates = _authorized_context_updates(
-                    context_updates,
-                    writer_id=LIVE_USER_CONTEXT_WRITER,
-                    context_authority_policy=self._context_authority_policy,
-                )
-                await self._channel.send(
-                    "",
-                    event_type=EV_CONTEXT_SET,
-                    event_data={"set": _json_safe_dict(safe_updates), "delete": []},
-                )
+                await self._apply_context_updates(context_updates)
             audience = self._next_agent_audience_for_user_text(str(message or "."))
-            await self._channel.send(str(message or "."), audience=audience)
+            await self._initiator.send(
+                self.channel_id,
+                str(message or "."),
+                audience=audience,
+            )
 
             result = await self._wait_for_settlement(seen_envelope_ids=seen_envelope_ids)
             result.wal = list(result.wal[self._wal_cursor :])
@@ -614,6 +706,28 @@ class _AG2LiveWorkflowRun:
             else:
                 await self.close()
             return result
+
+    async def apply_context_updates(self, updates: Mapping[str, Any]) -> None:
+        async with self._lock:
+            if self._closed:
+                raise RuntimeError("live_ag2_channel_closed")
+            await self._apply_context_updates(updates)
+
+    async def _apply_context_updates(self, updates: Mapping[str, Any]) -> None:
+        safe_updates = _authorized_context_updates(
+            updates,
+            writer_id=LIVE_USER_CONTEXT_WRITER,
+            context_authority_policy=self._context_authority_policy,
+        )
+        await self._initiator.post_envelope(
+            Envelope(
+                channel_id=self.channel_id,
+                sender_id=self._initiator.agent_id,
+                audience=[],
+                event_type=EV_CONTEXT_SET,
+                event_data={"set": _json_safe_dict(safe_updates), "delete": []},
+            )
+        )
 
     async def _wait_for_settlement(
         self,

--- a/mozaiksai/core/adapters/ag2_orchestration.py
+++ b/mozaiksai/core/adapters/ag2_orchestration.py
@@ -109,7 +109,7 @@ class AG2OrchestrationAdapter:
                 user_id=request.user_id,
                 initial_message=request.initial_message,
                 initial_agent_name_override=request.initial_agent_name_override,
-                **request.extra,
+                **self._with_network_store(request.app_id, request.chat_id, request.extra),
             )
 
             return self._interpret_result(request, result)
@@ -148,18 +148,10 @@ class AG2OrchestrationAdapter:
     async def resume(self, request: ResumeRequest) -> RunResult:
         """Resume a paused workflow.
 
-        Under the hood this is the same orchestration entrypoint, with
-        ``initial_agent_name_override`` set to ``resume_agent``.
-
-        In the current runtime, Mozaiks re-enters the orchestration loop for the
-        same ``chat_id`` after loading canonical AG2 run-stream events through
-        the workflow bootstrap layer. If ``injected_context`` is provided, it is
-        persisted before re-entry so the next agent sees it in
-        ``context_variables``.
-
-        The installed AG2 Network API does not expose durable channel resume, so
-        this remains a runtime-managed re-entry boundary rather than a wrapper
-        over ``Hub.resume()``.
+        The Network runner reopens the chat-scoped AG2 KnowledgeStore, lets AG2
+        hydrate the Hub/WAL, and reattaches the human and Agent identities. If
+        ``injected_context`` is provided, it is persisted before reconnection so
+        the next turn sees it in ``context_variables``.
         """
         try:
             # If injected_context is provided (e.g. task batch results),
@@ -171,6 +163,8 @@ class AG2OrchestrationAdapter:
                 run_workflow_orchestration,
             )
 
+            extra = self._with_network_store(request.app_id, request.chat_id, request.extra)
+            extra["resume_existing_only"] = True
             result = await run_workflow_orchestration(
                 workflow_name=request.workflow_name,
                 app_id=request.app_id,
@@ -178,7 +172,7 @@ class AG2OrchestrationAdapter:
                 user_id=request.user_id,
                 initial_message=None,
                 initial_agent_name_override=request.resume_agent,
-                **request.extra,
+                **extra,
             )
 
             return self._interpret_result(
@@ -257,6 +251,18 @@ class AG2OrchestrationAdapter:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _with_network_store(app_id: str, chat_id: str, extra: dict[str, Any]) -> dict[str, Any]:
+        resolved = dict(extra)
+        if "knowledge_store" not in resolved:
+            from mozaiksai.core.adapters.ag2_knowledge_store import MongoAG2KnowledgeStore
+
+            resolved["knowledge_store"] = MongoAG2KnowledgeStore(
+                app_id=app_id,
+                chat_id=chat_id,
+            )
+        return resolved
 
     def _interpret_result(
         self, request: RunRequest, raw: dict[str, Any] | None

--- a/mozaiksai/core/data/persistence/namespaces.py
+++ b/mozaiksai/core/data/persistence/namespaces.py
@@ -17,6 +17,7 @@ class RuntimeCollections:
     CHAT_SESSIONS = "ChatSessions"
     AG2_STREAM_EVENTS = "AG2StreamEvents"
     AG2_STREAM_HEADS = "AG2StreamHeads"
+    AG2_NETWORK_KNOWLEDGE = "AG2NetworkKnowledge"
     GENERAL_CHAT_SESSIONS = "GeneralChatSessions"
     GENERAL_CHAT_COUNTERS = "GeneralChatCounters"
     MEDIA_ASSETS = "MediaAssets"

--- a/mozaiksai/core/workflow/execution/run_bootstrap.py
+++ b/mozaiksai/core/workflow/execution/run_bootstrap.py
@@ -1,10 +1,7 @@
-"""Workflow run bootstrap from canonical AG2 event history.
+"""Prepare launch input without reconstructing AG2 Network execution state.
 
-This module owns only the deterministic boundary between a new workflow run
-and re-entering an existing run. AG2 typed events are the execution source of
-truth. Message dictionaries produced here are a temporary prompt projection for
-the current AG2 Network runner, which does not expose the beta ``Agent.resume``
-API in the installed AG2 version.
+The run stream is a UI/transport transcript. Durable Network state lives in
+AG2's Hub KnowledgeStore and is hydrated by the Network runner.
 """
 from __future__ import annotations
 
@@ -34,18 +31,18 @@ def _hidden_config_seed(config: dict[str, Any], *, suppress: bool) -> dict[str, 
     }
 
 
-def _latest_user_message(messages: list[dict[str, Any]]) -> dict[str, Any] | None:
-    for message in reversed(messages):
-        if not isinstance(message, dict):
+def _latest_user_event(events: list[Any]) -> dict[str, Any] | None:
+    from ag2.events.input_events import TextInput
+
+    for event in reversed(events):
+        if not isinstance(event, TextInput):
             continue
-        if message.get("role") != "user":
-            continue
-        content = str(message.get("content") or "").strip()
+        content = str(getattr(event, "content", "") or "").strip()
         if not content:
             continue
         return {
             "role": "user",
-            "name": str(message.get("name") or "user"),
+            "name": "user",
             "content": content,
             "_mozaiks_seed_kind": "ag2_event_trigger",
         }
@@ -63,11 +60,12 @@ async def bootstrap_run_messages(
     initial_agent_name: str | None,
     wf_logger: Any,
     suppress_config_seed: bool = False,
+    resume_existing_only: bool = False,
 ) -> tuple[bool, list[dict[str, Any]]]:
-    """Return ``(has_persisted_events, seed_messages)`` for AG2 Network.
+    """Return ``(has_run_events, launch_messages)`` for AG2 Network.
 
-    Existing runs are bootstrapped from AG2 typed event history. New runs are
-    seeded only from launch-time input/config and get a ``ChatSessions`` record.
+    Existing run events contribute only the newly queued user trigger. They are
+    never replayed as Network history; Hub hydration owns that state.
     """
     _ = initial_agent_name
     run_events = await persistence_manager.load_run_events(chat_id=chat_id, app_id=app_id) or []
@@ -75,29 +73,14 @@ async def bootstrap_run_messages(
     seed_messages: list[dict[str, Any]] = []
 
     if has_persisted_events:
-        event_projector = getattr(persistence_manager, "project_run_events_to_messages", None)
-        if not callable(event_projector):
-            raise RuntimeError("persistence_manager must provide project_run_events_to_messages")
-        projected_messages = event_projector(run_events)
-        meaningful_roles = {"user", "assistant", "agent", "tool"}
-        meaningful_count = sum(
-            1 for message in projected_messages
-            if isinstance(message, dict) and message.get("role") in meaningful_roles
+        latest_user = None if resume_existing_only else _latest_user_event(run_events)
+        seed_messages = [latest_user] if latest_user else []
+        wf_logger.debug(
+            "[RUN_BOOTSTRAP] Existing chat %s uses AG2 Hub hydration: events=%d trigger_messages=%d",
+            chat_id,
+            len(run_events),
+            len(seed_messages),
         )
-        if meaningful_count:
-            latest_user = _latest_user_message(projected_messages)
-            seed_messages = [latest_user] if latest_user else []
-            wf_logger.debug(
-                "[RUN_BOOTSTRAP] Re-entering chat %s from AG2 events: events=%d projected_messages=%d trigger_messages=%d",
-                chat_id, len(run_events), len(projected_messages), len(seed_messages),
-            )
-        else:
-            wf_logger.debug(
-                "[RUN_BOOTSTRAP] Existing AG2 events for %s have no prompt projection; continuing as fresh",
-                chat_id,
-            )
-            has_persisted_events = False
-            seed_messages = []
 
     if not has_persisted_events:
         hidden_seed = _hidden_config_seed(config, suppress=suppress_config_seed)

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -17,7 +17,7 @@ import asyncio
 import inspect
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from time import perf_counter
 from typing import Any, cast
 
@@ -661,6 +661,8 @@ async def _run_ag2_network_phase(
     agent_text_context_deriver: Callable[[str, str], dict[str, Any]] | None = None,
     knowledge_store: Any = None,
     context_authority_policy: Any = None,
+    resume_existing_only: bool = False,
+    resume_context_updates: Mapping[str, Any] | None = None,
 ) -> Any:
     return await AG2NetworkRunner().run(
         AG2NetworkRunnerRequest(
@@ -670,13 +672,15 @@ async def _run_ag2_network_phase(
             agents=agents,
             transition_rules=transition_rules,
             initial_agent_name=initial_agent_name,
-            initial_message=initial_message,
+            initial_message=None if resume_existing_only else initial_message,
             context_variables=context_variables,
             structured_registry=structured_registry,
             max_turns=max_turns,
             agent_text_context_deriver=agent_text_context_deriver,
             knowledge_store=knowledge_store,
             context_authority_policy=context_authority_policy,
+            resume_existing_only=resume_existing_only,
+            resume_context_updates=dict(resume_context_updates or {}),
         )
     )
 
@@ -739,6 +743,7 @@ async def run_workflow_orchestration(
     agents_factory: Callable | None = None,
     context_factory: Callable | None = None,
     knowledge_store: Any = None,
+    resume_existing_only: bool = False,
     **kwargs: Any,
 ) -> dict[str, Any] | None:
     start_time = perf_counter()
@@ -793,6 +798,7 @@ async def run_workflow_orchestration(
             initial_message=initial_message,
             initial_agent_name=initial_agent_name,
             wf_logger=wf_logger,
+            resume_existing_only=resume_existing_only,
         )
         resumed_mode = bool(has_persisted_events)
 
@@ -1146,6 +1152,8 @@ async def run_workflow_orchestration(
                 agent_text_context_deriver=agent_text_context_deriver,
                 knowledge_store=knowledge_store,
                 context_authority_policy=context_authority_policy,
+                resume_existing_only=resume_existing_only,
+                resume_context_updates=persisted_extra_ctx if resume_existing_only else None,
             )
             if first_phase_result.status is not RunStatus.COMPLETED:
                 runner_result = first_phase_result
@@ -1217,6 +1225,8 @@ async def run_workflow_orchestration(
                         agent_text_context_deriver=agent_text_context_deriver,
                         knowledge_store=knowledge_store,
                         context_authority_policy=context_authority_policy,
+                        resume_existing_only=resume_existing_only,
+                        resume_context_updates=persisted_extra_ctx if resume_existing_only else None,
                     )
                 else:
                     runner_result = first_phase_result
@@ -1236,6 +1246,8 @@ async def run_workflow_orchestration(
                 agent_text_context_deriver=agent_text_context_deriver,
                 knowledge_store=knowledge_store,
                 context_authority_policy=context_authority_policy,
+                resume_existing_only=resume_existing_only,
+                resume_context_updates=persisted_extra_ctx if resume_existing_only else None,
             )
 
         structured_validation_failed = _structured_output_validation_failed(runner_result)

--- a/tests/test_ag2_knowledge_store.py
+++ b/tests/test_ag2_knowledge_store.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.adapters.ag2_knowledge_store import MongoAG2KnowledgeStore
+
+
+class _Cursor:
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self.docs = docs
+
+    async def to_list(self, *, length: int) -> list[dict[str, Any]]:
+        return self.docs[:length]
+
+
+class _Collection:
+    def __init__(self) -> None:
+        self.find_one_result: dict[str, Any] | None = None
+        self.find_docs: list[dict[str, Any]] = []
+        self.find_one_calls: list[tuple[Any, ...]] = []
+        self.update_calls: list[tuple[Any, ...]] = []
+        self.append_calls: list[tuple[Any, ...]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+        self.index_calls: list[tuple[Any, ...]] = []
+
+    async def create_index(self, *args: Any, **kwargs: Any) -> None:
+        self.index_calls.append((args, kwargs))
+
+    async def find_one(self, *args: Any) -> dict[str, Any] | None:
+        self.find_one_calls.append(args)
+        return self.find_one_result
+
+    async def update_one(self, *args: Any, **kwargs: Any) -> None:
+        self.update_calls.append((*args, kwargs))
+
+    def find(self, *args: Any) -> _Cursor:
+        return _Cursor(self.find_docs)
+
+    async def delete_many(self, query: dict[str, Any]) -> None:
+        self.delete_calls.append(query)
+
+    async def find_one_and_update(self, *args: Any, **kwargs: Any) -> dict[str, Any] | None:
+        self.append_calls.append((*args, kwargs))
+        return self.find_one_result
+
+
+@pytest.mark.asyncio
+async def test_mongo_ag2_knowledge_store_scopes_paths_to_app_and_chat() -> None:
+    collection = _Collection()
+    collection.find_one_result = {"content": "hydrated"}
+    store = MongoAG2KnowledgeStore(
+        app_id="app-1",
+        chat_id="chat-1",
+        collection=collection,
+    )
+
+    assert await store.read("hub/agents/a.json") == "hydrated"
+    query = collection.find_one_calls[0][0]
+    assert query["path"] == "/hub/agents/a.json"
+    assert query["chat_id"] == "chat-1"
+    assert query["app_id"] == "app-1"
+    assert collection.index_calls[0][1]["unique"] is True
+
+
+@pytest.mark.asyncio
+async def test_mongo_ag2_knowledge_store_lists_virtual_children() -> None:
+    collection = _Collection()
+    collection.find_docs = [
+        {"path": "/hub/agents/one.json"},
+        {"path": "/hub/agents/nested/two.json"},
+        {"path": "/hub/agents/nested/three.json"},
+    ]
+    store = MongoAG2KnowledgeStore(
+        app_id="app-1",
+        chat_id="chat-1",
+        collection=collection,
+    )
+
+    assert await store.list("/hub/agents") == ["nested/", "one.json"]
+
+
+@pytest.mark.asyncio
+async def test_mongo_ag2_knowledge_store_append_returns_utf8_byte_offset() -> None:
+    collection = _Collection()
+    collection.find_one_result = {"content": "café"}
+    store = MongoAG2KnowledgeStore(
+        app_id="app-1",
+        chat_id="chat-1",
+        collection=collection,
+    )
+
+    assert await store.append("/channels/wal", "\nnext") == 5
+    query, update_pipeline, options = collection.append_calls[0]
+    assert query["path"] == "/channels/wal"
+    assert update_pipeline[0]["$set"]["content"]["$concat"][1] == "\nnext"
+    assert options["upsert"] is True
+
+
+@pytest.mark.asyncio
+async def test_mongo_ag2_knowledge_store_returns_noop_subscription() -> None:
+    collection = _Collection()
+    store = MongoAG2KnowledgeStore(
+        app_id="app-1",
+        chat_id="chat-1",
+        collection=collection,
+    )
+
+    subscription = await store.on_change("/channels", lambda _path: None)
+    await subscription.close()

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from ag2 import Agent
+from ag2.events.input_events import TextInput
 from ag2.knowledge import MemoryKnowledgeStore
 from ag2.network import (
     EV_CHANNEL_CLOSED,
@@ -657,6 +658,96 @@ async def test_ag2_network_runner_continues_paused_channel_with_user_message() -
 
 
 @pytest.mark.anyio
+async def test_ag2_network_runner_hydrates_and_continues_same_channel_after_restart() -> None:
+    store = MemoryKnowledgeStore()
+    transition_rules = [
+        {
+            "source_agent": "ValueInterviewAgent",
+            "target_agent": "user",
+            "transition_type": "after_turn",
+        },
+        {
+            "source_agent": "user",
+            "target_agent": "terminate",
+            "transition_type": "after_turn",
+        },
+    ]
+
+    first = await AG2NetworkRunner().run(
+        AG2NetworkRunnerRequest(
+            workflow_name="DurableResumeSmoke",
+            chat_id="chat-durable-resume",
+            app_id="app-durable-resume",
+            agents={
+                "ValueInterviewAgent": _DeterministicAgent(
+                    "ValueInterviewAgent",
+                    "Which audience should we target?",
+                )
+            },
+            transition_rules=transition_rules,
+            initial_agent_name="ValueInterviewAgent",
+            initial_message="Start the interview.",
+            knowledge_store=store,
+            close_timeout_seconds=10.0,
+        )
+    )
+    assert first.status is RunStatus.PAUSED
+    assert first.live_run is not None
+    first_channel_id = first.channel_id
+    first_wal_size = len(first.wal)
+    await first.live_run.close()
+
+    reconnected = await AG2NetworkRunner().run(
+        AG2NetworkRunnerRequest(
+            workflow_name="DurableResumeSmoke",
+            chat_id="chat-durable-resume",
+            app_id="app-durable-resume",
+            agents={
+                "ValueInterviewAgent": _DeterministicAgent(
+                    "ValueInterviewAgent",
+                    "This reply must not start a fresh channel.",
+                )
+            },
+            transition_rules=transition_rules,
+            initial_agent_name="ValueInterviewAgent",
+            initial_message=None,
+            knowledge_store=store,
+            resume_existing_only=True,
+            resume_context_updates={"approved_audience": "founders"},
+            close_timeout_seconds=10.0,
+        )
+    )
+    assert reconnected.status is RunStatus.PAUSED
+    assert reconnected.channel_id == first_channel_id
+    assert len(reconnected.wal) == first_wal_size + 1
+    assert reconnected.context_variables["approved_audience"] == "founders"
+    assert reconnected.live_run is not None
+    await reconnected.live_run.close()
+
+    continued = await AG2NetworkRunner().run(
+        AG2NetworkRunnerRequest(
+            workflow_name="DurableResumeSmoke",
+            chat_id="chat-durable-resume",
+            app_id="app-durable-resume",
+            agents={
+                "ValueInterviewAgent": _DeterministicAgent(
+                    "ValueInterviewAgent",
+                    "This reply must not start a fresh channel.",
+                )
+            },
+            transition_rules=transition_rules,
+            initial_agent_name="ValueInterviewAgent",
+            initial_message="Founders building agentic software.",
+            knowledge_store=store,
+            close_timeout_seconds=10.0,
+        )
+    )
+    assert continued.status is RunStatus.COMPLETED
+    assert continued.channel_id == first_channel_id
+    assert EV_CHANNEL_CLOSED in [entry["event_type"] for entry in continued.wal]
+
+
+@pytest.mark.anyio
 async def test_ag2_network_runner_commits_multiple_context_updates_and_deletes() -> None:
     context: dict[str, Any] = {"obsolete": "old", "route": "draft"}
     planner_agent = _ContextOperationAgent(
@@ -1045,7 +1136,7 @@ async def test_run_workflow_orchestration_resolves_user_reentry_to_next_agent(
             self.persisted_context: dict[str, Any] | None = None
 
         async def load_run_events(self, *, chat_id: str, app_id: str) -> list[Any]:
-            return [{"event_type": "text"}]
+            return [TextInput("Approved, proceed.")]
 
         def project_run_events_to_messages(self, events: list[Any]) -> list[dict[str, Any]]:
             return [{"role": "user", "name": "user", "content": "Approved, proceed."}]

--- a/tests/test_orchestration_seed_persistence.py
+++ b/tests/test_orchestration_seed_persistence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import pytest
+from ag2.events.input_events import TextInput
 
 from mozaiksai.core.workflow.execution.run_bootstrap import (
     bootstrap_run_messages as _bootstrap_run_messages,
@@ -134,7 +135,7 @@ async def test_run_bootstrap_propagates_required_session_creation_failure() -> N
 @pytest.mark.asyncio
 async def test_run_bootstrap_uses_latest_user_event_as_trigger_without_reinjecting_config_seed() -> None:
     pm = _StubPersistenceManager(
-        run_events=[object()],
+        run_events=[TextInput("Polymarket for AI startups")],
         event_messages=[
             {
                 "role": "assistant",


### PR DESCRIPTION
## Summary
- replace transcript-projection re-entry with AG2 Hub hydration and identity reattachment
- add a chat-scoped Mongo implementation of AG2's KnowledgeStore protocol for durable Network WAL/state
- preserve typed TextInput only as the newly queued user trigger; UI transcript events are no longer execution history
- carry explicit resume context updates into the hydrated workflow state

## Architecture impact
- AG2 continues to own Network channels, TransitionGraph state, WAL folding, Hub hydration, and agent identity attachment
- Mozaiks adds only the narrow Mongo KnowledgeStore adapter required for runtime tenant/chat persistence
- single-Agent resume is intentionally unchanged; Network continuation does not use Agent.resume
- no changes to ADR terminology, Slice 3E, issue #426, workflow_bridge.py, or runtime.py

## Persistence impact
- adds the framework-owned AG2NetworkKnowledge collection
- scopes every AG2 virtual path by app_id and chat_id
- append uses an atomic Mongo update and returns the prior UTF-8 byte offset required by AG2

## Tests
- `ruff check .` (pass)
- focused runtime/persistence/orchestration suite: 135 passed
- `pytest -q --no-cov` was attempted cleanly after rebase; it produced no failures but exceeded the 20-minute local command ceiling, leaving a child process that was stopped explicitly