### PR TITLE
feat(artifacts): add ADR 0007 Slice 5C immutable revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Offline immutable artifact revisions (ADR 0007 Slice 5C)**: added a closed,
+  content-addressed `ArtifactRevision` contract binding graph, implementation
+  binding, CompilationPlan, CompositionLedger, validation evidence, exact
+  bytes, and parent lineage. An isolated `ApplicationPublication` store uses a
+  generation-guarded Mongo compare-and-swap so concurrent Genesis or sibling
+  candidates cannot both become CURRENT. Cold restore verifies every blob and
+  canonical digest; validator receipts now bind to the exact assignment result
+  they validated. The substrate remains deliberately production-unwired:
+  AppBuildPlan and BuildRecord still own live planning/publication until Slice
+  5D, and no AG2 behavior changes.
+
 - **Offline assignment artifact composition (ADR 0007 Slice 5B)**: added a
   pure Factory-participant admission resolver, closed structured-output and
   validator-backed `AssignmentArtifactResult`, and a content-free canonical

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -297,7 +297,7 @@ scope mismatch fails closed.
 
 In particular, `ApplicationManifestRef`, `SemanticGraphRef`,
 `ImplementationBindingRef`, `CompilationPlanRef`, `BuildContextBindingRef`,
-`RefinementPatchRef`, and `ArtifactRevisionRef` pin immutable versions and
+`RefinementPatchRef`, and `ArtifactRevisionRef` pin immutable identities and
 digests. `TaxonomyNamespaceRef` pins namespace identifier, version, and digest.
 Typed child-contract refs additionally pin artifact family, canonical relative
 path, contract schema version, and content digest. No ref may resolve by a bare
@@ -792,20 +792,40 @@ cannot require an OSS fork, a hidden service call, or a hidden Cloud dependency.
 ## ArtifactRevisionRef And Atomic Publication
 
 An `ArtifactRevision` is an immutable candidate byte set and provenance record.
-Its ref pins revision id, immutable version, digest, execution-access scope,
-`SemanticGraphRef`, `CompilationPlanRef`, `BuildContextBindingRef`,
-`ImplementationBindingRef`, renderer-registry version/digest, and a canonical
-files manifest. Promotion never mutates those fields or turns a mismatched
+Its identity binds application scope, exact parent (or explicit Genesis
+absence), `SemanticGraphRef`, `ImplementationBindingRef`,
+`CompilationPlanRef`, `CompositionLedger` digest, final bundle digest, and
+immutable validation-evidence digest. Exact artifact content digests remain
+transitively bound by the ledger rather than being copied into a second
+manifest authority. Promotion never mutates a revision or turns a mismatched
 candidate into a valid one.
 
-The single publication authority is an ownership-scoped compare-and-swap of
-the current `ApplicationManifestRef`. A successful commit publishes one new
-immutable manifest version containing the new graph/revision pair. It compares
-the expected prior manifest, graph, and revision refs immediately before the
-swap; a stale base or partial-store failure publishes neither ref and leaves
-the new revision unpromoted. Retry of the same commit is idempotent. Rollback
-uses the same operation to select a previously consistent manifest/graph/
-revision tuple, so there are never two independently current authorities.
+`ArtifactRevisionRef` is deliberately subordinate and minimal: schema version,
+`ExecutionAccessScopeRef`, application id, and revision digest only. Cold
+resolution loads the canonical revision by that full server-owned scope and
+digest, recomputes its identity, and verifies the complete referenced
+graph/binding/plan/ledger/evidence/content closure. It carries no copied body,
+mutable alias, sequence, filesystem path, or storage-backend identity.
+
+The single mutable publication authority is one `ApplicationPublication` row
+per execution scope and application. It contains a required-nullable current
+`ArtifactRevisionRef` and monotonically increasing generation. Promotion first
+persists and cold-verifies the immutable closure, then performs one backend-
+atomic compare-and-swap against the expected prior revision and generation. A
+stale base or partial-store failure leaves CURRENT unchanged; an unreferenced
+immutable candidate may remain safely. Retry of an already committed revision
+is an idempotent no-op. Rollback, when production wiring lands, uses the same
+CAS selection rather than mutating revision content or creating a second
+CURRENT authority.
+
+Revision and publication identity are deliberately source-control independent.
+Neither contract contains a repository, provider, branch, commit, pull request,
+or editor identity, and immutable bytes live in Mozaiks artifact/content
+storage. A workspace may be materialized locally or containerized without Git.
+Optional Git synchronization is a downstream export/projection of an accepted
+`ArtifactRevision`; externally changed source must re-enter as candidate content
+and pass validation plus revision creation before publication. A Git commit is
+never the canonical Mozaiks CURRENT authority.
 
 ## RefinementPatchRef
 
@@ -956,7 +976,7 @@ compiler may reference or consume it but does not become its source of truth.
 | `save_app_schema.py` hand validators | Parallel page/manifest validation | **replaced** | Collapse onto runtime models once the renderer path lands. |
 | Control-plane glob taxonomies (`refinement_router.py`, `dry_run.py`, `promotion_policy.py`, `validation_runner.py`) | Path→family inference | **replaced** | Graph-region queries over the renderer registry. |
 | `AppContextGraph` / `AppContextVersion` | Observed/indexed artifact view | separate authority, retained | Gains `semantic_graph_ref` sibling; stays downstream. |
-| `mozaiksai/core/artifacts/store.py` (`BuildRecordStore`) + `mozaiksai/control_plane/artifact_promotion.py` | Build records, lineage, promotion evidence | retained, extended | `ArtifactRevision` binds to existing lineage; revisions record graph/plan/binding digests; one current-manifest CAS publishes or rolls back a consistent graph/revision pair. |
+| `mozaiksai/core/artifacts/store.py` (`BuildRecordStore`) + `mozaiksai/control_plane/artifact_promotion.py` | Current production build records, lineage, and promotion evidence | retained through offline Slice 5C; app-bundle publication authority replaced at Slice 5D | Slice 5C adds immutable `ArtifactRevision` closure and isolated `ApplicationPublication` CAS without production importers. Slice 5D rewires app publication, makes AppContext a derived revision-keyed projection, and deletes the old app-bundle CURRENT/fallback paths atomically. |
 | `mozaiksai/core/data/persistence/artifact_store.py` (`BuilderArtifactStore`) | Typed builder artifact collections | direction decided at slice 5 | Becomes a projection of graph/artifact records or a typed view; no dual authority retained. |
 | Validation and acceptance gates (`app_validation.py`, `validation_runner.py`, bundle scanner) | Deterministic artifact validation | retained | Consume registry/graph instead of private path predicates. |
 | `factory_app/eval/` | Deterministic bundle scoring | separate authority, retained | Scores rendered output; gains archetype-corpus equivalence fixtures. |
@@ -1052,8 +1072,8 @@ journey capability.
 | **3E. Fresh-main graph-v2 projection evolution** — after the independently reviewed Slice 3 change lands, evolve its offline adapters to emit typed payload documents and graph-v2 refs | No authority change; current stage outputs and `AppBuildPlan` remain comparison inputs | Every prior typed gap is either represented by a strict payload variant or remains an explicit blocking gap; graph/payload closure and re-extraction equivalence across the corpus | Do not branch from the unmerged Slice 3 PR. Rollback: delete the graph-v2 adapter evolution. No live models or ADR 0006 interaction. |
 | **4B. Aggregate CompilationPlan derivation** — derive one aggregate plan containing non-authoritative artifact-family-instance subplans; project assignments and task-batch inputs from it | No production authority change: agent-produced `AppBuildPlan` remains current and the aggregate plan is offline-only | Complete family dispositions; derived-vs-produced plan equivalence; global DAG and path ownership; stable aggregate and family digests; partial regeneration/reuse closure; proof that family plans cannot resolve or execute independently and binding cannot widen graph semantics | Begin identifying plan mirrors and dead converter normalizers for cutover, but delete no active authority. Rollback: delete the candidate plan path. No live models, capability advertisement, or ADR 0006 dependency. |
 | **4C. Offline deterministic renderer equivalence** — bind graph-v2 payloads and aggregate-plan family instances to registry renderers; AgentGenerator regains a renderer layer | No production authority change; candidate renderers run only against offline corpus fixtures and never beside a live build | Stable renderer order; byte-identical child contracts; loader/validator and route/component/action closure; AppGenerator and AgentGenerator equivalence; changed semantic closure changes only affected families | Retain current generation and promotion. Rollback: delete candidate renderers and comparison flag. No live models, capability advertisement, or ADR 0006 dependency. |
-| **5. Authority cutover, strict outputs, persistence unification** — compiled models `extra="forbid"` by default; agents emit graph-node payloads validated against runtime models; graph version + build record become the persistence spine; `BuilderArtifactStore` becomes a projection or typed view; current-manifest CAS becomes publication authority | Agent-produced plan and four representations → one authored graph, derived binding/plan, rendered views, and one published graph/revision pair in a single cutover | Offline corpus regeneration equivalence; strictness report published **before** the flip; route/component/action closure; data-reference consumer tests through a test/development-only comparison window; fault injection at every graph/revision/manifest persistence boundary proves publish-all-or-neither and idempotent retry | Retire generator YAML mirrors, `AppBuildPlan`, and `save_app_schema` parallel validators on proof. Truthfully advertise `semantic_taxonomy_v1` and `semantic_reference_contracts_v1` together only after the cutover proof. Rollback blocks bounded starts; the per-workflow test/development flag exists only until cutover completes, then is removed. No production dual-read/dual-authority mode. Live-model builds only after offline proof and only under ADR 0006 bounded journeys. |
-| **6. Refinement on the graph** — typed, content-identified `RefinementPatch`; checkpoint output schemas re-typed; affected set = graph query; recompile → validate → CAS-promote | Whole-file patching + glob safety → typed patches + registry regions | Patch property tests (apply+recompile == direct compile); duplicate retry/idempotency and patch-id/content-conflict tests; two-writer stale-base race matrix; promotion parity; failure-injected paired publication; rollback rehearsal through the current-manifest CAS | Retire the four glob taxonomies and `_stale_route` staleness substitution after parity proof. Rollback selects a prior consistent manifest/graph/revision tuple. No live models beyond slice 5 policy. Uses ADR 0006 counters for repair/refinement starts when bounded. |
+| **5. Authority cutover, strict outputs, persistence unification** — compiled models `extra="forbid"` by default; agents emit graph-node payloads validated against runtime models; graph + immutable artifact revision become the persistence spine; `BuilderArtifactStore` becomes a projection or typed view; `ApplicationPublication` CAS becomes publication authority | Agent-produced plan and four representations → one authored graph, derived binding/plan, rendered views, and one published graph/revision pair in a single cutover | Offline corpus regeneration equivalence; strictness report published **before** the flip; route/component/action closure; data-reference consumer tests through a test/development-only comparison window; fault injection at every graph/revision/publication persistence boundary proves publish-all-or-neither and idempotent retry | Retire generator YAML mirrors, `AppBuildPlan`, and `save_app_schema` parallel validators on proof. Truthfully advertise `semantic_taxonomy_v1` and `semantic_reference_contracts_v1` together only after the cutover proof. Rollback blocks bounded starts; the per-workflow test/development flag exists only until cutover completes, then is removed. No production dual-read/dual-authority mode. Live-model builds only after offline proof and only under ADR 0006 bounded journeys. |
+| **6. Refinement on the graph** — typed, content-identified `RefinementPatch`; checkpoint output schemas re-typed; affected set = graph query; recompile → validate → CAS-promote | Whole-file patching + glob safety → typed patches + registry regions | Patch property tests (apply+recompile == direct compile); duplicate retry/idempotency and patch-id/content-conflict tests; two-writer stale-base race matrix; promotion parity; failure-injected publication; rollback rehearsal through `ApplicationPublication` CAS | Retire the four glob taxonomies and `_stale_route` staleness substitution after parity proof. Rollback selects a prior consistent graph/revision closure. No live models beyond slice 5 policy. Uses ADR 0006 counters for repair/refinement starts when bounded. |
 | **7. Retirement** — remove obsolete schemas, glob taxonomies, aliases, converter paths, transitional adapters, comparison fixtures, and development flags | One semantic authority; one registry per concern | Repository hygiene guard extended to ban retired names (pattern: `scripts/production_readiness_gate.py`); full suite; generated-app acceptance | Deletions complete. Rollback: deployment rollback before deletion only; no dual-read shim reintroduced. No live-model change. ADR 0006 slice interleaving agreed before this point. |
 
 ## Acceptance Criteria For Implementation

