### PR TITLE
feat(semantics): ADR 0007 Slice 4B — aggregate authoritative CompilationPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Added
+
+- **Aggregate CompilationPlan derivation (ADR 0007 Slice 4B, offline-only)**:
+  one deterministic authoritative plan per immutable graph identity, derived
+  solely from validated graph-v2 semantics, typed payloads, and the sole
+  layout registry. Embedded family-instance plans are non-authoritative
+  subdocuments (no reference type, registration, or execution surface of
+  their own); every registry family row is disposed (render /
+  reuse-from-base / preserve-unowned / input-only / external-handoff /
+  inapplicable) or carried as an explicit typed gap — binding-owned
+  conditions and renderer resolution defer to the next slice, never guessed.
+  Portable-path output ownership with case-fold and prefix collision
+  rejection, dependency ordering from the registry's total order, complete
+  digest closure (payload -> graph -> plan Merkle chain), and a pure
+  regeneration-closure function that partitions plan units into
+  affected/reusable/added/removed for Refinement Runs without touching
+  production refinement authority. The agent-produced AppBuildPlan remains
+  the sole active operational plan; no production code consumes the new
+  contract and no capability is advertised.
+
 ### Fixed
 
 - **Distributed same-chat exclusion is now enforced (issue #426, sub-slice A)**:

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -18,9 +18,13 @@ extensions) and renderer resolution are typed gaps deferred to the
 implementation-binding slice — the plan never invents a semantic fact.
 
 This module is deterministic substrate: no filesystem, no network, no AG2
-imports, no model calls, no runtime or capability authority. The active
-agent-produced ``AppBuildPlan`` remains the sole operational plan until the
-Slice 5 cutover; nothing in production imports this module.
+imports, no model calls, no runtime or capability authority. The plan carries
+no live runtime identifiers of any execution engine: execution needs appear
+only as provider-neutral deterministic requirements (registry materializer
+declarations, dependency order, dispositions) that the authority-cutover
+slice may later bind onto runtime adapters and workflow transitions. The
+active agent-produced ``AppBuildPlan`` remains the sole operational plan until
+the Slice 5 cutover; nothing in production imports this module.
 """
 
 from __future__ import annotations

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -2,20 +2,33 @@
 
 Exactly one aggregate plan is derived per immutable graph identity from three
 inputs and nothing else: a validated ``SemanticGraphV2``, its typed payload
-closure, and the sole ``layout_registry``. The plan pins the complete input
-identity (graph quartet + registry digest) and embeds one non-authoritative
-``FamilyInstancePlan`` subdocument per applicable artifact-family instance.
-Embedded family plans have no independent reference type, registration,
-resolution, publication, or execution authority — they are valid only under
-the aggregate plan's identity and digest.
+closure, and a typed snapshot of the sole ``layout_registry``. The registry
+snapshot recomputes its own identity from the canonical row content it
+carries — a caller-claimed registry digest is never trusted — so substituted,
+forged, or internally inconsistent registries change or fail plan identity
+rather than hiding behind a retained digest. The snapshot is a projection of
+the one registry, never a parallel authority: it declares no rows of its own.
+
+The plan embeds one non-authoritative ``FamilyInstancePlan`` subdocument per
+applicable artifact-family instance. Embedded family plans have no independent
+reference type, registration, resolution, publication, or execution authority
+— they are valid only under the aggregate plan's identity and digest.
 
 Completeness rule: every registry family row is either disposed
 (render / reuse_from_base / preserve_unowned / input_only / external_handoff /
-inapplicable) or carried as an explicit typed ``PlanGap``. Omission is never
-an implicit decision. Conditions that graph-v2 semantics cannot decide
-(auth, custom routes, refinement harness, managed capabilities, staging,
-extensions) and renderer resolution are typed gaps deferred to the
-implementation-binding slice — the plan never invents a semantic fact.
+inapplicable) or carried as an explicit typed ``PlanGap`` with a closed reason
+code. Omission is never an implicit decision. Conditions that graph-v2
+semantics cannot decide, placeholders whose joint binding no typed graph
+relationship proves, and renderer resolution are typed gaps deferred to the
+implementation-binding slice — the plan never invents a semantic fact, and a
+validated unit can never carry an unresolved ``{placeholder}``.
+
+Every authoritative field obeys a closed value domain (enums or canonical
+lowercase identifier grammar); the document carries no free-form prose, so
+the contract is structurally incapable of smuggling arbitrary live runtime
+state. Output ownership is validated per physical destination root: global
+roots are one collision domain regardless of semantic instance, and
+instance-relative roots require an explicit instance identity.
 
 This module is deterministic substrate: no filesystem, no network, no AG2
 imports, no model calls, no runtime or capability authority. The plan carries
@@ -56,11 +69,224 @@ COMPILATION_PLAN_SCHEMA_VERSION: Literal["mozaiks.compilation_plan.v1"] = (
 )
 
 _PLACEHOLDER_RE = re.compile(r"\{([a-z][a-z0-9_]*)\}")
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_VALUE_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
 _UNIT_SEGMENT_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+_SCHEMA_VERSION_RE = re.compile(r"^[a-z][a-z0-9_.]*$")
+
+#: Path scopes that name one shared physical destination root: ownership is
+#: global across every unit regardless of semantic instance identity.
+_GLOBAL_PATH_SCOPES = frozenset(
+    {"app_bundle_root", "workspace_root", "deployment_derived", "generated_staging"}
+)
+#: Path scopes rooted at one semantic instance: the instance identity is the
+#: explicit physical root discriminator and must be present.
+_INSTANCE_PATH_SCOPES = frozenset({"module_relative", "workflow_relative"})
 
 
 class CompilationPlanError(ValueError):
     """The plan inputs or document violate the Slice 4B contract."""
+
+
+def _identifier(value: Any, *, field_name: str) -> str:
+    text = str(getattr(value, "value", value) or "").strip()
+    if _IDENTIFIER_RE.fullmatch(text) is None:
+        raise ValueError(f"{field_name} must be a lowercase identifier, got {value!r}")
+    return text
+
+
+def _template_text(value: str, *, field_name: str) -> str:
+    """Validate a registry path template: portable once placeholders resolve."""
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    probe = text
+    for name in _PLACEHOLDER_RE.findall(text):
+        probe = probe.replace("{" + name + "}", "x0")
+    if "{" in probe or "}" in probe:
+        raise ValueError(f"{field_name} contains a malformed placeholder: {value!r}")
+    validate_portable_path(probe)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Registry snapshot: recomputed identity, no trusted claimed digest
+# ---------------------------------------------------------------------------
+
+
+class RegistryFamilyRow(SemanticsModel):
+    """One consumed registry row, typed and closed.
+
+    ``row_digest`` is recomputed from this exact content; a unit's
+    ``family_identity_digest`` pins it, so every registry-derived value in the
+    plan traces to the recomputed snapshot identity rather than to anything
+    the caller claimed.
+    """
+
+    kind: str
+    owner: str
+    requirement: str
+    multiplicity: str
+    condition: str
+    path_scope: str
+    path_template: str
+    materializer: str
+    dependency_families: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator(
+        "kind", "owner", "requirement", "multiplicity", "condition", "path_scope", "materializer"
+    )
+    @classmethod
+    def _identifiers(cls, value: str, info: Any) -> str:
+        return _identifier(value, field_name=str(info.field_name))
+
+    @field_validator("path_template")
+    @classmethod
+    def _template(cls, value: str) -> str:
+        return _template_text(value, field_name="path_template")
+
+    @field_validator("dependency_families")
+    @classmethod
+    def _deps(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(
+            sorted({_identifier(item, field_name="dependency_families") for item in value})
+        )
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "owner": self.owner,
+            "requirement": self.requirement,
+            "multiplicity": self.multiplicity,
+            "condition": self.condition,
+            "path_scope": self.path_scope,
+            "path_template": self.path_template,
+            "materializer": self.materializer,
+            "dependency_families": list(self.dependency_families),
+        }
+
+    @property
+    def row_digest(self) -> str:
+        return canonical_digest(self.identity_payload)
+
+
+class LayoutRegistrySnapshot(SemanticsModel):
+    """Typed projection of the sole layout registry with recomputed identity.
+
+    ``snapshot_digest`` is verified against the carried row content, so two
+    snapshots with different rows can never share an identity and a forged
+    digest fails validation. The snapshot declares nothing of its own — it is
+    consumed, not authored, and is not a parallel registry authority.
+    """
+
+    registry_schema_version: str
+    rows: tuple[RegistryFamilyRow, ...] = Field(min_length=1)
+    snapshot_digest: str
+
+    @field_validator("registry_schema_version")
+    @classmethod
+    def _schema(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if _SCHEMA_VERSION_RE.fullmatch(text) is None:
+            raise ValueError(f"registry_schema_version must be a dotted identifier, got {value!r}")
+        return text
+
+    @field_validator("snapshot_digest")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="snapshot_digest")
+
+    @model_validator(mode="after")
+    def _validate_snapshot(self) -> LayoutRegistrySnapshot:
+        seen: set[tuple[str, str, str]] = set()
+        kinds: set[str] = {row.kind for row in self.rows}
+        first_position: dict[str, int] = {}
+        for index, row in enumerate(self.rows):
+            key = (row.kind, row.path_scope, row.path_template)
+            if key in seen:
+                raise ValueError(f"duplicate registry row {key!r}")
+            seen.add(key)
+            first_position.setdefault(row.kind, index)
+        for row in self.rows:
+            for dependency in row.dependency_families:
+                if dependency not in kinds:
+                    raise ValueError(
+                        f"registry row {row.kind!r} depends on unknown family {dependency!r}"
+                    )
+                if dependency == row.kind:
+                    raise ValueError(f"registry row {row.kind!r} depends on itself")
+                # Rows arrive in the registry's dependency-respecting total
+                # order; a dependency first appearing after its dependent is
+                # an inconsistent registry input.
+                if first_position[dependency] > first_position[row.kind]:
+                    raise ValueError(
+                        f"registry order places dependency {dependency!r} after its "
+                        f"dependent {row.kind!r}"
+                    )
+        expected = canonical_digest(
+            {
+                "registry_schema_version": self.registry_schema_version,
+                "rows": [row.identity_payload for row in self.rows],
+            }
+        )
+        if self.snapshot_digest != expected:
+            raise ValueError("snapshot_digest does not match snapshot row content")
+        return self
+
+
+def snapshot_layout_registry(registry: Any) -> LayoutRegistrySnapshot:
+    """Project the sole layout registry into its typed, self-digesting snapshot.
+
+    Reads only canonical row content from ``registry.ordered_families()`` and
+    ``registry.schema_version``; the registry's own claimed digest is never
+    consulted. Content that fails the closed row domains fails here.
+    """
+    try:
+        families = tuple(registry.ordered_families())
+        schema_version = str(registry.schema_version)
+    except (AttributeError, TypeError) as exc:
+        raise CompilationPlanError(f"registry input is not a layout registry: {exc}") from exc
+    try:
+        rows = tuple(
+            RegistryFamilyRow(
+                kind=getattr(family.kind, "value", family.kind),
+                owner=getattr(family.owner, "value", family.owner),
+                requirement=getattr(family.requirement, "value", family.requirement),
+                multiplicity=getattr(family.multiplicity, "value", family.multiplicity),
+                condition=getattr(family.condition, "value", family.condition),
+                path_scope=getattr(family.path_scope, "value", family.path_scope),
+                path_template=family.path_template,
+                materializer=getattr(family.materializer, "value", family.materializer),
+                dependency_families=tuple(
+                    getattr(item, "value", item) for item in family.dependency_families
+                ),
+            )
+            for family in families
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CompilationPlanError(
+            f"registry rows failed the closed snapshot domains: {exc}"
+        ) from exc
+    digest = canonical_digest(
+        {
+            "registry_schema_version": str(schema_version).strip(),
+            "rows": [row.identity_payload for row in rows],
+        }
+    )
+    try:
+        return LayoutRegistrySnapshot(
+            registry_schema_version=schema_version,
+            rows=rows,
+            snapshot_digest=digest,
+        )
+    except ValueError as exc:
+        raise CompilationPlanError(f"registry snapshot is internally inconsistent: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Plan documents
+# ---------------------------------------------------------------------------
 
 
 class PlanDisposition(StrEnum):
@@ -74,21 +300,59 @@ class PlanDisposition(StrEnum):
     INAPPLICABLE = "inapplicable"
 
 
-class PlanGap(SemanticsModel):
-    """One explicit deferred decision — never silent omission."""
+class PlanSourceScope(StrEnum):
+    """How a unit's reuse signature is sourced.
 
