### PR TITLE
fix(runtime): normalize generated Mongo response identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,20 @@ This project follows a practical pre-1.0 changelog format:
 
 - **Generated Mongo documents no longer break HTTP responses**: module action
   results are normalized at the ModuleExecutor boundary so BSON `ObjectId`
-  values (including `_id`, nested documents, list items, and mapping keys)
-  become their stable hex strings and `Decimal128` becomes its lossless
-  decimal string. Generated apps that list or read Mongo-backed records —
-  whose documents carry a driver-generated `ObjectId` `_id` — previously
-  produced a bare HTTP 500 at serialization on every read path (module
-  routes, profile panels/tabs, page hydration). Datetimes and other
+  *values* become their stable 24-character hexadecimal strings wherever
+  they occur as values — `_id`, ordinary fields, nested documents, and
+  arrays — and `Decimal128` values become their lossless decimal strings.
+  JSON object keys must already be exact strings: an `ObjectId` key, like
+  every other non-string mapping key, is rejected with a typed
+  `MODULE_RESULT_NOT_JSON_SAFE` outcome — no key normalization or coercion
+  occurs, so no post-normalization key collision is possible; the key domain
+  is closed before iteration. Generated apps that list or read Mongo-backed
+  records — whose documents carry a driver-generated `ObjectId` `_id` —
+  previously produced a bare HTTP 500 at serialization on every read path
+  (module routes, profile panels/tabs, page hydration). Datetimes and other
   JSON-encodable values keep their existing wire semantics through explicit
-  closed conversions, unknown types and non-string mapping keys fail closed
-  with a typed `MODULE_RESULT_NOT_JSON_SAFE` outcome (no silent key
-  collisions, no repr leaks), cyclic or absurdly nested results are rejected
+  closed conversions, unknown value types fail closed with the same typed
+  outcome (no repr leaks), cyclic or absurdly nested results are rejected
   instead of exhausting the stack, and the response-size gate now measures
   the exact strictly-encoded UTF-8 bytes (no `default=str` masking). Input
   documents are not mutated. The container domain is closed to exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,13 @@ This project follows a practical pre-1.0 changelog format:
   whose documents carry a driver-generated `ObjectId` `_id` — previously
   produced a bare HTTP 500 at serialization on every read path (module
   routes, profile panels/tabs, page hydration). Datetimes and other
-  JSON-encodable values are untouched, unknown types are never coerced
-  through a repr, and input documents are not mutated.
+  JSON-encodable values keep their existing wire semantics through explicit
+  closed conversions, unknown types and non-string mapping keys fail closed
+  with a typed `MODULE_RESULT_NOT_JSON_SAFE` outcome (no silent key
+  collisions, no repr leaks), cyclic or absurdly nested results are rejected
+  instead of exhausting the stack, and the response-size gate now measures
+  the exact strictly-encoded UTF-8 bytes (no `default=str` masking). Input
+  documents are not mutated.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,18 @@ This project follows a practical pre-1.0 changelog format:
   collisions, no repr leaks), cyclic or absurdly nested results are rejected
   instead of exhausting the stack, and the response-size gate now measures
   the exact strictly-encoded UTF-8 bytes (no `default=str` masking). Input
-  documents are not mutated.
+  documents are not mutated. The container domain is closed to exact
+  `dict`/`list`/`tuple`: sets and frozensets (no deterministic JSON form),
+  container subclasses, custom Mappings, and generators are rejected before
+  any iteration can run hostile code, and BSON `Int64` converts to the exact
+  builtin int. Non-finite `Decimal` values (NaN/Infinity), failing pydantic
+  serializers, malformed UTF-8 bytes, and unexpected conversion failures all
+  surface as the same typed error — never a raw exception — with hostile
+  payload contents kept out of error messages. The size gate's encoding is
+  byte-for-byte identical to what Starlette's `JSONResponse` emits (compact
+  separators, `ensure_ascii=False`, UTF-8), verified against real
+  `TestClient` response bodies, so a result at the limit passes and one byte
+  over fails.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **Generated Mongo documents no longer break HTTP responses**: module action
+  results are normalized at the ModuleExecutor boundary so BSON `ObjectId`
+  values (including `_id`, nested documents, list items, and mapping keys)
+  become their stable hex strings and `Decimal128` becomes its lossless
+  decimal string. Generated apps that list or read Mongo-backed records —
+  whose documents carry a driver-generated `ObjectId` `_id` — previously
+  produced a bare HTTP 500 at serialization on every read path (module
+  routes, profile panels/tabs, page hydration). Datetimes and other
+  JSON-encodable values are untouched, unknown types are never coerced
+  through a repr, and input documents are not mutated.
+
+
 ### Changed
 
 - Upgraded the AG2 runtime to 1.0.3, including ACP 0.12.1 compatibility and corrected usage-event accounting coverage.

--- a/mozaiksai/core/runtime/composition/bson_safe.py
+++ b/mozaiksai/core/runtime/composition/bson_safe.py
@@ -1,49 +1,133 @@
-"""Canonical BSON identifier normalization for module action results.
+"""Closed JSON transport contract for module action results.
 
-Module actions routinely return raw Mongo documents; ``ObjectId`` and
-``Decimal128`` are not JSON-encodable and previously escaped the executor to
-the FastAPI serializer as a bare HTTP 500. This is the one normalization
-authority for that boundary: only BSON-specific identifier/decimal types are
-converted. Values the platform's existing encoder already owns (``datetime``,
-``UUID``, sets, Pydantic models) pass through unchanged, and unknown types are
-never coerced through an arbitrary repr.
+The ModuleExecutor success boundary is the one point every module action
+result crosses before any serializer (HTTP module routes, profile panels and
+tabs, page hydration, relationship rows, WebSocket delivery). This module
+defines that boundary's closed value contract:
+
+* mapping keys must already be strings — Mongo documents use string field
+  names, and converting non-string keys can silently collide (ObjectId vs its
+  hex string, ``1`` vs ``"1"``), so every non-string key is rejected;
+* BSON identifier types are converted (``ObjectId`` → 24-hex string,
+  ``Decimal128`` → lossless decimal string);
+* values FastAPI's encoder already serialized for existing modules keep their
+  exact wire semantics through explicit conversions (datetime/date/time →
+  ISO strings, ``UUID`` → string, ``Decimal`` → FastAPI's decimal encoding,
+  ``Enum`` → its value, pydantic models → their JSON dump, ``bytes`` →
+  UTF-8 text, sets → lists);
+* everything else fails closed with a typed error — no ``str``/``repr``
+  fallback can leak object internals onto the wire;
+* cyclic containers and absurd nesting fail closed instead of exhausting the
+  stack. A shared non-cyclic child is encoded once per occurrence.
+
+The input is never mutated; containers are rebuilt.
 """
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
 from typing import Any
+from uuid import UUID
 
 from bson import ObjectId
 from bson.decimal128 import Decimal128
+from fastapi.encoders import decimal_encoder
+from pydantic import BaseModel
+
+MAX_RESULT_DEPTH = 100
 
 
-def _json_safe_key(key: Any) -> Any:
-    if isinstance(key, ObjectId):
-        return str(key)
-    return key
+class ModuleResultNormalizationError(ValueError):
+    """A module action result cannot be represented in the JSON transport contract."""
 
 
-def json_safe_bson(value: Any) -> Any:
-    """Return ``value`` with BSON identifier types converted to JSON-safe forms.
+def _fail(path: str, reason: str) -> ModuleResultNormalizationError:
+    location = path or "$"
+    return ModuleResultNormalizationError(f"{reason} at {location}")
 
