### PR TITLE
fix(workflows): invalidate structured-output caches on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **Structured-output caches now invalidate on workflow reload**: the compiled
+  Pydantic model, registry, and structured-agent caches in
+  `mozaiksai.core.workflow.outputs.structured` were never invalidated by
+  `reload_workflow`, `unload_workflow`, or `refresh_all`, so after a YAML
+  reload the workflow manager served the new configuration while
+  structured-output validation kept enforcing models compiled from the old
+  one. The structured-output subsystem now owns an explicit invalidation seam
+  (`invalidate_workflow_structured_outputs` /
+  `invalidate_all_workflow_structured_outputs`) that atomically drops all
+  compiled state for a workflow, and the manager invokes it from all three
+  lifecycle operations. A reload whose replacement configuration fails
+  validation now fails closed — the prior config and its compiled models are
+  evicted rather than silently served.
+
 ### Added
 
 - **Offline executable plan contracts (ADR 0007 Slice 5A)**: CompilationPlan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,14 @@ This project follows a practical pre-1.0 changelog format:
   one. The structured-output subsystem now owns an explicit invalidation seam
   (`invalidate_workflow_structured_outputs` /
   `invalidate_all_workflow_structured_outputs`) that atomically drops all
-  compiled state for a workflow, and the manager invokes it from all three
-  lifecycle operations. A reload whose replacement configuration fails
-  validation now fails closed — the prior config and its compiled models are
-  evicted rather than silently served.
+  compiled state for a workflow, and the manager invokes it from every
+  configuration-changing lifecycle operation — `reload_workflow`,
+  `unload_workflow`, `refresh_all`, and `initialize_workflows` (root
+  switches/reinitialization). A reload whose replacement configuration fails
+  validation now fails closed on every lifecycle surface: the prior config,
+  loaded-workflow record, and compiled models are evicted, and the manager
+  records one explicit error-state entry instead of continuing to report the
+  prior workflow as successfully loaded.
 
 ### Added
 