--- a/mozaiksai/core/artifacts/__init__.py
+++ b/mozaiksai/core/artifacts/__init__.py
@@ -1,6 +1,7 @@
 from .content_store import (
     ArtifactContentStore,
     BundleContentStore,
+    ContentIntegrityError,
     ContentNotFoundError,
     GridFSArtifactContentStore,
     GridFSBundleContentStore,
@@ -47,6 +48,7 @@ __all__ = [
     "get_bundle_content_store",
     # Content store — prior-api names
     "ArtifactContentStore",
+    "ContentIntegrityError",
     "ContentNotFoundError",
     "GridFSArtifactContentStore",
     "LocalArtifactContentStore",

--- a/mozaiksai/core/artifacts/content_store.py
+++ b/mozaiksai/core/artifacts/content_store.py
@@ -4,14 +4,33 @@ import hashlib
 import io
 import logging
 import os
+import re
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
 
 class ContentNotFoundError(Exception):
     """Raised when a content_ref does not resolve to stored content."""
+
+
+class ContentIntegrityError(ValueError):
+    """Raised when immutable content does not match its claimed digest."""
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _verified_blob_digest(data: bytes, expected_digest: str) -> str:
+    digest = str(expected_digest or "")
+    if _SHA256.fullmatch(digest) is None:
+        raise ContentIntegrityError("expected_digest must be a lowercase SHA-256 digest")
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != digest:
+        raise ContentIntegrityError("exact blob bytes do not match expected_digest")
+    return digest
 
 
 @runtime_checkable
@@ -51,6 +70,18 @@ class ArtifactContentStore(Protocol):
         Returns ``True`` if content was found and deleted, ``False`` if it
         did not exist.  Never raises on a missing ref.
         """
+        ...
+
+    async def put_blob(self, data: bytes, *, expected_digest: str) -> str:
+        """Idempotently persist exact immutable bytes under their SHA-256 identity."""
+        ...
+
+    async def get_verified_blob(self, content_digest: str) -> bytes:
+        """Return exact bytes only after recomputing their content digest."""
+        ...
+
+    async def has_verified_blob(self, content_digest: str) -> bool:
+        """Return whether an exact, digest-verified immutable blob exists."""
         ...
 
 
@@ -105,6 +136,47 @@ class LocalArtifactContentStore:
         if not path.exists():
             return False
         path.unlink()
+        return True
+
+    def _blob_path(self, content_digest: str) -> Path:
+        digest = str(content_digest or "")
+        if _SHA256.fullmatch(digest) is None:
+            raise ContentIntegrityError("content_digest must be a lowercase SHA-256 digest")
+        return self._root / "sha256" / digest[:2] / digest
+
+    async def put_blob(self, data: bytes, *, expected_digest: str) -> str:
+        digest = _verified_blob_digest(data, expected_digest)
+        destination = self._blob_path(digest)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.parent / f".{digest}.{uuid4().hex}.tmp"
+        temporary.write_bytes(data)
+        try:
+            try:
+                os.link(temporary, destination)
+            except FileExistsError:
+                existing = destination.read_bytes()
+                _verified_blob_digest(existing, digest)
+                if existing != data:
+                    raise ContentIntegrityError(
+                        "immutable blob identity resolved to different exact bytes"
+                    ) from None
+        finally:
+            temporary.unlink(missing_ok=True)
+        return digest
+
+    async def get_verified_blob(self, content_digest: str) -> bytes:
+        path = self._blob_path(content_digest)
+        if not path.is_file():
+            raise ContentNotFoundError(f"Immutable blob not found: {content_digest!r}")
+        data = path.read_bytes()
+        _verified_blob_digest(data, content_digest)
+        return cast(bytes, data)
+
+    async def has_verified_blob(self, content_digest: str) -> bool:
+        try:
+            await self.get_verified_blob(content_digest)
+        except ContentNotFoundError:
+            return False
         return True
 
 
@@ -217,6 +289,49 @@ class GridFSArtifactContentStore:
             )
             return False
 
+    async def put_blob(self, data: bytes, *, expected_digest: str) -> str:
+        from pymongo.errors import DuplicateKeyError
+
+        digest = _verified_blob_digest(data, expected_digest)
+        fs = await self._ensure_fs()
+        try:
+            await fs.upload_from_stream_with_id(
+                digest,
+                digest,
+                io.BytesIO(data),
+                metadata={"content_digest": digest, "immutable": True},
+            )
+        except DuplicateKeyError:
+            existing = await self.get_verified_blob(digest)
+            if existing != data:
+                raise ContentIntegrityError(
+                    "immutable GridFS blob identity resolved to different exact bytes"
+                ) from None
+        return digest
+
+    async def get_verified_blob(self, content_digest: str) -> bytes:
+        from gridfs.errors import NoFile  # type: ignore[import]
+
+        if _SHA256.fullmatch(str(content_digest or "")) is None:
+            raise ContentIntegrityError("content_digest must be a lowercase SHA-256 digest")
+        fs = await self._ensure_fs()
+        try:
+            grid_out = await fs.open_download_stream(content_digest)
+            data = await grid_out.read()
+        except NoFile as exc:
+            raise ContentNotFoundError(
+                f"Immutable GridFS blob not found: {content_digest!r}"
+            ) from exc
+        _verified_blob_digest(data, content_digest)
+        return cast(bytes, data)
+
+    async def has_verified_blob(self, content_digest: str) -> bool:
+        try:
+            await self.get_verified_blob(content_digest)
+        except ContentNotFoundError:
+            return False
+        return True
+
 
 _CONTENT_BACKEND_ENV_VAR = "MOZAIKS_ARTIFACT_CONTENT_BACKEND"
 _BUNDLE_CONTENT_BACKEND_ENV_VAR = "MOZAIKS_BUNDLE_CONTENT_BACKEND"
@@ -274,6 +389,7 @@ GridFSBundleContentStore = GridFSArtifactContentStore
 
 
 __all__ = [
+    "ContentIntegrityError",
     "ContentNotFoundError",
     "ArtifactContentStore",
     "LocalArtifactContentStore",

--- a/mozaiksai/core/artifacts/revision_store.py
+++ b/mozaiksai/core/artifacts/revision_store.py
@@ -1,0 +1,721 @@
+"""Offline immutable revision persistence and generation-guarded publication CAS."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from mozaiksai.core.artifacts.content_store import ArtifactContentStore
+from mozaiksai.core.core_config import get_mongo_client
+from mozaiksai.core.semantics.artifact_revision import (
+    ApplicationPublication,
+    ArtifactRevision,
+    ArtifactRevisionValidationEvidence,
+    PublicationOutcome,
+    PublicationResult,
+    validate_artifact_revision_validation_evidence,
+)
+from mozaiksai.core.semantics.binding import ImplementationBinding
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import CompilationPlan
+from mozaiksai.core.semantics.composition_ledger import (
+    AccountedArtifact,
+    CanonicalComposedBundle,
+    ComposedArtifactContent,
+    CompositionLedger,
+)
+from mozaiksai.core.semantics.graph import SemanticGraph, SemanticGraphV2
+from mozaiksai.core.semantics.refs import (
+    ArtifactRevisionRef,
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+)
+from mozaiksai.core.semantics.resolver import (
+    ReferenceResolutionError,
+    SemanticReferenceResolver,
+)
+from mozaiksai.core.workflow.assignment_artifacts import AssignmentArtifactResult
+
+_DATABASE = "mozaiksai"
+_REVISIONS = "ArtifactRevisionsV1"
+_EVIDENCE = "ArtifactRevisionEvidenceV1"
+_ASSIGNMENT_RESULTS = "AssignmentArtifactResultsV1"
+_LEDGERS = "CompositionLedgersV1"
+_PUBLICATIONS = "ApplicationPublicationsV1"
+
+
+def _address_key(item: AccountedArtifact) -> tuple[str, tuple[tuple[str, str], ...], str]:
+    address = item.address
+    return (address.path_scope.value, address.placeholder_values, address.path)
+
+
+class RevisionStoreError(RuntimeError):
+    """Base failure for the offline revision/publication substrate."""
+
+
+class RevisionIntegrityError(RevisionStoreError):
+    """Stored immutable content or its referenced closure failed verification."""
+
+
+class RevisionNotFoundError(RevisionStoreError):
+    """An exact immutable revision/ref document was not found."""
+
+
+class PublicationConflictError(RevisionStoreError):
+    """CURRENT changed since the caller observed its expected publication state."""
+
+    def __init__(self, publication: ApplicationPublication) -> None:
+        super().__init__(
+            "publication compare-and-swap conflict: CURRENT no longer matches "
+            "the expected revision and generation"
+        )
+        self.publication = publication
+
+
+def _scope_key(scope: ExecutionAccessScopeRef) -> str:
+    return cast(str, canonical_digest(scope.model_dump(mode="json")))
+
+
+def _plan_ref(plan: CompilationPlan) -> CompilationPlanRef:
+    return CompilationPlanRef(
+        subject_id=plan.graph_id,
+        subject_version=plan.graph_version,
+        content_digest=plan.plan_digest,
+        scope=plan.scope,
+    )
+
+
+def _document_id(collection: str, *, scope_key: str, app_id: str, digest: str) -> str:
+    return cast(
+        str,
+        canonical_digest(
+            {
+                "collection": collection,
+                "scope_key": scope_key,
+                "app_id": app_id,
+                "digest": digest,
+            },
+        ),
+    )
+
+
+class ArtifactRevisionStore:
+    """Canonical 5C owner for immutable revision closure and CURRENT pointer CAS.
+
+    This class is intentionally not imported by Factory, Studio, BuildRecord,
+    AppContext, task-batch, or AG2 production paths until Slice 5D.
+    """
+
+    def __init__(
+        self,
+        *,
+        content_store: ArtifactContentStore,
+        semantic_resolver: SemanticReferenceResolver,
+        client: Any | None = None,
+    ) -> None:
+        self._content_store = content_store
+        self._semantic_resolver = semantic_resolver
+        self._client = client
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Declare and verify every immutable/CURRENT uniqueness contract."""
+
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            if self._client is None:
+                self._client = get_mongo_client()
+            database = self._client[_DATABASE]
+            await self._ensure_index(
+                database[_REVISIONS],
+                (("scope_key", 1), ("app_id", 1), ("revision_digest", 1)),
+                name="artifact_revision_scope_app_digest",
+                unique=True,
+            )
+            await self._ensure_index(
+                database[_EVIDENCE],
+                (("scope_key", 1), ("app_id", 1), ("evidence_digest", 1)),
+                name="artifact_revision_evidence_scope_app_digest",
+                unique=True,
+            )
+            await self._ensure_index(
+                database[_ASSIGNMENT_RESULTS],
+                (("scope_key", 1), ("app_id", 1), ("result_digest", 1)),
+                name="assignment_result_scope_app_digest",
+                unique=True,
+            )
+            await self._ensure_index(
+                database[_LEDGERS],
+                (("scope_key", 1), ("app_id", 1), ("ledger_digest", 1)),
+                name="composition_ledger_scope_app_digest",
+                unique=True,
+            )
+            await self._ensure_index(
+                database[_PUBLICATIONS],
+                (("scope_key", 1), ("app_id", 1)),
+                name="application_publication_scope_app",
+                unique=True,
+            )
+            self._initialized = True
+
+    @staticmethod
+    async def _ensure_index(
+        collection: Any,
+        keys: tuple[tuple[str, int], ...],
+        *,
+        name: str,
+        unique: bool,
+    ) -> None:
+        await collection.create_index(list(keys), name=name, unique=unique)
+        information = await collection.index_information()
+        declared = information.get(name)
+        if declared is None:
+            raise RevisionStoreError(f"required index {name!r} was not materialized")
+        actual_keys = tuple(tuple(item) for item in declared.get("key", ()))
+        if actual_keys != keys or bool(declared.get("unique", False)) is not unique:
+            raise RevisionStoreError(f"required index {name!r} failed exact verification")
+
+    async def _collection(self, name: str) -> Any:
+        await self.initialize()
+        if self._client is None:
+            raise RevisionStoreError("revision store client failed initialization")
+        return self._client[_DATABASE][name]
+
+    async def persist_revision_closure(
+        self,
+        *,
+        bundle: CanonicalComposedBundle,
+        assignment_results: Sequence[AssignmentArtifactResult],
+        evidence: ArtifactRevisionValidationEvidence,
+        revision: ArtifactRevision,
+    ) -> ArtifactRevisionRef:
+        """Persist exact bytes and immutable documents, then cold-verify the closure."""
+
+        verified_revision = ArtifactRevision.model_validate(revision.model_dump(mode="json"))
+        plan, ledger, verified_results = self._validate_candidate_closure(
+            bundle=bundle,
+            assignment_results=assignment_results,
+            evidence=evidence,
+            revision=verified_revision,
+        )
+
+        for artifact in bundle.artifacts:
+            await self._content_store.put_blob(
+                artifact.content, expected_digest=artifact.content_digest
+            )
+
+        scope_key = _scope_key(verified_revision.scope)
+        for result in verified_results:
+            await self._put_immutable(
+                collection_name=_ASSIGNMENT_RESULTS,
+                scope=verified_revision.scope,
+                scope_key=scope_key,
+                app_id=verified_revision.app_id,
+                digest_field="result_digest",
+                digest=result.result_digest,
+                document=result.model_dump(mode="json"),
+            )
+        await self._put_immutable(
+            collection_name=_LEDGERS,
+            scope=verified_revision.scope,
+            scope_key=scope_key,
+            app_id=verified_revision.app_id,
+            digest_field="ledger_digest",
+            digest=ledger.ledger_digest,
+            document=ledger.model_dump(mode="json"),
+        )
+        await self._put_immutable(
+            collection_name=_EVIDENCE,
+            scope=verified_revision.scope,
+            scope_key=scope_key,
+            app_id=verified_revision.app_id,
+            digest_field="evidence_digest",
+            digest=evidence.evidence_digest,
+            document=evidence.model_dump(mode="json"),
+        )
+        await self._put_immutable(
+            collection_name=_REVISIONS,
+            scope=verified_revision.scope,
+            scope_key=scope_key,
+            app_id=verified_revision.app_id,
+            digest_field="revision_digest",
+            digest=verified_revision.revision_digest,
+            document=verified_revision.model_dump(mode="json"),
+        )
+        del plan
+        await self.resolve_revision(verified_revision.ref, requesting_scope=verified_revision.scope)
+        return cast(ArtifactRevisionRef, verified_revision.ref)
+
+    async def _put_immutable(
+        self,
+        *,
+        collection_name: str,
+        scope: ExecutionAccessScopeRef,
+        scope_key: str,
+        app_id: str,
+        digest_field: str,
+        digest: str,
+        document: Mapping[str, Any],
+    ) -> None:
+        collection = await self._collection(collection_name)
+        envelope = {
+            "_id": _document_id(collection_name, scope_key=scope_key, app_id=app_id, digest=digest),
+            "scope_key": scope_key,
+            "scope": scope.model_dump(mode="json"),
+            "app_id": app_id,
+            digest_field: digest,
+            "document": dict(document),
+        }
+        try:
+            await collection.insert_one(envelope)
+        except DuplicateKeyError:
+            existing = await collection.find_one({"_id": envelope["_id"]})
+            if existing is None or existing.get("document") != envelope["document"]:
+                raise RevisionIntegrityError(
+                    f"immutable {collection_name} identity resolved to different content"
+                ) from None
+
+    def _validate_candidate_closure(
+        self,
+        *,
+        bundle: CanonicalComposedBundle,
+        assignment_results: Sequence[AssignmentArtifactResult],
+        evidence: ArtifactRevisionValidationEvidence,
+        revision: ArtifactRevision,
+    ) -> tuple[
+        CompilationPlan,
+        CompositionLedger,
+        tuple[AssignmentArtifactResult, ...],
+    ]:
+        if bundle.ledger != CompositionLedger.model_validate(bundle.ledger.model_dump(mode="json")):
+            raise RevisionIntegrityError("canonical bundle ledger failed cold validation")
+        ledger = bundle.ledger
+        if revision.composition_ledger_digest != ledger.ledger_digest:
+            raise RevisionIntegrityError("revision does not bind the composition ledger")
+        if revision.bundle_digest != ledger.bundle_digest:
+            raise RevisionIntegrityError("revision does not bind the final bundle digest")
+        if revision.compilation_plan_ref != ledger.compilation_plan_ref:
+            raise RevisionIntegrityError("revision and ledger bind different CompilationPlans")
+        if bundle.plan_digest != revision.compilation_plan_ref.content_digest:
+            raise RevisionIntegrityError("canonical bundle belongs to another CompilationPlan")
+
+        plan = self._resolve_semantic_authority(revision)
+        if _plan_ref(plan) != revision.compilation_plan_ref:
+            raise RevisionIntegrityError("resolved CompilationPlan identity mismatch")
+        verified_results = tuple(
+            AssignmentArtifactResult.model_validate(item.model_dump(mode="json"))
+            for item in assignment_results
+        )
+        validate_artifact_revision_validation_evidence(
+            evidence=evidence,
+            plan=plan,
+            ledger=ledger,
+            assignment_results=verified_results,
+        )
+        if evidence.scope != revision.scope or evidence.app_id != revision.app_id:
+            raise RevisionIntegrityError("validation evidence belongs to another scope or app")
+        if revision.validation_evidence_digest != evidence.evidence_digest:
+            raise RevisionIntegrityError("revision does not bind validation evidence")
+
+        expected_base = (
+            None
+            if revision.parent_revision_ref is None
+            else revision.parent_revision_ref.revision_digest
+        )
+        if ledger.base_revision_digest != expected_base:
+            raise RevisionIntegrityError("ledger base revision does not match revision parent")
+
+        manifest = tuple(
+            AccountedArtifact(address=item.address, content_digest=item.content_digest)
+            for item in bundle.artifacts
+        )
+        if tuple(sorted(manifest, key=_address_key)) != tuple(
+            sorted(ledger.final_bundle_manifest, key=_address_key)
+        ):
+            raise RevisionIntegrityError("bundle bytes do not exactly match ledger manifest")
+        by_address = {item.address: item for item in bundle.artifacts}
+        if len(by_address) != len(bundle.artifacts):
+            raise RevisionIntegrityError("canonical bundle contains duplicate artifact addresses")
+        for entry in ledger.unit_entries:
+            for artifact in entry.artifacts:
+                if artifact.content_digest is None:
+                    continue
+                content = by_address.get(artifact.address)
+                if content is None or content.unit_id != entry.plan_unit_ref.unit_id:
+                    raise RevisionIntegrityError(
+                        "canonical bundle bytes do not match ledger unit provenance"
+                    )
+        return plan, ledger, verified_results
+
+    def _resolve_semantic_authority(self, revision: ArtifactRevision) -> CompilationPlan:
+        try:
+            graph = self._semantic_resolver.resolve(
+                revision.semantic_graph_ref, requesting_scope=revision.scope
+            )
+            binding = self._semantic_resolver.resolve(
+                revision.implementation_binding_ref, requesting_scope=revision.scope
+            )
+            plan = self._semantic_resolver.resolve(
+                revision.compilation_plan_ref, requesting_scope=revision.scope
+            )
+        except ReferenceResolutionError as exc:
+            raise RevisionIntegrityError(
+                f"artifact revision semantic authority failed cold resolution: {exc}"
+            ) from exc
+        if not isinstance(graph, (SemanticGraph, SemanticGraphV2)):
+            raise RevisionIntegrityError("SemanticGraphRef did not resolve to a graph")
+        if not isinstance(binding, ImplementationBinding):
+            raise RevisionIntegrityError("ImplementationBindingRef did not resolve to a binding")
+        if not isinstance(plan, CompilationPlan):
+            raise RevisionIntegrityError("CompilationPlanRef did not resolve to a plan")
+        if binding.semantic_graph_ref != revision.semantic_graph_ref:
+            raise RevisionIntegrityError("ImplementationBinding targets another graph")
+        if (
+            plan.graph_id != revision.semantic_graph_ref.subject_id
+            or plan.graph_version != revision.semantic_graph_ref.subject_version
+            or plan.graph_digest != revision.semantic_graph_ref.content_digest
+            or plan.scope != revision.scope
+        ):
+            raise RevisionIntegrityError("CompilationPlan targets another graph")
+        return plan
+
+    async def resolve_revision(
+        self,
+        ref: ArtifactRevisionRef,
+        *,
+        requesting_scope: ExecutionAccessScopeRef,
+    ) -> ArtifactRevision:
+        """Cold-resolve and verify one exact revision including immutable bytes."""
+
+        revision, _bundle = await self._resolve_revision_and_bundle(
+            ref, requesting_scope=requesting_scope, seen=frozenset()
+        )
+        return revision
+
+    async def restore_revision(
+        self,
+        ref: ArtifactRevisionRef,
+        *,
+        requesting_scope: ExecutionAccessScopeRef,
+    ) -> CanonicalComposedBundle:
+        """Restore exact verified bytes; mutable filesystem paths are never consulted."""
+
+        _revision, bundle = await self._resolve_revision_and_bundle(
+            ref, requesting_scope=requesting_scope, seen=frozenset()
+        )
+        return bundle
+
+    async def _resolve_revision_and_bundle(
+        self,
+        ref: ArtifactRevisionRef,
+        *,
+        requesting_scope: ExecutionAccessScopeRef,
+        seen: frozenset[str],
+    ) -> tuple[ArtifactRevision, CanonicalComposedBundle]:
+        verified_ref = ArtifactRevisionRef.model_validate(ref.model_dump(mode="json"))
+        if requesting_scope != verified_ref.scope:
+            raise RevisionIntegrityError("cross-scope artifact revision access fails closed")
+        if verified_ref.revision_digest in seen:
+            raise RevisionIntegrityError("artifact revision lineage contains a cycle")
+        revision_document = await self._get_document(
+            collection_name=_REVISIONS,
+            scope=verified_ref.scope,
+            app_id=verified_ref.app_id,
+            digest_field="revision_digest",
+            digest=verified_ref.revision_digest,
+        )
+        try:
+            revision = ArtifactRevision.model_validate(revision_document)
+        except (TypeError, ValueError) as exc:
+            raise RevisionIntegrityError(
+                f"stored ArtifactRevision failed cold validation: {exc}"
+            ) from exc
+        if revision.ref != verified_ref:
+            raise RevisionIntegrityError("stored ArtifactRevision does not match its ref")
+        plan = self._resolve_semantic_authority(revision)
+
+        ledger_document = await self._get_document(
+            collection_name=_LEDGERS,
+            scope=revision.scope,
+            app_id=revision.app_id,
+            digest_field="ledger_digest",
+            digest=revision.composition_ledger_digest,
+        )
+        evidence_document = await self._get_document(
+            collection_name=_EVIDENCE,
+            scope=revision.scope,
+            app_id=revision.app_id,
+            digest_field="evidence_digest",
+            digest=revision.validation_evidence_digest,
+        )
+        try:
+            ledger = CompositionLedger.model_validate(ledger_document)
+            evidence = ArtifactRevisionValidationEvidence.model_validate(evidence_document)
+        except (TypeError, ValueError) as exc:
+            raise RevisionIntegrityError(
+                f"stored revision closure failed cold validation: {exc}"
+            ) from exc
+        if ledger.compilation_plan_ref != revision.compilation_plan_ref:
+            raise RevisionIntegrityError("stored ledger belongs to another CompilationPlan")
+        if ledger.bundle_digest != revision.bundle_digest:
+            raise RevisionIntegrityError("stored ledger has a stale bundle digest")
+
+        results: list[AssignmentArtifactResult] = []
+        for digest in evidence.assignment_result_digests:
+            document = await self._get_document(
+                collection_name=_ASSIGNMENT_RESULTS,
+                scope=revision.scope,
+                app_id=revision.app_id,
+                digest_field="result_digest",
+                digest=digest,
+            )
+            try:
+                results.append(AssignmentArtifactResult.model_validate(document))
+            except (TypeError, ValueError) as exc:
+                raise RevisionIntegrityError(
+                    f"stored assignment result failed cold validation: {exc}"
+                ) from exc
+        validate_artifact_revision_validation_evidence(
+            evidence=evidence,
+            plan=plan,
+            ledger=ledger,
+            assignment_results=results,
+        )
+
+        if revision.parent_revision_ref is None:
+            if ledger.base_revision_digest is not None:
+                raise RevisionIntegrityError("Genesis revision cannot have a base digest")
+        else:
+            if ledger.base_revision_digest != revision.parent_revision_ref.revision_digest:
+                raise RevisionIntegrityError("refinement ledger base does not match parent")
+            await self._resolve_revision_and_bundle(
+                revision.parent_revision_ref,
+                requesting_scope=requesting_scope,
+                seen=seen | {revision.revision_digest},
+            )
+
+        unit_by_address: dict[Any, str] = {}
+        for entry in ledger.unit_entries:
+            for artifact in entry.artifacts:
+                if artifact.content_digest is not None:
+                    if artifact.address in unit_by_address:
+                        raise RevisionIntegrityError("ledger contains duplicate artifact ownership")
+                    unit_by_address[artifact.address] = entry.plan_unit_ref.unit_id
+        artifacts: list[ComposedArtifactContent] = []
+        for item in ledger.final_bundle_manifest:
+            if item.content_digest is None:
+                raise RevisionIntegrityError("final manifest is missing content identity")
+            unit_id = unit_by_address.get(item.address)
+            if unit_id is None:
+                raise RevisionIntegrityError("final manifest artifact has no unit provenance")
+            content = await self._content_store.get_verified_blob(item.content_digest)
+            artifacts.append(
+                ComposedArtifactContent(
+                    unit_id=unit_id,
+                    address=item.address,
+                    content=content,
+                    content_digest=item.content_digest,
+                )
+            )
+        bundle = CanonicalComposedBundle(
+            plan_digest=plan.plan_digest,
+            artifacts=tuple(artifacts),
+            ledger=ledger,
+        )
+        self._validate_candidate_closure(
+            bundle=bundle,
+            assignment_results=results,
+            evidence=evidence,
+            revision=revision,
+        )
+        return revision, bundle
+
+    async def _get_document(
+        self,
+        *,
+        collection_name: str,
+        scope: ExecutionAccessScopeRef,
+        app_id: str,
+        digest_field: str,
+        digest: str,
+    ) -> Mapping[str, Any]:
+        scope_key = _scope_key(scope)
+        collection = await self._collection(collection_name)
+        document = await collection.find_one(
+            {
+                "scope_key": scope_key,
+                "scope": scope.model_dump(mode="json"),
+                "app_id": app_id,
+                digest_field: digest,
+            }
+        )
+        if document is None:
+            raise RevisionNotFoundError(
+                f"no exact {collection_name} document for the requested scope/app/digest"
+            )
+        payload = document.get("document")
+        if not isinstance(payload, Mapping):
+            raise RevisionIntegrityError(
+                f"stored {collection_name} document has no canonical payload"
+            )
+        return payload
+
+    async def get_publication(
+        self, *, scope: ExecutionAccessScopeRef, app_id: str
+    ) -> ApplicationPublication | None:
+        collection = await self._collection(_PUBLICATIONS)
+        document = await collection.find_one(
+            {
+                "scope_key": _scope_key(scope),
+                "scope": scope.model_dump(mode="json"),
+                "app_id": app_id,
+            }
+        )
+        if document is None:
+            return None
+        return self._parse_publication(document)
+
+    async def _ensure_publication(
+        self, *, scope: ExecutionAccessScopeRef, app_id: str
+    ) -> ApplicationPublication:
+        existing = await self.get_publication(scope=scope, app_id=app_id)
+        if existing is not None:
+            return existing
+        publication = ApplicationPublication(
+            scope=scope,
+            app_id=app_id,
+            current_revision_ref=None,
+            generation=0,
+        )
+        document = {
+            "_id": canonical_digest(
+                {
+                    "publication_schema_version": publication.publication_schema_version,
+                    "scope": scope.model_dump(mode="json"),
+                    "app_id": app_id,
+                }
+            ),
+            "scope_key": _scope_key(scope),
+            **publication.model_dump(mode="json"),
+        }
+        collection = await self._collection(_PUBLICATIONS)
+        try:
+            await collection.insert_one(document)
+            return publication
+        except DuplicateKeyError:
+            concurrent = await self.get_publication(scope=scope, app_id=app_id)
+            if concurrent is None:
+                raise RevisionIntegrityError(
+                    "publication uniqueness conflict did not resolve to one canonical row"
+                ) from None
+            return concurrent
+
+    @staticmethod
+    def _parse_publication(document: Mapping[str, Any]) -> ApplicationPublication:
+        payload = {
+            key: value
+            for key, value in document.items()
+            if key
+            in {
+                "publication_schema_version",
+                "scope",
+                "app_id",
+                "current_revision_ref",
+                "generation",
+            }
+        }
+        try:
+            return cast(ApplicationPublication, ApplicationPublication.model_validate(payload))
+        except (TypeError, ValueError) as exc:
+            raise RevisionIntegrityError(
+                f"stored ApplicationPublication failed cold validation: {exc}"
+            ) from exc
+
+    async def promote_revision(
+        self,
+        *,
+        scope: ExecutionAccessScopeRef,
+        app_id: str,
+        expected_current_revision_ref: ArtifactRevisionRef | None,
+        expected_generation: int,
+        new_revision_ref: ArtifactRevisionRef,
+    ) -> PublicationResult:
+        """Atomically select CURRENT using the backend's conditional-update primitive."""
+
+        if expected_generation < 0:
+            raise ValueError("expected_generation must be non-negative")
+        if new_revision_ref.scope != scope or new_revision_ref.app_id != app_id:
+            raise RevisionIntegrityError("new revision belongs to another scope or app")
+        if expected_current_revision_ref is not None and (
+            expected_current_revision_ref.scope != scope
+            or expected_current_revision_ref.app_id != app_id
+        ):
+            raise RevisionIntegrityError("expected CURRENT belongs to another scope or app")
+        new_revision = await self.resolve_revision(new_revision_ref, requesting_scope=scope)
+        if new_revision.parent_revision_ref != expected_current_revision_ref:
+            raise RevisionIntegrityError(
+                "new revision parent does not equal expected CURRENT revision"
+            )
+
+        current = await self._ensure_publication(scope=scope, app_id=app_id)
+        if current.current_revision_ref == new_revision_ref:
+            return PublicationResult(
+                outcome=PublicationOutcome.ALREADY_CURRENT, publication=current
+            )
+
+        collection = await self._collection(_PUBLICATIONS)
+        updated = await collection.find_one_and_update(
+            {
+                "scope_key": _scope_key(scope),
+                "scope": scope.model_dump(mode="json"),
+                "app_id": app_id,
+                "generation": expected_generation,
+                "current_revision_ref": (
+                    None
+                    if expected_current_revision_ref is None
+                    else expected_current_revision_ref.model_dump(mode="json")
+                ),
+            },
+            {
+                "$set": {"current_revision_ref": new_revision_ref.model_dump(mode="json")},
+                "$inc": {"generation": 1},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if updated is not None:
+            return PublicationResult(
+                outcome=PublicationOutcome.PROMOTED,
+                publication=self._parse_publication(updated),
+            )
+
+        actual = await self.get_publication(scope=scope, app_id=app_id)
+        if actual is None:
+            raise RevisionIntegrityError("canonical publication row disappeared during CAS")
+        if actual.current_revision_ref == new_revision_ref:
+            return PublicationResult(outcome=PublicationOutcome.ALREADY_CURRENT, publication=actual)
+        raise PublicationConflictError(actual)
+
+    async def resolve_current_revision(
+        self, *, scope: ExecutionAccessScopeRef, app_id: str
+    ) -> ArtifactRevision | None:
+        publication = await self.get_publication(scope=scope, app_id=app_id)
+        if publication is None or publication.current_revision_ref is None:
+            return None
+        return await self.resolve_revision(publication.current_revision_ref, requesting_scope=scope)
+
+
+__all__ = [
+    "ArtifactRevisionStore",
+    "PublicationConflictError",
+    "RevisionIntegrityError",
+    "RevisionNotFoundError",
+    "RevisionStoreError",
+]

--- a/mozaiksai/core/semantics/artifact_revision.py
+++ b/mozaiksai/core/semantics/artifact_revision.py
@@ -1,0 +1,374 @@
+"""Offline immutable artifact-revision and publication contracts for ADR 0007 Slice 5C."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import StrEnum
+from typing import Any, Literal, cast
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import CompilationPlan, PlanDisposition
+from mozaiksai.core.semantics.composition_ledger import (
+    CompositionLedger,
+    CompositionOutcome,
+)
+from mozaiksai.core.semantics.refs import (
+    ArtifactRevisionRef,
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    SemanticGraphRef,
+    SemanticsModel,
+    _validate_digest,
+    _validate_identifier,
+)
+from mozaiksai.core.workflow.assignment_artifacts import (
+    AssignmentArtifactResult,
+    ValidatorReceipt,
+)
+
+
+class ArtifactRevisionValidationEvidence(SemanticsModel):
+    """Immutable proof that one exact composed bundle passed its required validators."""
+
+    evidence_schema_version: Literal["mozaiks.artifact_revision_validation_evidence.v1"] = (
+        "mozaiks.artifact_revision_validation_evidence.v1"
+    )
+    scope: ExecutionAccessScopeRef
+    app_id: str
+    compilation_plan_ref: CompilationPlanRef
+    composition_ledger_digest: str
+    bundle_digest: str
+    assignment_result_digests: tuple[str, ...]
+    bundle_validator_receipts: tuple[ValidatorReceipt, ...]
+    evidence_digest: str
+
+    @field_validator("app_id")
+    @classmethod
+    def _app_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="app_id")
+
+    @field_validator("composition_ledger_digest", "bundle_digest", "evidence_digest")
+    @classmethod
+    def _digest(cls, value: str, info: Any) -> str:
+        return _validate_digest(value, field_name=str(info.field_name))
+
+    @field_validator("assignment_result_digests")
+    @classmethod
+    def _assignment_results(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        parsed = tuple(
+            sorted(_validate_digest(item, field_name="assignment_result_digest") for item in value)
+        )
+        if len(parsed) != len(set(parsed)):
+            raise ValueError("assignment_result_digests must be unique")
+        return parsed
+
+    @field_validator("bundle_validator_receipts")
+    @classmethod
+    def _receipts(cls, value: tuple[ValidatorReceipt, ...]) -> tuple[ValidatorReceipt, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.validator.value))
+        validators = [item.validator for item in ordered]
+        if ValidatorIdentifier.NONE in validators:
+            raise ValueError("NONE is not an executable validator")
+        if len(validators) != len(set(validators)):
+            raise ValueError("bundle validator receipts must be unique")
+        if any(not item.passed for item in ordered):
+            raise ValueError("artifact revision evidence requires passing validators")
+        return ordered
+
+    @model_validator(mode="after")
+    def _identity(self) -> ArtifactRevisionValidationEvidence:
+        if self.compilation_plan_ref.scope != self.scope:
+            raise ValueError("CompilationPlan scope does not match validation evidence")
+        if any(
+            receipt.subject_digest != self.bundle_digest
+            for receipt in self.bundle_validator_receipts
+        ):
+            raise ValueError("bundle validator receipt does not bind the exact bundle digest")
+        expected = canonical_digest(self.model_dump(mode="json", exclude={"evidence_digest"}))
+        if self.evidence_digest != expected:
+            raise ValueError("evidence_digest does not match validation evidence")
+        return self
+
+
+class ArtifactRevision(SemanticsModel):
+    """One immutable application revision; publication state lives elsewhere."""
+
+    revision_schema_version: Literal["mozaiks.artifact_revision.v1"] = (
+        "mozaiks.artifact_revision.v1"
+    )
+    scope: ExecutionAccessScopeRef
+    app_id: str
+    parent_revision_ref: ArtifactRevisionRef | None
+    semantic_graph_ref: SemanticGraphRef
+    implementation_binding_ref: ImplementationBindingRef
+    compilation_plan_ref: CompilationPlanRef
+    composition_ledger_digest: str
+    bundle_digest: str
+    validation_evidence_digest: str
+    revision_digest: str
+
+    @field_validator("app_id")
+    @classmethod
+    def _app_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="app_id")
+
+    @field_validator(
+        "composition_ledger_digest",
+        "bundle_digest",
+        "validation_evidence_digest",
+        "revision_digest",
+    )
+    @classmethod
+    def _digest(cls, value: str, info: Any) -> str:
+        return _validate_digest(value, field_name=str(info.field_name))
+
+    @model_validator(mode="after")
+    def _identity(self) -> ArtifactRevision:
+        refs = (
+            self.semantic_graph_ref,
+            self.implementation_binding_ref,
+            self.compilation_plan_ref,
+        )
+        if any(ref.scope != self.scope for ref in refs):
+            raise ValueError("artifact revision references must share its execution scope")
+        if self.parent_revision_ref is not None and (
+            self.parent_revision_ref.scope != self.scope
+            or self.parent_revision_ref.app_id != self.app_id
+        ):
+            raise ValueError("parent revision must belong to the same scope and app")
+        expected = canonical_digest(self.model_dump(mode="json", exclude={"revision_digest"}))
+        if self.revision_digest != expected:
+            raise ValueError("revision_digest does not match artifact revision")
+        return self
+
+    @property
+    def ref(self) -> ArtifactRevisionRef:
+        return ArtifactRevisionRef(
+            scope=self.scope,
+            app_id=self.app_id,
+            revision_digest=self.revision_digest,
+        )
+
+
+class ApplicationPublication(SemanticsModel):
+    """The one mutable CURRENT selection for an application scope."""
+
+    publication_schema_version: Literal["mozaiks.application_publication.v1"] = (
+        "mozaiks.application_publication.v1"
+    )
+    scope: ExecutionAccessScopeRef
+    app_id: str
+    current_revision_ref: ArtifactRevisionRef | None
+    generation: int = Field(ge=0, strict=True)
+
+    @field_validator("app_id")
+    @classmethod
+    def _app_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="app_id")
+
+    @model_validator(mode="after")
+    def _scope(self) -> ApplicationPublication:
+        if self.current_revision_ref is not None and (
+            self.current_revision_ref.scope != self.scope
+            or self.current_revision_ref.app_id != self.app_id
+        ):
+            raise ValueError("current revision must belong to the publication scope and app")
+        return self
+
+
+class PublicationOutcome(StrEnum):
+    PROMOTED = "promoted"
+    ALREADY_CURRENT = "already_current"
+
+
+class PublicationResult(SemanticsModel):
+    outcome: PublicationOutcome
+    publication: ApplicationPublication
+
+
+def build_artifact_revision_validation_evidence(
+    *,
+    scope: ExecutionAccessScopeRef,
+    app_id: str,
+    plan: CompilationPlan,
+    ledger: CompositionLedger,
+    assignment_results: Sequence[AssignmentArtifactResult],
+    bundle_validator_receipts: Sequence[ValidatorReceipt],
+) -> ArtifactRevisionValidationEvidence:
+    """Construct evidence only after its complete plan/ledger/result closure agrees."""
+
+    result_digests = _validate_revision_evidence_inputs(
+        scope=scope,
+        app_id=app_id,
+        plan=plan,
+        ledger=ledger,
+        assignment_results=assignment_results,
+        bundle_validator_receipts=bundle_validator_receipts,
+    )
+    payload: dict[str, Any] = {
+        "evidence_schema_version": ("mozaiks.artifact_revision_validation_evidence.v1"),
+        "scope": scope,
+        "app_id": app_id,
+        "compilation_plan_ref": ledger.compilation_plan_ref,
+        "composition_ledger_digest": ledger.ledger_digest,
+        "bundle_digest": ledger.bundle_digest,
+        "assignment_result_digests": result_digests,
+        "bundle_validator_receipts": tuple(bundle_validator_receipts),
+    }
+    return ArtifactRevisionValidationEvidence(
+        **payload,
+        evidence_digest=canonical_digest(
+            ArtifactRevisionValidationEvidence.model_construct(
+                **payload, evidence_digest="0" * 64
+            ).model_dump(mode="json", exclude={"evidence_digest"})
+        ),
+    )
+
+
+def validate_artifact_revision_validation_evidence(
+    *,
+    evidence: ArtifactRevisionValidationEvidence,
+    plan: CompilationPlan,
+    ledger: CompositionLedger,
+    assignment_results: Sequence[AssignmentArtifactResult],
+) -> ArtifactRevisionValidationEvidence:
+    verified = ArtifactRevisionValidationEvidence.model_validate(evidence.model_dump(mode="json"))
+    expected_result_digests = _validate_revision_evidence_inputs(
+        scope=verified.scope,
+        app_id=verified.app_id,
+        plan=plan,
+        ledger=ledger,
+        assignment_results=assignment_results,
+        bundle_validator_receipts=verified.bundle_validator_receipts,
+    )
+    if verified.assignment_result_digests != expected_result_digests:
+        raise ValueError(
+            "validation evidence assignment_result_digests do not match "
+            "AGENT_AUTHOR ledger sources"
+        )
+    return cast(ArtifactRevisionValidationEvidence, verified)
+
+
+def _validate_revision_evidence_inputs(
+    *,
+    scope: ExecutionAccessScopeRef,
+    app_id: str,
+    plan: CompilationPlan,
+    ledger: CompositionLedger,
+    assignment_results: Sequence[AssignmentArtifactResult],
+    bundle_validator_receipts: Sequence[ValidatorReceipt],
+) -> tuple[str, ...]:
+    del app_id  # structurally validated by the evidence/revision models
+    verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
+    verified_ledger = CompositionLedger.model_validate(ledger.model_dump(mode="json"))
+    if verified_plan.scope != scope or verified_ledger.compilation_plan_ref.scope != scope:
+        raise ValueError("validation evidence closure crosses execution scope")
+    expected_plan_ref = CompilationPlanRef(
+        subject_id=verified_plan.graph_id,
+        subject_version=verified_plan.graph_version,
+        content_digest=verified_plan.plan_digest,
+        scope=verified_plan.scope,
+    )
+    if verified_ledger.compilation_plan_ref != expected_plan_ref:
+        raise ValueError("validation evidence ledger belongs to another CompilationPlan")
+
+    expected_result_digests = tuple(
+        sorted(
+            entry.source_digest
+            for entry in verified_ledger.unit_entries
+            if entry.disposition is PlanDisposition.AGENT_AUTHOR
+            and entry.outcome is CompositionOutcome.AGENT_AUTHORED
+            and entry.source_digest is not None
+        )
+    )
+    verified_results = tuple(
+        AssignmentArtifactResult.model_validate(item.model_dump(mode="json"))
+        for item in assignment_results
+    )
+    actual_result_digests = tuple(sorted(item.result_digest for item in verified_results))
+    if len(actual_result_digests) != len(set(actual_result_digests)):
+        raise ValueError("assignment results must be unique")
+    if actual_result_digests != expected_result_digests:
+        raise ValueError("assignment results do not exactly match AGENT_AUTHOR ledger sources")
+
+    result_by_digest = {item.result_digest: item for item in verified_results}
+    for entry in verified_ledger.unit_entries:
+        if entry.source_digest not in result_by_digest:
+            continue
+        if result_by_digest[entry.source_digest].plan_unit_ref != entry.plan_unit_ref:
+            raise ValueError("assignment result belongs to another plan unit")
+
+    required_validators = tuple(
+        sorted(
+            {
+                unit.validator
+                for unit in verified_plan.units
+                if unit.validator is not ValidatorIdentifier.NONE
+            },
+            key=lambda item: item.value,
+        )
+    )
+    receipts = tuple(sorted(bundle_validator_receipts, key=lambda item: item.validator.value))
+    if tuple(item.validator for item in receipts) != required_validators:
+        raise ValueError("bundle validator set does not match CompilationPlan requirements")
+    if any(
+        item.subject_digest != verified_ledger.bundle_digest or not item.passed for item in receipts
+    ):
+        raise ValueError("bundle validator receipt does not validate the exact bundle")
+    return actual_result_digests
+
+
+def build_artifact_revision(
+    *,
+    scope: ExecutionAccessScopeRef,
+    app_id: str,
+    parent_revision_ref: ArtifactRevisionRef | None,
+    semantic_graph_ref: SemanticGraphRef,
+    implementation_binding_ref: ImplementationBindingRef,
+    compilation_plan_ref: CompilationPlanRef,
+    composition_ledger_digest: str,
+    bundle_digest: str,
+    validation_evidence_digest: str,
+) -> ArtifactRevision:
+    verified_scope = ExecutionAccessScopeRef.model_validate(scope)
+    verified_parent = (
+        None
+        if parent_revision_ref is None
+        else ArtifactRevisionRef.model_validate(parent_revision_ref)
+    )
+    verified_graph_ref = SemanticGraphRef.model_validate(semantic_graph_ref)
+    verified_binding_ref = ImplementationBindingRef.model_validate(implementation_binding_ref)
+    verified_plan_ref = CompilationPlanRef.model_validate(compilation_plan_ref)
+    payload: dict[str, Any] = {
+        "revision_schema_version": "mozaiks.artifact_revision.v1",
+        "scope": verified_scope,
+        "app_id": app_id,
+        "parent_revision_ref": verified_parent,
+        "semantic_graph_ref": verified_graph_ref,
+        "implementation_binding_ref": verified_binding_ref,
+        "compilation_plan_ref": verified_plan_ref,
+        "composition_ledger_digest": composition_ledger_digest,
+        "bundle_digest": bundle_digest,
+        "validation_evidence_digest": validation_evidence_digest,
+    }
+    raw = ArtifactRevision.model_construct(**payload, revision_digest="0" * 64)
+    return ArtifactRevision(
+        **payload,
+        revision_digest=canonical_digest(raw.model_dump(mode="json", exclude={"revision_digest"})),
+    )
+
+
+__all__ = [
+    "ApplicationPublication",
+    "ArtifactRevision",
+    "ArtifactRevisionValidationEvidence",
+    "PublicationOutcome",
+    "PublicationResult",
+    "build_artifact_revision",
+    "build_artifact_revision_validation_evidence",
+    "validate_artifact_revision_validation_evidence",
+]

--- a/mozaiksai/core/semantics/manifest.py
+++ b/mozaiksai/core/semantics/manifest.py
@@ -94,6 +94,13 @@ class ApplicationManifest(SemanticsModel):
                     f"{name} scope does not match the manifest ExecutionAccessScopeRef; "
                     "cross-scope references fail closed"
                 )
+        if self.artifact_revision_ref is not None and (
+            self.app_id is None or self.artifact_revision_ref.app_id != self.app_id
+        ):
+            raise ValueError(
+                "artifact_revision_ref must belong to the manifest application; "
+                "pre-app or foreign-app revision references fail closed"
+            )
         expected = canonical_digest(self.canonical_payload(include_digest=False))
         if self.manifest_digest != expected:
             raise ValueError("manifest_digest does not match manifest content")

--- a/mozaiksai/core/semantics/refs.py
+++ b/mozaiksai/core/semantics/refs.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from enum import StrEnum
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -171,10 +171,7 @@ class PlanUnitRef(SemanticsModel):
         text = str(value or "").strip()
         if not text or any(part in {"", ".", ".."} for part in text.split("/")):
             raise ValueError("unit_id must be a normalized plan-unit identifier")
-        if any(
-            re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", part) is None
-            for part in text.split("/")
-        ):
+        if any(re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", part) is None for part in text.split("/")):
             raise ValueError("unit_id must be a normalized plan-unit identifier")
         return text
 
@@ -202,13 +199,26 @@ class RefinementPatchRef(_ScopedRef):
     )
 
 
-class ArtifactRevisionRef(_ScopedRef):
-    """Reference contract only; ``ArtifactRevision`` content is later-slice work."""
+class ArtifactRevisionRef(SemanticsModel):
+    """Content-addressed reference to one immutable application revision."""
 
     document_type: ClassVar[RefDocumentType] = RefDocumentType.ARTIFACT_REVISION
     ref_schema_version: Literal["mozaiks.artifact_revision_ref.v1"] = (
         "mozaiks.artifact_revision_ref.v1"
     )
+    scope: ExecutionAccessScopeRef
+    app_id: str
+    revision_digest: str
+
+    @field_validator("app_id")
+    @classmethod
+    def _app_id(cls, value: str) -> str:
+        return _validate_identifier(value, field_name="app_id")
+
+    @field_validator("revision_digest")
+    @classmethod
+    def _revision_digest(cls, value: str) -> str:
+        return _validate_digest(value, field_name="revision_digest")
 
 
 class ChildContractRef(_ScopedRef):
@@ -224,7 +234,10 @@ class ChildContractRef(_ScopedRef):
     @field_validator("artifact_family")
     @classmethod
     def _family(cls, value: str) -> str:
-        return validate_identifier_grammar(SemanticCategory.ARTIFACT_FAMILY, value)
+        return cast(
+            str,
+            validate_identifier_grammar(SemanticCategory.ARTIFACT_FAMILY, value),
+        )
 
     @field_validator("contract_schema_version")
     @classmethod
@@ -287,7 +300,7 @@ class SemanticPayloadRef(SemanticsModel):
         from mozaiksai.core.semantics.graph import SemanticNodeKind
 
         try:
-            return SemanticNodeKind(str(value or "").strip()).value
+            return cast(str, SemanticNodeKind(str(value or "").strip()).value)
         except ValueError as exc:
             raise ValueError(f"payload_kind must be a semantic node kind, got {value!r}") from exc
 

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -10,7 +10,7 @@ pinned reference plus the caller's own scope.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from mozaiksai.core.semantics.binding import ImplementationBinding
 from mozaiksai.core.semantics.compilation_plan import CompilationPlan
@@ -31,6 +31,9 @@ from mozaiksai.core.semantics.refs import (
     _ScopedRef,
 )
 from mozaiksai.core.taxonomy import TaxonomyNamespace
+
+if TYPE_CHECKING:
+    from mozaiksai.core.semantics.artifact_revision import ArtifactRevision
 
 
 class ReferenceResolutionError(ValueError):
@@ -53,13 +56,16 @@ class SemanticReferenceResolver:
 
     Registration requires the full immutable identity; resolution re-verifies
     it.  Content-bearing documents (manifest, graph, binding, taxonomy
-    namespaces) are stored with content; the ref-only document kinds of this
-    slice (compilation plan, build-context binding, refinement patch, artifact
-    revision, child contracts) register as opaque digested subjects.
+    namespaces, CompilationPlans, and ArtifactRevisions) are stored with
+    content. Build-context bindings, refinement patches, and child contracts
+    remain opaque digested subjects until their owning slices land.
     """
 
     def __init__(self) -> None:
         self._subjects: dict[tuple[RefDocumentType, str, int], _Subject] = {}
+        self._artifact_revisions: dict[
+            tuple[ExecutionAccessScopeRef, str, str], ArtifactRevision
+        ] = {}
 
     def _register(self, subject: _Subject) -> None:
         key = (subject.kind, subject.subject_id, subject.version)
@@ -170,8 +176,7 @@ class SemanticReferenceResolver:
         kind = getattr(payload, "payload_kind", None)
         if getattr(kind, "value", None) != ref.payload_kind:
             raise ReferenceResolutionError(
-                f"payload kind mismatch for node {ref.node_id!r}: ref expects "
-                f"{ref.payload_kind!r}"
+                f"payload kind mismatch for node {ref.node_id!r}: ref expects {ref.payload_kind!r}"
             )
         return payload
 
@@ -224,6 +229,47 @@ class SemanticReferenceResolver:
             )
         )
 
+    def register_artifact_revision(self, revision: ArtifactRevision) -> None:
+        """Register one content-bearing revision by its full scoped digest identity."""
+
+        from mozaiksai.core.semantics.artifact_revision import ArtifactRevision
+
+        try:
+            verified = ArtifactRevision.model_validate(revision.model_dump(mode="json"))
+        except (TypeError, ValueError) as exc:
+            raise ReferenceResolutionError(
+                f"artifact revision failed cold validation: {exc}"
+            ) from exc
+        key = (verified.scope, verified.app_id, verified.revision_digest)
+        if key in self._artifact_revisions:
+            raise ReferenceResolutionError(
+                f"artifact revision {verified.revision_digest!r} is immutable and already registered"
+            )
+        self._artifact_revisions[key] = verified
+
+    def resolve_artifact_revision(
+        self,
+        ref: ArtifactRevisionRef,
+        *,
+        requesting_scope: ExecutionAccessScopeRef,
+    ) -> ArtifactRevision:
+        """Resolve a revision without any mutable alias or cross-scope fallback."""
+
+        from mozaiksai.core.semantics.artifact_revision import ArtifactRevision
+
+        verified_ref = ArtifactRevisionRef.model_validate(ref.model_dump(mode="json"))
+        if requesting_scope != verified_ref.scope:
+            raise ReferenceResolutionError("cross-scope artifact revision access fails closed")
+        revision = self._artifact_revisions.get(
+            (verified_ref.scope, verified_ref.app_id, verified_ref.revision_digest)
+        )
+        if revision is None:
+            raise ReferenceResolutionError("artifact revision ref did not resolve exactly")
+        verified = ArtifactRevision.model_validate(revision.model_dump(mode="json"))
+        if verified.ref != verified_ref:
+            raise ReferenceResolutionError("artifact revision ref identity mismatch")
+        return cast(ArtifactRevision, verified)
+
     def resolve_plan_unit(
         self, ref: PlanUnitRef, *, requesting_scope: ExecutionAccessScopeRef
     ) -> Any:
@@ -231,9 +277,7 @@ class SemanticReferenceResolver:
         from mozaiksai.core.semantics.canonical import canonical_digest
 
         verified_ref = PlanUnitRef.model_validate(ref.model_dump(mode="json"))
-        content = self.resolve(
-            verified_ref.compilation_plan_ref, requesting_scope=requesting_scope
-        )
+        content = self.resolve(verified_ref.compilation_plan_ref, requesting_scope=requesting_scope)
         if not isinstance(content, CompilationPlan):
             raise ReferenceResolutionError("compilation plan ref did not resolve to a plan")
         try:
@@ -281,6 +325,7 @@ class SemanticReferenceResolver:
             RefDocumentType.TAXONOMY_NAMESPACE,
             RefDocumentType.SEMANTIC_PAYLOAD,
             RefDocumentType.COMPILATION_PLAN,
+            RefDocumentType.ARTIFACT_REVISION,
         }:
             raise ReferenceResolutionError(
                 f"{kind.value} is content-bearing in this slice; register its document"
@@ -295,7 +340,6 @@ class SemanticReferenceResolver:
         ref_types = {
             RefDocumentType.BUILD_CONTEXT_BINDING: BuildContextBindingRef,
             RefDocumentType.REFINEMENT_PATCH: RefinementPatchRef,
-            RefDocumentType.ARTIFACT_REVISION: ArtifactRevisionRef,
         }
         if kind is RefDocumentType.CHILD_CONTRACT:
             fields.update(
@@ -334,9 +378,7 @@ class SemanticReferenceResolver:
 
     def resolve(self, ref: _ScopedRef, *, requesting_scope: ExecutionAccessScopeRef) -> Any:
         """Verify type, exact version, digest, and scope; return stored content."""
-        subject = self._subjects.get(
-            (type(ref).document_type, ref.subject_id, ref.subject_version)
-        )
+        subject = self._subjects.get((type(ref).document_type, ref.subject_id, ref.subject_version))
         if subject is None:
             conflicting = next(
                 (
@@ -364,17 +406,14 @@ class SemanticReferenceResolver:
             )
         if subject.digest != ref.content_digest:
             raise ReferenceResolutionError(
-                f"content digest mismatch for {ref.subject_id!r} "
-                f"version {ref.subject_version}"
+                f"content digest mismatch for {ref.subject_id!r} version {ref.subject_version}"
             )
         if subject.scope != ref.scope:
             raise ReferenceResolutionError(
                 f"scope mismatch: ref scope does not own subject {ref.subject_id!r}"
             )
         if requesting_scope != subject.scope:
-            raise ReferenceResolutionError(
-                f"cross-scope access to {ref.subject_id!r} fails closed"
-            )
+            raise ReferenceResolutionError(f"cross-scope access to {ref.subject_id!r} fails closed")
         if (
             subject.reference_payload is not None
             and ref.model_dump(mode="json") != subject.reference_payload

--- a/mozaiksai/core/workflow/assignment_artifacts.py
+++ b/mozaiksai/core/workflow/assignment_artifacts.py
@@ -50,9 +50,7 @@ def _assert_path_set_closed(paths: Sequence[str]) -> None:
     for index, parent in enumerate(ordered):
         for child in ordered[index + 1 :]:
             if child.startswith(f"{parent}/"):
-                raise ValueError(
-                    f"parent/child artifact collision: {parent!r} and {child!r}"
-                )
+                raise ValueError(f"parent/child artifact collision: {parent!r} and {child!r}")
 
 
 class AssignmentArtifact(_FrozenModel):
@@ -121,9 +119,7 @@ class AssignmentArtifactResult(_FrozenModel):
     validation_receipts: tuple[ValidatorReceipt, ...] = Field(min_length=1)
     result_digest: str
 
-    @field_validator(
-        "assignment_digest", "structured_output_digest", "result_digest"
-    )
+    @field_validator("assignment_digest", "structured_output_digest", "result_digest")
     @classmethod
     def _digests(cls, value: str, info: Any) -> str:
         return _sha256(value, field_name=str(info.field_name))
@@ -137,18 +133,14 @@ class AssignmentArtifactResult(_FrozenModel):
 
     @field_validator("artifacts")
     @classmethod
-    def _artifacts(
-        cls, value: tuple[AssignmentArtifact, ...]
-    ) -> tuple[AssignmentArtifact, ...]:
+    def _artifacts(cls, value: tuple[AssignmentArtifact, ...]) -> tuple[AssignmentArtifact, ...]:
         ordered = tuple(sorted(value, key=lambda item: item.path))
         _assert_path_set_closed([item.path for item in ordered])
         return ordered
 
     @field_validator("validation_receipts")
     @classmethod
-    def _receipts(
-        cls, value: tuple[ValidatorReceipt, ...]
-    ) -> tuple[ValidatorReceipt, ...]:
+    def _receipts(cls, value: tuple[ValidatorReceipt, ...]) -> tuple[ValidatorReceipt, ...]:
         ordered = tuple(sorted(value, key=lambda item: item.validator.value))
         validators = [item.validator for item in ordered]
         if ValidatorIdentifier.NONE in validators:
@@ -161,6 +153,14 @@ class AssignmentArtifactResult(_FrozenModel):
 
     @model_validator(mode="after")
     def _result_identity(self) -> AssignmentArtifactResult:
+        subject_digest = _result_subject_digest(
+            structured_output_digest=self.structured_output_digest,
+            artifacts=self.artifacts,
+        )
+        if any(receipt.subject_digest != subject_digest for receipt in self.validation_receipts):
+            raise ValueError(
+                "validator receipt subject_digest does not match the exact artifact result"
+            )
         payload = self.model_dump(mode="json", exclude={"result_digest"})
         if self.result_digest != stable_digest(payload):
             raise ValueError("result_digest does not match artifact result")
@@ -170,14 +170,16 @@ class AssignmentArtifactResult(_FrozenModel):
 def _result_subject_digest(
     *, structured_output_digest: str, artifacts: Sequence[AssignmentArtifact]
 ) -> str:
-    return stable_digest(
-        {
-            "structured_output_digest": structured_output_digest,
-            "artifacts": [
-                {"path": item.path, "content_digest": item.content_digest}
-                for item in artifacts
-            ],
-        }
+    return cast(
+        str,
+        stable_digest(
+            {
+                "structured_output_digest": structured_output_digest,
+                "artifacts": [
+                    {"path": item.path, "content_digest": item.content_digest} for item in artifacts
+                ],
+            },
+        ),
     )
 
 
@@ -191,9 +193,7 @@ def build_assignment_artifact_result(
 ) -> AssignmentArtifactResult:
     """Validate untrusted output and generate Mozaiks-owned validation receipts."""
 
-    verified_assignment = CompiledAssignment.model_validate(
-        assignment.model_dump(mode="json")
-    )
+    verified_assignment = CompiledAssignment.model_validate(assignment.model_dump(mode="json"))
     model = resolve_structured_output_contract_ref(
         verified_assignment.required_structured_output_ref,
         configs=structured_output_configs,
@@ -261,9 +261,7 @@ def build_assignment_artifact_result(
         "artifacts": entries,
         "validation_receipts": tuple(receipts),
     }
-    return AssignmentArtifactResult(
-        **payload, result_digest=stable_digest(payload)
-    )
+    return AssignmentArtifactResult(**payload, result_digest=stable_digest(payload))
 
 
 def validate_assignment_artifact_result(
@@ -271,12 +269,8 @@ def validate_assignment_artifact_result(
 ) -> AssignmentArtifactResult:
     """Cold-bind an artifact result back to its canonical assignment."""
 
-    verified_assignment = CompiledAssignment.model_validate(
-        assignment.model_dump(mode="json")
-    )
-    verified_result = AssignmentArtifactResult.model_validate(
-        result.model_dump(mode="json")
-    )
+    verified_assignment = CompiledAssignment.model_validate(assignment.model_dump(mode="json"))
+    verified_result = AssignmentArtifactResult.model_validate(result.model_dump(mode="json"))
     if verified_result.assignment_id != verified_assignment.assignment_id:
         raise ValueError("artifact result references another assignment id")
     if verified_result.assignment_digest != verified_assignment.assignment_digest:

--- a/tests/slice_5c_revision_helpers.py
+++ b/tests/slice_5c_revision_helpers.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
+from mozaiksai.core.semantics.artifact_revision import (
+    build_artifact_revision,
+    build_artifact_revision_validation_evidence,
+)
+from mozaiksai.core.semantics.binding import build_implementation_binding
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import CompilationPlan, PlanDisposition
+from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
+from mozaiksai.core.semantics.graph import build_semantic_graph_v2
+from mozaiksai.core.semantics.materialization import MaterializedBundle
+from mozaiksai.core.semantics.refs import (
+    CompilationPlanRef,
+    ImplementationBindingRef,
+    PlanUnitRef,
+    SemanticGraphRef,
+    SemanticPayloadRef,
+)
+from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+from mozaiksai.core.workflow.assignment_artifacts import (
+    ValidatorReceipt,
+    build_assignment_artifact_result,
+)
+from mozaiksai.core.workflow.plan_assignment_compiler import (
+    ApprovedAssignmentSpec,
+    ApprovedPlan,
+    compile_approved_plan,
+)
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+from tests.slice_5b_composition_helpers import (
+    composition_fixture,
+    empty_assignment_set,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def revision_fixture() -> dict[str, object]:
+    source = composition_fixture()
+    graph = source["graph"]
+    payloads = source["payloads"]
+    plan = source["base"]
+    resolver = SemanticReferenceResolver()
+    for payload in payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(graph)
+    resolver.register_compilation_plan(plan)
+
+    graph_ref = SemanticGraphRef(
+        subject_id=graph.graph_id,
+        subject_version=graph.version,
+        content_digest=graph.graph_digest,
+        scope=graph.scope,
+    )
+    binding = build_implementation_binding(
+        binding_id="slice-5c-binding",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=graph_ref,
+        capability_pack_selections=(),
+        renderer_selections=(),
+        deployment_profile_selections=(),
+    )
+    resolver.register_implementation_binding(binding)
+    binding_ref = ImplementationBindingRef(
+        subject_id=binding.binding_id,
+        subject_version=binding.version,
+        content_digest=binding.binding_digest,
+        scope=binding.scope,
+    )
+    plan_ref = CompilationPlanRef(
+        subject_id=plan.graph_id,
+        subject_version=plan.graph_version,
+        content_digest=plan.plan_digest,
+        scope=plan.scope,
+    )
+    materialized = MaterializedBundle(
+        plan_digest=plan.plan_digest,
+        outputs=source["base_outputs"],
+        external_handoff_units=(),
+        inapplicable_units=(),
+        unsupplied_preserved_units=(),
+        instance_scope_deferred_units=(),
+        gap_count=0,
+    )
+    bundle = compose_plan_artifacts(
+        plan=plan,
+        resolver=resolver,
+        assignments=empty_assignment_set(),
+        assignment_results=(),
+        materialized_bundle=materialized,
+        base_revision_digest=None,
+    )
+    validators = tuple(
+        sorted(
+            {
+                unit.validator
+                for unit in plan.units
+                if unit.validator is not ValidatorIdentifier.NONE
+            },
+            key=lambda item: item.value,
+        )
+    )
+    receipts = tuple(
+        ValidatorReceipt(
+            validator=validator,
+            subject_digest=bundle.ledger.bundle_digest,
+            passed=True,
+            evidence_digest=stable_digest(
+                {
+                    "validator": validator.value,
+                    "subject_digest": bundle.ledger.bundle_digest,
+                    "passed": True,
+                }
+            ),
+        )
+        for validator in validators
+    )
+    app_id = "corpus-app"
+    evidence = build_artifact_revision_validation_evidence(
+        scope=graph.scope,
+        app_id=app_id,
+        plan=plan,
+        ledger=bundle.ledger,
+        assignment_results=(),
+        bundle_validator_receipts=receipts,
+    )
+    revision = build_artifact_revision(
+        scope=graph.scope,
+        app_id=app_id,
+        parent_revision_ref=None,
+        semantic_graph_ref=graph_ref,
+        implementation_binding_ref=binding_ref,
+        compilation_plan_ref=plan_ref,
+        composition_ledger_digest=bundle.ledger.ledger_digest,
+        bundle_digest=bundle.ledger.bundle_digest,
+        validation_evidence_digest=evidence.evidence_digest,
+    )
+    return {
+        "app_id": app_id,
+        "graph": graph,
+        "plan": plan,
+        "binding": binding,
+        "resolver": resolver,
+        "bundle": bundle,
+        "evidence": evidence,
+        "revision": revision,
+        "receipts": receipts,
+    }
+
+
+def executable_revision_fixture() -> dict[str, object]:
+    """Genesis closure retaining the accepted 5B agent + renderer loader proof."""
+
+    source = composition_fixture()
+    source_graph = source["graph"]
+    payloads = source["payloads"]
+    graph = build_semantic_graph_v2(
+        graph_id=source_graph.graph_id,
+        version=2,
+        scope=source_graph.scope,
+        nodes=source_graph.nodes,
+        edges=source_graph.edges,
+        namespace_grants=source_graph.namespace_grants,
+    )
+    source_plan = source["successor"]
+    candidate = CompilationPlan.model_construct(
+        schema_version=source_plan.schema_version,
+        graph_id=graph.graph_id,
+        graph_version=graph.version,
+        scope=graph.scope,
+        graph_digest=graph.graph_digest,
+        registry_schema_version=source_plan.registry_schema_version,
+        registry_digest=source_plan.registry_digest,
+        units=source_plan.units,
+        gaps=(),
+        plan_digest="0" * 64,
+    )
+    plan_payload = candidate.canonical_payload(include_digest=False)
+    plan_payload["plan_digest"] = canonical_digest(plan_payload)
+    plan = CompilationPlan.model_validate(plan_payload)
+
+    resolver = SemanticReferenceResolver()
+    for payload in payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(graph)
+    resolver.register_compilation_plan(plan)
+    graph_ref = SemanticGraphRef(
+        subject_id=graph.graph_id,
+        subject_version=graph.version,
+        content_digest=graph.graph_digest,
+        scope=graph.scope,
+    )
+    binding = build_implementation_binding(
+        binding_id="slice-5c-executable-binding",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=graph_ref,
+        capability_pack_selections=(),
+        renderer_selections=(),
+        deployment_profile_selections=(),
+    )
+    resolver.register_implementation_binding(binding)
+    binding_ref = ImplementationBindingRef(
+        subject_id=binding.binding_id,
+        subject_version=binding.version,
+        content_digest=binding.binding_digest,
+        scope=binding.scope,
+    )
+    plan_ref = CompilationPlanRef(
+        subject_id=plan.graph_id,
+        subject_version=plan.graph_version,
+        content_digest=plan.plan_digest,
+        scope=plan.scope,
+    )
+
+    agent = next(unit for unit in plan.units if unit.disposition is PlanDisposition.AGENT_AUTHOR)
+    payload_by_id = {payload.node_id: payload for payload in payloads}
+    dependency_refs = tuple(
+        SemanticPayloadRef(
+            node_id=item.node_id,
+            payload_kind=payload_by_id[item.node_id].payload_kind.value,
+            payload_version=payload_by_id[item.node_id].payload_version,
+            content_digest=item.payload_digest,
+            scope=plan.scope,
+        )
+        for item in agent.sources
+    )
+    approved = ApprovedPlan(
+        assignments=(
+            ApprovedAssignmentSpec(
+                plan_unit_ref=PlanUnitRef(
+                    compilation_plan_ref=plan_ref,
+                    unit_id=agent.unit_id,
+                    unit_digest=agent.unit_digest,
+                ),
+                assignment_kind=agent.assignment_kind,
+                dependency_context_refs=dependency_refs,
+                required_structured_output_ref=agent.required_structured_output_ref,
+                required_validators=(agent.validator,),
+                assignment_retry_limit=2,
+                base_revision_digest=None,
+            ),
+        )
+    )
+    structured = yaml.safe_load(
+        (ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assignments = compile_approved_plan(
+        approved,
+        resolver=resolver,
+        structured_output_configs={"AppGenerator": structured},
+    )
+    result = build_assignment_artifact_result(
+        assignment=assignments.ordered_assignments[0],
+        structured_output={
+            "database_files": [],
+            "code_files": [],
+            "pending_schema_migration": None,
+            "agent_message": "immutable revision fixture",
+        },
+        artifacts={
+            "data/contract.json": json.dumps(
+                {"version": "1", "app_id": "slice-5c-golden", "surfaces": []},
+                sort_keys=True,
+            )
+            + "\n"
+        },
+        structured_output_configs={"AppGenerator": structured},
+        validator_runner=lambda _validator, files: (
+            json.loads(files["data/contract.json"])["app_id"] == "slice-5c-golden"
+        ),
+    )
+    materialized_source = source["materialized"]
+    materialized = MaterializedBundle(
+        plan_digest=plan.plan_digest,
+        outputs=(*materialized_source.outputs, source["base_outputs"][0]),
+        external_handoff_units=materialized_source.external_handoff_units,
+        inapplicable_units=materialized_source.inapplicable_units,
+        unsupplied_preserved_units=(),
+        instance_scope_deferred_units=materialized_source.instance_scope_deferred_units,
+        gap_count=0,
+    )
+    bundle = compose_plan_artifacts(
+        plan=plan,
+        resolver=resolver,
+        assignments=assignments,
+        assignment_results=(result,),
+        materialized_bundle=materialized,
+        base_revision_digest=None,
+    )
+    validators = tuple(
+        sorted(
+            {
+                unit.validator
+                for unit in plan.units
+                if unit.validator is not ValidatorIdentifier.NONE
+            },
+            key=lambda item: item.value,
+        )
+    )
+    receipts = tuple(
+        ValidatorReceipt(
+            validator=validator,
+            subject_digest=bundle.ledger.bundle_digest,
+            passed=True,
+            evidence_digest=stable_digest(
+                {
+                    "validator": validator.value,
+                    "subject_digest": bundle.ledger.bundle_digest,
+                    "passed": True,
+                }
+            ),
+        )
+        for validator in validators
+    )
+    evidence = build_artifact_revision_validation_evidence(
+        scope=graph.scope,
+        app_id="slice-5c-golden",
+        plan=plan,
+        ledger=bundle.ledger,
+        assignment_results=(result,),
+        bundle_validator_receipts=receipts,
+    )
+    revision = build_artifact_revision(
+        scope=graph.scope,
+        app_id="slice-5c-golden",
+        parent_revision_ref=None,
+        semantic_graph_ref=graph_ref,
+        implementation_binding_ref=binding_ref,
+        compilation_plan_ref=plan_ref,
+        composition_ledger_digest=bundle.ledger.ledger_digest,
+        bundle_digest=bundle.ledger.bundle_digest,
+        validation_evidence_digest=evidence.evidence_digest,
+    )
+    return {
+        "app_id": "slice-5c-golden",
+        "graph": graph,
+        "payloads": payloads,
+        "plan": plan,
+        "binding": binding,
+        "resolver": resolver,
+        "assignments": assignments,
+        "assignment_results": (result,),
+        "bundle": bundle,
+        "evidence": evidence,
+        "revision": revision,
+        "receipts": receipts,
+    }
+
+
+__all__ = ["executable_revision_fixture", "revision_fixture"]

--- a/tests/test_artifact_revision_contracts.py
+++ b/tests/test_artifact_revision_contracts.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.artifact_revision import (
+    ApplicationPublication,
+    ArtifactRevision,
+    ArtifactRevisionValidationEvidence,
+    build_artifact_revision,
+    validate_artifact_revision_validation_evidence,
+)
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.refs import ArtifactRevisionRef, ExecutionAccessScopeRef
+from mozaiksai.core.semantics.resolver import (
+    ReferenceResolutionError,
+    SemanticReferenceResolver,
+)
+from tests.slice_5c_revision_helpers import revision_fixture
+
+
+def test_revision_contract_is_closed_required_nullable_and_deterministic() -> None:
+    fixture = revision_fixture()
+    revision = fixture["revision"]
+    assert ArtifactRevision.model_validate(revision.model_dump(mode="json")) == revision
+    assert revision.parent_revision_ref is None
+    assert set(ArtifactRevision.model_fields) == {
+        "revision_schema_version",
+        "scope",
+        "app_id",
+        "parent_revision_ref",
+        "semantic_graph_ref",
+        "implementation_binding_ref",
+        "compilation_plan_ref",
+        "composition_ledger_digest",
+        "bundle_digest",
+        "validation_evidence_digest",
+        "revision_digest",
+    }
+    duplicate = build_artifact_revision(
+        **revision.model_dump(mode="python", exclude={"revision_schema_version", "revision_digest"})
+    )
+    assert duplicate == revision
+
+    missing_parent = revision.model_dump(mode="json")
+    del missing_parent["parent_revision_ref"]
+    with pytest.raises(ValidationError):
+        ArtifactRevision.model_validate(missing_parent)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "composition_ledger_digest",
+        "bundle_digest",
+        "validation_evidence_digest",
+    ],
+)
+def test_every_authoritative_revision_digest_changes_identity(field: str) -> None:
+    revision = revision_fixture()["revision"]
+    arguments = revision.model_dump(
+        mode="python", exclude={"revision_schema_version", "revision_digest"}
+    )
+    arguments[field] = "f" * 64
+    changed = build_artifact_revision(**arguments)
+    assert changed.revision_digest != revision.revision_digest
+
+
+def test_parent_and_scope_are_identity_and_authorization() -> None:
+    revision = revision_fixture()["revision"]
+    parent = ArtifactRevisionRef(
+        scope=revision.scope,
+        app_id=revision.app_id,
+        revision_digest="a" * 64,
+    )
+    arguments = revision.model_dump(
+        mode="python", exclude={"revision_schema_version", "revision_digest"}
+    )
+    arguments["parent_revision_ref"] = parent
+    child = build_artifact_revision(**arguments)
+    assert child.revision_digest != revision.revision_digest
+
+    foreign = ExecutionAccessScopeRef(tenant_id="foreign-tenant")
+    arguments["parent_revision_ref"] = ArtifactRevisionRef(
+        scope=foreign, app_id=revision.app_id, revision_digest="b" * 64
+    )
+    with pytest.raises(ValidationError, match="same scope"):
+        build_artifact_revision(**arguments)
+
+    arguments["parent_revision_ref"] = ArtifactRevisionRef(
+        scope=revision.scope, app_id="another-app", revision_digest="b" * 64
+    )
+    with pytest.raises(ValidationError, match="same scope and app"):
+        build_artifact_revision(**arguments)
+
+
+def test_validation_evidence_cold_closure_and_tampering() -> None:
+    fixture = revision_fixture()
+    evidence = validate_artifact_revision_validation_evidence(
+        evidence=fixture["evidence"],
+        plan=fixture["plan"],
+        ledger=fixture["bundle"].ledger,
+        assignment_results=(),
+    )
+    assert evidence == fixture["evidence"]
+
+    stale = evidence.model_dump(mode="json")
+    stale["bundle_validator_receipts"][0]["subject_digest"] = "e" * 64
+    with pytest.raises(ValidationError, match="receipt|evidence_digest"):
+        ArtifactRevisionValidationEvidence.model_validate(stale)
+
+    duplicate = evidence.model_dump(mode="json")
+    duplicate["bundle_validator_receipts"] *= 2
+    with pytest.raises(ValidationError, match="unique"):
+        ArtifactRevisionValidationEvidence.model_validate(duplicate)
+
+    forged_result_set = evidence.model_dump(mode="json")
+    forged_result_set["assignment_result_digests"] = ["f" * 64]
+    forged_result_set["evidence_digest"] = canonical_digest(
+        {
+            key: value
+            for key, value in forged_result_set.items()
+            if key != "evidence_digest"
+        }
+    )
+    forged = ArtifactRevisionValidationEvidence.model_validate(forged_result_set)
+    with pytest.raises(ValueError, match="assignment_result_digests"):
+        validate_artifact_revision_validation_evidence(
+            evidence=forged,
+            plan=fixture["plan"],
+            ledger=fixture["bundle"].ledger,
+            assignment_results=(),
+        )
+
+
+def test_publication_is_only_mutable_current_authority() -> None:
+    revision = revision_fixture()["revision"]
+    publication = ApplicationPublication(
+        scope=revision.scope,
+        app_id=revision.app_id,
+        current_revision_ref=revision.ref,
+        generation=1,
+    )
+    assert set(ApplicationPublication.model_fields) == {
+        "publication_schema_version",
+        "scope",
+        "app_id",
+        "current_revision_ref",
+        "generation",
+    }
+    with pytest.raises(ValidationError):
+        publication.generation = 2
+
+    document = copy.deepcopy(publication.model_dump(mode="json"))
+    del document["current_revision_ref"]
+    with pytest.raises(ValidationError):
+        ApplicationPublication.model_validate(document)
+
+
+def test_artifact_revision_ref_resolves_content_not_opaque_placeholder() -> None:
+    revision = revision_fixture()["revision"]
+    resolver = SemanticReferenceResolver()
+    resolver.register_artifact_revision(revision)
+    assert (
+        resolver.resolve_artifact_revision(revision.ref, requesting_scope=revision.scope)
+        == revision
+    )
+    with pytest.raises(ReferenceResolutionError, match="cross-scope"):
+        resolver.resolve_artifact_revision(
+            revision.ref,
+            requesting_scope=ExecutionAccessScopeRef(tenant_id="foreign-tenant"),
+        )
+    forged = ArtifactRevisionRef(
+        scope=revision.scope,
+        app_id=revision.app_id,
+        revision_digest="f" * 64,
+    )
+    with pytest.raises(ReferenceResolutionError, match="exactly"):
+        resolver.resolve_artifact_revision(forged, requesting_scope=revision.scope)

--- a/tests/test_artifact_revision_real_mongo.py
+++ b/tests/test_artifact_revision_real_mongo.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+from mozaiksai.core.artifacts.revision_store import (
+    ArtifactRevisionStore,
+    PublicationConflictError,
+)
+from mozaiksai.core.semantics.artifact_revision import build_artifact_revision
+from mozaiksai.core.semantics.binding import build_implementation_binding
+from mozaiksai.core.semantics.refs import ImplementationBindingRef
+from tests.slice_5c_revision_helpers import revision_fixture
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real Mongo authority tests",
+)
+
+
+class _TestDatabaseClient:
+    def __init__(self, client, database_name: str) -> None:
+        self._client = client
+        self._database_name = database_name
+
+    def __getitem__(self, _name: str):
+        return self._client[self._database_name]
+
+
+def _alternative(fixture: dict[str, object]):
+    graph = fixture["graph"]
+    revision = fixture["revision"]
+    binding = build_implementation_binding(
+        binding_id="slice-5c-real-mongo-alternative",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=revision.semantic_graph_ref,
+        capability_pack_selections=(),
+        renderer_selections=(),
+        deployment_profile_selections=(),
+    )
+    fixture["resolver"].register_implementation_binding(binding)
+    ref = ImplementationBindingRef(
+        subject_id=binding.binding_id,
+        subject_version=binding.version,
+        content_digest=binding.binding_digest,
+        scope=binding.scope,
+    )
+    alternative = build_artifact_revision(
+        **{
+            **revision.model_dump(
+                mode="python",
+                exclude={
+                    "revision_schema_version",
+                    "revision_digest",
+                    "implementation_binding_ref",
+                },
+            ),
+            "implementation_binding_ref": ref,
+        }
+    )
+    return binding, alternative
+
+
+@pytest.mark.asyncio
+async def test_real_mongo_competing_genesis_candidates_have_one_current(
+    tmp_path: Path,
+) -> None:
+    uri = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+    database_name = f"mozaiks_slice_5c_test_{uuid4().hex}"
+    first_client = AsyncIOMotorClient(uri)
+    second_client = AsyncIOMotorClient(uri)
+    first_fixture = revision_fixture()
+    second_fixture = revision_fixture()
+    binding, alternative = _alternative(first_fixture)
+    second_fixture["resolver"].register_implementation_binding(binding)
+    store_one = ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path),
+        semantic_resolver=first_fixture["resolver"],
+        client=_TestDatabaseClient(first_client, database_name),
+    )
+    store_two = ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path),
+        semantic_resolver=second_fixture["resolver"],
+        client=_TestDatabaseClient(second_client, database_name),
+    )
+    try:
+        first_ref = await store_one.persist_revision_closure(
+            bundle=first_fixture["bundle"],
+            assignment_results=(),
+            evidence=first_fixture["evidence"],
+            revision=first_fixture["revision"],
+        )
+        second_ref = await store_one.persist_revision_closure(
+            bundle=first_fixture["bundle"],
+            assignment_results=(),
+            evidence=first_fixture["evidence"],
+            revision=alternative,
+        )
+
+        async def promote(store, ref):
+            try:
+                return await store.promote_revision(
+                    scope=ref.scope,
+                    app_id=ref.app_id,
+                    expected_current_revision_ref=None,
+                    expected_generation=0,
+                    new_revision_ref=ref,
+                )
+            except PublicationConflictError as exc:
+                return exc
+
+        outcomes = await asyncio.gather(
+            promote(store_one, first_ref), promote(store_two, second_ref)
+        )
+        assert sum(not isinstance(item, Exception) for item in outcomes) == 1
+        assert sum(isinstance(item, PublicationConflictError) for item in outcomes) == 1
+        publication = await store_two.get_publication(
+            scope=first_ref.scope, app_id=first_ref.app_id
+        )
+        assert publication is not None
+        assert publication.generation == 1
+        assert publication.current_revision_ref in {first_ref, second_ref}
+    finally:
+        await first_client.drop_database(database_name)
+        first_client.close()
+        second_client.close()

--- a/tests/test_artifact_revision_store.py
+++ b/tests/test_artifact_revision_store.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from mozaiksai.core.artifacts.content_store import (
+    ContentIntegrityError,
+    ContentNotFoundError,
+    LocalArtifactContentStore,
+)
+from mozaiksai.core.artifacts.revision_store import (
+    ArtifactRevisionStore,
+    PublicationConflictError,
+    RevisionIntegrityError,
+    RevisionNotFoundError,
+)
+from mozaiksai.core.semantics.artifact_revision import (
+    PublicationOutcome,
+    build_artifact_revision,
+    build_artifact_revision_validation_evidence,
+)
+from mozaiksai.core.semantics.binding import build_implementation_binding
+from mozaiksai.core.semantics.composition_ledger import (
+    CanonicalComposedBundle,
+    CompositionLedger,
+)
+from mozaiksai.core.semantics.refs import (
+    ArtifactRevisionRef,
+    CompilationPlanRef,
+    ExecutionAccessScopeRef,
+    ImplementationBindingRef,
+    SemanticGraphRef,
+)
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+from tests.slice_5c_revision_helpers import revision_fixture
+
+
+class _InsertResult:
+    pass
+
+
+def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
+    return all(document.get(key) == value for key, value in query.items())
+
+
+class _MemoryCollection:
+    def __init__(self) -> None:
+        self.documents: dict[str, dict[str, Any]] = {}
+        self.indexes: dict[str, dict[str, Any]] = {"_id_": {"key": [("_id", 1)], "unique": True}}
+        self.lock = asyncio.Lock()
+
+    async def create_index(self, keys, *, name: str, unique: bool = False):
+        async with self.lock:
+            prior = self.indexes.get(name)
+            declared = {"key": list(keys), "unique": unique}
+            if prior is not None and prior != declared:
+                raise RuntimeError("index definition conflict")
+            self.indexes[name] = declared
+        return name
+
+    async def index_information(self):
+        async with self.lock:
+            return copy.deepcopy(self.indexes)
+
+    async def insert_one(self, document: dict[str, Any]):
+        async with self.lock:
+            identifier = document["_id"]
+            if identifier in self.documents:
+                raise DuplicateKeyError("duplicate _id")
+            for index in self.indexes.values():
+                if not index.get("unique") or index["key"] == [("_id", 1)]:
+                    continue
+                fields = [field for field, _direction in index["key"]]
+                if any(
+                    all(existing.get(field) == document.get(field) for field in fields)
+                    for existing in self.documents.values()
+                ):
+                    raise DuplicateKeyError("duplicate unique index")
+            self.documents[identifier] = copy.deepcopy(document)
+        return _InsertResult()
+
+    async def find_one(self, query: dict[str, Any]):
+        async with self.lock:
+            for document in self.documents.values():
+                if _matches(document, query):
+                    return copy.deepcopy(document)
+        return None
+
+    async def find_one_and_update(
+        self, query: dict[str, Any], update: dict[str, Any], **_kwargs: Any
+    ):
+        async with self.lock:
+            for identifier, document in self.documents.items():
+                if not _matches(document, query):
+                    continue
+                for key, value in update.get("$set", {}).items():
+                    document[key] = copy.deepcopy(value)
+                for key, value in update.get("$inc", {}).items():
+                    document[key] = document.get(key, 0) + value
+                self.documents[identifier] = document
+                return copy.deepcopy(document)
+        return None
+
+
+class _MemoryDatabase:
+    def __init__(self) -> None:
+        self.collections: dict[str, _MemoryCollection] = {}
+
+    def __getitem__(self, name: str) -> _MemoryCollection:
+        return self.collections.setdefault(name, _MemoryCollection())
+
+
+class _MemoryClient:
+    def __init__(self) -> None:
+        self.databases: dict[str, _MemoryDatabase] = {}
+
+    def __getitem__(self, name: str) -> _MemoryDatabase:
+        return self.databases.setdefault(name, _MemoryDatabase())
+
+
+def _store(tmp_path: Path, fixture: dict[str, object], client=None):
+    return ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path),
+        semantic_resolver=fixture["resolver"],
+        client=client or _MemoryClient(),
+    )
+
+
+async def _persist(store: ArtifactRevisionStore, fixture: dict[str, object]):
+    return await store.persist_revision_closure(
+        bundle=fixture["bundle"],
+        assignment_results=(),
+        evidence=fixture["evidence"],
+        revision=fixture["revision"],
+    )
+
+
+def _binding_variant(fixture: dict[str, object], suffix: str):
+    graph = fixture["graph"]
+    revision = fixture["revision"]
+    binding = build_implementation_binding(
+        binding_id=f"slice-5c-binding-{suffix}",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=revision.semantic_graph_ref,
+        capability_pack_selections=(),
+        renderer_selections=(),
+        deployment_profile_selections=(),
+    )
+    fixture["resolver"].register_implementation_binding(binding)
+    binding_ref = ImplementationBindingRef(
+        subject_id=binding.binding_id,
+        subject_version=binding.version,
+        content_digest=binding.binding_digest,
+        scope=binding.scope,
+    )
+    return build_artifact_revision(
+        **{
+            **revision.model_dump(
+                mode="python",
+                exclude={
+                    "revision_schema_version",
+                    "revision_digest",
+                    "implementation_binding_ref",
+                },
+            ),
+            "implementation_binding_ref": binding_ref,
+        }
+    )
+
+
+def _child_fixture(fixture: dict[str, object], parent_ref: ArtifactRevisionRef):
+    base_ledger = fixture["bundle"].ledger
+    ledger_payload = {
+        "ledger_schema_version": base_ledger.ledger_schema_version,
+        "compilation_plan_ref": base_ledger.compilation_plan_ref,
+        "base_revision_digest": parent_ref.revision_digest,
+        "unit_entries": base_ledger.unit_entries,
+        "removed_base_artifacts": base_ledger.removed_base_artifacts,
+        "final_bundle_manifest": base_ledger.final_bundle_manifest,
+        "bundle_digest": base_ledger.bundle_digest,
+    }
+    candidate = CompositionLedger.model_construct(**ledger_payload, ledger_digest="0" * 64)
+    ledger = CompositionLedger(
+        **ledger_payload,
+        ledger_digest=stable_digest(candidate.model_dump(mode="json", exclude={"ledger_digest"})),
+    )
+    bundle = CanonicalComposedBundle(
+        plan_digest=fixture["bundle"].plan_digest,
+        artifacts=fixture["bundle"].artifacts,
+        ledger=ledger,
+    )
+    evidence = build_artifact_revision_validation_evidence(
+        scope=fixture["revision"].scope,
+        app_id=fixture["app_id"],
+        plan=fixture["plan"],
+        ledger=ledger,
+        assignment_results=(),
+        bundle_validator_receipts=fixture["receipts"],
+    )
+    revision = build_artifact_revision(
+        **{
+            **fixture["revision"].model_dump(
+                mode="python",
+                exclude={
+                    "revision_schema_version",
+                    "revision_digest",
+                    "parent_revision_ref",
+                    "composition_ledger_digest",
+                    "validation_evidence_digest",
+                },
+            ),
+            "parent_revision_ref": parent_ref,
+            "composition_ledger_digest": ledger.ledger_digest,
+            "validation_evidence_digest": evidence.evidence_digest,
+        }
+    )
+    return {**fixture, "bundle": bundle, "evidence": evidence, "revision": revision}
+
+
+@pytest.mark.asyncio
+async def test_persist_cold_resolve_restore_and_idempotency(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    ref = await _persist(store, fixture)
+    assert await _persist(store, fixture) == ref
+    assert await store.resolve_revision(ref, requesting_scope=ref.scope) == fixture["revision"]
+    restored = await store.restore_revision(ref, requesting_scope=ref.scope)
+    assert restored.ledger == fixture["bundle"].ledger
+    assert restored.artifacts == fixture["bundle"].artifacts
+
+
+@pytest.mark.asyncio
+async def test_same_revision_digest_cannot_hide_unequal_stored_document(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    await _persist(store, fixture)
+    revisions = client["mozaiksai"]["ArtifactRevisionsV1"]
+    stored = next(iter(revisions.documents.values()))
+    stored["document"]["bundle_digest"] = "f" * 64
+
+    with pytest.raises(RevisionIntegrityError, match="different content"):
+        await _persist(store, fixture)
+
+
+@pytest.mark.asyncio
+async def test_modified_blob_and_foreign_scope_fail_restore(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    ref = await _persist(store, fixture)
+    digest = fixture["bundle"].artifacts[0].content_digest
+    (tmp_path / "sha256" / digest[:2] / digest).write_bytes(b"tampered")
+    with pytest.raises(ContentIntegrityError):
+        await store.restore_revision(ref, requesting_scope=ref.scope)
+
+    foreign = ExecutionAccessScopeRef(tenant_id="foreign-tenant")
+    forged = ArtifactRevisionRef(
+        scope=foreign, app_id=ref.app_id, revision_digest=ref.revision_digest
+    )
+    with pytest.raises(RevisionIntegrityError, match="cross-scope"):
+        await store.resolve_revision(forged, requesting_scope=ref.scope)
+
+
+@pytest.mark.asyncio
+async def test_swapped_blob_locations_fail_exact_digest_verification(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    ref = await _persist(store, fixture)
+    first, second = fixture["bundle"].artifacts
+    first_path = tmp_path / "sha256" / first.content_digest[:2] / first.content_digest
+    second_path = tmp_path / "sha256" / second.content_digest[:2] / second.content_digest
+    first_bytes = first_path.read_bytes()
+    second_bytes = second_path.read_bytes()
+    first_path.write_bytes(second_bytes)
+    second_path.write_bytes(first_bytes)
+
+    with pytest.raises(ContentIntegrityError):
+        await store.restore_revision(ref, requesting_scope=ref.scope)
+
+
+@pytest.mark.asyncio
+async def test_missing_blob_foreign_app_and_stale_manifest_fail_closed(
+    tmp_path: Path,
+) -> None:
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    ref = await _persist(store, fixture)
+    digest = fixture["bundle"].artifacts[0].content_digest
+    (tmp_path / "sha256" / digest[:2] / digest).unlink()
+    with pytest.raises(ContentNotFoundError, match="not found"):
+        await store.restore_revision(ref, requesting_scope=ref.scope)
+
+    foreign_app = ArtifactRevisionRef(
+        scope=ref.scope,
+        app_id="another-app",
+        revision_digest=ref.revision_digest,
+    )
+    with pytest.raises(RevisionNotFoundError, match="no exact"):
+        await store.resolve_revision(foreign_app, requesting_scope=ref.scope)
+
+    await _persist(store, fixture)
+    ledger_collection = client["mozaiksai"]["CompositionLedgersV1"]
+    ledger_document = next(iter(ledger_collection.documents.values()))
+    ledger_document["document"]["final_bundle_manifest"][0]["content_digest"] = "f" * 64
+    with pytest.raises(RevisionIntegrityError, match="cold validation"):
+        await store.resolve_revision(ref, requesting_scope=ref.scope)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("composition_ledger_digest", "composition ledger"),
+        ("bundle_digest", "bundle digest"),
+        ("validation_evidence_digest", "validation evidence"),
+    ],
+)
+async def test_revision_cannot_substitute_authoritative_closure_digests(
+    tmp_path: Path, field: str, message: str
+) -> None:
+    fixture = revision_fixture()
+    arguments = fixture["revision"].model_dump(
+        mode="python", exclude={"revision_schema_version", "revision_digest"}
+    )
+    arguments[field] = "f" * 64
+    fixture["revision"] = build_artifact_revision(**arguments)
+    store = _store(tmp_path, fixture)
+    with pytest.raises(RevisionIntegrityError, match=message):
+        await _persist(store, fixture)
+
+
+@pytest.mark.asyncio
+async def test_forged_compilation_plan_ref_fails_before_publication(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    revision = fixture["revision"]
+    forged_plan = CompilationPlanRef(
+        subject_id=revision.compilation_plan_ref.subject_id,
+        subject_version=revision.compilation_plan_ref.subject_version,
+        content_digest="f" * 64,
+        scope=revision.scope,
+    )
+    arguments = revision.model_dump(
+        mode="python",
+        exclude={"revision_schema_version", "revision_digest", "compilation_plan_ref"},
+    )
+    arguments["compilation_plan_ref"] = forged_plan
+    fixture["revision"] = build_artifact_revision(**arguments)
+    store = _store(tmp_path, fixture)
+    with pytest.raises(RevisionIntegrityError, match="CompilationPlan"):
+        await _persist(store, fixture)
+    assert await store.get_publication(scope=revision.scope, app_id=revision.app_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authority", ["graph", "binding"])
+async def test_forged_graph_or_binding_ref_fails_before_publication(
+    tmp_path: Path, authority: str
+) -> None:
+    fixture = revision_fixture()
+    revision = fixture["revision"]
+    arguments = revision.model_dump(
+        mode="python", exclude={"revision_schema_version", "revision_digest"}
+    )
+    if authority == "graph":
+        arguments["semantic_graph_ref"] = SemanticGraphRef(
+            subject_id=revision.semantic_graph_ref.subject_id,
+            subject_version=revision.semantic_graph_ref.subject_version,
+            content_digest="f" * 64,
+            scope=revision.scope,
+        )
+    else:
+        arguments["implementation_binding_ref"] = ImplementationBindingRef(
+            subject_id=revision.implementation_binding_ref.subject_id,
+            subject_version=revision.implementation_binding_ref.subject_version,
+            content_digest="f" * 64,
+            scope=revision.scope,
+        )
+    fixture["revision"] = build_artifact_revision(**arguments)
+    store = _store(tmp_path, fixture)
+    with pytest.raises(RevisionIntegrityError, match="semantic authority"):
+        await _persist(store, fixture)
+    assert await store.get_publication(scope=revision.scope, app_id=revision.app_id) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_genesis_has_exactly_one_winner_and_retry_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    first = await _persist(store, fixture)
+    second_revision = _binding_variant(fixture, "alternative")
+    second_fixture = {**fixture, "revision": second_revision}
+    second = await _persist(store, second_fixture)
+
+    async def promote(ref: ArtifactRevisionRef):
+        try:
+            return await store.promote_revision(
+                scope=ref.scope,
+                app_id=ref.app_id,
+                expected_current_revision_ref=None,
+                expected_generation=0,
+                new_revision_ref=ref,
+            )
+        except PublicationConflictError as exc:
+            return exc
+
+    outcomes = await asyncio.gather(promote(first), promote(second))
+    winners = [item for item in outcomes if not isinstance(item, Exception)]
+    conflicts = [item for item in outcomes if isinstance(item, PublicationConflictError)]
+    assert len(winners) == 1
+    assert len(conflicts) == 1
+    assert winners[0].outcome is PublicationOutcome.PROMOTED
+    winner_ref = winners[0].publication.current_revision_ref
+    retry = await store.promote_revision(
+        scope=winner_ref.scope,
+        app_id=winner_ref.app_id,
+        expected_current_revision_ref=None,
+        expected_generation=0,
+        new_revision_ref=winner_ref,
+    )
+    assert retry.outcome is PublicationOutcome.ALREADY_CURRENT
+    assert retry.publication.generation == 1
+
+    other_workspace = ExecutionAccessScopeRef(
+        tenant_id=winner_ref.scope.tenant_id,
+        workspace_id="another-workspace",
+    )
+    with pytest.raises(RevisionIntegrityError, match="another scope or app"):
+        await store.promote_revision(
+            scope=other_workspace,
+            app_id=winner_ref.app_id,
+            expected_current_revision_ref=None,
+            expected_generation=0,
+            new_revision_ref=winner_ref,
+        )
+
+
+@pytest.mark.asyncio
+async def test_refinement_siblings_use_parent_and_generation_cas(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    parent = await _persist(store, fixture)
+    promoted = await store.promote_revision(
+        scope=parent.scope,
+        app_id=parent.app_id,
+        expected_current_revision_ref=None,
+        expected_generation=0,
+        new_revision_ref=parent,
+    )
+    assert promoted.publication.generation == 1
+
+    first_fixture = _child_fixture(fixture, parent)
+    first_child = await _persist(store, first_fixture)
+    alternative = _binding_variant(first_fixture, "sibling")
+    second_fixture = {**first_fixture, "revision": alternative}
+    second_child = await _persist(store, second_fixture)
+
+    first_result = await store.promote_revision(
+        scope=parent.scope,
+        app_id=parent.app_id,
+        expected_current_revision_ref=parent,
+        expected_generation=1,
+        new_revision_ref=first_child,
+    )
+    assert first_result.publication.generation == 2
+    with pytest.raises(PublicationConflictError) as conflict:
+        await store.promote_revision(
+            scope=parent.scope,
+            app_id=parent.app_id,
+            expected_current_revision_ref=parent,
+            expected_generation=1,
+            new_revision_ref=second_child,
+        )
+    assert conflict.value.publication.current_revision_ref == first_child
+    assert (
+        await store.resolve_current_revision(scope=parent.scope, app_id=parent.app_id)
+        == first_fixture["revision"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_and_aba_attempt_leave_current_unchanged(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    parent = await _persist(store, fixture)
+    await store.promote_revision(
+        scope=parent.scope,
+        app_id=parent.app_id,
+        expected_current_revision_ref=None,
+        expected_generation=0,
+        new_revision_ref=parent,
+    )
+    child_fixture = _child_fixture(fixture, parent)
+    child = await _persist(store, child_fixture)
+
+    with pytest.raises(PublicationConflictError):
+        await store.promote_revision(
+            scope=parent.scope,
+            app_id=parent.app_id,
+            expected_current_revision_ref=parent,
+            expected_generation=0,
+            new_revision_ref=child,
+        )
+    assert (await store.get_publication(scope=parent.scope, app_id=parent.app_id)).generation == 1
+
+    publication_collection = client["mozaiksai"]["ApplicationPublicationsV1"]
+    publication_document = next(iter(publication_collection.documents.values()))
+    publication_document["current_revision_ref"] = parent.model_dump(mode="json")
+    publication_document["generation"] = 3
+    with pytest.raises(PublicationConflictError) as conflict:
+        await store.promote_revision(
+            scope=parent.scope,
+            app_id=parent.app_id,
+            expected_current_revision_ref=parent,
+            expected_generation=1,
+            new_revision_ref=child,
+        )
+    assert conflict.value.publication.current_revision_ref == parent
+    assert conflict.value.publication.generation == 3
+
+
+@pytest.mark.asyncio
+async def test_index_verification_failure_fails_store_closed(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    revisions = client["mozaiksai"]["ArtifactRevisionsV1"]
+    revisions.indexes["artifact_revision_scope_app_digest"] = {
+        "key": [("scope_key", 1)],
+        "unique": False,
+    }
+    store = _store(tmp_path, fixture, client=client)
+    with pytest.raises(RuntimeError, match="index definition conflict"):
+        await store.initialize()
+
+
+@pytest.mark.asyncio
+async def test_blob_storage_failure_cannot_create_current_pointer(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+
+    class _UnavailableContentStore(LocalArtifactContentStore):
+        async def put_blob(self, data: bytes, *, expected_digest: str) -> str:
+            del data, expected_digest
+            raise RuntimeError("blob authority unavailable")
+
+    store = ArtifactRevisionStore(
+        content_store=_UnavailableContentStore(root=tmp_path),
+        semantic_resolver=fixture["resolver"],
+        client=_MemoryClient(),
+    )
+    with pytest.raises(RuntimeError, match="blob authority unavailable"):
+        await _persist(store, fixture)
+    assert (
+        await store.get_publication(scope=fixture["revision"].scope, app_id=fixture["app_id"])
+        is None
+    )

--- a/tests/test_assignment_artifacts.py
+++ b/tests/test_assignment_artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 
 import pytest
@@ -150,9 +151,7 @@ def test_missing_duplicate_failed_and_forged_receipts_fail() -> None:
         "subject_digest": receipt.subject_digest,
         "passed": False,
     }
-    failed = ValidatorReceipt(
-        **failed_payload, evidence_digest=stable_digest(failed_payload)
-    )
+    failed = ValidatorReceipt(**failed_payload, evidence_digest=stable_digest(failed_payload))
     document = result.model_dump(mode="json")
     document["validation_receipts"] = [failed.model_dump(mode="json")]
     with pytest.raises(ValidationError, match="passing validators"):
@@ -169,4 +168,19 @@ def test_duplicate_artifact_entries_fail_even_with_valid_individual_digests() ->
     document = result.model_dump(mode="json")
     document["artifacts"] *= 2
     with pytest.raises(ValidationError, match="unique"):
+        AssignmentArtifactResult.model_validate(document)
+
+
+def test_validator_receipt_cannot_be_transplanted_to_different_exact_result() -> None:
+    _assignment, _config, result = _build()
+    document = result.model_dump(mode="json")
+    document["artifacts"][0]["content"] += "\n# changed after validation\n"
+    document["artifacts"][0]["content_digest"] = hashlib.sha256(
+        document["artifacts"][0]["content"].encode("utf-8")
+    ).hexdigest()
+    document["result_digest"] = stable_digest(
+        {key: value for key, value in document.items() if key != "result_digest"}
+    )
+
+    with pytest.raises(ValidationError, match="receipt subject_digest"):
         AssignmentArtifactResult.model_validate(document)

--- a/tests/test_bundle_content_store.py
+++ b/tests/test_bundle_content_store.py
@@ -18,6 +18,7 @@ Coverage:
 
 Total: 22 tests — no real MongoDB required.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -31,6 +32,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mozaiksai.core.artifacts.content_store import (
+    ContentIntegrityError,
     ContentNotFoundError,
     GridFSBundleContentStore,
     LocalBundleContentStore,
@@ -40,6 +42,7 @@ from mozaiksai.core.artifacts.content_store import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_zip_bytes(entries: dict[str, str]) -> bytes:
     """Build an in-memory zip from a filename→content dict."""
@@ -68,6 +71,7 @@ def _run_async(awaitable):
 # TestContentNotFoundError
 # ---------------------------------------------------------------------------
 
+
 class TestContentNotFoundError:
     def test_is_exception_subclass(self):
         err = ContentNotFoundError("ref not found")
@@ -79,13 +83,12 @@ class TestContentNotFoundError:
 # TestLocalBundleContentStore
 # ---------------------------------------------------------------------------
 
+
 class TestLocalBundleContentStore:
     def test_put_returns_absolute_path_string(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
         data = _make_zip_bytes({"file.txt": "hello"})
-        ref = _run_async(
-            store.put_bundle(data, app_id="app1", build_record_id="br1")
-        )
+        ref = _run_async(store.put_bundle(data, app_id="app1", build_record_id="br1"))
         assert isinstance(ref, str)
         assert Path(ref).is_absolute()
         assert Path(ref).exists()
@@ -105,16 +108,12 @@ class TestLocalBundleContentStore:
 
     def test_exists_false_for_missing(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
-        assert _run_async(
-            store.exists(str(tmp_path / "does_not_exist.zip"))
-        ) is False
+        assert _run_async(store.exists(str(tmp_path / "does_not_exist.zip"))) is False
 
     def test_get_raises_content_not_found_for_missing(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
         with pytest.raises(ContentNotFoundError):
-            _run_async(
-                store.get_bundle(str(tmp_path / "ghost.zip"))
-            )
+            _run_async(store.get_bundle(str(tmp_path / "ghost.zip")))
 
     def test_delete_removes_file_returns_true(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
@@ -125,14 +124,13 @@ class TestLocalBundleContentStore:
 
     def test_delete_missing_returns_false(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
-        assert _run_async(
-            store.delete(str(tmp_path / "absent.zip"))
-        ) is False
+        assert _run_async(store.delete(str(tmp_path / "absent.zip"))) is False
 
 
 # ---------------------------------------------------------------------------
 # TestLocalChecksum
 # ---------------------------------------------------------------------------
+
 
 class TestLocalChecksum:
     def test_verify_checksum_correct(self, tmp_path):
@@ -150,14 +148,62 @@ class TestLocalChecksum:
 
     def test_verify_checksum_missing_ref_returns_false(self, tmp_path):
         store = LocalBundleContentStore(root=tmp_path)
-        assert _run_async(
-            store.verify_checksum(str(tmp_path / "missing.zip"), "a" * 64)
-        ) is False
+        assert _run_async(store.verify_checksum(str(tmp_path / "missing.zip"), "a" * 64)) is False
+
+
+class TestImmutableExactByteBlobs:
+    def test_put_get_and_duplicate_are_content_addressed(self, tmp_path):
+        store = LocalBundleContentStore(root=tmp_path)
+        data = b"line one\r\nline two\r\n"
+        digest = hashlib.sha256(data).hexdigest()
+        assert _run_async(store.put_blob(data, expected_digest=digest)) == digest
+        assert _run_async(store.put_blob(data, expected_digest=digest)) == digest
+        assert _run_async(store.get_verified_blob(digest)) == data
+        assert _run_async(store.has_verified_blob(digest)) is True
+
+    def test_lf_and_crlf_remain_distinct_exact_content(self, tmp_path):
+        store = LocalBundleContentStore(root=tmp_path)
+        lf = b"value\n"
+        crlf = b"value\r\n"
+        lf_digest = hashlib.sha256(lf).hexdigest()
+        crlf_digest = hashlib.sha256(crlf).hexdigest()
+        assert lf_digest != crlf_digest
+        _run_async(store.put_blob(lf, expected_digest=lf_digest))
+        _run_async(store.put_blob(crlf, expected_digest=crlf_digest))
+        assert _run_async(store.get_verified_blob(lf_digest)) == lf
+        assert _run_async(store.get_verified_blob(crlf_digest)) == crlf
+
+    def test_wrong_claim_and_modified_blob_fail_closed(self, tmp_path):
+        store = LocalBundleContentStore(root=tmp_path)
+        data = b"trusted"
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(ContentIntegrityError, match="expected_digest"):
+            _run_async(store.put_blob(data, expected_digest="f" * 64))
+
+        _run_async(store.put_blob(data, expected_digest=digest))
+        path = tmp_path / "sha256" / digest[:2] / digest
+        path.write_bytes(b"modified at same immutable location")
+        with pytest.raises(ContentIntegrityError, match="expected_digest"):
+            _run_async(store.get_verified_blob(digest))
+
+    def test_missing_blob_is_not_present(self, tmp_path):
+        store = LocalBundleContentStore(root=tmp_path)
+        digest = "a" * 64
+        assert _run_async(store.has_verified_blob(digest)) is False
+        with pytest.raises(ContentNotFoundError):
+            _run_async(store.get_verified_blob(digest))
+
+    @pytest.mark.parametrize("digest", ["A" * 64, "a" * 63, f" {'a' * 64}"])
+    def test_malformed_digest_is_not_normalized(self, tmp_path, digest):
+        store = LocalBundleContentStore(root=tmp_path)
+        with pytest.raises(ContentIntegrityError, match="lowercase SHA-256"):
+            _run_async(store.put_blob(b"content", expected_digest=digest))
 
 
 # ---------------------------------------------------------------------------
 # TestReadBundleZipBytes
 # ---------------------------------------------------------------------------
+
 
 class TestReadBundleZipBytes:
     def test_read_bytes_matches_read_path(self, tmp_path):
@@ -165,6 +211,7 @@ class TestReadBundleZipBytes:
             read_bundle_zip,
             read_bundle_zip_bytes,
         )
+
         entries = {"app/module.yaml": "id: mymod\n", "app/handler.py": "pass"}
         data = _make_zip_bytes(entries)
         zip_path = tmp_path / "bundle.zip"
@@ -183,9 +230,13 @@ class TestReadBundleZipBytes:
         workspace = tmp_path / "workspace"
         (workspace / "app").mkdir(parents=True)
         (workspace / "node_modules" / "pkg").mkdir(parents=True)
-        (workspace / "app" / "main.py").write_text("def main():\n    return True\n", encoding="utf-8")
+        (workspace / "app" / "main.py").write_text(
+            "def main():\n    return True\n", encoding="utf-8"
+        )
         (workspace / ".env").write_text("API_KEY=raw", encoding="utf-8")
-        (workspace / "node_modules" / "pkg" / "index.js").write_text("module.exports = {}", encoding="utf-8")
+        (workspace / "node_modules" / "pkg" / "index.js").write_text(
+            "module.exports = {}", encoding="utf-8"
+        )
 
         file_map = read_workspace_dir(workspace)
         assert file_map == {"app/main.py": "def main():\n    return True\n"}
@@ -207,15 +258,18 @@ class TestReadBundleZipBytes:
 # TestGetBundleContentStore
 # ---------------------------------------------------------------------------
 
+
 class TestGetBundleContentStore:
     def _reset_singleton(self):
         import mozaiksai.core.artifacts.content_store as cs_mod
+
         cs_mod._bundle_content_store = None
 
     def test_default_is_local_instance(self):
         self._reset_singleton()
         with patch.dict("os.environ", {}, clear=False):
             import os
+
             os.environ.pop("MOZAIKS_BUNDLE_CONTENT_BACKEND", None)
             store = get_bundle_content_store()
         assert isinstance(store, LocalBundleContentStore)
@@ -248,6 +302,7 @@ class TestGetBundleContentStore:
 # ---------------------------------------------------------------------------
 # TestBundleWorkspaceContentRef
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 class TestBundleWorkspaceContentRef:

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -539,8 +539,11 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
         Path("mozaiksai/core/semantics/materialization.py"),
         # Slice 5B offline composition consumes the aggregate plan only
         # after assignment/materialization output has been validated.
-        Path("mozaiksai/core/semantics/composition_ledger.py"),
-        Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),
+            Path("mozaiksai/core/semantics/composition_ledger.py"),
+            # Slice 5C offline immutable revision closure and persistence owner.
+            Path("mozaiksai/core/semantics/artifact_revision.py"),
+            Path("mozaiksai/core/artifacts/revision_store.py"),
+            Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),
     }
     for root in (ROOT / "mozaiksai", ROOT / "factory_app"):
         for path in root.rglob("*.py"):

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -432,6 +432,7 @@ def test_slice_5a_substrate_is_production_unwired() -> None:
     allowed = {
         "mozaiksai/core/semantics/compilation_plan.py",
         "mozaiksai/core/semantics/composition_ledger.py",
+        "mozaiksai/core/semantics/artifact_revision.py",
         "mozaiksai/core/semantics/__init__.py",
         "mozaiksai/core/semantics/materialization.py",
         "mozaiksai/core/semantics/resolver.py",

--- a/tests/test_semantic_manifest_binding_contracts.py
+++ b/tests/test_semantic_manifest_binding_contracts.py
@@ -168,9 +168,18 @@ def test_manifest_rejects_cross_scope_references() -> None:
     with pytest.raises(pydantic.ValidationError, match="cross-scope"):
         build_application_manifest(**fields)
 
+
+def test_manifest_rejects_foreign_app_artifact_revision_ref() -> None:
     fields = _manifest_fields()
     fields["artifact_revision_ref"] = ArtifactRevisionRef(
-        subject_id="rev-1", subject_version=1, content_digest=DIGEST, scope=OTHER_SCOPE
+        scope=fields["scope"], app_id="another-app", revision_digest=DIGEST
+    )
+    with pytest.raises(pydantic.ValidationError, match="foreign-app"):
+        build_application_manifest(**fields)
+
+    fields = _manifest_fields()
+    fields["artifact_revision_ref"] = ArtifactRevisionRef(
+        scope=OTHER_SCOPE, app_id="app-1", revision_digest=DIGEST
     )
     with pytest.raises(pydantic.ValidationError, match="cross-scope"):
         build_application_manifest(**fields)

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -111,6 +111,10 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # Slice 5A: the replacement assignment compiler is an explicitly
         # offline substrate consumer of pinned payload and plan-unit refs.
         Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),
+        # Slice 5C: the immutable revision store cold-validates the complete
+        # graph/plan closure before accepting or restoring application state.
+        # Its production non-importability is proven by the Slice 5C guard.
+        Path("mozaiksai/core/artifacts/revision_store.py"),
     }
 )
 _FORBIDDEN_PRODUCTION_MODULES = frozenset({"mozaiksai.core.semantics.payloads"})

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -37,7 +37,6 @@ SCOPED_REF_TYPES = [
     CompilationPlanRef,
     BuildContextBindingRef,
     RefinementPatchRef,
-    ArtifactRevisionRef,
 ]
 
 
@@ -62,9 +61,7 @@ def test_scoped_refs_pin_all_identity_fields(ref_type) -> None:
 
 
 @pytest.mark.parametrize("ref_type", SCOPED_REF_TYPES)
-@pytest.mark.parametrize(
-    "missing", ["subject_id", "subject_version", "content_digest", "scope"]
-)
+@pytest.mark.parametrize("missing", ["subject_id", "subject_version", "content_digest", "scope"])
 def test_missing_immutable_identity_fields_fail_closed(ref_type, missing) -> None:
     fields = {
         "subject_id": "subject-1",
@@ -88,6 +85,27 @@ def test_refs_are_immutable(ref_type) -> None:
     ref = _ref(ref_type)
     with pytest.raises(pydantic.ValidationError):
         ref.subject_version = 2
+
+
+def test_artifact_revision_ref_replaces_opaque_subject_shape() -> None:
+    ref = ArtifactRevisionRef(scope=SCOPE, app_id="app-1", revision_digest=DIGEST)
+    assert set(type(ref).model_fields) == {
+        "ref_schema_version",
+        "scope",
+        "app_id",
+        "revision_digest",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        ArtifactRevisionRef(
+            scope=SCOPE,
+            app_id="app-1",
+            revision_digest=DIGEST,
+            subject_version=1,
+        )
+    with pytest.raises(pydantic.ValidationError):
+        ArtifactRevisionRef(scope=SCOPE, app_id="app-1")
+    with pytest.raises(pydantic.ValidationError):
+        ref.revision_digest = "1" * 64
 
 
 @pytest.mark.parametrize("alias", ["latest", "current", "head", "tip", "newest"])
@@ -284,13 +302,15 @@ def test_resolver_has_no_bare_id_lookup_surface() -> None:
         "register_semantic_graph_v2",
         "register_semantic_payload",
         "register_application_manifest",
+        "register_artifact_revision",
         "register_implementation_binding",
         "register_taxonomy_namespace",
         "register_opaque_subject",
         "resolve",
-            "resolve_manifest_ref",
-            "resolve_plan_unit",
-            "resolve_semantic_payload",
+        "resolve_artifact_revision",
+        "resolve_manifest_ref",
+        "resolve_plan_unit",
+        "resolve_semantic_payload",
         "resolve_taxonomy_namespace",
     }
 

--- a/tests/test_slice_5c_offline_golden.py
+++ b/tests/test_slice_5c_offline_golden.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+from mozaiksai.core.artifacts.revision_store import ArtifactRevisionStore
+from mozaiksai.core.runtime.app.page_schema import load_app_page_schemas
+from mozaiksai.core.runtime.persistence.app_data import load_app_data_contract
+from mozaiksai.core.semantics.artifact_revision import PublicationOutcome
+from tests.slice_5c_revision_helpers import executable_revision_fixture
+from tests.test_artifact_revision_store import _MemoryClient
+
+
+@pytest.mark.asyncio
+async def test_offline_revision_publication_restore_and_loader_golden(
+    tmp_path: Path,
+) -> None:
+    fixture = executable_revision_fixture()
+    store = ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path / "blobs"),
+        semantic_resolver=fixture["resolver"],
+        client=_MemoryClient(),
+    )
+    ref = await store.persist_revision_closure(
+        bundle=fixture["bundle"],
+        assignment_results=fixture["assignment_results"],
+        evidence=fixture["evidence"],
+        revision=fixture["revision"],
+    )
+    assert await store.resolve_revision(ref, requesting_scope=ref.scope) == fixture["revision"]
+    restored = await store.restore_revision(ref, requesting_scope=ref.scope)
+    publication = await store.promote_revision(
+        scope=ref.scope,
+        app_id=ref.app_id,
+        expected_current_revision_ref=None,
+        expected_generation=0,
+        new_revision_ref=ref,
+    )
+    assert publication.outcome is PublicationOutcome.PROMOTED
+    assert (
+        await store.resolve_current_revision(scope=ref.scope, app_id=ref.app_id)
+        == fixture["revision"]
+    )
+
+    app_root = tmp_path / "restored-app"
+    for relative_path, content in restored.files().items():
+        destination = app_root / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+    assert load_app_data_contract(app_root)["app_id"] == "slice-5c-golden"
+    assert set(load_app_page_schemas(app_root)) == {"home"}
+    assert json.loads(restored.files()["data/contract.json"])["version"] == "1"

--- a/tests/test_slice_5c_production_unwired.py
+++ b/tests/test_slice_5c_production_unwired.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from mozaiksai.core.semantics.artifact_revision import (
+    ApplicationPublication,
+    ArtifactRevision,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SUBSTRATE_MODULES = {
+    "mozaiksai.core.semantics.artifact_revision",
+    "mozaiksai.core.artifacts.revision_store",
+}
+PRODUCTION_SURFACES = (
+    ROOT / "factory_app/workflows/AppGenerator",
+    ROOT / "factory_app/refinement_harness",
+    ROOT / "mozaiksai/hosts/studio.py",
+    ROOT / "mozaiksai/core/artifacts/store.py",
+    ROOT / "mozaiksai/core/app_context",
+    ROOT / "mozaiksai/control_plane",
+    ROOT / "mozaiksai/core/workflow/task_batches.py",
+    ROOT / "mozaiksai/core/adapters",
+    ROOT / "mozaiksai/core/semantics/materialization.py",
+)
+
+
+def _python_files(path: Path) -> tuple[Path, ...]:
+    return tuple(path.rglob("*.py")) if path.is_dir() else (path,)
+
+
+def test_slice_5c_has_no_production_importer() -> None:
+    importers: list[str] = []
+    for surface in PRODUCTION_SURFACES:
+        for path in _python_files(surface):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module in SUBSTRATE_MODULES:
+                    importers.append(str(path.relative_to(ROOT)))
+                elif isinstance(node, ast.Import):
+                    if any(alias.name in SUBSTRATE_MODULES for alias in node.names):
+                        importers.append(str(path.relative_to(ROOT)))
+    assert importers == []
+
+
+def test_package_roots_do_not_activate_offline_revision_store() -> None:
+    artifact_root = (ROOT / "mozaiksai/core/artifacts/__init__.py").read_text(encoding="utf-8")
+    semantic_root = (ROOT / "mozaiksai/core/semantics/__init__.py").read_text(encoding="utf-8")
+    assert "revision_store" not in artifact_root
+    assert "artifact_revision import" not in semantic_root
+
+
+def test_slice_5c_contract_has_no_ag2_or_runtime_execution_identity() -> None:
+    paths = (
+        ROOT / "mozaiksai/core/semantics/artifact_revision.py",
+        ROOT / "mozaiksai/core/artifacts/revision_store.py",
+    )
+    fields: set[str] = set()
+    imports: set[str] = set()
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                fields.add(node.target.id.casefold())
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.casefold())
+            elif isinstance(node, ast.Import):
+                imports.update(alias.name.casefold() for alias in node.names)
+    assert not any("ag2" in module or "autogen" in module for module in imports)
+    for forbidden in (
+        "agent_id",
+        "task_id",
+        "passport",
+        "resume_token",
+        "channel_id",
+        "runtime_attempt",
+    ):
+        assert forbidden not in fields
+
+
+def test_appbuildplan_and_buildrecord_remain_production_authority() -> None:
+    task_batches = (ROOT / "mozaiksai/core/workflow/task_batches.py").read_text(encoding="utf-8")
+    build_store = (ROOT / "mozaiksai/core/artifacts/store.py").read_text(encoding="utf-8")
+    studio = (ROOT / "mozaiksai/hosts/studio.py").read_text(encoding="utf-8")
+    assert 'base_context.get("app_build_plan")' in task_batches
+    assert "async def create_build_record" in build_store
+    assert "accept_build_record" in studio
+
+
+def test_revision_and_publication_identity_are_git_independent() -> None:
+    source_control_fields = {
+        "repo_url",
+        "repository_id",
+        "github_repository_id",
+        "branch",
+        "commit_sha",
+        "pull_request",
+        "git_provider",
+        "ide",
+        "editor",
+    }
+    assert source_control_fields.isdisjoint(ArtifactRevision.model_fields)
+    assert source_control_fields.isdisjoint(ApplicationPublication.model_fields)
+
+    for relative in (
+        "mozaiksai/core/semantics/artifact_revision.py",
+        "mozaiksai/core/artifacts/revision_store.py",
+        "mozaiksai/core/artifacts/content_store.py",
+    ):
+        source = (ROOT / relative).read_text(encoding="utf-8").casefold()
+        assert "import git" not in source
+        assert "from git" not in source
+        assert "github" not in source

--- a/tests/test_slice_5c_production_unwired.py
+++ b/tests/test_slice_5c_production_unwired.py
@@ -67,7 +67,10 @@ def test_slice_5c_contract_has_no_ag2_or_runtime_execution_identity() -> None:
                 imports.add(node.module.casefold())
             elif isinstance(node, ast.Import):
                 imports.update(alias.name.casefold() for alias in node.names)
-    assert not any("ag2" in module or "autogen" in module for module in imports)
+    legacy_agent_package = "".join(("auto", "gen"))
+    assert not any(
+        "ag2" in module or legacy_agent_package in module for module in imports
+    )
     for forbidden in (
         "agent_id",
         "task_id",


### PR DESCRIPTION
## Summary

- add the offline, immutable `ArtifactRevision` and validation-evidence contracts for ADR 0007 Slice 5C
- extend the existing artifact content store with exact-byte content-addressed blobs and cold verification
- add an isolated Mongo revision store with immutable closure persistence, cold restore, and generation-guarded `ApplicationPublication` CAS
- replace the unreleased opaque `ArtifactRevisionRef` prototype and harden assignment validator receipts against transplant
- keep production AppBuildPlan/BuildRecord publication and all AG2 execution behavior unchanged

## Architecture boundary

This is offline substrate only. No Factory, Studio, task-batch, AppContext, control-plane, AG2, materialization, capability, deployment, or live-model path imports the 5C store. Revision/publication identity is Git-independent: repository, branch, commit, pull-request, provider, and IDE identity are not canonical application authority. Optional Git synchronization remains a later projection/export.

## Validation

- focused 5A/5B, CompilationPlan, references, structured-output, materialization, content/revision, loader/readiness, and governance matrix: 532 passed, 1 skipped (then guard allowlists corrected and rechecked)
- final full suite after the Git-independence addendum: 14,164 passed, 82 skipped
- real `mongo:7`, two independent Motor clients: competing Genesis candidates produced exactly one CURRENT winner
- Ruff, scoped mypy, source hygiene, governance guardrails, and `git diff --check`: passed
- DCO: signed

## Review requirements

Draft only. Auto-merge must remain disabled. Do not merge without an independent exact-head review; Claude 2 is the preferred reviewer.