### PR TITLE
docs(adr): ADR 0008 — Deterministic Engineering Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **ADR 0008 (Proposed): Deterministic Engineering Context** — documents the
+  entitlement contract for software-engineering assignments (Mozaiks owns
+  WHAT an assignment may know; AG2 owns HOW it becomes runtime context), the
+  prompt/schema/Skills authoring policy, retrieval grants, symbolic context
+  budget classes, the determinism boundary, AppGenerator decomposition and
+  user-facing-state rules, the superseded-mechanism cleanup discipline, and
+  slice placement (no 4C impact; Slice 5 landing-zone grammars; post-Slice-5
+  implementation; Slice 6 closure-driven scoping). Companion evidence
+  inventory at docs/architecture/workflows/appgenerator-context-debt.md.
+  Documentation only — no runtime behavior changes.
+
 - **Deterministic offline page materialization (ADR 0007 Slice 4C)**: a pure
   renderer materializes canonical `app_ui_page_schema` bytes from a validated
   graph-v2 payload closure, its CompilationPlan unit's complete source

--- a/docs/adr/0008-deterministic-engineering-context.md
+++ b/docs/adr/0008-deterministic-engineering-context.md
@@ -1,0 +1,303 @@
+# ADR 0008: Deterministic Engineering Context for Software-Engineering Assignments
+
+Date: 2026-08-31
+
+Status: Proposed
+
+## Context
+
+Mozaiks assigns software-engineering work to AG2 agents. Today the context
+those agents receive accumulated around older internal patterns rather than a
+contract:
+
+- `factory_app/workflows/AppGenerator/agents.yaml` carries roughly 266k
+  characters of static prompt prose across 19 agents, concatenated with no
+  templating by `mozaiksai/core/workflow/agents/factory.py`.
+- Context variables are rendered by bare `str()` with no size cap
+  (`mozaiksai/core/workflow/context/context_utils.py`) and frozen into system
+  messages at agent construction. The whole generated-bundle file map
+  (`generated_files`) is injected into four agents on repair re-entry.
+- Output semantics are stated twice: prose `[OUTPUT FORMAT]` sections restate
+  what `structured_outputs.yaml` (218 models) already enforces structurally.
+- Catalog injections repeat: the same file-contract, language-profile, and
+  subscription facts are delivered to up to seven agents, re-derived on every
+  LLM call by prompt middleware.
+- The code-writing agents have no bounded retrieval tools. That is a
+  deliberate, test-locked consolidation
+  (`tests/test_graph_authority_contract.py` asserts the removal of the old
+  AppGenerator-local code-context machinery); code intelligence lives in
+  `mozaiksai/core/app_context/` and is exposed today only through the
+  refinement harness.
+- The refinement harness demonstrates the intended pattern already: a
+  33-line policy prompt plus bounded, checkpoint-gated retrieval tools
+  (`factory_app/refinement_harness/config/harness.yaml`, `config/tools.yaml`)
+  over the tree-sitter-backed context graph.
+- `ARCHITECTURE.md` states the invariant — agents receive compact context
+  first and retrieve exact sources through tools — but the only test of it is
+  a string-presence check, not behavior.
+
+AG2 1.0.2 (pinned) supplies the runtime primitives: fragment system prompts
+and dynamic prompt hooks, `SkillPlugin`/`SkillsToolkit` progressive
+disclosure, caller-supplied `AssemblyPolicy`, `TokenBudgetPolicy`,
+`CompactStrategy`/`CompactTrigger`, deterministic `ViewPolicy` projections,
+per-agent variables with call overrides, and network capability
+advertisement via free-form `Resume.claimed_capabilities`. AG2 deliberately
+has no serializable per-assignment statement of what an agent is entitled to
+know: assembly is a runtime pipeline, not a data contract.
+
+Mozaiks is pre-1.0. Unreleased internal prompt/context architecture carries
+no compatibility obligation.
+
+### Relationship to issue #411
+
+Issue #411 is a design prompt, not architecture authority. This ADR does not
+adopt a typed decision ledger as a second authority for application meaning:
+the entitlement contract defined here carries references to canonical
+contracts and never restates or re-decides semantic facts. To the extent
+#411 gestures at deterministic, inspectable inputs to agent work, this ADR
+adopts that direction; everything else in #411 is deferred.
+
+## Decision
+
+Mozaiks deterministically defines WHAT an engineering assignment is entitled
+to know. AG2 owns HOW that entitlement becomes runtime model context.
+
+Concretely:
+
+1. One narrow, reference-oriented entitlement contract is introduced (final
+   class name to be fixed at implementation; working name
+   "assignment context manifest"). It is derived deterministically from the
+   `CompilationPlan` unit, the layout registry, and the closed capability
+   taxonomy. It is `extra="forbid"`, closed-domain, and self-digested —
+   the same contract standard as `CompilationPlan`.
+2. Mozaiks builds no general-purpose context engine and does not duplicate
+   AG2 prompt assembly, Skills runtime, KnowledgeStore mechanics, Views,
+   compaction, middleware, or network execution. Where an accepted AG2
+   primitive exists, Mozaiks uses it.
+3. Runtime context (retrieved bytes, history, KnowledgeStore state, provider
+   serialization, compaction output) never becomes semantic authority.
+
+### The entitlement contract
+
+Only five concepts are genuinely new; everything else reuses existing
+canonical contracts, and this ADR explicitly rejects duplicating those facts
+in another metadata object:
+
+New:
+
+- `CompilationPlan` unit join/reference (plan digest + unit id);
+- required local engineering Skill identifiers (closed set, selected by
+  family + taxonomy);
+- retrieval grants (see below);
+- context budget class (symbolic identifier only);
+- manifest content digest.
+
+Reused, never duplicated:
+
+- semantic source identities: the unit's `sources`
+  (`mozaiksai/core/semantics/compilation_plan.py`);
+- owned outputs: the unit's `outputs` plus existing owned-path enforcement
+  in `mozaiksai/core/workflow/task_batches.py`;
+- base artifacts: `ChildContractRef`;
+- dependency references: `ApprovedAssignmentSpec.dependency_context_refs`
+  (`mozaiksai/core/workflow/plan_assignment_compiler.py`) — populated with a
+  defined reference grammar rather than free-form strings;
+- validation: `required_validators` and `required_structured_output_id` on
+  the same spec;
+- capability requirements: the closed capability taxonomy
+  (`mozaiksai/core/taxonomy.py`).
+
+The contract carries references, not content. It contains no prompt prose,
+no model names, no AG2 channel/envelope identifiers, no runtime history, no
+free-form metadata, and no inlined file contents.
+
+### Retrieval grants (the novel concept)
+
+An assignment receives a deterministic authorization describing which
+reference and scope classes it MAY retrieve just in time. Candidate grant
+surfaces include semantic payload references, dependency artifact
+references, assigned base artifacts, approved app-context graph
+neighborhoods, required contract documents, and permitted source paths.
+Grants are part of the manifest and therefore digested and auditable. The
+manifest does not eagerly contain retrieved content, and an agent asking for
+broader filesystem or repository access is not a reason to grant it.
+Retrieval flows through the consolidated `mozaiksai/core/app_context/`
+authority using bounded, harness-shaped tools; the graph-authority contract
+tests remain in force.
+
+### Context budget class
+
+The manifest names a symbolic budget class. Numeric token limits and
+provider-specific context parameters are runtime policy, set from evaluation
+evidence, and are out of scope for canonical contracts. This ADR fixes no
+numbers.
+
+### Prompt / schema / Skills policy
+
+- Structured-output schemas own machine-enforced output shape, required
+  fields, and types.
+- Prompts own semantic responsibility, reasoning constraints, invariants,
+  authority boundaries, and failure behavior — at the altitude the
+  refinement harness's coding prompt already demonstrates.
+- Skills own reusable specialized engineering methodology, one per artifact
+  family, progressively disclosed via AG2's skills runtime.
+- Examples are justified only to explain semantic ambiguity, ownership
+  boundaries, edge cases, or reasoning patterns. Examples that merely
+  demonstrate JSON/YAML/Pydantic shape duplicate the schema and are
+  migration debt, not a pattern to perpetuate.
+
+### The context pattern
+
+Small high-signal policy context, plus deterministically authorized
+references, plus bounded just-in-time retrieval. Eager: what is
+authoritative and small. Referenced: what is bulky but verifiable by
+digest. Retrieved: what is exploratory, through granted bounded tools. The
+refinement harness is the internal evidence that this pattern already works
+in production.
+
+### AG2 runtime mapping
+
+| Entitlement element | AG2 primitive |
+|---|---|
+| Role + policy prompt | `Agent(prompt=[fragments])` |
+| Manifest reference rendering | dynamic prompt hooks (once per turn) |
+| Family methodology | `SkillPlugin` / `SkillsToolkit` |
+| Volatile small facts | per-agent variables + call overrides |
+| Manifest and tool handles | `Inject` / `Context` dependency injection |
+| Granted retrieval | bounded tools over `core/app_context` |
+| Run state | `KnowledgeStore` (unchanged boundary) |
+| Ordering + budget | `AssemblyPolicy`, `TokenBudgetPolicy` |
+| History reduction | `CompactStrategy` / `CompactTrigger` per budget class |
+| Network history scope | deterministic `ViewPolicy` per checkpoint class |
+| Peer capability | `Resume.claimed_capabilities`, taxonomy-validated |
+
+Runtime identifiers and state never enter the deterministic contract.
+
+### Local Skills vs network skills
+
+These are distinct AG2 concepts and stay distinct in Mozaiks:
+
+- Local Skills: reusable, progressively disclosed task methodology and
+  content. The Mozaiks engineering-skill requirement (closed identifiers in
+  the manifest) selects validated local skill activation.
+- Network skills / claimed capabilities: peer capability discovery and
+  advertisement. Mozaiks' closed capability taxonomy validates what an agent
+  advertises; free-form AG2 network capability strings are never canonical
+  Mozaiks authority and are never consumed for routing unvalidated.
+
+Two mappings, two directions, never merged.
+
+### Determinism boundary
+
+Deterministic (digestable, auditable): the entitlement manifest, semantic
+and artifact references, allowed retrieval surfaces, Skill requirements,
+validation requirements, owned outputs, budget policy class, view class.
+
+Runtime/dynamic: retrieved bytes, conversation history, KnowledgeStore
+results, provider serialization, model-specific prompt structure, and
+compaction output where LLM summarization is used. Dynamic context informs a
+run; it never becomes semantic authority.
+
+### AppGenerator evolution and product states
+
+AppGenerator is not to be split merely because individual prompts are large;
+oversized prompts are debt under this ADR's prompt policy, not workflow
+shape. Future decomposition occurs only at meaningful boundaries: user
+interaction, persistence, authority, context regime, recovery/retry
+isolation, or durable milestone. The pre-Slice-5 planning path is not split
+before its authority cutover (ADR 0007 Slice 5); splitting a path scheduled
+for replacement is wasted motion.
+
+Users see meaningful product states, not internal workflow topology. A
+transition is user-facing only when user input is needed, ambiguity must be
+resolved, approval or confirmation is required, a meaningful decision
+exists, a consequential action requires permission, a durable result is
+ready, or a recoverable failure requires user action. Projection,
+`CompilationPlan` derivation, assignment compilation, materialization,
+validation, repair loops, and persistence internals stay behind the UI.
+
+A non-normative example progression — product copy, not architecture
+identifiers:
+
+Understanding → Designing → Building → Verifying → Ready.
+
+### Superseded-mechanism cleanup discipline
+
+No direct residue of older AG2 group-chat APIs exists in this repository
+(verified by search). The debt is Mozaiks-built parallel mechanisms that
+accepted AG2 primitives now supersede. The migration discipline:
+
+When the accepted AG2 primitive (or a contract from this ADR) supersedes a
+Mozaiks-built mechanism, the superseded path is deleted atomically in the
+same change that lands the replacement — every in-repo caller, test, and doc
+updated; no compatibility flags; no dual old/new execution paths; no
+shim-by-default. Evidence is required before deletion: a mechanism is
+removed because its replacement is accepted and its callers are migrated,
+never merely because it looks old.
+
+Debt categories to audit in future slices: bespoke prompt concatenation
+superseded by accepted assembly policy; construction-time bulk
+stringification superseded by bounded retrieval; per-call catalog
+re-rendering superseded by Skills progressive disclosure;
+schema-duplicating prose; parallel local context systems; watch-only budget
+logic once an active AG2 budget/compaction policy is authoritative; older
+routing/history assumptions superseded by Network Views; compatibility
+flags selecting between internal execution paths.
+
+The companion inventory
+[appgenerator-context-debt](../architecture/workflows/appgenerator-context-debt.md)
+records the concrete, evidence-backed findings.
+
+### Slice placement
+
+- ADR 0007 Slice 4C: no engineering-context implementation.
+- Slice 5: assignment projection must populate the existing landing zones
+  (`dependency_context_refs`, `required_validators`,
+  `required_structured_output_id`, `allowed_agent_ids`) with
+  manifest-compatible grammars. Slice 5 must not introduce free-form
+  reference or validator identifiers that would later require migration.
+- Post-Slice-5 bounded slice: the likely implementation point for the
+  entitlement contract, skills, grants, and budget classes.
+- Slice 6: plan/refinement closure becomes the context-scope authority for
+  Refinement Runs; manifests carry that swap.
+- AG2 distributed-runtime track: network Views, reconnect, delivery, and
+  runtime identity remain separate concerns.
+
+### Evaluation
+
+Behavioral evaluation is required before numeric thresholds are fixed:
+eager-context size per budget class; irrelevant and duplicate context;
+retrieval count and volume; owned-path violations; first-pass validation
+rate; hallucinated-dependency rate; repair retry count; token usage; and
+output-quality regression against the acceptance gate. Thresholds come from
+corpus evidence, not this document. These evaluations become the behavioral
+enforcement of the `ARCHITECTURE.md` compact-context invariant.
+
+## Consequences
+
+- One narrow contract makes each assignment's knowledge entitlement
+  auditable, cacheable, and reproducible without duplicating any canonical
+  fact.
+- AG2 adoption replaces several Mozaiks-built mechanisms; each replacement
+  deletes its predecessor, shrinking surface rather than growing it.
+- Coding agents gain bounded retrieval through the consolidated
+  app-context authority rather than eager whole-bundle exposure, aligning
+  AppGenerator with the already-proven harness pattern and the documented
+  architecture invariant.
+- No work is added to Slice 4C; Slice 5 gains one seam obligation it is
+  already positioned to satisfy.
+
+## Alternatives considered and rejected
+
+1. Prompt refactor without a contract — leaves entitlement unauditable and
+   refinement caching impossible.
+2. A Mozaiks context engine over AG2 — duplicates AG2's deliberately
+   runtime assembly and violates the ownership boundary.
+3. Folding context facts into `CompilationPlan` — contaminates a semantic
+   authority with execution ergonomics, rejected by the Slice 4B boundary
+   corrections.
+4. Per-agent local retrieval tools inside AppGenerator — reinstates a
+   deliberately removed subsystem against a test-enforced consolidation.
+5. Treating network capability strings as skills or as routing authority —
+   merges distinct AG2 concepts and launders free-form strings into
+   canonical authority.