-    * ``ObjectId`` becomes its stable 24-hex-character string, wherever it
-      appears — ``_id`` fields, nested documents, list items, or mapping keys.
-    * ``Decimal128`` becomes its lossless decimal string representation.
-    * Mappings, lists, and tuples are rebuilt recursively (tuples become
-      lists, matching JSON array semantics); the input is never mutated.
-    * Every other value is returned unchanged.
-    """
+
+def _normalize(value: Any, *, path: str, depth: int, active: set[int]) -> Any:
+    if depth > MAX_RESULT_DEPTH:
+        raise _fail(path, f"result nesting exceeds {MAX_RESULT_DEPTH} levels")
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise _fail(path, "non-finite float is not JSON-safe")
+        return value
     if isinstance(value, ObjectId):
         return str(value)
     if isinstance(value, Decimal128):
         return str(value.to_decimal())
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return decimal_encoder(value)
+    if isinstance(value, Enum):
+        return _normalize(value.value, path=path, depth=depth + 1, active=active)
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise _fail(path, "bytes value is not valid UTF-8") from exc
+    if isinstance(value, BaseModel):
+        return _normalize(
+            value.model_dump(mode="json"), path=path, depth=depth + 1, active=active
+        )
     if isinstance(value, Mapping):
-        return {
-            _json_safe_key(key): json_safe_bson(item) for key, item in value.items()
-        }
-    if isinstance(value, (list, tuple)):
-        return [json_safe_bson(item) for item in value]
-    return value
+        identity = id(value)
+        if identity in active:
+            raise _fail(path, "cyclic mapping is not JSON-safe")
+        active.add(identity)
+        try:
+            normalized: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise _fail(
+                        path,
+                        "mapping keys must be strings; got "
+                        f"{type(key).__name__} key",
+                    )
+                normalized[key] = _normalize(
+                    item, path=f"{path}.{key}", depth=depth + 1, active=active
+                )
+            return normalized
+        finally:
+            active.discard(identity)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        identity = id(value)
+        if identity in active:
+            raise _fail(path, "cyclic sequence is not JSON-safe")
+        active.add(identity)
+        try:
+            items = list(value)
+            return [
+                _normalize(item, path=f"{path}[{index}]", depth=depth + 1, active=active)
+                for index, item in enumerate(items)
+            ]
+        finally:
+            active.discard(identity)
+
+    raise _fail(path, f"unsupported value type {type(value).__name__}")
 
 
-__all__ = ["json_safe_bson"]
+def json_safe_bson(value: Any) -> Any:
+    """Normalize a module action result into the closed JSON transport domain.
+
+    Raises :class:`ModuleResultNormalizationError` when the result contains a
+    non-string mapping key, an unsupported value type, a non-finite float, a
+    cyclic container, or nesting beyond :data:`MAX_RESULT_DEPTH`.
+    """
+    return _normalize(value, path="", depth=0, active=set())
+
+
+__all__ = [
+    "MAX_RESULT_DEPTH",
+    "ModuleResultNormalizationError",
+    "json_safe_bson",
+]

--- a/mozaiksai/core/runtime/composition/bson_safe.py
+++ b/mozaiksai/core/runtime/composition/bson_safe.py
@@ -1,0 +1,49 @@
+"""Canonical BSON identifier normalization for module action results.
+
+Module actions routinely return raw Mongo documents; ``ObjectId`` and
+``Decimal128`` are not JSON-encodable and previously escaped the executor to
+the FastAPI serializer as a bare HTTP 500. This is the one normalization
+authority for that boundary: only BSON-specific identifier/decimal types are
+converted. Values the platform's existing encoder already owns (``datetime``,
+``UUID``, sets, Pydantic models) pass through unchanged, and unknown types are
+never coerced through an arbitrary repr.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from bson import ObjectId
+from bson.decimal128 import Decimal128
+
+
+def _json_safe_key(key: Any) -> Any:
+    if isinstance(key, ObjectId):
+        return str(key)
+    return key
+
+
+def json_safe_bson(value: Any) -> Any:
+    """Return ``value`` with BSON identifier types converted to JSON-safe forms.
+
+    * ``ObjectId`` becomes its stable 24-hex-character string, wherever it
+      appears — ``_id`` fields, nested documents, list items, or mapping keys.
+    * ``Decimal128`` becomes its lossless decimal string representation.
+    * Mappings, lists, and tuples are rebuilt recursively (tuples become
+      lists, matching JSON array semantics); the input is never mutated.
+    * Every other value is returned unchanged.
+    """
+    if isinstance(value, ObjectId):
+        return str(value)
+    if isinstance(value, Decimal128):
+        return str(value.to_decimal())
+    if isinstance(value, Mapping):
+        return {
+            _json_safe_key(key): json_safe_bson(item) for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [json_safe_bson(item) for item in value]
+    return value
+
+
+__all__ = ["json_safe_bson"]

--- a/mozaiksai/core/runtime/composition/bson_safe.py
+++ b/mozaiksai/core/runtime/composition/bson_safe.py
@@ -5,6 +5,12 @@ result crosses before any serializer (HTTP module routes, profile panels and
 tabs, page hydration, relationship rows, WebSocket delivery). This module
 defines that boundary's closed value contract:
 
+* the container domain is exactly ``dict``, ``list``, and ``tuple`` — the
+  types trusted code and Mongo documents actually produce. Sets have no JSON
+  representation and hash-order-dependent output, and subclasses or custom
+  Mapping/iterable types can run arbitrary code during iteration, so every
+  container that is not one of the three exact builtins is rejected *before*
+  any ``.items()`` call or iteration executes;
 * mapping keys must already be strings — Mongo documents use string field
   names, and converting non-string keys can silently collide (ObjectId vs its
   hex string, ``1`` vs ``"1"``), so every non-string key is rejected;
@@ -12,11 +18,14 @@ defines that boundary's closed value contract:
   ``Decimal128`` → lossless decimal string);
 * values FastAPI's encoder already serialized for existing modules keep their
   exact wire semantics through explicit conversions (datetime/date/time →
-  ISO strings, ``UUID`` → string, ``Decimal`` → FastAPI's decimal encoding,
-  ``Enum`` → its value, pydantic models → their JSON dump, ``bytes`` →
-  UTF-8 text, sets → lists);
-* everything else fails closed with a typed error — no ``str``/``repr``
-  fallback can leak object internals onto the wire;
+  ISO strings, ``UUID`` → string, finite ``Decimal`` → FastAPI's decimal
+  encoding, ``Enum`` → its recursively normalized value, pydantic models →
+  their JSON-mode dump, ``bytes`` → UTF-8 text). Non-finite floats and
+  Decimals are rejected: the wire renderer forbids NaN/Infinity;
+* everything else fails closed with :class:`ModuleResultNormalizationError` —
+  no ``str``/``repr`` fallback can leak object internals onto the wire, and
+  no conversion failure (Decimal, pydantic serialization, UTF-8 decode)
+  escapes as a raw exception;
 * cyclic containers and absurd nesting fail closed instead of exhausting the
   stack. A shared non-cyclic child is encoded once per occurrence.
 
@@ -33,6 +42,7 @@ from uuid import UUID
 
 from bson import ObjectId
 from bson.decimal128 import Decimal128
+from bson.int64 import Int64
 from fastapi.encoders import decimal_encoder
 from pydantic import BaseModel
 
@@ -52,34 +62,67 @@ def _normalize(value: Any, *, path: str, depth: int, active: set[int]) -> Any:
     if depth > MAX_RESULT_DEPTH:
         raise _fail(path, f"result nesting exceeds {MAX_RESULT_DEPTH} levels")
 
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or type(value) is bool:
         return value
-    if isinstance(value, float):
+    # Enum before the scalar checks: IntEnum/StrEnum members are int/str
+    # instances but their transport value is the recursively normalized
+    # member value, not the member object.
+    if isinstance(value, Enum):
+        return _normalize(value.value, path=path, depth=depth + 1, active=active)
+    if type(value) is int:
+        return value
+    # PyMongo decodes BSON int64 as bson.Int64, an int subclass produced by
+    # the driver itself; convert to the exact builtin. Arbitrary user int
+    # subclasses stay outside the domain.
+    if type(value) is Int64:
+        return int(value)
+    if type(value) is float:
         if value != value or value in (float("inf"), float("-inf")):
             raise _fail(path, "non-finite float is not JSON-safe")
         return value
+    if type(value) is str:
+        return value
+    # Conversion types use unbound base-class methods so a hostile subclass
+    # cannot substitute its own conversion code.
     if isinstance(value, ObjectId):
-        return str(value)
+        return ObjectId.__str__(value)
     if isinstance(value, Decimal128):
-        return str(value.to_decimal())
-    if isinstance(value, (datetime, date, time)):
-        return value.isoformat()
+        return str(Decimal128.to_decimal(value))
+    if isinstance(value, datetime):
+        return datetime.isoformat(value)
+    if isinstance(value, date):
+        return date.isoformat(value)
+    if isinstance(value, time):
+        return time.isoformat(value)
     if isinstance(value, UUID):
-        return str(value)
+        return UUID.__str__(value)
     if isinstance(value, Decimal):
-        return decimal_encoder(value)
-    if isinstance(value, Enum):
-        return _normalize(value.value, path=path, depth=depth + 1, active=active)
+        if not Decimal.is_finite(value):
+            raise _fail(path, "non-finite Decimal is not JSON-safe")
+        try:
+            return decimal_encoder(value)
+        except Exception as exc:
+            raise _fail(path, "Decimal value could not be encoded") from exc
     if isinstance(value, bytes):
         try:
-            return value.decode("utf-8")
+            # Unbound builtin decode: a hostile bytes subclass cannot swap in
+            # its own decode implementation.
+            return bytes.decode(value, "utf-8")
         except UnicodeDecodeError as exc:
             raise _fail(path, "bytes value is not valid UTF-8") from exc
     if isinstance(value, BaseModel):
-        return _normalize(
-            value.model_dump(mode="json"), path=path, depth=depth + 1, active=active
-        )
-    if isinstance(value, Mapping):
+        try:
+            dumped = value.model_dump(mode="json")
+        except Exception as exc:
+            raise _fail(
+                path,
+                f"pydantic model {type(value).__name__} could not be serialized",
+            ) from exc
+        return _normalize(dumped, path=path, depth=depth + 1, active=active)
+
+    # Exact container domain. The type check runs BEFORE any .items() call or
+    # iteration so a hostile Mapping/sequence subclass never executes code.
+    if type(value) is dict:
         identity = id(value)
         if identity in active:
             raise _fail(path, "cyclic mapping is not JSON-safe")
@@ -87,7 +130,7 @@ def _normalize(value: Any, *, path: str, depth: int, active: set[int]) -> Any:
         try:
             normalized: dict[str, Any] = {}
             for key, item in value.items():
