### PR TITLE
feat(runtime): wire durable workflow admission (issue #426 sub-slice B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Durable workflow execution admission is now wired (issue #426, sub-slice B)**:
+  persisted and production hosts record immutable tenant/workspace/app/chat/
+  workflow/run/operation identity in MongoDB before mutable session, WAL, AG2,
+  model, or tool execution. Exact replay returns the recorded outcome instead
+  of starting a second run; claims renew and complete only for their current
+  holder, authority and index failures fail closed, and bounded retry/dead-letter
+  states stay distinct. Expired claims may be recovered only before execution
+  starts; once side effects are possible, replay dead-letters rather than
+  re-spending tokens without an idempotency proof. Explicit `local` mode remains
+  available as a clearly non-durable single-process boundary. The existing chat
+  execution lease remains the per-chat mutation authority after admission.
+
 - **Distributed same-chat exclusion is now enforced (issue #426, sub-slice A)**:
   the MongoDB chat lock at
   `mozaiksai/core/runtime/persistence/distributed_lock.py` — previously dead

--- a/docs/architecture/workflows/execution-admission.md
+++ b/docs/architecture/workflows/execution-admission.md
@@ -1,0 +1,45 @@
+# Workflow Execution Admission
+
+Production workflow execution has two ordered authorities:
+
+1. Mongo workflow admission owns immutable run-turn identity, cross-process
+   claim ownership, bounded attempts, and terminal outcome replay.
+2. The chat execution lease owns mutable `(app_id, chat_id)` session, WAL, UI,
+   pending-input, AG2 stream, and AG2 Network knowledge writes for the admitted
+   execution.
+
+The canonical execution funnel is
+`SimpleTransport.handle_user_input_from_api`. HTTP input, WebSocket user turns,
+host auto-start, workflow start/switch/batch handlers, journey spawns, live AG2
+Network continuation, Genesis Build, and Refinement Run launches converge on
+that funnel before AG2 runs. Task-batch concurrency remains internal to the
+already-admitted AG2 execution. Read-only reconnect/history replay does not
+claim admission or the chat execution lease.
+
+The Mongo queue stores tenant, workspace, app, chat, workflow, run, operation,
+and user identity plus the admitted request digest as immutable top-level
+fields. Payload data is not identity authority. Reusing an operation id with
+changed request content is rejected. A deterministic admission id makes concurrent identical producers
+converge on one record. The ingress instance uses a targeted atomic claim so
+the process that owns the live WebSocket also owns UI delivery; the previously
+documented autonomous global poller did not exist and is not introduced here.
+
+Claim renewal is holder-scoped. Completion, failure, and dead-letter transitions
+require the current claim token, so a stale release cannot affect a successor.
+An expired claim is reclaimable only while `execution_started_at` is absent.
+Once execution starts, an expired claim is terminally dead-lettered on replay;
+automatic rerun would otherwise risk repeating an externally visible model or
+tool side effect without an idempotency proof.
+
+`required` mode is selected whenever database persistence is enabled and fails
+startup or execution closed if Mongo or required indexes cannot be verified.
+`local` mode is explicit, process-local, and non-durable. The existing local
+semaphore remains only a resource throttle.
+
+Current exclusions are intentional: no cancellation endpoint, orphan adoption
+or reconciliation, storage-level fencing token, token reservation, workflow
+rewrite, or AG2 replacement is part of this slice. Process-local cancellation
+currently has no production API caller. A crash before the execution-started
+marker is safely reclaimable; a crash after it remains dead-lettered for the
+later orphan-reconciliation lane rather than being silently rerun. Existing
+`IN_PROGRESS` session records are not adopted by this slice.

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -14,7 +14,7 @@ How to scale Mozaiks horizontally to handle higher workflow concurrency and user
 
 All runtime instances share:
 - **MongoDB** — all session state, chat history, artifacts, audit logs
-- **Redis** (optional) — JWKS cache, app context cache, workflow queue
+- **Redis** (optional) — JWKS cache and app context cache
 - **Object store** (optional) — large artifact blobs (S3/MinIO)
 
 Each instance is stateless — any instance can serve any request.
@@ -26,24 +26,32 @@ must reconnect if instance A restarts. This is handled automatically by the chat
 
 ## Workflow Concurrency
 
-### Per-instance (default)
+### Explicit local mode
 
 ```bash
 MOZAIKS_MAX_PARALLEL_WORKFLOWS=4  # per-instance concurrency limit
+MOZAIKS_WORKFLOW_ADMISSION_MODE=local
 ```
 
-With 4 instances: up to 16 concurrent workflows globally (no coordination).
+Local mode is single-process and non-durable. Do not use it as a horizontal
+execution-safety boundary.
 
-### Global queue (recommended for production)
+### Durable admission (required for persisted/production hosts)
 
-Enable MongoDB-backed global queue:
+Persisted and production hosts resolve this mode automatically. It can also be
+selected explicitly:
 
 ```bash
-WORKFLOW_QUEUE_BACKEND=mongo
-WORKFLOW_QUEUE_MAX_CONCURRENCY=20  # global limit across all instances
+MOZAIKS_WORKFLOW_ADMISSION_MODE=required
 ```
 
-This ensures fair scheduling regardless of how many instances are running.
+MongoDB records immutable admission identity before mutable workflow execution,
+atomically rejects duplicate consumers, renews holder-scoped claims, and fails
+closed when the queue or its required indexes cannot be verified. The ingress
+instance claims its own item because WebSocket delivery remains instance-sticky;
+there is no autonomous cross-instance polling or orphan adoption in this slice.
+`MOZAIKS_MAX_PARALLEL_WORKFLOWS` remains a per-process resource throttle and is
+not the durable admission authority.
 
 ---
 

--- a/mozaiksai/core/data/persistence/namespaces.py
+++ b/mozaiksai/core/data/persistence/namespaces.py
@@ -26,6 +26,7 @@ class RuntimeCollections:
     RUNTIME_TOKEN_WALLET_BALANCES = "RuntimeTokenWalletBalances"
     RUNTIME_TOKEN_WALLET_ENTRIES = "RuntimeTokenWalletEntries"
     RUNTIME_BILLING_FULFILLMENT_COMMANDS = "RuntimeBillingFulfillmentCommands"
+    WORKFLOW_QUEUE = "WorkflowQueue"
 
 
 class BuilderCollections:
@@ -53,4 +54,3 @@ __all__ = [
     "BuilderCollections",
     "PlatformCollections",
 ]
-

--- a/mozaiksai/core/runtime/execution_admission.py
+++ b/mozaiksai/core/runtime/execution_admission.py
@@ -1,0 +1,260 @@
+"""Durable workflow execution admission ahead of chat mutation and AG2.
+
+Mongo owns immutable admission, cross-process claim ownership, bounded retry
+state, and terminal replay. The existing chat execution lease remains the
+per-chat mutation authority inside the admitted callback. Local mode is an
+explicit single-process, non-durable boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from mozaiksai.core.workflow.queue import (
+    MongoWorkflowQueue,
+    QueueAuthorityUnavailableError,
+    QueueIdentityConflictError,
+    QueueItem,
+    QueueItemStatus,
+    WorkflowAdmissionMode,
+    canonical_admission_id,
+    get_workflow_admission_mode,
+    get_workflow_queue,
+)
+
+
+class WorkflowAdmissionBusyError(RuntimeError):
+    """Another consumer currently owns this execution admission."""
+
+
+class WorkflowAdmissionRejectedError(RuntimeError):
+    """The durable admission is terminal and cannot be executed."""
+
+
+class WorkflowAdmissionExpiredError(RuntimeError):
+    """A started claim expired and was refused automatic replay."""
+
+
+class WorkflowAdmissionDeadLetterError(RuntimeError):
+    """The admission already reached the durable dead-letter state."""
+
+
+class WorkflowClaimLostError(RuntimeError):
+    """The active consumer lost its renewable Mongo claim."""
+
+
+@dataclass(frozen=True)
+class WorkflowAdmissionRequest:
+    tenant_id: str
+    workspace_id: str
+    app_id: str
+    chat_id: str
+    workflow_name: str
+    run_id: str
+    operation_id: str
+    request_digest: str
+    user_id: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in (
+            "tenant_id",
+            "workspace_id",
+            "app_id",
+            "chat_id",
+            "workflow_name",
+            "run_id",
+            "operation_id",
+            "request_digest",
+        ):
+            if not str(getattr(self, name) or "").strip():
+                raise ValueError(f"{name} is required for workflow admission")
+
+    @property
+    def admission_id(self) -> str:
+        return canonical_admission_id(
+            tenant_id=self.tenant_id,
+            workspace_id=self.workspace_id,
+            app_id=self.app_id,
+            chat_id=self.chat_id,
+            workflow_name=self.workflow_name,
+            run_id=self.run_id,
+            operation_id=self.operation_id,
+        )
+
+
+_local_locks: dict[str, asyncio.Lock] = {}
+_local_request_digests: dict[str, str] = {}
+_local_results: dict[str, dict[str, Any]] = {}
+_local_semaphore = asyncio.Semaphore(
+    max(1, int(os.getenv("MOZAIKS_MAX_PARALLEL_WORKFLOWS", "4")))
+)
+
+
+def _worker_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid4()}"
+
+
+async def _run_local(
+    request: WorkflowAdmissionRequest,
+    execute: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    lock = _local_locks.setdefault(request.admission_id, asyncio.Lock())
+    async with lock:
+        previous_digest = _local_request_digests.get(request.admission_id)
+        if previous_digest is not None and previous_digest != request.request_digest:
+            raise QueueIdentityConflictError(
+                f"local admission identity conflict for {request.admission_id}"
+            )
+        if request.admission_id in _local_results:
+            return dict(_local_results[request.admission_id])
+        _local_request_digests[request.admission_id] = request.request_digest
+        async with _local_semaphore:
+            result = await execute()
+        _local_results[request.admission_id] = dict(result)
+        return result
+
+
+async def execute_with_workflow_admission(
+    request: WorkflowAdmissionRequest,
+    execute: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Execute exactly once per immutable admission identity.
+
+    Automatic claim recovery is permitted only before ``execution_started_at``.
+    A crash after that marker is terminally dead-lettered on replay so Mozaiks
+    never re-spends model tokens or repeats a tool/external side effect without
+    an independent idempotency proof.
+    """
+    if get_workflow_admission_mode() is WorkflowAdmissionMode.LOCAL:
+        return await _run_local(request, execute)
+
+    queue = get_workflow_queue()
+    if not isinstance(queue, MongoWorkflowQueue):
+        raise QueueAuthorityUnavailableError("required workflow admission is not Mongo-backed")
+
+    item = QueueItem(
+        item_id=request.admission_id,
+        tenant_id=request.tenant_id,
+        workspace_id=request.workspace_id,
+        app_id=request.app_id,
+        chat_id=request.chat_id,
+        workflow_name=request.workflow_name,
+        run_id=request.run_id,
+        operation_id=request.operation_id,
+        request_digest=request.request_digest,
+        user_id=request.user_id,
+        payload={},
+    )
+    await queue.enqueue(item, max_attempts=3)
+    claim = await queue.claim_item(request.admission_id, _worker_id())
+    if not claim.claimed or not claim.claim_token:
+        await queue.dead_letter_exhausted(request.admission_id)
+        current = await queue.get(request.admission_id)
+        if current is None:
+            raise QueueAuthorityUnavailableError("durable admission disappeared after enqueue")
+        if current.status is QueueItemStatus.COMPLETED:
+            return dict(current.completed_result or {})
+        if current.status is QueueItemStatus.DEAD_LETTER:
+            raise WorkflowAdmissionDeadLetterError(current.error_category or "dead_letter")
+        if (
+            current.status is QueueItemStatus.CLAIMED
+            and current.execution_started_at is not None
+            and await queue.dead_letter_expired_started(request.admission_id)
+        ):
+            raise WorkflowAdmissionExpiredError("expired_after_execution_started")
+        raise WorkflowAdmissionBusyError(request.admission_id)
+
+    claim_token = claim.claim_token
+    lease_seconds = max(10, int(os.getenv("WORKFLOW_QUEUE_LEASE_SECONDS", "300")))
+    owner = asyncio.current_task()
+    lost = asyncio.Event()
+
+    async def _renew() -> None:
+        try:
+            while True:
+                await asyncio.sleep(max(1.0, lease_seconds / 3))
+                if not await queue.renew_lease(
+                    request.admission_id,
+                    claim_token=claim_token,
+                    extend_seconds=lease_seconds,
+                ):
+                    lost.set()
+                    if owner is not None:
+                        owner.cancel()
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            lost.set()
+            if owner is not None:
+                owner.cancel()
+
+    renewal = asyncio.create_task(_renew(), name=f"workflow-admission-renew:{request.admission_id}")
+    started = False
+    try:
+        started = await queue.mark_execution_started(
+            request.admission_id,
+            claim_token=claim_token,
+        )
+        if not started:
+            raise WorkflowClaimLostError(request.admission_id)
+        result = await execute()
+        if lost.is_set():
+            raise WorkflowClaimLostError(request.admission_id)
+        if not await queue.complete(
+            request.admission_id,
+            claim_token=claim_token,
+            result=result,
+        ):
+            raise WorkflowClaimLostError(request.admission_id)
+        return result
+    except asyncio.CancelledError as exc:
+        if lost.is_set():
+            raise WorkflowClaimLostError(request.admission_id) from exc
+        raise
+    except WorkflowClaimLostError:
+        raise
+    except Exception:
+        if started:
+            with contextlib.suppress(Exception):
+                await queue.dead_letter(
+                    request.admission_id,
+                    claim_token=claim_token,
+                    error_category="execution_failed_after_start",
+                )
+        else:
+            with contextlib.suppress(Exception):
+                await queue.fail(
+                    request.admission_id,
+                    claim_token=claim_token,
+                    error_category="admission_failed_before_start",
+                )
+        raise
+    finally:
+        renewal.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await renewal
+
+
+def reset_local_workflow_admission() -> None:
+    _local_locks.clear()
+    _local_request_digests.clear()
+    _local_results.clear()
+
+
+__all__ = [
+    "WorkflowAdmissionBusyError",
+    "WorkflowAdmissionDeadLetterError",
+    "WorkflowAdmissionExpiredError",
+    "WorkflowAdmissionRejectedError",
+    "WorkflowAdmissionRequest",
+    "WorkflowClaimLostError",
+    "execute_with_workflow_admission",
+    "reset_local_workflow_admission",
+]

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -1552,6 +1552,8 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         ws_id: int | None = None,
         token_exp: int = 0,
         suppress_history_replay: bool = False,
+        tenant_id: str | None = None,
+        workspace_id: str | None = None,
     ) -> None:
         """Handle WebSocket connection for real-time communication with multi-workflow session support"""
         if self._owner_loop is None:
@@ -1615,6 +1617,8 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
             "user_id": user_id,
             "workflow_name": workflow_name,
             "app_id": app_id,
+            "tenant_id": tenant_id,
+            "workspace_id": workspace_id,
             "active": True,
             "ws_id": ws_id,  # Track WebSocket ID for session switching
             "token_exp": token_exp,  # JWT expiry (unix epoch); 0 means no expiry check

--- a/mozaiksai/core/transport/workflow_bridge.py
+++ b/mozaiksai/core/transport/workflow_bridge.py
@@ -18,6 +18,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -223,6 +224,99 @@ class WorkflowBridgeMixin:
         return updated
 
     async def handle_user_input_from_api(
+        self,
+        chat_id: str,
+        user_id: str | None,
+        workflow_name: str,
+        message: str | None,
+        app_id: str,
+        initial_agent_name_override: str | None = None,
+        *,
+        tenant_id: str | None = None,
+        workspace_id: str | None = None,
+        operation_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Admit one immutable execution turn before any mutable run work."""
+        from mozaiksai.core.runtime.execution_admission import (
+            WorkflowAdmissionBusyError,
+            WorkflowAdmissionDeadLetterError,
+            WorkflowAdmissionExpiredError,
+            WorkflowAdmissionRejectedError,
+            WorkflowAdmissionRequest,
+            WorkflowClaimLostError,
+            execute_with_workflow_admission,
+        )
+        from mozaiksai.core.workflow.queue import (
+            QueueAuthorityUnavailableError,
+            QueueIdentityConflictError,
+        )
+
+        get_conn_meta = getattr(self, "_get_conn_meta", None)
+        conn = get_conn_meta(chat_id) if callable(get_conn_meta) else {}
+        trusted_tenant = str(tenant_id or conn.get("tenant_id") or app_id)
+        trusted_workspace = str(workspace_id or conn.get("workspace_id") or app_id)
+        resolved_operation = str(operation_id or "").strip()
+        if not resolved_operation:
+            pm = self._get_or_create_persistence_manager()
+            get_version = getattr(pm, "get_session_version", None)
+            version = await get_version(chat_id, app_id) if callable(get_version) else 0
+            message_digest = hashlib.sha256(str(message or "").encode()).hexdigest()
+            resolved_operation = (
+                f"turn:{int(version or 0)}:{message_digest}:"
+                f"{str(initial_agent_name_override or '')}"
+            )
+
+        request = WorkflowAdmissionRequest(
+            tenant_id=trusted_tenant,
+            workspace_id=trusted_workspace,
+            app_id=app_id,
+            chat_id=chat_id,
+            workflow_name=workflow_name,
+            run_id=chat_id,
+            operation_id=resolved_operation,
+            request_digest=hashlib.sha256(
+                (
+                    f"message={str(message or '')}\n"
+                    f"initial_agent={str(initial_agent_name_override or '')}"
+                ).encode()
+            ).hexdigest(),
+            user_id=user_id,
+        )
+
+        async def _execute() -> dict[str, Any]:
+            return await self._handle_user_input_after_admission(
+                chat_id=chat_id,
+                user_id=user_id,
+                workflow_name=workflow_name,
+                message=message,
+                app_id=app_id,
+                initial_agent_name_override=initial_agent_name_override,
+            )
+
+        try:
+            return await execute_with_workflow_admission(request, _execute)
+        except WorkflowAdmissionBusyError:
+            code, route, status = "WORKFLOW_QUEUE_BUSY", "queue_busy", "busy"
+            detail = "This execution is already admitted elsewhere."
+        except QueueAuthorityUnavailableError:
+            code, route, status = "WORKFLOW_QUEUE_UNAVAILABLE", "queue_unavailable", "error"
+            detail = "Workflow admission authority is unavailable."
+        except (WorkflowAdmissionRejectedError, QueueIdentityConflictError):
+            code, route, status = "WORKFLOW_QUEUE_REJECTED", "queue_rejected", "error"
+            detail = "This execution admission cannot be replayed."
+        except WorkflowAdmissionExpiredError:
+            code, route, status = "WORKFLOW_QUEUE_EXPIRED", "queue_expired", "error"
+            detail = "A prior execution claim expired after execution started."
+        except WorkflowAdmissionDeadLetterError:
+            code, route, status = "WORKFLOW_QUEUE_DEAD_LETTER", "queue_dead_letter", "error"
+            detail = "This execution admission is dead-lettered."
+        except WorkflowClaimLostError:
+            code, route, status = "WORKFLOW_QUEUE_CLAIM_LOST", "queue_claim_lost", "error"
+            detail = "Workflow execution ownership was lost."
+        await self.send_error(error_message=detail, error_code=code, chat_id=chat_id)
+        return {"status": status, "chat_id": chat_id, "message": detail, "route": route}
+
+    async def _handle_user_input_after_admission(
         self,
         chat_id: str,
         user_id: str | None,

--- a/mozaiksai/core/workflow/queue.py
+++ b/mozaiksai/core/workflow/queue.py
@@ -3,9 +3,9 @@
 # DESCRIPTION: Durable global workflow queue with crash-safe leases, fencing,
 #              bounded retries, and dead-letter state.
 #
-#              Replaces per-instance concurrency limits with a globally fair
-#              scheduler. Workflow runs are enqueued and dequeued by workers
-#              on any instance, respecting the global concurrency limit.
+#              Production ingress uses targeted claims so the instance that
+#              owns the live transport also owns execution. The process-local
+#              semaphore remains a resource throttle, not admission authority.
 #
 # State Machine
 # -------------
@@ -22,9 +22,11 @@
 #
 # Delivery Guarantee
 # ------------------
-# Lease-based at-least-once processing with fenced completion.
+# Lease-based processing with holder-scoped completion. Automatic recovery is
+# allowed only before execution_started_at. An expired started claim is
+# dead-lettered rather than replayed without a side-effect idempotency proof.
 #
-# Each claim receives a unique ``claim_token`` (fencing token). ``complete()``
+# Each claim receives a unique holder token. ``complete()``
 # and ``fail()`` only succeed for the current claim_token holder.  A stale
 # worker whose lease expired cannot complete or fail the newer attempt.
 #
@@ -46,20 +48,20 @@
 # to enable TTL-based retention cleanup.  Active work (PENDING, CLAIMED,
 # RETRYABLE) has ``expires_at=None`` and is never deleted by the TTL sweeper.
 #
-# Backends:
-#   MongoWorkflowQueue  -- MongoDB collection (default, no extra infra)
-#   NoOpWorkflowQueue   -- preserves per-instance semaphore behavior (no durability)
+# Modes:
+#   required -- MongoDB is authoritative and failures close admission
+#   local    -- explicit single-process, non-durable execution boundary
 #
 # Configuration (env vars):
-#   WORKFLOW_QUEUE_BACKEND          -- "mongo" | "noop" (default: "noop")
-#   WORKFLOW_QUEUE_MAX_CONCURRENCY  -- global max concurrent workflows (default: 20)
+#   MOZAIKS_WORKFLOW_ADMISSION_MODE -- "required" | "local"
 #   WORKFLOW_QUEUE_ITEM_TTL_SECONDS -- max age of a queued item before it expires (default: 3600)
-#   WORKFLOW_QUEUE_POLL_INTERVAL    -- worker poll interval in seconds (default: 1.0)
 #   WORKFLOW_QUEUE_LEASE_SECONDS    -- claim lease duration (default: 300, bounds: [10, 3600])
 # ==============================================================================
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -67,14 +69,17 @@ from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 from uuid import uuid4
 
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
 from logs.logging_config import get_core_logger
+from mozaiksai.core.core_config import get_mongo_client
+from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE, RuntimeCollections
 
 logger = get_core_logger("workflow_queue")
 
-_BACKEND = os.getenv("WORKFLOW_QUEUE_BACKEND", "noop").strip().lower()
 _MAX_CONCURRENCY = int(os.getenv("WORKFLOW_QUEUE_MAX_CONCURRENCY", "20").strip() or "20")
 _ITEM_TTL = int(os.getenv("WORKFLOW_QUEUE_ITEM_TTL_SECONDS", "3600").strip() or "3600")
-_POLL_INTERVAL = float(os.getenv("WORKFLOW_QUEUE_POLL_INTERVAL", "1.0").strip() or "1.0")
 _DEFAULT_LEASE_SECONDS = int(
     (os.getenv("WORKFLOW_QUEUE_LEASE_SECONDS") or "300").strip() or "300"
 )
@@ -86,8 +91,41 @@ _DEFAULT_MAX_ATTEMPTS: int = 3
 _MIN_MAX_ATTEMPTS: int = 1
 _MAX_MAX_ATTEMPTS: int = 25
 
-_QUEUE_DB = os.getenv("MOZAIKS_APP_DATABASE_NAME", "mozaiks_apps")
-_QUEUE_COLLECTION = "workflow_queue"
+_QUEUE_DB = SYSTEM_DATABASE
+_QUEUE_COLLECTION = RuntimeCollections.WORKFLOW_QUEUE
+
+
+class QueueAuthorityUnavailableError(RuntimeError):
+    """Mongo admission authority could not prove a queue transition."""
+
+
+class QueueIdentityConflictError(RuntimeError):
+    """An admission id was replayed with different immutable identity."""
+
+
+def canonical_admission_id(
+    *,
+    tenant_id: str,
+    workspace_id: str,
+    app_id: str,
+    chat_id: str,
+    workflow_name: str,
+    run_id: str,
+    operation_id: str,
+) -> str:
+    """Return the immutable, payload-independent identity for one admission."""
+    fields = {
+        "v": 1,
+        "tenant_id": tenant_id,
+        "workspace_id": workspace_id,
+        "app_id": app_id,
+        "chat_id": chat_id,
+        "workflow_name": workflow_name,
+        "run_id": run_id,
+        "operation_id": operation_id,
+    }
+    encoded = json.dumps(fields, sort_keys=True, separators=(",", ":")).encode()
+    return "wqa_" + hashlib.sha256(encoded).hexdigest()
 
 
 class QueueItemStatus(StrEnum):
@@ -123,6 +161,10 @@ class QueueItem:
     app_id: str
     user_id: str | None = None
     tenant_id: str | None = None
+    workspace_id: str | None = None
+    run_id: str | None = None
+    operation_id: str | None = None
+    request_digest: str | None = None
     payload: dict[str, Any] = field(default_factory=dict)
     priority: int = 0                    # Higher = executed first
     item_id: str = field(default_factory=lambda: str(uuid4()))
@@ -142,6 +184,8 @@ class QueueItem:
     last_failed_at: str | None = None
     dead_lettered_at: str | None = None
     error_category: str | None = None
+    execution_started_at: str | None = None
+    completed_result: dict[str, Any] | None = None
 
     def to_document(self) -> dict[str, Any]:
         return {
@@ -151,6 +195,10 @@ class QueueItem:
             "app_id": self.app_id,
             "user_id": self.user_id,
             "tenant_id": self.tenant_id,
+            "workspace_id": self.workspace_id,
+            "run_id": self.run_id or self.chat_id,
+            "operation_id": self.operation_id or self.item_id,
+            "request_digest": self.request_digest,
             "payload": self.payload,
             "priority": self.priority,
             "enqueued_at": self.enqueued_at,
@@ -167,6 +215,8 @@ class QueueItem:
             "last_failed_at": self.last_failed_at,
             "dead_lettered_at": self.dead_lettered_at,
             "error_category": self.error_category,
+            "execution_started_at": self.execution_started_at,
+            "completed_result": self.completed_result,
         }
 
     @classmethod
@@ -198,6 +248,10 @@ class QueueItem:
             app_id=doc["app_id"],
             user_id=doc.get("user_id"),
             tenant_id=doc.get("tenant_id"),
+            workspace_id=doc.get("workspace_id"),
+            run_id=doc.get("run_id") or doc["chat_id"],
+            operation_id=doc.get("operation_id") or str(_id),
+            request_digest=doc.get("request_digest"),
             payload=doc.get("payload", {}),
             priority=int(doc.get("priority", 0)),
             enqueued_at=doc.get("enqueued_at", ""),
@@ -214,6 +268,8 @@ class QueueItem:
             last_failed_at=doc.get("last_failed_at"),
             dead_lettered_at=doc.get("dead_lettered_at"),
             error_category=doc.get("error_category"),
+            execution_started_at=doc.get("execution_started_at"),
+            completed_result=doc.get("completed_result"),
         )
 
 
@@ -340,7 +396,7 @@ class WorkflowQueue(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# No-op (existing per-instance semaphore behaviour -- default)
+# No-op (explicit local single-process behavior)
 # ---------------------------------------------------------------------------
 
 class NoOpWorkflowQueue:
@@ -428,7 +484,8 @@ class MongoWorkflowQueue:
 
     _instance_id: str = str(uuid4())
 
-    def __init__(self, *, _now_fn: Any | None = None) -> None:
+    def __init__(self, *, client: Any | None = None, _now_fn: Any | None = None) -> None:
+        self._client = client
         self._now_fn = _now_fn if _now_fn is not None else lambda: datetime.now(UTC)
 
     def _now(self) -> datetime:
@@ -436,14 +493,18 @@ class MongoWorkflowQueue:
 
     def _col(self, name: str = _QUEUE_COLLECTION) -> Any | None:
         try:
-            from mozaiksai.core.core_config import get_mongo_client
-
-            client = get_mongo_client()
+            client = self._client or get_mongo_client()
             if client is None:
                 return None
             return client[_QUEUE_DB][name]
         except Exception:
             return None
+
+    def _required_col(self) -> Any:
+        collection = self._col()
+        if collection is None:
+            raise QueueAuthorityUnavailableError("Mongo workflow queue collection unavailable")
+        return collection
 
     async def ensure_indexes(self) -> None:
         """Create required indexes.  Safe to call on every startup.
@@ -452,10 +513,13 @@ class MongoWorkflowQueue:
         DEAD_LETTER) where the field is non-null.  Active work has
         ``expires_at=None`` and is never touched by the TTL sweeper.
         """
-        col = self._col()
-        if col is None:
-            return
+        col = self._required_col()
         try:
+            await col.create_index(
+                [("tenant_id", 1), ("workspace_id", 1), ("app_id", 1), ("operation_id", 1)],
+                name="wq_scope_operation_idx",
+                background=True,
+            )
             # Primary eligibility index for claim_next.
             await col.create_index(
                 [("status", 1), ("priority", -1), ("enqueued_at", 1)],
@@ -481,8 +545,23 @@ class MongoWorkflowQueue:
                 name="wq_ttl_idx",
                 background=True,
             )
+            indexes = await col.list_indexes().to_list(length=None)
+            names = {str(spec.get("name")) for spec in indexes}
+            required = {
+                "wq_scope_operation_idx",
+                "wq_claim_idx",
+                "wq_lease_expiry_idx",
+                "wq_retry_idx",
+                "wq_ttl_idx",
+            }
+            if not required.issubset(names):
+                raise QueueAuthorityUnavailableError(
+                    f"workflow queue indexes not verified: {sorted(required - names)}"
+                )
         except Exception as exc:
-            logger.warning("WorkflowQueue index creation failed: %s", exc)
+            raise QueueAuthorityUnavailableError(
+                f"workflow queue index creation or verification failed: {exc}"
+            ) from exc
 
     async def enqueue(
         self,
@@ -493,19 +572,203 @@ class MongoWorkflowQueue:
     ) -> str:
         item.max_attempts = _validated_max_attempts(max_attempts)
         item.retry_delay_seconds = max(0, int(retry_delay_seconds))
-        col = self._col()
-        if col is None:
-            return item.item_id
+        col = self._required_col()
+        document = item.to_document()
+        immutable_fields = (
+            "_id",
+            "tenant_id",
+            "workspace_id",
+            "app_id",
+            "chat_id",
+            "workflow_name",
+            "run_id",
+            "operation_id",
+            "request_digest",
+            "user_id",
+        )
         try:
-            await col.insert_one(item.to_document())
+            await col.insert_one(document)
             logger.debug(
                 "QUEUE_ENQUEUED item_id=%s workflow=%s",
                 item.item_id,
                 item.workflow_name,
             )
+        except DuplicateKeyError:
+            existing = await col.find_one({"_id": item.item_id})
+            if not isinstance(existing, dict):
+                raise QueueAuthorityUnavailableError(
+                    "duplicate admission could not be read back"
+                ) from None
+            mismatched = [
+                name for name in immutable_fields if existing.get(name) != document.get(name)
+            ]
+            if mismatched:
+                raise QueueIdentityConflictError(
+                    f"admission identity conflict for {item.item_id}: {mismatched}"
+                ) from None
+        except (QueueAuthorityUnavailableError, QueueIdentityConflictError):
+            raise
         except Exception as exc:
-            logger.error("QUEUE_ENQUEUE_FAIL: %s", exc)
+            raise QueueAuthorityUnavailableError(f"workflow admission failed: {exc}") from exc
         return item.item_id
+
+    async def get(self, item_id: str) -> QueueItem | None:
+        """Read one durable admission, failing closed on authority errors."""
+        try:
+            doc = await self._required_col().find_one({"_id": item_id})
+        except QueueAuthorityUnavailableError:
+            raise
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(f"workflow admission read failed: {exc}") from exc
+        return QueueItem.from_document(doc) if isinstance(doc, dict) else None
+
+    async def claim_item(
+        self,
+        item_id: str,
+        worker_id: str,
+        *,
+        lease_seconds: int = _DEFAULT_LEASE_SECONDS,
+    ) -> ClaimResult:
+        """Atomically claim one ingress-owned admission.
+
+        Expired claims are reclaimable only before execution started. Once an
+        owner crossed the side-effect boundary, automatic replay is forbidden.
+        """
+        col = self._required_col()
+        now = self._now()
+        now_iso = now.isoformat()
+        token = str(uuid4())
+        lease_exp = (now + timedelta(seconds=_bounded_lease(lease_seconds))).isoformat()
+        query = {
+            "_id": item_id,
+            "$expr": {
+                "$lt": [
+                    {"$ifNull": ["$attempt_count", 0]},
+                    {"$ifNull": ["$max_attempts", _DEFAULT_MAX_ATTEMPTS]},
+                ]
+            },
+            "$or": [
+                {"status": QueueItemStatus.PENDING.value},
+                {
+                    "status": QueueItemStatus.RETRYABLE.value,
+                    "$or": [
+                        {"next_attempt_at": None},
+                        {"next_attempt_at": {"$lte": now_iso}},
+                    ],
+                },
+                {
+                    "status": QueueItemStatus.CLAIMED.value,
+                    "lease_expires_at": {"$lte": now_iso},
+                    "execution_started_at": None,
+                },
+            ],
+        }
+        try:
+            doc = await col.find_one_and_update(
+                query,
+                {
+                    "$set": {
+                        "status": QueueItemStatus.CLAIMED.value,
+                        "claimed_by": worker_id,
+                        "claim_token": token,
+                        "claimed_at": now_iso,
+                        "lease_expires_at": lease_exp,
+                    },
+                    "$inc": {"attempt_count": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(f"workflow claim failed: {exc}") from exc
+        if not isinstance(doc, dict):
+            return ClaimResult(claimed=False)
+        item = QueueItem.from_document(doc)
+        return ClaimResult(True, item, token, item.attempt_count)
+
+    async def mark_execution_started(self, item_id: str, *, claim_token: str) -> bool:
+        """Cross the no-retry side-effect boundary for the current holder."""
+        now_iso = self._now().isoformat()
+        try:
+            result = await self._required_col().update_one(
+                {
+                    "_id": item_id,
+                    "status": QueueItemStatus.CLAIMED.value,
+                    "claim_token": claim_token,
+                    "lease_expires_at": {"$gt": now_iso},
+                    "execution_started_at": None,
+                },
+                {"$set": {"execution_started_at": now_iso}},
+            )
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(
+                f"workflow side-effect boundary could not be recorded: {exc}"
+            ) from exc
+        return bool(result.modified_count == 1)
+
+    async def dead_letter_exhausted(self, item_id: str) -> bool:
+        """Terminally close an expired pre-start claim with no attempts left."""
+        now = self._now()
+        now_iso = now.isoformat()
+        retain_until = (now + timedelta(seconds=_ITEM_TTL)).isoformat()
+        try:
+            result = await self._required_col().update_one(
+                {
+                    "_id": item_id,
+                    "status": QueueItemStatus.CLAIMED.value,
+                    "lease_expires_at": {"$lte": now_iso},
+                    "$expr": {
+                        "$gte": [
+                            {"$ifNull": ["$attempt_count", 0]},
+                            {"$ifNull": ["$max_attempts", _DEFAULT_MAX_ATTEMPTS]},
+                        ]
+                    },
+                },
+                {
+                    "$set": {
+                        "status": QueueItemStatus.DEAD_LETTER.value,
+                        "dead_lettered_at": now_iso,
+                        "last_failed_at": now_iso,
+                        "error_category": "claim_attempts_exhausted",
+                        "next_attempt_at": None,
+                        "expires_at": retain_until,
+                    }
+                },
+            )
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(
+                f"exhausted workflow claim could not be dead-lettered: {exc}"
+            ) from exc
+        return bool(result.modified_count == 1)
+
+    async def dead_letter_expired_started(self, item_id: str) -> bool:
+        """Terminally refuse automatic replay after an expired started claim."""
+        now = self._now()
+        now_iso = now.isoformat()
+        retain_until = (now + timedelta(seconds=_ITEM_TTL)).isoformat()
+        try:
+            result = await self._required_col().update_one(
+                {
+                    "_id": item_id,
+                    "status": QueueItemStatus.CLAIMED.value,
+                    "lease_expires_at": {"$lte": now_iso},
+                    "execution_started_at": {"$ne": None},
+                },
+                {
+                    "$set": {
+                        "status": QueueItemStatus.DEAD_LETTER.value,
+                        "dead_lettered_at": now_iso,
+                        "last_failed_at": now_iso,
+                        "error_category": "expired_after_execution_started",
+                        "next_attempt_at": None,
+                        "expires_at": retain_until,
+                    }
+                },
+            )
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(
+                f"expired workflow claim could not be dead-lettered: {exc}"
+            ) from exc
+        return bool(result.modified_count == 1)
 
     async def claim_next(
         self,
@@ -518,13 +781,14 @@ class MongoWorkflowQueue:
         Eligible items are:
           - ``PENDING``
           - ``RETRYABLE`` with ``next_attempt_at <= now``
-          - ``CLAIMED`` with ``lease_expires_at <= now`` (crash recovery)
+          - pre-start ``CLAIMED`` with ``lease_expires_at <= now``
+
+        Every claim is also constrained by the item's finite attempt budget.
+        Authority failure is distinct from an empty or contended queue.
 
         Returns ``ClaimResult(claimed=True, ...)`` on success.
         """
-        col = self._col()
-        if col is None:
-            return ClaimResult(claimed=False)
+        col = self._required_col()
 
         now = self._now()
         now_iso = now.isoformat()
@@ -535,18 +799,28 @@ class MongoWorkflowQueue:
         try:
             doc = await col.find_one_and_update(
                 {
+                    "$expr": {
+                        "$lt": [
+                            {"$ifNull": ["$attempt_count", 0]},
+                            {"$ifNull": ["$max_attempts", _DEFAULT_MAX_ATTEMPTS]},
+                        ]
+                    },
                     "$or": [
                         # Normal pending items.
                         {"status": QueueItemStatus.PENDING.value},
                         # Retry-eligible items.
                         {
                             "status": QueueItemStatus.RETRYABLE.value,
-                            "next_attempt_at": {"$lte": now_iso},
+                            "$or": [
+                                {"next_attempt_at": None},
+                                {"next_attempt_at": {"$lte": now_iso}},
+                            ],
                         },
                         # Crash recovery: lease expired on a claimed item.
                         {
                             "status": QueueItemStatus.CLAIMED.value,
                             "lease_expires_at": {"$lte": now_iso},
+                            "execution_started_at": None,
                         },
                     ],
                 },
@@ -561,7 +835,7 @@ class MongoWorkflowQueue:
                     "$inc": {"attempt_count": 1},
                 },
                 sort=[("priority", -1), ("enqueued_at", 1)],
-                return_document=True,
+                return_document=ReturnDocument.AFTER,
             )
             if doc is None:
                 return ClaimResult(claimed=False)
