### PR TITLE
chore(ag2): upgrade runtime to 1.0.3

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,7 +544,7 @@ App workspaces and generated app output must not bundle their own copies of Reac
 **What it does:** Executes multi-agent AI workflows using AG2.
 
 **Key responsibilities:**
-- Run AI workflow executions with AG2 1.0 beta agents and transition graphs
+- Run AI workflow executions with AG2 1.0 agents and transition graphs
 - Stream events to frontend via WebSocket
 - Persist chat sessions to MongoDB
 - Handle tool calls from agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Changed
+
+- Upgraded the AG2 runtime to 1.0.3, including ACP 0.12.1 compatibility and corrected usage-event accounting coverage.
+
 ### Fixed
 
 - **Structured-output caches now invalidate on workflow reload**: the compiled

--- a/docs/adr/0008-deterministic-engineering-context.md
+++ b/docs/adr/0008-deterministic-engineering-context.md
@@ -36,7 +36,7 @@ contract:
   first and retrieve exact sources through tools — but the only test of it is
   a string-presence check, not behavior.
 
-AG2 1.0.2 (pinned) supplies the runtime primitives: fragment system prompts
+AG2 1.0.3 (pinned) supplies the runtime primitives: fragment system prompts
 and dynamic prompt hooks, `SkillPlugin`/`SkillsToolkit` progressive
 disclosure, caller-supplied `AssemblyPolicy`, `TokenBudgetPolicy`,
 `CompactStrategy`/`CompactTrigger`, deterministic `ViewPolicy` projections,

--- a/docs/architecture/app/app-bundle-declaratives.md
+++ b/docs/architecture/app/app-bundle-declaratives.md
@@ -64,7 +64,7 @@ Plans may also declare `usage_limits` for meters such as `ai_tokens`. These
 limits are deterministic app intent used by admin, billing, and selected
 managed-capability facade surfaces, including the MozaiksPay facade
 when that pack is selected. Token measurements themselves come from runtime
-AG2 1.0 beta usage middleware and `/api/me/usage` or `/api/admin/usage`; generated
+AG2 1.0 usage middleware and `/api/me/usage` or `/api/admin/usage`; generated
 modules must not create a second usage ledger.
 
 Plans may also declare provider-neutral `token_allowances`, and apps may declare

--- a/docs/architecture/builder/app-builder-architecture.md
+++ b/docs/architecture/builder/app-builder-architecture.md
@@ -121,7 +121,7 @@ Internally, the builder may still use specialized workflows for:
 - bundle compilation
 - validation
 
-In practice, those internal workflows may be AG2 1.0 beta workflow runs.
+In practice, those internal workflows may be AG2 1.0 workflow runs.
 
 That is acceptable only if they stay behind typed builder contracts such as:
 

--- a/docs/architecture/builder/app-planning-contracts.md
+++ b/docs/architecture/builder/app-planning-contracts.md
@@ -214,7 +214,7 @@ Important rule:
 - tasks that plan do not write bundle paths
 - tasks that write bundle paths must declare which declarative family they own
 
-This is what lets AG2 1.0 beta workflow runs operate as constrained implementation workers
+This is what lets AG2 1.0 workflow runs operate as constrained implementation workers
 instead of becoming the architecture themselves.
 
 ## `BuildGraph`

--- a/docs/architecture/builder/builder-execution-model.md
+++ b/docs/architecture/builder/builder-execution-model.md
@@ -104,7 +104,7 @@ This is where actual file writing happens.
 
 ## AG2 Implementation Note
 
-The builder may be implemented as a set of AG2 1.0 beta workflow runs.
+The builder may be implemented as a set of AG2 1.0 workflow runs.
 
 That is compatible with this model only if:
 

--- a/docs/architecture/foundations/core-product-app-bundle-boundary.md
+++ b/docs/architecture/foundations/core-product-app-bundle-boundary.md
@@ -56,7 +56,7 @@ Owns agent-native semantics.
 AG2 should continue to own native concepts such as:
 
 - handoffs
-- AG2 1.0 beta workflow progression
+- AG2 1.0 workflow progression
 - reply hooks
 - tool calling
 

--- a/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
+++ b/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
@@ -40,7 +40,7 @@ Current implemented workflow-run persistence contract:
   longer available.
 - AG2 agent-turn, LLM-call, tool-call, and HITL telemetry is emitted through AG2
   beta `TelemetryMiddleware` as OpenTelemetry spans.
-- LLM token usage is emitted by Mozaiks AG2 1.0 beta usage middleware as
+- LLM token usage is emitted by Mozaiks AG2 1.0 usage middleware as
   `chat.usage_delta` events and stored in `RuntimeUsageEvents`. This ledger is
   measurement-only. It does not enforce entitlements, quotas, pricing, or
   hosted billing.

--- a/docs/architecture/frontend/chat-ui/ag-ui-copilotkit-comparison.md
+++ b/docs/architecture/frontend/chat-ui/ag-ui-copilotkit-comparison.md
@@ -19,9 +19,9 @@ comparison intended to answer:
 
 External references:
 