+    ``declared`` units pin an explicit node/payload footprint; ``graph_wide``
+    units depend on the whole graph identity, so any graph change affects
+    them. The dependency on the entire graph is explicit, never an empty
+    source list masquerading as independence.
+    """
+
+    DECLARED = "declared"
+    GRAPH_WIDE = "graph_wide"
+
+
+class PlanGapCode(StrEnum):
+    """Closed reason codes for explicit deferrals — never free prose."""
+
+    BINDING_CONDITION_DEFERRED = "binding_condition_deferred"
+    STAGING_TRANSPORT_EXCLUDED = "staging_transport_excluded"
+    CONDITION_UNDERIVABLE = "condition_underivable"
+    PLACEHOLDER_UNDERIVABLE = "placeholder_underivable"
+    PLACEHOLDER_RELATIONSHIP_UNPROVABLE = "placeholder_relationship_unprovable"
+    RENDERER_RESOLUTION_DEFERRED = "renderer_resolution_deferred"
+
+
+class PlanGap(SemanticsModel):
+    """One explicit deferred decision, fully typed.
+
+    ``subject`` names the deferred condition or placeholder set (identifier
+    grammar); there is no prose field, so a gap cannot carry arbitrary text.
+    """
+
+    code: PlanGapCode
     family_kind: str
     path_template: str
-    reason: str
+    subject: str | None = None
     adr_slice: int = Field(ge=4, le=7, strict=True)
 
-    @field_validator("family_kind", "path_template", "reason")
+    @field_validator("family_kind")
     @classmethod
-    def _text(cls, value: str) -> str:
-        text = str(value or "").strip()
-        if not text:
-            raise ValueError("plan gap fields must be non-empty")
-        return text
+    def _family(cls, value: str) -> str:
+        return _identifier(value, field_name="family_kind")
+
+    @field_validator("path_template")
+    @classmethod
+    def _template(cls, value: str) -> str:
+        return _template_text(value, field_name="path_template")
+
+    @field_validator("subject")
+    @classmethod
+    def _subject(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _identifier(value, field_name="subject")
 
 
 class PlanSource(SemanticsModel):
@@ -117,15 +381,15 @@ class PlanOutput(SemanticsModel):
     @field_validator("path_scope")
     @classmethod
     def _scope(cls, value: str) -> str:
-        text = str(value or "").strip()
-        if not text:
-            raise ValueError("path_scope must be non-empty")
-        return text
+        return _identifier(value, field_name="path_scope")
 
     @field_validator("path")
     @classmethod
     def _path(cls, value: str) -> str:
-        return validate_portable_path(value).text
+        text = validate_portable_path(value).text
+        if "{" in text or "}" in text:
+            raise ValueError(f"planned output path carries an unresolved placeholder: {value!r}")
+        return text
 
 
 class FamilyInstancePlan(SemanticsModel):
@@ -140,6 +404,7 @@ class FamilyInstancePlan(SemanticsModel):
     family_kind: str
     family_identity_digest: str
     disposition: PlanDisposition
+    source_scope: PlanSourceScope
     placeholder_values: tuple[tuple[str, str], ...] = Field(default_factory=tuple)
     outputs: tuple[PlanOutput, ...] = Field(default_factory=tuple)
     sources: tuple[PlanSource, ...] = Field(default_factory=tuple)
@@ -151,17 +416,15 @@ class FamilyInstancePlan(SemanticsModel):
     @classmethod
     def _unit_id(cls, value: str) -> str:
         text = str(value or "").strip()
-        if not all(_UNIT_SEGMENT_RE.fullmatch(part) for part in text.split("/") if True):
+        parts = text.split("/")
+        if not parts or not all(_UNIT_SEGMENT_RE.fullmatch(part) for part in parts):
             raise ValueError(f"unit_id must be a normalized identifier path, got {value!r}")
         return text
 
     @field_validator("family_kind", "materializer")
     @classmethod
-    def _identifier(cls, value: str) -> str:
-        text = str(value or "").strip()
-        if not text:
-            raise ValueError("identifier fields must be non-empty")
-        return text
+    def _identifiers(cls, value: str, info: Any) -> str:
+        return _identifier(value, field_name=str(info.field_name))
 
     @field_validator("family_identity_digest")
     @classmethod
@@ -178,11 +441,17 @@ class FamilyInstancePlan(SemanticsModel):
     @field_validator("placeholder_values")
     @classmethod
     def _placeholders(cls, value: tuple[tuple[str, str], ...]) -> tuple[tuple[str, str], ...]:
-        ordered = tuple(sorted(value))
-        names = [name for name, _v in ordered]
+        normalized: list[tuple[str, str]] = []
+        for name, item in sorted(value):
+            clean_name = _identifier(name, field_name="placeholder name")
+            clean_value = str(item).strip()
+            if _VALUE_RE.fullmatch(clean_value) is None:
+                raise ValueError(f"placeholder value {item!r} is outside the closed domain")
+            normalized.append((clean_name, clean_value))
+        names = [name for name, _v in normalized]
         if len(names) != len(set(names)):
             raise ValueError("duplicate placeholder names in one unit")
-        return ordered
+        return tuple(normalized)
 
     @field_validator("outputs")
     @classmethod
@@ -211,13 +480,21 @@ class FamilyInstancePlan(SemanticsModel):
         return ordered
 
     @model_validator(mode="after")
-    def _reuse_shape(self) -> FamilyInstancePlan:
+    def _shape(self) -> FamilyInstancePlan:
         if (self.disposition is PlanDisposition.REUSE_FROM_BASE) != (
             self.base_plan_digest is not None
         ):
             raise ValueError(
                 "base_plan_digest is required exactly when disposition is reuse_from_base"
             )
+        if self.source_scope is PlanSourceScope.GRAPH_WIDE and self.sources:
+            raise ValueError("graph_wide units must not also declare explicit sources")
+        for output in self.outputs:
+            if output.path_scope in _INSTANCE_PATH_SCOPES and not self.placeholder_values:
+                raise ValueError(
+                    f"instance-relative output scope {output.path_scope!r} requires an "
+                    "explicit instance identity"
+                )
         return self
 
     @property
@@ -227,6 +504,7 @@ class FamilyInstancePlan(SemanticsModel):
             "family_kind": self.family_kind,
             "family_identity_digest": self.family_identity_digest,
             "disposition": self.disposition.value,
+            "source_scope": self.source_scope.value,
             "placeholder_values": [list(pair) for pair in self.placeholder_values],
             "outputs": [
                 {"path_scope": output.path_scope, "path": output.path}
@@ -256,36 +534,59 @@ class CompilationPlan(SemanticsModel):
     gaps: tuple[PlanGap, ...] = Field(default_factory=tuple)
     plan_digest: str
 
-    @field_validator("graph_digest")
+    @field_validator("graph_digest", "registry_digest")
     @classmethod
-    def _graph_digest(cls, value: str) -> str:
-        return _validate_digest(value, field_name="graph_digest")
+    def _digests(cls, value: str, info: Any) -> str:
+        return _validate_digest(value, field_name=str(info.field_name))
 
     @field_validator("plan_digest")
     @classmethod
     def _plan_digest_field(cls, value: str) -> str:
         return _validate_digest(value, field_name="plan_digest")
 
-    @field_validator("registry_schema_version", "registry_digest", "graph_id")
+    @field_validator("registry_schema_version")
     @classmethod
-    def _nonempty(cls, value: str) -> str:
+    def _registry_schema(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if _SCHEMA_VERSION_RE.fullmatch(text) is None:
+            raise ValueError(f"registry_schema_version must be a dotted identifier, got {value!r}")
+        return text
+
+    @field_validator("graph_id")
+    @classmethod
+    def _graph_id(cls, value: str) -> str:
         text = str(value or "").strip()
         if not text:
-            raise ValueError("plan identity fields must be non-empty")
+            raise ValueError("graph_id must be non-empty")
         return text
 
     @field_validator("gaps")
     @classmethod
     def _gaps(cls, value: tuple[PlanGap, ...]) -> tuple[PlanGap, ...]:
-        return tuple(
-            sorted(value, key=lambda gap: (gap.family_kind, gap.path_template, gap.reason))
+        ordered = tuple(
+            sorted(
+                value,
+                key=lambda gap: (
+                    gap.family_kind,
+                    gap.path_template,
+                    gap.code.value,
+                    gap.subject or "",
+                ),
+            )
         )
+        keys = [
+            (gap.family_kind, gap.path_template, gap.code, gap.subject) for gap in ordered
+        ]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate plan gaps")
+        return ordered
 
     @model_validator(mode="after")
     def _validate_plan(self) -> CompilationPlan:
         unit_ids = [unit.unit_id for unit in self.units]
         if len(unit_ids) != len(set(unit_ids)):
-            raise ValueError("duplicate unit identities in one plan")
+            duplicates = sorted({item for item in unit_ids if unit_ids.count(item) > 1})
+            raise ValueError(f"duplicate unit identities in one plan: {duplicates}")
         known = set(unit_ids)
         edges: dict[str, tuple[str, ...]] = {}
         for unit in self.units:
@@ -297,8 +598,6 @@ class CompilationPlan(SemanticsModel):
                 if dependency == unit.unit_id:
                     raise ValueError(f"unit {unit.unit_id!r} depends on itself")
             edges[unit.unit_id] = unit.depends_on_units
-        # Iterative DFS cycle check: a forged document must not smuggle a
-        # dependency cycle past the registry's own acyclicity guarantee.
         state: dict[str, int] = {}
         for start in edges:
             if state.get(start):
@@ -313,9 +612,7 @@ class CompilationPlan(SemanticsModel):
                 for position in range(index, len(deps)):
                     dependency = deps[position]
                     if state.get(dependency) == 1:
-                        raise ValueError(
-                            f"dependency cycle through unit {dependency!r}"
-                        )
+                        raise ValueError(f"dependency cycle through unit {dependency!r}")
                     if state.get(dependency, 0) == 0:
                         stack.append((current, position + 1))
                         stack.append((dependency, 0))
@@ -323,24 +620,28 @@ class CompilationPlan(SemanticsModel):
                         break
                 if not advanced:
                     state[current] = 2
-        # Global path ownership: one owner per path, and the whole output set
-        # must be representable on every host (case-fold and file/dir-prefix
-        # collisions fail closed), per path scope root.
-        by_scope: dict[tuple[str, tuple[tuple[str, str], ...]], list[str]] = {}
+
+        # Physical output ownership: global roots form one collision domain
+        # regardless of semantic instance identity; instance-relative roots
+        # are discriminated by their explicit instance identity only.
+        by_domain: dict[tuple[str, tuple[tuple[str, str], ...]], list[str]] = {}
         for unit in self.units:
             for output in unit.outputs:
-                key = (output.path_scope, unit.placeholder_values)
-                by_scope.setdefault(key, []).append(output.path)
-        for scope_root, paths in sorted(by_scope.items()):
+                if output.path_scope in _INSTANCE_PATH_SCOPES:
+                    domain = (output.path_scope, unit.placeholder_values)
+                else:
+                    domain = (output.path_scope, ())
+                by_domain.setdefault(domain, []).append(output.path)
+        for domain, paths in sorted(by_domain.items()):
             if len(paths) != len(set(paths)):
                 duplicates = sorted({p for p in paths if paths.count(p) > 1})
                 raise ValueError(
-                    f"duplicate output ownership in scope {scope_root!r}: {duplicates}"
+                    f"duplicate output ownership in domain {domain[0]!r}: {duplicates}"
                 )
             try:
                 detect_collisions(paths)
             except ValueError as exc:
-                raise ValueError(f"output collision in scope {scope_root!r}: {exc}") from exc
+                raise ValueError(f"output collision in domain {domain[0]!r}: {exc}") from exc
         expected = canonical_digest(self.canonical_payload(include_digest=False))
         if self.plan_digest != expected:
             raise ValueError("plan_digest does not match plan content")
@@ -373,8 +674,6 @@ class CompilationPlan(SemanticsModel):
 # Derivation
 # ---------------------------------------------------------------------------
 
-#: Registry conditions decidable from graph-v2 semantics alone, mapped to the
-#: node kinds whose presence makes the condition true (empty tuple = always).
 _DERIVABLE_CONDITIONS: dict[str, tuple[SemanticNodeKind, ...]] = {
     "always": (),
     "when_app_declared": (),
@@ -386,9 +685,6 @@ _DERIVABLE_CONDITIONS: dict[str, tuple[SemanticNodeKind, ...]] = {
     "when_deployment_export_requested": (SemanticNodeKind.DEPLOYMENT_TARGET,),
 }
 
-#: Conditions that are implementation-binding or operator facts, not graph
-#: semantics. Deciding them here would invent meaning; each becomes a typed
-#: gap deferred to the binding slice.
 _BINDING_CONDITIONS: frozenset[str] = frozenset(
     {
         "when_auth_enabled",
@@ -400,15 +696,19 @@ _BINDING_CONDITIONS: frozenset[str] = frozenset(
     }
 )
 
-#: Placeholder names that instantiate one unit per semantic node of a kind.
 _INSTANCE_PLACEHOLDERS: dict[str, SemanticNodeKind] = {
     "module_id": SemanticNodeKind.MODULE,
     "page_id": SemanticNodeKind.PAGE,
     "workflow_id": SemanticNodeKind.WORKFLOW,
 }
 
-#: App-scoped single-instance families trace to the node kinds that carry the
-#: relevant semantics; empty means the whole graph (pinned by graph_digest).
+#: Instance-relative path scopes imply an instance placeholder even when the
+#: template does not spell it: the scope root itself is the instance.
+_SCOPE_IMPLIED_PLACEHOLDER: dict[str, str] = {
+    "module_relative": "module_id",
+    "workflow_relative": "workflow_id",
+}
+
 _FAMILY_SOURCE_KINDS: dict[str, tuple[SemanticNodeKind, ...]] = {
     "when_data_contract_required": (
         SemanticNodeKind.DATA_COLLECTION,
@@ -428,16 +728,9 @@ _FAMILY_SOURCE_KINDS: dict[str, tuple[SemanticNodeKind, ...]] = {
 
 
 def _node_local_identity(node_id: str) -> str:
-    """Deterministic path-safe unit identity from a node id.
-
-    ``mozaiks.module.reports_ab12`` -> ``reports_ab12``; dots in the local part
-    normalize to underscores so the value satisfies every path template
-    placeholder. Collision safety comes from the global output collision
-    check, never from this normalization.
-    """
     parts = validate_node_id_grammar(node_id).split(".")
     local = "_".join(parts[2:]) if len(parts) > 2 else parts[-1]
-    return local.replace(".", "_")
+    return local.replace(".", "_").replace("-", "_")
 
 
 def _cold_validate_inputs(
@@ -468,12 +761,17 @@ def derive_compilation_plan(
 ) -> CompilationPlan:
     """Derive the single aggregate plan for one immutable graph identity.
 
-    ``registry`` is the sole ``AppLayoutRegistry`` (duck-typed here so the
-    semantics contract layer does not import the runtime registry module; the
-    registry pins itself into the plan through its schema version and
-    self-verified digest, and each family row through its identity digest).
+    ``registry`` is the sole ``AppLayoutRegistry`` (or an already-built
+    :class:`LayoutRegistrySnapshot`). Registry identity is always recomputed
+    from the canonical row content actually consumed — a claimed digest on the
+    input object is never read.
     """
     verified_graph, payload_by_node = _cold_validate_inputs(graph, payloads)
+    snapshot = (
+        registry
+        if isinstance(registry, LayoutRegistrySnapshot)
+        else snapshot_layout_registry(registry)
+    )
 
     nodes_by_kind: dict[SemanticNodeKind, list[Any]] = {}
     for node in verified_graph.nodes:
@@ -491,215 +789,202 @@ def derive_compilation_plan(
                 )
         return tuple(collected)
 
-    ordered = list(registry.ordered_families())
     units: dict[str, FamilyInstancePlan] = {}
     gaps: list[PlanGap] = []
     unit_ids_by_kind: dict[str, list[str]] = {}
     unit_instance_index: dict[tuple[str, tuple[tuple[str, str], ...]], str] = {}
 
-    def _gap(family: Any, reason: str, *, adr_slice: int = 4) -> None:
+    def _add_unit(unit: FamilyInstancePlan) -> None:
+        if unit.unit_id in units:
+            raise CompilationPlanError(
+                f"derivation produced duplicate unit identity {unit.unit_id!r}"
+            )
+        units[unit.unit_id] = unit
+        unit_ids_by_kind.setdefault(unit.family_kind, []).append(unit.unit_id)
+
+    def _gap(
+        row: RegistryFamilyRow,
+        code: PlanGapCode,
+        *,
+        subject: str | None = None,
+        adr_slice: int = 4,
+    ) -> None:
         gaps.append(
             PlanGap(
-                family_kind=family.kind.value,
-                path_template=family.path_template,
-                reason=reason,
+                code=code,
+                family_kind=row.kind,
+                path_template=row.path_template,
+                subject=subject,
                 adr_slice=adr_slice,
             )
         )
 
-    for family in ordered:
-        kind_value = family.kind.value
-        requirement = family.requirement.value
-        condition = family.condition.value
-        family_digest = canonical_digest(family.identity_payload)
-        placeholders = tuple(_PLACEHOLDER_RE.findall(family.path_template))
+    for row in snapshot.rows:
+        row_digest = row.row_digest
+        placeholders = tuple(_PLACEHOLDER_RE.findall(row.path_template))
 
-        if requirement == "prohibited":
-            # Prohibited rows join the plan as explicit inapplicable units:
-            # the disposition set stays complete and the prohibition is a
-            # stated decision rather than a silent skip.
-            unit_id = f"{kind_value}/prohibited/{family_digest[:12]}"
-            units[unit_id] = FamilyInstancePlan(
-                unit_id=unit_id,
-                family_kind=kind_value,
-                family_identity_digest=family_digest,
-                disposition=PlanDisposition.INAPPLICABLE,
-                materializer=family.materializer.value,
-            )
-            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
-            continue
-
-        if condition in _BINDING_CONDITIONS:
-            _gap(
-                family,
-                f"condition {condition!r} is an implementation-binding or operator "
-                "fact that graph-v2 semantics cannot decide; disposition is "
-                "deferred to the binding slice",
+        if row.requirement == "prohibited":
+            _add_unit(
+                FamilyInstancePlan(
+                    unit_id=f"{row.kind}/prohibited/{row_digest[:12]}",
+                    family_kind=row.kind,
+                    family_identity_digest=row_digest,
+                    disposition=PlanDisposition.INAPPLICABLE,
+                    source_scope=PlanSourceScope.DECLARED,
+                    materializer=row.materializer,
+                )
             )
             continue
 
-        if family.path_scope.value == "generated_staging":
-            _gap(
-                family,
-                "generated-staging rows are factory transport locations, not "
-                "compiled application artifacts; they never join the plan",
-            )
+        if row.condition in _BINDING_CONDITIONS:
+            _gap(row, PlanGapCode.BINDING_CONDITION_DEFERRED, subject=row.condition)
             continue
 
-        trigger_kinds = _DERIVABLE_CONDITIONS.get(condition)
+        if row.path_scope == "generated_staging":
+            _gap(row, PlanGapCode.STAGING_TRANSPORT_EXCLUDED)
+            continue
+
+        trigger_kinds = _DERIVABLE_CONDITIONS.get(row.condition)
         if trigger_kinds is None:
+            _gap(row, PlanGapCode.CONDITION_UNDERIVABLE, subject=row.condition)
+            continue
+
+        bindable = {name for name in placeholders if name in _INSTANCE_PLACEHOLDERS}
+        unbindable = [name for name in placeholders if name not in _INSTANCE_PLACEHOLDERS]
+        scope_implied = _SCOPE_IMPLIED_PLACEHOLDER.get(row.path_scope)
+        if scope_implied is not None:
+            # The scope root is itself an instance: the implied placeholder
+            # joins the binding set even when the template does not spell it.
+            bindable.add(scope_implied)
+        if unbindable:
             _gap(
-                family,
-                f"condition {condition!r} has no graph-v2 derivation rule; "
-                "disposition is deferred rather than guessed",
+                row,
+                PlanGapCode.PLACEHOLDER_UNDERIVABLE,
+                subject="__".join(sorted(set(unbindable))),
+            )
+            continue
+        if len(bindable) > 1:
+            # Joint instantiation across two node kinds requires a typed graph
+            # relationship this slice cannot prove; never invent one.
+            _gap(
+                row,
+                PlanGapCode.PLACEHOLDER_RELATIONSHIP_UNPROVABLE,
+                subject="__".join(sorted(bindable)),
             )
             continue
 
         condition_met = not trigger_kinds or any(
             nodes_by_kind.get(kind) for kind in trigger_kinds
         )
-        instance_placeholder = next(
-            (name for name in placeholders if name in _INSTANCE_PLACEHOLDERS), None
-        )
-        unknown_placeholders = [
-            name
-            for name in placeholders
-            if name not in _INSTANCE_PLACEHOLDERS
-        ]
-        if unknown_placeholders:
-            _gap(
-                family,
-                f"path placeholders {unknown_placeholders!r} are not derivable "
-                "from graph-v2 node identities; instantiation is deferred",
-            )
-            continue
-
         disposition = (
             PlanDisposition.EXTERNAL_HANDOFF
-            if family.path_scope.value == "deployment_derived"
-            or family.owner.value == "download_renderer"
+            if row.path_scope == "deployment_derived" or row.owner == "download_renderer"
             else PlanDisposition.RENDER
         )
 
         if not condition_met:
-            unit_id = f"{kind_value}/{family_digest[:12]}"
-            unit = FamilyInstancePlan(
-                unit_id=unit_id,
-                family_kind=kind_value,
-                family_identity_digest=family_digest,
-                disposition=PlanDisposition.INAPPLICABLE,
-                materializer=family.materializer.value,
+            _add_unit(
+                FamilyInstancePlan(
+                    unit_id=f"{row.kind}/{row_digest[:12]}",
+                    family_kind=row.kind,
+                    family_identity_digest=row_digest,
+                    disposition=PlanDisposition.INAPPLICABLE,
+                    source_scope=PlanSourceScope.DECLARED,
+                    materializer=row.materializer,
+                )
             )
-            units[unit_id] = unit
-            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
             continue
 
-        if instance_placeholder is not None:
-            node_kind = _INSTANCE_PLACEHOLDERS[instance_placeholder]
+        if bindable:
+            placeholder = next(iter(bindable))
+            node_kind = _INSTANCE_PLACEHOLDERS[placeholder]
             for node in nodes_by_kind.get(node_kind, ()):
                 local = _node_local_identity(node.node_id)
-                values = ((instance_placeholder, local),)
-                path = family.path_template
-                for name, value in values:
-                    path = path.replace("{" + name + "}", value)
-                unit_id = f"{kind_value}/{local}/{family_digest[:12]}"
+                values = ((placeholder, local),)
+                path = row.path_template.replace("{" + placeholder + "}", local)
+                # Scope-implied instances keep the template text unchanged;
+                # their instance identity lives in placeholder_values and the
+                # collision domain, not the relative path.
+
                 unit = FamilyInstancePlan(
-                    unit_id=unit_id,
-                    family_kind=kind_value,
-                    family_identity_digest=family_digest,
+                    unit_id=f"{row.kind}/{local}/{row_digest[:12]}",
+                    family_kind=row.kind,
+                    family_identity_digest=row_digest,
                     disposition=disposition,
+                    source_scope=PlanSourceScope.DECLARED,
                     placeholder_values=values,
-                    outputs=(PlanOutput(path_scope=family.path_scope.value, path=path),),
+                    outputs=(PlanOutput(path_scope=row.path_scope, path=path),),
                     sources=(
                         PlanSource(
                             node_id=node.node_id,
                             payload_digest=payload_by_node[node.node_id].payload_digest,
                         ),
                     ),
-                    materializer=family.materializer.value,
+                    materializer=row.materializer,
                 )
-                units[unit_id] = unit
-                unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
-                unit_instance_index[(kind_value, values)] = unit_id
+                _add_unit(unit)
+                unit_instance_index[(row.kind, values)] = unit.unit_id
         else:
-            unit_id = f"{kind_value}/{family_digest[:12]}"
+            source_kinds = _FAMILY_SOURCE_KINDS.get(row.condition, ())
+            graph_wide = not trigger_kinds and not source_kinds
             unit = FamilyInstancePlan(
-                unit_id=unit_id,
-                family_kind=kind_value,
-                family_identity_digest=family_digest,
+                unit_id=f"{row.kind}/{row_digest[:12]}",
+                family_kind=row.kind,
+                family_identity_digest=row_digest,
                 disposition=disposition,
-                outputs=(
-                    PlanOutput(
-                        path_scope=family.path_scope.value, path=family.path_template
-                    ),
+                source_scope=(
+                    PlanSourceScope.GRAPH_WIDE if graph_wide else PlanSourceScope.DECLARED
                 ),
-                sources=_sources_for(_FAMILY_SOURCE_KINDS.get(condition, ())),
-                materializer=family.materializer.value,
+                outputs=(PlanOutput(path_scope=row.path_scope, path=row.path_template),),
+                sources=() if graph_wide else _sources_for(source_kinds),
+                materializer=row.materializer,
             )
-            units[unit_id] = unit
-            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
-            unit_instance_index[(kind_value, ())] = unit_id
+            _add_unit(unit)
+            unit_instance_index[(row.kind, ())] = unit.unit_id
 
-    # Renderer resolution stays a per-plan typed gap: the registry declares
-    # materializer identifiers, but resolving renderer versions is
-    # implementation-binding work owned by the next slice.
     gaps.append(
         PlanGap(
-            family_kind="*",
-            path_template="*",
-            reason=(
-                "renderer resolution and implementation-binding pinning are "
-                "deferred; registry materializer identifiers are declarations, "
-                "not resolved renderers"
-            ),
+            code=PlanGapCode.RENDERER_RESOLUTION_DEFERRED,
+            family_kind="registry",
+            path_template="registry",
             adr_slice=4,
         )
     )
 
-    # Dependency edges from the registry: same-instance link when the
-    # dependency family shares the instance placeholder, else every unit of
-    # the dependency kind.
+    row_by_digest: dict[str, RegistryFamilyRow] = {row.row_digest: row for row in snapshot.rows}
     dependency_map: dict[str, tuple[str, ...]] = {}
-    family_by_kind: dict[str, list[Any]] = {}
-    for family in ordered:
-        family_by_kind.setdefault(family.kind.value, []).append(family)
-    for unit in list(units.values()):
+    for unit in units.values():
         dep_ids: set[str] = set()
-        for family in family_by_kind.get(unit.family_kind, ()):
-            if canonical_digest(family.identity_payload) != unit.family_identity_digest:
-                continue
-            for dependency_kind in family.dependency_families:
-                dep_kind_value = dependency_kind.value
-                same_instance = unit_instance_index.get(
-                    (dep_kind_value, unit.placeholder_values)
-                )
-                if same_instance is not None:
-                    dep_ids.add(same_instance)
-                else:
-                    dep_ids.update(unit_ids_by_kind.get(dep_kind_value, ()))
+        row = row_by_digest[unit.family_identity_digest]
+        for dependency_kind in row.dependency_families:
+            same_instance = unit_instance_index.get((dependency_kind, unit.placeholder_values))
+            if same_instance is not None:
+                dep_ids.add(same_instance)
+            else:
+                dep_ids.update(unit_ids_by_kind.get(dependency_kind, ()))
         dependency_map[unit.unit_id] = tuple(sorted(dep_ids))
 
-    finished_units = tuple(
-        unit.model_copy(update={"depends_on_units": dependency_map[unit.unit_id]})
+    rebuilt_units = tuple(
+        FamilyInstancePlan.model_validate(
+            {
+                **unit.model_dump(mode="json"),
+                "depends_on_units": list(dependency_map[unit.unit_id]),
+            }
+        )
         for unit in units.values()
     )
-    # model_copy skips validators; rebuild through validation so nothing
-    # forged or unnormalized can survive into the plan document.
-    rebuilt_units = tuple(
-        FamilyInstancePlan.model_validate(unit.model_dump(mode="json"))
-        for unit in finished_units
-    )
-    ordered_kind_index = {
-        family.kind.value: index for index, family in enumerate(ordered)
-    }
+    kind_index = {row.kind: index for index, row in enumerate(snapshot.rows)}
     sorted_units = tuple(
         sorted(
             rebuilt_units,
-            key=lambda unit: (ordered_kind_index.get(unit.family_kind, 1_000_000), unit.unit_id),
+            key=lambda unit: (kind_index.get(unit.family_kind, 1_000_000), unit.unit_id),
         )
     )
     sorted_gaps = tuple(
-        sorted(set(gaps), key=lambda gap: (gap.family_kind, gap.path_template, gap.reason))
+        sorted(
+            set(gaps),
+            key=lambda gap: (gap.family_kind, gap.path_template, gap.code.value, gap.subject or ""),
+        )
     )
 
     payload: dict[str, Any] = {
@@ -708,8 +993,8 @@ def derive_compilation_plan(
         "graph_version": verified_graph.version,
         "scope": verified_graph.scope.model_dump(mode="json"),
         "graph_digest": verified_graph.graph_digest,
-        "registry_schema_version": str(registry.schema_version),
-        "registry_digest": str(registry.registry_digest),
+        "registry_schema_version": snapshot.registry_schema_version,
+        "registry_digest": snapshot.snapshot_digest,
         "units": [unit.identity_payload for unit in sorted_units],
         "gaps": [gap.model_dump(mode="json") for gap in sorted_gaps],
     }
@@ -718,8 +1003,8 @@ def derive_compilation_plan(
         graph_version=verified_graph.version,
         scope=verified_graph.scope,
         graph_digest=verified_graph.graph_digest,
-        registry_schema_version=str(registry.schema_version),
-        registry_digest=str(registry.registry_digest),
+        registry_schema_version=snapshot.registry_schema_version,
+        registry_digest=snapshot.snapshot_digest,
         units=sorted_units,
         gaps=sorted_gaps,
         plan_digest=canonical_digest(payload),
@@ -734,11 +1019,15 @@ def derive_compilation_plan(
 class RegenerationClosure(SemanticsModel):
     """Complete unit partition between a base plan and a successor plan.
 
