### PR TITLE
feat(semantics): close renderer inputs before ADR 0007 Slice 4C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Renderer-input closure prerequisite (ADR 0007 Slice 4C, offline-only)**:
+  graph-v2 page payloads now retain the canonical page identifier, route,
+  page type, layout, shell mode, roles, navigation, metadata, and validated
+  runtime section declaratives required to reconstruct the bounded page-schema
+  corpus without invention. CompilationPlan units pin complete canonical
+  linked-node and edge footprints; renderer-incomplete families remain typed
+  gaps, while opaque executable/model-authored UTF-8 bytes are preserved
+  exactly under digest-matched `ChildContractRef` identities. The existing
+  layout registry now declares truthful materializer categories, and the
+  implementation binding pins graph-v2-compatible materializer/family
+  implementation versions. This adds no renderer, production cutover, or
+  capability advertisement; AppBuildPlan remains runtime authority.
+
 - **Aggregate CompilationPlan derivation (ADR 0007 Slice 4B, offline-only)**:
   one deterministic authoritative plan per immutable graph identity, derived
   solely from validated graph-v2 semantics, typed payloads, and the sole

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -160,6 +160,7 @@ class MaterializerIdentifier(StrEnum):
     WORKFLOW_GENERATOR = "workflow_generator"
     CAPABILITY_PACK_MATERIALIZER = "capability_pack_materializer"
     DOWNLOAD_DEPLOYMENT_RENDERER = "download_deployment_renderer"
+    PRESERVED_OPAQUE = "preserved_opaque"
     HUMAN_AUTHORED = "human_authored"
     NONE = "none"
 
@@ -240,6 +241,7 @@ class ArtifactFamily(LayoutModel):
     assignment_kinds: tuple[AssignmentKind, ...] = Field(default_factory=tuple)
     allowed_stub_kinds: tuple[StubKind, ...] = Field(default_factory=tuple)
     dependency_families: tuple[ArtifactKind, ...] = Field(default_factory=tuple)
+    semantic_input_kinds: tuple[str, ...] = Field(default_factory=tuple)
     summary: str | None = None
 
     @field_validator("path_template")
@@ -265,6 +267,22 @@ class ArtifactFamily(LayoutModel):
         cls, value: tuple[ArtifactKind, ...]
     ) -> tuple[ArtifactKind, ...]:
         return tuple(sorted(set(value), key=lambda kind: kind.value))
+
+    @field_validator("semantic_input_kinds")
+    @classmethod
+    def _normalize_semantic_input_kinds(
+        cls, value: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        # Lazy import avoids a layout-registry <-> semantics package cycle.
+        from mozaiksai.core.semantics.graph import SemanticNodeKind
+
+        try:
+            normalized = tuple(sorted({SemanticNodeKind(item).value for item in value}))
+        except ValueError as exc:
+            raise ValueError("semantic_input_kinds contains an unknown node kind") from exc
+        if len(normalized) != len(value):
+            raise ValueError("semantic_input_kinds must be unique")
+        return normalized
 
     @model_validator(mode="after")
     def _validate_dependencies_exclude_self(self) -> ArtifactFamily:
@@ -302,6 +320,7 @@ class ArtifactFamily(LayoutModel):
             "assignment_kinds": [kind.value for kind in self.assignment_kinds],
             "allowed_stub_kinds": [kind.value for kind in self.allowed_stub_kinds],
             "dependency_families": [kind.value for kind in self.dependency_families],
+            "semantic_input_kinds": list(self.semantic_input_kinds),
         }
 
 
@@ -541,7 +560,39 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
     module = PathScope.MODULE_RELATIVE
     generated = PathScope.GENERATED_STAGING
     deployment = PathScope.DEPLOYMENT_DERIVED