--- a/docs/architecture/workflows/appgenerator-context-debt.md
+++ b/docs/architecture/workflows/appgenerator-context-debt.md
@@ -1,0 +1,47 @@
+# AppGenerator Prompt/Context Debt Inventory
+
+Companion to [ADR 0008](../../adr/0008-deterministic-engineering-context.md).
+This is an actionable inventory of evidence-backed findings, not normative
+architecture: it records what exists today so future slices can retire it
+under the ADR's cleanup discipline. Classification:
+
+- **P0** — architecture/correctness: violates a stated invariant or creates
+  a governance gap.
+- **P1** — quality/cost: measurable waste or degradation risk.
+- **P2** — cleanup: dead or duplicated mechanism with no behavior at stake.
+
+Line references are from the audit at main `e2c1ec0d`; verify before acting.
+
+| # | Finding | Evidence | Class |
+|---|---|---|---|
+| A | Whole generated-bundle file map (`generated_files`) rendered by `str()` into four agents' system messages on repair re-entry | `factory_app/workflows/AppGenerator/tools/assemble_app_tasks.py:411-415`; `mozaiksai/core/workflow/context/context_utils.py:148` | P0 |
+| B | `code_files` + `deleted_files` whole maps exposed to AssemblyAgent | `factory_app/workflows/AppGenerator/context_variables.yaml` agent block | P0 |
+| C | The compact-context invariant in `ARCHITECTURE.md` is enforced only by a string-presence test, not behavior | `tests/test_app_context_architecture_contract.py:93` | P0 |
+| D | Coding agents receive everything eagerly yet have no bounded retrieval; the fix must route through the consolidated `core/app_context` authority (local machinery removal is test-locked) | `factory_app/workflows/AppGenerator/tools.yaml`; `tests/test_graph_authority_contract.py:69-72` | P0 |
+| E | `stringify_context_value` is bare `str()` with no size cap anywhere in the exposure path | `mozaiksai/core/workflow/context/context_utils.py:69-83,148` | P0 |
+| F | Exposure `mapping` is built from all context variables, so a declared `template` could reference unexposed keys (latent, unexploited) | `context_utils.py:137-146` | P0 |
+| G | Assignment landing zones (`dependency_context_refs`, `allowed_agent_ids`, validator/output ids) are free-form and unpopulated; Slice 5 must fill them with manifest-compatible grammars or later migration is forced | `mozaiksai/core/workflow/plan_assignment_compiler.py` | P0 |
+| H | `[OUTPUT FORMAT]` prose restates registered response schemas (ServiceAgent section alone ~7,280 chars) | `agents.yaml`; `structured_outputs.yaml` | P1 |
+| I | 26 fenced JSON/YAML shape blocks in prompts alongside 218 structured-output models; classify per ADR 0008 (semantic guidance → skills; shape duplication → delete) | `agents.yaml` | P1 |
+| J | File-contract facts delivered up to three times per agent (prompt prose + hook injection + schema) | `factory_app/workflows/AppGenerator/tools/hook_file_contract_context.py:337-383` | P1 |
+| K | Language-profile hook duplicated across six agents | `middleware.yaml:76-93` | P1 |
+| L | Subscription contract triple-delivered (two variables + one hook) to the same agents | `middleware.yaml:52-60`; `context_variables.yaml` | P1 |
+| M | 35 prompt-middleware entries re-derive injections on every LLM call | `middleware.yaml:1-106`; `mozaiksai/core/workflow/execution/middleware.py:29-96` | P1 |
+| N | Module-archetype hook falls through to rendering the whole 45KB catalog when no archetype resolves | `hook_file_contract_context.py:238-292` | P1 |
+| O | AppPlanAgent static prompt ~87,662 chars (~21.9k tokens) | `agents.yaml` | P1 |
+| P | AppSchemaAgent single `[CONTEXT]` section of ~30,070 chars | `agents.yaml` | P1 |
+| Q | Seven overlapping intelligence-snapshot variables exposed to two agents for one snapshot | `context_variables.yaml:1441-1450,1494-1503` | P1 |
+| R | No token budget or compaction handed to AG2; watch-only alerts never truncate or block | `mozaiksai/core/usage/watchdog.py:205-264` | P1 |
+| S | Context values frozen into system messages at agent construction, so values go stale across a run | `factory.py:547-554` | P1 |
+| T | Two divergent `_compose_prompt_sections` implementations | `factory.py:271` vs `mozaiksai/core/workflow/context/projection.py:29` | P2 |
+| U | Older dict-shaped `prompt_sections` normalization path retained beside the list shape | `factory.py:271-300` | P2 |
+| V | `prompt_sections_custom` / `system_message` fallback chain with unverified consumers | `factory.py:540-544` | P2 |
+| W | `context_graph_pack` reachable only via hook while absent from every exposure list (asymmetric mechanism) | `_shared/context_graph/hook_context_graph.py`; `context_variables.yaml` | P2 |
+| X | `read_artifact_file` permits up to 80,000 characters per read, ungoverned by any grant | `factory_app/refinement_harness/config/tools.yaml:106-112` | P1 |
+| Y | `subscription_contract` and `subscription_contract_artifact` are two variables for one fact | `context_variables.yaml` | P2 |
+| Z | Write-only exposure entries with no production reader (e.g. `app_plan_ready`) | `context_variables.yaml:939-944`; test-only readers | P2 |
+
+Ordering note: P0 items G and A–F gate or shape Slice 5 and the post-Slice-5
+context slice; P1 items are candidates for ordinary maintenance under the
+ADR's deletion discipline; P2 items ride along with whichever change touches
+their file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,7 @@ nav:
           - Orchestration Control Loops: architecture/workflows/orchestration-control-loops.md
           - Structured Output Extraction: architecture/workflows/structured-output-extraction-contract.md
           - Refinement Engine: architecture/workflows/refinement-engine.md
