### PR TITLE
fix(deployment): boot generated app containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,7 @@ jobs:
       - name: Build and smoke-run representative generated app
         env:
           MOZAIKS_RUN_GENERATED_APP_DOCKER_SMOKE: '1'
-        run: pytest -q --reruns 0 tests/test_generated_app_container_smoke.py
+        run: pytest -q --no-cov --reruns 0 tests/test_generated_app_container_smoke.py
 
       - name: Setup Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,8 @@ jobs:
           test -f /tmp/mozaiks-package-init/app/brand/theme_config.json
 
   infra-build:
-    # Proves the repo-local infra/ artifacts (Dockerfile + Helm chart) actually
-    # build and run, instead of only being reviewed by hand. See
+    # Proves the repo-local infra/ artifacts and a representative generated-app
+    # Dockerfile actually build and run, instead of only being reviewed by hand. See
     # docs/architecture/deployment/oss-infra-and-generated-app-deployment.md.
     runs-on: ubuntu-latest
     services:
@@ -465,6 +465,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install generated-app smoke dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install -e ".[dev]"
 
       - name: Build repo host image
         run: docker build -t mozaiks-repo-host:ci -f infra/docker/Dockerfile .
@@ -499,6 +510,11 @@ jobs:
       - name: Stop smoke container
         if: always()
         run: docker rm -f mozaiks-repo-host-smoke || true
+
+      - name: Build and smoke-run representative generated app
+        env:
+          MOZAIKS_RUN_GENERATED_APP_DOCKER_SMOKE: '1'
+        run: pytest -q --reruns 0 tests/test_generated_app_container_smoke.py
 
       - name: Setup Helm
         uses: azure/setup-helm@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Generated application containers now boot through the packaged OSS platform host**:
+  AppGenerator's provider-neutral Dockerfile uses
+  `mozaiks serve . --host platform` with the declared listen address and
+  container port, so a standalone exported workspace starts without an
+  undeclared repository-local launcher. CI resolves the packaged CLI
+  entrypoint and smoke-tests a representative materialized app image against
+  MongoDB through health, page, and module-action requests.
+
 - **Distributed same-chat exclusion is now enforced (issue #426, sub-slice A)**:
   the MongoDB chat lock at
   `mozaiksai/core/runtime/persistence/distributed_lock.py` — previously dead
@@ -813,9 +821,9 @@ This project follows a practical pre-1.0 changelog format:
 ### Fixed
 
 - Ask-mode human-support escalation now short-circuits the LLM turn after rendering the support handoff UI, so users do not receive an extra assistant answer after requesting an operator.
-- **`infra/docker/Dockerfile` no longer references removed root files** (`run_server.py`, `shared_app.py`, `workflows/`, `config/`): it now installs the real `mozaiks` package from `pyproject.toml` (fixing missing runtime dependencies such as `jsonschema` and `limits` that the old `requirements.txt`-based build silently dropped) and serves the first-party `factory_app/` workspace via `mozaiks serve . --host studio`. Verified with a local `docker build` + container smoke test against MongoDB.
+- **`infra/docker/Dockerfile` no longer references removed root launcher and workspace files**: it now installs the real `mozaiks` package from `pyproject.toml` (fixing missing runtime dependencies such as `jsonschema` and `limits` that the old `requirements.txt`-based build silently dropped) and serves the first-party `factory_app/` workspace via `mozaiks serve . --host studio`. Verified with a local `docker build` + container smoke test against MongoDB.
 - **Helm chart liveness probe pointed at a 404** (`infra/helm/mozaiks/values.yaml`): `livenessProbe.httpGet.path` was `/api/health/liveness`, which does not exist; the real route is `/api/health/live` (`mozaiksai/hosts/runtime.py`). Verified by rendering the chart and confirming both probe paths resolve.
-- **`infra/compose/docker-compose.yml` dev `app` service used a broken `watchmedo`/`run_server.py` command** with no `watchdog` dependency installed: replaced with `mozaiks serve . --host studio --reload`, plus a `PYTHONPATH=/app` override so the bind-mounted repo shadows the image's installed first-party packages for live-reload dev. Verified end to end against a real container.
+- **`infra/compose/docker-compose.yml` dev `app` service used a broken removed-launcher command** with no `watchdog` dependency installed: replaced with `mozaiks serve . --host studio --reload`, plus a `PYTHONPATH=/app` override so the bind-mounted repo shadows the image's installed first-party packages for live-reload dev. Verified end to end against a real container.
 
 ### Added
 

--- a/docs/architecture/deployment/generated-app-deployment-contract.md
+++ b/docs/architecture/deployment/generated-app-deployment-contract.md
@@ -60,7 +60,7 @@ Required shape:
 - `runtime`
   - `container_port`
   - `health_path`
-  - `start_command` (optional)
+  - `start_command`: `mozaiks serve . --host platform --listen 0.0.0.0 --port <container_port>`
 - `artifact_outputs`
   - `Dockerfile` (optional)
   - `docker-compose.yml` (optional)
@@ -187,6 +187,12 @@ provider-neutral runtime preflight before the container smoke:
 The workflow reports only safe metadata such as check ids, status, public host
 names, and exception type. It must not print connection strings, API keys,
 passwords, tokens, or provider secrets.
+
+The root `Dockerfile` invokes the same packaged OSS CLI command in exec form.
+The generated workspace is the application root, and the headless platform
+host loads its declarative pages, modules, services, and workflows. Generated
+apps do not depend on a repository-local launcher, the Studio host, or
+BlocUnited-operated infrastructure.
 
 ### Authenticated App Contract
 

--- a/docs/architecture/deployment/oss-infra-and-generated-app-deployment.md
+++ b/docs/architecture/deployment/oss-infra-and-generated-app-deployment.md
@@ -188,13 +188,13 @@ consumption yet.
 Resolved in this pass:
 
 1. `infra/docker/Dockerfile` no longer references removed root files
-   (`run_server.py`, `shared_app.py`, `workflows/`, `config/`). It installs the
+   (the removed root launcher and stale workspace paths). It installs the
    real `mozaiks` package from `pyproject.toml` and serves `factory_app/`
    through `mozaiks serve . --host studio`.
 2. `infra/helm/mozaiks/values.yaml` liveness probe now targets the route that
    actually exists (`/api/health/live`), not `/api/health/liveness`.
 3. `infra/compose/docker-compose.yml`'s dev `app` service no longer runs a
-   `watchmedo`/`run_server.py` command with no matching dependency; it runs
+   removed-launcher command with no matching dependency; it runs
    `mozaiks serve . --host studio --reload` against the bind-mounted repo.
 4. CI now has an `infra-build` job (`.github/workflows/ci.yml`) that builds
    `infra/docker/Dockerfile`, smoke-runs the image against a real MongoDB

--- a/factory_app/workflows/AppGenerator/tools/deployment_contract.py
+++ b/factory_app/workflows/AppGenerator/tools/deployment_contract.py
@@ -88,6 +88,21 @@ _ENV_EXAMPLE_PATHS = (
 )
 
 
+def _platform_start_command(port: int) -> list[str]:
+    """Return the packaged OSS platform-host command for a generated workspace."""
+    return [
+        "mozaiks",
+        "serve",
+        ".",
+        "--host",
+        "platform",
+        "--listen",
+        "0.0.0.0",
+        "--port",
+        str(port),
+    ]
+
+
 def _bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
@@ -709,7 +724,7 @@ def build_deploy_target_spec(
         "runtime": {
             "container_port": DEFAULT_RUNTIME_PORT,
             "health_path": DEFAULT_HEALTH_PATH,
-            "start_command": None,
+            "start_command": " ".join(_platform_start_command(DEFAULT_RUNTIME_PORT)),
         },
         "artifact_outputs": outputs,
         "auth": auth,
@@ -1081,6 +1096,7 @@ def _render_env_examples(spec: dict[str, Any]) -> dict[str, str]:
 def _render_dockerfile(spec: dict[str, Any]) -> str:
     runtime = spec.get("runtime") if isinstance(spec.get("runtime"), dict) else {}
     port = int(runtime.get("container_port") or DEFAULT_RUNTIME_PORT)  # type: ignore[union-attr]
+    start_command = json.dumps(_platform_start_command(port), separators=(",", ":"))
     return "\n".join(
         [
             "FROM python:3.13-slim",
@@ -1089,7 +1105,7 @@ def _render_dockerfile(spec: dict[str, Any]) -> str:
             "RUN pip install --no-cache-dir -r requirements.txt",
             "COPY . .",
             f"EXPOSE {port}",
-            "CMD [\"python\", \"run_server.py\"]",
+            f"CMD {start_command}",
             "",
         ]
     )

--- a/tests/test_appgenerator_deployment_contract.py
+++ b/tests/test_appgenerator_deployment_contract.py
@@ -48,6 +48,9 @@ def test_deploy_target_spec_validates_generic_container() -> None:
     assert errors == []
     assert spec["target_kind"] == "container"
     assert spec["provider_profile"]["name"] == "generic"
+    assert spec["runtime"]["start_command"] == (
+        "mozaiks serve . --host platform --listen 0.0.0.0 --port 8000"
+    )
     assert spec["ci_secret_requirements"]["required"][0]["name"] == "REGISTRY_PUSH_TOKEN"
     assert spec["readiness_requirements"]["checks"][0]["id"] == "runtime_environment"
     for path in ENV_EXAMPLE_PATHS:

--- a/tests/test_deployment_contract_ci_and_render_helpers.py
+++ b/tests/test_deployment_contract_ci_and_render_helpers.py
@@ -42,7 +42,11 @@ Covers the CI secret requirements helpers and render helpers:
     - custom port from spec in ports line
     - static boilerplate present (services, env_file, build context)
 """
+
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 from factory_app.workflows.AppGenerator.tools.deployment_contract import (
     DEFAULT_RUNTIME_PORT,
@@ -54,10 +58,10 @@ from factory_app.workflows.AppGenerator.tools.deployment_contract import (
     _render_env_example,
 )
 
+
 # ---------------------------------------------------------------------------
 # 1. _empty_ci_secret_requirements
 # ---------------------------------------------------------------------------
-
 class TestEmptyCiSecretRequirements:
     def test_returns_dict(self):
         result = _empty_ci_secret_requirements()
@@ -80,7 +84,6 @@ class TestEmptyCiSecretRequirements:
 # ---------------------------------------------------------------------------
 # 2. _default_ci_secret_requirements
 # ---------------------------------------------------------------------------
-
 class TestDefaultCiSecretRequirements:
     def test_include_workflow_false_returns_empty(self):
         result = _default_ci_secret_requirements(include_workflow=False)
@@ -139,7 +142,6 @@ class TestDefaultCiSecretRequirements:
 # ---------------------------------------------------------------------------
 # 3. _normalize_ci_secret_requirements
 # ---------------------------------------------------------------------------
-
 class TestNormalizeCiSecretRequirements:
     def test_none_returns_empty(self):
         result = _normalize_ci_secret_requirements(None)
@@ -245,7 +247,6 @@ class TestNormalizeCiSecretRequirements:
 # ---------------------------------------------------------------------------
 # 4. _render_env_example
 # ---------------------------------------------------------------------------
-
 class TestRenderEnvExample:
     def test_empty_spec_produces_header(self):
         result = _render_env_example({})
@@ -297,7 +298,6 @@ class TestRenderEnvExample:
 # ---------------------------------------------------------------------------
 # 5. _render_dockerfile
 # ---------------------------------------------------------------------------
-
 class TestRenderDockerfile:
     def test_default_port_in_expose(self):
         result = _render_dockerfile({})
@@ -326,7 +326,34 @@ class TestRenderDockerfile:
 
     def test_cmd_line(self):
         result = _render_dockerfile({})
-        assert "CMD" in result
+        command = json.loads(
+            next(
+                line.removeprefix("CMD ") for line in result.splitlines() if line.startswith("CMD ")
+            )
+        )
+        assert command == [
+            "mozaiks",
+            "serve",
+            ".",
+            "--host",
+            "platform",
+            "--listen",
+            "0.0.0.0",
+            "--port",
+            str(DEFAULT_RUNTIME_PORT),
+        ]
+
+        pyproject = (Path(__file__).parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+        assert 'mozaiks = "mozaiks_cli.main:main"' in pyproject
+
+    def test_custom_port_in_start_command(self):
+        result = _render_dockerfile({"runtime": {"container_port": 9000}})
+        command = json.loads(
+            next(
+                line.removeprefix("CMD ") for line in result.splitlines() if line.startswith("CMD ")
+            )
+        )
+        assert command[-2:] == ["--port", "9000"]
 
     def test_runtime_none_uses_default_port(self):
         spec = {"runtime": None}
@@ -342,7 +369,6 @@ class TestRenderDockerfile:
 # ---------------------------------------------------------------------------
 # 6. _render_compose
 # ---------------------------------------------------------------------------
-
 class TestRenderCompose:
     def test_default_port_in_ports_line(self):
         result = _render_compose({})

--- a/tests/test_generated_app_container_smoke.py
+++ b/tests/test_generated_app_container_smoke.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from factory_app.workflows.AppGenerator.tools.deployment_contract import (
+    generate_deployment_artifacts,
+)
+from factory_app.workflows.AppGenerator.tools.requirements_scanner import scan_requirements
+from tests.test_continuous_deterministic_materialization import _write_bundle
+from tests.test_materialized_bundle_production_runtime import _assemble_from_payload
+
+
+class _QuietFileHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def _free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _request_json(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"} if body is not None else {},
+        method="POST" if body is not None else "GET",
+    )
+    with urllib.request.urlopen(request, timeout=3) as response:
+        return response.status, json.load(response)
+
+
+@pytest.mark.asyncio
+async def test_materialized_generated_app_image_boots_and_serves_runtime(
+    tmp_path: Path,
+) -> None:
+    if os.environ.get("MOZAIKS_RUN_GENERATED_APP_DOCKER_SMOKE") != "1":
+        pytest.skip("set MOZAIKS_RUN_GENERATED_APP_DOCKER_SMOKE=1 for the Docker smoke")
+
+    repo_root = Path(__file__).parents[1]
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(wheel_dir),
+            str(repo_root),
+        ],
+        check=True,
+        cwd=repo_root,
+    )
+    wheels = list(wheel_dir.glob("mozaiks-*.whl"))
+    assert len(wheels) == 1
+
+    package_port = _free_port()
+    handler = partial(_QuietFileHandler, directory=str(wheel_dir))
+    package_server = ThreadingHTTPServer(("0.0.0.0", package_port), handler)
+    package_thread = threading.Thread(target=package_server.serve_forever, daemon=True)
+    package_thread.start()
+
+    token = uuid.uuid4().hex[:12]
+    image = f"mozaiks-generated-app-smoke:{token}"
+    container = f"mozaiks-generated-app-smoke-{token}"
+    host_port = _free_port()
+    app_root = tmp_path / "generated-app"
+    logs = ""
+    try:
+        files, _ = await _assemble_from_payload()
+        requirements = scan_requirements(files).splitlines()
+        requirements[requirements.index("mozaiks")] = (
+            f"http://host.docker.internal:{package_port}/{wheels[0].name}"
+        )
+        files["requirements.txt"] = "\n".join(requirements) + "\n"
+        deployment = generate_deployment_artifacts(
+            app_id="deterministic-reports",
+            deployment_profile="production_container",
+            include_dockerfiles=True,
+            include_workflow=False,
+            include_compose=False,
+        )
+        assert deployment["deploy_target_spec_errors"] == []
+        assert deployment["bundle_errors"] == []
+        files.update(deployment["artifacts"])
+        _write_bundle(app_root, files)
+
+        subprocess.run(
+            [
+                "docker",
+                "build",
+                "--add-host=host.docker.internal:host-gateway",
+                "--tag",
+                image,
+                str(app_root),
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "--detach",
+                "--name",
+                container,
+                "--add-host=host.docker.internal:host-gateway",
+                "--publish",
+                f"{host_port}:8000",
+                "--env",
+                "AUTH_ENABLED=false",
+                "--env",
+                "RATE_LIMIT_ENABLED=false",
+                "--env",
+                "OPENAI_API_KEY=sk-test-placeholder",
+                "--env",
+                "MONGO_URI=mongodb://host.docker.internal:27017/ci_generated_app",
+                image,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        deadline = time.monotonic() + 90
+        health: tuple[int, Any] | None = None
+        while time.monotonic() < deadline:
+            try:
+                health = _request_json(f"http://127.0.0.1:{host_port}/api/health")
+                if health[0] == 200 and health[1].get("status") == "healthy":
+                    break
+            except (OSError, urllib.error.URLError, json.JSONDecodeError):
+                pass
+            time.sleep(2)
+        else:
+            logs = subprocess.run(
+                ["docker", "logs", container],
+                check=False,
+                capture_output=True,
+                text=True,
+            ).stdout
+            pytest.fail(f"generated app image did not become healthy:\n{logs}")
+
+        assert health is not None
+        assert health[0] == 200
+        assert health[1]["status"] == "healthy"
+        page_status, page = _request_json(f"http://127.0.0.1:{host_port}/api/pages/reports")
+        assert page_status == 200
+        assert page["sections"][0]["config"]["api_endpoint"] == (
+            "/api/modules/reports/list_reports"
+        )
+
+        action_status, action = _request_json(
+            f"http://127.0.0.1:{host_port}/api/modules/reports/list_reports",
+            payload={"params": {}},
+        )
+        assert action_status == 200
+        assert action == {"reports": [{"id": "report-1", "title": "Readiness", "status": "ready"}]}
+    finally:
+        package_server.shutdown()
+        package_server.server_close()
+        package_thread.join(timeout=5)
+        subprocess.run(
+            ["docker", "rm", "--force", container],
+            check=False,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["docker", "image", "rm", "--force", image],
+            check=False,
+            capture_output=True,
+        )


### PR DESCRIPTION
## Summary

- replace the stale generated-app launcher assumption with the packaged OSS platform-host command
- keep Dockerfile, deployment manifest, port, health path, and self-host documentation aligned
- add a representative generated-app container smoke to the existing Docker-capable CI job
- remove remaining legacy launcher references

## Root cause and proof

The deployment renderer emitted `CMD ["python", "run_server.py"]`, but no generator, template, fixture, or package artifact creates that file. A representative materialized bundle built after supplying the locally built OSS wheel, then exited immediately because `/app/run_server.py` was absent.

The corrected image starts with:

`mozaiks serve . --host platform --listen 0.0.0.0 --port 8000`

This uses the packaged console entrypoint and loads the generated workspace through the headless platform host, without Studio, BlocUnited callbacks, hosted infrastructure, or repository-local launcher files.

## Validation

- focused deployment/materialization: 217 passed, 1 expected opt-in skip
- real Docker self-host smoke: generated bundle -> local OSS wheel -> image build -> container -> Mongo-backed `/api/health` -> `/api/pages/reports` -> `reports/list_reports`: passed
- final full suite: 14,224 passed, 81 skipped
- Ruff: passed
- scoped mypy: passed
- source hygiene: passed
- `git diff --check`: passed
- DCO sign-off present

## Scope

Deployment-only. No ADR 0007, Slice 4C/5, AG2, context-engineering, prompt, #449, or proprietary-platform changes.

Independent review is required before merge. Keep this PR draft and auto-merge disabled.