### PR TITLE
docs: require current-main verification for bug fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,6 +10,11 @@ body:
         Thanks for taking the time to report a bug. Please search
         [existing issues](https://github.com/BlocUnited-LLC/mozaiks/issues) first
         to avoid duplicates.
+
+        If you are running from source, please sync with current `main` and
+        confirm the problem still reproduces before starting an implementation.
+        Mozaiks moves quickly, and older reports or suggested fixes may already
+        have been superseded.
   - type: textarea
     id: description
     attributes:
@@ -42,6 +47,14 @@ body:
       placeholder: e.g. 0.3.0, or a commit SHA if running from source
     validations:
       required: true
+  - type: checkboxes
+    id: current-main
+    attributes:
+      label: Current-main verification
+      description: Required when reporting against source rather than a released version.
+      options:
+        - label: If I am running from source, I synced with current `main` and confirmed the bug still reproduces there.
+          required: true
   - type: input
     id: python-version
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,10 @@
   maintainers have what they need to review efficiently. See CONTRIBUTING.md
   for the full contribution path.
 
+  Before implementing a bug fix, sync with current main and confirm the issue
+  still reproduces. Mozaiks moves quickly, and an older report or suggested
+  implementation may already have been superseded.
+
   Using an AI coding agent? That is welcome — see .github/AI_POLICY.md. The
   short version: make sure this description matches what the diff actually
   does, and that you can explain the change in review.
@@ -14,6 +18,17 @@
 ## Related issue
 
 <!-- Link the issue this PR addresses, e.g. "Closes #123". Write "N/A" if none. -->
+
+## Current-main verification
+
+- [ ] I synced/rebased onto current `main` before implementing this change.
+- [ ] For a bug fix, I confirmed the reported failure still reproduces on current `main`, or I explained below why reproduction is not applicable.
+
+<!--
+  For bug fixes, briefly state how you reproduced the problem on current main.
+  If the original issue no longer reproduces, do not carry forward an obsolete
+  local fix; comment on the issue/PR so maintainers can close it as superseded.
+-->
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Tightens the contributor intake path so stale bug reports and superseded fixes are caught before implementation.

- bug reports now tell source users to sync with current `main` and require confirmation that the bug still reproduces there;
- the pull request template now requires current-`main` sync/rebase and reproduction verification for bug fixes;
- contributors are explicitly told not to carry forward an obsolete local fix when the original issue no longer reproduces.

This addresses the exact failure mode seen in PR #434, where the original diagnosis was valid against an older fork point but the central serialization fix had already landed on `main`.

## Tests run

Docs/template-only change. Reviewed the rendered Markdown/YAML structure and kept the change scoped to contributor intake files.

## Boundary confirmation

- [x] OSS contributor guidance only; no runtime or hosted-product behavior changes.