-- [AG2 AG-UI overview](https://docs.ag2.ai/latest/docs/beta/ag-ui/)
-- [AG2 CopilotKit quickstart](https://docs.ag2.ai/latest/docs/beta/ag-ui/copilotkit-quickstart/)
-- [AG2 backend deep dive](https://docs.ag2.ai/latest/docs/beta/ag-ui/backend-deepdive/)
+- [AG2 AG-UI overview](https://docs.ag2.ai/docs/user-guide/ag-ui/)
+- [AG2 CopilotKit quickstart](https://docs.ag2.ai/docs/user-guide/ag-ui/copilotkit-quickstart/)
+- [AG2 backend deep dive](https://docs.ag2.ai/docs/user-guide/ag-ui/backend-deepdive/)
 - [AG-UI overview](https://docs.ag-ui.com/introduction)
 - [AG-UI events](https://docs.ag-ui.com/concepts/events)
 - [AG-UI state management](https://docs.ag-ui.com/concepts/state)

--- a/docs/architecture/mozaiksai/handoff-context-conditions.md
+++ b/docs/architecture/mozaiksai/handoff-context-conditions.md
@@ -48,5 +48,5 @@ transition_rules:
 - Keep `transition_graph.yaml`, `context_variables.yaml`, and `tools.yaml` as
   the three-file routing unit. Do not inline routing logic in agent prompts or
   tool implementations.
-- Workflow-local handoffs compile to AG2 1.0 beta Network `TransitionGraph`; they
+- Workflow-local handoffs compile to AG2 1.0 Network `TransitionGraph`; they
   do not run LLM classification during transition evaluation.

--- a/docs/architecture/mozaiksai/hook-system-deep-dive.md
+++ b/docs/architecture/mozaiksai/hook-system-deep-dive.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-Mozaiks uses `middleware.yaml` for AG2 1.0 beta prompt injection. Runtime execution
-is AG2 1.0 beta middleware, not prior hook registration style.
+Mozaiks uses `middleware.yaml` for AG2 1.0 prompt injection. Runtime execution
+is AG2 1.0 middleware, not prior hook registration style.
 
 Canonical declarations live in:
 

--- a/docs/architecture/mozaiksai/task-batches.md
+++ b/docs/architecture/mozaiksai/task-batches.md
@@ -5,7 +5,7 @@ DAGs inside one workflow. They replace persisted session-based decomposition
 for normal builder work such as generating modules, pages, services,
 contracts, and review items.
 
-They are intentionally different from AG2 1.0 beta `Task` and sub-agent delegation:
+They are intentionally different from AG2 1.0 `Task` and sub-agent delegation:
 
 - AG2 `Task` is a lifecycle and observability wrapper around a unit of work.
   It does not assign, schedule, dependency-sort, or merge artifact work.

--- a/docs/architecture/mozaiksai/universal-orchestrator.md
+++ b/docs/architecture/mozaiksai/universal-orchestrator.md
@@ -13,7 +13,7 @@ runtime surfaces:
 
 There is no global agent mesh and no workflow-local router that owns product
 intent. Workflow-local handoffs stay inside one workflow bundle and compile to
-AG2 1.0 beta Network `TransitionGraph` objects.
+AG2 1.0 Network `TransitionGraph` objects.
 
 ## Current Shape
 
@@ -24,7 +24,7 @@ User / API / UI event
       -> Refinement Engine refinement route
       -> workflow run route
   -> OrchestrationPort.run/resume/cancel
-  -> AG2 1.0 beta workflow execution
+  -> AG2 1.0 workflow execution
   -> runtime events + artifact persistence
 ```
 
@@ -42,7 +42,7 @@ The Refinement Engine owns builder-session interpretation:
 - coding-worker request preparation
 
 `OrchestrationPort` owns the runtime execution boundary. Everything above it is
-engine-agnostic; the AG2 adapter owns AG2 1.0 beta agent, stream, and Network
+engine-agnostic; the AG2 adapter owns AG2 1.0 agent, stream, and Network
 translation details.
 
 Current implementation note:
@@ -86,18 +86,18 @@ workflow-local transition can read deterministic context variables, tool results
 or typed structured-output state. Natural-language intent classification belongs
 in the Refinement Engine before the workflow run is started or resumed.
 
-For AG2 1.0 beta specifically, be careful with the word `resume`: AG2 typed events
+For AG2 1.0 specifically, be careful with the word `resume`: AG2 typed events
 are the runtime source of truth, while durable AG2 Network channel continuation
 is not available in the installed API. Mozaiks restores runtime-owned session
 routing state plus persistent AG2 run-stream history first and then re-enters
 the workflow through `OrchestrationPort`.
 
-## AG2 1.0 beta Mapping
+## AG2 1.0 Mapping
 
-Mozaiks keeps workflow YAML as its authoring contract and compiles it to AG2 1.0 beta
+Mozaiks keeps workflow YAML as its authoring contract and compiles it to AG2 1.0
 runtime objects:
 
-| Mozaiks contract | AG2 1.0 beta runtime object |
+| Mozaiks contract | AG2 1.0 runtime object |
 | --- | --- |
 | `agents.yaml` | `Agent` registration |
 | `transition_graph.yaml` | `TransitionGraph` |

--- a/docs/architecture/workflows/ag2-execution-alignment-plan.md
+++ b/docs/architecture/workflows/ag2-execution-alignment-plan.md
@@ -10,15 +10,15 @@ Related boundary: [AG2 Ownership Boundary](ag2-ownership-boundary.md).
 
 Reviewed against:
 
-- AG2 docs, 2026-06-08 pages:
-  - <https://docs.ag2.ai/latest/docs/beta/network/quick_start/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/hub_and_identity/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/agent_clients/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/adapters_overview/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/task_observation/>
-  - <https://docs.ag2.ai/latest/docs/beta/tasks/>
-  - <https://docs.ag2.ai/latest/docs/beta/task_delegation/>
-- Installed AG2 package inspected locally: `ag2==1.0.0`.
+- AG2 1.0.3 docs, reviewed 2026-09-01:
+  - <https://docs.ag2.ai/docs/user-guide/network/quick_start/>
+  - <https://docs.ag2.ai/docs/user-guide/network/hub_and_identity/>
+  - <https://docs.ag2.ai/docs/user-guide/network/agent_clients/>
+  - <https://docs.ag2.ai/docs/user-guide/network/adapters_overview/>
+  - <https://docs.ag2.ai/docs/user-guide/network/task_observation/>
+  - <https://docs.ag2.ai/docs/user-guide/tasks/>
+  - <https://docs.ag2.ai/docs/user-guide/agent_harness/>
+- Installed AG2 package inspected locally: `ag2==1.0.3`.
 
 Important AG2 facts:
 
@@ -190,7 +190,11 @@ Target worker execution options, in preference order:
    WAL replay, and task observation are needed.
 2. Use `Agent.as_tool()` or AG2 sub-task delegation only when the parent LLM
    should decide delegation dynamically.
-3. Direct `Agent.ask(...)` is not a task-batch execution path.
+3. A bare direct `Agent.ask(...)` is not a task-batch lifecycle. The current
+   narrow `AG2TaskBatchRunner` path is valid because an AG2 `Task` owns the
+   lifecycle and standalone stream while `Agent.ask(...)` performs the one
+   already-authorized worker turn. It does not claim Hub channels, scheduling,
+   delegation, or `TaskMirror` behavior.
 
 ### 6. Lifecycle Hooks
 
@@ -298,6 +302,10 @@ Current checkpoint:
 - Worker task context is passed through the scoped worker turn variables and
   dependencies; this standalone path does not create a per-task AG2 Network
   channel or WAL.
+- AG2 1.0.3 continues to expose both public primitives used here: `Task` for
+  lifecycle/observation and `Agent.ask(...)` for the preselected worker turn.
+  Deterministic success, failure, timeout, cancellation, and repeatability tests
+  prove this bounded composition without treating a bare ask as task execution.
 - `run_workflow_orchestration(...)` supports task-batch workflows through
   phased AG2 Network execution: trigger-agent phase, deterministic task
   lifecycle-wrapped worker turns, then downstream continuation phase with batch

--- a/docs/architecture/workflows/ag2-network-patternbook.md
+++ b/docs/architecture/workflows/ag2-network-patternbook.md
@@ -26,7 +26,7 @@ modules: curated generation intelligence, not runtime authority.
 | --- | --- |
 | Patternbook YAML | Pattern taxonomy, intent signals, required context/tools, handoff-generation strategy |
 | AgentGenerator | Reads the patternbook to select patterns and generate workflow YAML |
-| Runtime compiler | Validates workflow YAML, compiles handoffs into AG2 1.0 beta `TransitionGraph` objects, and resolves turns through `WorkflowAdapter` |
+| Runtime compiler | Validates workflow YAML, compiles handoffs into AG2 1.0 `TransitionGraph` objects, and resolves turns through `WorkflowAdapter` |
 | Refinement Engine | Classifies user/refinement intent before workflow launch or resume |
 
 The runtime does not route from the patternbook directly. It routes from the
@@ -62,7 +62,7 @@ The patternbook tracks both AG2 cookbook shape and Mozaiks support level.
 | Star | `compiled_now` | Hub-spoke return graph |
 | Triage with Tasks | `compiled_now` | Triage plan followed by typed task sequence |
 
-`Coordinator` is the AG2 1.0 beta replacement for open-ended manager/specialist
+`Coordinator` is the AG2 1.0 replacement for open-ended manager/specialist
 selection. It should be generated only when the target host supports the full
 WorkflowAdapter typed handoff path. Otherwise AgentGenerator should prefer
 Context-Aware Routing or Star.
@@ -96,7 +96,7 @@ mozaiksai.core.workflow.context.projection.inject_build_context_projections
 
 Workflow-specific Python prompt stubs do not own patternbook projection. This
 keeps each parallel builder worker focused, keeps the patternbook as the single
-catalog to evolve as AG2 1.0 beta Network support expands, and lets other workflows
+catalog to evolve as AG2 1.0 Network support expands, and lets other workflows
 use the same context-declared projection contract.
 
 ## Boundary

--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -11,20 +11,19 @@ current replacement plan lives in
 
 ## Current Baseline
 
-Reviewed on August 25, 2026 against:
+Reviewed on September 1, 2026 against:
 
-- installed package: `ag2==1.0.2` from the `ag2` import package
-- declared dependencies: `ag2[a2a,openai,tracing]==1.0.2`,
-  `ag2[gemini]==1.0.2`, and `ag2[anthropic]==1.0.2`
+- installed package: `ag2==1.0.3` from the `ag2` import package
+- declared dependencies: `ag2[a2a,openai,tracing]==1.0.3`,
+  `ag2[gemini]==1.0.3`, `ag2[anthropic]==1.0.3`, and `ag2[acp]==1.0.3`
 - AG2 docs:
-  - <https://docs.ag2.ai/latest/docs/beta/network/overview/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/hub_and_identity/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/agent_clients/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/adapters_overview/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/migration_from_group_chat/>
-  - <https://docs.ag2.ai/latest/docs/beta/network/task_observation/>
-  - <https://docs.ag2.ai/latest/docs/beta/tasks/>
-  - <https://docs.ag2.ai/latest/docs/beta/ag2_compatibility/>
+  - <https://docs.ag2.ai/docs/user-guide/network/overview/>
+  - <https://docs.ag2.ai/docs/user-guide/network/hub_and_identity/>
+  - <https://docs.ag2.ai/docs/user-guide/network/agent_clients/>
+  - <https://docs.ag2.ai/docs/user-guide/network/adapters_overview/>
+  - <https://docs.ag2.ai/docs/user-guide/network/migration_from_group_chat/>
+  - <https://docs.ag2.ai/docs/user-guide/network/task_observation/>
+  - <https://docs.ag2.ai/docs/user-guide/tasks/>
   - <https://docs.ag2.ai/docs/blog/2026/05/14/AG2-Action-Driven-Network/>
   - <https://docs.ag2.ai/docs/blog/2026/05/16/AG2-Network-What-Survives/>
   - <https://docs.ag2.ai/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/>
@@ -55,16 +54,16 @@ Mozaiks still owns deterministic product contracts around those primitives:
 | AG2 workflow runner boundary | `mozaiksai/core/adapters/ag2_network_runner.py`, `mozaiksai/core/adapters/ag2_orchestration.py` | Mozaiks must adapt workflow YAML, app/session IDs, structured-output registry, and Mozaiks `RunResult` semantics to AG2 Hub channels. | If AG2 adds a stable high-level workflow runner over `Hub`/`AgentClient`, shrink `AG2NetworkRunner` to request/result conversion only. |
 | Turn failure result mapping | `mozaiksai/core/adapters/ag2_network_runner.py` | AG2 reports agent turn crashes through `HubListener.on_turn_failed` while leaving the channel alive. Mozaiks maps that listener event to a failed `RunResult` so runtime callers do not wait for channel timeout. | If AG2 Workflow channels gain first-class failure policy or auto-close behavior for turn crashes, replace the local listener with the native channel result. |
 | Round-end context mutation bridge | `_install_context_update_handler` in `mozaiksai/core/adapters/ag2_network_runner.py` | Mozaiks tools mutate `ContextVariablesBridge`, while AG2 workflow routing reads packet `context_updates` before `WorkflowAdapter.fold(...)` selects the next speaker. The current bridge wraps AG2's default handler to merge those updates into `EV_PACKET`. | Replace with an AG2-supported round-end packet transform hook, default-handler middleware, or native context update helper when available. This is the most fragile divergence. |
-| Source-scoped deterministic transition conditions | `mozaiksai/core/adapters/ag2_transition_conditions.py`, `mozaiksai/core/workflow/execution/network_graph.py` | Mozaiks workflow YAML declares `source_agent` per rule, while AG2 `ContextEquals` and `ToolCalled` do not include source scope by themselves. AG2 1.0.2 does not ship an upstream expression evaluator for Mozaiks `${var}` workflow contracts, so Mozaiks keeps a small deterministic evaluator at the adapter boundary. | If AG2 adds native condition composition such as `FromSpeaker AND ContextEquals`, `FromSpeaker AND ToolCalled`, or a native expression evaluator, replace the local adapters with native composition. |
+| Source-scoped deterministic transition conditions | `mozaiksai/core/adapters/ag2_transition_conditions.py`, `mozaiksai/core/workflow/execution/network_graph.py` | Mozaiks workflow YAML declares `source_agent` per rule, while AG2 `ContextEquals` and `ToolCalled` do not include source scope by themselves. AG2 1.0.3 does not ship an upstream expression evaluator for Mozaiks `${var}` workflow contracts, so Mozaiks keeps a small deterministic evaluator at the adapter boundary. | If AG2 adds native condition composition such as `FromSpeaker AND ContextEquals`, `FromSpeaker AND ToolCalled`, or a native expression evaluator, replace the local adapters with native composition. |
 | App-preview/validation sandboxes vs AG2 code execution | `mozaiksai/core/ports/sandbox.py`, `mozaiksai/core/adapters/e2b_sandbox.py`, `mozaiksai/core/adapters/docker_sandbox.py`, `factory_app/workflows/AppGenerator/tools/app_validation.py`, `mozaiksai/core/sandbox/preview_sessions.py` | AG2's `SandboxCodeTool`/`SandboxShellTool` execute agent-written snippets and shell commands (fresh process per call, stdout/stderr, docker/daytona/tenki backends) and expose no long-lived app servers or preview URLs. Mozaiks' `SandboxPort` boots a full generated application (write bundle, install, dev server, preview URL, session lifecycle) — application-runtime behavior Mozaiks owns. Agent-level execution already uses AG2 (`sandbox_shell: true` agents via `ag2.tools.shell.SandboxShellTool`); the control-plane coding worker validates via local subprocess and deliberately excludes an `e2b` strategy label until a sandbox execution path exists. | If AG2 `CodeEnvironment` backends gain long-lived sessions with exposed service ports, preview URLs, and per-session budgets, collapse `SandboxPort` adapters into request/result conversion over `CodeEnvironment` and adopt AG2 backends (daytona/tenki) alongside or instead of e2b. If AG2 ships a sandboxed code-execution tool suitable for the coding worker, wire `validation_strategy: e2b`-class execution through it rather than a Mozaiks-owned runner. |
 | One-shot workflow bootstrap transition | `BootstrapInitialDispatch` in `mozaiksai/core/adapters/ag2_transition_conditions.py`, injected by `AG2NetworkRunner._compile_graph_with_initiator(...)` | Mozaiks opens workflow channels from a human initiator and injects a first-turn dispatch to the declared initial agent. This condition is intentionally bootstrap-only and cannot be configured as a general workflow-author transition. | Remove this adapter if AG2 exposes a native workflow-channel startup target that dispatches the initial message without adding a reusable human-speaker transition. |
 | Structured-output validation after AG2 packets | `mozaiksai/core/workflow/outputs/runtime_validation.py`, `mozaiksai/core/workflow/outputs/runtime_events.py`, `AG2NetworkRunner._validate_wal_structured_outputs(...)` | AG2 owns model execution; Mozaiks owns canonical app/workflow/module artifact schemas and hard validation. | If AG2 Network supports per-agent `response_schema` on workflow channels, use it for model pressure, but keep Mozaiks validation as the artifact contract authority. |
-| Task-batch scheduling and result merge | `mozaiksai/core/workflow/task_batches.py`, `mozaiksai/core/adapters/ag2_task_batch_runner.py` | AG2 `Task` is lifecycle/observation; it does not assign, dependency-sort, enforce owned paths, or merge generated artifact outputs. Mozaiks now wraps each already-authorized worker turn in an AG2 1.0.2 `Task`, subscribes to that task's standalone `MemoryStream`, and records normalized `TaskStarted`, `TaskCompleted`, `TaskFailed`, or `TaskExpired` evidence. `TaskMirror` is not active here because AG2 requires a `HubClient` or `Hub`; no AG2 channel id or durable channel resume is claimed for this standalone path. | If AG2 adds a deterministic task graph/scheduler with dependency and observation semantics, move worker execution and lifecycle there while keeping Mozaiks artifact ownership validation. If task batches move into real Hub/AgentClient worker channels, attach `TaskMirror` and use real channel ids from AG2. |
+| Task-batch scheduling and result merge | `mozaiksai/core/workflow/task_batches.py`, `mozaiksai/core/adapters/ag2_task_batch_runner.py` | AG2 `Task` is lifecycle/observation; it does not assign, dependency-sort, enforce owned paths, or merge generated artifact outputs. Mozaiks wraps each already-authorized worker turn in an AG2 1.0.3 `Task`, subscribes to that task's standalone `MemoryStream`, and invokes the preselected worker through public `Agent.ask(...)`. The Task owns lifecycle evidence; the ask owns the single worker turn. `TaskMirror` is not active because AG2 requires a `HubClient` or `Hub`; no AG2 channel id or durable channel resume is claimed for this standalone path. | If AG2 adds a deterministic task graph/scheduler with dependency and observation semantics, move worker execution and lifecycle there while keeping Mozaiks artifact ownership validation. If task batches move into real Hub/AgentClient worker channels, attach `TaskMirror` and use real channel ids from AG2. |
 | Phased task-batch workflow execution | `mozaiksai/core/workflow/orchestration_patterns.py` | A planning phase runs through AG2, Mozaiks executes deterministic task lifecycle-wrapped worker turns, then a continuation phase resumes with merged context. This keeps the DAG deterministic but splits one logical workflow across channels/task streams. | Replace with AG2-native parent/child workflow channels or task lineage when AG2 can preserve parent workflow context, WAL lineage, cancellation, and observation in one execution surface. |
 | Approved-generation smoke coordinator uses AG2 task primitive | `scripts/smoke_agentgenerator_live_pack.py` | Live AgentGenerator pack smoke found the single-agent AG2 Network coordinator/metadata path timing out before packet emission, while direct AG2 task calls completed reliably. The smoke keeps the production-critical parallel workflow generation path on the real AG2 task batch runner and keeps this one-shot approved-boundary coordinator outside Mozaiks runtime code. | The AG2 Consulting channel shape (one question, one reply, auto-close) is the likely native primitive for these one-shot coordinator/metadata calls. If Consulting channels gain deterministic packet emission/close behavior, move the smoke calls back through `AG2NetworkRunner` or a Consulting-channel path. |
 | Refinement Engine LLM checkpoints | `mozaiksai/control_plane/implementations/*`, `mozaiksai/core/adapters/ag2_agent_runner.py` | The Refinement Engine is deterministic artifact-aware policy; AG2 should only own the LLM call used for classifier/proposer/coding-plan structured output. | Each LLM checkpoint is semantically an AG2 Consulting interaction: one question, one structured reply, hard close. If AG2's Consulting channel shape hardens into a typed one-shot primitive with `response_schema` support, adapt `AG2StructuredAgentRunner` to use it. Do not move artifact routing, promotion, invalidation, or scoped patch policy into AG2. |
 | Studio/platform event projection | `_project_ag2_wal_to_mozaiks_transport(...)` in `mozaiksai/core/adapters/ag2_network_runner.py` | The frontend consumes Mozaiks websocket events and app-scoped chat persistence, not raw AG2 envelopes. | Prefer AG2 Hub listeners or channel event subscriptions for live projection when they support app-scoped transport and chat persistence boundaries. |
-| Durable human identity reattachment | `_attach_human_client(...)` in `mozaiksai/core/adapters/ag2_network_runner.py` | Chat-scoped `MongoAG2KnowledgeStore` hydration, Agent `HubClient.attach(...)`, and `resume_pending_turns()` now own restart recovery. AG2 1.0.2 does not expose a public human equivalent of `HubClient.attach(...)`, so Mozaiks locally reconnects the hydrated `HumanClient` identity through the same Hub records. UI transcript events are projection input only and never reconstruct Network execution state. | Replace the localized private-API seam as soon as AG2 exposes `HubClient.attach_human(...)` or an equivalent public identity-reconnection API. |
+| Durable human identity reattachment | `_attach_human_client(...)` in `mozaiksai/core/adapters/ag2_network_runner.py` | Chat-scoped `MongoAG2KnowledgeStore` hydration, Agent `HubClient.attach(...)`, and `resume_pending_turns()` now own restart recovery. AG2 1.0.3 still does not expose a public human equivalent of `HubClient.attach(...)`, so Mozaiks locally reconnects the hydrated `HumanClient` identity through the same Hub records. UI transcript events are projection input only and never reconstruct Network execution state. | Replace the localized private-API seam as soon as AG2 exposes `HubClient.attach_human(...)` or an equivalent public identity-reconnection API. |
 
 ## Too-Much-Ownership Flags
 
@@ -123,6 +122,24 @@ changes under `mozaiksai/core/workflow`, `mozaiksai/core/adapters`, or
 6. Update this file and any affected architecture docs in the same change.
 
 ## Current Decision Log
+
+### September 1, 2026
+
+- **AG2 1.0.3 compatibility upgrade**: all AG2 extras now share the exact
+  1.0.3 pin; ACP uses 0.12.1; AG2 owns the transitive MCP 2.x contract.
+- **Usage accounting follows `UsageEvent`**: the upstream `TokenMonitor` proof
+  now covers ordinary turns, failed-subtask rollups, compaction, aggregation,
+  and rejection of duplicate `ModelResponse` accounting. Mozaiks only projects
+  the resulting observer alert into app/run-scoped events.
+- **No persistent-subagent workaround existed in Mozaiks**: AG2 1.0.3's stream
+  identity fix required no local deletion or replacement.
+- **Task plus direct ask remains a narrow valid adapter composition**: AG2
+  `Task` owns lifecycle evidence while public `Agent.ask(...)` performs one
+  preselected worker turn. This standalone path remains intentionally distinct
+  from Hub channels, `TaskMirror`, and LLM-directed delegation.
+- **HITL failure semantics required no replacement framework**: unanswerable
+  input now fails upstream; the private durable-human reattachment seam remains
+  because AG2 still has no public equivalent.
 
 ### August 25, 2026
 

--- a/docs/architecture/workflows/declarative-ag2-mapping.md
+++ b/docs/architecture/workflows/declarative-ag2-mapping.md
@@ -24,10 +24,10 @@ Those are Mozaiks layers that exist before a workflow starts.
 | --- | --- | --- |
 | `orchestrator.yaml` | pattern, turns, startup behavior | mostly AG2-native |
 | `agents.yaml` | agent roster and prompts | AG2-native with Mozaiks composition helpers |
-| `transition_graph.yaml` | routing rules inside the workflow | AG2 1.0 beta WorkflowAdapter / TransitionGraph |
+| `transition_graph.yaml` | routing rules inside the workflow | AG2 1.0 WorkflowAdapter / TransitionGraph |
 | `context_variables.yaml` | workflow state bindings | AG2-native container plus Mozaiks adapters |
 | `tools.yaml` | tool declarations | AG2 tool calling plus Mozaiks wrappers |
-| `middleware.yaml` | prompt injection declarations | Mozaiks declarations compiled to AG2 1.0 beta middleware |
+| `middleware.yaml` | prompt injection declarations | Mozaiks declarations compiled to AG2 1.0 middleware |
 | `structured_outputs.yaml` | typed runtime validation | Mozaiks layer |
 | `ui_config.yaml` | frontend exposure metadata | frontend-only |
 | `extended_orchestration/task_batches.yaml` | workflow-local deterministic task DAG contract | Mozaiks contract layer executed through AG2 where possible |
@@ -58,9 +58,9 @@ tool binding.
 
 ### `transition_graph.yaml`
 
-Maps to AG2 1.0 beta Network transition conditions and targets. Mozaiks compiles
+Maps to AG2 1.0 Network transition conditions and targets. Mozaiks compiles
 the rules into a `TransitionGraph`; turn-to-turn routing is resolved through
-AG2 1.0 beta `WorkflowAdapter`.
+AG2 1.0 `WorkflowAdapter`.
 
 Runtime compilation rules:
 
@@ -68,7 +68,7 @@ Runtime compilation rules:
 - `condition_type: context_equals` rules compile to a source-scoped adapter over
   AG2 `ContextEquals`
 - `condition_type: context_expression` rules compile to a source-scoped custom
-  AG2 1.0 beta `TransitionCondition` that evaluates Mozaiks
+  AG2 1.0 `TransitionCondition` that evaluates Mozaiks
   `${context_variable}` syntax against workflow context state
 - `condition_type: tool_called` rules compile to a source-scoped adapter over
   AG2 `ToolCalled`
@@ -90,7 +90,7 @@ Termination is declarative. A workflow bundle ends through
 
 The runtime does not inspect message text for completion and does not use a
 separate Python termination handler. During execution, Mozaiks resolves the next
-speaker through AG2 1.0 beta `WorkflowAdapter`; when that resolution returns AG2
+speaker through AG2 1.0 `WorkflowAdapter`; when that resolution returns AG2
 `TerminateTarget`, the turn loop reports `run_completed=true` and the runtime
 marks the app-scoped `ChatSessions` run as completed. `max_turns` remains a
 safety cap, not the primary happy-path completion mechanism.
@@ -139,7 +139,7 @@ lifecycle_tools: []
 
 ### `middleware.yaml`
 
-Maps to Mozaiks prompt-injection declarations. Runtime registration is AG2 1.0 beta
+Maps to Mozaiks prompt-injection declarations. Runtime registration is AG2 1.0
 agent middleware, not prior hook registration style. Lifecycle behavior belongs
 in `tools.yaml` `lifecycle_tools`.
 

--- a/docs/architecture/workflows/index.md
+++ b/docs/architecture/workflows/index.md
@@ -16,7 +16,7 @@ handoffs, workflow routing, or session/refinement behavior.
 | [AG2 Update Watchpoints](ag2-update-watchpoints.md) | Living AG2 upgrade checks and intentional divergence log |
 | [AG2 Execution Alignment Plan](ag2-execution-alignment-plan.md) | Audit and replacement plan for shrinking Mozaiks-owned agentic runtime code |
 | [Declarative AG2 Mapping](declarative-ag2-mapping.md) | YAML-to-AG2 mapping rules |
-| [AG2 Network Patternbook](ag2-network-patternbook.md) | Canonical AgentGenerator pattern catalog for AG2 1.0 beta Network workflow shapes |
+| [AG2 Network Patternbook](ag2-network-patternbook.md) | Canonical AgentGenerator pattern catalog for AG2 1.0 Network workflow shapes |
 | [Build Context Packs](build-context-packs.md) | Targeted build-time catalogs, contracts, templates, and prompt projections |
 | [Domain-Agnostic Build Factory](domain-agnostic-build-factory.md) | Dev-pack architecture for shared harnesses and domain-specific workflow contracts |
 | [Strategy Extension Contract](strategy-extension-contract.md) | Public seams for app/operator strategy without changing canonical app contracts |

--- a/docs/architecture/workflows/refinement-harness-architecture.md
+++ b/docs/architecture/workflows/refinement-harness-architecture.md
@@ -282,7 +282,7 @@ It should not own the runtime engines.
 The harness is not:
 
 - a workflow
-- an AG2 1.0 beta workflow run
+- an AG2 1.0 workflow run
 - a module handler under `app/modules/*`
 - a global prompt wrapped around every message
 - a replacement for `extension_registry.json`

--- a/docs/architecture/workflows/workflow-authoring-contracts.md
+++ b/docs/architecture/workflows/workflow-authoring-contracts.md
@@ -200,14 +200,14 @@ Rules:
   compile to a source-scoped AG2 `ContextEquals` condition.
 - `context_expression` routes require `context_expression` using Mozaiks
   `${context_variable}` syntax over declared context references; they compile
-  to a registered AG2 1.0 beta `TransitionCondition`.
+  to a registered AG2 1.0 `TransitionCondition`.
 - `tool_called` routes require `tool_name`; they compile to a source-scoped AG2
   `ToolCalled` condition.
 - Same-source condition rules must appear before fallback `after_turn` rules
   because AG2 evaluates lower priority first.
 - LLM intent classification belongs in the Refinement Engine before a workflow run
   is started or resumed.
-- The runtime compiles these rules into an AG2 1.0 beta `TransitionGraph` and
+- The runtime compiles these rules into an AG2 1.0 `TransitionGraph` and
   resolves each turn through `WorkflowAdapter`.
 - AgentGenerator derives pattern-specific transition rules from
   `factory_app/build_context/AgentGenerator/ag2_network_patterns.yaml`.
@@ -400,7 +400,7 @@ prompt_middleware:
 ```
 
 Rules:
-- Prompt middleware declarations are compiled to AG2 1.0 beta middleware.
+- Prompt middleware declarations are compiled to AG2 1.0 middleware.
 - Use lifecycle tools for side effects and structured outputs/runtime
   validators for output validation.
 

--- a/docs/guides/adding-workflows/01-overview.md
+++ b/docs/guides/adding-workflows/01-overview.md
@@ -56,7 +56,7 @@ included only when the workflow needs them.
 3. Define `structured_outputs.yaml`: strict output models for generator agents.
 4. Define `agents.yaml`: conversational agents gather context; generator agents emit typed output.
 5. Define `tools.yaml`: bind dumb tools and optional UI emission.
-6. Define `transition_graph.yaml`: deterministic routing between agents and the user through AG2 1.0 beta WorkflowAdapter.
+6. Define `transition_graph.yaml`: deterministic routing between agents and the user through AG2 1.0 WorkflowAdapter.
 7. Define `ui_config.yaml`: list visual agents that should stream to the UI.
 
 ## Contract Snippets
@@ -181,7 +181,7 @@ them as contract references, not as full workflow examples.
     ```
 
     Handoffs should describe deterministic routing. The runtime compiles these
-    rules to a `TransitionGraph` and resolves each turn through AG2 1.0 beta
+    rules to a `TransitionGraph` and resolves each turn through AG2 1.0
     `WorkflowAdapter`. Use `context_equals`, `context_expression`, or
     `tool_called` conditions and put same-source condition routes before
     fallback `after_turn` routes.

--- a/factory_app/app/admin/pages/AppUsagePage.jsx
+++ b/factory_app/app/admin/pages/AppUsagePage.jsx
@@ -308,7 +308,7 @@ export default function AppUsagePage() {
           ) : (
             <StudioInlineEmptyState
               title="No usage breakdown available yet"
-              description="This view becomes informative once AG2 1.0 beta workflow agents produce metered LLM calls."
+              description="This view becomes informative once AG2 1.0 workflow agents produce metered LLM calls."
             />
           )}
         </Panel>

--- a/factory_app/build_context/AgentGenerator/ag2_network_patterns.yaml
+++ b/factory_app/build_context/AgentGenerator/ag2_network_patterns.yaml
@@ -1,8 +1,8 @@
 version: 1
-description: Canonical AG2 1.0 beta Network patternbook for generated Mozaiks workflows.
+description: Canonical AG2 1.0 Network patternbook for generated Mozaiks workflows.
 authority: factory_app/build_context/AgentGenerator/ag2_network_patterns.yaml
 global_rules:
-  - Workflow YAML remains the authoring contract; runtime compiles it to AG2 1.0 beta Network objects.
+  - Workflow YAML remains the authoring contract; runtime compiles it to AG2 1.0 Network objects.
   - Handoff conditions are deterministic only. Do not generate llm or string_llm condition types.
   - LLM reasoning can classify intent by setting context variables or returning structured output before routing.
   - Tools mutate workflow state or return typed routing objects; transition_graph.yaml must stay declarative and verifiable.
@@ -316,7 +316,7 @@ patterns:
         - non_coordinator_default_return
       terminal_rule: Coordinator calls finish(summary) to close the workflow.
     generator_notes:
-      - This is AG2 1.0 beta's replacement for open-ended manager selection.
+      - This is AG2 1.0's replacement for open-ended manager selection.
       - Generate handoff(to) and finish(summary) tools when the full WorkflowAdapter path is available.
       - Until typed routing tools are enabled for a host, prefer Context-Aware Routing or Pipeline.
     examples:

--- a/factory_app/workflows/AgentGenerator/agents.yaml
+++ b/factory_app/workflows/AgentGenerator/agents.yaml
@@ -611,7 +611,7 @@ agents:
       - Does it need to persist structured output to context? → `Agent_Tool` with `auto_tool_call: true`
       - Does it need to present UI to the user? → `UI_Tool` (interactive) or `UI_Surface` (one-way)
       - Does it call an external API? → `Agent_Tool` for the API call
-      - Does it route via Coordinator pattern? → `Agent_Tool` for a typed AG2 1.0 beta `Handoff(target=...)` result when WorkflowAdapter dynamic routing is required
+      - Does it route via Coordinator pattern? → `Agent_Tool` for a typed AG2 1.0 `Handoff(target=...)` result when WorkflowAdapter dynamic routing is required
 
       Prefer shipped workflow primitives (approval_card, form_card, diagram_viewer, download_center) over custom React. Only generate `ui/<WorkflowName>/*.jsx` for genuinely custom surfaces.
 
@@ -737,7 +737,7 @@ agents:
       - Use `condition_type: context_expression` with `context_expression` for composite deterministic context routing over declared `${context_variable}` references; prefer `context_equals` for simple equality.
       - Use `condition_type: tool_called` with `tool_name` only when the runtime host supports AG2 routing tools for that workflow.
       - Conditional rules are evaluated before fallback `after_turn` rules by the Mozaiks AG2 compiler; keep YAML order meaningful within each rule type.
-      - These rules compile to AG2 1.0 beta `TransitionGraph` and are resolved through `WorkflowAdapter`.
+      - These rules compile to AG2 1.0 `TransitionGraph` and are resolved through `WorkflowAdapter`.
       - Terminal agents route to `terminate` (background) or `user` (chat-facing).
       - Follow the pattern's `terminal_rule` exactly.
       - Every `source_agent` and every non-terminal `target_agent` must match

--- a/factory_app/workflows/AgentGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AgentGenerator/structured_outputs.yaml
@@ -68,7 +68,7 @@ models:
         type: literal
         values:
         - prompt_middleware
-        description: Mozaiks prompt-injection trigger compiled to AG2 1.0 beta middleware. Runtime lifecycle work belongs in lifecycle_tools, not prompt middleware.
+        description: Mozaiks prompt-injection trigger compiled to AG2 1.0 middleware. Runtime lifecycle work belongs in lifecycle_tools, not prompt middleware.
       purpose:
         type: str
         description: Brief explanation of why this middleware is needed (<=140 chars).
@@ -1458,7 +1458,7 @@ models:
       initial_agent:
         type: str
         description: Name of the first agent that receives control when the workflow
-          starts (maps to the AG2 1.0 beta Network initial speaker).
+          starts (maps to the AG2 1.0 Network initial speaker).
       visual_agents:
         type: optional_list
         items: str

--- a/factory_app/workflows/AgentGenerator/tools/ag2_patterns.py
+++ b/factory_app/workflows/AgentGenerator/tools/ag2_patterns.py
@@ -1,4 +1,4 @@
-"""Shared AG2 1.0 beta Network patternbook loader for factory workflows."""
+"""Shared AG2 1.0 Network patternbook loader for factory workflows."""
 
 from __future__ import annotations
 
@@ -134,7 +134,7 @@ def render_pattern_guidance(pattern_id: int | str | None) -> str:
         lines.append(f"- {avoid}")
 
     lines.append("")
-    lines.append("AG2 1.0 beta primitives:")
+    lines.append("AG2 1.0 primitives:")
     for primitive in pattern.get("beta_primitives") or []:
         lines.append(f"- {primitive}")
 

--- a/mozaiksai/README.md
+++ b/mozaiksai/README.md
@@ -21,12 +21,12 @@ compose app-local hosts on top of Studio instead of adding product hosts here.
 
 ## What This Layer Owns
 
-- Executes AI workflow runs with AG2 1.0 beta Agents and Network transition graphs
+- Executes AI workflow runs with AG2 1.0 Agents and Network transition graphs
 - Streams events to frontend via WebSocket
 - Persists chat sessions to MongoDB
 - Handles tool calls from agents
 - Manages workflow state (in-progress, completed)
-- AG2 1.0 beta telemetry and neutral runtime usage measurement
+- AG2 1.0 telemetry and neutral runtime usage measurement
 
 It must not own:
 
@@ -104,7 +104,7 @@ run_workflow_orchestration(workflow_name, chat_id, ...)
     ↓
 Load workflow config from factory_app/workflows/{name}/
     ↓
-Create AG2 1.0 beta agents and compile transition_graph.yaml to a TransitionGraph
+Create AG2 1.0 agents and compile transition_graph.yaml to a TransitionGraph
     ↓
 Run agent turns through the AG2 orchestration adapter
     ↓

--- a/mozaiksai/control_plane/implementations/acp_coding_provider.py
+++ b/mozaiksai/control_plane/implementations/acp_coding_provider.py
@@ -114,8 +114,8 @@ def build_acp_agent_config(
     the workspace is both ``cwd`` and ``fs_root``; the subprocess env is an
     explicit allowlist over ``env_source``; ``expose_tools=False`` (the AG2
     default is True) so no MCP gateway is started; ``allow_terminal=False``
-    because agent-requested terminal commands inherit the full host
-    environment in ag2 1.0.2 (``ag2/acp/bridge.py:123``); and
+    because agent-requested terminal commands would expand the provider beyond
+    the mediated disposable-workspace file bridge; and
     ``elicitation_policy="decline"`` so the question capability is never
     advertised in headless execution. ``permission_policy="auto"`` is safe
     only because the blast radius is the disposable workspace plus the

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -1,4 +1,4 @@
-"""AG2 1.0 beta Network runner for Mozaiks workflow execution.
+"""AG2 1.0 Network runner for Mozaiks workflow execution.
 
 This module is the narrow boundary where Mozaiks drives AG2 Network primitives
 directly. It does not load workflow YAML or create agents; callers pass already
@@ -283,7 +283,7 @@ class AG2NetworkRunnerResult:
 
 
 class AG2NetworkRunner:
-    """Execute one workflow as an AG2 1.0 beta Network workflow channel."""
+    """Execute one workflow as an AG2 1.0 Network workflow channel."""
 
     async def run(self, request: AG2NetworkRunnerRequest) -> AG2NetworkRunnerResult:
         # Bind workflow-level trace context so all tasks spawned during this

--- a/mozaiksai/core/adapters/ag2_orchestration.py
+++ b/mozaiksai/core/adapters/ag2_orchestration.py
@@ -16,7 +16,7 @@ Responsibilities:
     - cancel() → delegates to SimpleTransport.pause_background_workflow()
     - capabilities() → reports engine version and supported features
 
-This adapter does not own workflow-specific task planning. AG2 1.0 beta provides the
+This adapter does not own workflow-specific task planning. AG2 1.0 provides the
 agent and network execution substrate; Mozaiks owns deterministic contracts
 around AG2, such as workflow YAML loading, structured-output validation, context
 persistence, artifact materialization, and task-batch dependency contracts.

--- a/mozaiksai/core/data/models.py
+++ b/mozaiksai/core/data/models.py
@@ -5,7 +5,7 @@
 """Pydantic schemas for workflow session persistence.
 
 ChatSessions is a durable run index and UI-state projection. AG2 stream history
-is persisted through the AG2 stream storage adapter. AG2 1.0 beta middleware emits
+is persisted through the AG2 stream storage adapter. AG2 1.0 middleware emits
 token usage into RuntimeUsageEvents and telemetry spans into OpenTelemetry.
 
 ChatSessions Stored Fields (superset; some optional):

--- a/mozaiksai/core/data/persistence/namespaces.py
+++ b/mozaiksai/core/data/persistence/namespaces.py
@@ -4,7 +4,7 @@ Mozaiks uses one canonical system database for runtime state and builder
 artifacts. Generated/hosted app business collections are separate from these
 framework-owned collections and should be scoped by app/module contracts.
 
-AG2 1.0 beta telemetry is exported through OpenTelemetry spans. Runtime token usage
+AG2 1.0 telemetry is exported through OpenTelemetry spans. Runtime token usage
 measurements are stored separately in RuntimeUsageEvents.
 """
 

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -10,7 +10,7 @@ AG2 stream storage:
   * PersistenceManager: Mongo client + indexes (runtime-owned only)
   * AG2PersistenceManager: ChatSessions + AG2 run stream projections
 
-AG2 1.0 beta telemetry is middleware-based OpenTelemetry instrumentation and lives
+AG2 1.0 telemetry is middleware-based OpenTelemetry instrumentation and lives
 in ``mozaiksai.core.observability``. Do not add agent-turn telemetry collectors
 or in-memory performance counters here.
 """
@@ -303,7 +303,7 @@ class AG2PersistenceManager:
     and session/journey correlation metadata.
 
     LLM token usage belongs to RuntimeUsageEvents. Agent turn, LLM-call,
-    tool-call, and HITL telemetry spans belong to AG2 1.0 beta
+    tool-call, and HITL telemetry spans belong to AG2 1.0
     TelemetryMiddleware/OpenTelemetry.
     """
 

--- a/mozaiksai/core/events/__init__.py
+++ b/mozaiksai/core/events/__init__.py
@@ -18,7 +18,7 @@ This package handles two event categories:
 
 AG2 runtime events (agent messages, state changes, workflow execution) are
 handled directly by the orchestration layer via event_serialization.py and
-the AG2 1.0 beta MemoryStream subscription — no separate event wrapper needed.
+the AG2 1.0 MemoryStream subscription — no separate event wrapper needed.
 
 Usage Examples:
 

--- a/mozaiksai/core/observability/performance_manager.py
+++ b/mozaiksai/core/observability/performance_manager.py
@@ -1,4 +1,4 @@
-"""AG2 1.0 beta telemetry and metrics wiring for Mozaiks workflow agents.
+"""AG2 1.0 telemetry and metrics wiring for Mozaiks workflow agents.
 
 AG2 owns agent turn, LLM-call, tool-call, and human-input telemetry through
 ``TelemetryMiddleware`` (OTEL spans) and ``MetricsMiddleware`` (Prometheus
@@ -53,7 +53,7 @@ def _env_bool(name: str, *, default: bool) -> bool:
 
 @dataclass(frozen=True)
 class AG2TelemetryConfig:
-    """Runtime configuration for AG2 1.0 beta telemetry middleware."""
+    """Runtime configuration for AG2 1.0 telemetry middleware."""
 
     enabled: bool = False
     capture_content: bool = False
@@ -137,7 +137,7 @@ def build_ag2_telemetry_middleware(
     model_name: str | None = None,
     config: AG2TelemetryConfig | None = None,
 ) -> Any | None:
-    """Create AG2 ``TelemetryMiddleware`` wrapped as AG2 1.0 beta middleware.
+    """Create AG2 ``TelemetryMiddleware`` wrapped as AG2 1.0 middleware.
 
     Returns ``None`` when disabled or when tracing extras are not installed.
     """

--- a/mozaiksai/core/ports/orchestration.py
+++ b/mozaiksai/core/ports/orchestration.py
@@ -6,7 +6,7 @@
 # This is the single boundary between the runtime layer and the execution engine.
 # Everything above this contract (transport, API routes, websocket handlers) is
 # engine-agnostic. Everything below it (AG2 Agent loop, MemoryStream,
-# AG2 1.0 beta Network transition graph execution) is engine-specific and isolated
+# AG2 1.0 Network transition graph execution) is engine-specific and isolated
 # in adapters/.
 #
 # When the engine changes, ONLY the adapter changes.
@@ -137,7 +137,7 @@ class OrchestrationPort(Protocol):
         The adapter is responsible for:
         - loading workflow config
         - creating beta Agent instances with tools and context
-        - running the AG2 1.0 beta Network TransitionGraph-driven agent loop
+        - running the AG2 1.0 Network TransitionGraph-driven agent loop
         - streaming events to the transport via DomainEvent
         - returning a RunResult when the loop finishes or pauses for user input
         """

--- a/mozaiksai/core/transport/session_registry.py
+++ b/mozaiksai/core/transport/session_registry.py
@@ -15,7 +15,7 @@ Enables users to:
 Key Concepts:
 - One WebSocket connection can host multiple workflow sessions
 - Only ONE workflow is "active" at a time; others are "paused"
-- Each workflow has its own chat_id, AG2 1.0 beta workflow run, and artifact
+- Each workflow has its own chat_id, AG2 1.0 workflow run, and artifact
 - Session state persists in MongoDB; registry tracks runtime state only
 
 Example Flow:
@@ -71,7 +71,7 @@ class SessionRegistry:
     
     NOT Responsible For:
     - Persisting workflow state (MongoDB handles that)
-    - Starting/stopping AG2 1.0 beta workflow runs (orchestration layer)
+    - Starting/stopping AG2 1.0 workflow runs (orchestration layer)
     - LLM intent detection (UI buttons drive switching)
     """
     

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -1397,7 +1397,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
         })
 
     async def _handle_resume_request(self, chat_id: str, last_client_index: int, websocket) -> None:
-        """Resume protocol for persisted AG2 1.0 beta workflow runs.
+        """Resume protocol for persisted AG2 1.0 workflow runs.
 
         We DO NOT compute sequence diffs via a bespoke diff endpoint anymore.
         Instead we:

--- a/mozaiksai/core/usage/ledger.py
+++ b/mozaiksai/core/usage/ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Neutral runtime usage ledger.
 
 The ledger stores factual usage measurements so local OSS and Studio dashboards
-can query token usage from AG2 1.0 beta usage events. It is not a billing authority
+can query token usage from AG2 1.0 usage events. It is not a billing authority
 and does not enforce subscriptions or entitlements.
 """
 

--- a/mozaiksai/core/usage/middleware.py
+++ b/mozaiksai/core/usage/middleware.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""AG2 1.0 beta middleware that emits Mozaiks runtime usage events.
+"""AG2 1.0 middleware that emits Mozaiks runtime usage events.
 
 OpenTelemetry spans are handled by AG2's built-in TelemetryMiddleware. This
 middleware keeps a separate, queryable runtime ledger by emitting neutral
@@ -85,7 +85,7 @@ def _required_tokens_for_call(context_variables: Any) -> int:
 
 
 class MozaiksUsageMiddleware(BaseMiddleware):
-    """Emit factual usage deltas after AG2 1.0 beta LLM calls."""
+    """Emit factual usage deltas after AG2 1.0 LLM calls."""
 
     def __init__(
         self,
@@ -167,7 +167,7 @@ def build_ag2_usage_middleware(
     context_variables: Any,
     model_name: str | None = None,
 ) -> Middleware:
-    """Build AG2 1.0 beta middleware for neutral runtime usage metering."""
+    """Build AG2 1.0 middleware for neutral runtime usage metering."""
 
     return Middleware(
         MozaiksUsageMiddleware,

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -413,7 +413,7 @@ async def create_agents(
 ) -> dict[str, Agent]:
     """Create AG2 Agent instances for a workflow."""
 
-    logger.debug("[AGENTS] Creating beta agents for workflow: %s", workflow_name)
+    logger.debug("[AGENTS] Creating AG2 agents for workflow: %s", workflow_name)
 
     from time import perf_counter
 
@@ -700,7 +700,7 @@ async def create_agents(
             _wrap_tool_with_context(fn, context_bridge) for fn in raw_tool_fns
         ] + shell_tools + web_tools + image_generation_tools
 
-        # Load workflow-local AG2 1.0 beta prompt middleware declarations.
+        # Load workflow-local AG2 1.0 prompt middleware declarations.
         prompt_middleware_functions: list[Callable] = []
         try:
             from ..execution.middleware import _resolve_import, load_prompt_middleware_entries
@@ -851,7 +851,7 @@ async def create_agents(
         agents[agent_name] = agent
 
     duration = perf_counter() - start_time
-    logger.debug("[AGENTS] Created %d beta agents for '%s' in %.2fs", len(agents), workflow_name, duration)
+    logger.debug("[AGENTS] Created %d AG2 agents for '%s' in %.2fs", len(agents), workflow_name, duration)
 
     return agents
 
@@ -861,7 +861,7 @@ async def create_agents(
 # ------------------------------------------------------------------
 
 def list_agent_middleware(agent: Any) -> dict[str, list[str]]:
-    """Return Mozaiks prompt middleware registered as AG2 1.0 beta middleware."""
+    """Return Mozaiks prompt middleware registered as AG2 1.0 middleware."""
     out: dict[str, list[str]] = {}
     middleware_functions = getattr(agent, "_mozaiks_prompt_middleware", [])
     if middleware_functions:

--- a/mozaiksai/core/workflow/agents/tools.py
+++ b/mozaiksai/core/workflow/agents/tools.py
@@ -279,7 +279,7 @@ def load_agent_tool_functions(
     """Discover and import per-agent tool functions for a workflow.
 
     Reads workflows/<workflow_name>/tools.yaml and returns a mapping of
-    agent_name -> list[callable] so callers can bind tools during AG2 1.0 beta
+    agent_name -> list[callable] so callers can bind tools during AG2 1.0
     agent construction.
 
     Loads ALL tools (both Agent_Tool and UI_Tool types) as agent functions.

--- a/mozaiksai/core/workflow/agents/transition_graph.py
+++ b/mozaiksai/core/workflow/agents/transition_graph.py
@@ -1,4 +1,4 @@
-"""Transition graph validation for the AG2 1.0 beta Network workflow model."""
+"""Transition graph validation for the AG2 1.0 Network workflow model."""
 
 from __future__ import annotations
 

--- a/mozaiksai/core/workflow/execution/middleware.py
+++ b/mozaiksai/core/workflow/execution/middleware.py
@@ -1,7 +1,7 @@
-"""AG2 1.0 beta middleware support for Mozaiks workflow prompt injection.
+"""AG2 1.0 middleware support for Mozaiks workflow prompt injection.
 
 Mozaiks uses ``middleware.yaml`` as the declarative authoring file for
-workflow-local prompt middleware. Entries are compiled into agent-level AG2 1.0 beta
+workflow-local prompt middleware. Entries are compiled into agent-level AG2 1.0
 middleware that mutates ``Context.prompt`` before the model call.
 """
 
@@ -27,7 +27,7 @@ logger = logging.getLogger("middleware_loader")
 
 
 class MozaiksPromptMiddleware(BaseMiddleware):
-    """Run Mozaiks prompt middleware declarations via AG2 1.0 beta middleware."""
+    """Run Mozaiks prompt middleware declarations via AG2 1.0 middleware."""
 
     def __init__(
         self,
@@ -252,7 +252,7 @@ def build_prompt_middleware(
     base_system_message: str,
     context_bridge: Any,
 ) -> Middleware:
-    """Build the AG2 1.0 beta middleware factory for Mozaiks prompt middleware."""
+    """Build the AG2 1.0 middleware factory for Mozaiks prompt middleware."""
 
     return Middleware(
         MozaiksPromptMiddleware,

--- a/mozaiksai/core/workflow/execution/network_graph.py
+++ b/mozaiksai/core/workflow/execution/network_graph.py
@@ -1,4 +1,4 @@
-"""Compile Mozaiks workflow routing into AG2 1.0 beta Network transition graphs."""
+"""Compile Mozaiks workflow routing into AG2 1.0 Network transition graphs."""
 
 from __future__ import annotations
 
@@ -196,7 +196,7 @@ def resolve_next_agent(
     participant_order: Sequence[str] | None = None,
     turn_count: int = 1,
 ) -> str | None:
-    """Resolve the next workflow speaker through AG2 1.0 beta `WorkflowAdapter`.
+    """Resolve the next workflow speaker through AG2 1.0 `WorkflowAdapter`.
 
     Returns an agent name, `"user"` for a pause boundary, or `"terminate"`.
     Mozaiks owns transport, persistence, and UI integration; AG2's workflow

--- a/mozaiksai/core/workflow/llm_config.py
+++ b/mozaiksai/core/workflow/llm_config.py
@@ -274,7 +274,7 @@ async def get_llm_config(
 
     Returns a tuple (wrapper_placeholder, llm_config). The first element is
     reserved and currently always None; the second is the dict converted into
-    an AG2 1.0 beta OpenAIConfig.
+    an AG2 1.0 OpenAIConfig.
     """
     cache_key = _build_llm_cache_key(
         response_format=response_format, extra_config=extra_config

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -2,7 +2,7 @@
 # FILE: mozaiksai/core/workflow/orchestration_patterns.py
 # DESCRIPTION: Workflow orchestration entry point.
 #
-# Wires together the AG2 1.0 beta agent factory, run bootstrap, AG2 Network
+# Wires together the AG2 1.0 agent factory, run bootstrap, AG2 Network
 # execution, persistence, transport, lifecycle, and observability into a single
 # async function that callers use to start or re-enter a workflow run.
 #

--- a/mozaiksai/core/workflow/workflow_manager.py
+++ b/mozaiksai/core/workflow/workflow_manager.py
@@ -65,7 +65,7 @@ class UnifiedWorkflowManager:
     """Unified workflow manager focusing on config + UI tool metadata.
 
     Backend agent tools are bound directly during agent creation; prompt
-    middleware declarations are compiled into AG2 1.0 beta middleware.
+    middleware declarations are compiled into AG2 1.0 middleware.
     """
 
     _instance = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 keywords = ["mozaiks", "ag2", "ai", "agents", "workflows", "multi-tenant", "runtime"]
 
 dependencies = [
-    "ag2[a2a,openai,tracing]==1.0.2",
+    "ag2[a2a,openai,tracing]==1.0.3",
     "a2a-sdk[grpc]>=1.1.0,<2",
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.20.0",
@@ -52,21 +52,18 @@ dependencies = [
 
 [project.optional-dependencies]
 gemini = [
-    "ag2[gemini]==1.0.2",
+    "ag2[gemini]==1.0.3",
 ]
 anthropic = [
-    "ag2[anthropic]==1.0.2",
+    "ag2[anthropic]==1.0.3",
 ]
 # ACP-backed CLI coding provider (Codex, Claude Code, OpenCode) for the
 # refinement control plane. The adapter binaries (e.g. the
 # @agentclientprotocol/claude-agent-acp npm package) are deployment-time
 # dependencies and are NOT installed by this extra.
 acp-coding = [
-    "ag2[acp]==1.0.2",
-    # ag2 1.0.2 allows agent-client-protocol <0.13, but 0.12.1 removed
-    # acp.task.DefaultMessageDispatcher, which ag2's dispatch imports.
-    # Pin the last compatible version; re-check at every ag2 upgrade.
-    "agent-client-protocol==0.12.0",
+    "ag2[acp]==1.0.3",
+    "agent-client-protocol==0.12.1",
 ]
 azure = [
     "azure-identity>=1.15.0",
@@ -83,11 +80,9 @@ dev = [
     "types-PyYAML>=6.0",
     "mypy>=1.5.0",
     # dev installs the ACP extra so the fake-driven provider tests run in CI;
-    # extra-free installs skip them via importorskip. The
-    # agent-client-protocol pin matches the acp-coding extra (0.12.1 breaks
-    # ag2 1.0.2's dispatcher import).
-    "ag2[acp]==1.0.2",
-    "agent-client-protocol==0.12.0",
+    # extra-free installs skip them via importorskip.
+    "ag2[acp]==1.0.3",
+    "agent-client-protocol==0.12.1",
 ]
 docs = [
     "mkdocs>=1.6.1,<2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ﻿# mozaiksai Requirements
 # Core runtime
-ag2[a2a,openai,tracing]==1.0.2
+ag2[a2a,openai,tracing]==1.0.3
 a2a-sdk[grpc]>=1.1.0,<2
 fastapi>=0.100.0
 uvicorn[standard]>=0.20.0

--- a/tests/test_ag2_dependency_contract.py
+++ b/tests/test_ag2_dependency_contract.py
@@ -1,0 +1,45 @@
+"""Keep Mozaiks' exact AG2 dependency declarations synchronized."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AG2_REQUIREMENT = re.compile(r"^ag2(?:\[[^]]+\])?==(?P<version>[^;\s]+)$", re.IGNORECASE)
+
+
+def _declared_ag2_versions() -> list[str]:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    requirements = list(project["dependencies"])
+    for extra_requirements in project["optional-dependencies"].values():
+        requirements.extend(extra_requirements)
+
+    ag2_requirements = [item for item in requirements if item.lower().startswith("ag2")]
+    matches = [AG2_REQUIREMENT.fullmatch(item) for item in ag2_requirements]
+    assert all(matches), f"every AG2 declaration must use an exact pin: {ag2_requirements}"
+    return [match.group("version") for match in matches if match is not None]
+
+
+def _requirements_txt_ag2_version() -> str:
+    declarations = [
+        line.strip()
+        for line in (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+        if line.strip().lower().startswith("ag2")
+    ]
+    assert len(declarations) == 1, f"expected one requirements.txt AG2 pin: {declarations}"
+    match = AG2_REQUIREMENT.fullmatch(declarations[0])
+    assert match is not None, "requirements.txt AG2 declaration must use an exact pin"
+    return match.group("version")
+
+
+def test_ag2_dependency_declarations_and_installed_runtime_match() -> None:
+    versions = set(_declared_ag2_versions())
+    assert len(versions) == 1, f"mixed AG2 versions declared: {sorted(versions)}"
+
+    (declared_version,) = versions
+    assert _requirements_txt_ag2_version() == declared_version
+    assert importlib.metadata.version("ag2") == declared_version

--- a/tests/test_ag2_terminology_hygiene.py
+++ b/tests/test_ag2_terminology_hygiene.py
@@ -52,6 +52,8 @@ _FORBIDDEN_PATTERNS = [
         r"\bLocalShellTool\b",
         r"\bAG2RunnerAdapter\b",
         r"\bAG2 beta\b",
+        r"\bAG2 1\.0 beta\b",
+        r"docs\.ag2\.ai/latest/docs/beta/",
         r"\bAutoGen\b",
         r"\bautogen_ai_agents\b",
         r"formerly\s+autogen",

--- a/tests/test_task_batch_contracts.py
+++ b/tests/test_task_batch_contracts.py
@@ -11,6 +11,7 @@ from ag2.annotations import CONTEXT_OPTION_NAME, Inject
 from ag2.context import ConversationContext
 from ag2.network.policies import CHANNEL_STATE_DEP
 from ag2.stream import MemoryStream
+from ag2.testing import TestConfig
 from pydantic import BaseModel
 
 from mozaiksai.core.adapters.ag2_task_batch_runner import (
@@ -243,6 +244,23 @@ async def test_ag2_task_batch_runner_emits_authentic_start_and_completion_eviden
     assert "run_subtasks" not in repr(ask_kwargs)
     assert "background_agent_tool" not in repr(ask_kwargs)
     assert "dynamic_agent" not in repr(ask_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_ag2_task_batch_runner_composes_task_with_public_agent_ask() -> None:
+    agent = Agent(
+        "WorkerAgent",
+        prompt="deterministic test worker",
+        config=TestConfig('{"ok": true}'),
+    )
+
+    result = await AG2TaskBatchRunner().run(_runner_request(agent))
+
+    assert result.status is RunStatus.COMPLETED
+    assert result.output == {"ok": True}
+    assert result.lifecycle_status == "completed"
+    assert result.close_reason == "agent_ask_completed"
+    assert _event_names(result) == ["TaskStarted", "TaskCompleted"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_token_watchdog.py
+++ b/tests/test_token_watchdog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from ag2.events import ModelResponse
+from ag2.events import ModelResponse, TaskFailed, UsageEvent
 from ag2.events.types import Usage
 
 from mozaiksai.core.usage import watchdog as watchdog_mod
@@ -48,7 +48,7 @@ async def test_ag2_token_watchdog_bridge_emits_mozaiks_budget_alert(monkeypatch:
     )
 
     alert = await token_monitor.process(
-        [ModelResponse(usage=Usage(prompt_tokens=12, completion_tokens=10, total_tokens=22))],
+        [UsageEvent(Usage(prompt_tokens=12, completion_tokens=10, total_tokens=22))],
         SimpleNamespace(),
     )
     assert alert is not None
@@ -75,3 +75,54 @@ async def test_ag2_token_watchdog_bridge_emits_mozaiks_budget_alert(monkeypatch:
             "alert_threshold": 20,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_ag2_token_watchdog_counts_usage_events_once_across_work_kinds() -> None:
+    token_monitor, _bridge = watchdog_mod.build_ag2_token_watchdog_observers(
+        agent_name="PlannerAgent",
+        workflow_name="AppGenerator",
+        context_variables=_ContextBridge(),
+    )
+
+    ordinary_usage = Usage(prompt_tokens=4, completion_tokens=2, total_tokens=6)
+    await token_monitor.process(
+        [
+            UsageEvent(ordinary_usage, kind="model_call"),
+            # AG2 also emits a ModelResponse for an ordinary call. TokenMonitor
+            # must consume the accounting event only or this turn counts twice.
+            ModelResponse(usage=ordinary_usage),
+        ],
+        SimpleNamespace(),
+    )
+    await token_monitor.process(
+        [
+            UsageEvent(
+                Usage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+                kind="subtask",
+                label="WorkerAgent",
+            ),
+            TaskFailed(
+                task_id="task-1",
+                agent_name="WorkerAgent",
+                objective="Fail after spending tokens",
+                error=RuntimeError("planned failure"),
+            ),
+        ],
+        SimpleNamespace(),
+    )
+    await token_monitor.process(
+        [
+            UsageEvent(
+                Usage(prompt_tokens=2, completion_tokens=1, total_tokens=3),
+                kind="compaction",
+            ),
+            UsageEvent(
+                Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+                kind="aggregation",
+            ),
+        ],
+        SimpleNamespace(),
+    )
+
+    assert token_monitor.total_tokens == 16


### PR DESCRIPTION
## Summary

- upgrade every canonical AG2 declaration from 1.0.2 to 1.0.3 and ACP from 0.12.0 to 0.12.1
- add exact dependency/version drift probes and verify AG2-owned MCP 2.x resolution without a direct Mozaiks MCP pin
- update TokenMonitor compatibility coverage for AG2 1.0.3 UsageEvent accounting, including failed subtasks, compaction, aggregation, and duplicate prevention
- prove the existing bounded AG2 Task + public Agent.ask worker composition remains deterministic
- refresh active AG2 terminology and documentation while preserving historical records

## Compatibility findings

- AG2 1.0.3 metadata requires `agent-client-protocol>=0.12.1,<0.13`; resolved ACP is 0.12.1
- AG2's MCP extra resolves `mcp==2.1.1` and `mcp-types==2.1.1`; Mozaiks does not directly import that contract
- unanswerable HITL now fails promptly; existing result mapping works and the private durable-human identity seam remains required
- persistent subagent stream reuse is fixed upstream through stable stream identity/locking; Mozaiks had no workaround to delete
- no execution redesign or new agentic-framework abstraction is introduced

## Tests

- `pip check`
- installed dependency/import probe: AG2 1.0.3, ACP 0.12.1, MCP 2.1.1, mcp-types 2.1.1
- focused rebased compatibility suite: 82 passed
- broader focused AG2/runtime and deterministic acceptance suites: 448 passed, 6 skipped before final rebase; impacted tests repeated after rebase
- `ruff check .`
- relevant five-file `mypy`
- `mkdocs build --strict`
- `pytest -q --no-cov`: 14,251 passed, 80 skipped

## Scope boundaries

- #461 structured-output cache implementation and tests are unchanged
- Slice 5B, 5C, 5D, #449, `allowed_agent_ids`, agent-role bindings, CompilationPlan contracts, context engineering, and broad watchpoint governance are untouched
- auto-merge is intentionally disabled; independent review is required