### PR TITLE
fix(control-plane): align ACP config with pinned AG2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **ACP coding-provider configuration now matches the pinned AG2 API**:
+  hardened headless execution no longer passes an unsupported elicitation
+  option when constructing Claude Code, Codex, or OpenCode ACP configs.
 - **Generated custom-route clients now recognize real entitlement denials**:
   module-action and workflow-start failures unwrap FastAPI's structured
   `detail` envelope, so HTTP 402 responses reach the app's upgrade flow while

--- a/mozaiksai/control_plane/implementations/acp_coding_provider.py
+++ b/mozaiksai/control_plane/implementations/acp_coding_provider.py
@@ -10,10 +10,11 @@ Authority model: the provider receives an explicitly scoped
 holds no routing, scope, acceptance, or promotion authority, and nothing in
 this module trusts the CLI agent: the workspace contains only copies of the
 scoped files, the subprocess environment is an explicit allowlist, the agent's
-question/permission channels are closed (``elicitation_policy="decline"``,
-terminal capability not advertised), and every accepted change comes from the
-post-run hash harvest — never from the agent's own claims. Out-of-scope edits
-reject the whole proposal.
+permission requests are auto-resolved only inside that disposable workspace,
+the terminal capability is not advertised, and every accepted change comes
+from the post-run hash harvest — never from the agent's own claims. Out-of-scope
+edits reject the whole proposal. Pinned AG2 ACP exposes no elicitation/question
+client capability.
 
 This provider is dark by default: ``refinement_policy.yaml``'s
 ``coding.providers.acp.enabled`` is ``false``, the ``ag2[acp]`` extra is
@@ -116,10 +117,9 @@ def build_acp_agent_config(
     default is True) so no MCP gateway is started; ``allow_terminal=False``
     because agent-requested terminal commands inherit the full host
     environment in ag2 1.0.2 (``ag2/acp/bridge.py:123``); and
-    ``elicitation_policy="decline"`` so the question capability is never
-    advertised in headless execution. ``permission_policy="auto"`` is safe
-    only because the blast radius is the disposable workspace plus the
-    harvest filter.
+    pinned AG2 ACP exposes no elicitation/question client capability.
+    ``permission_policy="auto"`` is safe only because the blast radius is the
+    disposable workspace plus the harvest filter.
     """
     if not acp_available():  # pragma: no cover - guarded by caller
         raise RuntimeError(f"ag2[acp] extra is not installed: {_ACP_IMPORT_ERROR}")
@@ -137,7 +137,6 @@ def build_acp_agent_config(
         fs_root=str(workspace_root),
         env=env or None,
         permission_policy="auto",
-        elicitation_policy="decline",
         expose_tools=False,
         allow_terminal=False,
         turn_timeout=float(turn_timeout_seconds),

--- a/tests/test_acp_coding_provider.py
+++ b/tests/test_acp_coding_provider.py
@@ -87,7 +87,6 @@ class _FakeConfigFactory:
             cwd=str(workspace_root),
             fs_root=str(workspace_root),
             permission_policy="auto",
-            elicitation_policy="decline",
             expose_tools=False,
             allow_terminal=False,
             turn_timeout=float(turn_timeout_seconds),
@@ -282,7 +281,6 @@ def test_build_acp_agent_config_is_hardened(tmp_path: Path) -> None:
     assert config.cwd == str(tmp_path)
     assert config.fs_root == str(tmp_path)
     assert config.permission_policy == "auto"
-    assert config.elicitation_policy == "decline"
     assert config.expose_tools is False
     assert config.allow_terminal is False
     assert config.turn_timeout == 300.0


### PR DESCRIPTION
## Summary
- remove the unsupported `elicitation_policy` keyword from ACP config construction against pinned AG2 1.0.2
- align the hardened-config test and comments with the actual pinned ACP capability surface
- restore repository-wide mypy/lint health

## OSS Change Impact
- layer: refinement control-plane ACP provider only
- public/runtime contracts: no routing or artifact contract changes
- release note: added under Unreleased / Fixed

## Control-Plane / Refinement Impact
- classification affected: no
- artifact routing affected: no
- workflow sequence affected: no
- checkpoint/re-entry behavior: no
- provider remains dark by default and retains workspace confinement, env allowlisting, terminal denial, tool-gateway denial, harvest verification, and human review

## Tests
- `ruff check .` — pass
- `mypy mozaiksai/ factory_app/ --ignore-missing-imports --disable-error-code=import-untyped` — pass (583 files)
- focused control-plane suite — 157 passed, 1 skipped (optional ACP package absent locally)