-                if not isinstance(key, str):
+                if type(key) is not str:
                     raise _fail(
                         path,
                         "mapping keys must be strings; got "
@@ -99,19 +142,39 @@ def _normalize(value: Any, *, path: str, depth: int, active: set[int]) -> Any:
             return normalized
         finally:
             active.discard(identity)
-    if isinstance(value, (list, tuple, set, frozenset)):
+    if type(value) is list or type(value) is tuple:
         identity = id(value)
         if identity in active:
             raise _fail(path, "cyclic sequence is not JSON-safe")
         active.add(identity)
         try:
-            items = list(value)
             return [
                 _normalize(item, path=f"{path}[{index}]", depth=depth + 1, active=active)
-                for index, item in enumerate(items)
+                for index, item in enumerate(value)
             ]
         finally:
             active.discard(identity)
+
+    # Typed rejections for near-miss containers. Sets are rejected outright —
+    # they have no JSON form and hash-order-dependent iteration; subclasses
+    # and custom Mappings/iterables are rejected without being iterated.
+    if isinstance(value, set | frozenset):
+        raise _fail(
+            path,
+            f"{type(value).__name__} values have no deterministic JSON form",
+        )
+    if isinstance(value, Mapping | dict):
+        raise _fail(
+            path,
+            f"mapping type {type(value).__name__} is outside the exact "
+            "dict transport domain",
+        )
+    if isinstance(value, list | tuple):
+        raise _fail(
+            path,
+            f"sequence type {type(value).__name__} is outside the exact "
+            "list/tuple transport domain",
+        )
 
     raise _fail(path, f"unsupported value type {type(value).__name__}")
 
@@ -119,11 +182,23 @@ def _normalize(value: Any, *, path: str, depth: int, active: set[int]) -> Any:
 def json_safe_bson(value: Any) -> Any:
     """Normalize a module action result into the closed JSON transport domain.
 
-    Raises :class:`ModuleResultNormalizationError` when the result contains a
-    non-string mapping key, an unsupported value type, a non-finite float, a
-    cyclic container, or nesting beyond :data:`MAX_RESULT_DEPTH`.
+    Raises :class:`ModuleResultNormalizationError` — and only that type —
+    for any value outside the contract: non-string mapping keys, containers
+    other than exact dict/list/tuple (sets, subclasses, custom Mappings,
+    generators), unsupported value types, non-finite floats or Decimals,
+    malformed UTF-8 bytes, failing pydantic serializers, cyclic containers,
+    or nesting beyond :data:`MAX_RESULT_DEPTH`. Unexpected failures from the
+    approved conversions are wrapped into the same typed error by exception
+    type name only, so no hostile payload contents leak into the message.
     """
-    return _normalize(value, path="", depth=0, active=set())
+    try:
+        return _normalize(value, path="", depth=0, active=set())
+    except ModuleResultNormalizationError:
+        raise
+    except Exception as exc:
+        raise ModuleResultNormalizationError(
+            f"result normalization failed: {type(exc).__name__}"
+        ) from exc
 
 
 __all__ = [

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -39,7 +39,10 @@ from logs.logging_config import get_workflow_logger
 from mozaiksai.core.audit.audit_logger import get_audit_logger
 from mozaiksai.core.ports.entitlement import EntitlementPort, NoOpEntitlementAdapter
 from mozaiksai.core.runtime.app.module_loader import SettingDef
-from mozaiksai.core.runtime.composition.bson_safe import json_safe_bson
+from mozaiksai.core.runtime.composition.bson_safe import (
+    ModuleResultNormalizationError,
+    json_safe_bson,
+)
 from mozaiksai.core.runtime.composition.executor_registry import ExecutorType
 from mozaiksai.core.runtime.composition.module_authority import (
     ModuleDispatchAudit,
@@ -575,12 +578,33 @@ class ModuleExecutor:
                 error_code="EXECUTION_ERROR",
             )
 
-        # Module results routinely carry raw Mongo documents; normalize BSON
-        # identifier types here — the one choke point every action result
-        # crosses — so ObjectId/Decimal128 never reach a JSON serializer.
-        result = json_safe_bson(result)
+        # Module results routinely carry raw Mongo documents; normalize into
+        # the closed JSON transport contract here — the one choke point every
+        # action result crosses — so nothing a serializer cannot encode ever
+        # leaves the executor as a success. The action itself completed; an
+        # invalid transport result is its own typed outcome, not an
+        # execution failure.
+        try:
+            result = json_safe_bson(result)
+        except ModuleResultNormalizationError as exc:
+            logger.error(
+                "MODULE_RESULT_NOT_JSON_SAFE: module=%s action=%s error=%s",
+                request.module, request.action, exc,
+            )
+            asyncio.create_task(
+                self._emit_dispatch_audit(
+                    replace(dispatch_audit, outcome="failed", reason="MODULE_RESULT_NOT_JSON_SAFE"),
+                    error="MODULE_RESULT_NOT_JSON_SAFE",
+                )
+            )
+            return ModuleResult(
+                success=False,
+                error=f"Action {request.action!r} returned a result that is not JSON-safe",
+                error_code="MODULE_RESULT_NOT_JSON_SAFE",
+            )
 
-        # Output schema validation — warn only; don't fail the caller on a module contract bug.
+        # Output schema validation — warn only; don't fail the caller on a
+        # module contract bug. Validates the exact transport shape.
         if output_schema and result is not None:
             out_error = _validate_schema(result, output_schema)
             if out_error:
@@ -588,13 +612,24 @@ class ModuleExecutor:
                     "MODULE_OUTPUT_INVALID: module=%s action=%s error=%s",
                     request.module, request.action, out_error)
 
-        # Response size gate — prevent unbounded responses from being buffered
-        # in platform routes or sent over WebSocket payloads.
+        # Response size gate — strict encoding of the exact transport shape;
+        # the byte length is measured on the encoded UTF-8 bytes. A strict
+        # serialization failure here means the normalizer contract was
+        # violated and is the same typed outcome.
         if result is not None:
             try:
-                result_size = len(json.dumps(result, default=str))
-            except Exception:
-                result_size = 0
+                encoded = json.dumps(result, ensure_ascii=False, allow_nan=False)
+            except (TypeError, ValueError) as exc:
+                logger.error(
+                    "MODULE_RESULT_NOT_JSON_SAFE: module=%s action=%s strict serialization failed: %s",
+                    request.module, request.action, exc,
+                )
+                return ModuleResult(
+                    success=False,
+                    error=f"Action {request.action!r} returned a result that is not JSON-safe",
+                    error_code="MODULE_RESULT_NOT_JSON_SAFE",
+                )
+            result_size = len(encoded.encode("utf-8"))
             max_response = _response_max_bytes()
             if result_size > max_response:
                 logger.error(

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -39,6 +39,7 @@ from logs.logging_config import get_workflow_logger
 from mozaiksai.core.audit.audit_logger import get_audit_logger
 from mozaiksai.core.ports.entitlement import EntitlementPort, NoOpEntitlementAdapter
 from mozaiksai.core.runtime.app.module_loader import SettingDef
+from mozaiksai.core.runtime.composition.bson_safe import json_safe_bson
 from mozaiksai.core.runtime.composition.executor_registry import ExecutorType
 from mozaiksai.core.runtime.composition.module_authority import (
     ModuleDispatchAudit,
@@ -573,6 +574,11 @@ class ModuleExecutor:
                 error=f"Action {request.action!r} failed",
                 error_code="EXECUTION_ERROR",
             )
+
+        # Module results routinely carry raw Mongo documents; normalize BSON
+        # identifier types here — the one choke point every action result
+        # crosses — so ObjectId/Decimal128 never reach a JSON serializer.
+        result = json_safe_bson(result)
 
         # Output schema validation — warn only; don't fail the caller on a module contract bug.
         if output_schema and result is not None:

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -612,13 +612,21 @@ class ModuleExecutor:
                     "MODULE_OUTPUT_INVALID: module=%s action=%s error=%s",
                     request.module, request.action, out_error)
 
-        # Response size gate — strict encoding of the exact transport shape;
-        # the byte length is measured on the encoded UTF-8 bytes. A strict
-        # serialization failure here means the normalizer contract was
-        # violated and is the same typed outcome.
+        # Response size gate — the exact wire render. These dump options are
+        # byte-for-byte what starlette.responses.JSONResponse.render() emits
+        # (ensure_ascii=False, allow_nan=False, no indent, compact
+        # separators, UTF-8), verified by test against a real TestClient
+        # body. A strict serialization failure here means the normalizer
+        # contract was violated and is the same typed outcome.
         if result is not None:
             try:
-                encoded = json.dumps(result, ensure_ascii=False, allow_nan=False)
+                encoded = json.dumps(
+                    result,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    indent=None,
+                    separators=(",", ":"),
+                )
             except (TypeError, ValueError) as exc:
                 logger.error(
                     "MODULE_RESULT_NOT_JSON_SAFE: module=%s action=%s strict serialization failed: %s",

--- a/tests/test_generated_app_http_bson_safety.py
+++ b/tests/test_generated_app_http_bson_safety.py
@@ -57,7 +57,24 @@ class OrdersBaseHandler:
     async def archive_order(self, ctx, **params):
         deleted = await self._collection(ctx).delete_one({"order_id": params.get("order_id", "")})
         return {"archived": bool(deleted)}
+
+    async def corrupt_order(self, ctx, **params):
+        return {"handle": {"a", "b"}}
 '''
+
+_PROFILE_YAML = """
+schema_version: mozaiks.profile.v1
+panels:
+  - id: orders_panel
+    title: Orders
+    kind: list
+    action: list_orders
+    fields:
+      - id: order_id
+        label: Order
+      - id: customer_name
+        label: Customer
+"""
 
 _MODULE_YAML = """
 schema_version: mozaiks.module.v1
@@ -92,6 +109,11 @@ actions:
     handler_method: archive_order
     input_schema: {type: object, properties: {order_id: {type: string}}}
     output_schema: {type: object}
+  - id: corrupt_order
+    description: Return a value outside the JSON transport contract.
+    handler_method: corrupt_order
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
 """
 
 
@@ -103,6 +125,7 @@ def _persistence_bundle() -> dict[str, str]:
         if not path.startswith("modules/orders/")
     }
     files["modules/orders/module.yaml"] = _MODULE_YAML
+    files["modules/orders/contracts/profile.yaml"] = _PROFILE_YAML
     files["modules/orders/backend/__init__.py"] = ""
     files["modules/orders/backend/base_handler.py"] = _PERSISTENCE_HANDLER
     files["modules/orders/backend/handler.py"] = (
@@ -140,7 +163,7 @@ def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -
         with TestClient(platform.app, raise_server_exceptions=False) as client:
             created = _assert_json_200(
                 client.post(
-                    "/api/modules/orders/create_order",
+                    "/api/modules/orders/create_order?app_id=support-operations",
                     json={"params": {"customer_name": "Ada"}},
                 ),
                 "create_order",
@@ -149,7 +172,7 @@ def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -
             assert order_id
 
             listed = _assert_json_200(
-                client.post("/api/modules/orders/list_orders", json={}),
+                client.post("/api/modules/orders/list_orders?app_id=support-operations", json={}),
                 "list_orders",
             )
             assert listed["count"] >= 1
@@ -159,7 +182,7 @@ def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -
 
             read = _assert_json_200(
                 client.post(
-                    "/api/modules/orders/read_order",
+                    "/api/modules/orders/read_order?app_id=support-operations",
                     json={"params": {"order_id": order_id}},
                 ),
                 "read_order",
@@ -169,7 +192,7 @@ def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -
 
             updated = _assert_json_200(
                 client.post(
-                    "/api/modules/orders/update_order",
+                    "/api/modules/orders/update_order?app_id=support-operations",
                     json={"params": {"order_id": order_id, "customer_name": "Grace"}},
                 ),
                 "update_order",
@@ -179,14 +202,51 @@ def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -
 
             # GET module dispatch surface as an additional embedding path.
             listed_get = _assert_json_200(
-                client.get("/api/modules/orders/list_orders"),
+                client.get("/api/modules/orders/list_orders?app_id=support-operations"),
                 "list_orders (GET)",
             )
             assert any(isinstance(o.get("_id"), str) for o in listed_get["orders"])
 
+            # Profile-panel embedding surface: the platform hydrates the
+            # module action into the panel payload; the Mongo documents must
+            # arrive as valid JSON with string identifiers, no crash.
+            panels = _assert_json_200(
+                client.get("/api/me/profile-panels"),
+                "profile-panels",
+            )
+            orders_panel = next(
+                p for p in panels["panels"] if p["id"] == "orders_panel"
+            )
+            assert orders_panel["error"] is None, orders_panel
+            hydrated_orders = orders_panel["data"]["orders"]
+            assert any(
+                o["order_id"] == order_id and isinstance(o["_id"], str)
+                for o in hydrated_orders
+            ), f"order {order_id} missing from panel data: {hydrated_orders!r}"
+
+            # A result outside the transport contract fails typed at the
+            # executor and reaches the wire as the platform's controlled
+            # JSON error envelope (the host masks 500 details by policy).
+            # An unhandled FastAPI serialization crash would instead produce
+            # Starlette's plain-text "Internal Server Error" body — so a
+            # parseable JSON envelope here proves the typed path handled it.
+            corrupt_response = client.post(
+                "/api/modules/orders/corrupt_order?app_id=support-operations", json={}
+            )
+            assert corrupt_response.status_code == 500
+            corrupt_payload = json.loads(corrupt_response.text)
+            assert corrupt_payload == {"detail": "Internal server error"}
+
+            # The server survives the invalid result: the next request works.
+            still_alive = _assert_json_200(
+                client.get("/api/modules/orders/list_orders?app_id=support-operations"),
+                "list_orders (after corrupt)",
+            )
+            assert still_alive["count"] >= 1
+
             archived = _assert_json_200(
                 client.post(
-                    "/api/modules/orders/archive_order",
+                    "/api/modules/orders/archive_order?app_id=support-operations",
                     json={"params": {"order_id": order_id}},
                 ),
                 "archive_order",

--- a/tests/test_generated_app_http_bson_safety.py
+++ b/tests/test_generated_app_http_bson_safety.py
@@ -1,0 +1,207 @@
+"""Real-HTTP proof: Mongo-backed module CRUD through the packaged platform host.
+
+Boots the actual platform app over a generated-style bundle whose module repo
+uses ``ctx.persistence`` (documents get driver-generated ObjectId ``_id``) and
+drives create → list → read → update → delete over HTTP against real local
+Mongo. Every response must be valid JSON with stable string identifiers and no
+bare HTTP 500 — the exact defect shape this boundary previously produced.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+from tests.test_generated_app_functional_acceptance import (
+    _basic_crud_files,
+    _materialize_bundle,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real-Mongo HTTP BSON-safety tests",
+)
+
+_MONGO_URI = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+
+_PERSISTENCE_HANDLER = '''
+class OrdersBaseHandler:
+    def _collection(self, ctx):
+        return ctx.persistence.collection("orders", "orders")
+
+    async def list_orders(self, ctx, **params):
+        items = await self._collection(ctx).find_many({}, limit=50)
+        return {"orders": items, "count": len(items)}
+
+    async def create_order(self, ctx, **params):
+        import uuid as _uuid
+
+        order = {"order_id": str(_uuid.uuid4()), "customer_name": params.get("customer_name", "")}
+        await self._collection(ctx).insert_one(order)
+        return {"order": {"order_id": order["order_id"]}}
+
+    async def read_order(self, ctx, **params):
+        return {"order": await self._collection(ctx).find_one({"order_id": params.get("order_id", "")})}
+
+    async def update_order(self, ctx, **params):
+        collection = self._collection(ctx)
+        await collection.update_one(
+            {"order_id": params.get("order_id", "")},
+            {"$set": {"customer_name": params.get("customer_name", "")}},
+        )
+        return {"order": await collection.find_one({"order_id": params.get("order_id", "")})}
+
+    async def archive_order(self, ctx, **params):
+        deleted = await self._collection(ctx).delete_one({"order_id": params.get("order_id", "")})
+        return {"archived": bool(deleted)}
+'''
+
+_MODULE_YAML = """
+schema_version: mozaiks.module.v1
+module:
+  id: orders
+  display_name: Orders
+  version: 1.0.0
+  handler: backend.handler:OrdersHandler
+actions:
+  - id: list_orders
+    description: List orders.
+    handler_method: list_orders
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+  - id: create_order
+    description: Create an order.
+    handler_method: create_order
+    input_schema: {type: object, properties: {customer_name: {type: string}}}
+    output_schema: {type: object}
+  - id: read_order
+    description: Read one order.
+    handler_method: read_order
+    input_schema: {type: object, properties: {order_id: {type: string}}}
+    output_schema: {type: object}
+  - id: update_order
+    description: Update one order.
+    handler_method: update_order
+    input_schema: {type: object, properties: {order_id: {type: string}, customer_name: {type: string}}}
+    output_schema: {type: object}
+  - id: archive_order
+    description: Delete one order.
+    handler_method: archive_order
+    input_schema: {type: object, properties: {order_id: {type: string}}}
+    output_schema: {type: object}
+"""
+
+
+def _persistence_bundle() -> dict[str, str]:
+    files = _basic_crud_files()
+    files = {
+        path: content
+        for path, content in files.items()
+        if not path.startswith("modules/orders/")
+    }
+    files["modules/orders/module.yaml"] = _MODULE_YAML
+    files["modules/orders/backend/__init__.py"] = ""
+    files["modules/orders/backend/base_handler.py"] = _PERSISTENCE_HANDLER
+    files["modules/orders/backend/handler.py"] = (
+        "from .base_handler import OrdersBaseHandler\n\n\n"
+        "class OrdersHandler(OrdersBaseHandler):\n    pass\n"
+    )
+    return files
+
+
+def _assert_json_200(response, surface: str) -> dict:
+    assert response.status_code == 200, f"{surface}: {response.status_code} {response.text[:300]}"
+    payload = json.loads(response.text)
+    return payload
+
+
+def test_persistence_backed_crud_over_http_is_json_safe(tmp_path, monkeypatch) -> None:
+    app_root = tmp_path / "app"
+    _materialize_bundle(app_root, _persistence_bundle())
+    monkeypatch.setenv("PLATFORM_PATH", str(app_root))
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("MOZAIKS_DATABASE_STARTUP_POLICY", "best_effort")
+    monkeypatch.setenv("MONGO_URI", _MONGO_URI)
+    reset_auth_adapter()
+
+    from mozaiksai.core.runtime.persistence.mongo import MongoPersistenceContext
+
+    probe = MongoPersistenceContext(app_id="support-operations")
+    collection_name = probe.collection_name("orders", "orders")
+    database_name = probe.database_name
+
+    from mozaiksai.hosts import platform
+
+    try:
+        with TestClient(platform.app, raise_server_exceptions=False) as client:
+            created = _assert_json_200(
+                client.post(
+                    "/api/modules/orders/create_order",
+                    json={"params": {"customer_name": "Ada"}},
+                ),
+                "create_order",
+            )
+            order_id = created["order"]["order_id"]
+            assert order_id
+
+            listed = _assert_json_200(
+                client.post("/api/modules/orders/list_orders", json={}),
+                "list_orders",
+            )
+            assert listed["count"] >= 1
+            first = next(o for o in listed["orders"] if o["order_id"] == order_id)
+            # The driver-generated ObjectId reaches the wire as a stable string.
+            assert isinstance(first["_id"], str) and len(first["_id"]) == 24
+
+            read = _assert_json_200(
+                client.post(
+                    "/api/modules/orders/read_order",
+                    json={"params": {"order_id": order_id}},
+                ),
+                "read_order",
+            )
+            assert isinstance(read["order"]["_id"], str)
+            assert read["order"]["customer_name"] == "Ada"
+
+            updated = _assert_json_200(
+                client.post(
+                    "/api/modules/orders/update_order",
+                    json={"params": {"order_id": order_id, "customer_name": "Grace"}},
+                ),
+                "update_order",
+            )
+            assert updated["order"]["customer_name"] == "Grace"
+            assert isinstance(updated["order"]["_id"], str)
+
+            # GET module dispatch surface as an additional embedding path.
+            listed_get = _assert_json_200(
+                client.get("/api/modules/orders/list_orders"),
+                "list_orders (GET)",
+            )
+            assert any(isinstance(o.get("_id"), str) for o in listed_get["orders"])
+
+            archived = _assert_json_200(
+                client.post(
+                    "/api/modules/orders/archive_order",
+                    json={"params": {"order_id": order_id}},
+                ),
+                "archive_order",
+            )
+            assert archived["archived"] is True
+    finally:
+        import asyncio
+
+        from motor.motor_asyncio import AsyncIOMotorClient
+
+        async def _cleanup() -> None:
+            cleaner = AsyncIOMotorClient(_MONGO_URI)
+            try:
+                await cleaner[database_name].drop_collection(collection_name)
+            finally:
+                cleaner.close()
+
+        asyncio.run(_cleanup())

--- a/tests/test_module_result_bson_normalization.py
+++ b/tests/test_module_result_bson_normalization.py
@@ -83,7 +83,6 @@ def test_fastapi_equivalent_wire_semantics_preserved() -> None:
             "kind": _Kind.ACTIVE,
             "model": _Doc(name="a", when=stamp),
             "blob": b"text-bytes",
-            "tags": {"a"},
         }
     )
     assert normalized["when"] == stamp.isoformat()
@@ -94,7 +93,6 @@ def test_fastapi_equivalent_wire_semantics_preserved() -> None:
     assert normalized["kind"] == "active"
     assert normalized["model"]["name"] == "a"
     assert normalized["blob"] == "text-bytes"
-    assert normalized["tags"] == ["a"]
     json.dumps(normalized, allow_nan=False)
 
 
@@ -198,6 +196,273 @@ def test_shared_noncyclic_child_is_encoded_twice_deterministically() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Closed container domain — exact dict/list/tuple only, decided before any
+# iteration or .items() call can execute hostile code
+# ---------------------------------------------------------------------------
+
+
+def test_ordinary_set_and_frozenset_are_rejected() -> None:
+    with pytest.raises(ModuleResultNormalizationError, match="no deterministic JSON form"):
+        json_safe_bson({"tags": {"a", "b"}})
+    with pytest.raises(ModuleResultNormalizationError, match="no deterministic JSON form"):
+        json_safe_bson({"tags": frozenset({"a", "b"})})
+
+
+def test_container_subclasses_are_rejected_without_iteration() -> None:
+    executed: list[str] = []
+
+    class _HostileDict(dict):
+        def items(self):
+            executed.append("dict.items")
+            return super().items()
+
+    class _HostileList(list):
+        def __iter__(self):
+            executed.append("list.iter")
+            return super().__iter__()
+
+    class _HostileTuple(tuple):
+        def __iter__(self):
+            executed.append("tuple.iter")
+            return super().__iter__()
+
+    class _HostileSet(set):
+        def __iter__(self):
+            executed.append("set.iter")
+            raise RuntimeError("hostile iteration payload")
+
+    for hostile in (
+        _HostileDict({"k": "v"}),
+        _HostileList(["v"]),
+        _HostileTuple(("v",)),
+        _HostileSet({"v"}),
+    ):
+        with pytest.raises(ModuleResultNormalizationError):
+            json_safe_bson({"payload": hostile})
+    assert executed == []
+
+
+def test_custom_mapping_is_rejected_without_items_call() -> None:
+    from collections.abc import Iterator, Mapping
+
+    executed: list[str] = []
+
+    class _HostileMapping(Mapping):
+        def __getitem__(self, key):  # pragma: no cover - must never run
+            executed.append("getitem")
+            return "x"
+
+        def __iter__(self) -> Iterator[str]:  # pragma: no cover - must never run
+            executed.append("iter")
+            raise RuntimeError("hostile mapping payload")
+
+        def __len__(self) -> int:
+            return 1
+
+    with pytest.raises(ModuleResultNormalizationError, match="exact"):
+        json_safe_bson({"payload": _HostileMapping()})
+    assert executed == []
+
+
+def test_generators_and_arbitrary_iterables_are_rejected() -> None:
+    def _gen():  # pragma: no cover - must never be iterated
+        yield "leak"
+
+    with pytest.raises(ModuleResultNormalizationError, match="unsupported value type"):
+        json_safe_bson({"stream": _gen()})
+
+    class _Iterable:
+        def __iter__(self):  # pragma: no cover - must never run
+            raise RuntimeError("hostile")
+
+    with pytest.raises(ModuleResultNormalizationError, match="unsupported value type"):
+        json_safe_bson({"stream": _Iterable()})
+
+
+def test_scalar_subclasses_are_outside_the_exact_domain() -> None:
+    class _EvilInt(int):
+        pass
+
+    class _EvilStr(str):
+        pass
+
+    class _EvilFloat(float):
+        pass
+
+    for scalar in (_EvilInt(1), _EvilStr("s"), _EvilFloat(1.5)):
+        with pytest.raises(ModuleResultNormalizationError):
+            json_safe_bson({"v": scalar})
+
+
+def test_no_set_serialization_path_across_hash_seeds() -> None:
+    """Sets fail identically under different PYTHONHASHSEED values.
+
+    If any code path serialized a set, its ordering would vary with the hash
+    seed; the contract removes the path entirely, so every seed produces the
+    same typed rejection and the seed can never influence wire bytes.
+    """
+    import subprocess
+    import sys
+
+    snippet = (
+        "from mozaiksai.core.runtime.composition.bson_safe import "
+        "json_safe_bson, ModuleResultNormalizationError\n"
+        "try:\n"
+        "    json_safe_bson({'tags': {'a', 'b', 'c', 'd', 'e'}})\n"
+        "except ModuleResultNormalizationError as exc:\n"
+        "    print('REJECTED:' + str(exc))\n"
+        "else:\n"
+        "    print('ACCEPTED')\n"
+    )
+    outputs = set()
+    for seed in ("0", "1", "424242"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        proc = subprocess.run(
+            [sys.executable, "-c", snippet],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        outputs.add(proc.stdout.strip())
+    assert len(outputs) == 1
+    assert next(iter(outputs)).startswith("REJECTED:")
+
+
+# ---------------------------------------------------------------------------
+# Conversion failures are typed, never raw
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity", "sNaN"])
+def test_nonfinite_decimals_fail_closed(bad: str) -> None:
+    with pytest.raises(ModuleResultNormalizationError, match="non-finite Decimal"):
+        json_safe_bson({"amount": Decimal(bad)})
+
+
+def test_pydantic_model_with_unserializable_field_fails_typed() -> None:
+    from typing import Any as _Any
+
+    from pydantic import ConfigDict
+
+    class _Holder(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        payload: _Any
+
+    with pytest.raises(ModuleResultNormalizationError, match="could not be serialized"):
+        json_safe_bson({"doc": _Holder(payload=object())})
+
+
+def test_pydantic_model_with_throwing_serializer_fails_typed() -> None:
+    from pydantic import field_serializer
+
+    class _Throwing(BaseModel):
+        name: str
+
+        @field_serializer("name")
+        def _boom(self, value: str) -> str:
+            raise RuntimeError("serializer exploded with SECRET-DETAILS")
+
+    with pytest.raises(ModuleResultNormalizationError) as excinfo:
+        json_safe_bson({"doc": _Throwing(name="x")})
+    assert "SECRET-DETAILS" not in str(excinfo.value)
+
+
+def test_malformed_utf8_bytes_fail_typed() -> None:
+    with pytest.raises(ModuleResultNormalizationError, match="not valid UTF-8"):
+        json_safe_bson({"blob": b"\xff\xfe\xfa"})
+
+
+def test_enum_with_unsupported_value_fails_typed() -> None:
+    class _Weird(Enum):
+        MEMBER = object()
+
+    with pytest.raises(ModuleResultNormalizationError, match="unsupported value type"):
+        json_safe_bson({"kind": _Weird.MEMBER})
+
+
+def test_enum_with_set_value_fails_typed() -> None:
+    class _SetValued(Enum):
+        MEMBER = frozenset({"a"})
+
+    with pytest.raises(ModuleResultNormalizationError):
+        json_safe_bson({"kind": _SetValued.MEMBER})
+
+
+def test_unexpected_conversion_exception_is_wrapped_without_contents() -> None:
+    class _HostileDatetime(datetime):
+        def isoformat(self, *args, **kwargs):  # pragma: no cover - bypassed
+            raise RuntimeError("SECRET-CONTENT")
+
+    # Unbound datetime.isoformat is used, so the override never runs and the
+    # value converts through the base implementation.
+    normalized = json_safe_bson(
+        {"when": _HostileDatetime(2026, 9, 2, tzinfo=UTC)}
+    )
+    assert normalized["when"].startswith("2026-09-02")
+
+
+def test_top_level_wrapper_never_leaks_and_only_raises_typed_error() -> None:
+    class _RaisingEnum(Enum):
+        MEMBER = "ok"
+
+        @property
+        def value(self):  # noqa: PLR0206 - deliberate hostile property
+            raise RuntimeError("SECRET-ENUM-CONTENT")
+
+    with pytest.raises(ModuleResultNormalizationError) as excinfo:
+        json_safe_bson({"kind": _RaisingEnum.MEMBER})
+    message = str(excinfo.value)
+    assert "SECRET-ENUM-CONTENT" not in message
+    assert "RuntimeError" in message
+
+
+# ---------------------------------------------------------------------------
+# Exact FastAPI wire-byte parity
+# ---------------------------------------------------------------------------
+
+
+def _wire_bytes(value) -> bytes:
+    """The executor's exact wire render (must match JSONResponse.render)."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=None,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"text": "é"},
+        {"emoji": "🚀", "mixed": ["é", {"k": "ü"}], "n": 3, "f": 1.5, "none": None},
+        {"nested": {"a": [1, 2, 3], "b": "plain ascii"}},
+        [],
+        {},
+        ["é", "combining é"],
+    ],
+    ids=["latin-accent", "emoji-mixed", "nested", "empty-list", "empty-dict", "unicode-list"],
+)
+def test_measured_bytes_equal_actual_starlette_response_bytes(payload) -> None:
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/echo")
+    def _echo():
+        return JSONResponse(content=payload)
+
+    with TestClient(app) as client:
+        body = client.get("/echo").content
+    assert _wire_bytes(payload) == body
+    assert len(_wire_bytes(payload)) == len(body)
+
+
+# ---------------------------------------------------------------------------
 # Executor boundary behavior
 # ---------------------------------------------------------------------------
 
@@ -263,6 +528,63 @@ async def test_oversized_normalized_response_is_rejected_by_exact_bytes() -> Non
     result = await ex.execute(_request("records", "huge"))
     assert result.success is False
     assert result.error_code == "RESPONSE_TOO_LARGE"
+
+
+class _SizedHandler:
+    """Returns a payload whose exact wire bytes are controllable."""
+
+    def __init__(self, payload) -> None:
+        self._payload = payload
+
+    def sized(self, ctx, **params):
+        return self._payload
+
+
+def _exact_wire_size(value) -> int:
+    return len(
+        json.dumps(
+            value, ensure_ascii=False, allow_nan=False, indent=None, separators=(",", ":")
+        ).encode("utf-8")
+    )
+
+
+@pytest.mark.asyncio
+async def test_result_at_exact_limit_passes_and_one_byte_over_fails(monkeypatch) -> None:
+    # Multi-byte characters make encoded-string length diverge from byte
+    # length; the gate must measure the actual UTF-8 wire bytes.
+    payload = {"text": "é" * 10}
+    limit = _exact_wire_size(payload)
+
+    monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", str(limit))
+    ex = ModuleExecutor()
+    ex.register("sized", _SizedHandler(payload))
+    at_limit = await ex.execute(_request("sized", "sized"))
+    assert at_limit.success is True
+
+    monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", str(limit - 1))
+    ex2 = ModuleExecutor()
+    ex2.register("sized", _SizedHandler(payload))
+    over = await ex2.execute(_request("sized", "sized"))
+    assert over.success is False
+    assert over.error_code == "RESPONSE_TOO_LARGE"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_result_is_not_json_safe_never_a_size_outcome(monkeypatch) -> None:
+    monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", "1")
+    ex = ModuleExecutor()
+    ex.register("sized", _SizedHandler({"handle": object()}))
+    result = await ex.execute(_request("sized", "sized"))
+    assert result.success is False
+    assert result.error_code == "MODULE_RESULT_NOT_JSON_SAFE"
+
+
+def test_bson_int64_converts_to_exact_int() -> None:
+    from bson.int64 import Int64
+
+    normalized = json_safe_bson({"count": Int64(9_007_199_254_740_993)})
+    assert normalized["count"] == 9_007_199_254_740_993
+    assert type(normalized["count"]) is int
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_module_result_bson_normalization.py
+++ b/tests/test_module_result_bson_normalization.py
@@ -1,23 +1,29 @@
-"""Module action results must be JSON-safe at the executor boundary.
+"""Closed JSON transport contract at the ModuleExecutor success boundary.
 
-Generated app modules return raw Mongo documents; without normalization a
-document whose ``_id`` is an ``ObjectId`` reached FastAPI's serializer and
-produced a bare HTTP 500 on every list/read action. ``json_safe_bson`` at the
-ModuleExecutor success boundary is the single normalization authority.
+No ModuleExecutor success may later fail at FastAPI serialization: results are
+normalized into a closed value domain, non-string mapping keys and unsupported
+values fail closed with MODULE_RESULT_NOT_JSON_SAFE, and the size gate
+measures the exact strict-encoded UTF-8 bytes.
 """
 from __future__ import annotations
 
 import json
 import os
-from datetime import UTC, datetime
+import uuid
+from datetime import UTC, date, datetime
 from decimal import Decimal
-from uuid import uuid4
+from enum import Enum
 
 import pytest
 from bson import ObjectId
 from bson.decimal128 import Decimal128
+from pydantic import BaseModel
 
-from mozaiksai.core.runtime.composition.bson_safe import json_safe_bson
+from mozaiksai.core.runtime.composition.bson_safe import (
+    MAX_RESULT_DEPTH,
+    ModuleResultNormalizationError,
+    json_safe_bson,
+)
 from mozaiksai.core.runtime.composition.module_executor import (
     ModuleExecutor,
     ModuleRequest,
@@ -37,52 +43,59 @@ def _request(module: str, action: str, params: dict | None = None) -> ModuleRequ
 
 
 # ---------------------------------------------------------------------------
-# Normalizer unit behavior
+# Value domain
 # ---------------------------------------------------------------------------
 
 
-def test_object_id_becomes_stable_hex_string_everywhere() -> None:
+def test_object_id_values_become_stable_hex_strings() -> None:
     oid = ObjectId()
-    nested_oid = ObjectId()
-    key_oid = ObjectId()
-    document = {
-        "_id": oid,
-        "items": [{"ref": nested_oid}, (oid, "pair")],
-        key_oid: "keyed",
-    }
-
+    nested = ObjectId()
+    document = {"_id": oid, "items": [{"ref": nested}, (oid, "pair")]}
     normalized = json_safe_bson(document)
-
     assert normalized["_id"] == str(oid)
-    assert normalized["items"][0]["ref"] == str(nested_oid)
+    assert normalized["items"][0]["ref"] == str(nested)
     assert normalized["items"][1] == [str(oid), "pair"]
-    assert normalized[str(key_oid)] == "keyed"
-    assert json.loads(json.dumps(normalized))["_id"] == str(oid)
+    json.dumps(normalized, allow_nan=False)
 
 
-def test_decimal128_is_lossless_and_json_safe() -> None:
+def test_decimal128_is_lossless() -> None:
     value = Decimal128("1234567890.123456789012345678901234")
     normalized = json_safe_bson({"amount": value})
-    assert normalized["amount"] == "1234567890.123456789012345678901234"
     assert Decimal(normalized["amount"]) == value.to_decimal()
 
 
-def test_non_bson_values_pass_through_unchanged() -> None:
-    class _Opaque:
-        pass
+def test_fastapi_equivalent_wire_semantics_preserved() -> None:
+    class _Kind(Enum):
+        ACTIVE = "active"
 
-    stamp = datetime.now(UTC)
-    opaque = _Opaque()
+    class _Doc(BaseModel):
+        name: str
+        when: datetime
+
+    stamp = datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC)
     normalized = json_safe_bson(
-        {"when": stamp, "opaque": opaque, "n": 3, "flag": True, "none": None}
+        {
+            "when": stamp,
+            "day": date(2026, 9, 2),
+            "uid": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            "price": Decimal("9.90"),
+            "count": Decimal("3"),
+            "kind": _Kind.ACTIVE,
+            "model": _Doc(name="a", when=stamp),
+            "blob": b"text-bytes",
+            "tags": {"a"},
+        }
     )
-    # datetime stays owned by the platform's existing encoder; unknown types
-    # are never coerced through a repr.
-    assert normalized["when"] is stamp
-    assert normalized["opaque"] is opaque
-    assert normalized["n"] == 3
-    assert normalized["flag"] is True
-    assert normalized["none"] is None
+    assert normalized["when"] == stamp.isoformat()
+    assert normalized["day"] == "2026-09-02"
+    assert normalized["uid"] == "12345678-1234-5678-1234-567812345678"
+    assert normalized["price"] == float(Decimal("9.90"))
+    assert normalized["count"] == 3
+    assert normalized["kind"] == "active"
+    assert normalized["model"]["name"] == "a"
+    assert normalized["blob"] == "text-bytes"
+    assert normalized["tags"] == ["a"]
+    json.dumps(normalized, allow_nan=False)
 
 
 def test_input_documents_are_not_mutated() -> None:
@@ -94,12 +107,94 @@ def test_input_documents_are_not_mutated() -> None:
     assert document["items"][0] is oid
 
 
-def test_containers_are_handled_deterministically() -> None:
+# ---------------------------------------------------------------------------
+# Closed key domain — collisions are impossible because keys must be strings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ObjectId(),
+        1,
+        True,
+        None,
+        ("a", "b"),
+        b"k",
+        object(),
+    ],
+    ids=["objectid", "int", "bool", "none", "tuple", "bytes", "custom"],
+)
+def test_non_string_mapping_keys_fail_closed(key) -> None:
+    with pytest.raises(ModuleResultNormalizationError, match="keys must be strings"):
+        json_safe_bson({key: "value"})
+
+
+def test_objectid_key_never_collides_with_equivalent_string_key() -> None:
     oid = ObjectId()
-    assert json_safe_bson((1, oid)) == [1, str(oid)]
-    assert json_safe_bson([{"a": (oid,)}]) == [{"a": [str(oid)]}]
-    assert json_safe_bson({}) == {}
-    assert json_safe_bson([]) == []
+    with pytest.raises(ModuleResultNormalizationError):
+        json_safe_bson({oid: "a", str(oid): "b"})
+
+
+def test_integer_key_never_collides_with_string_key() -> None:
+    with pytest.raises(ModuleResultNormalizationError):
+        json_safe_bson({1: "a", "1": "b"})
+
+
+def test_none_key_never_collides_with_null_string_key() -> None:
+    with pytest.raises(ModuleResultNormalizationError):
+        json_safe_bson({None: "a", "null": "b"})
+
+
+# ---------------------------------------------------------------------------
+# Unsupported values, non-finite floats, cycles, and depth
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_value_fails_closed_without_repr_leak() -> None:
+    class _Secret:
+        def __repr__(self) -> str:  # pragma: no cover - must never be called
+            return "SECRET-CONTENT"
+
+    with pytest.raises(ModuleResultNormalizationError) as excinfo:
+        json_safe_bson({"item": _Secret()})
+    assert "SECRET-CONTENT" not in str(excinfo.value)
+    assert "_Secret" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_floats_fail_closed(bad) -> None:
+    with pytest.raises(ModuleResultNormalizationError, match="non-finite float"):
+        json_safe_bson({"x": bad})
+
+
+def test_cyclic_list_fails_closed() -> None:
+    items: list = []
+    items.append(items)
+    with pytest.raises(ModuleResultNormalizationError, match="cyclic"):
+        json_safe_bson(items)
+
+
+def test_cyclic_mapping_fails_closed() -> None:
+    document: dict = {}
+    document["self"] = document
+    with pytest.raises(ModuleResultNormalizationError, match="cyclic"):
+        json_safe_bson(document)
+
+
+def test_excessive_nesting_fails_closed() -> None:
+    value: dict = {"leaf": True}
+    for _ in range(MAX_RESULT_DEPTH + 5):
+        value = {"nested": value}
+    with pytest.raises(ModuleResultNormalizationError, match="nesting"):
+        json_safe_bson(value)
+
+
+def test_shared_noncyclic_child_is_encoded_twice_deterministically() -> None:
+    child = {"ref": ObjectId()}
+    normalized = json_safe_bson({"a": child, "b": child})
+    assert normalized["a"] == normalized["b"]
+    assert normalized["a"] is not normalized["b"]
 
 
 # ---------------------------------------------------------------------------
@@ -108,8 +203,6 @@ def test_containers_are_handled_deterministically() -> None:
 
 
 class _MongoShapedHandler:
-    """Returns document shapes exactly as generated repo code produces them."""
-
     def __init__(self) -> None:
         self.created_id = ObjectId()
 
@@ -122,8 +215,19 @@ class _MongoShapedHandler:
             "count": 2,
         }
 
-    def get_record(self, ctx, **params) -> dict:
-        return {"_id": self.created_id, "name": "alpha"}
+    def bad_keys(self, ctx, **params) -> dict:
+        return {1: "collides"}
+
+    def bad_value(self, ctx, **params) -> dict:
+        return {"handle": object()}
+
+    def cyclic(self, ctx, **params) -> dict:
+        document: dict = {}
+        document["self"] = document
+        return document
+
+    def huge(self, ctx, **params) -> dict:
+        return {"blob": "x" * 20_000_000}
 
 
 @pytest.mark.asyncio
@@ -134,16 +238,31 @@ async def test_executor_results_serialize_after_mongo_shaped_actions() -> None:
 
     listed = await ex.execute(_request("records", "list_records"))
     assert listed.success is True
-    encoded = json.dumps(listed.data)
-    assert str(handler.created_id) in encoded
+    json.dumps(listed.data, allow_nan=False)
     assert listed.data["items"][0]["_id"] == str(handler.created_id)
     assert listed.data["items"][0]["price"] == "9.99"
-    assert listed.data["count"] == 2
 
-    fetched = await ex.execute(_request("records", "get_record"))
-    assert fetched.success is True
-    json.dumps(fetched.data)
-    assert fetched.data["_id"] == str(handler.created_id)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["bad_keys", "bad_value", "cyclic"])
+async def test_invalid_transport_results_return_typed_error(action: str) -> None:
+    ex = ModuleExecutor()
+    ex.register("records", _MongoShapedHandler())
+    result = await ex.execute(_request("records", action))
+    assert result.success is False
+    assert result.error_code == "MODULE_RESULT_NOT_JSON_SAFE"
+    # The action completed; this is a transport-contract failure, and no raw
+    # object contents leak into the client-facing message.
+    assert "object" not in (result.error or "").lower() or "JSON-safe" in result.error
+
+
+@pytest.mark.asyncio
+async def test_oversized_normalized_response_is_rejected_by_exact_bytes() -> None:
+    ex = ModuleExecutor()
+    ex.register("records", _MongoShapedHandler())
+    result = await ex.execute(_request("records", "huge"))
+    assert result.success is False
+    assert result.error_code == "RESPONSE_TOO_LARGE"
 
 
 # ---------------------------------------------------------------------------
@@ -161,14 +280,12 @@ async def test_real_mongo_crud_results_are_json_safe_through_executor() -> None:
 
     uri = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
     client = AsyncIOMotorClient(uri)
-    database_name = f"mozaiks_bson_safe_test_{uuid4().hex}"
+    database_name = f"mozaiks_bson_safe_test_{uuid.uuid4().hex}"
     collection = client[database_name]["records"]
 
     class _RealRepoHandler:
         async def create_record(self, ctx, **params) -> dict:
-            # Generated services set a string "id" and rely on Mongo to
-            # autogenerate the ObjectId _id — the exact defect shape.
-            document = {"id": str(uuid4()), "name": params.get("name", "")}
+            document = {"id": str(uuid.uuid4()), "name": params.get("name", "")}
             await collection.insert_one(document)
             return {"created": document["id"]}
 
@@ -201,20 +318,17 @@ async def test_real_mongo_crud_results_are_json_safe_through_executor() -> None:
 
         listed = await ex.execute(_request("records", "list_records"))
         assert listed.success is True
-        json.dumps(listed.data)
-        assert listed.data["count"] == 1
+        json.dumps(listed.data, allow_nan=False)
         assert isinstance(listed.data["items"][0]["_id"], str)
 
         read = await ex.execute(_request("records", "read_record", {"id": record_id}))
         assert read.success is True
-        json.dumps(read.data)
         assert isinstance(read.data["item"]["_id"], str)
 
         updated = await ex.execute(
             _request("records", "update_record", {"id": record_id, "name": "beta"})
         )
         assert updated.success is True
-        json.dumps(updated.data)
         assert updated.data["item"]["name"] == "beta"
 
         deleted = await ex.execute(

--- a/tests/test_module_result_bson_normalization.py
+++ b/tests/test_module_result_bson_normalization.py
@@ -1,0 +1,227 @@
+"""Module action results must be JSON-safe at the executor boundary.
+
+Generated app modules return raw Mongo documents; without normalization a
+document whose ``_id`` is an ``ObjectId`` reached FastAPI's serializer and
+produced a bare HTTP 500 on every list/read action. ``json_safe_bson`` at the
+ModuleExecutor success boundary is the single normalization authority.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from bson import ObjectId
+from bson.decimal128 import Decimal128
+
+from mozaiksai.core.runtime.composition.bson_safe import json_safe_bson
+from mozaiksai.core.runtime.composition.module_executor import (
+    ModuleExecutor,
+    ModuleRequest,
+)
+from tests.module_authority_test_helpers import trusted_framework_authority
+
+
+def _request(module: str, action: str, params: dict | None = None) -> ModuleRequest:
+    return ModuleRequest(
+        module=module,
+        action=action,
+        params=params or {},
+        app_id="app-bson",
+        user_id="user-1",
+        authority=trusted_framework_authority(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalizer unit behavior
+# ---------------------------------------------------------------------------
+
+
+def test_object_id_becomes_stable_hex_string_everywhere() -> None:
+    oid = ObjectId()
+    nested_oid = ObjectId()
+    key_oid = ObjectId()
+    document = {
+        "_id": oid,
+        "items": [{"ref": nested_oid}, (oid, "pair")],
+        key_oid: "keyed",
+    }
+
+    normalized = json_safe_bson(document)
+
+    assert normalized["_id"] == str(oid)
+    assert normalized["items"][0]["ref"] == str(nested_oid)
+    assert normalized["items"][1] == [str(oid), "pair"]
+    assert normalized[str(key_oid)] == "keyed"
+    assert json.loads(json.dumps(normalized))["_id"] == str(oid)
+
+
+def test_decimal128_is_lossless_and_json_safe() -> None:
+    value = Decimal128("1234567890.123456789012345678901234")
+    normalized = json_safe_bson({"amount": value})
+    assert normalized["amount"] == "1234567890.123456789012345678901234"
+    assert Decimal(normalized["amount"]) == value.to_decimal()
+
+
+def test_non_bson_values_pass_through_unchanged() -> None:
+    class _Opaque:
+        pass
+
+    stamp = datetime.now(UTC)
+    opaque = _Opaque()
+    normalized = json_safe_bson(
+        {"when": stamp, "opaque": opaque, "n": 3, "flag": True, "none": None}
+    )
+    # datetime stays owned by the platform's existing encoder; unknown types
+    # are never coerced through a repr.
+    assert normalized["when"] is stamp
+    assert normalized["opaque"] is opaque
+    assert normalized["n"] == 3
+    assert normalized["flag"] is True
+    assert normalized["none"] is None
+
+
+def test_input_documents_are_not_mutated() -> None:
+    oid = ObjectId()
+    document = {"_id": oid, "nested": {"ref": oid}, "items": [oid]}
+    json_safe_bson(document)
+    assert document["_id"] is oid
+    assert document["nested"]["ref"] is oid
+    assert document["items"][0] is oid
+
+
+def test_containers_are_handled_deterministically() -> None:
+    oid = ObjectId()
+    assert json_safe_bson((1, oid)) == [1, str(oid)]
+    assert json_safe_bson([{"a": (oid,)}]) == [{"a": [str(oid)]}]
+    assert json_safe_bson({}) == {}
+    assert json_safe_bson([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Executor boundary behavior
+# ---------------------------------------------------------------------------
+
+
+class _MongoShapedHandler:
+    """Returns document shapes exactly as generated repo code produces them."""
+
+    def __init__(self) -> None:
+        self.created_id = ObjectId()
+
+    def list_records(self, ctx, **params) -> dict:
+        return {
+            "items": [
+                {"_id": self.created_id, "name": "alpha", "price": Decimal128("9.99")},
+                {"_id": ObjectId(), "name": "beta", "owner": {"_id": ObjectId()}},
+            ],
+            "count": 2,
+        }
+
+    def get_record(self, ctx, **params) -> dict:
+        return {"_id": self.created_id, "name": "alpha"}
+
+
+@pytest.mark.asyncio
+async def test_executor_results_serialize_after_mongo_shaped_actions() -> None:
+    ex = ModuleExecutor()
+    handler = _MongoShapedHandler()
+    ex.register("records", handler)
+
+    listed = await ex.execute(_request("records", "list_records"))
+    assert listed.success is True
+    encoded = json.dumps(listed.data)
+    assert str(handler.created_id) in encoded
+    assert listed.data["items"][0]["_id"] == str(handler.created_id)
+    assert listed.data["items"][0]["price"] == "9.99"
+    assert listed.data["count"] == 2
+
+    fetched = await ex.execute(_request("records", "get_record"))
+    assert fetched.success is True
+    json.dumps(fetched.data)
+    assert fetched.data["_id"] == str(handler.created_id)
+
+
+# ---------------------------------------------------------------------------
+# Real-Mongo CRUD through the persistence wrapper + executor boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real Mongo CRUD normalization tests",
+)
+@pytest.mark.asyncio
+async def test_real_mongo_crud_results_are_json_safe_through_executor() -> None:
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    uri = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+    client = AsyncIOMotorClient(uri)
+    database_name = f"mozaiks_bson_safe_test_{uuid4().hex}"
+    collection = client[database_name]["records"]
+
+    class _RealRepoHandler:
+        async def create_record(self, ctx, **params) -> dict:
+            # Generated services set a string "id" and rely on Mongo to
+            # autogenerate the ObjectId _id — the exact defect shape.
+            document = {"id": str(uuid4()), "name": params.get("name", "")}
+            await collection.insert_one(document)
+            return {"created": document["id"]}
+
+        async def list_records(self, ctx, **params) -> dict:
+            items = await collection.find({}).to_list(length=50)
+            return {"items": items, "count": len(items)}
+
+        async def read_record(self, ctx, **params) -> dict:
+            return {"item": await collection.find_one({"id": params["id"]})}
+
+        async def update_record(self, ctx, **params) -> dict:
+            await collection.update_one(
+                {"id": params["id"]}, {"$set": {"name": params["name"]}}
+            )
+            return {"item": await collection.find_one({"id": params["id"]})}
+
+        async def delete_record(self, ctx, **params) -> dict:
+            result = await collection.delete_one({"id": params["id"]})
+            return {"deleted": int(result.deleted_count)}
+
+    try:
+        ex = ModuleExecutor()
+        ex.register("records", _RealRepoHandler())
+
+        created = await ex.execute(
+            _request("records", "create_record", {"name": "alpha"})
+        )
+        assert created.success is True
+        record_id = created.data["created"]
+
+        listed = await ex.execute(_request("records", "list_records"))
+        assert listed.success is True
+        json.dumps(listed.data)
+        assert listed.data["count"] == 1
+        assert isinstance(listed.data["items"][0]["_id"], str)
+
+        read = await ex.execute(_request("records", "read_record", {"id": record_id}))
+        assert read.success is True
+        json.dumps(read.data)
+        assert isinstance(read.data["item"]["_id"], str)
+
+        updated = await ex.execute(
+            _request("records", "update_record", {"id": record_id, "name": "beta"})
+        )
+        assert updated.success is True
+        json.dumps(updated.data)
+        assert updated.data["item"]["name"] == "beta"
+
+        deleted = await ex.execute(
+            _request("records", "delete_record", {"id": record_id})
+        )
+        assert deleted.success is True
+        assert deleted.data == {"deleted": 1}
+    finally:
+        await client.drop_database(database_name)
+        client.close()


### PR DESCRIPTION
## Defect (reproduced by the read-only product baseline)

Generated app modules return raw Mongo documents from `ctx.persistence`-backed repos. Generated services set a string `id` and rely on the driver to autogenerate the `ObjectId` `_id` (the canonical-example and capability-pack repo pattern), so every list/read action over such records handed an `ObjectId` to FastAPI's serializer — which has no BSON branch — producing a bare HTTP 500 with no error code. The same unnormalized `result.data` flows to profile panels, profile tabs, page hydration, and relationship rows. The executor's response-size gate used `json.dumps(default=str)`, which masked the problem instead of surfacing it.

## Correction — one closed transport contract at one boundary

Normalization happens at `ModuleExecutor`'s success boundary — the single choke point every module action result crosses regardless of transport or how the module obtained its data — via one canonical normalizer, `mozaiksai/core/runtime/composition/bson_safe.json_safe_bson`. The contract is **closed**: this is not a universal serializer, and values outside the domain fail with a typed error rather than being coerced.

**Values:**

- BSON `ObjectId` **values** → their stable 24-character hexadecimal strings wherever they occur *as values*: `_id`, ordinary fields, nested documents, and arrays;
- `Decimal128` → its lossless decimal string; BSON `Int64` → exact builtin `int`;
- datetime/date/time → ISO strings, `UUID` → string, finite `Decimal` → the FastAPI-equivalent encoding, `Enum` → its recursively normalized value, valid-UTF-8 `bytes` → text, pydantic models → their explicit JSON-mode dump;
- non-finite floats and Decimals (NaN/Infinity), malformed UTF-8, scalar subclasses, and every unsupported type fail closed with `MODULE_RESULT_NOT_JSON_SAFE` — no `str`/`repr` fallback, no payload contents in error messages.

**Keys:**

- JSON object keys must already be **exact strings**;
- an `ObjectId` key — like every other non-string mapping key — is rejected with `MODULE_RESULT_NOT_JSON_SAFE`;
- no key normalization or key coercion occurs, so no post-normalization key collision is possible; the key domain is closed before iteration.

**Containers:**

- exactly `dict`/`list`/`tuple` are traversed (tuples become lists, matching JSON array semantics); the type check runs **before** any `.items()` call or iteration;
- sets/frozensets (no deterministic JSON form), container subclasses, custom Mappings, and generators are rejected without executing their code;
- cyclic containers and nesting beyond the depth guard are rejected; **input documents are never mutated**.

Normalization runs before output-schema validation and the size gate so both observe the JSON-safe shape. The size gate measures the exact response bytes: the same compact-separator, `ensure_ascii=False`, UTF-8 encoding Starlette's `JSONResponse` emits, verified byte-for-byte against real `TestClient` bodies. Narrower candidates were rejected deliberately: fixing only the HTTP module route would leave the four `platform.py` surfaces and WebSocket delivery broken; fixing the persistence wrapper would miss `literal_collection`/alias paths and `inserted_id`, and would strip BSON types modules may legitimately use internally.

## Proofs

- Normalizer attack matrix: ObjectId in every *value* position; ObjectId and other non-string keys rejected typed; Decimal128 losslessness; Decimal NaN/Infinity, hostile Mapping/set/dict/list/tuple subclasses (methods proven never executed), generators, malformed bytes, throwing pydantic serializers, Enum with unsupported values — all typed, never raw; cross-`PYTHONHASHSEED` proof that no set serialization path exists; no input mutation.
- Executor boundary: Mongo-shaped list/get results JSON-serialize with string ids through `ModuleExecutor.execute`; invalid results return `success=False` with `MODULE_RESULT_NOT_JSON_SAFE`; exact-limit passes and one-byte-over fails on real wire bytes.
- **Real Mongo over the packaged platform host** (`MOZAIKS_RUN_REAL_MONGO_TESTS=1`): create → list → read → update → delete over POST and GET dispatch, the profile-panel embedding surface hydrated from real documents, an invalid module result surfacing as the controlled JSON error envelope (not an unhandled serialization crash), and the server serving the next request normally.
- Product acceptance battery at this head: `test_generated_app_functional_acceptance.py` + `test_canonical_example_apps.py` + both boundary files green. Ruff, scoped mypy, `git diff --check` clean; full suite result in PR comments.

## Boundaries

No semantics/5D/AG2/hosted/evaluation surface touched; no serialization framework grown — one bounded, closed-domain normalizer at one boundary.

## OSS Change Impact

- Layer changed: runtime module-execution boundary (`mozaiksai/core/runtime/composition/`).
- Build workflow impact: none.
- Runtime/platform impact: module action results are JSON-safe on every response surface; behavior changes only for values that previously produced a 500 or that are now rejected typed instead of silently mis-serialized.
- App workspace impact: generated apps' read paths work without regeneration.
- Tests run: listed above + full suite (result in PR comment).
- Docs updated: CHANGELOG.
- Compatibility risk: none for previously-working responses; ObjectId-bearing responses change from 500 to strings; results carrying sets, non-string keys, or other out-of-domain values now fail typed instead of nondeterministically serializing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
