### PR TITLE
feat(semantics): ADR 0007 Slice 4C — deterministic offline page materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Deterministic offline page materialization (ADR 0007 Slice 4C)**: a pure
+  renderer materializes canonical `app_ui_page_schema` bytes from a validated
+  graph-v2 payload closure, its CompilationPlan unit's complete source
+  footprint, and the accepted graph-v2 ImplementationBinding — with one
+  canonical serialization (declaration-order YAML, omitted absent facts,
+  UTF-8/LF, no timestamps or provenance) proven byte-identical across
+  repeated runs, reordered inputs, and fresh processes. Implementation
+  resolution fails closed on any missing, wrong-family, wrong-materializer,
+  wrong-version, or wrong-graph binding with no fallback to historical
+  generators. `preserve_unowned` units place exact digest-verified bytes via
+  the existing `ChildContractRef` identity (empty files preserved, tampering
+  rejected); unsupported families stay typed gaps or explicit
+  handoff/deferred/unsupplied reports — nothing is silently omitted or
+  invented. Selective rematerialization drives the 4B regeneration closure: a
+  linked semantic section change rerenders only the affected page unit while
+  every unaffected output is reused byte-for-byte, and the proof suite
+  validates, loads, and boots both the base and successor bundles through the
+  real acceptance gate, `AppLoader`, and platform lifespan. Offline-only:
+  no AG2 imports, no AppBuildPlan consultation, no production wiring — the
+  agent-produced `AppBuildPlan` remains the sole operational authority until
+  the Slice 5 cutover.
+
 - **Renderer-input closure prerequisite (ADR 0007 Slice 4C, offline-only)**:
   graph-v2 page payloads now retain the canonical page identifier, route,
   page type, layout, shell mode, roles, navigation, metadata, and validated

--- a/mozaiksai/core/semantics/binding.py
+++ b/mozaiksai/core/semantics/binding.py
@@ -51,14 +51,30 @@ DEPLOYMENT_REQUIREMENT_KINDS = frozenset({SemanticNodeKind.DEPLOYMENT_TARGET})
 
 
 class _GraphSubject(Protocol):
-    """Structural surface shared by immutable graph v1 and graph v2."""
+    """Structural surface shared by immutable graph v1 and graph v2.
 
-    schema_version: str
-    graph_id: str
-    version: int
-    scope: ExecutionAccessScopeRef
-    graph_digest: str
-    nodes: tuple[Any, ...]
+    Members are read-only properties so frozen graph models with narrower
+    field types (graph v2's ``Literal`` schema version and typed node tuple)
+    satisfy the protocol covariantly.
+    """
+
+    @property
+    def schema_version(self) -> str: ...
+
+    @property
+    def graph_id(self) -> str: ...
+
+    @property
+    def version(self) -> int: ...
+
+    @property
+    def scope(self) -> ExecutionAccessScopeRef: ...
+
+    @property
+    def graph_digest(self) -> str: ...
+
+    @property
+    def nodes(self) -> tuple[Any, ...]: ...
 
 
 class ImplementationBindingError(ValueError):

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -325,14 +325,27 @@ def render_app_ui_page_schema_unit(
             f"unit {unit.unit_id!r} instance identity {unit.placeholder_values!r} does "
             f"not match page canonical id {page.page_id!r}"
         )