@@ -579,23 +853,27 @@ class MongoWorkflowQueue:
                 attempt_count=item.attempt_count,
             )
         except Exception as exc:
-            logger.error("QUEUE_CLAIM_FAIL: %s", exc)
-            return ClaimResult(claimed=False)
+            raise QueueAuthorityUnavailableError(f"workflow claim failed: {exc}") from exc
 
-    async def complete(self, item_id: str, *, claim_token: str) -> bool:
+    async def complete(
+        self,
+        item_id: str,
+        *,
+        claim_token: str,
+        result: dict[str, Any] | None = None,
+    ) -> bool:
         """Mark a claimed item as completed.
 
         Only succeeds for the current ``claim_token`` holder.
         Sets ``expires_at`` to enable TTL-based retention cleanup.
         """
-        col = self._col()
-        if col is None:
-            return False
+        col = self._required_col()
         try:
             now = self._now()
             now_iso = now.isoformat()
             retain_until = (now + timedelta(seconds=_ITEM_TTL)).isoformat()
-            result = await col.update_one(
+            outcome = result
+            update_result = await col.update_one(
                 {
                     "_id": item_id,
                     "status": QueueItemStatus.CLAIMED.value,
@@ -606,13 +884,15 @@ class MongoWorkflowQueue:
                         "status": QueueItemStatus.COMPLETED.value,
                         "completed_at": now_iso,
                         "expires_at": retain_until,
+                        "completed_result": outcome,
                     },
                 },
             )