+          - AppGenerator Context Debt: architecture/workflows/appgenerator-context-debt.md
           - End-to-End App Editing Loop: architecture/workflows/e2e-app-editing-loop.md
           - Refinement Harness Architecture: architecture/workflows/refinement-harness-architecture.md
           - Session Router: architecture/workflows/session-router.md
@@ -304,3 +305,4 @@ nav:
       - adr/0005-reference-factory-and-proprietary-build-intelligence-boundary.md
       - adr/0006-provider-neutral-bounded-multi-workflow-journey-execution.md
       - adr/0007-generalized-semantic-compiler.md
+      - adr/0008-deterministic-engineering-context.md


### PR DESCRIPTION
## Summary

**Documentation only — zero runtime code changes.** Adds **ADR 0008 (Proposed): Deterministic Engineering Context for Software-Engineering Assignments**, consolidating the accepted overnight research into a decision record, plus its companion evidence inventory.

Base: `43091bab` (current main, containing #450).

## What it decides

- **Ownership boundary**: Mozaiks deterministically defines WHAT an engineering assignment is entitled to know; AG2 owns HOW that entitlement becomes runtime model context. No Mozaiks general-purpose context engine; no duplication of AG2 prompt assembly, Skills, KnowledgeStore, Views, compaction, middleware, or network execution.
- **One narrow entitlement contract** (name deliberately unfixed) with exactly **five new concepts** — CompilationPlan unit ref, local Skill identifiers, **retrieval grants** (the genuinely novel piece: deterministic authorization of retrieval surfaces, digested and auditable), symbolic context **budget class** (no numeric limits in canonical contracts), and a manifest digest. Everything else reuses CompilationPlan `sources`/`outputs`, `ChildContractRef`, the `ApprovedAssignmentSpec` landing zones, and the closed taxonomy — the ADR explicitly rejects duplicating those facts in another metadata object.
- **Prompt/schema/Skills policy**: schemas own machine-enforced shape; prompts own responsibility/invariants/boundaries/failure behavior; Skills own reusable methodology; examples justify only semantics/boundaries/edge-cases/reasoning — schema-duplicating prose is recorded as migration debt.
- **Context pattern**: small high-signal policy context + deterministically authorized references + bounded just-in-time retrieval, with the refinement harness cited as the in-repo proof.
- **AppGenerator**: never split because prompts are large; decompose only at user-interaction/persistence/authority/context-regime/recovery/milestone boundaries, and not before the Slice 5 cutover. Users see product states (non-normative example: Understanding → Designing → Building → Verifying → Ready), never internal workflow topology.
- **Local vs network skills**: distinct mappings; free-form AG2 capability strings are never canonical authority.
- **Cleanup discipline**: no group-chat-era API residue exists (verified); the debt is Mozaiks-built parallel mechanisms — deleted atomically when their accepted replacement lands, evidence-gated, no shims for unreleased internals.
- **Slice placement**: nothing for 4C; Slice 5 must populate assignment landing zones with manifest-compatible grammars (not free-form strings); post-Slice-5 bounded implementation; Slice 6 makes refinement closure the context-scope authority; distributed-runtime concerns stay on the AG2 track.
- **Evaluation**: behavioral measures enumerated; thresholds only from corpus evidence.

## Companion inventory

`docs/architecture/workflows/appgenerator-context-debt.md` — the A–Z evidence-backed debt findings classified P0 (architecture/correctness, incl. the Slice 5 free-form landing-zone risk and whole-bundle `generated_files` exposure), P1 (quality/cost), P2 (cleanup). Actionable, explicitly non-normative.

## Files

`docs/adr/0008-deterministic-engineering-context.md` (new) · `docs/architecture/workflows/appgenerator-context-debt.md` (new) · `mkdocs.yml` (two nav entries) · `CHANGELOG.md` (Unreleased entry).

## Validation

`mkdocs build --strict` clean · `test_app_context_architecture_contract.py` + `test_graph_authority_contract.py` + `test_production_readiness_gate.py` (26 passed — the docs hygiene gate scans docs/) · `git diff --check` clean · DCO signed. No production Python/JS/workflow YAML touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