-    required = {
-        "route": page.route,
-        "title": page.title,
-        "page_type": page.page_type,
-        "layout": page.layout,
-    }
-    missing = sorted(name for name, value in required.items() if not value)
-    if missing or not page.sections:
+    route = page.route
+    title = page.title
+    page_type = page.page_type
+    layout = page.layout
+    if (
+        route is None
+        or title is None
+        or page_type is None
+        or layout is None
+        or not page.sections
+    ):
+        missing = sorted(
+            name
+            for name, value in (
+                ("route", route),
+                ("title", title),
+                ("page_type", page_type),
+                ("layout", layout),
+            )
+            if value is None
+        )
         raise MaterializationError(
             f"page {page.node_id!r} is not renderer-input complete; missing "
             f"{missing or ['sections']}"
@@ -354,10 +367,10 @@ def render_app_ui_page_schema_unit(
     schema = AppPageSchema(
         schema_version="mozaiks.app_page.v1",
         name=page.page_id,
-        route=page.route,
-        title=page.title,
-        page_type=page.page_type,
-        layout=page.layout,
+        route=route,
+        title=title,
+        page_type=page_type,
+        layout=layout,
         shell_mode=page.shell_mode,
         roles=None if page.roles is None else list(page.roles),
         navigation=page.navigation,

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -1,0 +1,757 @@
+"""ADR 0007 Slice 4C deterministic offline materialization (offline-only).
+
+This module implements the first honest deterministic materialization path:
+
+    SemanticGraphV2 -> CompilationPlan -> accepted ImplementationBinding
+    -> canonical ``app_ui_page_schema`` bytes -> composed candidate bundle
+
+Exactly one renderer family is renderer-ready in this slice:
+``app_ui_page_schema``. Its renderer is a pure function of the plan unit's
+complete semantic source footprint (the page payload plus its linked section
+payloads) and nothing else. It consumes no AppBuildPlan, agent context,
+generated files, conversation history, runtime state, environment variables,
+clocks, randomness, or filesystem enumeration — this module deliberately
+imports none of those capabilities.
+
+Authorities are unchanged: ``layout_registry`` remains the sole
+family/materializer authority; the ``CompilationPlan`` owns dispositions,
+source footprints, and physical output paths; the graph-v2
+``ImplementationBinding`` pins the one accepted deterministic implementation
+identity/version for the page-schema materializer. This module adds no
+registry, no alternate family map, no alternate output ownership, and no
+alternate artifact identity.
+
+Canonical serialization contract (``mozaiks.page_bytes.v1``): the rendered
+page document is the normative :class:`AppPageSchema` runtime model dumped in
+declaration order with ``None`` fields omitted, serialized as YAML with
+stable key order (no re-sorting), UTF-8 encoding, LF newlines, unbounded line
+width (no content-dependent wrapping), and no timestamps, identifiers,
+comments, or provenance. Same canonical input -> same path -> same bytes ->
+same content digest, across repeated invocations and fresh processes.
+
+Non-renderable dispositions stay truthful: ``preserve_unowned`` units consume
+exact caller-supplied bytes pinned by the existing ``ChildContractRef``
+identity (digest verified, never normalized or re-encoded);
+``external_handoff`` and ``inapplicable`` units and every typed ``PlanGap``
+are reported explicitly; nothing is silently omitted and no gap is turned
+into guessed content. Instance-relative output scopes (``module_relative``,
+``workflow_relative``) have no declared physical-root binding in this slice
+and are reported explicitly as deferred rather than being invented here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import UnionType
+from typing import Any, Literal, Union, get_args, get_origin
+
+import yaml
+from pydantic import BaseModel
+
+from mozaiksai.core.runtime.app.layout_registry import MaterializerIdentifier
+from mozaiksai.core.runtime.app.page_schema import (
+    _CHILD_CONFIG_MODELS,
+    _TOP_LEVEL_CONFIG_MODELS,
+    AppPageChildSection,
+    AppPageSchema,
+    AppPageSection,
+)
+from mozaiksai.core.semantics.binding import (
+    ImplementationBinding,
+    RendererSelection,
+    validate_implementation_binding_against_graph,
+)
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    FamilyInstancePlan,
+    LayoutRegistrySnapshot,
+    PlanDisposition,
+    RegenerationClosure,
+    plan_regeneration_closure,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.graph import SemanticGraphV2
+from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
+from mozaiksai.core.semantics.payloads import (
+    PagePayload,
+    SectionPayload,
+    SemanticPayloadBase,
+    parse_semantic_payload,
+)
+from mozaiksai.core.semantics.portable_path import detect_collisions
+
+PAGE_SCHEMA_FAMILY: Literal["app_ui_page_schema"] = "app_ui_page_schema"
+PAGE_BYTES_SCHEMA_VERSION: Literal["mozaiks.page_bytes.v1"] = "mozaiks.page_bytes.v1"
+
+#: The single accepted deterministic implementation identity for the
+#: ``page_schema_executor`` materializer in this slice. An ImplementationBinding
+#: must pin exactly this identity/version or materialization fails closed.
+PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID = "deterministic_page_schema_renderer"
+PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION = "1"
+
+#: Physical destination roots this slice can compose into one bundle file map.
+#: Instance-relative scopes have no declared physical-root binding yet.
+_COMPOSABLE_PATH_SCOPES = frozenset({"app_bundle_root", "workspace_root"})
+
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class MaterializationError(ValueError):
+    """The materialization inputs violate the Slice 4C contract."""
+
+
+# ---------------------------------------------------------------------------
+# Recursive structural closure gate (the general #450 compiler gate)
+# ---------------------------------------------------------------------------
+
+#: The only fields allowed to carry a generic mapping annotation: the page
+#: section config dispatchers, whose model validators exhaustively convert the
+#: raw mapping into a closed primitive-specific model before it can become
+#: authoritative content. Their closure is proven by probe, not trusted.
+_DISPATCHER_FIELDS = frozenset(
+    {(AppPageSection, "config"), (AppPageChildSection, "config")}
+)
+
+_CLOSED_SCALARS = (str, int, float, bool, bytes, type(None))
+
+
+def _is_closed_annotation(annotation: Any) -> bool:
+    if annotation in _CLOSED_SCALARS or annotation is Any:
+        return annotation is not Any
+    if isinstance(annotation, type):
+        if issubclass(annotation, Enum):
+            return True
+        if issubclass(annotation, BaseModel):
+            return True  # walked separately
+        return annotation in _CLOSED_SCALARS
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return True
+    if origin in (Union, UnionType):
+        return all(_is_closed_annotation(arg) for arg in get_args(annotation))
+    if origin in (list, tuple, frozenset, set):
+        return all(
+            _is_closed_annotation(arg) for arg in get_args(annotation) if arg is not Ellipsis
+        )
+    if origin is dict:
+        key_type, value_type = get_args(annotation)
+        return key_type is str and _is_closed_annotation(value_type)
+    return False
+
+
+def _walk_model_closure(
+    model: type[BaseModel], path: str, violations: list[str], visited: set[type[BaseModel]]
+) -> None:
+    if model in visited:
+        return
+    visited.add(model)
+    if model.model_config.get("extra") != "forbid":
+        violations.append(f"{path}: {model.__name__} does not forbid unknown fields")
+    for name, model_field in model.model_fields.items():
+        annotation = model_field.annotation
+        if (model, name) in _DISPATCHER_FIELDS:
+            continue  # closed by exhaustive dispatch, proven below
+        if not _is_closed_annotation(annotation):
+            violations.append(f"{path}.{name}: open annotation {annotation!r}")
+        stack: list[Any] = [annotation]
+        while stack:
+            candidate = stack.pop()
+            if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+                _walk_model_closure(candidate, f"{path}.{name}", violations, visited)
+            else:
+                stack.extend(get_args(candidate))
+
+
+_closure_gate_passed = False
+
+
+def validate_page_renderer_input_closure() -> None:
+    """Fail closed unless every reachable renderer input domain is closed.
+
+    Walks every model reachable from the semantic page/section payloads and
+    from the section-config primitive dispatch, then proves the dispatcher
+    exception empirically: every registered primitive must reject an unknown
+    config key, so the generic dispatcher annotation can never admit content
+    that survives into semantic authority. No family-specific exceptions.
+    """
+    global _closure_gate_passed
+    if _closure_gate_passed:
+        return
+    violations: list[str] = []
+    visited: set[type[BaseModel]] = set()
+    for entry_model in (PagePayload, SectionPayload, AppPageSchema, AppPageSection):
+        _walk_model_closure(entry_model, entry_model.__name__, violations, visited)
+    dispatch: dict[str, type[BaseModel]] = {}
+    dispatch.update(_TOP_LEVEL_CONFIG_MODELS)
+    dispatch.update(_CHILD_CONFIG_MODELS)
+    for primitive, config_model in sorted(dispatch.items()):
+        _walk_model_closure(config_model, f"config[{primitive}]", violations, visited)
+    for primitive in sorted(_TOP_LEVEL_CONFIG_MODELS):
+        try:
+            AppPageSection(
+                id="closure_probe",
+                primitive=primitive,
+                config={"mozaiks_closure_probe_key": 1},
+            )
+        except ValueError:
+            continue
+        violations.append(
+            f"config[{primitive}]: dispatcher accepted an unknown config key"
+        )
+    if violations:
+        raise MaterializationError(
+            "renderer input closure violated: " + "; ".join(sorted(violations))
+        )
+    _closure_gate_passed = True
+
+
+# ---------------------------------------------------------------------------
+# Implementation resolution (binding is the only implementation authority)
+# ---------------------------------------------------------------------------
+
+
+def resolve_page_schema_renderer_selection(
+    binding: ImplementationBinding,
+    *,
+    graph: SemanticGraphV2,
+    layout_registry: Any,
+) -> RendererSelection:
+    """Resolve the accepted page-schema renderer through the binding.
+
+    Fails closed when the binding carries no selection for the page family,
+    claims a materializer the registry does not declare for it, targets a
+    non-v2 graph, or pins any implementation identity/version other than the
+    single accepted deterministic implementation of this slice. There is no
+    fallback to any historical generator path.
+    """
+    try:
+        validate_implementation_binding_against_graph(
+            binding, graph, layout_registry=layout_registry
+        )
+    except ValueError as exc:
+        raise MaterializationError(f"implementation binding rejected: {exc}") from exc
+    matches = [
+        selection
+        for selection in binding.renderer_selections
+        if PAGE_SCHEMA_FAMILY in selection.artifact_families
+    ]
+    if not matches:
+        raise MaterializationError(
+            f"binding carries no renderer selection for {PAGE_SCHEMA_FAMILY!r}"
+        )
+    selection = matches[0]
+    if selection.materializer_id is not MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR:
+        raise MaterializationError(
+            f"renderer selection for {PAGE_SCHEMA_FAMILY!r} pins materializer "
+            f"{selection.materializer_id.value!r}, not the page schema executor"
+        )
+    if (
+        selection.implementation_id != PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID
+        or selection.implementation_version != PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION
+    ):
+        raise MaterializationError(
+            "binding pins unaccepted page renderer implementation "
+            f"{selection.implementation_id!r}@{selection.implementation_version!r}; "
+            f"accepted: {PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID!r}"
+            f"@{PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION!r}"
+        )
+    return selection
+
+
+# ---------------------------------------------------------------------------
+# Canonical page bytes
+# ---------------------------------------------------------------------------
+
+
+def _canonical_yaml_bytes(document: Mapping[str, Any]) -> bytes:
+    text = yaml.safe_dump(
+        dict(document),
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=2_000_000_000,
+    )
+    if not text.endswith("\n"):
+        text += "\n"
+    return text.replace("\r\n", "\n").encode("utf-8")
+
+
+def render_app_ui_page_schema_unit(
+    *,
+    unit: FamilyInstancePlan,
+    payload_by_node: Mapping[str, SemanticPayloadBase],
+) -> bytes:
+    """Render one page unit's canonical bytes from its footprint alone.
+
+    The renderer reads only payloads pinned by the unit's declared source
+    footprint; a page whose section list references any node outside that
+    footprint fails closed instead of reaching for wider state.
+    """
+    validate_page_renderer_input_closure()
+    if unit.family_kind != PAGE_SCHEMA_FAMILY:
+        raise MaterializationError(
+            f"unit {unit.unit_id!r} family {unit.family_kind!r} is not renderer-ready "
+            f"in this slice; only {PAGE_SCHEMA_FAMILY!r} renders"
+        )
+    if unit.disposition is not PlanDisposition.RENDER:
+        raise MaterializationError(
+            f"unit {unit.unit_id!r} disposition {unit.disposition.value!r} is not render"
+        )
+    footprint = {source.node_id for source in unit.sources}
+    pages = [
+        payload_by_node[node_id]
+        for node_id in sorted(footprint)
+        if isinstance(payload_by_node.get(node_id), PagePayload)
+    ]
+    if len(pages) != 1:
+        raise MaterializationError(
+            f"unit {unit.unit_id!r} footprint must pin exactly one page payload, "
+            f"found {len(pages)}"
+        )
+    page = pages[0]
+    for source in unit.sources:
+        pinned = payload_by_node.get(source.node_id)
+        if pinned is None or pinned.payload_digest != source.payload_digest:
+            raise MaterializationError(
+                f"unit {unit.unit_id!r} source {source.node_id!r} is missing or does "
+                "not match its pinned payload digest"
+            )
+    if unit.placeholder_values != (("page_id", page.page_id),):
+        raise MaterializationError(
+            f"unit {unit.unit_id!r} instance identity {unit.placeholder_values!r} does "
+            f"not match page canonical id {page.page_id!r}"
+        )
+    required = {
+        "route": page.route,
+        "title": page.title,
+        "page_type": page.page_type,
+        "layout": page.layout,
+    }
+    missing = sorted(name for name, value in required.items() if not value)
+    if missing or not page.sections:
+        raise MaterializationError(
+            f"page {page.node_id!r} is not renderer-input complete; missing "
+            f"{missing or ['sections']}"
+        )
+    declaratives = []
+    for entry in page.sections:
+        if entry.section_node_id not in footprint:
+            raise MaterializationError(
+                f"page {page.node_id!r} references section {entry.section_node_id!r} "
+                "outside the unit's declared source footprint"
+            )
+        section = payload_by_node[entry.section_node_id]
+        if not isinstance(section, SectionPayload) or section.declarative is None:
+            raise MaterializationError(
+                f"section {entry.section_node_id!r} carries no normative declarative; "
+                "the page is not renderer-input complete"
+            )
+        declaratives.append(section.declarative)
+    schema = AppPageSchema(
+        schema_version="mozaiks.app_page.v1",
+        name=page.page_id,
+        route=page.route,
+        title=page.title,
+        page_type=page.page_type,
+        layout=page.layout,
+        shell_mode=page.shell_mode,
+        roles=None if page.roles is None else list(page.roles),
+        navigation=page.navigation,
+        meta=page.meta,
+        sections=list(declaratives),
+    )
+    rendered = _canonical_yaml_bytes(schema.model_dump(mode="json", exclude_none=True))
+    reparsed = AppPageSchema.model_validate(yaml.safe_load(rendered.decode("utf-8")))
+    if reparsed != schema:
+        raise MaterializationError(
+            f"canonical page bytes for {page.page_id!r} failed round-trip verification"
+        )
+    return rendered
+
+
+# ---------------------------------------------------------------------------
+# Bundle materialization
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MaterializedOutput:
+    """One physical output produced under plan authority."""
+
+    unit_id: str
+    path_scope: str
+    path: str
+    content: bytes
+    origin: Literal["rendered", "preserved", "reused"]
+    content_digest: str
+
+
+@dataclass(frozen=True)
+class MaterializedBundle:
+    """Result of materializing one CompilationPlan. Not a wire contract."""
+
+    plan_digest: str
+    outputs: tuple[MaterializedOutput, ...]
+    external_handoff_units: tuple[str, ...]
+    inapplicable_units: tuple[str, ...]
+    unsupplied_preserved_units: tuple[str, ...]
+    instance_scope_deferred_units: tuple[str, ...]
+    gap_count: int
+    closure: RegenerationClosure | None = field(default=None)
+
+    def files(self) -> dict[str, bytes]:
+        return {output.path: output.content for output in self.outputs}
+
+
+def _cold_validate(plan: CompilationPlan, graph: SemanticGraphV2, payloads: Iterable[SemanticPayloadBase]):
+    try:
+        verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
+        verified_graph = SemanticGraphV2.model_validate(graph.model_dump(mode="json"))
+        verified_payloads = [
+            parse_semantic_payload(payload.model_dump(mode="json")) for payload in payloads
+        ]
+    except ValueError as exc:
+        raise MaterializationError(f"materialization inputs failed cold validation: {exc}") from exc
+    if verified_plan.graph_digest != verified_graph.graph_digest:
+        raise MaterializationError("plan does not pin the supplied graph identity")
+    return verified_plan, verified_graph, {p.node_id: p for p in verified_payloads}
+
+
+def _assert_registry_identity(plan: CompilationPlan, layout_registry: Any) -> None:
+    """The plan must pin the identity of the sole registry actually supplied.
+
+    A pre-built snapshot is cold-revalidated, so a forged or tampered
+    snapshot identity fails here rather than being trusted.
+    """
+    try:
+        snapshot = (
+            LayoutRegistrySnapshot.model_validate(layout_registry.model_dump(mode="json"))
+            if isinstance(layout_registry, LayoutRegistrySnapshot)
+            else snapshot_layout_registry(layout_registry)
+        )
+    except ValueError as exc:
+        raise MaterializationError(f"layout registry snapshot rejected: {exc}") from exc
+    if snapshot.snapshot_digest != plan.registry_digest:
+        raise MaterializationError(
+            "layout registry snapshot does not match the plan's pinned registry identity"
+        )
+
+
+def _match_preserved(
+    plan: CompilationPlan,
+    artifacts: Iterable[PreservedOpaqueArtifact],
+) -> dict[str, PreservedOpaqueArtifact]:
+    by_unit: dict[str, PreservedOpaqueArtifact] = {}
+    for artifact in artifacts:
+        ref = artifact.contract_ref
+        matches = [
+            unit
+            for unit in plan.units
+            if unit.disposition is PlanDisposition.PRESERVE_UNOWNED
+            and unit.family_kind == ref.artifact_family
+            and any(
+                output.path == ref.canonical_relative_path
+                and output.path_scope in _COMPOSABLE_PATH_SCOPES
+                for output in unit.outputs
+            )
+        ]
+        if len(matches) != 1:
+            raise MaterializationError(
+                f"preserved artifact {ref.artifact_family!r}:{ref.canonical_relative_path!r} "
+                f"matches {len(matches)} plan units; exactly one required"
+            )
+        unit = matches[0]
+        if unit.unit_id in by_unit:
+            raise MaterializationError(
+                f"unit {unit.unit_id!r} received more than one preserved artifact"
+            )
+        by_unit[unit.unit_id] = artifact
+    return by_unit
+
+
+def _materialize_unit(
+    unit: FamilyInstancePlan,
+    *,
+    payload_by_node: Mapping[str, SemanticPayloadBase],
+    preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
+    bundle_outputs: list[MaterializedOutput],
+    external: list[str],
+    inapplicable: list[str],
+    unsupplied: list[str],
+    deferred: list[str],
+) -> None:
+    composable = [o for o in unit.outputs if o.path_scope in _COMPOSABLE_PATH_SCOPES]
+    non_composable = [o for o in unit.outputs if o.path_scope not in _COMPOSABLE_PATH_SCOPES]
+    if non_composable:
+        deferred.append(unit.unit_id)
+    if unit.disposition is PlanDisposition.RENDER:
+        if not composable:
+            return
+        if len(composable) != 1:
+            raise MaterializationError(
+                f"render unit {unit.unit_id!r} must own exactly one composable output"
+            )
+        content = render_app_ui_page_schema_unit(unit=unit, payload_by_node=payload_by_node)
+        target = composable[0]
+        bundle_outputs.append(
+            MaterializedOutput(
+                unit_id=unit.unit_id,
+                path_scope=target.path_scope,
+                path=target.path,
+                content=content,
+                origin="rendered",
+                content_digest=hashlib.sha256(content).hexdigest(),
+            )
+        )
+    elif unit.disposition is PlanDisposition.PRESERVE_UNOWNED:
+        artifact = preserved_by_unit.get(unit.unit_id)
+        if artifact is None:
+            if composable:
+                unsupplied.append(unit.unit_id)
+            return
+        target = next(
+            output
+            for output in composable
+            if output.path == artifact.contract_ref.canonical_relative_path
+        )
+        bundle_outputs.append(
+            MaterializedOutput(
+                unit_id=unit.unit_id,
+                path_scope=target.path_scope,
+                path=target.path,
+                content=artifact.content,
+                origin="preserved",
+                content_digest=artifact.contract_ref.content_digest,
+            )
+        )
+    elif unit.disposition is PlanDisposition.EXTERNAL_HANDOFF:
+        external.append(unit.unit_id)
+    elif unit.disposition is PlanDisposition.INAPPLICABLE:
+        inapplicable.append(unit.unit_id)
+    else:
+        raise MaterializationError(
+            f"unit {unit.unit_id!r} disposition {unit.disposition.value!r} has no "
+            "materialization path in this slice"
+        )
+
+
+def materialize_plan(
+    *,
+    plan: CompilationPlan,
+    graph: SemanticGraphV2,
+    payloads: Iterable[SemanticPayloadBase],
+    binding: ImplementationBinding,
+    layout_registry: Any,
+    preserved_artifacts: Iterable[PreservedOpaqueArtifact] = (),
+) -> MaterializedBundle:
+    """Materialize every plan-authorized output for one CompilationPlan.
+
+    Renders exactly the renderer-ready page units through the bound accepted
+    implementation, places exact preserved bytes for supplied
+    ``preserve_unowned`` units, and reports every other unit's disposition
+    explicitly. The registry snapshot identity must match the plan's pinned
+    registry digest — a plan derived from a different registry fails closed.
+    """
+    verified_plan, verified_graph, payload_by_node = _cold_validate(plan, graph, payloads)
+    _assert_registry_identity(verified_plan, layout_registry)
+    resolve_page_schema_renderer_selection(
+        binding, graph=verified_graph, layout_registry=layout_registry
+    )
+    preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
+
+    outputs: list[MaterializedOutput] = []
+    external: list[str] = []
+    inapplicable: list[str] = []
+    unsupplied: list[str] = []
+    deferred: list[str] = []
+    for unit in verified_plan.units:
+        _materialize_unit(
+            unit,
+            payload_by_node=payload_by_node,
+            preserved_by_unit=preserved_by_unit,
+            bundle_outputs=outputs,
+            external=external,
+            inapplicable=inapplicable,
+            unsupplied=unsupplied,
+            deferred=deferred,
+        )
+    _assert_output_ownership(verified_plan, outputs)
+    return MaterializedBundle(
+        plan_digest=verified_plan.plan_digest,
+        outputs=tuple(sorted(outputs, key=lambda o: o.path)),
+        external_handoff_units=tuple(sorted(external)),
+        inapplicable_units=tuple(sorted(inapplicable)),
+        unsupplied_preserved_units=tuple(sorted(unsupplied)),
+        instance_scope_deferred_units=tuple(sorted(set(deferred))),
+        gap_count=len(verified_plan.gaps),
+    )
+
+
+def _assert_output_ownership(plan: CompilationPlan, outputs: list[MaterializedOutput]) -> None:
+    """Every produced path must be the plan-assigned path of its own unit."""
+    assigned: dict[tuple[str, str], str] = {}
+    for unit in plan.units:
+        for output in unit.outputs:
+            assigned[(output.path_scope, output.path)] = unit.unit_id
+    seen: set[str] = set()
+    for produced in outputs:
+        owner = assigned.get((produced.path_scope, produced.path))
+        if owner != produced.unit_id:
+            raise MaterializationError(
+                f"output {produced.path!r} is not assigned to unit {produced.unit_id!r} "
+                "by the compilation plan"
+            )
+        if produced.path in seen:
+            raise MaterializationError(f"duplicate materialized output {produced.path!r}")
+        seen.add(produced.path)
+    detect_collisions(sorted(seen))
+
+
+def rematerialize_plan(
+    *,
+    base_bundle: MaterializedBundle,
+    base_plan: CompilationPlan,
+    successor_plan: CompilationPlan,
+    graph: SemanticGraphV2,
+    payloads: Iterable[SemanticPayloadBase],
+    binding: ImplementationBinding,
+    layout_registry: Any,
+    preserved_artifacts: Iterable[PreservedOpaqueArtifact] = (),
+) -> MaterializedBundle:
+    """Selectively rematerialize a successor plan against a base bundle.
+
+    Affected and added units are produced fresh; reusable units are copied
+    byte-for-byte from the base bundle (preserved reuse re-verifies the
+    pinned content digest); removed units' outputs are absent. The closure is
+    computed by the 4B authority and attached to the result for inspection.
+    """
+    if base_bundle.plan_digest != base_plan.plan_digest:
+        raise MaterializationError("base bundle does not correspond to the base plan")
+    closure = plan_regeneration_closure(base_plan, successor_plan)
+    reusable_ids = set(closure.reusable)
+
+    verified_plan, verified_graph, payload_by_node = _cold_validate(
+        successor_plan, graph, payloads
+    )
+    _assert_registry_identity(verified_plan, layout_registry)
+    resolve_page_schema_renderer_selection(
+        binding, graph=verified_graph, layout_registry=layout_registry
+    )
+    preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
+    base_by_unit: dict[str, list[MaterializedOutput]] = {}
+    for output in base_bundle.outputs:
+        base_by_unit.setdefault(output.unit_id, []).append(output)
+
+    outputs: list[MaterializedOutput] = []
+    external: list[str] = []
+    inapplicable: list[str] = []
+    unsupplied: list[str] = []
+    deferred: list[str] = []
+    for unit in verified_plan.units:
+        if unit.unit_id in reusable_ids:
+            reused = base_by_unit.get(unit.unit_id, [])
+            expected_paths = {
+                (o.path_scope, o.path)
+                for o in unit.outputs
+                if o.path_scope in _COMPOSABLE_PATH_SCOPES
+            }
+            if unit.disposition in (PlanDisposition.RENDER, PlanDisposition.PRESERVE_UNOWNED):
+                produced_paths = {(o.path_scope, o.path) for o in reused}
+                if expected_paths and produced_paths != expected_paths:
+                    if unit.disposition is PlanDisposition.PRESERVE_UNOWNED and not reused:
+                        unsupplied.append(unit.unit_id)
+                        continue
+                    raise MaterializationError(
+                        f"reusable unit {unit.unit_id!r} has no matching base outputs "
+                        "to reuse byte-for-byte"
+                    )
+                for prior in reused:
+                    if hashlib.sha256(prior.content).hexdigest() != prior.content_digest:
+                        raise MaterializationError(
+                            f"base output {prior.path!r} failed digest re-verification"
+                        )
+                    outputs.append(
+                        MaterializedOutput(
+                            unit_id=prior.unit_id,
+                            path_scope=prior.path_scope,
+                            path=prior.path,
+                            content=prior.content,
+                            origin="reused",
+                            content_digest=prior.content_digest,
+                        )
+                    )
+            elif unit.disposition is PlanDisposition.EXTERNAL_HANDOFF:
+                external.append(unit.unit_id)
+            elif unit.disposition is PlanDisposition.INAPPLICABLE:
+                inapplicable.append(unit.unit_id)
+            if any(o.path_scope not in _COMPOSABLE_PATH_SCOPES for o in unit.outputs):
+                deferred.append(unit.unit_id)
+            continue
+        _materialize_unit(
+            unit,
+            payload_by_node=payload_by_node,
+            preserved_by_unit=preserved_by_unit,
+            bundle_outputs=outputs,
+            external=external,
+            inapplicable=inapplicable,
+            unsupplied=unsupplied,
+            deferred=deferred,
+        )
+    _assert_output_ownership(verified_plan, outputs)
+    return MaterializedBundle(
+        plan_digest=verified_plan.plan_digest,
+        outputs=tuple(sorted(outputs, key=lambda o: o.path)),
+        external_handoff_units=tuple(sorted(external)),
+        inapplicable_units=tuple(sorted(inapplicable)),
+        unsupplied_preserved_units=tuple(sorted(unsupplied)),
+        instance_scope_deferred_units=tuple(sorted(set(deferred))),
+        gap_count=len(verified_plan.gaps),
+        closure=closure,
+    )
+
+
+def compose_bundle(
+    bundle: MaterializedBundle,
+    authored_files: Mapping[str, str | bytes],
+) -> dict[str, bytes]:
+    """Compose plan-owned outputs with authored files for gapped families.
+
+    Authored files represent families whose legitimate disposition is a typed
+    gap or authored content in this slice. They may never overlap — or
+    collide under case-fold/prefix rules — with any plan-owned output path.
+    """
+    plan_owned = bundle.files()
+    authored: dict[str, bytes] = {
+        path: (content.encode("utf-8") if isinstance(content, str) else bytes(content))
+        for path, content in authored_files.items()
+    }
+    overlap = sorted(set(plan_owned) & set(authored))
+    if overlap:
+        raise MaterializationError(
+            f"authored files overlap plan-owned outputs: {overlap}"
+        )
+    detect_collisions(sorted(set(plan_owned) | set(authored)))
+    combined = dict(authored)
+    combined.update(plan_owned)
+    return combined
+
+
+__all__ = [
+    "PAGE_BYTES_SCHEMA_VERSION",
+    "PAGE_SCHEMA_FAMILY",
+    "PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID",
+    "PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION",
+    "MaterializationError",
+    "MaterializedBundle",
+    "MaterializedOutput",
+    "compose_bundle",
+    "materialize_plan",
+    "rematerialize_plan",
+    "render_app_ui_page_schema_unit",
+    "resolve_page_schema_renderer_selection",
+    "validate_page_renderer_input_closure",
+]

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -302,11 +302,11 @@ def render_app_ui_page_schema_unit(
             f"unit {unit.unit_id!r} disposition {unit.disposition.value!r} is not render"
         )
     footprint = {source.node_id for source in unit.sources}
-    pages = [
-        payload_by_node[node_id]
-        for node_id in sorted(footprint)
-        if isinstance(payload_by_node.get(node_id), PagePayload)
-    ]
+    pages: list[PagePayload] = []
+    for node_id in sorted(footprint):
+        candidate = payload_by_node.get(node_id)
+        if isinstance(candidate, PagePayload):
+            pages.append(candidate)
     if len(pages) != 1:
         raise MaterializationError(
             f"unit {unit.unit_id!r} footprint must pin exactly one page payload, "
@@ -337,7 +337,7 @@ def render_app_ui_page_schema_unit(
             f"page {page.node_id!r} is not renderer-input complete; missing "
             f"{missing or ['sections']}"
         )
-    declaratives = []
+    declaratives: list[AppPageSection] = []
     for entry in page.sections:
         if entry.section_node_id not in footprint:
             raise MaterializationError(

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -508,6 +508,10 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
         Path("mozaiksai/core/semantics/compilation_plan.py"),
         Path("mozaiksai/core/semantics/resolver.py"),
         Path("mozaiksai/core/semantics/refs.py"),
+        # Slice 4C offline materializer: consumes the plan inside the
+        # semantics layer only; its own proof suite asserts it has no
+        # production, AG2, or ambient-capability imports.
+        Path("mozaiksai/core/semantics/materialization.py"),
     }
     for root in (ROOT / "mozaiksai", ROOT / "factory_app"):
         for path in root.rglob("*.py"):

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -1,0 +1,821 @@
+"""ADR 0007 Slice 4C proof gate: deterministic offline page materialization.
+
+Proves the first honest deterministic materialization path:
+
+    SemanticGraphV2 -> CompilationPlan -> accepted ImplementationBinding
+    -> canonical ``app_ui_page_schema`` bytes -> existing validation/loading
+    -> successor-bundle runtime proof
+
+Covers: exact canonical bytes, repeated/cross-process/input-order determinism,
+fail-closed implementation resolution, plan output ownership, byte-exact
+opaque preservation, explicit gaps, selective regeneration through the 4B
+closure (linked-section change -> page affected; unrelated change -> page
+reusable), successor validation + AppLoader + lifespan-owned platform boot,
+the recursive closed-domain gate, and the renderer's structural isolation
+from AppBuildPlan/AG2/runtime state.
+
+The bounded claim proven here: a typed semantic page change deterministically
+produces a validated, loadable/bootable successor bundle while unrelated
+opaque artifacts are preserved byte-exact. Nothing here claims whole-app
+regeneration; unsupported families remain typed gaps or authored files.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from factory_app.workflows.AppGenerator.tools.app_validation import (
+    run_app_bundle_acceptance_gate,
+)
+from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
+    scan_generated_bundle,
+)
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+from mozaiksai.core.runtime.app.layout_registry import (
+    MaterializerIdentifier,
+    build_app_layout_registry,
+)
+from mozaiksai.core.runtime.app.loader import AppLoader
+from mozaiksai.core.runtime.app.page_schema import AppPageSchema
+from mozaiksai.core.semantics.binding import (
+    RendererSelection,
+    build_implementation_binding,
+)
+from mozaiksai.core.semantics.compilation_plan import (
+    PlanDisposition,
+    derive_compilation_plan,
+)
+from mozaiksai.core.semantics.materialization import (
+    PAGE_SCHEMA_FAMILY,
+    PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+    PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+    MaterializationError,
+    compose_bundle,
+    materialize_plan,
+    rematerialize_plan,
+    render_app_ui_page_schema_unit,
+    resolve_page_schema_renderer_selection,
+    validate_page_renderer_input_closure,
+)
+from mozaiksai.core.semantics.offline_projection import project_semantic_graph
+from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
+from mozaiksai.core.semantics.refs import (
+    ChildContractRef,
+    ExecutionAccessScopeRef,
+    SemanticGraphRef,
+)
+from mozaiksai.core.validation.functional_generated_app import (
+    scan_functional_generated_app,
+)
+from tests.test_continuous_deterministic_materialization import (
+    _FakeMongoClient,
+    _write_bundle,
+)
+from tests.test_materialized_bundle_production_runtime import (
+    _restore_platform_state,
+    _save_platform_state,
+)
+from tests.test_semantic_offline_projection import _pinned_registry
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
+
+_HANDLER_BYTES = b"""from .service import OrdersService
+
+
+class OrdersModule:
+    def __init__(self):
+        self.service = OrdersService()
+
+    async def list_orders(self, ctx, **params):
+        return await self.service.list_orders(ctx, **params)
+
+    async def create_order(self, ctx, **params):
+        return await self.service.create_order(ctx, **params)
+"""
+
+_SERVICE_BYTES = b"""class OrdersService:
+    async def list_orders(self, ctx, **params):
+        return {"orders": []}
+
+    async def create_order(self, ctx, **params):
+        return {"order": {"customer_name": params.get("customer_name")}}
+"""
+
+
+def _source(*, column_label: str = "Order") -> dict:
+    """Semantic source corpus: one page linked to one module, v1 page doc."""
+    return {
+        "pages": [
+            {
+                "schema_version": "mozaiks.app_page.v1",
+                "name": "orders",
+                "route": "/orders",
+                "title": "Orders",
+                "page_type": "record_list",
+                "layout": "full-width",
+                "sections": [
+                    {
+                        "id": "orders-list",
+                        "primitive": "DataTable",
+                        "config": {
+                            "columns": [{"key": "order_id", "label": column_label}],
+                            "api_endpoint": "/api/modules/orders/list_orders",
+                        },
+                    },
+                    {
+                        "id": "create-order",
+                        "primitive": "Form",
+                        "config": {
+                            "fields": [
+                                {"name": "customer_name", "label": "Customer", "type": "text"}
+                            ],
+                            "submit_action": {
+                                "label": "Create Order",
+                                "action_type": "submit",
+                                "href": "/api/modules/orders/create_order",
+                            },
+                        },
+                    },
+                ],
+            }
+        ],
+        "modules": [
+            {
+                "manifest": {
+                    "module": {"id": "orders", "description": "Order management"},
+                    "actions": [
+                        {"id": "list_orders", "description": "List orders."},
+                        {"id": "create_order", "description": "Create an order."},
+                    ],
+                }
+            }
+        ],
+    }
+
+
+def _registry():
+    return build_app_layout_registry(())
+
+
+def _build(source: dict, *, graph_id: str = "slice4c"):
+    result = project_semantic_graph(
+        source, graph_id=graph_id, version=1, scope=_SCOPE, taxonomy_registry=_pinned_registry()
+    )
+    plan = derive_compilation_plan(
+        graph=result.graph, payloads=result.payloads, registry=_registry()
+    )
+    return result, plan
+
+
+def _selection(**overrides) -> RendererSelection:
+    fields = {
+        "materializer_id": MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+        "implementation_id": PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+        "implementation_version": PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+        "artifact_families": (PAGE_SCHEMA_FAMILY,),
+    }
+    fields.update(overrides)
+    return RendererSelection(**fields)
+
+
+def _binding(graph, selection: RendererSelection | None = None):
+    return build_implementation_binding(
+        binding_id="slice4c_binding",
+        version=1,
+        scope=_SCOPE,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(selection if selection is not None else _selection(),),
+    )
+
+
+def _opaque(family: str, path: str, content: bytes) -> PreservedOpaqueArtifact:
+    return PreservedOpaqueArtifact(
+        contract_ref=ChildContractRef(
+            subject_id=path.replace("/", "_").replace(".", "_"),
+            subject_version=1,
+            scope=_SCOPE,
+            content_digest=hashlib.sha256(content).hexdigest(),
+            artifact_family=family,
+            canonical_relative_path=path,
+            contract_schema_version="mozaiks.child_contract.v1",
+        ),
+        content=content,
+    )
+
+
+def _preserved_artifacts() -> tuple[PreservedOpaqueArtifact, ...]:
+    return (
+        _opaque("module_backend_handler", "modules/orders/backend/handler.py", _HANDLER_BYTES),
+        _opaque("module_backend_service", "modules/orders/backend/service.py", _SERVICE_BYTES),
+    )
+
+
+def _materialize(source: dict):
+    result, plan = _build(source)
+    bundle = materialize_plan(
+        plan=plan,
+        graph=result.graph,
+        payloads=result.payloads,
+        binding=_binding(result.graph),
+        layout_registry=_registry(),
+        preserved_artifacts=_preserved_artifacts(),
+    )
+    return result, plan, bundle
+
+
+def _authored_skeleton() -> dict[str, str]:
+    """Families whose legitimate disposition today is a typed gap or authored
+    content — never produced by the renderer, never overlapping plan outputs."""
+    return {
+        "app.json": json.dumps(
+            {
+                "appId": "slice4c-orders",
+                "appName": "Slice4C Orders",
+                "version": "1.0.0",
+                "startup": {"landing_spot": "/orders"},
+            }
+        ),
+        "config/ai.json": json.dumps({"chat": {"chat_startup_mode": "ask"}}),
+        "config/shell.json": json.dumps({"navigation": {"autoFromPages": True}}),
+        "ui/route_manifest.json": json.dumps(
+            {
+                "pages": [
+                    {
+                        "path": "/orders",
+                        "component": "SchemaPage",
+                        "label": "Orders",
+                        "schema": "orders",
+                    }
+                ]
+            }
+        ),
+        "data/contract.json": json.dumps(
+            {
+                "version": "1",
+                "app_id": "slice4c-orders",
+                "surfaces": [
+                    {
+                        "surface_id": "orders",
+                        "surface_kind": "module",
+                        "collections": [{"name": "orders"}],
+                    }
+                ],
+            }
+        ),
+        "security/secrets.yaml": "version: 1\nsecrets: []\n",
+        "modules/orders/module.yaml": (
+            "schema_version: mozaiks.module.v1\n"
+            "module:\n"
+            "  id: orders\n"
+            "  display_name: Orders\n"
+            "  version: 1.0.0\n"
+            "  handler: backend.handler:OrdersModule\n"
+            "actions:\n"
+            "  - id: list_orders\n"
+            "    description: List orders.\n"
+            "    handler_method: list_orders\n"
+            "    input_schema: {type: object, properties: {}}\n"
+            "    output_schema: {type: object}\n"
+            "  - id: create_order\n"
+            "    description: Create an order.\n"
+            "    handler_method: create_order\n"
+            "    input_schema:\n"
+            "      type: object\n"
+            "      required: [customer_name]\n"
+            "      properties:\n"
+            "        customer_name: {type: string}\n"
+            "    output_schema: {type: object}\n"
+        ),
+        "modules/orders/backend/__init__.py": "",
+    }
+
+
+def _page_unit(plan):
+    units = [u for u in plan.units if u.family_kind == PAGE_SCHEMA_FAMILY]
+    assert len(units) == 1
+    return units[0]
+
+
+# ---------------------------------------------------------------------------
+# Canonical bytes + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_exact_canonical_page_bytes() -> None:
+    _result, _plan, bundle = _materialize(_source())
+    rendered = bundle.files()["ui/pages/orders.yaml"]
+    text = rendered.decode("utf-8")
+    assert "\r" not in text
+    assert text.endswith("\n")
+    assert "{" not in text or "{customer_name" not in text  # no placeholders
+    document = yaml.safe_load(text)
+    assert list(document)[:7] == [
+        "schema_version",
+        "name",
+        "route",
+        "title",
+        "page_type",
+        "layout",
+        "sections",
+    ]
+    schema = AppPageSchema.model_validate(document)
+    assert schema.name == "orders"
+    assert schema.route == "/orders"
+    assert [section.id for section in schema.sections] == ["orders-list", "create-order"]
+    assert schema.sections[0].config["api_endpoint"] == "/api/modules/orders/list_orders"
+    # None-valued optionals are omitted, never serialized as nulls.
+    assert "shell_mode" not in document
+    assert "null" not in text
+
+
+def test_repeated_materialization_is_byte_identical() -> None:
+    _r1, _p1, first = _materialize(_source())
+    _r2, _p2, second = _materialize(_source())
+    assert first.files() == second.files()
+    assert first.plan_digest == second.plan_digest
+    assert [o.content_digest for o in first.outputs] == [
+        o.content_digest for o in second.outputs
+    ]
+
+
+def test_input_order_invariance() -> None:
+    result, plan = _build(_source())
+    reference = materialize_plan(
+        plan=plan,
+        graph=result.graph,
+        payloads=result.payloads,
+        binding=_binding(result.graph),
+        layout_registry=_registry(),
+        preserved_artifacts=_preserved_artifacts(),
+    )
+    reordered = materialize_plan(
+        plan=plan,
+        graph=result.graph,
+        payloads=tuple(reversed(list(result.payloads))),
+        binding=_binding(result.graph),
+        layout_registry=_registry(),
+        preserved_artifacts=tuple(reversed(_preserved_artifacts())),
+    )
+    assert reference.files() == reordered.files()
+
+
+def _cross_process_page_digest() -> str:
+    """Subprocess entry point: rebuild everything fresh and digest the page."""
+    _result, _plan, bundle = _materialize(_source())
+    return hashlib.sha256(bundle.files()["ui/pages/orders.yaml"]).hexdigest()
+
+
+def test_cross_process_determinism() -> None:
+    local_digest = _cross_process_page_digest()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tests.test_deterministic_page_materialization import "
+            "_cross_process_page_digest; print(_cross_process_page_digest())",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=300,
+    )
+    assert completed.stdout.strip() == local_digest
+
+
+# ---------------------------------------------------------------------------
+# Implementation resolution fails closed
+# ---------------------------------------------------------------------------
+
+
+def test_binding_without_page_selection_is_rejected() -> None:
+    result, plan = _build(_source())
+    binding = build_implementation_binding(
+        binding_id="slice4c_binding",
+        version=1,
+        scope=_SCOPE,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=result.graph.graph_id,
+            subject_version=result.graph.version,
+            content_digest=result.graph.graph_digest,
+            scope=result.graph.scope,
+        ),
+    )
+    with pytest.raises(MaterializationError, match="no renderer selection"):
+        materialize_plan(
+            plan=plan,
+            graph=result.graph,
+            payloads=result.payloads,
+            binding=binding,
+            layout_registry=_registry(),
+        )
+
+
+def test_unaccepted_implementation_identity_is_rejected() -> None:
+    result, _plan = _build(_source())
+    for override in (
+        {"implementation_id": "historical_app_generator"},
+        {"implementation_version": "2"},
+    ):
+        binding = _binding(result.graph, _selection(**override))
+        with pytest.raises(MaterializationError, match="unaccepted page renderer"):
+            resolve_page_schema_renderer_selection(
+                binding, graph=result.graph, layout_registry=_registry()
+            )
+
+
+def test_wrong_materializer_and_wrong_family_are_rejected() -> None:
+    result, plan = _build(_source())
+    mismatched = _binding(
+        result.graph,
+        _selection(materializer_id=MaterializerIdentifier.MODULE_CONTRACT_EXECUTOR),
+    )
+    with pytest.raises(MaterializationError, match="implementation binding rejected"):
+        resolve_page_schema_renderer_selection(
+            mismatched, graph=result.graph, layout_registry=_registry()
+        )
+    preserved_unit = next(
+        u for u in plan.units if u.disposition is PlanDisposition.PRESERVE_UNOWNED
+    )
+    payload_by_node = {p.node_id: p for p in result.payloads}
+    with pytest.raises(MaterializationError, match="not renderer-ready"):
+        render_app_ui_page_schema_unit(unit=preserved_unit, payload_by_node=payload_by_node)
+
+
+def test_binding_pinned_to_a_different_graph_is_rejected() -> None:
+    base, plan = _build(_source())
+    other, _other_plan = _build(_source(column_label="Other"), graph_id="slice4c-other")
+    with pytest.raises(MaterializationError, match="implementation binding rejected"):
+        materialize_plan(
+            plan=plan,
+            graph=base.graph,
+            payloads=base.payloads,
+            binding=_binding(other.graph),
+            layout_registry=_registry(),
+        )
+
+
+def test_registry_identity_mismatch_is_rejected() -> None:
+    result, plan = _build(_source())
+    extended = build_app_layout_registry(())
+    snapshot = None
+    from mozaiksai.core.semantics.compilation_plan import snapshot_layout_registry
+
+    snapshot = snapshot_layout_registry(extended)
+    forged = snapshot.model_copy(update={"snapshot_digest": "a" * 64})
+    with pytest.raises(MaterializationError):
+        materialize_plan(
+            plan=plan,
+            graph=result.graph,
+            payloads=result.payloads,
+            binding=_binding(result.graph),
+            layout_registry=forged,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output ownership
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_are_exactly_the_plan_assigned_paths() -> None:
+    _result, plan, bundle = _materialize(_source())
+    page_unit = _page_unit(plan)
+    assert bundle.files().keys() == {
+        "ui/pages/orders.yaml",
+        "modules/orders/backend/handler.py",
+        "modules/orders/backend/service.py",
+    }
+    assert page_unit.outputs[0].path == "ui/pages/orders.yaml"
+    origins = {o.path: o.origin for o in bundle.outputs}
+    assert origins["ui/pages/orders.yaml"] == "rendered"
+    assert origins["modules/orders/backend/handler.py"] == "preserved"
+
+
+def test_compose_rejects_overlap_and_collisions() -> None:
+    _result, _plan, bundle = _materialize(_source())
+    with pytest.raises(MaterializationError, match="overlap"):
+        compose_bundle(bundle, {"ui/pages/orders.yaml": "authored duplicate"})
+    with pytest.raises(ValueError):
+        compose_bundle(bundle, {"UI/pages/orders.yaml": "case-fold twin"})
+    with pytest.raises(ValueError):
+        compose_bundle(bundle, {"ui/pages/orders.yaml/extra.txt": "prefix collision"})
+
+
+def test_unmatched_preserved_artifact_is_rejected() -> None:
+    result, plan = _build(_source())
+    stray = _opaque("module_backend_handler", "modules/ghost/backend/handler.py", b"x\n")
+    with pytest.raises(MaterializationError, match="matches 0 plan units"):
+        materialize_plan(
+            plan=plan,
+            graph=result.graph,
+            payloads=result.payloads,
+            binding=_binding(result.graph),
+            layout_registry=_registry(),
+            preserved_artifacts=(stray,),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preserved opaque artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_preserved_bytes_are_exact_including_empty() -> None:
+    result, plan = _build(_source())
+    empty = _opaque("module_backend_policy", "modules/orders/backend/policy.py", b"")
+    bundle = materialize_plan(
+        plan=plan,
+        graph=result.graph,
+        payloads=result.payloads,
+        binding=_binding(result.graph),
+        layout_registry=_registry(),
+        preserved_artifacts=(*_preserved_artifacts(), empty),
+    )
+    files = bundle.files()
+    assert files["modules/orders/backend/handler.py"] == _HANDLER_BYTES
+    assert files["modules/orders/backend/policy.py"] == b""
+    # Explicit report: preserved units without supplied bytes are named.
+    assert bundle.unsupplied_preserved_units
+    assert all(
+        unit_id not in bundle.unsupplied_preserved_units
+        for unit_id in (o.unit_id for o in bundle.outputs)
+    )
+
+
+def test_mutated_opaque_digest_is_rejected() -> None:
+    ref = _opaque("module_backend_handler", "modules/orders/backend/handler.py", _HANDLER_BYTES)
+    with pytest.raises(ValueError, match="do not match"):
+        PreservedOpaqueArtifact(
+            contract_ref=ref.contract_ref, content=_HANDLER_BYTES + b"# tampered\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit gaps: unsupported families never materialize
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_families_stay_gapped_and_unrendered() -> None:
+    _result, plan, bundle = _materialize(_source())
+    files = bundle.files()
+    for forbidden in (
+        "app.json",
+        "modules/orders/module.yaml",
+        "config/subscriptions.yaml",
+        "data/contract.json",
+        "Dockerfile",
+    ):
+        assert forbidden not in files
+    assert bundle.gap_count == len(plan.gaps) > 0
+    gap_families = {gap.family_kind for gap in plan.gaps}
+    assert "module_manifest" in gap_families or any(
+        u.family_kind == "module_manifest" for u in plan.units
+    )
+    # Deployment stays an external Download-renderer handoff, never rendered.
+    deployment_units = [
+        u.unit_id
+        for u in plan.units
+        if u.disposition is PlanDisposition.EXTERNAL_HANDOFF
+    ]
+    assert set(deployment_units) == set(bundle.external_handoff_units)
+
+
+# ---------------------------------------------------------------------------
+# Recursive closed-domain gate
+# ---------------------------------------------------------------------------
+
+
+def test_recursive_closed_domain_gate_passes_on_current_models() -> None:
+    validate_page_renderer_input_closure()
+
+
+def test_closed_domain_gate_rejects_an_open_model(monkeypatch) -> None:
+    from typing import Any as _Any
+
+    from mozaiksai.core.semantics import materialization as module
+    from mozaiksai.core.semantics.payloads import SectionPayload as _SectionPayload
+
+    class OpenLeaf(_SectionPayload.__mro__[1].__mro__[0]):  # SemanticsModel base
+        blob: dict[str, _Any]
+
+    monkeypatch.setattr(module, "_closure_gate_passed", False)
+    original = module._walk_model_closure
+
+    def _walk_with_injection(model, path, violations, visited):
+        original(model, path, violations, visited)
+        if model is _SectionPayload:
+            original(OpenLeaf, f"{path}.injected", violations, visited)
+
+    monkeypatch.setattr(module, "_walk_model_closure", _walk_with_injection)
+    with pytest.raises(MaterializationError, match="open annotation"):
+        module.validate_page_renderer_input_closure()
+    monkeypatch.setattr(module, "_closure_gate_passed", False)
+
+
+# ---------------------------------------------------------------------------
+# Structural isolation: no AppBuildPlan, no AG2, no ambient state
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_module_imports_no_runtime_or_ambient_capabilities() -> None:
+    source = (ROOT / "mozaiksai" / "core" / "semantics" / "materialization.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+    forbidden_roots = (
+        "ag2",
+        "autogen",
+        "os",
+        "time",
+        "datetime",
+        "random",
+        "uuid",
+        "pathlib",
+        "subprocess",
+        "socket",
+        "asyncio",
+        "httpx",
+        "requests",
+        "factory_app",
+        "mozaiksai.core.transport",
+        "mozaiksai.core.workflow",
+        "mozaiksai.core.adapters",
+        "mozaiksai.hosts",
+    )
+    violations = [
+        name
+        for name in imported
+        if any(name == root or name.startswith(root + ".") for root in forbidden_roots)
+    ]
+    assert violations == [], violations
+    # No CODE reference to the retiring plan authority (the module docstring
+    # documenting the prohibition is not a reference).
+    code_identifiers = {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    } | {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+    assert "AppBuildPlan" not in code_identifiers
+    assert "app_build_plan" not in code_identifiers
+    assert "app_build_plan" not in imported and "AppBuildPlan" not in imported
+
+
+# ---------------------------------------------------------------------------
+# Selective regeneration + successor validation/load/boot
+# ---------------------------------------------------------------------------
+
+
+def _boot_and_assert(
+    app_root: Path, monkeypatch: pytest.MonkeyPatch, *, expected_column_label: str
+) -> None:
+    fake_mongo_client = _FakeMongoClient()
+    monkeypatch.setenv("PLATFORM_PATH", str(app_root))
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    monkeypatch.setattr(
+        "mozaiksai.hosts.runtime.get_mongo_client", lambda: fake_mongo_client
+    )
+    monkeypatch.setattr(
+        "mozaiksai.core.startup.validation.get_mongo_client", lambda: fake_mongo_client
+    )
+    reset_auth_adapter()
+
+    from mozaiksai.core.runtime.composition.executor_registry import ExecutorRegistry
+    from mozaiksai.hosts import platform
+
+    saved = _save_platform_state(platform)
+    platform.executor_registry = ExecutorRegistry()
+    platform.app.state.executor_registry = platform.executor_registry
+    monkeypatch.setattr(platform.runtime_app, "mongo_client", fake_mongo_client)
+    try:
+        with TestClient(platform.app, raise_server_exceptions=False) as client:
+            health = client.get("/health")
+            assert health.status_code == 200, health.text
+
+            page = client.get("/api/pages/orders")
+            assert page.status_code == 200, page.text
+            body = page.json()
+            table = next(s for s in body["sections"] if s["id"] == "orders-list")
+            assert table["config"]["columns"][0]["label"] == expected_column_label
+            assert table["config"]["api_endpoint"] == "/api/modules/orders/list_orders"
+
+            action = client.post("/api/modules/orders/list_orders", json={"params": {}})
+            assert action.status_code == 200, action.text
+            assert action.json() == {"orders": []}
+    finally:
+        _restore_platform_state(platform, saved)
+
+
+async def _validate_and_load(files: dict[str, bytes], app_root: Path):
+    text_files = {path: content.decode("utf-8") for path, content in files.items()}
+    assert scan_generated_bundle(text_files) == []
+    assert scan_functional_generated_app(text_files) == []
+    gate = await run_app_bundle_acceptance_gate(files=text_files)
+    assert gate["passed"] is True, gate
+    _write_bundle(app_root, text_files)
+    loaded = await AppLoader.load(str(app_root))
+    assert loaded.failed_module_names == []
+    return loaded
+
+
+@pytest.mark.asyncio
+async def test_semantic_page_change_selectively_rematerializes_and_boots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_result, base_plan, base_bundle = _materialize(_source())
+    page_unit_id = _page_unit(base_plan).unit_id
+    base_files = compose_bundle(base_bundle, _authored_skeleton())
+    base_page_bytes = base_files["ui/pages/orders.yaml"]
+
+    await _validate_and_load(base_files, tmp_path / "base_app")
+    _boot_and_assert(tmp_path / "base_app", monkeypatch, expected_column_label="Order")
+
+    # ONE linked semantic section mutation; route untouched, manifest untouched.
+    successor_result, successor_plan = _build(_source(column_label="Order #"))
+    successor_bundle = rematerialize_plan(
+        base_bundle=base_bundle,
+        base_plan=base_plan,
+        successor_plan=successor_plan,
+        graph=successor_result.graph,
+        payloads=successor_result.payloads,
+        binding=_binding(successor_result.graph),
+        layout_registry=_registry(),
+    )
+    closure = successor_bundle.closure
+    assert closure is not None
+
+    # The changed linked section makes the page unit affected...
+    assert page_unit_id in closure.affected
+    assert not closure.added and not closure.removed
+    # ...its bytes change...
+    successor_files = compose_bundle(successor_bundle, _authored_skeleton())
+    assert successor_files["ui/pages/orders.yaml"] != base_page_bytes
+    assert b"Order #" in successor_files["ui/pages/orders.yaml"]
+    # ...only the affected renderer-ready unit was rerendered...
+    origins = {o.path: o.origin for o in successor_bundle.outputs}
+    assert origins["ui/pages/orders.yaml"] == "rendered"
+    assert origins["modules/orders/backend/handler.py"] == "reused"
+    assert origins["modules/orders/backend/service.py"] == "reused"
+    # ...unrelated outputs and preserved digests are byte-identical...
+    assert successor_files["modules/orders/backend/handler.py"] == _HANDLER_BYTES
+    assert successor_files["modules/orders/backend/service.py"] == _SERVICE_BYTES
+    base_digests = {o.path: o.content_digest for o in base_bundle.outputs}
+    successor_digests = {o.path: o.content_digest for o in successor_bundle.outputs}
+    for path in (
+        "modules/orders/backend/handler.py",
+        "modules/orders/backend/service.py",
+    ):
+        assert successor_digests[path] == base_digests[path]
+    # ...gapped families did not magically materialize...
+    assert successor_bundle.files().keys() == base_bundle.files().keys()
+    # ...and the successor bundle validates, loads, and boots.
+    await _validate_and_load(successor_files, tmp_path / "successor_app")
+    _boot_and_assert(
+        tmp_path / "successor_app", monkeypatch, expected_column_label="Order #"
+    )
+
+
+def test_unrelated_semantic_change_keeps_page_reusable() -> None:
+    base_result, base_plan, base_bundle = _materialize(_source())
+    page_unit_id = _page_unit(base_plan).unit_id
+    unrelated = _source()
+    unrelated["modules"][0]["manifest"]["module"]["description"] = "Order management v2"
+    successor_result, successor_plan = _build(unrelated)
+    successor_bundle = rematerialize_plan(
+        base_bundle=base_bundle,
+        base_plan=base_plan,
+        successor_plan=successor_plan,
+        graph=successor_result.graph,
+        payloads=successor_result.payloads,
+        binding=_binding(successor_result.graph),
+        layout_registry=_registry(),
+    )
+    assert page_unit_id in successor_bundle.closure.reusable
+    assert (
+        successor_bundle.files()["ui/pages/orders.yaml"]
+        == base_bundle.files()["ui/pages/orders.yaml"]
+    )
+    origins = {o.path: o.origin for o in successor_bundle.outputs}
+    assert origins["ui/pages/orders.yaml"] == "reused"

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -471,6 +471,43 @@ def test_binding_pinned_to_a_different_graph_is_rejected() -> None:
         )
 
 
+def test_renderer_rejects_page_missing_required_fields() -> None:
+    """The runtime completeness guard fails closed on absent required facts."""
+    from mozaiksai.core.semantics.compilation_plan import FamilyInstancePlan, PlanSource
+    from mozaiksai.core.semantics.payloads import PagePayload, build_semantic_payload
+
+    page = build_semantic_payload(
+        PagePayload,
+        node_id="mozaiks.page.incomplete",
+        payload_version=1,
+        scope=_SCOPE,
+        page_id="incomplete",
+        route=None,
+        title="Incomplete",
+        intent=None,
+        page_type=None,
+        layout="full-width",
+        shell_mode=None,
+        roles=None,
+        navigation=None,
+        meta=None,
+    )
+    unit = FamilyInstancePlan(
+        unit_id="app_ui_page_schema/incomplete/aaaaaaaaaaaa",
+        family_kind=PAGE_SCHEMA_FAMILY,
+        family_identity_digest="a" * 64,
+        disposition=PlanDisposition.RENDER,
+        source_scope="declared",
+        placeholder_values=(("page_id", "incomplete"),),
+        sources=(PlanSource(node_id=page.node_id, payload_digest=page.payload_digest),),
+        materializer="page_schema_executor",
+    )
+    with pytest.raises(MaterializationError, match="not renderer-input complete"):
+        render_app_ui_page_schema_unit(
+            unit=unit, payload_by_node={page.node_id: page}
+        )
+
+
 def test_registry_identity_mismatch_is_rejected() -> None:
     result, plan = _build(_source())
     extended = build_app_layout_registry(())

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -647,7 +647,6 @@ def test_renderer_module_imports_no_runtime_or_ambient_capabilities() -> None:
             imported.add(node.module or "")
     forbidden_roots = (
         "ag2",
-        "autogen",
         "os",
         "time",
         "datetime",

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -102,6 +102,11 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # payloads. It is offline-only; its own non-importability is proven
         # by the hygiene scan in tests/test_compilation_plan.py.
         Path("mozaiksai/core/semantics/compilation_plan.py"),
+        # Slice 4C: the offline materializer renders page bytes from graph v2
+        # + payloads + the plan. It is offline-only; its structural isolation
+        # and non-importability are proven by its own proof suite and the
+        # hygiene scan in tests/test_compilation_plan.py.
+        Path("mozaiksai/core/semantics/materialization.py"),
     }
 )
 _FORBIDDEN_PRODUCTION_MODULES = frozenset({"mozaiksai.core.semantics.payloads"})


### PR DESCRIPTION
## ADR 0007 Slice 4C — deterministic offline page materialization

Implements the first honest deterministic materialization path on top of merged Slices 2E/3E/4A/4B and the #450 renderer-input closure:

```
SemanticGraphV2 → CompilationPlan → accepted ImplementationBinding
→ canonical app_ui_page_schema bytes → existing validation/loading
→ successor-bundle runtime proof
```

**Bounded claim (deliberately narrow):** a typed semantic page change deterministically produces a validated, loadable/bootable successor bundle while unrelated opaque artifacts are preserved byte-exact. This is NOT whole-application regeneration; exactly one family (`app_ui_page_schema`) is renderer-ready, and everything else keeps its truthful disposition.

### What's new

- `mozaiksai/core/semantics/materialization.py` — offline-only:
  - **Page renderer**: a pure function of the plan unit's complete semantic source footprint (page payload + linked section declaratives, digest-pinned) reconstructing the normative `AppPageSchema` runtime model — no second page schema, no AppBuildPlan/agent-context/generated-files/env/clock/random/filesystem inputs (enforced by an AST test).
  - **Canonical serialization** (`mozaiks.page_bytes.v1`): declaration-order YAML, absent facts omitted, UTF-8/LF, unbounded width, no timestamps/uuids/comments/provenance; round-trip self-verified. Same input → same path → same bytes → same digest across repeated runs, reordered inputs, and fresh processes (subprocess-proven).
  - **Implementation resolution** through the #450 graph-v2 `ImplementationBinding`: the `page_schema_executor` selection must pin exactly `deterministic_page_schema_renderer@1`; missing/wrong-family/wrong-materializer/wrong-version/wrong-graph bindings fail closed with no fallback to historical generators. No dynamic imports, no caller-supplied callables, no RendererRegistry.
  - **Preserved opaque artifacts**: exact bytes via the existing `ChildContractRef` identity — digest verified, empty files preserved, tampering/unmatched artifacts rejected, zero normalization or re-encoding.
  - **Explicit dispositions**: external handoffs, inapplicable units, typed gaps, unsupplied preserved units, and instance-relative-scope units (whose physical-root binding is later-slice work) are all reported by name; nothing silently omitted, no gap turned into guessed content.
  - **Output ownership**: every produced path must be the plan-assigned path of its own unit; 4A `detect_collisions` re-applied over produced + composed paths; authored gapped-family files may never overlap or case-fold/prefix-collide with plan-owned outputs.
  - **Selective rematerialization** driven by the 4B `plan_regeneration_closure`: affected/added units render fresh; reusable units are byte-for-byte copies from the base bundle with digest re-verification; removed units' outputs are absent.
  - **Recursive structural closure gate**: before any rendering, every model reachable from the page/section payloads and the section-config primitive dispatch must terminate in closed typed domains — with the dispatcher fields proven closed empirically (every registered primitive must reject an unknown key). No family-specific exceptions.
- `tests/test_deterministic_page_materialization.py` — 20-test proof gate covering the full checklist, ending in the real acceptance gate + `AppLoader` + **lifespan-owned platform boot** (health, page serving with the changed content, module action round-trip) of BOTH the base and the successor bundle.
- One-line roster update in `tests/test_compilation_plan.py`'s no-production-wiring guard (the new module is semantics-layer offline substrate; its own AST test enforces the isolation the guard exists to protect).

### Authorities unchanged

`layout_registry` remains the sole family/materializer authority; `CompilationPlan` owns dispositions/footprints/paths; the binding pins implementation identity. **The agent-produced `AppBuildPlan` remains the sole operational plan authority — nothing in production imports this module** (verified: zero importers outside tests), no capability advertisement, no Slice 5 cutover, no AG2 imports, no prompt/context changes, no #449 or deployment-lane content.

### Limitations deferred (truthfully) to later slices

- Only `app_ui_page_schema` renders; module manifests/contracts, data contracts, subscriptions, workflow orchestrators, app.json, deployment remain gaps/handoffs/authored (their typed semantics are incomplete — Slice 4C-follow-ups/5).
- Instance-relative path scopes (`module_relative`/`workflow_relative`) have no declared physical-root binding; their units are reported as deferred rather than invented.
- Boot proof is the strongest truthful current tier: in-process lifespan-owned ASGI boot (fake Mongo, auth off) — process/container boot is acceptance-harness work, not 4C.
- Production wiring, AppBuildPlan retirement, CAS publication: Slice 5. Typed RefinementPatch + apply-recompile equivalence: Slice 6.

### Validation

- New proof suite: 20/20 passing (canonical bytes, repeated/cross-process/order determinism, all fail-closed resolution paths, ownership, opaque preservation incl. empty+tamper, explicit gaps, closed-domain gate incl. injected-open-model rejection, AST isolation, linked-section-affected + unrelated-reusable selective proofs, base+successor validate/load/boot).
- Focused battery (materialization, renderer-input closure, compilation plan incl. golden vectors, payload/graph v2, projection, manifest binding, reference contracts, page-schema runtime validation, bundle scanner, functional acceptance, plan-assignment compiler, materialized-bundle production runtime, e2e deterministic gate, portable substrate): **594 passed, 0 failed** after the guard-roster update.
- Ruff clean; scoped mypy clean on the new module; source hygiene clean; `git diff --check` clean; DCO signed. Full repository suite result recorded in the PR checks.

Reviewer note: Claude 1 is the designated independent reviewer for the exact head (did not author this code). Draft, auto-merge off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