-    Every successor unit lands in exactly one of ``affected`` (a source
-    identity changed — must render), ``reusable`` (identical sources — may
-    reuse from base, pinned to the base plan digest), or ``added``; every
-    base-only unit lands in ``removed``. Nothing is omitted, so omission can
-    never masquerade as preservation.
+    Directly changed units are found from complete reuse signatures (family
+    row identity, disposition, outputs, placeholders, materializer, declared
+    sources, and — for graph-wide units — the graph identity itself), then
+    affectedness propagates through the reverse dependency DAG: a dependent of
+    an affected unit can never remain reusable, because no contract proves its
+    output independent of the changed dependency. Every successor unit lands
+    in exactly one of ``affected``/``reusable``/``added``; every base-only
+    unit lands in ``removed``. Nothing is omitted and nothing is silently
+    preserved.
     """
 
     base_plan_digest: str
@@ -754,6 +1043,20 @@ class RegenerationClosure(SemanticsModel):
         return _validate_digest(value, field_name="plan digest")
 
 
+def _reuse_signature(unit: FamilyInstancePlan, plan: CompilationPlan) -> Any:
+    return (
+        unit.family_identity_digest,
+        unit.disposition.value,
+        unit.source_scope.value,
+        unit.placeholder_values,
+        tuple((output.path_scope, output.path) for output in unit.outputs),
+        tuple((source.node_id, source.payload_digest) for source in unit.sources),
+        unit.depends_on_units,
+        unit.materializer,
+        plan.graph_digest if unit.source_scope is PlanSourceScope.GRAPH_WIDE else None,
+    )
+
+
 def plan_regeneration_closure(
     base: CompilationPlan, successor: CompilationPlan
 ) -> RegenerationClosure:
@@ -767,36 +1070,53 @@ def plan_regeneration_closure(
         u.unit_id: u for u in successor.units
     }
 
-    def _signature(unit: FamilyInstancePlan) -> Any:
-        return (
-            unit.family_identity_digest,
-            tuple((s.node_id, s.payload_digest) for s in unit.sources),
-            tuple((o.path_scope, o.path) for o in unit.outputs),
-            unit.disposition.value,
-        )
+    added = sorted(unit_id for unit_id in successor_units if unit_id not in base_units)
+    removed = sorted(unit_id for unit_id in base_units if unit_id not in successor_units)
+    directly_affected = {
+        unit_id
+        for unit_id, unit in successor_units.items()
+        if unit_id in base_units
+        and _reuse_signature(unit, successor) != _reuse_signature(base_units[unit_id], base)
+    }
 
-    affected: list[str] = []
-    reusable: list[str] = []
-    added: list[str] = []
+    # Reverse-dependency propagation to a fixed point: dependents of any
+    # affected or added unit are affected too.
+    dependents: dict[str, set[str]] = {unit_id: set() for unit_id in successor_units}
     for unit_id, unit in successor_units.items():
-        if unit_id not in base_units:
-            added.append(unit_id)
-        elif _signature(unit) != _signature(base_units[unit_id]):
-            affected.append(unit_id)
-        else:
-            reusable.append(unit_id)
-    removed = [unit_id for unit_id in base_units if unit_id not in successor_units]
+        for dependency in unit.depends_on_units:
+            dependents.setdefault(dependency, set()).add(unit_id)
+    frontier = set(directly_affected) | set(added)
+    affected: set[str] = set(directly_affected)
+    while frontier:
+        next_frontier: set[str] = set()
+        for unit_id in frontier:
+            for dependent in dependents.get(unit_id, ()):
+                if dependent not in affected and dependent not in added:
+                    affected.add(dependent)
+                    next_frontier.add(dependent)
+        frontier = next_frontier
+
+    reusable = sorted(
+        unit_id
+        for unit_id in successor_units
+        if unit_id not in affected and unit_id not in added
+    )
 
     closure = RegenerationClosure(
         base_plan_digest=base.plan_digest,
         successor_plan_digest=successor.plan_digest,
         affected=tuple(sorted(affected)),
-        reusable=tuple(sorted(reusable)),
-        added=tuple(sorted(added)),
-        removed=tuple(sorted(removed)),
+        reusable=tuple(reusable),
+        added=tuple(added),
+        removed=tuple(removed),
     )
     partition = set(closure.affected) | set(closure.reusable) | set(closure.added)
-    if partition != set(successor_units) or (
+    overlap = (
+        (set(closure.affected) & set(closure.reusable))
+        | (set(closure.affected) & set(closure.added))
+        | (set(closure.reusable) & set(closure.added))
+    )
+    if partition != set(successor_units) or overlap or (
         set(closure.removed) != set(base_units) - set(successor_units)
     ):
         raise CompilationPlanError("regeneration closure failed to partition all units")
@@ -808,11 +1128,16 @@ __all__ = [
     "CompilationPlan",
     "CompilationPlanError",
     "FamilyInstancePlan",
+    "LayoutRegistrySnapshot",
     "PlanDisposition",
     "PlanGap",
+    "PlanGapCode",
     "PlanOutput",
     "PlanSource",
+    "PlanSourceScope",
     "RegenerationClosure",
+    "RegistryFamilyRow",
     "derive_compilation_plan",
     "plan_regeneration_closure",
+    "snapshot_layout_registry",
 ]

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -1,0 +1,814 @@
+"""ADR 0007 Slice 4B aggregate ``CompilationPlan`` derivation (offline-only).
+
+Exactly one aggregate plan is derived per immutable graph identity from three
+inputs and nothing else: a validated ``SemanticGraphV2``, its typed payload
+closure, and the sole ``layout_registry``. The plan pins the complete input
+identity (graph quartet + registry digest) and embeds one non-authoritative
+``FamilyInstancePlan`` subdocument per applicable artifact-family instance.
+Embedded family plans have no independent reference type, registration,
+resolution, publication, or execution authority — they are valid only under
+the aggregate plan's identity and digest.
+
+Completeness rule: every registry family row is either disposed
+(render / reuse_from_base / preserve_unowned / input_only / external_handoff /
+inapplicable) or carried as an explicit typed ``PlanGap``. Omission is never
+an implicit decision. Conditions that graph-v2 semantics cannot decide
+(auth, custom routes, refinement harness, managed capabilities, staging,
+extensions) and renderer resolution are typed gaps deferred to the
+implementation-binding slice — the plan never invents a semantic fact.
+
+This module is deterministic substrate: no filesystem, no network, no AG2
+imports, no model calls, no runtime or capability authority. The active
+agent-produced ``AppBuildPlan`` remains the sole operational plan until the
+Slice 5 cutover; nothing in production imports this module.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.graph import SemanticGraphV2, SemanticNodeKind
+from mozaiksai.core.semantics.payloads import (
+    SemanticPayloadBase,
+    parse_semantic_payload,
+    validate_semantic_graph_v2_payload_closure,
+)
+from mozaiksai.core.semantics.portable_path import detect_collisions, validate_portable_path
+from mozaiksai.core.semantics.refs import (
+    ExecutionAccessScopeRef,
+    SemanticsModel,
+    _validate_digest,
+    validate_node_id_grammar,
+)
+
+COMPILATION_PLAN_SCHEMA_VERSION: Literal["mozaiks.compilation_plan.v1"] = (
+    "mozaiks.compilation_plan.v1"
+)
+
+_PLACEHOLDER_RE = re.compile(r"\{([a-z][a-z0-9_]*)\}")
+_UNIT_SEGMENT_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+
+
+class CompilationPlanError(ValueError):
+    """The plan inputs or document violate the Slice 4B contract."""
+
+
+class PlanDisposition(StrEnum):
+    """Complete disposition vocabulary from the ADR aggregate-authority rule."""
+
+    RENDER = "render"
+    REUSE_FROM_BASE = "reuse_from_base"
+    PRESERVE_UNOWNED = "preserve_unowned"
+    INPUT_ONLY = "input_only"
+    EXTERNAL_HANDOFF = "external_handoff"
+    INAPPLICABLE = "inapplicable"
+
+
+class PlanGap(SemanticsModel):
+    """One explicit deferred decision — never silent omission."""
+
+    family_kind: str
+    path_template: str
+    reason: str
+    adr_slice: int = Field(ge=4, le=7, strict=True)
+
+    @field_validator("family_kind", "path_template", "reason")
+    @classmethod
+    def _text(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("plan gap fields must be non-empty")
+        return text
+
+
+class PlanSource(SemanticsModel):
+    """Traceability leaf: one semantic node/payload identity behind an output."""
+
+    node_id: str
+    payload_digest: str
+
+    @field_validator("node_id")
+    @classmethod
+    def _node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("payload_digest")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="payload_digest")
+
+
+class PlanOutput(SemanticsModel):
+    """One planned output path inside its registry path scope."""
+
+    path_scope: str
+    path: str
+
+    @field_validator("path_scope")
+    @classmethod
+    def _scope(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("path_scope must be non-empty")
+        return text
+
+    @field_validator("path")
+    @classmethod
+    def _path(cls, value: str) -> str:
+        return validate_portable_path(value).text
+
+
+class FamilyInstancePlan(SemanticsModel):
+    """Embedded, non-authoritative per-family-instance subplan.
+
+    Valid only under its aggregate plan's identity and digest: there is no
+    reference type, resolver registration, or execution surface for a family
+    plan on its own, and this model carries no self-digest to stand on.
+    """
+
+    unit_id: str
+    family_kind: str
+    family_identity_digest: str
+    disposition: PlanDisposition
+    placeholder_values: tuple[tuple[str, str], ...] = Field(default_factory=tuple)
+    outputs: tuple[PlanOutput, ...] = Field(default_factory=tuple)
+    sources: tuple[PlanSource, ...] = Field(default_factory=tuple)
+    depends_on_units: tuple[str, ...] = Field(default_factory=tuple)
+    materializer: str
+    base_plan_digest: str | None = None
+
+    @field_validator("unit_id")
+    @classmethod
+    def _unit_id(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not all(_UNIT_SEGMENT_RE.fullmatch(part) for part in text.split("/") if True):
+            raise ValueError(f"unit_id must be a normalized identifier path, got {value!r}")
+        return text
+
+    @field_validator("family_kind", "materializer")
+    @classmethod
+    def _identifier(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("identifier fields must be non-empty")
+        return text
+
+    @field_validator("family_identity_digest")
+    @classmethod
+    def _family_digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="family_identity_digest")
+
+    @field_validator("base_plan_digest")
+    @classmethod
+    def _base_digest(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_digest(value, field_name="base_plan_digest")
+
+    @field_validator("placeholder_values")
+    @classmethod
+    def _placeholders(cls, value: tuple[tuple[str, str], ...]) -> tuple[tuple[str, str], ...]:
+        ordered = tuple(sorted(value))
+        names = [name for name, _v in ordered]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate placeholder names in one unit")
+        return ordered
+
+    @field_validator("outputs")
+    @classmethod
+    def _outputs(cls, value: tuple[PlanOutput, ...]) -> tuple[PlanOutput, ...]:
+        ordered = tuple(sorted(value, key=lambda item: (item.path_scope, item.path)))
+        keys = [(item.path_scope, item.path) for item in ordered]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate output paths in one unit")
+        return ordered
+
+    @field_validator("sources")
+    @classmethod
+    def _sources(cls, value: tuple[PlanSource, ...]) -> tuple[PlanSource, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.node_id))
+        node_ids = [item.node_id for item in ordered]
+        if len(node_ids) != len(set(node_ids)):
+            raise ValueError("duplicate source node identities in one unit")
+        return ordered
+
+    @field_validator("depends_on_units")
+    @classmethod
+    def _deps(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        ordered = tuple(sorted(str(item).strip() for item in value))
+        if len(ordered) != len(set(ordered)):
+            raise ValueError("duplicate unit dependencies")
+        return ordered
+
+    @model_validator(mode="after")
+    def _reuse_shape(self) -> FamilyInstancePlan:
+        if (self.disposition is PlanDisposition.REUSE_FROM_BASE) != (
+            self.base_plan_digest is not None
+        ):
+            raise ValueError(
+                "base_plan_digest is required exactly when disposition is reuse_from_base"
+            )
+        return self
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "family_kind": self.family_kind,
+            "family_identity_digest": self.family_identity_digest,
+            "disposition": self.disposition.value,
+            "placeholder_values": [list(pair) for pair in self.placeholder_values],
+            "outputs": [
+                {"path_scope": output.path_scope, "path": output.path}
+                for output in self.outputs
+            ],
+            "sources": [
+                {"node_id": source.node_id, "payload_digest": source.payload_digest}
+                for source in self.sources
+            ],
+            "depends_on_units": list(self.depends_on_units),
+            "materializer": self.materializer,
+            "base_plan_digest": self.base_plan_digest,
+        }
+
+
+class CompilationPlan(SemanticsModel):
+    """One aggregate authoritative plan per immutable graph identity."""
+
+    schema_version: Literal["mozaiks.compilation_plan.v1"] = COMPILATION_PLAN_SCHEMA_VERSION
+    graph_id: str
+    graph_version: int = Field(ge=1, strict=True)
+    scope: ExecutionAccessScopeRef
+    graph_digest: str
+    registry_schema_version: str
+    registry_digest: str
+    units: tuple[FamilyInstancePlan, ...]
+    gaps: tuple[PlanGap, ...] = Field(default_factory=tuple)
+    plan_digest: str
+
+    @field_validator("graph_digest")
+    @classmethod
+    def _graph_digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="graph_digest")
+
+    @field_validator("plan_digest")
+    @classmethod
+    def _plan_digest_field(cls, value: str) -> str:
+        return _validate_digest(value, field_name="plan_digest")
+
+    @field_validator("registry_schema_version", "registry_digest", "graph_id")
+    @classmethod
+    def _nonempty(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ValueError("plan identity fields must be non-empty")
+        return text
+
+    @field_validator("gaps")
+    @classmethod
+    def _gaps(cls, value: tuple[PlanGap, ...]) -> tuple[PlanGap, ...]:
+        return tuple(
+            sorted(value, key=lambda gap: (gap.family_kind, gap.path_template, gap.reason))
+        )
+
+    @model_validator(mode="after")
+    def _validate_plan(self) -> CompilationPlan:
+        unit_ids = [unit.unit_id for unit in self.units]
+        if len(unit_ids) != len(set(unit_ids)):
+            raise ValueError("duplicate unit identities in one plan")
+        known = set(unit_ids)
+        edges: dict[str, tuple[str, ...]] = {}
+        for unit in self.units:
+            for dependency in unit.depends_on_units:
+                if dependency not in known:
+                    raise ValueError(
+                        f"unit {unit.unit_id!r} depends on unknown unit {dependency!r}"
+                    )
+                if dependency == unit.unit_id:
+                    raise ValueError(f"unit {unit.unit_id!r} depends on itself")
+            edges[unit.unit_id] = unit.depends_on_units
+        # Iterative DFS cycle check: a forged document must not smuggle a
+        # dependency cycle past the registry's own acyclicity guarantee.
+        state: dict[str, int] = {}
+        for start in edges:
+            if state.get(start):
+                continue
+            stack: list[tuple[str, int]] = [(start, 0)]
+            while stack:
+                current, index = stack.pop()
+                if index == 0:
+                    state[current] = 1
+                deps = edges[current]
+                advanced = False
+                for position in range(index, len(deps)):
+                    dependency = deps[position]
+                    if state.get(dependency) == 1:
+                        raise ValueError(
+                            f"dependency cycle through unit {dependency!r}"
+                        )
+                    if state.get(dependency, 0) == 0:
+                        stack.append((current, position + 1))
+                        stack.append((dependency, 0))
+                        advanced = True
+                        break
+                if not advanced:
+                    state[current] = 2
+        # Global path ownership: one owner per path, and the whole output set
+        # must be representable on every host (case-fold and file/dir-prefix
+        # collisions fail closed), per path scope root.
+        by_scope: dict[tuple[str, tuple[tuple[str, str], ...]], list[str]] = {}
+        for unit in self.units:
+            for output in unit.outputs:
+                key = (output.path_scope, unit.placeholder_values)
+                by_scope.setdefault(key, []).append(output.path)
+        for scope_root, paths in sorted(by_scope.items()):
+            if len(paths) != len(set(paths)):
+                duplicates = sorted({p for p in paths if paths.count(p) > 1})
+                raise ValueError(
+                    f"duplicate output ownership in scope {scope_root!r}: {duplicates}"
+                )
+            try:
+                detect_collisions(paths)
+            except ValueError as exc:
+                raise ValueError(f"output collision in scope {scope_root!r}: {exc}") from exc
+        expected = canonical_digest(self.canonical_payload(include_digest=False))
+        if self.plan_digest != expected:
+            raise ValueError("plan_digest does not match plan content")
+        return self
+
+    def canonical_payload(self, *, include_digest: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "graph_id": self.graph_id,
+            "graph_version": self.graph_version,
+            "scope": self.scope.model_dump(mode="json"),
+            "graph_digest": self.graph_digest,
+            "registry_schema_version": self.registry_schema_version,
+            "registry_digest": self.registry_digest,
+            "units": [unit.identity_payload for unit in self.units],
+            "gaps": [gap.model_dump(mode="json") for gap in self.gaps],
+        }
+        if include_digest:
+            payload["plan_digest"] = self.plan_digest
+        return payload
+
+    def unit(self, unit_id: str) -> FamilyInstancePlan:
+        for candidate in self.units:
+            if candidate.unit_id == unit_id:
+                return candidate
+        raise CompilationPlanError(f"unknown plan unit {unit_id!r}")
+
+
+# ---------------------------------------------------------------------------
+# Derivation
+# ---------------------------------------------------------------------------
+
+#: Registry conditions decidable from graph-v2 semantics alone, mapped to the
+#: node kinds whose presence makes the condition true (empty tuple = always).
+_DERIVABLE_CONDITIONS: dict[str, tuple[SemanticNodeKind, ...]] = {
+    "always": (),
+    "when_app_declared": (),
+    "when_module_declared": (SemanticNodeKind.MODULE,),
+    "when_page_declared": (SemanticNodeKind.PAGE,),
+    "when_workflow_declared": (SemanticNodeKind.WORKFLOW,),
+    "when_data_contract_required": (SemanticNodeKind.DATA_COLLECTION,),
+    "when_subscriptions_required": (SemanticNodeKind.PLAN,),
+    "when_deployment_export_requested": (SemanticNodeKind.DEPLOYMENT_TARGET,),
+}
+
+#: Conditions that are implementation-binding or operator facts, not graph
+#: semantics. Deciding them here would invent meaning; each becomes a typed
+#: gap deferred to the binding slice.
+_BINDING_CONDITIONS: frozenset[str] = frozenset(
+    {
+        "when_auth_enabled",
+        "when_custom_route_declared",
+        "when_refinement_harness_required",
+        "when_managed_capability_selected",
+        "when_generated_staging_selected",
+        "when_extension_selected",
+    }
+)
+
+#: Placeholder names that instantiate one unit per semantic node of a kind.
+_INSTANCE_PLACEHOLDERS: dict[str, SemanticNodeKind] = {
+    "module_id": SemanticNodeKind.MODULE,
+    "page_id": SemanticNodeKind.PAGE,
+    "workflow_id": SemanticNodeKind.WORKFLOW,
+}
+
+#: App-scoped single-instance families trace to the node kinds that carry the
+#: relevant semantics; empty means the whole graph (pinned by graph_digest).
+_FAMILY_SOURCE_KINDS: dict[str, tuple[SemanticNodeKind, ...]] = {
+    "when_data_contract_required": (
+        SemanticNodeKind.DATA_COLLECTION,
+        SemanticNodeKind.DATA_ALIAS,
+    ),
+    "when_subscriptions_required": (
+        SemanticNodeKind.PLAN,
+        SemanticNodeKind.PRODUCT,
+        SemanticNodeKind.METER,
+        SemanticNodeKind.LIMIT,
+    ),
+    "when_deployment_export_requested": (SemanticNodeKind.DEPLOYMENT_TARGET,),
+    "when_page_declared": (SemanticNodeKind.PAGE,),
+    "when_workflow_declared": (SemanticNodeKind.WORKFLOW,),
+    "when_module_declared": (SemanticNodeKind.MODULE,),
+}
+
+
+def _node_local_identity(node_id: str) -> str:
+    """Deterministic path-safe unit identity from a node id.
+
+    ``mozaiks.module.reports_ab12`` -> ``reports_ab12``; dots in the local part
+    normalize to underscores so the value satisfies every path template
+    placeholder. Collision safety comes from the global output collision
+    check, never from this normalization.
+    """
+    parts = validate_node_id_grammar(node_id).split(".")
+    local = "_".join(parts[2:]) if len(parts) > 2 else parts[-1]
+    return local.replace(".", "_")
+
+
+def _cold_validate_inputs(
+    graph: SemanticGraphV2, payloads: Iterable[SemanticPayloadBase]
+) -> tuple[SemanticGraphV2, dict[str, SemanticPayloadBase]]:
+    try:
+        verified_graph = SemanticGraphV2.model_validate(graph.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise CompilationPlanError(f"semantic graph failed cold validation: {exc}") from exc
+    verified_payloads: list[SemanticPayloadBase] = []
+    for payload in payloads:
+        try:
+            verified_payloads.append(parse_semantic_payload(payload.model_dump(mode="json")))
+        except (TypeError, ValueError) as exc:
+            raise CompilationPlanError(f"semantic payload failed cold validation: {exc}") from exc
+    try:
+        validate_semantic_graph_v2_payload_closure(verified_graph, verified_payloads)
+    except ValueError as exc:
+        raise CompilationPlanError(f"payload closure failed: {exc}") from exc
+    return verified_graph, {payload.node_id: payload for payload in verified_payloads}
+
+
+def derive_compilation_plan(
+    *,
+    graph: SemanticGraphV2,
+    payloads: Iterable[SemanticPayloadBase],
+    registry: Any,
+) -> CompilationPlan:
+    """Derive the single aggregate plan for one immutable graph identity.
+
+    ``registry`` is the sole ``AppLayoutRegistry`` (duck-typed here so the
+    semantics contract layer does not import the runtime registry module; the
+    registry pins itself into the plan through its schema version and
+    self-verified digest, and each family row through its identity digest).
+    """
+    verified_graph, payload_by_node = _cold_validate_inputs(graph, payloads)
+
+    nodes_by_kind: dict[SemanticNodeKind, list[Any]] = {}
+    for node in verified_graph.nodes:
+        nodes_by_kind.setdefault(node.kind, []).append(node)
+
+    def _sources_for(kinds: tuple[SemanticNodeKind, ...]) -> tuple[PlanSource, ...]:
+        collected = []
+        for kind in kinds:
+            for node in nodes_by_kind.get(kind, ()):
+                collected.append(
+                    PlanSource(
+                        node_id=node.node_id,
+                        payload_digest=payload_by_node[node.node_id].payload_digest,
+                    )
+                )
+        return tuple(collected)
+
+    ordered = list(registry.ordered_families())
+    units: dict[str, FamilyInstancePlan] = {}
+    gaps: list[PlanGap] = []
+    unit_ids_by_kind: dict[str, list[str]] = {}
+    unit_instance_index: dict[tuple[str, tuple[tuple[str, str], ...]], str] = {}
+
+    def _gap(family: Any, reason: str, *, adr_slice: int = 4) -> None:
+        gaps.append(
+            PlanGap(
+                family_kind=family.kind.value,
+                path_template=family.path_template,
+                reason=reason,
+                adr_slice=adr_slice,
+            )
+        )
+
+    for family in ordered:
+        kind_value = family.kind.value
+        requirement = family.requirement.value
+        condition = family.condition.value
+        family_digest = canonical_digest(family.identity_payload)
+        placeholders = tuple(_PLACEHOLDER_RE.findall(family.path_template))
+
+        if requirement == "prohibited":
+            # Prohibited rows join the plan as explicit inapplicable units:
+            # the disposition set stays complete and the prohibition is a
+            # stated decision rather than a silent skip.
+            unit_id = f"{kind_value}/prohibited/{family_digest[:12]}"
+            units[unit_id] = FamilyInstancePlan(
+                unit_id=unit_id,
+                family_kind=kind_value,
+                family_identity_digest=family_digest,
+                disposition=PlanDisposition.INAPPLICABLE,
+                materializer=family.materializer.value,
+            )
+            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
+            continue
+
+        if condition in _BINDING_CONDITIONS:
+            _gap(
+                family,
+                f"condition {condition!r} is an implementation-binding or operator "
+                "fact that graph-v2 semantics cannot decide; disposition is "
+                "deferred to the binding slice",
+            )
+            continue
+
+        if family.path_scope.value == "generated_staging":
+            _gap(
+                family,
+                "generated-staging rows are factory transport locations, not "
+                "compiled application artifacts; they never join the plan",
+            )
+            continue
+
+        trigger_kinds = _DERIVABLE_CONDITIONS.get(condition)
+        if trigger_kinds is None:
+            _gap(
+                family,
+                f"condition {condition!r} has no graph-v2 derivation rule; "
+                "disposition is deferred rather than guessed",
+            )
+            continue
+
+        condition_met = not trigger_kinds or any(
+            nodes_by_kind.get(kind) for kind in trigger_kinds
+        )
+        instance_placeholder = next(
+            (name for name in placeholders if name in _INSTANCE_PLACEHOLDERS), None
+        )
+        unknown_placeholders = [
+            name
+            for name in placeholders
+            if name not in _INSTANCE_PLACEHOLDERS
+        ]
+        if unknown_placeholders:
+            _gap(
+                family,
+                f"path placeholders {unknown_placeholders!r} are not derivable "
+                "from graph-v2 node identities; instantiation is deferred",
+            )
+            continue
+
+        disposition = (
+            PlanDisposition.EXTERNAL_HANDOFF
+            if family.path_scope.value == "deployment_derived"
+            or family.owner.value == "download_renderer"
+            else PlanDisposition.RENDER
+        )
+
+        if not condition_met:
+            unit_id = f"{kind_value}/{family_digest[:12]}"
+            unit = FamilyInstancePlan(
+                unit_id=unit_id,
+                family_kind=kind_value,
+                family_identity_digest=family_digest,
+                disposition=PlanDisposition.INAPPLICABLE,
+                materializer=family.materializer.value,
+            )
+            units[unit_id] = unit
+            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
+            continue
+
+        if instance_placeholder is not None:
+            node_kind = _INSTANCE_PLACEHOLDERS[instance_placeholder]
+            for node in nodes_by_kind.get(node_kind, ()):
+                local = _node_local_identity(node.node_id)
+                values = ((instance_placeholder, local),)
+                path = family.path_template
+                for name, value in values:
+                    path = path.replace("{" + name + "}", value)
+                unit_id = f"{kind_value}/{local}/{family_digest[:12]}"
+                unit = FamilyInstancePlan(
+                    unit_id=unit_id,
+                    family_kind=kind_value,
+                    family_identity_digest=family_digest,
+                    disposition=disposition,
+                    placeholder_values=values,
+                    outputs=(PlanOutput(path_scope=family.path_scope.value, path=path),),
+                    sources=(
+                        PlanSource(
+                            node_id=node.node_id,
+                            payload_digest=payload_by_node[node.node_id].payload_digest,
+                        ),
+                    ),
+                    materializer=family.materializer.value,
+                )
+                units[unit_id] = unit
+                unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
+                unit_instance_index[(kind_value, values)] = unit_id
+        else:
+            unit_id = f"{kind_value}/{family_digest[:12]}"
+            unit = FamilyInstancePlan(
+                unit_id=unit_id,
+                family_kind=kind_value,
+                family_identity_digest=family_digest,
+                disposition=disposition,
+                outputs=(
+                    PlanOutput(
+                        path_scope=family.path_scope.value, path=family.path_template
+                    ),
+                ),
+                sources=_sources_for(_FAMILY_SOURCE_KINDS.get(condition, ())),
+                materializer=family.materializer.value,
+            )
+            units[unit_id] = unit
+            unit_ids_by_kind.setdefault(kind_value, []).append(unit_id)
+            unit_instance_index[(kind_value, ())] = unit_id
+
+    # Renderer resolution stays a per-plan typed gap: the registry declares
+    # materializer identifiers, but resolving renderer versions is
+    # implementation-binding work owned by the next slice.
+    gaps.append(
+        PlanGap(
+            family_kind="*",
+            path_template="*",
+            reason=(
+                "renderer resolution and implementation-binding pinning are "
+                "deferred; registry materializer identifiers are declarations, "
+                "not resolved renderers"
+            ),
+            adr_slice=4,
+        )
+    )
+
+    # Dependency edges from the registry: same-instance link when the
+    # dependency family shares the instance placeholder, else every unit of
+    # the dependency kind.
+    dependency_map: dict[str, tuple[str, ...]] = {}
+    family_by_kind: dict[str, list[Any]] = {}
+    for family in ordered:
+        family_by_kind.setdefault(family.kind.value, []).append(family)
+    for unit in list(units.values()):
+        dep_ids: set[str] = set()
+        for family in family_by_kind.get(unit.family_kind, ()):
+            if canonical_digest(family.identity_payload) != unit.family_identity_digest:
+                continue
+            for dependency_kind in family.dependency_families:
+                dep_kind_value = dependency_kind.value
+                same_instance = unit_instance_index.get(
+                    (dep_kind_value, unit.placeholder_values)
+                )
+                if same_instance is not None:
+                    dep_ids.add(same_instance)
+                else:
+                    dep_ids.update(unit_ids_by_kind.get(dep_kind_value, ()))
+        dependency_map[unit.unit_id] = tuple(sorted(dep_ids))
+
+    finished_units = tuple(
+        unit.model_copy(update={"depends_on_units": dependency_map[unit.unit_id]})
+        for unit in units.values()
+    )
+    # model_copy skips validators; rebuild through validation so nothing
+    # forged or unnormalized can survive into the plan document.
+    rebuilt_units = tuple(
+        FamilyInstancePlan.model_validate(unit.model_dump(mode="json"))
+        for unit in finished_units
+    )
+    ordered_kind_index = {
+        family.kind.value: index for index, family in enumerate(ordered)
+    }
+    sorted_units = tuple(
+        sorted(
+            rebuilt_units,
+            key=lambda unit: (ordered_kind_index.get(unit.family_kind, 1_000_000), unit.unit_id),
+        )
+    )
+    sorted_gaps = tuple(
+        sorted(set(gaps), key=lambda gap: (gap.family_kind, gap.path_template, gap.reason))
+    )
+
+    payload: dict[str, Any] = {
+        "schema_version": COMPILATION_PLAN_SCHEMA_VERSION,
+        "graph_id": verified_graph.graph_id,
+        "graph_version": verified_graph.version,
+        "scope": verified_graph.scope.model_dump(mode="json"),
+        "graph_digest": verified_graph.graph_digest,
+        "registry_schema_version": str(registry.schema_version),
+        "registry_digest": str(registry.registry_digest),
+        "units": [unit.identity_payload for unit in sorted_units],
+        "gaps": [gap.model_dump(mode="json") for gap in sorted_gaps],
+    }
+    return CompilationPlan(
+        graph_id=verified_graph.graph_id,
+        graph_version=verified_graph.version,
+        scope=verified_graph.scope,
+        graph_digest=verified_graph.graph_digest,
+        registry_schema_version=str(registry.schema_version),
+        registry_digest=str(registry.registry_digest),
+        units=sorted_units,
+        gaps=sorted_gaps,
+        plan_digest=canonical_digest(payload),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refinement impact (pure comparison; mutates no production authority)
+# ---------------------------------------------------------------------------
+
+
+class RegenerationClosure(SemanticsModel):
+    """Complete unit partition between a base plan and a successor plan.
+
+    Every successor unit lands in exactly one of ``affected`` (a source
+    identity changed — must render), ``reusable`` (identical sources — may
+    reuse from base, pinned to the base plan digest), or ``added``; every
+    base-only unit lands in ``removed``. Nothing is omitted, so omission can
+    never masquerade as preservation.
+    """
+
+    base_plan_digest: str
+    successor_plan_digest: str
+    affected: tuple[str, ...]
+    reusable: tuple[str, ...]
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+
+    @field_validator("base_plan_digest", "successor_plan_digest")
+    @classmethod
+    def _digests(cls, value: str) -> str:
+        return _validate_digest(value, field_name="plan digest")
+
+
+def plan_regeneration_closure(
+    base: CompilationPlan, successor: CompilationPlan
+) -> RegenerationClosure:
+    """Identify affected plan units between two plans of one graph lineage."""
+    if (base.graph_id, base.scope) != (successor.graph_id, successor.scope):
+        raise CompilationPlanError(
+            "regeneration closure requires plans from one graph lineage and scope"
+        )
+    base_units: Mapping[str, FamilyInstancePlan] = {u.unit_id: u for u in base.units}
+    successor_units: Mapping[str, FamilyInstancePlan] = {
+        u.unit_id: u for u in successor.units
+    }
+
+    def _signature(unit: FamilyInstancePlan) -> Any:
+        return (
+            unit.family_identity_digest,
+            tuple((s.node_id, s.payload_digest) for s in unit.sources),
+            tuple((o.path_scope, o.path) for o in unit.outputs),
+            unit.disposition.value,
+        )
+
+    affected: list[str] = []
+    reusable: list[str] = []
+    added: list[str] = []
+    for unit_id, unit in successor_units.items():
+        if unit_id not in base_units:
+            added.append(unit_id)
+        elif _signature(unit) != _signature(base_units[unit_id]):
+            affected.append(unit_id)
+        else:
+            reusable.append(unit_id)
+    removed = [unit_id for unit_id in base_units if unit_id not in successor_units]
+
+    closure = RegenerationClosure(
+        base_plan_digest=base.plan_digest,
+        successor_plan_digest=successor.plan_digest,
+        affected=tuple(sorted(affected)),
+        reusable=tuple(sorted(reusable)),
+        added=tuple(sorted(added)),
+        removed=tuple(sorted(removed)),
+    )
+    partition = set(closure.affected) | set(closure.reusable) | set(closure.added)
+    if partition != set(successor_units) or (
+        set(closure.removed) != set(base_units) - set(successor_units)
+    ):
+        raise CompilationPlanError("regeneration closure failed to partition all units")
+    return closure
+
+
+__all__ = [
+    "COMPILATION_PLAN_SCHEMA_VERSION",
+    "CompilationPlan",
+    "CompilationPlanError",
+    "FamilyInstancePlan",
+    "PlanDisposition",
+    "PlanGap",
+    "PlanOutput",
+    "PlanSource",
+    "RegenerationClosure",
+    "derive_compilation_plan",
+    "plan_regeneration_closure",
+]

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from mozaiksai.core.semantics.binding import ImplementationBinding
+from mozaiksai.core.semantics.compilation_plan import CompilationPlan
 from mozaiksai.core.semantics.graph import SemanticGraph, SemanticGraphV2
 from mozaiksai.core.semantics.manifest import ApplicationManifest
 from mozaiksai.core.semantics.payloads import SemanticPayloadBase, parse_semantic_payload
@@ -21,7 +22,6 @@ from mozaiksai.core.semantics.refs import (
     ArtifactRevisionRef,
     BuildContextBindingRef,
     ChildContractRef,
-    CompilationPlanRef,
     ExecutionAccessScopeRef,
     RefDocumentType,
     RefinementPatchRef,
@@ -198,6 +198,29 @@ class SemanticReferenceResolver:
             )
         )
 
+    def register_compilation_plan(self, plan: CompilationPlan) -> None:
+        """Register the aggregate plan as an immutable content-bearing subject.
+
+        Only the aggregate registers: embedded family-instance plans have no
+        document type and no registration surface of their own.
+        """
+        try:
+            verified = CompilationPlan.model_validate(plan.model_dump(mode="json"))
+        except (TypeError, ValueError) as exc:
+            raise ReferenceResolutionError(
+                f"compilation plan failed cold validation: {exc}"
+            ) from exc
+        self._register(
+            _Subject(
+                kind=RefDocumentType.COMPILATION_PLAN,
+                subject_id=verified.graph_id,
+                version=verified.graph_version,
+                digest=verified.plan_digest,
+                scope=verified.scope,
+                content=verified,
+            )
+        )
+
     def register_taxonomy_namespace(self, namespace: TaxonomyNamespace, digest: str) -> None:
         ref = TaxonomyNamespaceRef(
             namespace_id=namespace.namespace_id,
@@ -233,6 +256,7 @@ class SemanticReferenceResolver:
             RefDocumentType.IMPLEMENTATION_BINDING,
             RefDocumentType.TAXONOMY_NAMESPACE,
             RefDocumentType.SEMANTIC_PAYLOAD,
+            RefDocumentType.COMPILATION_PLAN,
         }:
             raise ReferenceResolutionError(
                 f"{kind.value} is content-bearing in this slice; register its document"
@@ -245,7 +269,6 @@ class SemanticReferenceResolver:
             "scope": scope,
         }
         ref_types = {
-            RefDocumentType.COMPILATION_PLAN: CompilationPlanRef,
             RefDocumentType.BUILD_CONTEXT_BINDING: BuildContextBindingRef,
             RefDocumentType.REFINEMENT_PATCH: RefinementPatchRef,
             RefDocumentType.ARTIFACT_REVISION: ArtifactRevisionRef,

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -522,3 +522,117 @@ def test_derived_plan_families_cover_produced_plan_owned_paths() -> None:
             uncovered.append(f"{path} -> {kind}")
     assert classified, "fixture paths must classify against the registry"
     assert uncovered == []
+
+
+def test_plan_models_carry_no_live_runtime_identifiers() -> None:
+    """Amended Slice 4B boundary: the plan is provider-neutral and offline.
+
+    The model field universe is closed and none of it names or can carry live
+    execution-engine state — no agent/participant identity, transport channel,
+    message envelope, connection, inbox/log, delivery/retry/reconnect state,
+    live model assignment, or task-checkpoint location. Execution needs exist
+    only as deterministic registry declarations for a later binding slice.
+    """
+    from mozaiksai.core.semantics.compilation_plan import (
+        PlanGap,
+        PlanOutput,
+        PlanSource,
+        RegenerationClosure,
+    )
+
+    allowed_fields = {
+        CompilationPlan: {
+            "schema_version",
+            "graph_id",
+            "graph_version",
+            "scope",
+            "graph_digest",
+            "registry_schema_version",
+            "registry_digest",
+            "units",
+            "gaps",
+            "plan_digest",
+        },
+        FamilyInstancePlan: {
+            "unit_id",
+            "family_kind",
+            "family_identity_digest",
+            "disposition",
+            "placeholder_values",
+            "outputs",
+            "sources",
+            "depends_on_units",
+            "materializer",
+            "base_plan_digest",
+        },
+        PlanOutput: {"path_scope", "path"},
+        PlanSource: {"node_id", "payload_digest"},
+        PlanGap: {"family_kind", "path_template", "reason", "adr_slice"},
+        RegenerationClosure: {
+            "base_plan_digest",
+            "successor_plan_digest",
+            "affected",
+            "reusable",
+            "added",
+            "removed",
+        },
+    }
+    forbidden_tokens = (
+        "agent",
+        "passport",
+        "channel",
+        "envelope",
+        "hub",
+        "inbox",
+        "wal",
+        "checkpoint",
+        "retry",
+        "reconnect",
+        "delivery",
+        "connection",
+        "session",
+        "model_assignment",
+    )
+    for model, fields in allowed_fields.items():
+        assert set(model.model_fields) == fields, model.__name__
+        for name in fields:
+            assert not any(token in name for token in forbidden_tokens), name
+
+    source = (ROOT / "mozaiksai/core/semantics/compilation_plan.py").read_text(
+        encoding="utf-8"
+    ).lower()
+    for token in (
+        "passport",
+        "envelope",
+        "channel",
+        "inbox",
+        "reconnect",
+        "task_checkpoint",
+        "agent_id",
+        "model_assignment",
+        "websocket",
+    ):
+        assert token not in source, token
+
+    # The canonical payload's key universe is closed too: a derived plan
+    # cannot smuggle live identifiers through untyped keys.
+    def _keys(value, into):
+        if isinstance(value, dict):
+            for key, item in value.items():
+                into.add(key)
+                _keys(item, into)
+        elif isinstance(value, list):
+            for item in value:
+                _keys(item, into)
+
+    seen: set[str] = set()
+    _keys(_plan().canonical_payload(), seen)
+    expected = (
+        allowed_fields[CompilationPlan]
+        | allowed_fields[FamilyInstancePlan]
+        | allowed_fields[PlanOutput]
+        | allowed_fields[PlanSource]
+        | allowed_fields[PlanGap]
+        | {"ref_schema_version", "tenant_id", "workspace_id", "pre_app_scope_id"}
+    )
+    assert seen <= expected, sorted(seen - expected)

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -1,0 +1,524 @@
+"""ADR 0007 Slice 4B proof gate: aggregate ``CompilationPlan`` derivation.
+
+Adversarial matrix: input substitution, scope/version substitution, forged
+plan documents (missing/extra units, duplicate paths, case-fold and prefix
+collisions, dependency cycles), ordering determinism, cross-process canonical
+equality, input immutability, unknown families and unresolved renderers as
+typed gaps, digest propagation payload → graph → plan, regeneration closure,
+family-plan non-authority, completeness over every registry row, and zero
+production/AG2/authority surface.
+"""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.capabilities import advertised_semantic_compiler_capabilities
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    CompilationPlanError,
+    FamilyInstancePlan,
+    PlanDisposition,
+    derive_compilation_plan,
+    plan_regeneration_closure,
+)
+from mozaiksai.core.semantics.refs import (
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+    RefDocumentType,
+)
+from mozaiksai.core.semantics.resolver import (
+    ReferenceResolutionError,
+    SemanticReferenceResolver,
+)
+from tests.test_semantic_payload_graph_v2 import _corpus_graph
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
+_OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
+
+# Golden aggregate digest for the full 2E corpus over the built-in registry.
+_GOLDEN_PLAN_DIGEST = "b99aafc84caa39a867f2bf7eb09a0dbfed51f7b94de4e2219d7a64728e28226a"
+
+
+def _registry():
+    return build_app_layout_registry(())
+
+
+def _plan(*, home_title: str = "Home"):
+    graph, payloads = _corpus_graph(home_title=home_title)
+    return derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+
+
+# ---------------------------------------------------------------------------
+# Derivation identity, determinism, immutability
+# ---------------------------------------------------------------------------
+
+
+def test_one_aggregate_plan_per_immutable_graph_identity() -> None:
+    graph, payloads = _corpus_graph()
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    assert plan.graph_id == graph.graph_id
+    assert plan.graph_version == graph.version
+    assert plan.scope == graph.scope
+    assert plan.graph_digest == graph.graph_digest
+    registry = _registry()
+    assert plan.registry_digest == registry.registry_digest
+    assert plan.registry_schema_version == str(registry.schema_version)
+    # Same immutable inputs -> byte-identical plan.
+    again = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    assert again.plan_digest == plan.plan_digest
+    assert again.canonical_payload() == plan.canonical_payload()
+
+
+def test_ordering_is_deterministic_and_input_order_independent() -> None:
+    graph, payloads = _corpus_graph()
+    permuted = list(reversed(payloads))
+    plan_a = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    plan_b = derive_compilation_plan(graph=graph, payloads=permuted, registry=_registry())
+    assert plan_a.plan_digest == plan_b.plan_digest
+    assert [u.unit_id for u in plan_a.units] == [u.unit_id for u in plan_b.units]
+    # Family order respects the registry's dependency-respecting total order:
+    # a unit never precedes a dependency unit of another family kind.
+    position = {unit.unit_id: index for index, unit in enumerate(plan_a.units)}
+    for unit in plan_a.units:
+        for dependency in unit.depends_on_units:
+            assert position[dependency] < position[unit.unit_id], (
+                unit.unit_id,
+                dependency,
+            )
+
+
+def test_cross_process_canonical_equality() -> None:
+    plan = _plan()
+    assert plan.plan_digest == _GOLDEN_PLAN_DIGEST
+    probe = (
+        "from tests.test_compilation_plan import _plan\n"
+        "print(_plan().plan_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == _GOLDEN_PLAN_DIGEST
+
+
+def test_inputs_are_never_mutated() -> None:
+    graph, payloads = _corpus_graph()
+    graph_before = graph.model_dump(mode="json")
+    payloads_before = [payload.model_dump(mode="json") for payload in payloads]
+    registry = _registry()
+    registry_digest_before = registry.registry_digest
+    derive_compilation_plan(graph=graph, payloads=payloads, registry=registry)
+    assert graph.model_dump(mode="json") == graph_before
+    assert [payload.model_dump(mode="json") for payload in payloads] == payloads_before
+    assert registry.registry_digest == registry_digest_before
+
+
+# ---------------------------------------------------------------------------
+# Input substitution
+# ---------------------------------------------------------------------------
+
+
+def test_forged_graph_fails_cold_validation() -> None:
+    graph, payloads = _corpus_graph()
+    forged = graph.model_copy(update={"graph_digest": "f" * 64})
+    with pytest.raises(CompilationPlanError, match="cold validation"):
+        derive_compilation_plan(graph=forged, payloads=payloads, registry=_registry())
+
+
+def test_payload_substitution_fails_closure() -> None:
+    graph, payloads = _corpus_graph()
+    foreign = list(_corpus_graph(home_title="Home!")[1])
+    swapped = [
+        next(p for p in foreign if p.node_id == payload.node_id)
+        if payload.node_id == "mozaiks.page.home"
+        else payload
+        for payload in payloads
+    ]
+    with pytest.raises(CompilationPlanError, match="closure"):
+        derive_compilation_plan(graph=graph, payloads=swapped, registry=_registry())
+
+
+def test_scope_and_version_substitution_produce_distinct_plans() -> None:
+    base = _plan()
+    graph_v2, payloads_v2 = _corpus_graph()
+    from mozaiksai.core.semantics.graph import build_semantic_graph_v2
+
+    successor_graph = build_semantic_graph_v2(
+        graph_id=graph_v2.graph_id,
+        version=2,
+        scope=graph_v2.scope,
+        nodes=graph_v2.nodes,
+        edges=graph_v2.edges,
+        namespace_grants=graph_v2.namespace_grants,
+    )
+    successor = derive_compilation_plan(
+        graph=successor_graph, payloads=payloads_v2, registry=_registry()
+    )
+    assert successor.plan_digest != base.plan_digest
+    assert successor.graph_version == 2
+
+    other_scope_graph, other_scope_payloads = _corpus_graph(scope=_OTHER_SCOPE)
+    other = derive_compilation_plan(
+        graph=other_scope_graph, payloads=other_scope_payloads, registry=_registry()
+    )
+    assert other.plan_digest != base.plan_digest
+    with pytest.raises(CompilationPlanError, match="lineage"):
+        plan_regeneration_closure(base, other)
+
+
+# ---------------------------------------------------------------------------
+# Forged plan documents
+# ---------------------------------------------------------------------------
+
+
+def _document(plan: CompilationPlan) -> dict:
+    return plan.model_dump(mode="json")
+
+
+def test_missing_and_extra_units_fail_closed() -> None:
+    plan = _plan()
+    missing = _document(plan)
+    removed = missing["units"].pop()
+    with pytest.raises(ValidationError, match="plan_digest does not match"):
+        CompilationPlan.model_validate(missing)
+
+    extra = _document(plan)
+    duplicate = copy.deepcopy(removed)
+    extra["units"].append(duplicate)
+    extra["units"].append(copy.deepcopy(duplicate))
+    with pytest.raises(ValidationError, match="duplicate unit identities|plan_digest"):
+        CompilationPlan.model_validate(extra)
+
+
+def test_duplicate_output_ownership_fails_closed() -> None:
+    plan = _plan()
+    document = _document(plan)
+    render_units = [u for u in document["units"] if u["outputs"]]
+    victim, thief = render_units[0], render_units[1]
+    thief["outputs"] = copy.deepcopy(victim["outputs"])
+    thief["placeholder_values"] = copy.deepcopy(victim["placeholder_values"])
+    with pytest.raises(ValidationError, match="duplicate output ownership|plan_digest"):
+        CompilationPlan.model_validate(document)
+
+
+def test_case_fold_and_prefix_collisions_fail_closed() -> None:
+    plan = _plan()
+    document = _document(plan)
+    units = [u for u in document["units"] if u["outputs"] and not u["placeholder_values"]]
+    first, second = units[0], units[1]
+    first["outputs"] = [{"path_scope": "app_bundle_root", "path": "shared/Config.json"}]
+    second["outputs"] = [{"path_scope": "app_bundle_root", "path": "shared/config.JSON"}]
+    with pytest.raises(ValidationError, match="output collision|plan_digest"):
+        CompilationPlan.model_validate(document)
+
+    document = _document(plan)
+    units = [u for u in document["units"] if u["outputs"] and not u["placeholder_values"]]
+    first, second = units[0], units[1]
+    first["outputs"] = [{"path_scope": "app_bundle_root", "path": "shared/config"}]
+    second["outputs"] = [{"path_scope": "app_bundle_root", "path": "shared/config/x.json"}]
+    with pytest.raises(ValidationError, match="output collision|plan_digest"):
+        CompilationPlan.model_validate(document)
+
+
+def test_dependency_cycles_fail_closed() -> None:
+    plan = _plan()
+    document = _document(plan)
+    with_deps = [u for u in document["units"] if u["depends_on_units"]]
+    dependent = with_deps[0]
+    dependency_id = dependent["depends_on_units"][0]
+    dependency = next(u for u in document["units"] if u["unit_id"] == dependency_id)
+    dependency["depends_on_units"] = [dependent["unit_id"]]
+    with pytest.raises(ValidationError, match="dependency cycle|plan_digest"):
+        CompilationPlan.model_validate(document)
+
+    document = _document(plan)
+    document["units"][0]["depends_on_units"] = [document["units"][0]["unit_id"]]
+    with pytest.raises(ValidationError, match="depends on itself|plan_digest"):
+        CompilationPlan.model_validate(document)
+
+
+def test_stale_plan_digest_is_rejected() -> None:
+    plan = _plan()
+    document = _document(plan)
+    document["graph_digest"] = "f" * 64
+    with pytest.raises(ValidationError, match="plan_digest does not match"):
+        CompilationPlan.model_validate(document)
+
+
+# ---------------------------------------------------------------------------
+# Completeness, gaps, unknown families, unresolved renderers
+# ---------------------------------------------------------------------------
+
+
+def test_every_registry_row_is_disposed_or_explicitly_gapped() -> None:
+    plan = _plan()
+    registry = _registry()
+    disposed = {unit.family_identity_digest for unit in plan.units}
+    gapped = {(gap.family_kind, gap.path_template) for gap in plan.gaps}
+    for family in registry.ordered_families():
+        digest = canonical_digest(family.identity_payload)
+        covered = digest in disposed or (
+            (family.kind.value, family.path_template) in gapped
+        )
+        assert covered, (family.kind.value, family.path_template)
+
+
+def test_binding_conditions_are_typed_gaps_never_guesses() -> None:
+    from mozaiksai.core.semantics.compilation_plan import _BINDING_CONDITIONS
+
+    plan = _plan()
+    reasons = "\n".join(gap.reason for gap in plan.gaps)
+    registry_conditions = {
+        family.condition.value for family in _registry().ordered_families()
+    }
+    expected = sorted(_BINDING_CONDITIONS & registry_conditions)
+    assert expected, "registry must carry binding-owned conditions"
+    for condition in expected:
+        assert condition in reasons, condition
+    assert all(gap.adr_slice in (4, 5, 6, 7) for gap in plan.gaps)
+
+
+def test_unknown_layout_family_condition_becomes_a_typed_gap() -> None:
+    registry = _registry()
+
+    class _NovelCondition:
+        value = "when_something_new"
+
+    class _NovelFamily:
+        kind = type("K", (), {"value": "novel_family"})()
+        requirement = type("R", (), {"value": "conditional"})()
+        condition = _NovelCondition()
+        path_scope = type("S", (), {"value": "app_bundle_root"})()
+        path_template = "novel/output.yaml"
+        materializer = type("M", (), {"value": "unknown"})()
+        owner = type("O", (), {"value": "app_workspace"})()
+        dependency_families = ()
+        identity_payload = {"kind": "novel_family", "path_template": "novel/output.yaml"}
+
+    class _NovelRegistry:
+        schema_version = registry.schema_version
+        registry_digest = registry.registry_digest
+
+        def ordered_families(self):
+            return (*registry.ordered_families(), _NovelFamily())
+
+    graph, payloads = _corpus_graph()
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_NovelRegistry())
+    assert any(
+        gap.family_kind == "novel_family" and "no graph-v2 derivation rule" in gap.reason
+        for gap in plan.gaps
+    )
+
+
+def test_renderer_resolution_is_an_explicit_gap_and_units_cannot_claim_one() -> None:
+    plan = _plan()
+    assert any("renderer resolution" in gap.reason for gap in plan.gaps)
+    assert "renderer" not in FamilyInstancePlan.model_fields
+    assert "renderer_version" not in FamilyInstancePlan.model_fields
+
+
+def test_dispositions_are_complete_and_external_handoff_covers_deployment() -> None:
+    plan = _plan()
+    assert {unit.disposition for unit in plan.units} <= set(PlanDisposition)
+    handoff = [u for u in plan.units if u.disposition is PlanDisposition.EXTERNAL_HANDOFF]
+    assert handoff, "deployment artifacts must be external handoff units"
+    for unit in handoff:
+        assert unit.family_kind in {"app_deployment_artifact"}, unit.family_kind
+
+
+# ---------------------------------------------------------------------------
+# Digest propagation and regeneration closure
+# ---------------------------------------------------------------------------
+
+
+def test_digest_propagates_payload_to_graph_to_plan() -> None:
+    base = _plan()
+    changed = _plan(home_title="Home!")
+    assert base.graph_digest != changed.graph_digest
+    assert base.plan_digest != changed.plan_digest
+    closure = plan_regeneration_closure(base, changed)
+    # The page payload changed: exactly the units sourcing that node flip to
+    # affected; everything else stays reusable. Nothing is omitted.
+    page_units = {
+        unit.unit_id
+        for unit in changed.units
+        if any(source.node_id == "mozaiks.page.home" for source in unit.sources)
+    }
+    assert page_units
+    assert set(closure.affected) == page_units
+    assert not closure.added and not closure.removed
+    assert set(closure.affected) | set(closure.reusable) == {
+        unit.unit_id for unit in changed.units
+    }
+
+
+def test_regeneration_closure_partitions_everything() -> None:
+    base = _plan()
+    closure = plan_regeneration_closure(base, base)
+    assert closure.affected == () and closure.added == () and closure.removed == ()
+    assert set(closure.reusable) == {unit.unit_id for unit in base.units}
+
+
+def test_reuse_from_base_requires_base_plan_digest() -> None:
+    plan = _plan()
+    unit = plan.units[0]
+    with pytest.raises(ValidationError, match="reuse_from_base"):
+        FamilyInstancePlan(
+            unit_id="x/y",
+            family_kind="app_manifest",
+            family_identity_digest=unit.family_identity_digest,
+            disposition=PlanDisposition.REUSE_FROM_BASE,
+            materializer="none",
+        )
+    with pytest.raises(ValidationError, match="reuse_from_base"):
+        FamilyInstancePlan(
+            unit_id="x/y",
+            family_kind="app_manifest",
+            family_identity_digest=unit.family_identity_digest,
+            disposition=PlanDisposition.RENDER,
+            materializer="none",
+            base_plan_digest="a" * 64,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Traceability
+# ---------------------------------------------------------------------------
+
+
+def test_every_instance_output_traces_to_node_and_payload_identity() -> None:
+    graph, payloads = _corpus_graph()
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    payload_digest_by_node = {p.node_id: p.payload_digest for p in payloads}
+    node_ids = {node.node_id for node in graph.nodes}
+    for unit in plan.units:
+        if unit.placeholder_values:
+            assert unit.sources, unit.unit_id
+        for source in unit.sources:
+            assert source.node_id in node_ids
+            assert source.payload_digest == payload_digest_by_node[source.node_id]
+
+
+# ---------------------------------------------------------------------------
+# Non-authority: family plans, resolver, production, AG2
+# ---------------------------------------------------------------------------
+
+
+def test_family_plans_cannot_register_or_resolve_independently() -> None:
+    plan = _plan()
+    resolver = SemanticReferenceResolver()
+    resolver.register_compilation_plan(plan)
+    ref = CompilationPlanRef(
+        subject_id=plan.graph_id,
+        subject_version=plan.graph_version,
+        content_digest=plan.plan_digest,
+        scope=plan.scope,
+    )
+    resolved = resolver.resolve(ref, requesting_scope=plan.scope)
+    assert isinstance(resolved, CompilationPlan)
+    # Only the aggregate has a document type; nothing names a family plan.
+    assert not any("family" in member.value for member in RefDocumentType)
+    with pytest.raises(ReferenceResolutionError, match="content-bearing"):
+        resolver.register_opaque_subject(
+            kind=RefDocumentType.COMPILATION_PLAN,
+            subject_id="freestanding-unit",
+            version=1,
+            digest="a" * 64,
+            scope=plan.scope,
+        )
+    # Duplicate registration of the aggregate stays immutable.
+    with pytest.raises(ReferenceResolutionError, match="immutable"):
+        resolver.register_compilation_plan(plan)
+
+
+def test_forged_plan_cannot_register() -> None:
+    plan = _plan()
+    forged = plan.model_copy(update={"plan_digest": "e" * 64})
+    resolver = SemanticReferenceResolver()
+    with pytest.raises(ReferenceResolutionError, match="cold validation"):
+        resolver.register_compilation_plan(forged)
+
+
+def test_no_production_imports_no_advertisement_no_ag2() -> None:
+    assert advertised_semantic_compiler_capabilities() == ()
+    source = (ROOT / "mozaiksai/core/semantics/compilation_plan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "import ag2" not in source and "from ag2" not in source
+    # The semantics layer must not import the runtime registry module; the
+    # registry arrives as a parameter.
+    assert "runtime.app.layout_registry" not in source
+
+    offenders: list[str] = []
+    excluded = {
+        Path("mozaiksai/core/semantics/compilation_plan.py"),
+        Path("mozaiksai/core/semantics/resolver.py"),
+        Path("mozaiksai/core/semantics/refs.py"),
+    }
+    for root in (ROOT / "mozaiksai", ROOT / "factory_app"):
+        for path in root.rglob("*.py"):
+            relative = path.relative_to(ROOT)
+            if relative in excluded:
+                continue
+            if "compilation_plan" in path.read_text(encoding="utf-8"):
+                offenders.append(relative.as_posix())
+    assert offenders == []
+
+
+def test_derived_plan_families_cover_produced_plan_owned_paths() -> None:
+    """Bounded derived-vs-produced bridge: every artifact family the recorded
+    agent-produced plan writes into is disposed or explicitly gapped by the
+    derived plan's family universe (family-level coverage; instance-level
+    equivalence is cutover work)."""
+    import json
+
+    fixture = json.loads(
+        (ROOT / "tests/fixtures/appplan_persistent_projects_output.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    produced = fixture.get("app_build_plan") or fixture.get("AppBuildPlan") or {}
+    owned_paths = [
+        path
+        for task in (produced.get("build_tasks") or [])
+        for path in (task.get("owned_paths") or [])
+    ]
+    assert owned_paths, "fixture must carry produced owned paths"
+
+    registry = _registry()
+    plan = _plan()
+    disposed_kinds = {unit.family_kind for unit in plan.units}
+    gapped_kinds = {gap.family_kind for gap in plan.gaps}
+    uncovered: list[str] = []
+    classified = 0
+    for path in owned_paths:
+        match = None
+        for scope in ("app_bundle_root", "workspace_root"):
+            try:
+                match = registry.match_path(path, scope)
+                break
+            except (ValueError, KeyError):
+                continue
+        if match is None:
+            continue  # unclassifiable paths are the scanner's concern
+        classified += 1
+        kind = match.family.kind.value
+        if kind not in disposed_kinds and kind not in gapped_kinds:
+            uncovered.append(f"{path} -> {kind}")
+    assert classified, "fixture paths must classify against the registry"
+    assert uncovered == []

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -47,7 +47,7 @@ _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
-_GOLDEN_PLAN_DIGEST = "b99aafc84caa39a867f2bf7eb09a0dbfed51f7b94de4e2219d7a64728e28226a"
+_GOLDEN_PLAN_DIGEST = "19a296c255fb07ba4f19ddb23ed847e4a626efcdef623239081e63c11df67562"
 
 
 def _registry():
@@ -72,7 +72,12 @@ def test_one_aggregate_plan_per_immutable_graph_identity() -> None:
     assert plan.scope == graph.scope
     assert plan.graph_digest == graph.graph_digest
     registry = _registry()
-    assert plan.registry_digest == registry.registry_digest
+    from mozaiksai.core.semantics.compilation_plan import snapshot_layout_registry
+
+    # Blocker-1 semantics: the plan pins the RECOMPUTED snapshot identity,
+    # never the registry object's claimed digest.
+    assert plan.registry_digest == snapshot_layout_registry(registry).snapshot_digest
+    assert plan.registry_digest != registry.registry_digest
     assert plan.registry_schema_version == str(registry.schema_version)
     # Same immutable inputs -> byte-identical plan.
     again = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
@@ -266,30 +271,33 @@ def test_stale_plan_digest_is_rejected() -> None:
 
 
 def test_every_registry_row_is_disposed_or_explicitly_gapped() -> None:
+    from mozaiksai.core.semantics.compilation_plan import snapshot_layout_registry
+
     plan = _plan()
-    registry = _registry()
+    snapshot = snapshot_layout_registry(_registry())
+    assert plan.registry_digest == snapshot.snapshot_digest
     disposed = {unit.family_identity_digest for unit in plan.units}
     gapped = {(gap.family_kind, gap.path_template) for gap in plan.gaps}
-    for family in registry.ordered_families():
-        digest = canonical_digest(family.identity_payload)
-        covered = digest in disposed or (
-            (family.kind.value, family.path_template) in gapped
-        )
-        assert covered, (family.kind.value, family.path_template)
+    for row in snapshot.rows:
+        covered = row.row_digest in disposed or ((row.kind, row.path_template) in gapped)
+        assert covered, (row.kind, row.path_template)
 
 
 def test_binding_conditions_are_typed_gaps_never_guesses() -> None:
-    from mozaiksai.core.semantics.compilation_plan import _BINDING_CONDITIONS
+    from mozaiksai.core.semantics.compilation_plan import _BINDING_CONDITIONS, PlanGapCode
 
     plan = _plan()
-    reasons = "\n".join(gap.reason for gap in plan.gaps)
+    deferred_subjects = {
+        gap.subject
+        for gap in plan.gaps
+        if gap.code is PlanGapCode.BINDING_CONDITION_DEFERRED
+    }
     registry_conditions = {
         family.condition.value for family in _registry().ordered_families()
     }
-    expected = sorted(_BINDING_CONDITIONS & registry_conditions)
+    expected = _BINDING_CONDITIONS & registry_conditions
     assert expected, "registry must carry binding-owned conditions"
-    for condition in expected:
-        assert condition in reasons, condition
+    assert expected <= deferred_subjects
     assert all(gap.adr_slice in (4, 5, 6, 7) for gap in plan.gaps)
 
 
@@ -302,13 +310,13 @@ def test_unknown_layout_family_condition_becomes_a_typed_gap() -> None:
     class _NovelFamily:
         kind = type("K", (), {"value": "novel_family"})()
         requirement = type("R", (), {"value": "conditional"})()
+        multiplicity = type("Mu", (), {"value": "single"})()
         condition = _NovelCondition()
         path_scope = type("S", (), {"value": "app_bundle_root"})()
         path_template = "novel/output.yaml"
         materializer = type("M", (), {"value": "unknown"})()
         owner = type("O", (), {"value": "app_workspace"})()
         dependency_families = ()
-        identity_payload = {"kind": "novel_family", "path_template": "novel/output.yaml"}
 
     class _NovelRegistry:
         schema_version = registry.schema_version
@@ -319,15 +327,23 @@ def test_unknown_layout_family_condition_becomes_a_typed_gap() -> None:
 
     graph, payloads = _corpus_graph()
     plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_NovelRegistry())
+    from mozaiksai.core.semantics.compilation_plan import PlanGapCode
+
     assert any(
-        gap.family_kind == "novel_family" and "no graph-v2 derivation rule" in gap.reason
+        gap.family_kind == "novel_family"
+        and gap.code is PlanGapCode.CONDITION_UNDERIVABLE
+        and gap.subject == "when_something_new"
         for gap in plan.gaps
     )
 
 
 def test_renderer_resolution_is_an_explicit_gap_and_units_cannot_claim_one() -> None:
+    from mozaiksai.core.semantics.compilation_plan import PlanGapCode
+
     plan = _plan()
-    assert any("renderer resolution" in gap.reason for gap in plan.gaps)
+    assert any(
+        gap.code is PlanGapCode.RENDERER_RESOLUTION_DEFERRED for gap in plan.gaps
+    )
     assert "renderer" not in FamilyInstancePlan.model_fields
     assert "renderer_version" not in FamilyInstancePlan.model_fields
 
@@ -347,24 +363,45 @@ def test_dispositions_are_complete_and_external_handoff_covers_deployment() -> N
 
 
 def test_digest_propagates_payload_to_graph_to_plan() -> None:
+    from mozaiksai.core.semantics.compilation_plan import PlanSourceScope
+
     base = _plan()
     changed = _plan(home_title="Home!")
     assert base.graph_digest != changed.graph_digest
     assert base.plan_digest != changed.plan_digest
     closure = plan_regeneration_closure(base, changed)
-    # The page payload changed: exactly the units sourcing that node flip to
-    # affected; everything else stays reusable. Nothing is omitted.
+    affected = set(closure.affected)
+    # Directly sourced units are affected...
     page_units = {
         unit.unit_id
         for unit in changed.units
         if any(source.node_id == "mozaiks.page.home" for source in unit.sources)
     }
-    assert page_units
-    assert set(closure.affected) == page_units
-    assert not closure.added and not closure.removed
-    assert set(closure.affected) | set(closure.reusable) == {
-        unit.unit_id for unit in changed.units
+    assert page_units and page_units <= affected
+    # ...graph-wide consumers are affected by any graph change...
+    graph_wide = {
+        unit.unit_id
+        for unit in changed.units
+        if unit.source_scope is PlanSourceScope.GRAPH_WIDE
     }
+    assert graph_wide and graph_wide <= affected
+    # ...reverse dependents of affected units are affected...
+    route_manifest = {
+        unit.unit_id
+        for unit in changed.units
+        if unit.family_kind == "app_ui_route_manifest"
+    }
+    assert route_manifest and route_manifest <= affected
+    # ...and unrelated declared units with unchanged footprints stay reusable.
+    module_units = {
+        unit.unit_id
+        for unit in changed.units
+        if unit.family_kind == "module_manifest"
+        and unit.disposition is PlanDisposition.RENDER
+    }
+    assert module_units and module_units <= set(closure.reusable)
+    assert not closure.added and not closure.removed
+    assert affected | set(closure.reusable) == {unit.unit_id for unit in changed.units}
 
 
 def test_regeneration_closure_partitions_everything() -> None:
@@ -383,6 +420,7 @@ def test_reuse_from_base_requires_base_plan_digest() -> None:
             family_kind="app_manifest",
             family_identity_digest=unit.family_identity_digest,
             disposition=PlanDisposition.REUSE_FROM_BASE,
+            source_scope="declared",
             materializer="none",
         )
     with pytest.raises(ValidationError, match="reuse_from_base"):
@@ -391,6 +429,7 @@ def test_reuse_from_base_requires_base_plan_digest() -> None:
             family_kind="app_manifest",
             family_identity_digest=unit.family_identity_digest,
             disposition=PlanDisposition.RENDER,
+            source_scope="declared",
             materializer="none",
             base_plan_digest="a" * 64,
         )
@@ -558,6 +597,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
             "family_kind",
             "family_identity_digest",
             "disposition",
+            "source_scope",
             "placeholder_values",
             "outputs",
             "sources",
@@ -567,7 +607,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         },
         PlanOutput: {"path_scope", "path"},
         PlanSource: {"node_id", "payload_digest"},
-        PlanGap: {"family_kind", "path_template", "reason", "adr_slice"},
+        PlanGap: {"code", "family_kind", "path_template", "subject", "adr_slice"},
         RegenerationClosure: {
             "base_plan_digest",
             "successor_plan_digest",
@@ -634,5 +674,411 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         | allowed_fields[PlanSource]
         | allowed_fields[PlanGap]
         | {"ref_schema_version", "tenant_id", "workspace_id", "pre_app_scope_id"}
+        | {"source_scope", "code", "subject"}
     )
     assert seen <= expected, sorted(seen - expected)
+
+
+# ---------------------------------------------------------------------------
+# Correction round: regressions reproducing the five independent-review attacks
+# ---------------------------------------------------------------------------
+
+
+def _redigest(document: dict) -> dict:
+    """Recompute plan_digest the way the model does — the attacker's move."""
+    body = {key: value for key, value in document.items() if key != "plan_digest"}
+    document["plan_digest"] = canonical_digest(body)
+    return document
+
+
+def test_blocker1_registry_identity_is_recomputed_not_trusted() -> None:
+    from mozaiksai.core.semantics.compilation_plan import (
+        LayoutRegistrySnapshot,
+        snapshot_layout_registry,
+    )
+
+    real = _registry()
+    graph, payloads = _corpus_graph()
+
+    class _Forged:
+        """Different row content, same claimed digest as the real registry."""
+
+        schema_version = real.schema_version
+        registry_digest = real.registry_digest  # the retained/forged claim
+
+        def ordered_families(self):
+            rows = list(real.ordered_families())
+
+            class _Swapped:
+                kind = rows[0].kind
+                owner = rows[0].owner
+                requirement = rows[0].requirement
+                multiplicity = rows[0].multiplicity
+                condition = rows[0].condition
+                path_scope = rows[0].path_scope
+                path_template = "forged/other_output.json"
+                materializer = rows[0].materializer
+                dependency_families = rows[0].dependency_families
+
+            return (_Swapped(), *rows[1:])
+
+    honest = derive_compilation_plan(graph=graph, payloads=payloads, registry=real)
+    forged = derive_compilation_plan(graph=graph, payloads=payloads, registry=_Forged())
+    # Distinct registry semantics can never hide under one registry identity.
+    assert forged.registry_digest != honest.registry_digest
+    assert forged.plan_digest != honest.plan_digest
+
+    # A snapshot that retains its digest while a row changes fails closed.
+    snapshot = snapshot_layout_registry(real)
+    document = snapshot.model_dump(mode="json")
+    document["rows"][0]["path_template"] = "forged/other_output.json"
+    with pytest.raises(ValidationError, match="snapshot_digest does not match"):
+        LayoutRegistrySnapshot.model_validate(document)
+
+    # Rows outside the closed domains are rejected, not consumed.
+    class _BadRow:
+        kind = "Bad Kind!"
+        owner = "app_workspace"
+        requirement = "conditional"
+        multiplicity = "single"
+        condition = "always"
+        path_scope = "app_bundle_root"
+        path_template = "x/y.json"
+        materializer = "app_generator"
+        dependency_families = ()
+
+    class _BadRegistry:
+        schema_version = real.schema_version
+
+        def ordered_families(self):
+            return (_BadRow(),)
+
+    with pytest.raises(CompilationPlanError, match="closed snapshot domains"):
+        derive_compilation_plan(graph=graph, payloads=payloads, registry=_BadRegistry())
+
+    # Internally inconsistent registries (dangling dependency) are rejected.
+    class _DanglingRow(_BadRow):
+        kind = "lonely_family"
+        dependency_families = ("missing_family",)
+
+    class _DanglingRegistry:
+        schema_version = real.schema_version
+
+        def ordered_families(self):
+            return (_DanglingRow(),)
+
+    with pytest.raises(CompilationPlanError, match="internally inconsistent"):
+        derive_compilation_plan(
+            graph=graph, payloads=payloads, registry=_DanglingRegistry()
+        )
+
+
+def test_blocker2_multi_placeholder_rows_gap_instead_of_leaking_braces() -> None:
+    import re as _re
+
+    from mozaiksai.core.semantics.compilation_plan import (
+        PlanGapCode,
+        PlanOutput,
+        snapshot_layout_registry,
+    )
+
+    plan = _plan()
+    # The built-in registry carries real multi-placeholder rows (for example
+    # modules/{module_id}/ui/admin/{page_id}.jsx): every such row must be an
+    # explicit typed gap and no validated output may carry a brace.
+    snapshot = snapshot_layout_registry(_registry())
+    multi_rows = [
+        row
+        for row in snapshot.rows
+        if len(set(_re.findall(r"\{([a-z][a-z0-9_]*)\}", row.path_template))) > 1
+        and row.requirement != "prohibited"  # prohibited rows dispose as units
+    ]
+    assert multi_rows, "registry must contain multi-placeholder rows for this proof"
+    gapped = {
+        (gap.family_kind, gap.path_template)
+        for gap in plan.gaps
+        if gap.code
+        in (
+            PlanGapCode.PLACEHOLDER_RELATIONSHIP_UNPROVABLE,
+            PlanGapCode.PLACEHOLDER_UNDERIVABLE,
+            PlanGapCode.BINDING_CONDITION_DEFERRED,
+            PlanGapCode.STAGING_TRANSPORT_EXCLUDED,
+        )
+    }
+    for row in multi_rows:
+        assert (row.kind, row.path_template) in gapped, row.path_template
+    for unit in plan.units:
+        for output in unit.outputs:
+            assert "{" not in output.path and "}" not in output.path
+
+    # A unit output can never carry an unresolved placeholder at all.
+    with pytest.raises(ValidationError, match="unresolved placeholder"):
+        PlanOutput(path_scope="app_bundle_root", path="modules/reports/ui/{page_id}.jsx")
+
+    # Deterministic gap emission independent of payload input ordering.
+    graph, payloads = _corpus_graph()
+    again = derive_compilation_plan(
+        graph=graph, payloads=list(reversed(payloads)), registry=_registry()
+    )
+    assert [g.model_dump(mode="json") for g in again.gaps] == [
+        g.model_dump(mode="json") for g in plan.gaps
+    ]
+
+
+def test_blocker3_cross_instance_physical_ownership_conflicts_fail() -> None:
+    plan = _plan()
+
+    # THE review attack: a page unit and a module unit both claim
+    # ui/pages/home.yaml in the app bundle root, with the document re-digested
+    # so the digest check cannot save us — physical ownership must.
+    document = _document(plan)
+    render_units = [
+        u for u in document["units"] if u["outputs"] and u["placeholder_values"]
+    ]
+    page_like = render_units[0]
+    module_like = next(
+        u
+        for u in render_units
+        if u["placeholder_values"] != page_like["placeholder_values"]
+    )
+    for victim in (page_like, module_like):
+        victim["outputs"] = [
+            {"path_scope": "app_bundle_root", "path": "ui/pages/home.yaml"}
+        ]
+    _redigest(document)
+    with pytest.raises(ValidationError, match="duplicate output ownership"):
+        CompilationPlan.model_validate(document)
+
+    # Duplicate unit identities cannot slip through a re-digested document.
+    document = _document(plan)
+    clone = copy.deepcopy(document["units"][0])
+    document["units"].append(clone)
+    _redigest(document)
+    with pytest.raises(ValidationError, match="duplicate unit identities"):
+        CompilationPlan.model_validate(document)
+
+    # Case-fold and prefix collisions across DIFFERENT units in one global root.
+    for second_path in ("UI/Pages/Home.YAML", "ui/pages/home.yaml/extra.txt"):
+        document = _document(plan)
+        units = [
+            u
+            for u in document["units"]
+            if u["outputs"] and u["outputs"][0]["path_scope"] == "app_bundle_root"
+        ]
+        units[0]["outputs"] = [
+            {"path_scope": "app_bundle_root", "path": "ui/pages/home.yaml"}
+        ]
+        units[1]["outputs"] = [{"path_scope": "app_bundle_root", "path": second_path}]
+        _redigest(document)
+        with pytest.raises(
+            ValidationError, match="output collision|duplicate output ownership"
+        ):
+            CompilationPlan.model_validate(document)
+
+    # Genuinely distinct instance roots remain valid: the same relative path
+    # under two different module instances is two physical destinations.
+    document = _document(plan)
+    module_units = [
+        u
+        for u in document["units"]
+        if u["outputs"] and u["outputs"][0]["path_scope"] == "module_relative"
+    ]
+    assert module_units, "corpus must produce module-relative units"
+    second = copy.deepcopy(module_units[0])
+    second["unit_id"] = second["unit_id"] + "-second"
+    second["placeholder_values"] = [["module_id", "second_module"]]
+    second["depends_on_units"] = []
+    document["units"].append(second)
+    _redigest(document)
+    validated = CompilationPlan.model_validate(document)
+    assert validated.plan_digest == document["plan_digest"]
+
+
+def test_blocker4_closed_domains_reject_runtime_identifier_smuggling() -> None:
+    plan = _plan()
+    hostile = "resume AG2 channel_id=chan-live envelope_id=env-live"
+
+    # Through a gap subject (the review's attack surface, now grammar-closed).
+    document = _document(plan)
+    document["gaps"][0]["subject"] = hostile
+    _redigest(document)
+    with pytest.raises(ValidationError, match="subject must be a lowercase identifier"):
+        CompilationPlan.model_validate(document)
+
+    # Through a unit materializer.
+    document = _document(plan)
+    document["units"][0]["materializer"] = hostile
+    _redigest(document)
+    with pytest.raises(
+        ValidationError, match="materializer must be a lowercase identifier"
+    ):
+        CompilationPlan.model_validate(document)
+
+    # Through a placeholder value.
+    document = _document(plan)
+    with_values = next(u for u in document["units"] if u["placeholder_values"])
+    with_values["placeholder_values"] = [["module_id", hostile]]
+    _redigest(document)
+    with pytest.raises(ValidationError, match="outside the closed domain"):
+        CompilationPlan.model_validate(document)
+
+    # Registration cold-validates: a forged in-memory object whose digest was
+    # re-computed over hostile content never registers.
+    resolver = SemanticReferenceResolver()
+    document = _document(plan)
+    document["gaps"][0]["subject"] = hostile
+    _redigest(document)
+    forged = CompilationPlan.model_construct(
+        **{
+            **{name: getattr(plan, name) for name in CompilationPlan.model_fields},
+            "gaps": tuple(
+                type(plan.gaps[0]).model_construct(**{**gap_fields, "subject": hostile})
+                if index == 0
+                else plan.gaps[index]
+                for index, gap_fields in enumerate(
+                    {name: getattr(gap, name) for name in type(gap).model_fields}
+                    for gap in plan.gaps
+                )
+            ),
+            "plan_digest": document["plan_digest"],
+        }
+    )
+    with pytest.raises(ReferenceResolutionError, match="cold validation"):
+        resolver.register_compilation_plan(forged)
+
+
+def test_blocker5_reverse_dependency_and_graph_wide_propagation() -> None:
+    from mozaiksai.core.semantics.compilation_plan import PlanSourceScope
+
+    def _mini_unit(
+        unit_id: str,
+        *,
+        source_digest: str | None,
+        deps: tuple[str, ...] = (),
+        graph_wide: bool = False,
+        path: str,
+    ) -> dict:
+        return {
+            "unit_id": unit_id,
+            "family_kind": "app_config",
+            "family_identity_digest": canonical_digest(unit_id),
+            "disposition": "render",
+            "source_scope": "graph_wide" if graph_wide else "declared",
+            "placeholder_values": [],
+            "outputs": [{"path_scope": "app_bundle_root", "path": path}],
+            "sources": (
+                []
+                if graph_wide or source_digest is None
+                else [{"node_id": "mozaiks.node.x", "payload_digest": source_digest}]
+            ),
+            "depends_on_units": list(deps),
+            "materializer": "app_generator",
+            "base_plan_digest": None,
+        }
+
+    def _mini_plan(graph_digest: str, units: list[dict]) -> CompilationPlan:
+        document = {
+            "schema_version": "mozaiks.compilation_plan.v1",
+            "graph_id": "mini",
+            "graph_version": 1,
+            "scope": _SCOPE.model_dump(mode="json"),
+            "graph_digest": graph_digest,
+            "registry_schema_version": "mozaiks.app_layout.v2",
+            "registry_digest": canonical_digest("registry"),
+            "units": units,
+            "gaps": [],
+        }
+        return CompilationPlan.model_validate(_redigest(document))
+
+    d1, d2 = canonical_digest("payload-1"), canonical_digest("payload-2")
+    g1, g2 = canonical_digest("graph-1"), canonical_digest("graph-2")
+
+    def _fleet(graph_digest: str, a_source: str, last: dict) -> CompilationPlan:
+        return _mini_plan(
+            graph_digest,
+            [
+                _mini_unit("a/1", source_digest=a_source, path="a.json"),
+                _mini_unit(
+                    "b/1",
+                    source_digest=canonical_digest("b"),
+                    deps=("a/1",),
+                    path="b.json",
+                ),
+                _mini_unit(
+                    "c/1",
+                    source_digest=canonical_digest("c"),
+                    deps=("b/1",),
+                    path="c.json",
+                ),
+                _mini_unit("g/1", source_digest=None, graph_wide=True, path="g.json"),
+                _mini_unit("z/1", source_digest=canonical_digest("z"), path="z.json"),
+                last,
+            ],
+        )
+
+    base = _fleet(
+        g1, d1, _mini_unit("gone/1", source_digest=canonical_digest("gone"), path="gone.json")
+    )
+    successor = _fleet(
+        g2, d2, _mini_unit("new/1", source_digest=canonical_digest("new"), path="new.json")
+    )
+    closure = plan_regeneration_closure(base, successor)
+    # Direct change, transitive reverse-dependency chain, and graph-wide unit
+    # are all affected; the independent unit is provably reusable.
+    assert set(closure.affected) == {"a/1", "b/1", "c/1", "g/1"}
+    assert closure.reusable == ("z/1",)
+    assert closure.added == ("new/1",)
+    assert closure.removed == ("gone/1",)
+
+    # Graph-only change (no payload change): exactly the graph-wide unit moves.
+    successor_graph_only = _fleet(
+        g2, d1, _mini_unit("gone/1", source_digest=canonical_digest("gone"), path="gone.json")
+    )
+    closure2 = plan_regeneration_closure(base, successor_graph_only)
+    assert set(closure2.affected) == {"g/1"}
+    assert set(closure2.reusable) == {"a/1", "b/1", "c/1", "z/1", "gone/1"}
+
+    # Real derivation cross-check: a graph-only change (extra edge, unchanged
+    # payloads) affects graph-wide units and leaves independent declared
+    # instance units reusable.
+    from mozaiksai.core.semantics.graph import (
+        SemanticEdge,
+        SemanticEdgeKind,
+        build_semantic_graph_v2,
+    )
+
+    graph, payloads = _corpus_graph()
+    surface = next(n for n in graph.nodes if n.kind.value == "surface")
+    module = next(n for n in graph.nodes if n.kind.value == "module")
+    extra_edge = SemanticEdge(
+        kind=SemanticEdgeKind.OWNS,
+        source_node_id=surface.node_id,
+        target_node_id=module.node_id,
+    )
+    changed_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=graph.scope,
+        nodes=graph.nodes,
+        edges=(*graph.edges, extra_edge),
+        namespace_grants=graph.namespace_grants,
+    )
+    base_plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    edge_plan = derive_compilation_plan(
+        graph=changed_graph, payloads=payloads, registry=_registry()
+    )
+    closure3 = plan_regeneration_closure(base_plan, edge_plan)
+    graph_wide_ids = {
+        u.unit_id for u in edge_plan.units if u.source_scope is PlanSourceScope.GRAPH_WIDE
+    }
+    assert graph_wide_ids <= set(closure3.affected)
+    independent_instance_ids = {
+        u.unit_id
+        for u in edge_plan.units
+        if u.source_scope is PlanSourceScope.DECLARED
+        and u.placeholder_values
+        and not u.depends_on_units
+        and u.disposition is PlanDisposition.RENDER
+    }
+    assert independent_instance_ids
+    assert independent_instance_ids & set(closure3.reusable) == independent_instance_ids

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -98,6 +98,10 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # It stays outside production imports itself (proven by the Slice 3
         # hygiene test scanning for offline_projection references).
         Path("mozaiksai/core/semantics/offline_projection.py"),
+        # Slice 4B: the aggregate CompilationPlan derives from graph v2 +
+        # payloads. It is offline-only; its own non-importability is proven
+        # by the hygiene scan in tests/test_compilation_plan.py.
+        Path("mozaiksai/core/semantics/compilation_plan.py"),
     }
 )
 _FORBIDDEN_PRODUCTION_MODULES = frozenset({"mozaiksai.core.semantics.payloads"})

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -279,6 +279,7 @@ def test_resolver_has_no_bare_id_lookup_surface() -> None:
     resolver = SemanticReferenceResolver()
     public = [name for name in dir(resolver) if not name.startswith("_")]
     assert set(public) == {
+        "register_compilation_plan",
         "register_semantic_graph",
         "register_semantic_graph_v2",
         "register_semantic_payload",
@@ -296,14 +297,14 @@ def test_resolver_has_no_bare_id_lookup_surface() -> None:
 def test_opaque_subjects_resolve_for_ref_only_kinds() -> None:
     resolver = SemanticReferenceResolver()
     resolver.register_opaque_subject(
-        kind=RefDocumentType.COMPILATION_PLAN,
-        subject_id="plan-1",
+        kind=RefDocumentType.BUILD_CONTEXT_BINDING,
+        subject_id="binding-ctx-1",
         version=1,
         digest=DIGEST,
         scope=SCOPE,
     )
-    ref = CompilationPlanRef(
-        subject_id="plan-1", subject_version=1, content_digest=DIGEST, scope=SCOPE
+    ref = BuildContextBindingRef(
+        subject_id="binding-ctx-1", subject_version=1, content_digest=DIGEST, scope=SCOPE
     )
     assert resolver.resolve(ref, requesting_scope=SCOPE) is None
 
@@ -324,7 +325,7 @@ def test_opaque_registration_validates_immutable_identity() -> None:
     resolver = SemanticReferenceResolver()
     with pytest.raises(pydantic.ValidationError, match="mutable alias"):
         resolver.register_opaque_subject(
-            kind=RefDocumentType.COMPILATION_PLAN,
+            kind=RefDocumentType.BUILD_CONTEXT_BINDING,
             subject_id="latest",
             version=1,
             digest=DIGEST,
@@ -332,7 +333,7 @@ def test_opaque_registration_validates_immutable_identity() -> None:
         )
     with pytest.raises(pydantic.ValidationError, match="greater than or equal to 1"):
         resolver.register_opaque_subject(
-            kind=RefDocumentType.COMPILATION_PLAN,
+            kind=RefDocumentType.BUILD_CONTEXT_BINDING,
             subject_id="plan-1",
             version=0,
             digest=DIGEST,
@@ -340,7 +341,7 @@ def test_opaque_registration_validates_immutable_identity() -> None:
         )
     with pytest.raises(pydantic.ValidationError, match="lowercase hex"):
         resolver.register_opaque_subject(
-            kind=RefDocumentType.COMPILATION_PLAN,
+            kind=RefDocumentType.BUILD_CONTEXT_BINDING,
             subject_id="plan-1",
             version=1,
             digest="Z" * 64,
@@ -449,7 +450,7 @@ def test_child_contract_document_type_substitution_fails_closed() -> None:
         canonical_relative_path="modules/users/module.yaml",
         contract_schema_version="mozaiks.module.v1",
     )
-    substituted = CompilationPlanRef(
+    substituted = BuildContextBindingRef(
         subject_id="child-1", subject_version=1, content_digest=DIGEST, scope=SCOPE
     )
     with pytest.raises(ReferenceResolutionError, match="document type mismatch"):
@@ -507,8 +508,8 @@ def test_non_child_registration_rejects_child_identity_fields(field: str, value:
     resolver = SemanticReferenceResolver()
     with pytest.raises(ReferenceResolutionError, match="only for child contracts"):
         resolver.register_opaque_subject(
-            kind=RefDocumentType.COMPILATION_PLAN,
-            subject_id="plan-1",
+            kind=RefDocumentType.BUILD_CONTEXT_BINDING,
+            subject_id="binding-ctx-1",
             version=1,
             digest=DIGEST,
             scope=SCOPE,


### PR DESCRIPTION
## Summary

Implements **ADR 0007 Slice 4B**: one deterministic, aggregate, authoritative `CompilationPlan` per immutable graph identity, derived **solely** from validated `SemanticGraphV2` + typed payload closure + the sole `layout_registry`. **Offline-only** per the ADR rollout row: the agent-produced `AppBuildPlan` remains the sole active operational plan, no production code consumes the new contract, no capability is advertised, no renderer executes, no AG2 import exists, and no model ran.

Base: `11daf2fa` (main = the Slice 3E squash).

## Stage A — vision checkpoint (performed first, evidence-backed)

Traced Genesis Build / Refinement Run end to end at current main. **Verdict: 4B is the precise missing bridge.** Key evidence:

- **Planning authorities today**: `AppBuildPlan` is the only authoritative plan — YAML structured output with no Python class, held in context variables only, never persisted, silently dropping `surface_map`/`workflow_touchpoints` at normalization; enforced solely through `task_batches` owned-paths. `AppSchemaOutput` is an embedded authoritative UI-family sub-plan (`save_app_schema` path tables); `file_contracts.yaml` and `generation_order` are advisory prompt text.
- **Materialization** is agent-file-map-driven (`files_map` keys from agent `code_files`), with the layout registry consulted only **post-hoc** for validation classification. `ordered_families()`, `dependency_families`, and `allowed_stub_kinds` had **zero production consumers** before this slice's offline consumer.
- **Lineage** pins record IDs (`canonical_inputs_version`), not content digests; `ArtifactRevision` lacks `compilation_plan_digest` (cutover-slice work, untouched here).
- **Refinement impact** is keyword/path heuristics (`refinement_router`, `dry_run`) with mixed granularity and no complete family disposition — omission is implicit preservation today, which the ADR forbids.
- **`plan_assignment_compiler.py`** is an already-built, *unwired* deterministic plan→assignment compiler — the natural consumer of plan projections at cutover. This slice does **not** duplicate or wire it (its tests still pass unmodified).
- **Genesis/Refinement unification**: one lineage, one artifact chain; a Genesis Build is the degenerate all-`render` disposition; a Refinement Run mixes `render`/`reuse-from-base`/`preserve-unowned` against a base plan.

Product invariant held: dynamic intelligence (AG2 agents authoring semantics upstream) producing deterministic application contracts (this plan) — no agent framework surface, no AG2 mechanics duplicated.

## Stage B — what's in it

**`mozaiksai/core/semantics/compilation_plan.py` (new)** — `mozaiks.compilation_plan.v1`:

- **Identity**: pins the graph quartet (`graph_id`, `graph_version`, `scope`, `graph_digest`) + registry (`schema_version`, self-verified `registry_digest`); every family row pins through its `identity_payload` digest. `plan_digest` closes the whole document (canonical serializer — payload → graph → plan Merkle chain proven by test).
- **Inputs are cold-revalidated** (2E review standard): forged `model_copy`/`model_construct` graphs and substituted payloads fail before derivation.
- **Embedded `FamilyInstancePlan` subdocuments** are non-authoritative: no document type names them, no resolver surface accepts them, no self-digest lets them stand alone (adversarial tests).
- **Complete dispositions**: every registry row → unit(s) (`render` / `external_handoff` for deployment-derived rows / `inapplicable` incl. prohibited rows as explicit units) **or** typed `PlanGap`. Eight conditions derive from graph semantics (module/page/workflow/data/plan/deployment declarations, app, always); the six binding/operator conditions (`when_auth_enabled`, custom routes, refinement harness, managed capabilities, staging, extensions) and renderer resolution are explicit gaps deferred to the binding slice — the plan **never invents a semantic fact** and never silently omits.
- **Instances**: MANY-multiplicity families instantiate per semantic node; placeholder values derive deterministically from node local identity; output paths validate through the Slice 4A portable profile with **global per-scope-instance ownership** — duplicate, case-fold, and file/dir-prefix collisions fail closed. Registry-declared `materializer` identifiers are carried as declarations (not resolved renderers — `FamilyInstancePlan` has no renderer field to claim one).
- **Dependency DAG**: unit dependencies instantiate the registry's `dependency_families` (same-instance when the placeholder is shared, else all units of the dependency kind); plan ordering follows `ordered_families()`'s dependency-respecting total order (asserted: no unit precedes its dependency); forged documents with cycles or self-dependencies are rejected by an iterative DFS validator.
- **Refinement without cutover**: `plan_regeneration_closure(base, successor)` is a pure function partitioning every unit into affected / reusable / added / removed by source payload-digest comparison — proven to identify exactly the units sourcing a changed payload, with nothing omitted, while production refinement authority is untouched.
- **Resolver**: `COMPILATION_PLAN` becomes content-bearing (`register_compilation_plan` with cold revalidation; opaque registration now refuses it). The ref-only roster examples in the reference-contract tests moved to `BuildContextBindingRef` — the only pre-existing test file changed.
- **Layering**: the semantics module does **not** import the runtime registry (the registry arrives as a parameter and pins itself via digest); no AG2 imports; hygiene test proves no production file references `compilation_plan`.

## Correction round — five material defects from the independent review (all fixed)

Codex 1 reviewed exact head `295fde2a` and returned five blocking findings. Each is corrected at the contract level (never patched around) with a regression test reproducing the exact attack:

1. **Registry identity was not pinned** — derivation trusted a duck-typed registry's claimed digest. Now: a typed `LayoutRegistrySnapshot` recomputes its identity from the canonical row content actually consumed (closed row domains, internal-consistency checks: unknown/self/dep-order violations and duplicate rows fail); the plan pins the **recomputed** snapshot digest and each unit pins its snapshot **row digest**. Proven: two registries with one claimed digest but different rows yield different plan identities; a snapshot retaining its digest over a changed row fails; out-of-domain and inconsistent registries are rejected. No parallel authority: the snapshot declares nothing — it is a validated projection of the one registry.
2. **Multi-placeholder templates leaked unresolved paths** — the registry really carries rows like `modules/{module_id}/ui/admin/{page_id}.jsx`. Now: expansion is generic — the binding set is all template placeholders plus the scope-implied instance placeholder (`module_relative`/`workflow_relative` roots are instances even when the template doesn't spell it); more than one bindable kind → typed `placeholder_relationship_unprovable` gap (no relationship is ever invented); unbindable names → `placeholder_underivable` gap; and `PlanOutput` **structurally rejects any `{`/`}`**, so a validated unit cannot exist with an unresolved placeholder. Proven over every real multi-placeholder row plus input-order-independent gap emission.
3. **Cross-instance output collisions passed** — collision domains were keyed by placeholder tuple. Now: domains model **physical destination roots** — global scopes (app bundle, workspace, deployment, staging) are one domain regardless of semantic instance; instance-relative scopes require an explicit instance identity (a relative-scoped output without one is invalid). Exact, case-fold, and prefix collisions are checked across every unit per domain, duplicate unit ids are rejected both at derivation (before any dict insertion) and at cold validation. Proven with the exact re-digested page-unit/module-unit `ui/pages/home.yaml` forgery, duplicate-id forgery, case-fold and prefix forgeries — and the legitimate case (same relative path under two module instances) still validates.
4. **Free-form strings could smuggle runtime state** — `PlanGap.reason` prose is **gone**; gaps carry a closed `PlanGapCode` enum plus a grammar-validated `subject`. Every authoritative string field now obeys a closed domain (lowercase identifier grammar for family kinds, materializers, path scopes, placeholder names/values, unit-id segments; dotted grammar for schema versions; portable+brace-free paths). The document is structurally incapable of carrying `resume AG2 channel_id=…`-style content anywhere — proven by re-digested forgeries through gap subject, materializer, and placeholder value, and by `register_compilation_plan` cold-validating a forged in-memory object. No token-scanning; no AG2 integration.
5. **Refinement closure silently reused downstream artifacts** — graph-wide dependency is now explicit (`source_scope: declared|graph_wide`; a graph-wide unit may not fake an empty footprint), the reuse signature covers every render-relevant identity input (row digest, disposition, outputs, placeholders, materializer, sources, dependency set, and the graph digest for graph-wide units), and affectedness **propagates through the reverse dependency DAG to a fixed point** — dependents of affected units can never remain reusable. The partition (affected/reusable/added/removed) is complete, overlap-free, and verified. Proven: direct change → transitive chain affected; graph-only change (extra edge, unchanged payloads) affects exactly graph-wide units in the synthetic fleet and all graph-wide units in the real derivation while independent instance units stay reusable; added/removed handled.

Post-correction architecture check: still offline, deterministic, provider-neutral, zero AG2 imports, no live runtime identifiers, no advertisement, no renderer execution, no cutover, no generator/runtime wiring, no parallel registries, no metadata dicts, no duplicate compiler; `AppBuildPlan` untouched; the Slice 5 binding map stays documentation-only. New golden plan digest `19a296c2…` (cross-process pinned).

## Amended boundary — no live runtime identifiers (design-review addition)

AG2 Network owns live agent identity, channels, envelopes, channel WAL, turn order, expectations, task observation, reconnect replay, and distributed agent communication. Slice 4B stays offline, provider-neutral, and zero-AG2-imports — and the plan **cannot contain or derive** AG2 agent/Passport IDs, channel IDs, envelope IDs, hub connection state, inbox/WAL state, live model assignments, delivery/retry/reconnect state, or task-checkpoint locations. This is enforced structurally (every model is `extra=forbid` with a closed field set of digests, portable paths, node identities, and registry declarations) and proven by a dedicated test that pins the exact field universe of all six plan models, scans field names and module source for runtime-identifier tokens, and asserts the derived plan's canonical-payload **key universe** is closed — untyped keys cannot smuggle live identifiers. Execution needs appear only as provider-neutral deterministic requirements (registry `materializer` declarations, dependency order, dispositions) for the later binding.

### Slice 5 future-binding map (recorded, deliberately NOT implemented here)

| Mozaiks contract (this slice and earlier) | Slice 5 binding target |
|---|---|
| Workflow identities (`WORKFLOW` nodes, `workflow_id` placeholder instances) | AG2 agent/network identities |
| Mozaiks workflow transitions (`transition_graph.yaml` contracts) | AG2 `WorkflowAdapter` / `TransitionGraph` |
| Closed Mozaiks capability taxonomy (Slice 1 grammar + registry) | Validated AG2 capability tags — free-form AG2 capability strings never replace the closed taxonomy |
| Server-owned tenant scope (`ExecutionAccessScopeRef` pinned in graph and plan) | AG2 Passport ownership — never accepted from untrusted envelope payloads |
| Compilation units (`FamilyInstancePlan`) | Runtime tasks via the existing assignment/task-batch projections, without embedding live runtime IDs in the plan |

## Proof gate (tests/test_compilation_plan.py, 31 tests)

Identity + byte-identical rederivation · input-order-independent ordering with dependency-respecting positions · **pinned golden plan digest `19a296c2…` + cross-process equality** · input immutability · forged-graph and substituted-payload rejection · scope/version substitution yields distinct plans and refuses cross-lineage closure · forged documents: missing/extra units, duplicate output ownership, case-fold + prefix collisions, dependency cycles and self-dependency, stale digests — all fail closed · completeness over **every** registry row (disposed-or-gapped) · binding conditions as typed gaps (dynamically derived from the registry's actual condition set) · unknown/novel family condition → typed gap · renderer non-resolution asserted structurally · disposition vocabulary complete, deployment rows external-handoff · digest propagation + regeneration closure partition proofs · reuse-from-base digest pinning rules · per-instance output traceability to node/payload identities · family-plan non-authority (no ref type, no independent registration, aggregate-only resolution, forged plan refused) · no production imports / no advertisement / no AG2.

**Bounded derived-vs-produced bridge**: the recorded agent-produced `AppBuildPlan` fixture's `owned_paths` classify through `registry.match_path`, and every classified family is disposed-or-gapped by the derived plan (family-level coverage; instance-level equivalence on the archetype corpus is cutover-gate work, per the ADR's no-dual-authority discipline).

## Validation

Focused battery **674 passed** (4B 25 · 2E 82 · 3E projection 44 · reference contracts 106 with the roster update · graph/portable/taxonomy/canonical/manifest suites · layout registry+validation · `plan_assignment_compiler` unmodified · readiness gates) · full local suite **14,213 passed, 0 failed**, re-verified across the four exact CI shard partitions after the re-shard caused by the new test file (3693/3553/3483/3484, no latent order-dependent pair woke) · `ruff check .` clean · `mypy mozaiksai/core/semantics/` clean (13 files) · `git diff --check` clean · DCO signed.

## Scope confirmation

Untouched: `AppBuildPlan` and every generator/workflow (Stage A read-only), `task_batches.py`, `plan_assignment_compiler.py`, renderers/materialization, `layout_registry` itself, `ArtifactRevision`/promotion, refinement router/dry-run, `capabilities.py` (still `()`), archive/ZIP (no authority), issues #426 remainder, MatrAIx, 4C/Slice 5. No compatibility shims, no parallel registries, no metadata dicts, no duplicate compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