-
+    page_inputs = (
+        "page",
+        "section",
+        "action",
+        "workflow",
+    )
+    module_inputs = (
+        "module",
+        "action",
+        "capability",
+        "permission",
+        "event",
+        "reaction",
+        "notification",
+    )
+    data_inputs = (
+        "data_collection",
+        "data_alias",
+        "module",
+    )
+    subscription_inputs = (
+        "plan",
+        "product",
+        "meter",
+        "limit",
+        "capability",
+    )
+    workflow_inputs = (
+        "workflow",
+        "trigger",
+        "event",
+        "capability",
+    )
     return (
         _family(ArtifactKind.APP_MANIFEST, LayoutOwner.PLATFORM, Requirement.REQUIRED, app, "app.json", ValidatorIdentifier.APP_LOADER, RuntimeConsumerIdentifier.APP_LOADER),
         _family(ArtifactKind.APP_CONFIG, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "config/ai.json", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.PLATFORM_HOST),
@@ -552,16 +603,16 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_INTEGRATIONS_CONFIG, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "config/integrations.yml", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_APP_DECLARED),
         _family(ArtifactKind.APP_REFINEMENT_POLICY, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "config/refinement_policy.yaml", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.REFINEMENT_ENGINE, condition=ConditionIdentifier.WHEN_REFINEMENT_HARNESS_REQUIRED, assignment=(AssignmentKind.REFINEMENT_HARNESS,)),
         _family(ArtifactKind.APP_SHELL_CONFIG, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "config/shell.json", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
-        _family(ArtifactKind.APP_SUBSCRIPTION_CONFIG, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "config/subscriptions.yaml", ValidatorIdentifier.SUBSCRIPTIONS_LOADER, RuntimeConsumerIdentifier.ENTITLEMENT_ADAPTER, condition=ConditionIdentifier.WHEN_SUBSCRIPTIONS_REQUIRED, assignment=(AssignmentKind.SUBSCRIPTION_CONFIG,)),
+        _family(ArtifactKind.APP_SUBSCRIPTION_CONFIG, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "config/subscriptions.yaml", ValidatorIdentifier.SUBSCRIPTIONS_LOADER, RuntimeConsumerIdentifier.ENTITLEMENT_ADAPTER, condition=ConditionIdentifier.WHEN_SUBSCRIPTIONS_REQUIRED, assignment=(AssignmentKind.SUBSCRIPTION_CONFIG,), inputs=subscription_inputs),
         _family(ArtifactKind.APP_TARGETS_CONFIG, LayoutOwner.APP_WORKSPACE, Requirement.OPTIONAL, app, "config/targets.json", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.PLATFORM_HOST),
-        _family(ArtifactKind.APP_DATA_CONTRACT, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "data/contract.json", ValidatorIdentifier.DATA_CONTRACT_LOADER, RuntimeConsumerIdentifier.APP_LOADER, condition=ConditionIdentifier.WHEN_DATA_CONTRACT_REQUIRED, assignment=(AssignmentKind.PERSISTENCE_CONTRACT,)),
+        _family(ArtifactKind.APP_DATA_CONTRACT, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "data/contract.json", ValidatorIdentifier.DATA_CONTRACT_LOADER, RuntimeConsumerIdentifier.APP_LOADER, condition=ConditionIdentifier.WHEN_DATA_CONTRACT_REQUIRED, assignment=(AssignmentKind.PERSISTENCE_CONTRACT,), inputs=data_inputs),
         _family(ArtifactKind.APP_DATA_MIGRATION, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "data/migrations/{migration_id}.json", ValidatorIdentifier.DATA_CONTRACT_LOADER, RuntimeConsumerIdentifier.APP_LOADER, condition=ConditionIdentifier.WHEN_DATA_CONTRACT_REQUIRED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.DATA_MIGRATIONS,)),
         _family(ArtifactKind.APP_SECRET_REFERENCES, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "security/secrets.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_APP_DECLARED, security=SecurityClass.SECRET_REFERENCE_NAMES, assignment=(AssignmentKind.SERVICE_FOUNDATION,)),
         _family(ArtifactKind.APP_PROVENANCE, LayoutOwner.FACTORY, Requirement.OPTIONAL, app, "provenance.yaml", ValidatorIdentifier.PROVENANCE_LOADER, RuntimeConsumerIdentifier.PROVENANCE_LOADER, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_BRAND_THEME, LayoutOwner.APP_WORKSPACE, Requirement.OPTIONAL, app, "brand/theme_config.json", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_DASHBOARD, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "dashboard/dashboard.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_ROUTE_MANIFEST, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "ui/route_manifest.json", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, assignment=(AssignmentKind.PAGE_BUNDLE,), deps=(ArtifactKind.APP_UI_CUSTOM_ROUTE, ArtifactKind.APP_UI_PAGE_SCHEMA)),
-        _family(ArtifactKind.APP_UI_PAGE_SCHEMA, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_PAGE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,), stubs=(StubKind.JS_FRONTEND,)),
+        _family(ArtifactKind.APP_UI_PAGE_SCHEMA, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/{page_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_PAGE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.PAGE_BUNDLE,), stubs=(StubKind.JS_FRONTEND,), inputs=page_inputs),
         _family(ArtifactKind.APP_UI_CUSTOM_ROUTE, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/pages/custom/{page_id}.jsx", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, multiplicity=Multiplicity.MANY, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_AUTH_ADAPTER, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/auth/authAdapter.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_AUTH_ENABLED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,)),
         _family(ArtifactKind.APP_UI_EXTENSION_BARREL, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "ui/index.js", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.PLATFORM_HOST, condition=ConditionIdentifier.WHEN_CUSTOM_ROUTE_DECLARED, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.PAGE_BUNDLE,), deps=(ArtifactKind.APP_UI_CUSTOM_ROUTE,)),
@@ -573,7 +624,7 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_REFINEMENT_HARNESS, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "refinement_harness/config/tools.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.REFINEMENT_ENGINE, condition=ConditionIdentifier.WHEN_REFINEMENT_HARNESS_REQUIRED, assignment=(AssignmentKind.REFINEMENT_HARNESS,)),
         _family(ArtifactKind.APP_REFINEMENT_HARNESS, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "refinement_harness/config/policies.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.REFINEMENT_ENGINE, condition=ConditionIdentifier.WHEN_REFINEMENT_HARNESS_REQUIRED, assignment=(AssignmentKind.REFINEMENT_HARNESS,)),
         _family(ArtifactKind.APP_REFINEMENT_HARNESS, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, app, "refinement_harness/prompts/{pack_id}.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.REFINEMENT_ENGINE, condition=ConditionIdentifier.WHEN_REFINEMENT_HARNESS_REQUIRED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.REFINEMENT_HARNESS,)),
-        _family(ArtifactKind.MODULE_MANIFEST, LayoutOwner.MODULE, Requirement.CONDITIONAL, app, "modules/{module_id}/module.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_LOADER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.MODULE_CONTRACT,), stubs=(StubKind.PYTHON_BACKEND,)),
+        _family(ArtifactKind.MODULE_MANIFEST, LayoutOwner.MODULE, Requirement.CONDITIONAL, app, "modules/{module_id}/module.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_LOADER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.MODULE_CONTRACT,), stubs=(StubKind.PYTHON_BACKEND,), inputs=module_inputs),
         _family(ArtifactKind.MODULE_CONTRACT, LayoutOwner.MODULE, Requirement.CONDITIONAL, app, "modules/{module_id}/contracts/events.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_EVENT_ROUTER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.MODULE_CONTRACT,), deps=(ArtifactKind.MODULE_MANIFEST,)),
         _family(ArtifactKind.MODULE_CONTRACT, LayoutOwner.MODULE, Requirement.CONDITIONAL, app, "modules/{module_id}/contracts/reactions.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_EVENT_ROUTER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.MODULE_CONTRACT,), deps=(ArtifactKind.MODULE_MANIFEST,)),
         _family(ArtifactKind.MODULE_CONTRACT, LayoutOwner.MODULE, Requirement.CONDITIONAL, app, "modules/{module_id}/contracts/notifications.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_EVENT_ROUTER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, multiplicity=Multiplicity.MANY, assignment=(AssignmentKind.MODULE_CONTRACT,), deps=(ArtifactKind.MODULE_MANIFEST,)),
@@ -609,9 +660,9 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, ".github/workflows/deploy.yml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
         _family(ArtifactKind.APP_DEPLOYMENT_ARTIFACT, LayoutOwner.DOWNLOAD_RENDERER, Requirement.GENERATED, deployment, ".github/workflows/readiness.yml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.DOWNLOAD_EXPORT, condition=ConditionIdentifier.WHEN_DEPLOYMENT_EXPORT_REQUESTED, security=SecurityClass.DEPLOYMENT_METADATA),
         _family(ArtifactKind.APP_MANIFEST, LayoutOwner.PLATFORM, Requirement.REQUIRED, workspace, "app/app.json", ValidatorIdentifier.APP_LOADER, RuntimeConsumerIdentifier.APP_LOADER),
-        _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workspace, "workflows/{workflow_id}/orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, multiplicity=Multiplicity.MANY),
+        _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workspace, "workflows/{workflow_id}/orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, multiplicity=Multiplicity.MANY, inputs=workflow_inputs),
         _family(ArtifactKind.BUILD_CONTEXT_REGISTRY, LayoutOwner.CAPABILITY_PACK, Requirement.OPTIONAL, workspace, "build_context/{pack_id}/context.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.NONE, multiplicity=Multiplicity.MANY),
-        _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workflow, "orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED),
+        _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workflow, "orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, inputs=workflow_inputs),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "agents.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "context_variables.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "structured_outputs.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
@@ -861,12 +912,17 @@ def _family(
     *,
     condition: ConditionIdentifier | None = None,
     multiplicity: Multiplicity = Multiplicity.SINGLE,
-    materializer: MaterializerIdentifier = MaterializerIdentifier.APP_GENERATOR,
+    materializer: MaterializerIdentifier | None = None,
     security: SecurityClass = SecurityClass.INTERNAL_CONTRACT,
     assignment: tuple[AssignmentKind, ...] = (),
     stubs: tuple[StubKind, ...] = (),
     deps: tuple[ArtifactKind, ...] = (),
+    inputs: tuple[str, ...] = (),
 ) -> ArtifactFamily:
+    resolved_materializer = materializer or _materializer_for_family(
+        kind=kind, owner=owner, security=security
+    )
+    resolved_inputs = inputs or _semantic_inputs_for_family(kind)
     resolved_condition = condition or (
         ConditionIdentifier.ALWAYS if requirement == Requirement.REQUIRED else ConditionIdentifier.WHEN_APP_DECLARED
     )
@@ -878,14 +934,96 @@ def _family(
         condition=resolved_condition,
         path_scope=scope,
         path_template=template,
-        materializer=materializer,
+        materializer=resolved_materializer,
         validator=validator,
         runtime_consumer=consumer,
         security_class=security,
         assignment_kinds=assignment,
         allowed_stub_kinds=stubs,
         dependency_families=deps,
+        semantic_input_kinds=resolved_inputs,
     )
+
+
+def _materializer_for_family(
+    *, kind: ArtifactKind, owner: LayoutOwner, security: SecurityClass
+) -> MaterializerIdentifier:
+    """Return the truthful historical materializer category for a core row.
+
+    This replaces the former blanket ``APP_GENERATOR`` default.  It declares
+    ownership category only; it does not claim that a deterministic renderer
+    implementation exists or that its semantic inputs are complete.
+    """
+    if security is SecurityClass.EXECUTABLE_STUB:
+        return MaterializerIdentifier.PRESERVED_OPAQUE
+    if kind is ArtifactKind.APP_UI_PAGE_SCHEMA:
+        return MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR
+    if kind in {
+        ArtifactKind.MODULE_MANIFEST,
+        ArtifactKind.MODULE_CONTRACT,
+        ArtifactKind.MODULE_RUNTIME_EXTENSIONS,
+    }:
+        return MaterializerIdentifier.MODULE_CONTRACT_EXECUTOR
+    if kind is ArtifactKind.WORKFLOW_MANIFEST:
+        return MaterializerIdentifier.WORKFLOW_GENERATOR
+    if kind in {
+        ArtifactKind.WORKFLOW_CONFIG,
+        ArtifactKind.WORKFLOW_TASK_BATCH,
+        ArtifactKind.WORKFLOW_TOOL,
+        ArtifactKind.WORKFLOW_UI,
+    }:
+        return MaterializerIdentifier.PRESERVED_OPAQUE
+    if kind in {ArtifactKind.BUILD_CONTEXT_REGISTRY, ArtifactKind.CAPABILITY_PACK_OUTPUT}:
+        return MaterializerIdentifier.CAPABILITY_PACK_MATERIALIZER
+    if owner is LayoutOwner.DOWNLOAD_RENDERER or kind is ArtifactKind.APP_DEPLOYMENT_ARTIFACT:
+        return MaterializerIdentifier.DOWNLOAD_DEPLOYMENT_RENDERER
+    return MaterializerIdentifier.APP_GENERATOR
+
+
+def _semantic_inputs_for_family(kind: ArtifactKind) -> tuple[str, ...]:
+    """Declare graph-v2 input kinds for the bounded renderer corpus."""
+    return {
+        ArtifactKind.APP_UI_PAGE_SCHEMA: (
+            "page",
+            "section",
+            "action",
+            "workflow",
+        ),
+        ArtifactKind.MODULE_MANIFEST: (
+            "module",
+            "action",
+            "capability",
+            "permission",
+            "event",
+        ),
+        ArtifactKind.MODULE_CONTRACT: (
+            "module",
+            "event",
+            "reaction",
+            "notification",
+        ),
+        ArtifactKind.APP_DATA_CONTRACT: (
+            "data_collection",
+            "data_alias",
+            "module",
+        ),
+        ArtifactKind.APP_SUBSCRIPTION_CONFIG: (
+            "plan",
+            "product",
+            "meter",
+            "limit",
+            "capability",
+        ),
+        ArtifactKind.WORKFLOW_MANIFEST: (
+            "workflow",
+            "trigger",
+            "event",
+            "capability",
+        ),
+        ArtifactKind.APP_DEPLOYMENT_ARTIFACT: (
+            "deployment_target",
+        ),
+    }.get(kind, ())
 
 
 def _prohibited(scope: PathScope, template: str) -> ArtifactFamily:

--- a/mozaiksai/core/runtime/app/page_schema.py
+++ b/mozaiksai/core/runtime/app/page_schema.py
@@ -343,6 +343,54 @@ class AppSegmentedBarConfig(PageContractModel):
     segments: list[AppSegment]
 
 
+class AppPricingCatalogManagedAI(PageContractModel):
+    display: str | None = None
+
+
+class AppPricingCatalogUsageLimit(PageContractModel):
+    label: str | None = None
+    monthly_limit_display: str | None = None
+
+
+class AppPricingCatalogPrice(PageContractModel):
+    display: str | None = None
+    interval: str | None = None
+
+
+class AppPricingCatalogPlan(PageContractModel):
+    plan_id: str
+    label: str
+    description: str | None = None
+    price_display: str | None = None
+    cta_label: str | None = None
+    highlights: list[str] | None = None
+    managed_ai: AppPricingCatalogManagedAI | None = None
+    usage_limits: list[AppPricingCatalogUsageLimit] | None = None
+    pricing: AppPricingCatalogPrice | None = None
+    is_default: bool | None = None
+
+
+class AppPricingCatalogGroup(PageContractModel):
+    group_id: str
+    label: str
+    description: str | None = None
+    kind: Literal["subscription", "service", "add_on", "mixed"] | None = None
+    plan_ids: list[str] | None = None
+    capability_groups: list[str] | None = None
+    add_on_ids: list[str] | None = None
+
+
+class AppPricingCatalogAddOn(PageContractModel):
+    id: str | None = None
+    add_on_id: str | None = None
+    label: str
+    description: str | None = None
+    price_display: str | None = None
+    price: AppPricingCatalogPrice | None = None
+    cta_label: str | None = None
+    highlights: list[str] | None = None
+
+
 class AppPricingCatalogConfig(DataBackedConfig):
     title: str | None = None
     subtitle: str | None = None
@@ -355,9 +403,9 @@ class AppPricingCatalogConfig(DataBackedConfig):
     highlighted_plan_id: str | None = None
     plan_action_label: str | None = None
     add_on_action_label: str | None = None
-    plans: list[dict[str, Any]] | None = None
-    groups: list[dict[str, Any]] | None = None
-    add_ons: list[dict[str, Any]] | None = None
+    plans: list[AppPricingCatalogPlan] | None = None
+    groups: list[AppPricingCatalogGroup] | None = None
+    add_ons: list[AppPricingCatalogAddOn] | None = None
     plan_action: AppPageAction | None = None
     add_on_action: AppPageAction | None = None
 

--- a/mozaiksai/core/semantics/__init__.py
+++ b/mozaiksai/core/semantics/__init__.py
@@ -41,6 +41,7 @@ from mozaiksai.core.semantics.manifest import (
     ApplicationManifest,
     build_application_manifest,
 )
+from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
 from mozaiksai.core.semantics.refs import (
     ApplicationManifestRef,
     ArtifactRevisionRef,
@@ -74,6 +75,7 @@ __all__ = [
     "ExecutionAccessScopeRef",
     "ImplementationBinding",
     "ImplementationBindingRef",
+    "PreservedOpaqueArtifact",
     "RefDocumentType",
     "ReferenceResolutionError",
     "RefinementPatchRef",

--- a/mozaiksai/core/semantics/binding.py
+++ b/mozaiksai/core/semantics/binding.py
@@ -1,24 +1,32 @@
 """Immutable ``mozaiks.implementation_binding.v1`` contract.
 
 An implementation binding maps graph-authored requirements to verified
-capability-pack identities and digests, renderer/adapter identities and
-versions, and deployment-target implementation profiles.  Structurally it can
-only *select* implementations for requirement nodes that already exist in the
-pinned graph: it carries no fields that could add pages, actions, events,
-entitlements, data requirements, or provider obligations, and validation
-rejects any selection whose requirement node is absent from, or of the wrong
-kind for, the graph.  No private strategy, build-context input, or provider
-choice becomes a second semantic authority.
+capability-pack identities and digests, registry-owned artifact families to
+renderer implementation/version identities, and deployment-target
+implementation profiles. Capability and deployment selections can only name
+typed requirement nodes in the pinned graph. Renderer selections can only
+name existing layout-registry families under their declared materializer and
+must target graph v2. No selection can add semantic facts, registry rows,
+private strategy, build-context input, or provider policy.
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from pydantic import Field, field_validator, model_validator
 
+from mozaiksai.core.runtime.app.layout_registry import (
+    AppLayoutRegistry,
+    MaterializerIdentifier,
+    default_app_layout_registry,
+)
 from mozaiksai.core.semantics.canonical import canonical_digest
-from mozaiksai.core.semantics.graph import SemanticGraph, SemanticNodeKind, _validate_node_id
+from mozaiksai.core.semantics.graph import (
+    SemanticGraph,
+    SemanticNodeKind,
+    _validate_node_id,
+)
 from mozaiksai.core.semantics.refs import (
     ExecutionAccessScopeRef,
     SemanticGraphRef,
@@ -36,10 +44,21 @@ IMPLEMENTATION_BINDING_SCHEMA_VERSION: Literal["mozaiks.implementation_binding.v
 CAPABILITY_PACK_REQUIREMENT_KINDS = frozenset(
     {SemanticNodeKind.CAPABILITY, SemanticNodeKind.MODULE}
 )
-RENDERER_REQUIREMENT_KINDS = frozenset(
-    {SemanticNodeKind.SURFACE, SemanticNodeKind.PAGE, SemanticNodeKind.SECTION}
+RENDERER_GRAPH_SCHEMA_VERSION: Literal["mozaiks.semantic_graph.v2"] = (
+    "mozaiks.semantic_graph.v2"
 )
 DEPLOYMENT_REQUIREMENT_KINDS = frozenset({SemanticNodeKind.DEPLOYMENT_TARGET})
+
+
+class _GraphSubject(Protocol):
+    """Structural surface shared by immutable graph v1 and graph v2."""
+
+    schema_version: str
+    graph_id: str
+    version: int
+    scope: ExecutionAccessScopeRef
+    graph_digest: str
+    nodes: tuple[Any, ...]
 
 
 class ImplementationBindingError(ValueError):
@@ -70,22 +89,60 @@ class CapabilityPackSelection(_Selection):
         return _validate_digest(value, field_name="pack_digest")
 
 
-class RendererSelection(_Selection):
-    renderer_id: str
-    renderer_version: str
+class RendererSelection(SemanticsModel):
+    """Bind registry materializer categories to deterministic implementations.
 
-    @field_validator("renderer_id")
-    @classmethod
-    def _renderer_id(cls, value: str) -> str:
-        return _validate_identifier(value, field_name="renderer_id")
+    Artifact families remain owned by ``layout_registry``.  This selection
+    merely pins an implementation identity/version for rows whose declared
+    materializer matches, and explicitly states graph-v2 compatibility.
+    """
 
-    @field_validator("renderer_version")
+    materializer_id: MaterializerIdentifier
+    implementation_id: str
+    implementation_version: str
+    artifact_families: tuple[str, ...] = Field(min_length=1)
+    graph_schema_versions: tuple[Literal["mozaiks.semantic_graph.v2"], ...] = (
+        RENDERER_GRAPH_SCHEMA_VERSION,
+    )
+
+    @field_validator("implementation_id")
     @classmethod
-    def _renderer_version(cls, value: str) -> str:
+    def _implementation_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="implementation_id")
+
+    @field_validator("implementation_version")
+    @classmethod
+    def _implementation_version(cls, value: str) -> str:
         text = str(value or "").strip()
         if not text:
-            raise ValueError("renderer_version must be non-empty")
+            raise ValueError("implementation_version must be non-empty")
         return text
+
+    @field_validator("artifact_families")
+    @classmethod
+    def _families(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_grammar
+
+        ordered = tuple(
+            sorted(
+                {
+                    validate_identifier_grammar(SemanticCategory.ARTIFACT_FAMILY, item)
+                    for item in value
+                }
+            )
+        )
+        if len(ordered) != len(value):
+            raise ValueError("artifact_families must be unique")
+        return ordered
+
+    @field_validator("graph_schema_versions")
+    @classmethod
+    def _graph_versions(
+        cls, value: tuple[Literal["mozaiks.semantic_graph.v2"], ...]
+    ) -> tuple[Literal["mozaiks.semantic_graph.v2"], ...]:
+        if value != (RENDERER_GRAPH_SCHEMA_VERSION,):
+            raise ValueError("renderer implementations must explicitly target graph v2")
+        return value
 
 
 class DeploymentProfileSelection(_Selection):
@@ -144,7 +201,20 @@ class ImplementationBinding(SemanticsModel):
     @field_validator("renderer_selections")
     @classmethod
     def _renderers(cls, value):
-        return _sorted_unique(value, category="renderer")
+        ordered = tuple(
+            sorted(
+                value,
+                key=lambda item: (
+                    item.materializer_id.value,
+                    item.implementation_id,
+                    item.implementation_version,
+                ),
+            )
+        )
+        families = [family for item in ordered for family in item.artifact_families]
+        if len(families) != len(set(families)):
+            raise ValueError("one artifact family cannot select multiple renderer implementations")
+        return ordered
 
     @field_validator("deployment_profile_selections")
     @classmethod
@@ -197,7 +267,11 @@ def build_implementation_binding(**fields: Any) -> ImplementationBinding:
         "renderer_selections": tuple(
             sorted(
                 tuple(fields.get("renderer_selections", ())),
-                key=lambda item: item.requirement_node_id,
+                key=lambda item: (
+                    item.materializer_id.value,
+                    item.implementation_id,
+                    item.implementation_version,
+                ),
             )
         ),
         "deployment_profile_selections": tuple(
@@ -229,7 +303,10 @@ def build_implementation_binding(**fields: Any) -> ImplementationBinding:
 
 
 def validate_implementation_binding_against_graph(
-    binding: ImplementationBinding, graph: SemanticGraph
+    binding: ImplementationBinding,
+    graph: SemanticGraph | _GraphSubject,
+    *,
+    layout_registry: AppLayoutRegistry | None = None,
 ) -> None:
     """Fail closed unless every selection satisfies an existing typed requirement.
 
@@ -252,7 +329,6 @@ def validate_implementation_binding_against_graph(
     known = {node.node_id: node for node in graph.nodes}
     checks = (
         ("capability-pack", binding.capability_pack_selections, CAPABILITY_PACK_REQUIREMENT_KINDS),
-        ("renderer", binding.renderer_selections, RENDERER_REQUIREMENT_KINDS),
         ("deployment-profile", binding.deployment_profile_selections, DEPLOYMENT_REQUIREMENT_KINDS),
     )
     for category, selections, allowed_kinds in checks:
@@ -271,6 +347,33 @@ def validate_implementation_binding_against_graph(
                     f"{sorted(kind.value for kind in allowed_kinds)}"
                 )
 
+    if binding.renderer_selections and graph.schema_version != RENDERER_GRAPH_SCHEMA_VERSION:
+        raise ImplementationBindingError(
+            "renderer implementation selections require a semantic graph v2 subject"
+        )
+    registry = layout_registry or default_app_layout_registry()
+    rows_by_kind: dict[str, list] = {}
+    for row in registry.families:
+        rows_by_kind.setdefault(row.kind.value, []).append(row)
+    for renderer in binding.renderer_selections:
+        for family in renderer.artifact_families:
+            rows = rows_by_kind.get(family)
+            if not rows:
+                raise ImplementationBindingError(
+                    f"renderer selection targets unregistered artifact family {family!r}"
+                )
+            mismatched = [
+                row.materializer.value
+                for row in rows
+                if row.materializer is not renderer.materializer_id
+            ]
+            if mismatched:
+                raise ImplementationBindingError(
+                    f"renderer selection for {family!r} claims materializer "
+                    f"{renderer.materializer_id.value!r}, but layout_registry declares "
+                    f"{sorted(set(mismatched))!r}"
+                )
+
 
 __all__ = [
     "CAPABILITY_PACK_REQUIREMENT_KINDS",
@@ -280,7 +383,7 @@ __all__ = [
     "IMPLEMENTATION_BINDING_SCHEMA_VERSION",
     "ImplementationBinding",
     "ImplementationBindingError",
-    "RENDERER_REQUIREMENT_KINDS",
+    "RENDERER_GRAPH_SCHEMA_VERSION",
     "RendererSelection",
     "build_implementation_binding",
     "validate_implementation_binding_against_graph",

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -19,9 +19,10 @@ Completeness rule: every registry family row is either disposed
 inapplicable) or carried as an explicit typed ``PlanGap`` with a closed reason
 code. Omission is never an implicit decision. Conditions that graph-v2
 semantics cannot decide, placeholders whose joint binding no typed graph
-relationship proves, and renderer resolution are typed gaps deferred to the
-implementation-binding slice — the plan never invents a semantic fact, and a
-validated unit can never carry an unresolved ``{placeholder}``.
+relationship proves, and incomplete renderer inputs are typed gaps. Renderer
+implementation/version selection remains in the separate implementation
+binding — the plan never invents a semantic fact, and a validated unit can
+never carry an unresolved ``{placeholder}``.
 
 Every authoritative field obeys a closed value domain (enums or canonical
 lowercase identifier grammar); the document carries no free-form prose, so
@@ -50,8 +51,13 @@ from typing import Any, Literal
 from pydantic import Field, field_validator, model_validator
 
 from mozaiksai.core.semantics.canonical import canonical_digest
-from mozaiksai.core.semantics.graph import SemanticGraphV2, SemanticNodeKind
+from mozaiksai.core.semantics.graph import (
+    SemanticEdgeKind,
+    SemanticGraphV2,
+    SemanticNodeKind,
+)
 from mozaiksai.core.semantics.payloads import (
+    PagePayload,
     SemanticPayloadBase,
     parse_semantic_payload,
     validate_semantic_graph_v2_payload_closure,
@@ -132,6 +138,7 @@ class RegistryFamilyRow(SemanticsModel):
     path_template: str
     materializer: str
     dependency_families: tuple[str, ...] = Field(default_factory=tuple)
+    semantic_input_kinds: tuple[str, ...] = Field(default_factory=tuple)
 
     @field_validator(
         "kind", "owner", "requirement", "multiplicity", "condition", "path_scope", "materializer"
@@ -152,6 +159,14 @@ class RegistryFamilyRow(SemanticsModel):
             sorted({_identifier(item, field_name="dependency_families") for item in value})
         )
 
+    @field_validator("semantic_input_kinds")
+    @classmethod
+    def _semantic_inputs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        try:
+            return tuple(sorted({SemanticNodeKind(item).value for item in value}))
+        except ValueError as exc:
+            raise ValueError("semantic_input_kinds contains an unknown node kind") from exc
+
     @property
     def identity_payload(self) -> dict[str, Any]:
         return {
@@ -164,6 +179,7 @@ class RegistryFamilyRow(SemanticsModel):
             "path_template": self.path_template,
             "materializer": self.materializer,
             "dependency_families": list(self.dependency_families),
+            "semantic_input_kinds": list(self.semantic_input_kinds),
         }
 
     @property
@@ -261,6 +277,10 @@ def snapshot_layout_registry(registry: Any) -> LayoutRegistrySnapshot:
                 dependency_families=tuple(
                     getattr(item, "value", item) for item in family.dependency_families
                 ),
+                semantic_input_kinds=tuple(
+                    getattr(item, "value", item)
+                    for item in getattr(family, "semantic_input_kinds", ())
+                ),
             )
             for family in families
         )
@@ -322,6 +342,8 @@ class PlanGapCode(StrEnum):
     PLACEHOLDER_UNDERIVABLE = "placeholder_underivable"
     PLACEHOLDER_RELATIONSHIP_UNPROVABLE = "placeholder_relationship_unprovable"
     RENDERER_RESOLUTION_DEFERRED = "renderer_resolution_deferred"
+    RENDERER_INPUT_UNDECLARED = "renderer_input_undeclared"
+    RENDERER_INPUT_INCOMPLETE = "renderer_input_incomplete"
 
 
 class PlanGap(SemanticsModel):
@@ -372,6 +394,50 @@ class PlanSource(SemanticsModel):
         return _validate_digest(value, field_name="payload_digest")
 
 
+class PlanEdgeSource(SemanticsModel):
+    """One complete graph relationship whose facts can affect rendered bytes."""
+
+    kind: SemanticEdgeKind
+    source_node_id: str
+    target_node_id: str
+    discriminator: str | None = None
+    edge_identity: str
+
+    @field_validator("source_node_id", "target_node_id")
+    @classmethod
+    def _endpoint(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("discriminator")
+    @classmethod
+    def _discriminator(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            raise ValueError("discriminator must be non-empty when present")
+        return text
+
+    @field_validator("edge_identity")
+    @classmethod
+    def _identity(cls, value: str) -> str:
+        return _validate_digest(value, field_name="edge_identity")
+
+    @model_validator(mode="after")
+    def _identity_matches_facts(self) -> PlanEdgeSource:
+        expected = canonical_digest(
+            {
+                "kind": self.kind.value,
+                "source_node_id": self.source_node_id,
+                "target_node_id": self.target_node_id,
+                "discriminator": self.discriminator,
+            }
+        )
+        if self.edge_identity != expected:
+            raise ValueError("edge_identity does not match edge source facts")
+        return self
+
+
 class PlanOutput(SemanticsModel):
     """One planned output path inside its registry path scope."""
 
@@ -408,6 +474,7 @@ class FamilyInstancePlan(SemanticsModel):
     placeholder_values: tuple[tuple[str, str], ...] = Field(default_factory=tuple)
     outputs: tuple[PlanOutput, ...] = Field(default_factory=tuple)
     sources: tuple[PlanSource, ...] = Field(default_factory=tuple)
+    edge_sources: tuple[PlanEdgeSource, ...] = Field(default_factory=tuple)
     depends_on_units: tuple[str, ...] = Field(default_factory=tuple)
     materializer: str
     base_plan_digest: str | None = None
@@ -471,6 +538,15 @@ class FamilyInstancePlan(SemanticsModel):
             raise ValueError("duplicate source node identities in one unit")
         return ordered
 
+    @field_validator("edge_sources")
+    @classmethod
+    def _edge_sources(cls, value: tuple[PlanEdgeSource, ...]) -> tuple[PlanEdgeSource, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.edge_identity))
+        identities = [item.edge_identity for item in ordered]
+        if len(identities) != len(set(identities)):
+            raise ValueError("duplicate edge source identities in one unit")
+        return ordered
+
     @field_validator("depends_on_units")
     @classmethod
     def _deps(cls, value: tuple[str, ...]) -> tuple[str, ...]:
@@ -487,7 +563,9 @@ class FamilyInstancePlan(SemanticsModel):
             raise ValueError(
                 "base_plan_digest is required exactly when disposition is reuse_from_base"
             )
-        if self.source_scope is PlanSourceScope.GRAPH_WIDE and self.sources:
+        if self.source_scope is PlanSourceScope.GRAPH_WIDE and (
+            self.sources or self.edge_sources
+        ):
             raise ValueError("graph_wide units must not also declare explicit sources")
         for output in self.outputs:
             if output.path_scope in _INSTANCE_PATH_SCOPES and not self.placeholder_values:
@@ -514,6 +592,7 @@ class FamilyInstancePlan(SemanticsModel):
                 {"node_id": source.node_id, "payload_digest": source.payload_digest}
                 for source in self.sources
             ],
+            "edge_sources": [source.model_dump(mode="json") for source in self.edge_sources],
             "depends_on_units": list(self.depends_on_units),
             "materializer": self.materializer,
             "base_plan_digest": self.base_plan_digest,
@@ -727,12 +806,6 @@ _FAMILY_SOURCE_KINDS: dict[str, tuple[SemanticNodeKind, ...]] = {
 }
 
 
-def _node_local_identity(node_id: str) -> str:
-    parts = validate_node_id_grammar(node_id).split(".")
-    local = "_".join(parts[2:]) if len(parts) > 2 else parts[-1]
-    return local.replace(".", "_").replace("-", "_")
-
-
 def _cold_validate_inputs(
     graph: SemanticGraphV2, payloads: Iterable[SemanticPayloadBase]
 ) -> tuple[SemanticGraphV2, dict[str, SemanticPayloadBase]]:
@@ -788,6 +861,120 @@ def derive_compilation_plan(
                     )
                 )
         return tuple(collected)
+
+    node_by_id = {node.node_id: node for node in verified_graph.nodes}
+
+    def _renderer_footprint(
+        row: RegistryFamilyRow, *, root_node_id: str | None = None
+    ) -> tuple[tuple[PlanSource, ...], tuple[PlanEdgeSource, ...]]:
+        allowed = {SemanticNodeKind(kind) for kind in row.semantic_input_kinds}
+        if not allowed:
+            return (), ()
+        if root_node_id is None:
+            selected = {
+                node.node_id for node in verified_graph.nodes if node.kind in allowed
+            }
+        else:
+            selected = {root_node_id}
+            root_payload = payload_by_node[root_node_id]
+            if isinstance(root_payload, PagePayload):
+                selected.update(
+                    entry.section_node_id
+                    for entry in root_payload.sections
+                    if node_by_id[entry.section_node_id].kind in allowed
+                )
+            for edge in verified_graph.edges:
+                if edge.source_node_id == root_node_id:
+                    other = edge.target_node_id
+                elif edge.target_node_id == root_node_id:
+                    other = edge.source_node_id
+                else:
+                    continue
+                if node_by_id[other].kind in allowed:
+                    selected.add(other)
+            expandable = {
+                SemanticNodeKind.ACTION,
+                SemanticNodeKind.TRIGGER,
+                SemanticNodeKind.REACTION,
+                SemanticNodeKind.NOTIFICATION,
+            }
+            for linked_id in tuple(selected):
+                if node_by_id[linked_id].kind not in expandable:
+                    continue
+                for edge in verified_graph.edges:
+                    if edge.source_node_id == linked_id:
+                        other = edge.target_node_id
+                    elif edge.target_node_id == linked_id:
+                        other = edge.source_node_id
+                    else:
+                        continue
+                    if node_by_id[other].kind in allowed:
+                        selected.add(other)
+        sources = tuple(
+            PlanSource(
+                node_id=node_id,
+                payload_digest=payload_by_node[node_id].payload_digest,
+            )
+            for node_id in sorted(selected)
+        )
+        edge_sources = tuple(
+            PlanEdgeSource(
+                kind=edge.kind,
+                source_node_id=edge.source_node_id,
+                target_node_id=edge.target_node_id,
+                discriminator=edge.discriminator,
+                edge_identity=edge.edge_identity,
+            )
+            for edge in verified_graph.edges
+            if edge.source_node_id in selected and edge.target_node_id in selected
+        )
+        return sources, edge_sources
+
+    def _placeholder_value(placeholder: str, node_id: str) -> str:
+        identity_fields = {
+            "page_id": "page_id",
+            "module_id": "module_id",
+            "workflow_id": "workflow_id",
+        }
+        field = identity_fields[placeholder]
+        value = str(getattr(payload_by_node[node_id], field, "") or "").strip()
+        if _VALUE_RE.fullmatch(value) is None:
+            raise CompilationPlanError(
+                f"payload {node_id!r} lacks canonical renderer identity {field!r}"
+            )
+        return value
+
+    def _renderer_inputs_complete(
+        row: RegistryFamilyRow, *, root_node_id: str | None
+    ) -> bool:
+        """Recognize only the bounded corpus whose semantic facts are closed.
+
+        Other declared footprints are useful dependency evidence, but they do
+        not imply byte-complete renderer inputs.  Those families remain typed
+        gaps until a later prerequisite explicitly closes their normative
+        source models.
+        """
+        if row.kind != "app_ui_page_schema" or root_node_id is None:
+            return False
+        page = payload_by_node[root_node_id]
+        if not isinstance(page, PagePayload):
+            return False
+        if not all(
+            (
+                page.page_id,
+                page.route,
+                page.title,
+                page.page_type,
+                page.layout,
+                page.sections,
+            )
+        ):
+            return False
+        return all(
+            getattr(payload_by_node.get(entry.section_node_id), "declarative", None)
+            is not None
+            for entry in page.sections
+        )
 
     units: dict[str, FamilyInstancePlan] = {}
     gaps: list[PlanGap] = []
@@ -877,11 +1064,12 @@ def derive_compilation_plan(
             nodes_by_kind.get(kind) for kind in trigger_kinds
         )
         disposition = (
-            PlanDisposition.EXTERNAL_HANDOFF
+            PlanDisposition.PRESERVE_UNOWNED
+            if row.materializer in {"human_authored", "preserved_opaque"}
+            else PlanDisposition.EXTERNAL_HANDOFF
             if row.path_scope == "deployment_derived" or row.owner == "download_renderer"
             else PlanDisposition.RENDER
         )
-
         if not condition_met:
             _add_unit(
                 FamilyInstancePlan(
@@ -895,17 +1083,34 @@ def derive_compilation_plan(
             )
             continue
 
+        if disposition is PlanDisposition.RENDER and not row.semantic_input_kinds:
+            _gap(row, PlanGapCode.RENDERER_INPUT_UNDECLARED, adr_slice=4)
+            continue
+
         if bindable:
             placeholder = next(iter(bindable))
             node_kind = _INSTANCE_PLACEHOLDERS[placeholder]
             for node in nodes_by_kind.get(node_kind, ()):
-                local = _node_local_identity(node.node_id)
+                local = _placeholder_value(placeholder, node.node_id)
+                if disposition is PlanDisposition.RENDER and not _renderer_inputs_complete(
+                    row, root_node_id=node.node_id
+                ):
+                    _gap(
+                        row,
+                        PlanGapCode.RENDERER_INPUT_INCOMPLETE,
+                        subject=local,
+                        adr_slice=4,
+                    )
+                    continue
                 values = ((placeholder, local),)
                 path = row.path_template.replace("{" + placeholder + "}", local)
                 # Scope-implied instances keep the template text unchanged;
                 # their instance identity lives in placeholder_values and the
                 # collision domain, not the relative path.
 
+                unit_sources, unit_edge_sources = _renderer_footprint(
+                    row, root_node_id=node.node_id
+                )
                 unit = FamilyInstancePlan(
                     unit_id=f"{row.kind}/{local}/{row_digest[:12]}",
                     family_kind=row.kind,
@@ -914,19 +1119,27 @@ def derive_compilation_plan(
                     source_scope=PlanSourceScope.DECLARED,
                     placeholder_values=values,
                     outputs=(PlanOutput(path_scope=row.path_scope, path=path),),
-                    sources=(
+                    sources=unit_sources
+                    or (
                         PlanSource(
                             node_id=node.node_id,
                             payload_digest=payload_by_node[node.node_id].payload_digest,
                         ),
                     ),
+                    edge_sources=unit_edge_sources,
                     materializer=row.materializer,
                 )
                 _add_unit(unit)
                 unit_instance_index[(row.kind, values)] = unit.unit_id
         else:
+            if disposition is PlanDisposition.RENDER and not _renderer_inputs_complete(
+                row, root_node_id=None
+            ):
+                _gap(row, PlanGapCode.RENDERER_INPUT_INCOMPLETE, adr_slice=4)
+                continue
             source_kinds = _FAMILY_SOURCE_KINDS.get(row.condition, ())
-            graph_wide = not trigger_kinds and not source_kinds
+            declared_sources, declared_edge_sources = _renderer_footprint(row)
+            graph_wide = not trigger_kinds and not source_kinds and not row.semantic_input_kinds
             unit = FamilyInstancePlan(
                 unit_id=f"{row.kind}/{row_digest[:12]}",
                 family_kind=row.kind,
@@ -936,7 +1149,12 @@ def derive_compilation_plan(
                     PlanSourceScope.GRAPH_WIDE if graph_wide else PlanSourceScope.DECLARED
                 ),
                 outputs=(PlanOutput(path_scope=row.path_scope, path=row.path_template),),
-                sources=() if graph_wide else _sources_for(source_kinds),
+                sources=(
+                    ()
+                    if graph_wide
+                    else declared_sources or _sources_for(source_kinds)
+                ),
+                edge_sources=() if graph_wide else declared_edge_sources,
                 materializer=row.materializer,
             )
             _add_unit(unit)
@@ -1051,6 +1269,7 @@ def _reuse_signature(unit: FamilyInstancePlan, plan: CompilationPlan) -> Any:
         unit.placeholder_values,
         tuple((output.path_scope, output.path) for output in unit.outputs),
         tuple((source.node_id, source.payload_digest) for source in unit.sources),
+        tuple(source.edge_identity for source in unit.edge_sources),
         unit.depends_on_units,
         unit.materializer,
         plan.graph_digest if unit.source_scope is PlanSourceScope.GRAPH_WIDE else None,
@@ -1132,6 +1351,7 @@ __all__ = [
     "PlanDisposition",
     "PlanGap",
     "PlanGapCode",
+    "PlanEdgeSource",
     "PlanOutput",
     "PlanSource",
     "PlanSourceScope",

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, get_args
 import yaml
 from pydantic import Field
 
+from mozaiksai.core.runtime.app.page_schema import AppPageSection
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.graph import (
     SemanticEdge,
@@ -604,6 +605,7 @@ class _Builder:
         path: str,
         group: str,
         taxonomy: tuple[SemanticCategory, str] | None = None,
+        renderer_identity: Any | None = None,
     ) -> str:
         node_id = _node_id(kind, identity)
         if (group, node_id) in self.node_groups:
@@ -660,6 +662,20 @@ class _Builder:
                 ]
             )
         self.nodes[node_id] = candidate
+        renderer_identity_fields = {
+            SemanticNodeKind.PAGE: "page_id",
+            SemanticNodeKind.SECTION: "section_id",
+            SemanticNodeKind.MODULE: "module_id",
+            SemanticNodeKind.WORKFLOW: "workflow_id",
+        }
+        renderer_identity_field = renderer_identity_fields.get(kind)
+        if renderer_identity_field is not None:
+            source_identity = (
+                _slug(identity)
+                if renderer_identity is None
+                else str(renderer_identity).strip()
+            )
+            self.content_field(node_id, renderer_identity_field, source_identity, path)
         self.mark(
             path,
             node=kind,
@@ -866,6 +882,7 @@ class _Builder:
             path = f"{root}.pages[{i}].name" if item.get("name") else f"{root}.pages[{i}].route"
             self.observe("page", identity, "route", item.get("route"), f"{root}.pages[{i}].route")
             page = self.node(SemanticNodeKind.PAGE, identity, path=path, group=f"{root}.pages")
+            self.content_field(page, "route", item.get("route"), f"{root}.pages[{i}].route")
             self.content_field(page, "title", item.get("title"), f"{root}.pages[{i}].title")
             self.content_field(page, "intent", item.get("purpose"), f"{root}.pages[{i}].purpose")
         for i, raw in enumerate(_as_list(plan.get("entities"))):
@@ -946,8 +963,19 @@ class _Builder:
             key = next(key for key in ("page_id", "name", "route") if item.get(key))
             self.observe("page", identity, "route", item.get("route"), f"{root}[{i}].route")
             page = self.node(SemanticNodeKind.PAGE, identity, path=f"{root}[{i}].{key}", group=root)
+            self.content_field(page, "route", item.get("route"), f"{root}[{i}].route")
             self.content_field(page, "title", item.get("title"), f"{root}[{i}].title")
             self.content_field(page, "intent", item.get("description"), f"{root}[{i}].description")
+            self.content_field(page, "page_type", item.get("page_type"), f"{root}[{i}].page_type")
+            self.content_field(page, "layout", item.get("layout"), f"{root}[{i}].layout")
+            self.content_field(
+                page, "shell_mode", item.get("shell_mode"), f"{root}[{i}].shell_mode"
+            )
+            self.content_field(page, "roles", item.get("roles"), f"{root}[{i}].roles")
+            self.content_field(
+                page, "navigation", item.get("navigation"), f"{root}[{i}].navigation"
+            )
+            self.content_field(page, "meta", item.get("meta"), f"{root}[{i}].meta")
             sections = _as_list(item.get("sections"))
             if item.get("schema_version") == "mozaiks.app_page.v1" and not sections:
                 raise ProjectionError(
@@ -970,6 +998,7 @@ class _Builder:
                         f"{identity}_{section_id}",
                         path=f"{root}[{i}].sections[{j}].{key}",
                         group=f"{root}[{i}].sections",
+                        renderer_identity=section_id,
                     )
                     self.edge(
                         SemanticEdgeKind.RENDERS,
@@ -993,6 +1022,30 @@ class _Builder:
                         section.get("description"),
                         f"{root}[{i}].sections[{j}].description",
                     )
+                    try:
+                        declarative = AppPageSection.model_validate(section)
+                    except ValueError as exc:
+                        if item.get("schema_version") == "mozaiks.app_page.v1":
+                            raise ProjectionError(
+                                [
+                                    ProjectionGap(
+                                        kind=ProjectionGapKind.AMBIGUOUS,
+                                        source_path=f"{root}[{i}].sections[{j}]",
+                                        reason=(
+                                            "declared runtime page section failed the "
+                                            f"AppPageSection contract: {exc}"
+                                        ),
+                                    )
+                                ]
+                            ) from exc
+                        declarative = None
+                    if declarative is not None:
+                        self.content_field(
+                            child,
+                            "declarative",
+                            declarative,
+                            f"{root}[{i}].sections[{j}]",
+                        )
                 self._page_bindings(section, page, f"{root}[{i}].sections[{j}]")
             if section_entries:
                 # The declared source order is the semantic order: it survives

--- a/mozaiksai/core/semantics/opaque_artifact.py
+++ b/mozaiksai/core/semantics/opaque_artifact.py
@@ -1,0 +1,41 @@
+"""Exact preservation contract for opaque, non-rendered child artifacts.
+
+Executable/model-authored bytes are never promoted to semantic facts merely
+to make an offline renderer appear complete.  This contract couples the exact
+bytes to the existing ``ChildContractRef`` identity and fails closed on digest
+substitution.  It performs no filesystem access and grants no execution or
+promotion authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import field_validator, model_validator
+
+from mozaiksai.core.semantics.refs import ChildContractRef, SemanticsModel
+
+
+class PreservedOpaqueArtifact(SemanticsModel):
+    contract_ref: ChildContractRef
+    content: bytes
+
+    @field_validator("content")
+    @classmethod
+    def _utf8_content(cls, value: bytes) -> bytes:
+        data = bytes(value)
+        try:
+            data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("preserved opaque artifact content must be UTF-8") from exc
+        return data
+
+    @model_validator(mode="after")
+    def _verify_content_digest(self) -> PreservedOpaqueArtifact:
+        digest = hashlib.sha256(self.content).hexdigest()
+        if digest != self.contract_ref.content_digest:
+            raise ValueError("preserved opaque artifact bytes do not match ChildContractRef")
+        return self
+
+
+__all__ = ["PreservedOpaqueArtifact"]

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -6,7 +6,8 @@ graph-v2 node pins its payload by full identity through
 content a node's graph identity cannot — canonical artifact identifiers,
 titles, intent text, typed field shapes, prices, ordered entries, and selected
 normative runtime declaratives.  Runtime declaratives retain their existing
-typed model validation; payloads add no generic metadata escape hatch.
+typed model validation; authoritative payload closure never admits an untyped
+``dict[str, Any]`` escape hatch.
 
 Ordering rule: order-bearing collections (page sections, section entries) use
 explicit dense ``position`` integers, so canonical sorting cannot destroy

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -3,9 +3,10 @@
 Exactly one strict payload variant exists per :class:`SemanticNodeKind`; a
 graph-v2 node pins its payload by full identity through
 :class:`~mozaiksai.core.semantics.refs.SemanticPayloadRef`.  Payloads carry the
-content a node's identity cannot — titles, intent text, typed field shapes,
-prices, ordered entries — never a second copy of identity facts the node
-already owns, and never untyped ``dict[str, Any]`` escape hatches.
+content a node's graph identity cannot — canonical artifact identifiers,
+titles, intent text, typed field shapes, prices, ordered entries, and selected
+normative runtime declaratives.  Runtime declaratives retain their existing
+typed model validation; payloads add no generic metadata escape hatch.
 
 Ordering rule: order-bearing collections (page sections, section entries) use
 explicit dense ``position`` integers, so canonical sorting cannot destroy
@@ -28,6 +29,11 @@ from typing import Annotated, Any, Literal
 
 from pydantic import Field, TypeAdapter, ValidationInfo, field_validator, model_validator
 
+from mozaiksai.core.runtime.app.page_schema import (
+    AppPageMeta,
+    AppPageNavigation,
+    AppPageSection,
+)
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.graph import SemanticGraphV2, SemanticNodeKind
 from mozaiksai.core.semantics.portable_path import validate_portable_path
@@ -47,6 +53,7 @@ SEMANTIC_PAYLOAD_SCHEMA_VERSION: Literal["mozaiks.semantic_payload.v1"] = (
 
 _MAX_TEXT_CHARS = 4000
 _FIELD_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+_PAGE_ROUTE = re.compile(r"^/[A-Za-z0-9_./:{}?-]*$")
 _ENTRYPOINT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # ISO 4217 Maintenance Agency List One (current currencies and funds),
 # captured for this schema version on 2026-08-29.  Shape validation alone is
@@ -357,10 +364,46 @@ class SurfacePayload(SemanticPayloadBase):
 
 class PagePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PAGE] = SemanticNodeKind.PAGE
+    page_id: str
+    route: str | None
     title: str | None
     intent: str | None
+    page_type: Literal[
+        "record_list",
+        "record_detail",
+        "analytics_dashboard",
+        "workflow_board",
+        "activity_feed",
+        "gallery",
+        "wizard",
+        "split_view",
+        "settings",
+        "landing",
+    ] | None
+    layout: Literal["grid", "sidebar", "full-width", "split"] | None
+    shell_mode: Literal[
+        "standard", "workspace", "conversation", "focused", "immersive", "public"
+    ] | None
+    roles: tuple[str, ...] | None
+    navigation: AppPageNavigation | None
+    meta: AppPageMeta | None
     layout_id: str | None = None
     sections: tuple[PageSectionEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("page_id")
+    @classmethod
+    def _page_id(cls, value: str) -> str:
+        return _field_name(value, field_name="page_id")
+
+    @field_validator("route")
+    @classmethod
+    def _route(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if ".." in text or _PAGE_ROUTE.fullmatch(text) is None:
+            raise ValueError(f"route must be a safe absolute app route, got {value!r}")
+        return text
 
     @field_validator("title", "intent")
     @classmethod
@@ -376,6 +419,16 @@ class PagePayload(SemanticPayloadBase):
             return None
         return _field_name(value, field_name="layout_id")
 
+    @field_validator("roles")
+    @classmethod
+    def _roles(cls, value: tuple[str, ...] | None) -> tuple[str, ...] | None:
+        if value is None:
+            return None
+        normalized = tuple(sorted({_field_name(item, field_name="role") for item in value}))
+        if len(normalized) != len(value):
+            raise ValueError("roles must be unique")
+        return normalized
+
     @field_validator("sections")
     @classmethod
     def _sections(cls, value: tuple[PageSectionEntry, ...]) -> tuple[PageSectionEntry, ...]:
@@ -388,9 +441,19 @@ class PagePayload(SemanticPayloadBase):
 
 class SectionPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.SECTION] = SemanticNodeKind.SECTION
+    section_id: str
     title: str | None
     intent: str | None
+    declarative: AppPageSection | None
     entries: tuple[SectionContentEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("section_id")
+    @classmethod
+    def _section_id(cls, value: str) -> str:
+        text = str(value or "").strip()
+        if re.fullmatch(r"[a-z][a-z0-9_-]*", text) is None:
+            raise ValueError("section_id must be a lowercase declarative identifier")
+        return text
 
     @field_validator("title", "intent")
     @classmethod
@@ -404,10 +467,22 @@ class SectionPayload(SemanticPayloadBase):
     def _entries(cls, value: tuple[SectionContentEntry, ...]) -> tuple[SectionContentEntry, ...]:
         return _ordered_dense(value, field_name="entries")
 
+    @model_validator(mode="after")
+    def _declarative_identity(self) -> SectionPayload:
+        if self.declarative is not None and self.declarative.id != self.section_id:
+            raise ValueError("declarative section id must match section_id")
+        return self
+
 
 class ModulePayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.MODULE] = SemanticNodeKind.MODULE
+    module_id: str
     description: str | None
+
+    @field_validator("module_id")
+    @classmethod
+    def _module_id(cls, value: str) -> str:
+        return _field_name(value, field_name="module_id")
 
     @field_validator("description")
     @classmethod
@@ -603,8 +678,14 @@ class DataAliasPayload(SemanticPayloadBase):
 
 class WorkflowPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.WORKFLOW] = SemanticNodeKind.WORKFLOW
+    workflow_id: str
     description: str | None
     startup_mode: WorkflowStartupMode | None
+
+    @field_validator("workflow_id")
+    @classmethod
+    def _workflow_id(cls, value: str) -> str:
+        return _field_name(value, field_name="workflow_id")
 
     @field_validator("description")
     @classmethod

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -47,7 +47,7 @@ _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
-_GOLDEN_PLAN_DIGEST = "19a296c255fb07ba4f19ddb23ed847e4a626efcdef623239081e63c11df67562"
+_GOLDEN_PLAN_DIGEST = "cb402f62734fdfd559ef5589ddd9335ae749a5d1217eefcd48d86b7995ed6e9c"
 
 
 def _registry():
@@ -243,12 +243,11 @@ def test_case_fold_and_prefix_collisions_fail_closed() -> None:
 def test_dependency_cycles_fail_closed() -> None:
     plan = _plan()
     document = _document(plan)
-    with_deps = [u for u in document["units"] if u["depends_on_units"]]
-    dependent = with_deps[0]
-    dependency_id = dependent["depends_on_units"][0]
-    dependency = next(u for u in document["units"] if u["unit_id"] == dependency_id)
-    dependency["depends_on_units"] = [dependent["unit_id"]]
-    with pytest.raises(ValidationError, match="dependency cycle|plan_digest"):
+    first, second = document["units"][:2]
+    first["depends_on_units"] = [second["unit_id"]]
+    second["depends_on_units"] = [first["unit_id"]]
+    _redigest(document)
+    with pytest.raises(ValidationError, match="dependency cycle"):
         CompilationPlan.model_validate(document)
 
     document = _document(plan)
@@ -385,19 +384,20 @@ def test_digest_propagates_payload_to_graph_to_plan() -> None:
         if unit.source_scope is PlanSourceScope.GRAPH_WIDE
     }
     assert graph_wide and graph_wide <= affected
-    # ...reverse dependents of affected units are affected...
-    route_manifest = {
-        unit.unit_id
-        for unit in changed.units
-        if unit.family_kind == "app_ui_route_manifest"
-    }
-    assert route_manifest and route_manifest <= affected
+    # Unsupported route-manifest rendering stays a typed gap rather than a
+    # false dependent renderer unit.
+    assert not any(unit.family_kind == "app_ui_route_manifest" for unit in changed.units)
+    assert any(
+        gap.family_kind == "app_ui_route_manifest"
+        and gap.code.value == "renderer_input_undeclared"
+        for gap in changed.gaps
+    )
     # ...and unrelated declared units with unchanged footprints stay reusable.
     module_units = {
         unit.unit_id
         for unit in changed.units
-        if unit.family_kind == "module_manifest"
-        and unit.disposition is PlanDisposition.RENDER
+        if unit.family_kind == "module_backend_handler"
+        and unit.disposition is PlanDisposition.PRESERVE_UNOWNED
     }
     assert module_units and module_units <= set(closure.reusable)
     assert not closure.added and not closure.removed
@@ -573,6 +573,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
     only as deterministic registry declarations for a later binding slice.
     """
     from mozaiksai.core.semantics.compilation_plan import (
+        PlanEdgeSource,
         PlanGap,
         PlanOutput,
         PlanSource,
@@ -601,12 +602,20 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
             "placeholder_values",
             "outputs",
             "sources",
+            "edge_sources",
             "depends_on_units",
             "materializer",
             "base_plan_digest",
         },
         PlanOutput: {"path_scope", "path"},
         PlanSource: {"node_id", "payload_digest"},
+        PlanEdgeSource: {
+            "kind",
+            "source_node_id",
+            "target_node_id",
+            "discriminator",
+            "edge_identity",
+        },
         PlanGap: {"code", "family_kind", "path_template", "subject", "adr_slice"},
         RegenerationClosure: {
             "base_plan_digest",
@@ -672,6 +681,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         | allowed_fields[FamilyInstancePlan]
         | allowed_fields[PlanOutput]
         | allowed_fields[PlanSource]
+        | allowed_fields[PlanEdgeSource]
         | allowed_fields[PlanGap]
         | {"ref_schema_version", "tenant_id", "workspace_id", "pre_app_scope_id"}
         | {"source_scope", "code", "subject"}
@@ -971,6 +981,7 @@ def test_blocker5_reverse_dependency_and_graph_wide_propagation() -> None:
                 if graph_wide or source_digest is None
                 else [{"node_id": "mozaiks.node.x", "payload_digest": source_digest}]
             ),
+            "edge_sources": [],
             "depends_on_units": list(deps),
             "materializer": "app_generator",
             "base_plan_digest": None,

--- a/tests/test_page_schema_runtime_validation.py
+++ b/tests/test_page_schema_runtime_validation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 import yaml
@@ -11,7 +11,10 @@ from fastapi.testclient import TestClient
 
 from mozaiksai.core.runtime.app.loader import AppLoader, AppLoadError
 from mozaiksai.core.runtime.app.page_schema import (
+    _TOP_LEVEL_CONFIG_MODELS,
     PAGE_SCHEMA_VERSION,
+    AppPageChildSection,
+    AppPageSection,
     PageSchemaValidationError,
     load_and_validate_page_schema,
     validate_page_schema,
@@ -98,6 +101,161 @@ def test_malformed_primitive_configuration_fails() -> None:
         validate_page_schema(page)
 
     assert any("missing" in diagnostic.code for diagnostic in exc_info.value.diagnostics)
+
+
+def _pricing_catalog_config() -> dict[str, Any]:
+    return {
+        "plans": [
+            {
+                "plan_id": "pro",
+                "label": "Pro",
+                "description": "For growing teams.",
+                "price_display": "$29",
+                "cta_label": "Choose Pro",
+                "highlights": ["Unlimited projects"],
+                "managed_ai": {"display": "100K AI tokens"},
+                "usage_limits": [
+                    {"label": "AI tokens", "monthly_limit_display": "100K/month"}
+                ],
+                "pricing": {"display": "$29", "interval": "month"},
+                "is_default": False,
+            }
+        ],
+        "groups": [
+            {
+                "group_id": "platform",
+                "label": "Platform",
+                "description": "Core plans.",
+                "kind": "subscription",
+                "plan_ids": ["pro"],
+                "capability_groups": ["platform"],
+                "add_on_ids": ["priority_review"],
+            }
+        ],
+        "add_ons": [
+            {
+                "id": "priority",
+                "add_on_id": "priority_review",
+                "label": "Priority review",
+                "description": "Faster review.",
+                "price_display": "$25",
+                "price": {"display": "$25", "interval": "one_time"},
+                "cta_label": "Add review",
+                "highlights": ["One-time purchase"],
+            }
+        ],
+    }
+
+
+def test_pricing_catalog_inline_entries_are_closed_and_preserve_valid_shapes() -> None:
+    page = _valid_page(
+        sections=[
+            {
+                "id": "pricing",
+                "primitive": "PricingCatalog",
+                "config": _pricing_catalog_config(),
+            }
+        ]
+    )
+
+    validated = validate_page_schema(page)
+
+    assert validated.sections[0].config == _pricing_catalog_config()
+    for value in ([], None):
+        config = {"plans": value, "groups": value, "add_ons": value}
+        validated = validate_page_schema(
+            _valid_page(
+                sections=[
+                    {"id": "pricing", "primitive": "PricingCatalog", "config": config}
+                ]
+            )
+        )
+        expected = config if value == [] else {}
+        assert validated.sections[0].config == expected
+
+
+@pytest.mark.parametrize(
+    "malformed_config",
+    [
+        {"plans": [{"plan_id": "pro", "label": "Pro", "agent_id": "live-agent"}]},
+        {
+            "plans": [
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "managed_ai": {
+                        "display": "100K",
+                        "channel": {"websocket": {"connected": True}},
+                    },
+                }
+            ]
+        },
+        {
+            "groups": [
+                {
+                    "group_id": "platform",
+                    "label": "Platform",
+                    "checkpoint": {"path": "/tmp/runtime.chk"},
+                }
+            ]
+        },
+        {
+            "add_ons": [
+                {
+                    "label": "Priority",
+                    "price": {"display": "$25", "envelope": {"wal_id": "wal-1"}},
+                }
+            ]
+        },
+        {"plans": [{"plan_id": "pro", "label": "Pro", "price_display": {"usd": 29}}]},
+    ],
+)
+def test_pricing_catalog_rejects_open_runtime_state(malformed_config: dict[str, Any]) -> None:
+    with pytest.raises(PageSchemaValidationError):
+        validate_page_schema(
+            _valid_page(
+                sections=[
+                    {
+                        "id": "pricing",
+                        "primitive": "PricingCatalog",
+                        "config": malformed_config,
+                    }
+                ]
+            )
+        )
+
+
+def test_primitive_config_model_graph_has_no_terminal_any_escape_hatch() -> None:
+    models = {AppPageSection, AppPageChildSection, *_TOP_LEVEL_CONFIG_MODELS.values()}
+    visited: set[type] = set()
+    any_fields: set[tuple[str, str]] = set()
+
+    def contains_any(annotation: Any) -> bool:
+        return annotation is Any or any(contains_any(arg) for arg in get_args(annotation))
+
+    def visit(model: type) -> None:
+        if model in visited or not hasattr(model, "model_fields"):
+            return
+        visited.add(model)
+        for name, field in model.model_fields.items():
+            if contains_any(field.annotation):
+                any_fields.add((model.__name__, name))
+            visit_annotation(field.annotation)
+
+    def visit_annotation(annotation: Any) -> None:
+        candidate = getattr(annotation, "__origin__", None) or annotation
+        if isinstance(candidate, type) and hasattr(candidate, "model_fields"):
+            visit(candidate)
+        for argument in get_args(annotation):
+            visit_annotation(argument)
+
+    for model in models:
+        visit(model)
+
+    assert any_fields == {
+        ("AppPageSection", "config"),
+        ("AppPageChildSection", "config"),
+    }
 
 
 def test_unknown_runtime_field_fails() -> None:

--- a/tests/test_renderer_input_closure.py
+++ b/tests/test_renderer_input_closure.py
@@ -209,6 +209,107 @@ def test_malformed_declared_runtime_section_fails_instead_of_becoming_absent() -
         )
 
 
+def test_pricing_catalog_runtime_state_cannot_enter_semantic_closure() -> None:
+    page = {
+        "schema_version": "mozaiks.app_page.v1",
+        "name": "pricing",
+        "route": "/pricing",
+        "title": "Pricing",
+        "page_type": "landing",
+        "layout": "full-width",
+        "sections": [
+            {
+                "id": "catalog",
+                "primitive": "PricingCatalog",
+                "config": {
+                    "plans": [
+                        {
+                            "plan_id": "pro",
+                            "label": "Pro",
+                            "managed_ai": {"display": "100K AI tokens"},
+                            "usage_limits": [
+                                {
+                                    "label": "AI tokens",
+                                    "monthly_limit_display": "100K/month",
+                                }
+                            ],
+                            "pricing": {"display": "$29", "interval": "month"},
+                        }
+                    ],
+                    "groups": [
+                        {
+                            "group_id": "platform",
+                            "label": "Platform",
+                            "kind": "subscription",
+                            "plan_ids": ["pro"],
+                        }
+                    ],
+                    "add_ons": [
+                        {
+                            "add_on_id": "priority_review",
+                            "label": "Priority review",
+                            "price": {"display": "$25", "interval": "one_time"},
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+    result = project_semantic_graph(
+        {"pages": [page]},
+        graph_id="pricing-closure",
+        version=1,
+        scope=_corpus_graph()[0].scope,
+        taxonomy_registry=_pinned_registry(),
+    )
+    section = next(
+        payload for payload in result.payloads if payload.payload_kind.value == "section"
+    )
+    node = next(node for node in result.graph.nodes if node.node_id == section.node_id)
+    assert node.payload_ref.content_digest == section.payload_digest
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+    )
+    page_unit = next(unit for unit in plan.units if unit.family_kind == "app_ui_page_schema")
+    assert any(source.node_id == section.node_id for source in page_unit.sources)
+
+    attacked = page.copy()
+    attacked["sections"] = [
+        {
+            **page["sections"][0],
+            "config": {
+                "plans": [
+                    {
+                        "plan_id": "pro",
+                        "label": "Pro",
+                        "managed_ai": {
+                            "display": "100K AI tokens",
+                            "agent_id": "live-agent",
+                            "channel": {
+                                "websocket": {"connected": True},
+                                "wal": [{"envelope_id": "env-1"}],
+                            },
+                            "model": {"identifier": "live-model"},
+                            "checkpoint_path": "/tmp/ag2.chk",
+                            "passport": {"tenant_id": "foreign-tenant"},
+                        },
+                    }
+                ]
+            },
+        }
+    ]
+    with pytest.raises(ProjectionError, match="AppPageSection contract"):
+        project_semantic_graph(
+            {"pages": [attacked]},
+            graph_id="pricing-smuggling",
+            version=1,
+            scope=result.graph.scope,
+            taxonomy_registry=_pinned_registry(),
+        )
+
+
 def test_page_payload_rejects_custom_route_only_page_type_and_unsafe_route() -> None:
     _graph, payloads = _corpus_graph()
     page = next(payload for payload in payloads if payload.payload_kind.value == "page")

--- a/tests/test_renderer_input_closure.py
+++ b/tests/test_renderer_input_closure.py
@@ -1,0 +1,458 @@
+"""ADR 0007 Slice 4C prerequisite: renderer-input closure proofs.
+
+This suite proves the bounded page-declarative corpus and exact preservation
+contract only.  It deliberately proves that module, data, subscription,
+workflow, app-manifest, and deployment rendering remain deferred rather than
+pretending their historical bytes are already semantic renderer inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    ArtifactKind,
+    MaterializerIdentifier,
+    build_app_layout_registry,
+)
+from mozaiksai.core.runtime.app.page_schema import AppPageSchema
+from mozaiksai.core.semantics.binding import (
+    ImplementationBindingError,
+    RendererSelection,
+    build_implementation_binding,
+    validate_implementation_binding_against_graph,
+)
+from mozaiksai.core.semantics.compilation_plan import (
+    PlanDisposition,
+    PlanGapCode,
+    derive_compilation_plan,
+    plan_regeneration_closure,
+)
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticNodeV2,
+    build_semantic_graph_v2,
+)
+from mozaiksai.core.semantics.offline_projection import (
+    ProjectionError,
+    project_semantic_graph,
+)
+from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
+from mozaiksai.core.semantics.payloads import (
+    PagePayload,
+    SectionPayload,
+    WorkflowPayload,
+    build_semantic_payload,
+    semantic_payload_ref,
+)
+from mozaiksai.core.semantics.refs import ChildContractRef, SemanticGraphRef
+from tests.test_semantic_manifest_binding_contracts import _graph as _v1_graph
+from tests.test_semantic_offline_projection import _pinned_registry
+from tests.test_semantic_payload_graph_v2 import _corpus_graph
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _registry():
+    return build_app_layout_registry(())
+
+
+def _plan():
+    graph, payloads = _corpus_graph()
+    return derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+
+
+def _replace_payload(graph, payloads, replacement):
+    updated = tuple(
+        replacement if payload.node_id == replacement.node_id else payload
+        for payload in payloads
+    )
+    nodes = tuple(
+        SemanticNodeV2(
+            node_id=payload.node_id,
+            kind=payload.payload_kind,
+            payload_ref=semantic_payload_ref(payload),
+        )
+        for payload in updated
+    )
+    return (
+        build_semantic_graph_v2(
+            graph_id=graph.graph_id,
+            version=graph.version,
+            scope=graph.scope,
+            nodes=nodes,
+            edges=graph.edges,
+            namespace_grants=graph.namespace_grants,
+        ),
+        updated,
+    )
+
+
+def _renderer_binding():
+    graph, _payloads = _corpus_graph()
+    return build_implementation_binding(
+        binding_id="page-renderer-binding",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id="canonical-page-schema",
+                implementation_version="1.0.0",
+                artifact_families=(ArtifactKind.APP_UI_PAGE_SCHEMA.value,),
+            ),
+        ),
+    )
+
+
+def test_page_payload_reconstructs_normative_runtime_model_without_invention() -> None:
+    source_page = {
+        "schema_version": "mozaiks.app_page.v1",
+        "name": "home",
+        "route": "/home",
+        "title": "Home",
+        "page_type": "landing",
+        "layout": "full-width",
+        "shell_mode": "public",
+        "roles": ["admin"],
+        "navigation": {"label": "Home", "scope": "global"},
+        "meta": {"requiresAuth": False, "shellMode": "public"},
+        "sections": [
+            {
+                "id": "hero",
+                "primitive": "PageHeader",
+                "config": {"title": "Welcome"},
+            }
+        ],
+    }
+    result = project_semantic_graph(
+        {"pages": [source_page]},
+        graph_id="page-closure",
+        version=1,
+        scope=_corpus_graph()[0].scope,
+        taxonomy_registry=_pinned_registry(),
+    )
+    page = next(payload for payload in result.payloads if payload.payload_kind.value == "page")
+    sections = {
+        payload.node_id: payload
+        for payload in result.payloads
+        if payload.payload_kind.value == "section"
+    }
+    reconstructed = AppPageSchema(
+        schema_version="mozaiks.app_page.v1",
+        name=page.page_id,
+        route=page.route,
+        title=page.title,
+        page_type=page.page_type,
+        layout=page.layout,
+        shell_mode=page.shell_mode,
+        roles=None if page.roles is None else list(page.roles),
+        navigation=page.navigation,
+        meta=page.meta,
+        sections=[sections[item.section_node_id].declarative for item in page.sections],
+    )
+    assert reconstructed == AppPageSchema.model_validate(source_page)
+
+    absent_source = dict(source_page)
+    for field in ("shell_mode", "roles", "navigation", "meta"):
+        absent_source.pop(field)
+    absent_result = project_semantic_graph(
+        {"pages": [absent_source]},
+        graph_id="page-absence",
+        version=1,
+        scope=result.graph.scope,
+        taxonomy_registry=_pinned_registry(),
+    )
+    absent_page = next(
+        payload
+        for payload in absent_result.payloads
+        if payload.payload_kind.value == "page"
+    )
+    assert (
+        absent_page.shell_mode,
+        absent_page.roles,
+        absent_page.navigation,
+        absent_page.meta,
+    ) == (None, None, None, None)
+
+
+def test_malformed_declared_runtime_section_fails_instead_of_becoming_absent() -> None:
+    page = {
+        "schema_version": "mozaiks.app_page.v1",
+        "name": "broken",
+        "route": "/broken",
+        "title": "Broken",
+        "page_type": "landing",
+        "layout": "full-width",
+        "sections": [{"id": "hero", "primitive": "PageHeader", "config": {}}],
+    }
+    with pytest.raises(ProjectionError, match="AppPageSection contract"):
+        project_semantic_graph(
+            {"pages": [page]},
+            graph_id="bad-page",
+            version=1,
+            scope=_corpus_graph()[0].scope,
+            taxonomy_registry=_pinned_registry(),
+        )
+
+
+def test_page_payload_rejects_custom_route_only_page_type_and_unsafe_route() -> None:
+    _graph, payloads = _corpus_graph()
+    page = next(payload for payload in payloads if payload.payload_kind.value == "page")
+    common = page.model_dump(
+        exclude={"payload_schema_version", "payload_kind", "payload_digest"}
+    )
+    with pytest.raises(ValidationError, match="page_type"):
+        build_semantic_payload(PagePayload, **{**common, "page_type": "checkout_success"})
+    with pytest.raises(ValidationError, match="safe absolute app route"):
+        build_semantic_payload(PagePayload, **{**common, "route": "/bad|route"})
+
+
+def test_page_unit_has_complete_linked_node_and_edge_footprint() -> None:
+    unit = next(unit for unit in _plan().units if unit.family_kind == "app_ui_page_schema")
+    assert unit.disposition is PlanDisposition.RENDER
+    assert {source.node_id for source in unit.sources} == {
+        "mozaiks.page.home",
+        "mozaiks.section.hero",
+        "mozaiks.section.pricing",
+    }
+    assert len(unit.edge_sources) == 1
+    edge = unit.edge_sources[0]
+    assert edge.kind is SemanticEdgeKind.RENDERS
+    assert edge.source_node_id == "mozaiks.page.home"
+    assert edge.target_node_id == "mozaiks.section.hero"
+
+
+def test_linked_section_and_internal_edge_changes_selectively_invalidate_page() -> None:
+    graph, payloads = _corpus_graph()
+    base = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    section = next(payload for payload in payloads if payload.node_id == "mozaiks.section.hero")
+    changed_section = build_semantic_payload(
+        SectionPayload,
+        node_id=section.node_id,
+        payload_version=section.payload_version,
+        scope=section.scope,
+        section_id=section.section_id,
+        title=section.title,
+        intent=section.intent,
+        declarative=section.declarative.model_copy(
+            update={"config": {"title": "Changed welcome"}}
+        ),
+        entries=section.entries,
+    )
+    changed_graph, changed_payloads = _replace_payload(graph, payloads, changed_section)
+    changed = derive_compilation_plan(
+        graph=changed_graph, payloads=changed_payloads, registry=_registry()
+    )
+    closure = plan_regeneration_closure(base, changed)
+    page_unit = next(unit.unit_id for unit in changed.units if unit.family_kind == "app_ui_page_schema")
+    assert page_unit in closure.affected
+
+    pricing_edge = SemanticEdge(
+        kind=SemanticEdgeKind.RENDERS,
+        source_node_id="mozaiks.page.home",
+        target_node_id="mozaiks.section.pricing",
+    )
+    edge_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=graph.scope,
+        nodes=graph.nodes,
+        edges=(*graph.edges, pricing_edge),
+        namespace_grants=graph.namespace_grants,
+    )
+    edge_plan = derive_compilation_plan(
+        graph=edge_graph, payloads=payloads, registry=_registry()
+    )
+    assert page_unit in plan_regeneration_closure(base, edge_plan).affected
+
+
+def test_unrelated_workflow_change_leaves_page_and_opaque_module_units_reusable() -> None:
+    graph, payloads = _corpus_graph()
+    base = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    workflow = next(payload for payload in payloads if payload.payload_kind.value == "workflow")
+    replacement = build_semantic_payload(
+        WorkflowPayload,
+        node_id=workflow.node_id,
+        payload_version=workflow.payload_version,
+        scope=workflow.scope,
+        workflow_id=workflow.workflow_id,
+        description="Changed workflow description",
+        startup_mode=workflow.startup_mode,
+    )
+    changed_graph, changed_payloads = _replace_payload(graph, payloads, replacement)
+    changed = derive_compilation_plan(
+        graph=changed_graph, payloads=changed_payloads, registry=_registry()
+    )
+    reusable = set(plan_regeneration_closure(base, changed).reusable)
+    page_unit = next(unit.unit_id for unit in changed.units if unit.family_kind == "app_ui_page_schema")
+    handler_units = {
+        unit.unit_id
+        for unit in changed.units
+        if unit.family_kind == "module_backend_handler"
+    }
+    assert page_unit in reusable
+    assert handler_units and handler_units <= reusable
+
+
+def test_layout_registry_declares_truthful_materializer_categories() -> None:
+    rows = _registry().families
+    expected = {
+        ArtifactKind.APP_UI_PAGE_SCHEMA: MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+        ArtifactKind.MODULE_MANIFEST: MaterializerIdentifier.MODULE_CONTRACT_EXECUTOR,
+        ArtifactKind.WORKFLOW_MANIFEST: MaterializerIdentifier.WORKFLOW_GENERATOR,
+        ArtifactKind.APP_DEPLOYMENT_ARTIFACT: MaterializerIdentifier.DOWNLOAD_DEPLOYMENT_RENDERER,
+        ArtifactKind.MODULE_BACKEND_HANDLER: MaterializerIdentifier.PRESERVED_OPAQUE,
+        ArtifactKind.WORKFLOW_CONFIG: MaterializerIdentifier.PRESERVED_OPAQUE,
+        ArtifactKind.WORKFLOW_TOOL: MaterializerIdentifier.PRESERVED_OPAQUE,
+    }
+    for family, materializer in expected.items():
+        matching = [row for row in rows if row.kind is family]
+        assert matching
+        assert {row.materializer for row in matching} == {materializer}
+
+
+def test_graph_v2_renderer_binding_pins_family_implementation_and_version() -> None:
+    graph, _payloads = _corpus_graph()
+    binding = _renderer_binding()
+    validate_implementation_binding_against_graph(binding, graph, layout_registry=_registry())
+    assert binding.renderer_selections[0].graph_schema_versions == (
+        "mozaiks.semantic_graph.v2",
+    )
+    changed = build_implementation_binding(
+        binding_id=binding.binding_id,
+        version=binding.version,
+        scope=binding.scope,
+        semantic_graph_ref=binding.semantic_graph_ref,
+        renderer_selections=(
+            binding.renderer_selections[0].model_copy(
+                update={"implementation_version": "1.0.1"}
+            ),
+        ),
+    )
+    assert changed.binding_digest != binding.binding_digest
+
+    mismatched = build_implementation_binding(
+        binding_id=binding.binding_id,
+        version=binding.version,
+        scope=binding.scope,
+        semantic_graph_ref=binding.semantic_graph_ref,
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.APP_GENERATOR,
+                implementation_id="wrong-owner",
+                implementation_version="1.0.0",
+                artifact_families=(ArtifactKind.APP_UI_PAGE_SCHEMA.value,),
+            ),
+        ),
+    )
+    with pytest.raises(ImplementationBindingError, match="layout_registry declares"):
+        validate_implementation_binding_against_graph(
+            mismatched, graph, layout_registry=_registry()
+        )
+
+    v1 = _v1_graph()
+    v1_binding = build_implementation_binding(
+        binding_id="v1-renderer-binding",
+        version=1,
+        scope=v1.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=v1.graph_id,
+            subject_version=v1.version,
+            content_digest=v1.graph_digest,
+            scope=v1.scope,
+        ),
+        renderer_selections=binding.renderer_selections,
+    )
+    with pytest.raises(ImplementationBindingError, match="require a semantic graph v2"):
+        validate_implementation_binding_against_graph(v1_binding, v1)
+
+
+def test_opaque_artifact_preserves_exact_bytes_and_matches_plan_ownership() -> None:
+    content = b"def handle(ctx):\n    return {'ok': True}\n"
+    digest = hashlib.sha256(content).hexdigest()
+    graph, _payloads = _corpus_graph()
+    ref = ChildContractRef(
+        subject_id="reports-handler",
+        subject_version=1,
+        content_digest=digest,
+        scope=graph.scope,
+        artifact_family=ArtifactKind.MODULE_BACKEND_HANDLER.value,
+        canonical_relative_path="modules/reports/backend/handler.py",
+        contract_schema_version="opaque.utf8.v1",
+    )
+    artifact = PreservedOpaqueArtifact(contract_ref=ref, content=content)
+    assert artifact.content == content
+    unit = next(
+        unit
+        for unit in _plan().units
+        if unit.family_kind == ref.artifact_family
+        and any(output.path == ref.canonical_relative_path for output in unit.outputs)
+    )
+    assert unit.disposition is PlanDisposition.PRESERVE_UNOWNED
+    with pytest.raises(ValidationError, match="do not match"):
+        PreservedOpaqueArtifact(contract_ref=ref, content=content + b"# changed\n")
+
+    empty_ref = ref.model_copy(
+        update={
+            "subject_id": "empty-handler",
+            "content_digest": hashlib.sha256(b"").hexdigest(),
+        }
+    )
+    assert PreservedOpaqueArtifact(contract_ref=empty_ref, content=b"").content == b""
+
+
+def test_unsupported_renderer_families_remain_explicit_typed_gaps() -> None:
+    plan = _plan()
+    incomplete = {
+        gap.family_kind
+        for gap in plan.gaps
+        if gap.code is PlanGapCode.RENDERER_INPUT_INCOMPLETE
+    }
+    assert {
+        "module_manifest",
+        "app_data_contract",
+        "app_subscription_config",
+        "workflow_manifest",
+    } <= incomplete
+    assert any(
+        gap.family_kind == "app_manifest"
+        and gap.code is PlanGapCode.RENDERER_INPUT_UNDECLARED
+        for gap in plan.gaps
+    )
+    assert not any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in incomplete | {"app_manifest"}
+        for unit in plan.units
+    )
+
+
+def test_contract_identity_is_stable_across_processes() -> None:
+    expected = f"{_plan().plan_digest}\n{_renderer_binding().binding_digest}"
+    probe = (
+        "from tests.test_renderer_input_closure import _plan, _renderer_binding\n"
+        "print(_plan().plan_digest)\n"
+        "print(_renderer_binding().binding_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == expected

--- a/tests/test_semantic_manifest_binding_contracts.py
+++ b/tests/test_semantic_manifest_binding_contracts.py
@@ -17,7 +17,6 @@ from mozaiksai.core.semantics import (
     DeploymentProfileSelection,
     ExecutionAccessScopeRef,
     ImplementationBindingRef,
-    RendererSelection,
     SemanticEdge,
     SemanticEdgeKind,
     SemanticGraphRef,
@@ -80,13 +79,7 @@ def _binding(graph, **overrides):
                 pack_digest=DIGEST,
             ),
         ),
-        "renderer_selections": (
-            RendererSelection(
-                requirement_node_id="mozaiks.pages.home",
-                renderer_id="page_schema_renderer",
-                renderer_version="1.0.0",
-            ),
-        ),
+        "renderer_selections": (),
         "deployment_profile_selections": (
             DeploymentProfileSelection(
                 requirement_node_id="mozaiks.targets.default",
@@ -261,11 +254,11 @@ def test_binding_cannot_select_against_wrong_node_kind() -> None:
     graph = _graph()
     binding = _binding(
         graph,
-        renderer_selections=(
-            RendererSelection(
+        capability_pack_selections=(
+            CapabilityPackSelection(
                 requirement_node_id="mozaiks.events.paid",
-                renderer_id="page_schema_renderer",
-                renderer_version="1.0.0",
+                pack_id="mozaikspay",
+                pack_digest=DIGEST,
             ),
         ),
     )

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -211,8 +211,8 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden Merkle-root vector: pinned digests for the full-corpus v2 graph and
 # its archived fixture.  Independent of host, process, and input order.
-_GOLDEN_GRAPH_DIGEST = "a4eaa86709134dc5677a0b67b99e00a02b0cedfa4b45d39e37ade35f4f8b85f4"
-_GOLDEN_ARCHIVE_DIGEST = "sha256:53b569a6c62e9ae4c1ce0bed9b86cd2eed5a18147f5bdb531cd763c7bafff20b"
+_GOLDEN_GRAPH_DIGEST = "adb01417eac21a97cd3061ed5a9216a6d6501447699c228e4e85bfe83bdf602f"
+_GOLDEN_ARCHIVE_DIGEST = "sha256:8e95d5bcce6b61528a46a1f09a18ab6766ffbfaa58905461c626fd6de31018ea"
 
 
 def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str = "Home"):
@@ -231,8 +231,16 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
             node_id="mozaiks.page.home",
             payload_version=1,
             scope=scope,
+            page_id="home",
+            route="/home",
             title=home_title,
             intent="Landing page",
+            page_type="landing",
+            layout="full-width",
+            shell_mode=None,
+            roles=None,
+            navigation=None,
+            meta=None,
             sections=(
                 PageSectionEntry(position=1, section_node_id="mozaiks.section.pricing"),
                 PageSectionEntry(position=0, section_node_id="mozaiks.section.hero"),
@@ -243,8 +251,14 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
             node_id="mozaiks.section.hero",
             payload_version=1,
             scope=scope,
+            section_id="hero",
             title="Hero",
             intent="Welcome banner",
+            declarative={
+                "id": "hero",
+                "primitive": "PageHeader",
+                "config": {"title": "Welcome"},
+            },
             entries=(
                 SectionContentEntry(
                     position=0, entry_kind=SectionEntryKind.TEXT, text="Welcome"
@@ -262,6 +276,7 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
             node_id="mozaiks.module.reports",
             payload_version=1,
             scope=scope,
+            module_id="reports",
             description="Reporting module",
         ),
         SemanticNodeKind.ACTION: build_semantic_payload(
@@ -341,6 +356,7 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
             node_id="mozaiks.workflow.digest",
             payload_version=1,
             scope=scope,
+            workflow_id="digest",
             description="Weekly digest workflow",
             startup_mode=WorkflowStartupMode.EVENT_DRIVEN,
         ),
@@ -419,8 +435,14 @@ def _pricing_section(scope: ExecutionAccessScopeRef = _SCOPE) -> SectionPayload:
         node_id="mozaiks.section.pricing",
         payload_version=1,
         scope=scope,
+        section_id="pricing",
         title="Pricing",
         intent="Plans overview",
+        declarative={
+            "id": "pricing",
+            "primitive": "PageHeader",
+            "config": {"title": "Pricing"},
+        },
     )
 
 
@@ -485,8 +507,18 @@ def test_each_kind_round_trips_through_the_discriminated_union(
 def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
     required_nullable = {
         SurfacePayload: ("description",),
-        PagePayload: ("title", "intent"),
-        SectionPayload: ("title", "intent"),
+        PagePayload: (
+            "route",
+            "title",
+            "intent",
+            "page_type",
+            "layout",
+            "shell_mode",
+            "roles",
+            "navigation",
+            "meta",
+        ),
+        SectionPayload: ("title", "intent", "declarative"),
         ModulePayload: ("description",),
         ActionPayload: ("description",),
         CapabilityPayload: ("description",),
@@ -537,6 +569,7 @@ def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
         node_id="mozaiks.module.explicit_absence",
         payload_version=1,
         scope=_SCOPE,
+        module_id="explicit_absence",
         description=None,
     )
     assert explicit_absence.description is None
@@ -1084,8 +1117,16 @@ def test_order_bearing_input_permutations_do_not_change_page_or_section_digests(
         node_id=page.node_id,
         payload_version=page.payload_version,
         scope=page.scope,
+        page_id=page.page_id,
+        route=page.route,
         title=page.title,
         intent=page.intent,
+        page_type=page.page_type,
+        layout=page.layout,
+        shell_mode=page.shell_mode,
+        roles=page.roles,
+        navigation=page.navigation,
+        meta=page.meta,
         sections=tuple(reversed(page.sections)),
     )
     assert permuted_page.payload_digest == page.payload_digest
@@ -1099,8 +1140,10 @@ def test_order_bearing_input_permutations_do_not_change_page_or_section_digests(
         node_id=section.node_id,
         payload_version=section.payload_version,
         scope=section.scope,
+        section_id=section.section_id,
         title=section.title,
         intent=section.intent,
+        declarative=section.declarative,
         entries=tuple(reversed(section.entries)),
     )
     assert permuted_section.payload_digest == section.payload_digest
@@ -1150,8 +1193,16 @@ def test_meaningful_page_and_section_order_changes_identity() -> None:
         node_id=page.node_id,
         payload_version=page.payload_version,
         scope=page.scope,
+        page_id=page.page_id,
         title=page.title,
         intent=page.intent,
+        route=page.route,
+        page_type=page.page_type,
+        layout=page.layout,
+        shell_mode=page.shell_mode,
+        roles=page.roles,
+        navigation=page.navigation,
+        meta=page.meta,
         sections=tuple(
             entry.model_copy(update={"position": 1 - entry.position})
             for entry in page.sections
@@ -1168,8 +1219,10 @@ def test_meaningful_page_and_section_order_changes_identity() -> None:
         node_id=section.node_id,
         payload_version=section.payload_version,
         scope=section.scope,
+        section_id=section.section_id,
         title=section.title,
         intent=section.intent,
+        declarative=section.declarative,
         entries=tuple(
             entry.model_copy(update={"position": 1 - entry.position})
             for entry in section.entries
@@ -1192,8 +1245,16 @@ def test_negative_duplicate_sparse_and_non_dense_positions_fail_closed() -> None
                 node_id=page.node_id,
                 payload_version=page.payload_version,
                 scope=page.scope,
+                page_id=page.page_id,
+                route=page.route,
                 title=page.title,
                 intent=page.intent,
+                page_type=page.page_type,
+                layout=page.layout,
+                shell_mode=page.shell_mode,
+                roles=page.roles,
+                navigation=page.navigation,
+                meta=page.meta,
                 sections=tuple(
                     entry.model_copy(update={"position": position})
                     for entry, position in zip(page.sections, positions, strict=True)


### PR DESCRIPTION
## Purpose

Bounded prerequisite for ADR 0007 Slice 4C. This closes renderer inputs for the first honest offline corpus without implementing rendering or changing production authority.

Exact base: `e2c1ec0d6e8e6cc45a4f8c30300f224217000836`

## Selected corpus and fact matrix

| Family | Normative model | Facts closed here | Result |
|---|---|---|---|
| `app_ui_page_schema` | `AppPageSchema` / `AppPageSection` | canonical page and section ids, route, title, page type, layout, shell mode, roles, navigation, meta, ordered validated sections, linked actions | renderer-input complete for the bounded page-declarative corpus |
| `module_manifest` / `module_contract` | module loader contracts | module/action/capability/permission/event footprint declared, but historical manifest/contract facts are not all represented | explicit `renderer_input_incomplete` gap |
| `app_data_contract` | data contract loader | collection/alias/module footprint declared, but the complete rendered document is not yet represented | explicit `renderer_input_incomplete` gap |
| `app_subscription_config` | subscriptions loader | plan/product/meter/limit/capability footprint declared, but complete configuration facts are not yet represented | explicit `renderer_input_incomplete` gap |
| `workflow_manifest` | workflow manager orchestrator contract | workflow/trigger/event/capability footprint declared, but complete orchestrator bytes are not yet represented | explicit `renderer_input_incomplete` gap |
| `app_deployment_artifact` | DownloadAgent deployment contract | deployment-target inputs and existing Download renderer ownership remain explicit | external handoff; no 4C renderer claim |
| executable/model-authored artifacts | existing `ChildContractRef` | exact UTF-8 bytes plus digest, family, path, scope, version | `preserved_opaque`; never claimed as deterministic renderer output |
| `app_manifest` and other unsupported families | current runtime loaders | no inferred display name, auth, route, or config facts | explicit `renderer_input_undeclared` gap |

## Contract changes

- Page payloads retain all selected provider-neutral declarative facts and preserve required-nullable absence.
- Runtime page sections are validated as `AppPageSection`; malformed supplied sections fail rather than becoming absence.
- Compilation units carry canonical linked-node payload identities and complete edge facts/identity.
- Canonical output placeholders use payload-owned page/module/workflow ids rather than graph-node hash suffixes.
- Renderer-incomplete/undeclared families create typed gaps and cannot emit false `render` units.
- The existing layout registry remains sole family/materializer authority and now distinguishes deterministic executors, Download handoff, and `preserved_opaque` content.
- `ImplementationBinding` pins materializer id, implementation id/version, applicable registry families, and graph-v2 compatibility.
- `PreservedOpaqueArtifact` verifies exact bytes against `ChildContractRef.content_digest`.

## Adversarial proofs

- normative page-model reconstruction and explicit absence/no-invention
- malformed page sections, unsafe routes, and custom-route-only types fail closed
- linked section and internal edge changes invalidate the page unit
- unrelated workflow changes preserve the page and opaque module units
- full node/edge footprint identity and canonical ordering
- truthful materializer categories and unsupported-family typed gaps
- graph-v2-only renderer binding, materializer mismatch rejection, and version digest propagation
- exact opaque-byte preservation, including empty artifacts and mutation rejection
- cross-process plan and binding identity equality
- existing 2E/3E/4B golden and resolver/reference contracts

## Validation

- focused semantic/projection/layout/plan/binding suite: `285 passed`
- runtime loader/reference/readiness suite: `302 passed`
- complete backend suite: `14215 passed, 80 skipped`
- `ruff check .`: passed
- source hygiene scan: passed
- governance guardrails: passed
- `git diff --check`: passed
- DCO: signed
- local full mypy checked 586 source files; the only diagnostic is the unchanged exact-base `acp_coding_provider.py:135` third-party `elicitation_policy` signature mismatch. Modified files have no mypy diagnostics; exact-head CI is authoritative.

## Explicit exclusions

No renderer implementation, callable resolution, generated bytes, production cutover, AppGenerator/AgentGenerator change, AppBuildPlan authority change, task execution, promotion, capability advertisement, AG2 change, Slice 5 work, Refinement Run routing change, or PR #449 change.

Auto-merge must remain disabled. This PR must stay draft and stop at independent review after exact-head CI. Claude 2 must independently review the exact head before any further slice proceeds.