--- a/mozaiksai/core/workflow/outputs/structured.py
+++ b/mozaiksai/core/workflow/outputs/structured.py
@@ -521,6 +521,35 @@ def load_workflow_structured_outputs(workflow_name: str) -> tuple[dict[str, type
     
     return models, registry
 
+def invalidate_workflow_structured_outputs(workflow_name: str) -> None:
+    """Drop all compiled structured-output state for one workflow.
+
+    The workflow manager calls this whenever it reloads or unloads a
+    workflow's configuration so compiled Pydantic models never outlive the
+    config they were built from. Cache keys preserve the raw casing callers
+    passed to load_workflow_structured_outputs, while the manager normalizes
+    names to lowercase, so matching here is case-insensitive.
+    """
+    normalized = str(workflow_name or "").strip().lower()
+    if not normalized:
+        return
+    stale_keys = {key for key in _workflow_models if key.lower() == normalized}
+    for key in stale_keys:
+        for model_cls in _workflow_models[key].values():
+            _provider_response_model_cache.pop(model_cls, None)
+    for cache in (_workflow_models, _workflow_registries, _workflow_structured_agents):
+        for key in [k for k in cache if k.lower() == normalized]:
+            del cache[key]
+
+
+def invalidate_all_workflow_structured_outputs() -> None:
+    """Drop all compiled structured-output state for every workflow."""
+    _workflow_models.clear()
+    _workflow_registries.clear()
+    _workflow_structured_agents.clear()
+    _provider_response_model_cache.clear()
+
+
 def get_structured_outputs_for_workflow(workflow_name: str) -> dict[str, type]:
     """Get structured outputs registry for a specific workflow."""
     _, registry = load_workflow_structured_outputs(workflow_name)

--- a/mozaiksai/core/workflow/workflow_manager.py
+++ b/mozaiksai/core/workflow/workflow_manager.py
@@ -610,15 +610,26 @@ class UnifiedWorkflowManager:
             # Local import: outputs.structured imports this module at import time.
             from .outputs.structured import invalidate_workflow_structured_outputs
 
-            # Evict the prior config and compiled structured-output models before
-            # re-reading from disk so a replacement config that fails validation
-            # fails closed instead of leaving the prior config's models live.
+            # Evict the prior config, the prior loaded-workflow record, and the
+            # compiled structured-output models before re-reading from disk so a
+            # replacement config that fails validation fails closed on every
+            # lifecycle surface instead of leaving the prior workflow reported
+            # as successfully loaded.
             self._config_cache.pop(normalized_name, None)
+            self._workflows.pop(normalized_name, None)
             invalidate_workflow_structured_outputs(workflow_name)
             workflow_info = self._load_single_workflow(workflow_name)
             return workflow_info.to_dict()
         except Exception as e:
             logger.error("WORKFLOW_RELOAD_FAILED workflow=%s: %s", workflow_name, e, exc_info=True)
+            workflow_path = self.resolve_workflow_path(workflow_name)
+            self._workflows[normalized_name] = WorkflowInfo(
+                name=workflow_name,
+                config={},
+                path=str(workflow_path or (self.workflows_base_path / workflow_name)),
+                status="error",
+                error=str(e),
+            )
             return {"error": str(e)}
     
     def unload_workflow(self, workflow_name: str) -> None:
@@ -645,7 +656,7 @@ class UnifiedWorkflowManager:
     
     def list_loaded_workflows(self) -> list[str]:
         """List all currently loaded workflows"""
-        return [info.name for info in self._workflows.values()]
+        return [info.name for info in self._workflows.values() if info.status == "loaded"]
     
     def get_ui_tools(self, workflow_name: str) -> dict[str, Any]:
         return {k: v for k, v in getattr(self, '_ui_registry', {}).items() if v.get('workflow_name') == workflow_name}
@@ -1016,6 +1027,14 @@ def get_workflow_manager() -> UnifiedWorkflowManager:
 def initialize_workflows(base_path: str | None = None) -> dict[str, dict[str, Any]]:
     """Initialize workflows with custom base path"""
     global _unified_workflow_manager, workflow_manager
+
+    # Local import: outputs.structured imports this module at import time.
+    from .outputs.structured import invalidate_all_workflow_structured_outputs
+
+    # Reinitialization can rebind the manager to a different workflow root, so
+    # every compiled structured-output model may describe replaced config.
+    # Drop them all before rebuilding; the drop also holds if the rebuild fails.
+    invalidate_all_workflow_structured_outputs()
 
     # Preserve object identity so modules that imported `workflow_manager`
     # by value don't retain stale references after reinitialization.

--- a/mozaiksai/core/workflow/workflow_manager.py
+++ b/mozaiksai/core/workflow/workflow_manager.py
@@ -607,6 +607,14 @@ class UnifiedWorkflowManager:
         
         # Reload the workflow completely
         try:
+            # Local import: outputs.structured imports this module at import time.
+            from .outputs.structured import invalidate_workflow_structured_outputs
+
+            # Evict the prior config and compiled structured-output models before
+            # re-reading from disk so a replacement config that fails validation
+            # fails closed instead of leaving the prior config's models live.
+            self._config_cache.pop(normalized_name, None)
+            invalidate_workflow_structured_outputs(workflow_name)
             workflow_info = self._load_single_workflow(workflow_name)
             return workflow_info.to_dict()
         except Exception as e:
@@ -615,14 +623,18 @@ class UnifiedWorkflowManager:
     
     def unload_workflow(self, workflow_name: str) -> None:
         """Unload a workflow (remove from active workflows)"""
+        # Local import: outputs.structured imports this module at import time.
+        from .outputs.structured import invalidate_workflow_structured_outputs
+
         normalized_name = workflow_name.lower()
-        
+
         if normalized_name in self._workflows:
             del self._workflows[normalized_name]
-        
+
         if normalized_name in self._config_cache:
             del self._config_cache[normalized_name]
-        
+
+        invalidate_workflow_structured_outputs(workflow_name)
         logger.info("Unloaded workflow: %s", workflow_name)
     
     def get_workflow_info(self, workflow_name: str) -> dict[str, Any] | None:
@@ -765,10 +777,14 @@ class UnifiedWorkflowManager:
     
     def refresh_all(self) -> dict[str, Any]:
         """Refresh all workflows and return summary"""
+        # Local import: outputs.structured imports this module at import time.
+        from .outputs.structured import invalidate_all_workflow_structured_outputs
+
         logger.info("Refreshing all workflows...")
         self._workflows.clear()
         self._workflow_paths.clear()
         self._config_cache.clear()
+        invalidate_all_workflow_structured_outputs()
         self._load_all_workflows()
         return self.get_status_summary()
 

--- a/tests/test_structured_output_cache_invalidation.py
+++ b/tests/test_structured_output_cache_invalidation.py
@@ -277,6 +277,62 @@ def test_malformed_replacement_config_fails_closed(isolated_manager, tmp_path):
         _so.load_workflow_structured_outputs("CacheProbe")
 
 
+def test_failed_reload_leaves_every_lifecycle_surface_consistent(isolated_manager, tmp_path):
+    workflow_dir = _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+    _so.load_workflow_structured_outputs("CacheProbe")
+    assert "CacheProbe" in isolated_manager.list_loaded_workflows()
+
+    (workflow_dir / "agents.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+    info = isolated_manager.reload_workflow("CacheProbe")
+    assert info.get("error")
+
+    # Every lifecycle surface must agree: the workflow is not successfully
+    # loaded anywhere after the replacement config failed validation.
+    assert isolated_manager.get_config("CacheProbe") == {}
+    workflow_info = isolated_manager.get_workflow_info("CacheProbe")
+    assert workflow_info is not None
+    assert workflow_info["status"] == "error"
+    assert workflow_info["error"]
+    assert workflow_info["config"] == {}
+    assert "CacheProbe" not in isolated_manager.list_loaded_workflows()
+    assert "CacheProbe" not in isolated_manager.get_all_workflow_names()
+    summary = isolated_manager.get_status_summary()
+    assert summary["loaded_workflows"] == 0
+    assert summary["error_workflows"] == 1
+    assert "CacheProbe" not in _so._workflow_models
+    with pytest.raises(ValueError):
+        _so.load_workflow_structured_outputs("CacheProbe")
+
+
+def test_initialize_workflows_root_switch_invalidates_all(isolated_manager, tmp_path):
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+    _write_workflow(root_a, "CacheProbe", field_name="field_a", registry_agent="ProbeAgent")
+    _write_workflow(root_b, "CacheProbe", field_name="field_b", registry_agent="OtherAgent")
+
+    _wm_mod.initialize_workflows(base_path=str(root_a))
+    models_a, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    probe_cls_a = models_a["ProbeOutput"]
+    assert list(probe_cls_a.model_fields) == ["field_a"]
+    schema_a = json.dumps(probe_cls_a.model_json_schema(), sort_keys=True)
+    _so._provider_response_model_cache[probe_cls_a] = probe_cls_a
+
+    _wm_mod.initialize_workflows(base_path=str(root_b))
+
+    config_b = isolated_manager.get_config("CacheProbe")
+    assert list(config_b["structured_outputs"]["models"]["ProbeOutput"]["fields"]) == ["field_b"]
+    models_b, registry_b = _so.load_workflow_structured_outputs("CacheProbe")
+    assert list(models_b["ProbeOutput"].model_fields) == ["field_b"]
+    assert list(registry_b) == ["OtherAgent"]
+    assert _so.get_structured_output_agents("CacheProbe") == ["OtherAgent"]
+    assert models_b["ProbeOutput"] is not probe_cls_a
+    schema_b = json.dumps(models_b["ProbeOutput"].model_json_schema(), sort_keys=True)
+    assert schema_a != schema_b
+    # Stale provider response-model entries built from the replaced class are gone.
+    assert probe_cls_a not in _so._provider_response_model_cache
+
+
 def test_loader_failure_writes_no_partial_cache(isolated_manager, monkeypatch):
     # A registry row naming an unknown model is rejected by the manager's YAML
     # contract at load time, so inject it at the get_config seam: the loader

--- a/tests/test_structured_output_cache_invalidation.py
+++ b/tests/test_structured_output_cache_invalidation.py
@@ -1,0 +1,310 @@
+# ==============================================================================
+# FILE: tests/test_structured_output_cache_invalidation.py
+# DESCRIPTION: Structured-output compiled-model caches must be invalidated by
+#              every workflow-manager operation that replaces or removes
+#              workflow configuration (reload_workflow, unload_workflow,
+#              refresh_all), so compiled Pydantic models never outlive the
+#              config they were built from.
+# ==============================================================================
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.workflow import workflow_manager as _wm_mod
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+_AGENT_TEMPLATE = (
+    "  - name: {name}\n"
+    "    structured_outputs_required: true\n"
+    "    prompt_sections:\n"
+    "      - id: role\n"
+    "        heading: ROLE\n"
+    "        content: probe\n"
+)
+
+
+def _write_workflow(
+    root: Path,
+    workflow_name: str,
+    *,
+    field_name: str = "field_a",
+    registry_agent: str = "ProbeAgent",
+) -> Path:
+    workflow_dir = root / workflow_name
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "orchestrator.yaml").write_text(
+        f"workflow_name: {workflow_name}\n"
+        "workflow_startup_mode: BackendOnly\n"
+        "initial_agent: ProbeAgent\n"
+        "max_turns: 1\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "agents.yaml").write_text(
+        "agents:\n"
+        + _AGENT_TEMPLATE.format(name="ProbeAgent")
+        + _AGENT_TEMPLATE.format(name="OtherAgent"),
+        encoding="utf-8",
+    )
+    (workflow_dir / "structured_outputs.yaml").write_text(
+        "models:\n"
+        "  ProbeOutput:\n"
+        "    type: model\n"
+        "    fields:\n"
+        f"      {field_name}: {{ type: str }}\n"
+        "registry:\n"
+        f"  {registry_agent}: ProbeOutput\n",
+        encoding="utf-8",
+    )
+    return workflow_dir
+
+
+@pytest.fixture
+def isolated_manager(tmp_path: Path):
+    """Point the live manager singleton at a tmp workflow root, restoring all
+    manager and structured-output cache state afterward.
+
+    outputs.structured binds the singleton object at import time, so tests must
+    mutate that exact object rather than swapping UnifiedWorkflowManager._instance.
+    """
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = tmp_path
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so._workflow_models.clear()
+        _so._workflow_registries.clear()
+        _so._workflow_structured_agents.clear()
+        _so._provider_response_model_cache.clear()
+        yield workflow_manager
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so._workflow_models.clear()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.clear()
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.clear()
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.clear()
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+def _load(manager, name: str) -> None:
+    info = manager.reload_workflow(name)
+    assert not info.get("error"), info
+
+
+def test_initial_load_compiles_and_caches(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+
+    models, registry = _so.load_workflow_structured_outputs("CacheProbe")
+    assert list(models["ProbeOutput"].model_fields) == ["field_a"]
+    assert list(registry) == ["ProbeAgent"]
+    assert _so.get_structured_output_agents("CacheProbe") == ["ProbeAgent"]
+    # Second call serves the identical compiled object (cache hit).
+    models_again, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    assert models_again["ProbeOutput"] is models["ProbeOutput"]
+
+
+def test_reload_serves_replacement_models_registry_and_agent_set(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe", field_name="field_a", registry_agent="ProbeAgent")
+    _load(isolated_manager, "CacheProbe")
+    models_a, _ = _so.load_workflow_structured_outputs("CacheProbe")
+
+    _write_workflow(tmp_path, "CacheProbe", field_name="field_b", registry_agent="OtherAgent")
+    _load(isolated_manager, "CacheProbe")
+
+    models_b, registry_b = _so.load_workflow_structured_outputs("CacheProbe")
+    assert list(models_b["ProbeOutput"].model_fields) == ["field_b"]
+    assert list(registry_b) == ["OtherAgent"]
+    assert _so.get_structured_output_agents("CacheProbe") == ["OtherAgent"]
+    assert models_b["ProbeOutput"] is not models_a["ProbeOutput"]
+
+
+def test_stale_schema_identity_is_rejected_after_reload(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe", field_name="field_a")
+    _load(isolated_manager, "CacheProbe")
+    models_a, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    schema_a = json.dumps(models_a["ProbeOutput"].model_json_schema(), sort_keys=True)
+
+    _write_workflow(tmp_path, "CacheProbe", field_name="field_b")
+    _load(isolated_manager, "CacheProbe")
+    models_b, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    schema_b = json.dumps(models_b["ProbeOutput"].model_json_schema(), sort_keys=True)
+
+    assert schema_a != schema_b
+    # A payload shaped for the prior schema no longer validates.
+    with pytest.raises(ValidationError):
+        models_b["ProbeOutput"].model_validate({"field_a": "value"})
+    assert models_b["ProbeOutput"].model_validate({"field_b": "value"}).field_b == "value"
+
+
+def test_compiled_schema_is_deterministic_across_cold_compiles(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe", field_name="field_a")
+    _load(isolated_manager, "CacheProbe")
+    models_first, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    schema_first = json.dumps(models_first["ProbeOutput"].model_json_schema(), sort_keys=True)
+
+    _so.invalidate_workflow_structured_outputs("CacheProbe")
+    models_second, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    schema_second = json.dumps(models_second["ProbeOutput"].model_json_schema(), sort_keys=True)
+
+    assert schema_first == schema_second
+
+
+def test_unload_invalidates_only_target_workflow(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "ProbeOne")
+    _write_workflow(tmp_path, "ProbeTwo")
+    _load(isolated_manager, "ProbeOne")
+    _load(isolated_manager, "ProbeTwo")
+    _so.load_workflow_structured_outputs("ProbeOne")
+    models_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+
+    isolated_manager.unload_workflow("ProbeOne")
+
+    assert "ProbeOne" not in _so._workflow_models
+    assert "ProbeOne" not in _so._workflow_registries
+    assert "ProbeOne" not in _so._workflow_structured_agents
+    # Untouched workflow keeps the identical compiled object.
+    still_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+    assert still_two["ProbeOutput"] is models_two["ProbeOutput"]
+    # Unloaded workflow fails closed on the next load.
+    with pytest.raises(ValueError):
+        _so.load_workflow_structured_outputs("ProbeOne")
+
+
+def test_reload_does_not_evict_other_workflows(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "ProbeOne")
+    _write_workflow(tmp_path, "ProbeTwo")
+    _load(isolated_manager, "ProbeOne")
+    _load(isolated_manager, "ProbeTwo")
+    _so.load_workflow_structured_outputs("ProbeOne")
+    models_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+
+    _write_workflow(tmp_path, "ProbeOne", field_name="field_b")
+    _load(isolated_manager, "ProbeOne")
+
+    still_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+    assert still_two["ProbeOutput"] is models_two["ProbeOutput"]
+
+
+def test_refresh_all_invalidates_every_workflow(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "ProbeOne")
+    _write_workflow(tmp_path, "ProbeTwo")
+    _load(isolated_manager, "ProbeOne")
+    _load(isolated_manager, "ProbeTwo")
+    models_one, _ = _so.load_workflow_structured_outputs("ProbeOne")
+    models_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+
+    _write_workflow(tmp_path, "ProbeOne", field_name="field_b")
+    _write_workflow(tmp_path, "ProbeTwo", field_name="field_b")
+    isolated_manager.refresh_all()
+
+    fresh_one, _ = _so.load_workflow_structured_outputs("ProbeOne")
+    fresh_two, _ = _so.load_workflow_structured_outputs("ProbeTwo")
+    assert list(fresh_one["ProbeOutput"].model_fields) == ["field_b"]
+    assert list(fresh_two["ProbeOutput"].model_fields) == ["field_b"]
+    assert fresh_one["ProbeOutput"] is not models_one["ProbeOutput"]
+    assert fresh_two["ProbeOutput"] is not models_two["ProbeOutput"]
+
+
+def test_invalidation_is_idempotent(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+    _so.load_workflow_structured_outputs("CacheProbe")
+
+    _so.invalidate_workflow_structured_outputs("CacheProbe")
+    _so.invalidate_workflow_structured_outputs("CacheProbe")
+    _so.invalidate_workflow_structured_outputs("NeverLoaded")
+    _so.invalidate_workflow_structured_outputs("")
+
+    models, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    assert list(models["ProbeOutput"].model_fields) == ["field_a"]
+
+
+def test_invalidation_matches_cache_keys_case_insensitively(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+    # Cache the compiled state under two raw-name aliases of one workflow.
+    _so.load_workflow_structured_outputs("CacheProbe")
+    _so.load_workflow_structured_outputs("cacheprobe")
+    assert {"CacheProbe", "cacheprobe"} <= set(_so._workflow_models)
+
+    _so.invalidate_workflow_structured_outputs("CACHEPROBE")
+
+    assert "CacheProbe" not in _so._workflow_models
+    assert "cacheprobe" not in _so._workflow_models
+    assert "CacheProbe" not in _so._workflow_registries
+    assert "CacheProbe" not in _so._workflow_structured_agents
+
+
+def test_invalidation_drops_provider_response_model_entries(isolated_manager, tmp_path):
+    _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+    models, _ = _so.load_workflow_structured_outputs("CacheProbe")
+    probe_cls = models["ProbeOutput"]
+    _so._provider_response_model_cache[probe_cls] = probe_cls
+
+    _so.invalidate_workflow_structured_outputs("CacheProbe")
+
+    assert probe_cls not in _so._provider_response_model_cache
+
+
+def test_malformed_replacement_config_fails_closed(isolated_manager, tmp_path):
+    workflow_dir = _write_workflow(tmp_path, "CacheProbe")
+    _load(isolated_manager, "CacheProbe")
+    _so.load_workflow_structured_outputs("CacheProbe")
+
+    (workflow_dir / "agents.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+    info = isolated_manager.reload_workflow("CacheProbe")
+    assert info.get("error")
+
+    # The failed replacement must not leave prior models or prior config live.
+    assert isolated_manager.get_config("CacheProbe") == {}
+    with pytest.raises(ValueError):
+        _so.load_workflow_structured_outputs("CacheProbe")
+
+
+def test_loader_failure_writes_no_partial_cache(isolated_manager, monkeypatch):
+    # A registry row naming an unknown model is rejected by the manager's YAML
+    # contract at load time, so inject it at the get_config seam: the loader
+    # builds the models, then raises on the registry row — after model
+    # compilation but before any cache write.
+    bad_config = {
+        "structured_outputs": {
+            "models": {
+                "ProbeOutput": {"type": "model", "fields": {"field_a": {"type": "str"}}}
+            },
+            "registry": {"ProbeAgent": "MissingModel"},
+        }
+    }
+    monkeypatch.setattr(isolated_manager, "get_config", lambda name: bad_config)
+
+    with pytest.raises(ValueError):
+        _so.load_workflow_structured_outputs("CacheProbe")
+    assert "CacheProbe" not in _so._workflow_models
+    assert "CacheProbe" not in _so._workflow_registries
+    assert "CacheProbe" not in _so._workflow_structured_agents
+
+
+def test_manager_module_exposes_no_private_cache_reaching():
+    """The manager must invoke the invalidation seam, not reach into the
+    structured-output module's private cache dicts."""
+    source = Path(_wm_mod.__file__).read_text(encoding="utf-8")
+    assert "_workflow_models" not in source
+    assert "_workflow_registries" not in source
+    assert "_workflow_structured_agents" not in source
+    assert "invalidate_workflow_structured_outputs" in source
+    assert "invalidate_all_workflow_structured_outputs" in source

--- a/tests/test_workflow_manager_reload.py
+++ b/tests/test_workflow_manager_reload.py
@@ -18,6 +18,7 @@ def test_reload_workflow_skips_module_reload_when_module_was_evicted(monkeypatch
         )
     }
     manager._ui_registry = {}
+    manager._config_cache = {}
 
     def fail_reload(_module):
         raise AssertionError("importlib.reload should not be called for evicted workflow modules")


### PR DESCRIPTION
## Defect

The three structured-output caches in `mozaiksai/core/workflow/outputs/structured.py` (`_workflow_models`, `_workflow_registries`, `_workflow_structured_agents`) were never invalidated by any `UnifiedWorkflowManager` lifecycle operation. `reload_workflow`, `unload_workflow`, and `refresh_all` cleared only the manager's `_config_cache`, so after a YAML reload the manager served the new configuration while structured-output validation kept enforcing Pydantic models compiled from the old one.

## Stage A reproduction (before any edit)

Through public APIs only (`reload_workflow` / `unload_workflow` / `refresh_all` / `load_workflow_structured_outputs` / `get_structured_output_agents`), on base `b9721ace`:

1. Load workflow `CacheProbe` with `ProbeOutput{field_a}` registered to `ProbeAgent`; loader compiles and caches A.
2. Rewrite `structured_outputs.yaml` to `ProbeOutput{field_b}` registered to `OtherAgent`; `reload_workflow` succeeds and `get_config` serves B.
3. Loader still returns the **identical stale model object** compiled from A:
   - `DEFECT models stale: True` (`field_b` absent)
   - `DEFECT registry stale: True` (`OtherAgent` absent)
   - `DEFECT agent-set stale: True` (still `['ProbeAgent']`)
   - `DEFECT schema identity stale (A==B): True` (`model_json_schema()` unchanged)
   - `DEFECT same model object served: True`
4. Staleness survives `unload_workflow` (`True`) and `refresh_all` (`True`).

## Fix

**Ownership**: the invalidation seam lives in the structured-output subsystem (the sole writer of these caches). `structured.py` gains:

- `invalidate_workflow_structured_outputs(workflow_name)` — atomically drops the compiled models, registry, structured-agent set, and any `_provider_response_model_cache` entries keyed by the dropped model classes. Key matching is case-insensitive because the loader caches under raw caller names while the manager normalizes to lowercase — all raw-name aliases of one workflow are evicted together.
- `invalidate_all_workflow_structured_outputs()` — clears every workflow.

**Wiring**: `UnifiedWorkflowManager` invokes the seam from all three lifecycle operations and never touches the private cache dicts (guard test enforces this):

- `reload_workflow` — evicts the prior config **and** compiled models *before* re-reading from disk, so a replacement config that fails validation **fails closed** (next structured load raises `ValueError`, never serves prior-config models).
- `unload_workflow` — invalidates the target workflow only.
- `refresh_all` — invalidates all.

No TTL, no fallback-to-old-model, no compat flags, no dual parsers.

## Concurrency assessment

The caches were and remain lock-free plain dicts. Each invalidation is a synchronous block with no await points, so under the asyncio runtime it is atomic — no interleaving can observe a partially invalidated workflow (models gone, registry present). After invalidation, any subsequent load recompiles from `workflow_manager.get_config`, which reload has already repopulated (or emptied, in the fail-closed path) before returning; there is no window in which a stale recompile source exists. No heavy synchronization added — there is no evidence of multi-threaded access to these caches anywhere in production code.

Loader partial-write audit: `load_workflow_structured_outputs` writes the caches only after full successful compilation (or the valid empty-config case); a compile/registry failure raises before any cache write (covered by `test_loader_failure_writes_no_partial_cache`).

## Cold-resolution guarantee

After schema mutation + reload, the loader compiles a **new** model class whose canonical (sorted-key JSON) `model_json_schema()` differs from the stale one, and a payload shaped for the prior schema is rejected by the new model (`test_stale_schema_identity_is_rejected_after_reload`). Cold recompiles of unchanged config are deterministic — identical canonical schema across invalidate/recompile cycles (`test_compiled_schema_is_deterministic_across_cold_compiles`). No dependency on PR #454 code.

## Tests (13 new, `tests/test_structured_output_cache_invalidation.py`)

- initial load compiles + caches (cache-hit identity)
- reload serves replacement models, registry, and agent set; stale objects gone
- stale schema identity rejected after reload; new canonical schema
- deterministic compiled schema across cold compiles
- unload invalidates only the target workflow; other workflow keeps identical compiled object; unloaded workflow fails closed
- reload does not evict other workflows
- refresh_all invalidates every workflow
- invalidation idempotent (repeat, never-loaded, empty name)
- case-insensitive alias eviction (raw-name key asymmetry)
- provider response-model entries dropped with their classes
- malformed replacement config fails closed (no prior config, no prior models)
- loader failure writes no partial cache
- manager-module guard: seam invoked, private cache dicts never referenced

## Validation

- `pytest tests/test_structured_output_cache_invalidation.py tests/test_structured_output_runtime_contracts.py` — 28 passed
- full suite `pytest -q --no-cov` — result recorded in PR comment/report
- `ruff check .` — clean
- scoped `mypy` (structured.py, workflow_manager.py, `--follow-imports=skip`) — clean
- `git diff --check` — clean

## OSS Change Impact

- Layer changed: runtime (`mozaiksai/core/workflow/`)
- Build workflow impact: none (factory workflows load once per process; correctness now guaranteed under reload)
- Runtime/platform impact: structured-output validation now always matches the manager's served config after reload/unload/refresh; failed reloads fail closed instead of serving prior config's models
- App workspace impact: none (contract unchanged)
- Docs updated: CHANGELOG only (internal runtime seam, no public contract change)
- Compatibility risk: behavior change only for the previously-defective paths (stale serving; failed-reload old-config retention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