-            return bool(result.modified_count == 1)
+            return bool(update_result.modified_count == 1)
         except Exception as exc:
-            logger.error("QUEUE_COMPLETE_FAIL item_id=%s: %s", item_id, exc)
-            return False
+            raise QueueAuthorityUnavailableError(
+                f"workflow completion failed for {item_id}: {exc}"
+            ) from exc
 
     async def fail(
         self,
@@ -642,9 +922,7 @@ class MongoWorkflowQueue:
         to determine the new status; a fenced ``update_one`` performs the
         actual transition.
         """
-        col = self._col()
-        if col is None:
-            return None
+        col = self._required_col()
 
         now = self._now()
         now_iso = now.isoformat()
@@ -710,8 +988,9 @@ class MongoWorkflowQueue:
             )
             return new_status
         except Exception as exc:
-            logger.error("QUEUE_FAIL_FAIL item_id=%s: %s", item_id, exc)
-            return None
+            raise QueueAuthorityUnavailableError(
+                f"workflow failure transition failed for {item_id}: {exc}"
+            ) from exc
 
     async def dead_letter(
         self,
@@ -721,9 +1000,7 @@ class MongoWorkflowQueue:
         error_category: str | None = None,
     ) -> bool:
         """Terminally dead-letter a CLAIMED item using the fencing token."""
-        col = self._col()
-        if col is None:
-            return False
+        col = self._required_col()
 
         now = self._now()
         now_iso = now.isoformat()
@@ -748,8 +1025,9 @@ class MongoWorkflowQueue:
             )
             return bool(result.modified_count == 1)
         except Exception as exc:
-            logger.error("QUEUE_DEAD_LETTER_FAIL item_id=%s: %s", item_id, exc)
-            return False
+            raise QueueAuthorityUnavailableError(
+                f"workflow dead-letter transition failed for {item_id}: {exc}"
+            ) from exc
 
     async def renew_lease(
         self,
@@ -763,9 +1041,7 @@ class MongoWorkflowQueue:
         Only succeeds if the lease has not yet expired and ``claim_token``
         matches.
         """
-        col = self._col()
-        if col is None:
-            return False
+        col = self._required_col()
 
         now = self._now()
         now_iso = now.isoformat()
@@ -784,34 +1060,35 @@ class MongoWorkflowQueue:
             )
             return bool(result.modified_count == 1)
         except Exception as exc:
-            logger.error("QUEUE_RENEW_FAIL item_id=%s: %s", item_id, exc)
-            return False
+            raise QueueAuthorityUnavailableError(
+                f"workflow claim renewal failed for {item_id}: {exc}"
+            ) from exc
 
     async def active_count(self) -> int:
-        col = self._col()
-        if col is None:
-            return 0
+        col = self._required_col()
         try:
             return int(
                 await col.count_documents(
                     {"status": QueueItemStatus.CLAIMED.value}
                 )
             )
-        except Exception:
-            return 0
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(
+                f"workflow active-count read failed: {exc}"
+            ) from exc
 
     async def queue_depth(self) -> int:
-        col = self._col()
-        if col is None:
-            return 0
+        col = self._required_col()
         try:
             return int(
                 await col.count_documents(
                     {"status": QueueItemStatus.PENDING.value}
                 )
             )
-        except Exception:
-            return 0
+        except Exception as exc:
+            raise QueueAuthorityUnavailableError(
+                f"workflow queue-depth read failed: {exc}"
+            ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -821,17 +1098,70 @@ class MongoWorkflowQueue:
 _queue: WorkflowQueue | None = None
 
 
+class WorkflowAdmissionMode(StrEnum):
+    REQUIRED = "required"
+    LOCAL = "local"
+
+
+_configured_admission_mode: WorkflowAdmissionMode | None = None
+
+
+def configure_workflow_admission(
+    mode: WorkflowAdmissionMode | str | None = None,
+    *,
+    client: Any | None = None,
+) -> WorkflowAdmissionMode:
+    """Pin durable admission for persisted/production hosts and local otherwise."""
+    global _configured_admission_mode, _queue
+    raw = str(mode or os.getenv("MOZAIKS_WORKFLOW_ADMISSION_MODE") or "").strip().lower()
+    if raw:
+        resolved = WorkflowAdmissionMode(raw)
+    else:
+        from mozaiksai.core.runtime.persistence.startup_policy import (
+            database_persistence_is_enabled,
+            get_database_startup_policy,
+        )
+
+        resolved = (
+            WorkflowAdmissionMode.REQUIRED
+            if database_persistence_is_enabled(get_database_startup_policy())
+            else WorkflowAdmissionMode.LOCAL
+        )
+    _configured_admission_mode = resolved
+    _queue = (
+        MongoWorkflowQueue(client=client)
+        if resolved is WorkflowAdmissionMode.REQUIRED
+        else NoOpWorkflowQueue()
+    )
+    logger.info("Workflow admission mode configured: %s", resolved)
+    return resolved
+
+
+def get_workflow_admission_mode() -> WorkflowAdmissionMode:
+    if _configured_admission_mode is not None:
+        return _configured_admission_mode
+    raw = (os.getenv("MOZAIKS_WORKFLOW_ADMISSION_MODE") or "").strip().lower()
+    return WorkflowAdmissionMode(raw) if raw else WorkflowAdmissionMode.LOCAL
+
+
+def reset_workflow_admission_state() -> None:
+    """Test hook for the configured queue and local admission registry."""
+    global _configured_admission_mode, _queue
+    _configured_admission_mode = None
+    _queue = None
+
+
 def get_workflow_queue() -> WorkflowQueue:
     """Return the configured global workflow queue (process-wide singleton)."""
     global _queue
     if _queue is None:
-        if _BACKEND == "mongo":
+        if get_workflow_admission_mode() is WorkflowAdmissionMode.REQUIRED:
             _queue = MongoWorkflowQueue()
         else:
             _queue = NoOpWorkflowQueue()
         logger.info(
-            "WorkflowQueue backend: %s (max_concurrency=%d)",
-            _BACKEND,
+            "Workflow admission mode: %s (local_max_concurrency=%d)",
+            get_workflow_admission_mode(),
             _MAX_CONCURRENCY,
         )
     return _queue
@@ -844,7 +1174,14 @@ __all__ = [
     "QueueItem",
     "QueueItemStatus",
     "WorkflowQueue",
+    "WorkflowAdmissionMode",
+    "QueueAuthorityUnavailableError",
+    "QueueIdentityConflictError",
+    "canonical_admission_id",
+    "configure_workflow_admission",
     "get_workflow_queue",
+    "get_workflow_admission_mode",
+    "reset_workflow_admission_state",
     "_DEFAULT_MAX_ATTEMPTS",
     "_MIN_MAX_ATTEMPTS",
     "_MAX_MAX_ATTEMPTS",

--- a/mozaiksai/core/workflow/work_assignment_worker.py
+++ b/mozaiksai/core/workflow/work_assignment_worker.py
@@ -524,7 +524,7 @@ def _coerce_work_result(value: WorkResult | Mapping[str, Any]) -> WorkResult:
 
 
 def _workspace_id(item: QueueItem) -> str | None:
-    value = item.payload.get("workspace_id") if isinstance(item.payload, Mapping) else None
+    value = item.workspace_id
     text = str(value or "").strip()
     return text or None
 

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -3786,6 +3786,8 @@ async def websocket_endpoint(
             app_id=app_id,
             ws_id=ws_id,
             suppress_history_replay=suppress_history_replay,
+            tenant_id=str(getattr(ws_user, "tenant_id", None) or app_id),
+            workspace_id=str(getattr(ws_user, "workspace_id", None) or app_id),
         )
     finally:
         session_registry.remove_session(ws_id)

--- a/mozaiksai/hosts/runtime.py
+++ b/mozaiksai/hosts/runtime.py
@@ -66,6 +66,12 @@ from mozaiksai.core.transport.request_middleware import (
 from mozaiksai.core.transport.security_headers import SecurityHeadersMiddleware
 from mozaiksai.core.transport.simple_transport import SimpleTransport
 from mozaiksai.core.workflow.idempotency import ensure_idempotency_indexes
+from mozaiksai.core.workflow.queue import (
+    MongoWorkflowQueue,
+    WorkflowAdmissionMode,
+    configure_workflow_admission,
+    get_workflow_queue,
+)
 from mozaiksai.core.workflow.workflow_manager import (
     get_workflow_tools,
     get_workflow_transport,
@@ -358,6 +364,19 @@ async def _runtime_startup() -> None:
     )
 
     # Ensure enterprise infrastructure indexes exist.
+    admission_mode = configure_workflow_admission(client=mongo_client)
+    admission_queue = get_workflow_queue()
+    admission_ready = (
+        admission_mode is WorkflowAdmissionMode.LOCAL
+        or isinstance(admission_queue, MongoWorkflowQueue)
+    )
+    if admission_mode is WorkflowAdmissionMode.REQUIRED:
+        if not isinstance(admission_queue, MongoWorkflowQueue):
+            raise RuntimeError("required workflow admission is not Mongo-backed")
+        await admission_queue.ensure_indexes()
+    app.state.workflow_admission_ready = admission_ready
+    app.state.workflow_admission_mode = admission_mode.value
+
     await asyncio.gather(
         ensure_lock_indexes(),
         ensure_idempotency_indexes(),
@@ -460,6 +479,18 @@ async def health_readiness(request: Request):
         degraded = True
     else:
         checks["transport"] = "ok"
+
+    admission_mode = getattr(request.app.state, "workflow_admission_mode", "local")
+    admission_ready = getattr(
+        request.app.state,
+        "workflow_admission_ready",
+        admission_mode == WorkflowAdmissionMode.LOCAL.value,
+    )
+    if not admission_ready:
+        checks["workflow_admission"] = f"error:{admission_mode}"
+        degraded = True
+    else:
+        checks["workflow_admission"] = f"ok:{admission_mode}"
 
     # Platform startup degradation — set when module loading fails unexpectedly.
     startup_degraded = getattr(request.app.state, "startup_degraded", False)
@@ -1156,6 +1187,9 @@ async def websocket_endpoint(
                         workflow_name=resolved_workflow_name,
                         message=None,
                         app_id=app_id,
+                        tenant_id=str(getattr(ws_user, "tenant_id", None) or app_id),
+                        workspace_id=str(getattr(ws_user, "workspace_id", None) or app_id),
+                        operation_id=f"start:{resolved_chat_id}",
                     )
                 )
                 simple_transport._background_tasks[resolved_chat_id] = _agent_start_task
@@ -1189,6 +1223,8 @@ async def websocket_endpoint(
             ws_id=ws_id,
             token_exp=_token_exp,
             suppress_history_replay=suppress_history_replay,
+            tenant_id=str(getattr(ws_user, "tenant_id", None) or app_id),
+            workspace_id=str(getattr(ws_user, "workspace_id", None) or app_id),
         )
     except Exception as ownership_err:
         wf_logger.warning("WS_CHAT_PREP_FAILED: %s", ownership_err)
@@ -1247,6 +1283,9 @@ async def handle_user_input(
         workflow_name=workflow_name,
         message=message,
         app_id=app_id,
+        tenant_id=str(principal.tenant_id or app_id),
+        workspace_id=str(principal.workspace_id or app_id),
+        operation_id=str(getattr(request.state, "request_id", "") or ""),
     )
     return {"status": "Message received and is being processed.", "result": result}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,8 +79,8 @@ def app_root() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_chat_lock_state():
-    """Reset the chat execution lock's process-level state before each test.
+def _isolate_execution_authority_state(monkeypatch: pytest.MonkeyPatch):
+    """Reset process-global chat-lock and workflow-admission state per test.
 
     The lock module keeps process-global state (configured mode, held local
     locks, the lease registry). A test that runs host startup pins `required`
@@ -89,8 +89,19 @@ def _isolate_chat_lock_state():
     test. Entering each test with clean lock state keeps tests
     order-independent.
     """
+    from mozaiksai.core.runtime.execution_admission import reset_local_workflow_admission
     from mozaiksai.core.runtime.persistence.distributed_lock import reset_chat_lock_state
+    from mozaiksai.core.workflow.queue import reset_workflow_admission_state
 
     reset_chat_lock_state()
+    reset_workflow_admission_state()
+    reset_local_workflow_admission()
+    # Tests and embedded transports are explicitly single-process unless a
+    # focused admission test opts into required mode. This prevents a
+    # developer .env MONGO_URI from silently changing unrelated test meaning.
+    monkeypatch.setenv("MOZAIKS_WORKFLOW_ADMISSION_MODE", "local")
     yield
+    reset_chat_lock_state()
+    reset_workflow_admission_state()
+    reset_local_workflow_admission()
 

--- a/tests/test_continuous_deterministic_materialization.py
+++ b/tests/test_continuous_deterministic_materialization.py
@@ -52,9 +52,19 @@ class _FakeMongoAdmin:
         return {"ok": 1}
 
 
+class _FakeIndexCursor:
+    def __init__(self, names: set[str]) -> None:
+        self.names = names
+
+    async def to_list(self, *, length: int | None = None) -> list[dict[str, str]]:
+        del length
+        return [{"name": name} for name in sorted(self.names)]
+
+
 class _FakeMongoClient:
     def __init__(self) -> None:
         self.admin = _FakeMongoAdmin()
+        self.index_names: set[str] = {"_id_"}
 
     def __getitem__(self, _name: str) -> _FakeMongoClient:
         return self
@@ -64,6 +74,13 @@ class _FakeMongoClient:
 
     async def command(self, *_args: Any, **_kwargs: Any) -> dict[str, int]:
         return {"ok": 1}
+
+    async def create_index(self, *_args: Any, name: str, **_kwargs: Any) -> str:
+        self.index_names.add(name)
+        return name
+
+    def list_indexes(self) -> _FakeIndexCursor:
+        return _FakeIndexCursor(self.index_names)
 
     def close(self) -> None:
         return None

--- a/tests/test_module_contract_executor.py
+++ b/tests/test_module_contract_executor.py
@@ -72,7 +72,8 @@ def _item(assignment: WorkAssignment) -> QueueItem:
         app_id="app-1",
         user_id="user-1",
         tenant_id="tenant-1",
-        payload={WORK_ASSIGNMENT_PAYLOAD_KEY: assignment.model_dump(mode="json"), "workspace_id": "workspace-1"},
+        workspace_id="workspace-1",
+        payload={WORK_ASSIGNMENT_PAYLOAD_KEY: assignment.model_dump(mode="json")},
     )
 
 

--- a/tests/test_runtime_websocket_contract.py
+++ b/tests/test_runtime_websocket_contract.py
@@ -275,6 +275,8 @@ async def test_runtime_websocket_endpoint_uses_resolved_resume_chat(monkeypatch:
             "ws_id": harness.transport.handle_websocket_calls[0]["ws_id"],
             "token_exp": 0,
             "suppress_history_replay": False,
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
         }
     ]
     assert harness.added_workflows == [
@@ -476,6 +478,9 @@ async def test_runtime_websocket_endpoint_auto_starts_empty_agent_driven_chat(mo
             "workflow_name": "AgentGenerator",
             "message": None,
             "app_id": "app_1",
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
+            "operation_id": "start:chat_agent_1",
         }
     ]
     assert harness.transport.connections["chat_agent_1"]["autostarted"] is True
@@ -579,6 +584,8 @@ async def test_runtime_websocket_endpoint_honors_persisted_workflow_for_stale_cl
             "ws_id": harness.transport.handle_websocket_calls[0]["ws_id"],
             "token_exp": 0,
             "suppress_history_replay": False,
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
         }
     ]
     assert harness.transport.ui_events == [
@@ -661,6 +668,8 @@ async def test_runtime_websocket_endpoint_repairs_non_runnable_persisted_workflo
             "ws_id": harness.transport.handle_websocket_calls[0]["ws_id"],
             "token_exp": 0,
             "suppress_history_replay": False,
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
         }
     ]
     assert harness.transport.ui_events == [
@@ -769,6 +778,8 @@ async def test_runtime_websocket_endpoint_backfills_missing_resolved_chat_before
             "ws_id": harness.transport.handle_websocket_calls[0]["ws_id"],
             "token_exp": 0,
             "suppress_history_replay": False,
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
         }
     ]
     assert harness.transport.ui_events == [
@@ -863,6 +874,8 @@ async def test_runtime_websocket_endpoint_backfills_missing_resolved_chat_with_r
             "ws_id": harness.transport.handle_websocket_calls[0]["ws_id"],
             "token_exp": 0,
             "suppress_history_replay": False,
+            "tenant_id": "app_1",
+            "workspace_id": "app_1",
         }
     ]
     assert harness.transport.ui_events[0][0]["workflow_name"] == "ValueEngine"

--- a/tests/test_work_assignment_worker.py
+++ b/tests/test_work_assignment_worker.py
@@ -231,7 +231,6 @@ def _outside_result(assignment: WorkAssignment) -> WorkResult:
 def _item(assignment: WorkAssignment, **payload_overrides: Any) -> QueueItem:
     payload = {
         WORK_ASSIGNMENT_PAYLOAD_KEY: assignment.model_dump(mode="json"),
-        "workspace_id": "workspace-1",
     }
     payload.update(payload_overrides)
     return QueueItem(
@@ -240,6 +239,7 @@ def _item(assignment: WorkAssignment, **payload_overrides: Any) -> QueueItem:
         app_id="app-1",
         user_id="user-1",
         tenant_id="tenant-1",
+        workspace_id="workspace-1",
         payload=payload,
     )
 

--- a/tests/test_workflow_execution_admission.py
+++ b/tests/test_workflow_execution_admission.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.runtime.execution_admission import (
+    WorkflowAdmissionBusyError,
+    WorkflowAdmissionRequest,
+    execute_with_workflow_admission,
+    reset_local_workflow_admission,
+)
+from mozaiksai.core.workflow import queue as queue_mod
+from mozaiksai.core.workflow.queue import (
+    ClaimResult,
+    MongoWorkflowQueue,
+    QueueAuthorityUnavailableError,
+    QueueItem,
+    QueueItemStatus,
+    WorkflowAdmissionMode,
+    canonical_admission_id,
+)
+
+
+class _MemoryMongoQueue(MongoWorkflowQueue):
+    def __init__(self) -> None:
+        super().__init__()
+        self.item: QueueItem | None = None
+        self.token = "claim-token"
+        self.claim_calls = 0
+        self.fail_enqueue = False
+        self.enqueue_gate: asyncio.Event | None = None
+
+    async def enqueue(self, item: QueueItem, **_kwargs: Any) -> str:
+        if self.enqueue_gate is not None:
+            await self.enqueue_gate.wait()
+        if self.fail_enqueue:
+            raise QueueAuthorityUnavailableError("outage")
+        if self.item is None:
+            self.item = item
+        return item.item_id
+
+    async def claim_item(self, item_id: str, worker_id: str, **_kwargs: Any) -> ClaimResult:
+        del item_id, worker_id
+        self.claim_calls += 1
+        assert self.item is not None
+        if self.item.status is not QueueItemStatus.PENDING:
+            return ClaimResult(False)
+        self.item.status = QueueItemStatus.CLAIMED
+        self.item.claim_token = self.token
+        self.item.attempt_count = 1
+        return ClaimResult(True, self.item, self.token, 1)
+
+    async def get(self, _item_id: str) -> QueueItem | None:
+        return self.item
+
+    async def mark_execution_started(self, _item_id: str, *, claim_token: str) -> bool:
+        assert self.item is not None
+        if self.item.claim_token != claim_token:
+            return False
+        self.item.execution_started_at = "started"
+        return True
+
+    async def renew_lease(self, *_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    async def complete(
+        self,
+        _item_id: str,
+        *,
+        claim_token: str,
+        result: dict[str, Any] | None = None,
+    ) -> bool:
+        assert self.item is not None
+        if self.item.claim_token != claim_token:
+            return False
+        self.item.status = QueueItemStatus.COMPLETED
+        self.item.completed_result = result
+        return True
+
+    async def dead_letter_expired_started(self, _item_id: str) -> bool:
+        return False
+
+    async def dead_letter_exhausted(self, _item_id: str) -> bool:
+        return False
+
+    async def dead_letter(self, *_args: Any, **_kwargs: Any) -> bool:
+        assert self.item is not None
+        self.item.status = QueueItemStatus.DEAD_LETTER
+        return True
+
+    async def fail(self, *_args: Any, **_kwargs: Any) -> str | None:
+        assert self.item is not None
+        self.item.status = QueueItemStatus.RETRYABLE
+        return QueueItemStatus.RETRYABLE.value
+
+
+@pytest.fixture(autouse=True)
+def _reset_admission() -> None:
+    queue_mod.reset_workflow_admission_state()
+    reset_local_workflow_admission()
+    yield
+    queue_mod.reset_workflow_admission_state()
+    reset_local_workflow_admission()
+
+
+def _request(*, tenant_id: str = "tenant-a") -> WorkflowAdmissionRequest:
+    return WorkflowAdmissionRequest(
+        tenant_id=tenant_id,
+        workspace_id="workspace-a",
+        app_id="app-a",
+        chat_id="chat-a",
+        workflow_name="GenesisBuild",
+        run_id="chat-a",
+        operation_id="request-1",
+        request_digest="a" * 64,
+        user_id="user-a",
+    )
+
+
+def _required(fake: _MemoryMongoQueue) -> None:
+    queue_mod._configured_admission_mode = WorkflowAdmissionMode.REQUIRED
+    queue_mod._queue = fake
+
+
+async def test_exact_completed_replay_does_not_execute_twice() -> None:
+    fake = _MemoryMongoQueue()
+    _required(fake)
+    executions = 0
+
+    async def execute() -> dict[str, Any]:
+        nonlocal executions
+        executions += 1
+        return {"status": "success", "value": 7}
+
+    assert await execute_with_workflow_admission(_request(), execute) == {
+        "status": "success",
+        "value": 7,
+    }
+    assert await execute_with_workflow_admission(_request(), execute) == {
+        "status": "success",
+        "value": 7,
+    }
+    assert executions == 1
+
+
+async def test_concurrent_identical_consumer_is_busy_without_side_effect() -> None:
+    fake = _MemoryMongoQueue()
+    _required(fake)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    executions = 0
+
+    async def execute() -> dict[str, Any]:
+        nonlocal executions
+        executions += 1
+        entered.set()
+        await release.wait()
+        return {"status": "success"}
+
+    owner = asyncio.create_task(execute_with_workflow_admission(_request(), execute))
+    await entered.wait()
+    with pytest.raises(WorkflowAdmissionBusyError):
+        await execute_with_workflow_admission(_request(), execute)
+    assert executions == 1
+    release.set()
+    await owner
+
+
+async def test_queue_outage_refuses_before_execution() -> None:
+    fake = _MemoryMongoQueue()
+    fake.fail_enqueue = True
+    _required(fake)
+    executed = False
+
+    async def execute() -> dict[str, Any]:
+        nonlocal executed
+        executed = True
+        return {"status": "success"}
+
+    with pytest.raises(QueueAuthorityUnavailableError):
+        await execute_with_workflow_admission(_request(), execute)
+    assert not executed
+    assert fake.claim_calls == 0
+
+
+async def test_required_index_verification_failure_is_authority_failure(monkeypatch) -> None:
+    class _BrokenCollection:
+        async def create_index(self, *_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("index denied")
+
+    queue = MongoWorkflowQueue()
+    monkeypatch.setattr(queue, "_col", lambda *_args, **_kwargs: _BrokenCollection())
+    with pytest.raises(QueueAuthorityUnavailableError, match="index"):
+        await queue.ensure_indexes()
+
+
+async def test_cancelled_producer_waiting_to_enqueue_never_claims_or_executes() -> None:
+    fake = _MemoryMongoQueue()
+    fake.enqueue_gate = asyncio.Event()
+    _required(fake)
+    executed = False
+
+    async def execute() -> dict[str, Any]:
+        nonlocal executed
+        executed = True
+        return {"status": "success"}
+
+    task = asyncio.create_task(execute_with_workflow_admission(_request(), execute))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert fake.claim_calls == 0
+    assert not executed
+
+
+def test_canonical_admission_identity_is_scope_bound_and_payload_independent() -> None:
+    base = dict(
+        workspace_id="workspace-a",
+        app_id="app-a",
+        chat_id="chat-a",
+        workflow_name="RefinementRun",
+        run_id="chat-a",
+        operation_id="request-1",
+    )
+    assert canonical_admission_id(tenant_id="tenant-a", **base) != canonical_admission_id(
+        tenant_id="tenant-b", **base
+    )
+
+
+async def test_explicit_local_mode_remains_usable_and_non_durable() -> None:
+    queue_mod.configure_workflow_admission(WorkflowAdmissionMode.LOCAL)
+    executions = 0
+
+    async def execute() -> dict[str, Any]:
+        nonlocal executions
+        executions += 1
+        return {"status": "success"}
+
+    await execute_with_workflow_admission(_request(), execute)
+    await execute_with_workflow_admission(_request(), execute)
+    assert executions == 1
+
+    reset_local_workflow_admission()
+    await execute_with_workflow_admission(_request(), execute)
+    assert executions == 2
+
+
+def test_persisted_host_auto_selects_required_mode(monkeypatch) -> None:
+    monkeypatch.delenv("MOZAIKS_WORKFLOW_ADMISSION_MODE", raising=False)
+    monkeypatch.setenv("MONGO_URI", "mongodb://authority.example:27017")
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    assert queue_mod.configure_workflow_admission() is WorkflowAdmissionMode.REQUIRED

--- a/tests/test_workflow_queue_real_mongo.py
+++ b/tests/test_workflow_queue_real_mongo.py
@@ -1,0 +1,239 @@
+"""Real-Mongo cross-process proofs for durable workflow admission."""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from mozaiksai.core.core_config import close_mongo_client
+from mozaiksai.core.workflow.queue import (
+    MongoWorkflowQueue,
+    QueueAuthorityUnavailableError,
+    QueueIdentityConflictError,
+    QueueItem,
+    QueueItemStatus,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _mongo_uri() -> str | None:
+    return next(
+        (value for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL") if (value := (os.getenv(name) or "").strip())),
+        None,
+    )
+
+
+def _mongo_reachable() -> bool:
+    uri = _mongo_uri()
+    if not uri:
+        return False
+    try:
+        from pymongo import MongoClient
+
+        MongoClient(uri, serverSelectionTimeoutMS=2000).admin.command("ping")
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _mongo_reachable(), reason="requires reachable mongo:7")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_client(monkeypatch):
+    monkeypatch.setenv("MONGO_URI", _mongo_uri() or "")
+    close_mongo_client()
+    yield
+    close_mongo_client()
+
+
+def _item(tag: str) -> QueueItem:
+    return QueueItem(
+        item_id=f"admission-{tag}",
+        tenant_id=f"tenant-{tag}",
+        workspace_id=f"workspace-{tag}",
+        app_id=f"app-{tag}",
+        chat_id=f"chat-{tag}",
+        workflow_name="GenesisBuild",
+        run_id=f"chat-{tag}",
+        operation_id=f"request-{tag}",
+        request_digest="a" * 64,
+        user_id="user-a",
+    )
+
+
+async def _cleanup(item_id: str) -> None:
+    col = MongoWorkflowQueue()._required_col()
+    await col.delete_many({"_id": item_id})
+
+
+async def test_many_identical_producers_create_one_admission() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    queue = MongoWorkflowQueue()
+    try:
+        await queue.ensure_indexes()
+        ids = await asyncio.gather(*(queue.enqueue(_item(tag)) for _ in range(32)))
+        assert set(ids) == {item.item_id}
+        assert await queue._required_col().count_documents({"_id": item.item_id}) == 1
+    finally:
+        await _cleanup(item.item_id)
+
+
+async def test_same_operation_with_changed_request_is_rejected() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    queue = MongoWorkflowQueue()
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item)
+        changed = _item(tag)
+        changed.request_digest = "b" * 64
+        with pytest.raises(QueueIdentityConflictError, match="request_digest"):
+            await queue.enqueue(changed)
+    finally:
+        await _cleanup(item.item_id)
+
+
+_SUBPROCESS_CLAIMER = r"""
+import asyncio, sys
+from mozaiksai.core.workflow.queue import MongoWorkflowQueue
+async def main():
+    result = await MongoWorkflowQueue().claim_item(sys.argv[1], sys.argv[2], lease_seconds=60)
+    print("CLAIMED" if result.claimed else "BUSY", flush=True)
+asyncio.run(main())
+"""
+
+
+async def test_multiple_process_consumers_produce_one_owner() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    queue = MongoWorkflowQueue()
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item)
+        procs = [
+            await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                _SUBPROCESS_CLAIMER,
+                item.item_id,
+                f"worker-{index}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(_REPO_ROOT),
+                env=env,
+            )
+            for index in range(6)
+        ]
+        outputs = []
+        for proc in procs:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+            assert proc.returncode == 0, stderr.decode()[:2000]
+            outputs.append(stdout.decode().strip())
+        assert outputs.count("CLAIMED") == 1, outputs
+        assert outputs.count("BUSY") == 5, outputs
+    finally:
+        await _cleanup(item.item_id)
+
+
+async def test_expired_prestart_claim_has_safe_successor_and_stale_release_fails() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    now = datetime.now(UTC)
+    clock = [now]
+    queue = MongoWorkflowQueue(_now_fn=lambda: clock[0])
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item)
+        first = await queue.claim_item(item.item_id, "old", lease_seconds=10)
+        assert first.claimed and first.claim_token
+        clock[0] = now + timedelta(seconds=11)
+        successor = await queue.claim_item(item.item_id, "new", lease_seconds=60)
+        assert successor.claimed and successor.claim_token != first.claim_token
+        assert not await queue.complete(item.item_id, claim_token=first.claim_token)
+        assert await queue.complete(item.item_id, claim_token=successor.claim_token)
+    finally:
+        await _cleanup(item.item_id)
+
+
+async def test_expired_started_claim_dead_letters_without_reexecution() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    now = datetime.now(UTC)
+    clock = [now]
+    queue = MongoWorkflowQueue(_now_fn=lambda: clock[0])
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item)
+        claim = await queue.claim_item(item.item_id, "old", lease_seconds=10)
+        assert claim.claimed and claim.claim_token
+        assert await queue.mark_execution_started(item.item_id, claim_token=claim.claim_token)
+        clock[0] = now + timedelta(seconds=11)
+        assert not (await queue.claim_item(item.item_id, "new", lease_seconds=60)).claimed
+        assert await queue.dead_letter_expired_started(item.item_id)
+        stored = await queue.get(item.item_id)
+        assert stored is not None
+        assert stored.status is QueueItemStatus.DEAD_LETTER
+        assert stored.error_category == "expired_after_execution_started"
+    finally:
+        await _cleanup(item.item_id)
+
+
+async def test_expired_prestart_claims_exhaust_bounded_budget() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    now = datetime.now(UTC)
+    clock = [now]
+    queue = MongoWorkflowQueue(_now_fn=lambda: clock[0])
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item, max_attempts=2)
+        assert (await queue.claim_item(item.item_id, "one", lease_seconds=10)).claimed
+        clock[0] = now + timedelta(seconds=11)
+        assert (await queue.claim_item(item.item_id, "two", lease_seconds=10)).claimed
+        clock[0] = now + timedelta(seconds=22)
+        assert not (await queue.claim_item(item.item_id, "three", lease_seconds=10)).claimed
+        assert await queue.dead_letter_exhausted(item.item_id)
+        stored = await queue.get(item.item_id)
+        assert stored is not None
+        assert stored.status is QueueItemStatus.DEAD_LETTER
+        assert stored.attempt_count == 2
+        assert stored.error_category == "claim_attempts_exhausted"
+    finally:
+        await _cleanup(item.item_id)
+
+
+async def test_queue_authority_outage_is_not_reported_as_contention(monkeypatch) -> None:
+    queue = MongoWorkflowQueue()
+    monkeypatch.setattr(queue, "_col", lambda *_args, **_kwargs: None)
+    with pytest.raises(QueueAuthorityUnavailableError):
+        await queue.enqueue(_item(uuid4().hex))
+    with pytest.raises(QueueAuthorityUnavailableError):
+        await queue.claim_next("worker-a")
+
+
+async def test_generic_consumer_claims_respect_bounded_budget() -> None:
+    tag = uuid4().hex
+    item = _item(tag)
+    now = datetime.now(UTC)
+    clock = [now]
+    queue = MongoWorkflowQueue(_now_fn=lambda: clock[0])
+    try:
+        await queue.ensure_indexes()
+        await queue.enqueue(item, max_attempts=1)
+        first = await queue.claim_next("one", lease_seconds=10)
+        assert first.claimed
+        clock[0] = now + timedelta(seconds=11)
+        assert not (await queue.claim_next("two", lease_seconds=10)).claimed
+        assert await queue.dead_letter_exhausted(item.item_id)
+    finally:
+        await _cleanup(item.item_id)


### PR DESCRIPTION
## Summary

- wires the existing Mongo-backed workflow queue as the authoritative production admission boundary before mutable workflow execution
- preserves the merged per-chat execution lease as the mutation authority after admission
- gives persisted hosts fail-closed required mode and keeps explicit local mode single-process and non-durable
- adds immutable scoped admission identity, exact replay, renewable holder-scoped claims, bounded attempts, and terminal dead-letter behavior after the side-effect boundary

## Stage A authority map

- New runs, paused-run continuation, restart/resume, Genesis Build, Refinement Run, workflow start/switch/batch handlers, journey spawns, and AG2 Network continuation converge on `SimpleTransport.handle_user_input_from_api` before AG2 execution.
- Task-batch concurrency remains internal to an already-admitted AG2 execution.
- The former process-local semaphore is only a resource throttle and was bypassed by direct REST/WebSocket paths.
- `MongoWorkflowQueue` existed but was not the production execution authority; the only explicit consumer was `WorkAssignmentWorker`, and workspace scope was taken from payload data.
- No autonomous global queue consumer/orphan reconciler exists. Targeted ingress claims are the smallest safe slice because WebSocket/UI delivery is instance-sticky.
- Cancellation remains process-local and has no production API caller. No cancellation endpoint is introduced.
- Existing `IN_PROGRESS` adoption/reconciliation is deferred. Pre-start expired claims can be reclaimed; post-start expiry dead-letters rather than risking repeated model/tool side effects.
- The PR #438 chat lease remains the `(app_id, chat_id)` mutation authority after admission.

## Contract

- Durable identity binds tenant, workspace, app, chat, workflow, run, operation, user, and request digest in top-level queue fields.
- Concurrent identical producers converge on one `_id`; changed content under the same identity is rejected.
- Required mode fails closed on Mongo, claim, completion, or index authority failure. Local mode deduplicates only within its process and intentionally loses replay state at restart.
- Claims renew with a holder token. Stale completion/release cannot affect a successor.
- Retry attempts are finite. Automatic recovery stops once execution has crossed `execution_started_at`.
- Read-only reconnect/history paths do not claim workflow admission.

## Tests

- `pytest -q --no-cov` — 14,189 passed, 80 skipped
- real Mongo 7 queue + chat lease tests — 18 passed
- focused queue/admission/worker tests — 103 passed
- focused transport, persistence, AG2 Network, Genesis/Refinement/task-batch/readiness tests — 191 passed, 1 skipped
- `ruff check .`
- scoped mypy for queue, admission, transport, and hosts
- source hygiene scan
- governance guardrails
- DCO sign-off and `git diff --check`

## Scope exclusions

No cancellation API/UI, orphan adoption/reconciliation, storage-level fencing tokens, token reservation, filesystem isolation, ADR 0007 work, semantic/compilation/layout changes, workflow YAML rewrites, AG2 replacements, MatrAIx, proprietary-platform behavior, or live-model execution.

## Review state

Draft for independent review. Auto-merge is intentionally disabled. Do not merge from this PR state.