### PR TITLE
feat(semantics): deterministically render application-family artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,18 @@ This project follows a practical pre-1.0 changelog format:
 
 - **Deterministic application-family rendering (ADR 0007 Slice 5D-0B2A)**: the
   offline semantic compiler can now render canonical application-configuration
-  bytes — `app.json`, `ui/route_manifest.json`, `config/ai.json`,
-  `config/integrations.yaml`, and names-only `security/secrets.yaml` — from
-  accepted semantic facts through a single binding-resolved
-  `deterministic_app_config_renderer@1` authority, under two named byte
-  contracts (`mozaiks.json_decl_bytes.v1`, `mozaiks.yaml_decl_bytes.v1`).
-  Production generation is unchanged: AppGenerator writers remain the
-  authoritative emitters of these paths until the atomic 5D cutover, and
-  guards prove the new renderer is not wired into any production path.
+  bytes for four application-level families — `app.json`,
+  `ui/route_manifest.json`, `config/integrations.yaml`, and names-only
+  `security/secrets.yaml` — from accepted semantic facts through a single
+  binding-resolved `deterministic_app_config_renderer@1` authority with
+  family-local render inputs, under two named byte contracts
+  (`mozaiks.json_decl_bytes.v1`, `mozaiks.yaml_decl_bytes.v1`).
+  `config/ai.json` is explicitly deferred: application-level AI-launch
+  semantics (chat startup mode, workflow entry point) have no typed semantic
+  home yet and are never inferred from per-workflow facts. Production
+  generation is unchanged: AppGenerator writers remain the authoritative
+  emitters of these paths until the atomic 5D cutover, and guards prove the
+  new renderer is not wired into any production path.
 
 ### Fixed
 - **Server-owned session fields and the canonical bundle entry are closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Added
+
+- **Deterministic application-family rendering (ADR 0007 Slice 5D-0B2A)**: the
+  offline semantic compiler can now render canonical application-configuration
+  bytes — `app.json`, `ui/route_manifest.json`, `config/ai.json`,
+  `config/integrations.yaml`, and names-only `security/secrets.yaml` — from
+  accepted semantic facts through a single binding-resolved
+  `deterministic_app_config_renderer@1` authority, under two named byte
+  contracts (`mozaiks.json_decl_bytes.v1`, `mozaiks.yaml_decl_bytes.v1`).
+  Production generation is unchanged: AppGenerator writers remain the
+  authoritative emitters of these paths until the atomic 5D cutover, and
+  guards prove the new renderer is not wired into any production path.
+
 ### Fixed
 - **Server-owned session fields and the canonical bundle entry are closed
   boundaries**: the chat-session lifecycle authority fields
@@ -79,7 +92,6 @@ This project follows a practical pre-1.0 changelog format:
   separators, `ensure_ascii=False`, UTF-8), verified against real
   `TestClient` response bodies, so a result at the limit passes and one byte
   over fails.
-
 
 ### Changed
 

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -319,6 +319,29 @@ no renderer, invokes no AG2 primitive, and is not imported by production
 AppGenerator, task execution, assembly, persistence, publication, Studio, or
 refinement paths. Those gates remain for 5D-0B2, 5D-0B3, and the atomic cutover.
 
+Slice 5D-0B2A makes the application-configuration subset of those `render`
+families deterministic. One renderer authority,
+`deterministic_app_config_renderer@1`, is resolved only through an
+`ImplementationBinding` renderer selection bound to the
+`app_config_executor` materializer, and renders exactly five families —
+`app_manifest` (`app.json`), `app_ui_route_manifest`
+(`ui/route_manifest.json`), `app_config` (`config/ai.json`),
+`app_integrations_config` (`config/integrations.yaml`), and
+`app_secret_references` (`security/secrets.yaml`, secret names only) — from
+accepted semantic payloads alone. Two named byte contracts,
+`mozaiks.json_decl_bytes.v1` and `mozaiks.yaml_decl_bytes.v1`, fix
+serialization (UTF-8, LF, trailing newline, declaration-order preservation,
+round-trip equality) so identical facts always produce identical bytes; the
+renderer reads no clock, environment, filesystem, `AppBuildPlan`, or Git
+state. Families whose required facts still lack a typed semantic home —
+`app_subscription_config` (default plan and assignment-store wiring),
+`app_data_contract` (collection-to-module ownership edges), and asset
+manifests (no typed asset facts) — remain typed gaps with recorded
+prerequisites for 5D-0B2B. Production AppGenerator writers remain the
+authoritative emitters of these paths until the atomic 5D cutover; hygiene
+guards prove they do not call the B2A renderer and that no production module
+imports it.
+
 ## ApplicationManifest
 
 `ApplicationManifest` is the minimal root identity and reference document,

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -322,18 +322,28 @@ refinement paths. Those gates remain for 5D-0B2, 5D-0B3, and the atomic cutover.
 Slice 5D-0B2A makes the application-configuration subset of those `render`
 families deterministic. One renderer authority,
 `deterministic_app_config_renderer@1`, is resolved only through an
-`ImplementationBinding` renderer selection bound to the
-`app_config_executor` materializer, and renders exactly five families —
-`app_manifest` (`app.json`), `app_ui_route_manifest`
-(`ui/route_manifest.json`), `app_config` (`config/ai.json`),
-`app_integrations_config` (`config/integrations.yaml`), and
-`app_secret_references` (`security/secrets.yaml`, secret names only) — from
-accepted semantic payloads alone. Two named byte contracts,
-`mozaiks.json_decl_bytes.v1` and `mozaiks.yaml_decl_bytes.v1`, fix
-serialization (UTF-8, LF, trailing newline, declaration-order preservation,
-round-trip equality) so identical facts always produce identical bytes; the
-renderer reads no clock, environment, filesystem, `AppBuildPlan`, or Git
-state. Families whose required facts still lack a typed semantic home —
+`ImplementationBinding` renderer selection that must declare exactly its
+four-family capability set on the `app_config_executor` materializer, and
+renders `app_manifest` (`app.json`), `app_ui_route_manifest`
+(`ui/route_manifest.json`), `app_integrations_config`
+(`config/integrations.yaml`), and `app_secret_references`
+(`security/secrets.yaml`, secret names only) from accepted semantic payloads
+alone. Each family consumes its own closed, frozen, family-local render input
+projected lazily per plan unit by the offline materialization owner, so a
+typed gap in one family never blocks another whose own source closure is
+complete. Completion is selection-honest per consuming family: SELECTED
+requires the typed facts present and declared-absent facts must be absent —
+missing selected evidence stays a typed gap, never an empty rendering. Two
+named byte contracts, `mozaiks.json_decl_bytes.v1` and
+`mozaiks.yaml_decl_bytes.v1`, fix serialization (UTF-8, LF, trailing newline,
+declaration-order preservation, round-trip equality) so identical facts
+always produce identical bytes; the renderer reads no clock, environment,
+filesystem, `AppBuildPlan`, or Git state. `app_config` (`config/ai.json`) is
+explicitly deferred: per-workflow `workflow_startup_mode` is not
+application-level chat launch authority, and application-level AI-launch
+facts (chat startup mode, workflow entry point) have no typed semantic home
+yet — the family stays a typed gap and no startup mode is ever inferred.
+Families whose required facts likewise lack a typed home —
 `app_subscription_config` (default plan and assignment-store wiring),
 `app_data_contract` (collection-to-module ownership edges), and asset
 manifests (no typed asset facts) — remain typed gaps with recorded

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -1141,9 +1141,14 @@ def _semantic_inputs_for_family(kind: ArtifactKind) -> tuple[str, ...]:
             "application",
             "workflow",
         ),
+        # security/secrets.yaml emits application integration-selection
+        # evidence plus integration configuration requirements whose value
+        # kind is secret. AuthPayload carries no typed secret/configuration
+        # requirement today, so auth is NOT a source of this family;
+        # provider-neutral auth secret declaration is a separate typed
+        # prerequisite.
         ArtifactKind.APP_SECRET_REFERENCES: (
             "application",
-            "auth",
             "integration",
         ),
     }.get(kind, ())

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -172,6 +172,7 @@ class MaterializerIdentifier(StrEnum):
     MODULE_CONTRACT_EXECUTOR = "module_contract_executor"
     MODULE_BACKEND_EXECUTOR = "module_backend_executor"
     PAGE_SCHEMA_EXECUTOR = "page_schema_executor"
+    APP_CONFIG_EXECUTOR = "app_config_executor"
     WORKFLOW_GENERATOR = "workflow_generator"
     CAPABILITY_PACK_MATERIALIZER = "capability_pack_materializer"
     DOWNLOAD_DEPLOYMENT_RENDERER = "download_deployment_renderer"
@@ -644,9 +645,9 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         "event",
         "capability",
     )
-    application_inputs = ("application",)
+    application_inputs = ("application", "auth")
     auth_inputs = ("auth",)
-    integration_inputs = ("integration",)
+    integration_inputs = ("application", "integration")
     return (
         _family(ArtifactKind.APP_MANIFEST, LayoutOwner.PLATFORM, Requirement.REQUIRED, app, "app.json", ValidatorIdentifier.APP_LOADER, RuntimeConsumerIdentifier.APP_LOADER, inputs=application_inputs),
         _family(ArtifactKind.APP_CONFIG, LayoutOwner.PLATFORM, Requirement.OPTIONAL, app, "config/ai.json", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.PLATFORM_HOST),
@@ -1021,6 +1022,16 @@ def _materializer_for_family(
     if kind is ArtifactKind.APP_UI_PAGE_SCHEMA:
         return MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR
     if kind in {
+        ArtifactKind.APP_MANIFEST,
+        ArtifactKind.APP_CONFIG,
+        ArtifactKind.APP_INTEGRATIONS_CONFIG,
+        ArtifactKind.APP_SECRET_REFERENCES,
+        ArtifactKind.APP_SUBSCRIPTION_CONFIG,
+        ArtifactKind.APP_DATA_CONTRACT,
+        ArtifactKind.APP_UI_ROUTE_MANIFEST,
+    }:
+        return MaterializerIdentifier.APP_CONFIG_EXECUTOR
+    if kind in {
         ArtifactKind.MODULE_MANIFEST,
         ArtifactKind.MODULE_CONTRACT,
         ArtifactKind.MODULE_RUNTIME_EXTENSIONS,
@@ -1121,6 +1132,19 @@ def _semantic_inputs_for_family(kind: ArtifactKind) -> tuple[str, ...]:
         ),
         ArtifactKind.APP_DEPLOYMENT_ARTIFACT: (
             "deployment_target",
+        ),
+        ArtifactKind.APP_UI_ROUTE_MANIFEST: (
+            "application",
+            "page",
+        ),
+        ArtifactKind.APP_CONFIG: (
+            "application",
+            "workflow",
+        ),
+        ArtifactKind.APP_SECRET_REFERENCES: (
+            "application",
+            "auth",
+            "integration",
         ),
     }.get(kind, ())
 

--- a/mozaiksai/core/semantics/app_config_materialization.py
+++ b/mozaiksai/core/semantics/app_config_materialization.py
@@ -6,29 +6,33 @@ whose complete input authority exists on accepted semantic payloads:
 
 - ``app_manifest``            -> ``app.json``
 - ``app_ui_route_manifest``   -> ``ui/route_manifest.json``
-- ``app_config``              -> ``config/ai.json``
 - ``app_integrations_config`` -> ``config/integrations.yaml``
 - ``app_secret_references``   -> ``security/secrets.yaml``
 
-Dependency direction is one-way: the central offline materialization owner
-(``mozaiksai.core.semantics.materialization``) resolves semantic refs,
-validates the graph/plan/binding relationship, and projects the accepted
-payload facts into one closed, immutable :class:`ApplicationFamilyRenderInput`
-snapshot. This module consumes only that snapshot. It imports no semantic
-payload classes, no graph model, and no binding machinery — the snapshot is
-derived data pinned to exact source payload digests, never a second authored
-semantic model.
+``app_config`` (``config/ai.json``) is deliberately NOT renderer-ready in this
+slice: per-workflow ``workflow_startup_mode`` is not application-level chat
+launch authority, and the semantic model has no application-level AI-launch
+facts (chat startup mode, workflow entry point). The family stays a typed
+plan gap until that prerequisite exists; nothing here infers a startup mode
+or entry point.
+
+Each family consumes its own closed, frozen, family-local render input —
+``AppManifestRenderInput``, ``RouteManifestRenderInput``,
+``IntegrationsConfigRenderInput``, ``SecretReferencesRenderInput`` — projected
+by the central offline materialization owner from exactly that unit's
+plan-pinned sources. Missing facts for one family never block another family
+whose own source closure is complete. Dependency direction stays one-way:
+this module imports no semantic payload classes, no graph model, and no
+binding machinery; the inputs are derived data pinned to exact source payload
+digests, never a second authored semantic model.
 
 The renderer is offline substrate: no filesystem, no clocks, no environment,
-no AG2, no AppBuildPlan, no production callers. Families whose facts lack a
-typed semantic home (subscriptions ``default_plan_id`` and assignment-store
-wiring; data-contract collection->module surface ownership) are NOT rendered
-here — they remain typed plan gaps for 5D-0B2B with their prerequisites
-recorded in the slice tests.
+no AG2, no AppBuildPlan, no production callers.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -44,31 +48,29 @@ APP_FAMILY_RENDER_INPUT_VERSION: Literal["mozaiks.app_family_render_input.v1"] =
 )
 
 #: The closed family set this renderer implementation may produce.
+#: ``app_config`` is intentionally excluded: application-level AI-launch
+#: authority does not exist in the semantic model yet.
 APP_CONFIG_FAMILIES: frozenset[str] = frozenset(
     {
         "app_manifest",
         "app_ui_route_manifest",
-        "app_config",
         "app_integrations_config",
         "app_secret_references",
     }
 )
 
-#: Output templates this implementation renders. ``config/asset_manifest.json``
-#: shares the ``app_config`` family kind but has no typed semantic source yet;
-#: rendering it fails closed as an explicit 0B2B boundary.
+#: Output templates this implementation renders. ``config/ai.json`` and
+#: ``config/asset_manifest.json`` are not in this set; rendering them fails
+#: closed as explicit deferred-prerequisite boundaries.
 _RENDERED_TEMPLATES: frozenset[str] = frozenset(
     {
         "app.json",
         "app/app.json",
         "ui/route_manifest.json",
-        "config/ai.json",
         "config/integrations.yaml",
         "security/secrets.yaml",
     }
 )
-
-_CHAT_STARTUP_DEFAULT = "ask"
 
 
 class AppConfigMaterializationError(ValueError):
@@ -76,7 +78,7 @@ class AppConfigMaterializationError(ValueError):
 
 
 class _ClosedRenderInputModel(BaseModel):
-    """Frozen, unknown-field-rejecting base for every snapshot component."""
+    """Frozen, unknown-field-rejecting base for every render-input component."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -115,54 +117,27 @@ class RenderInputIntegration(_ClosedRenderInputModel):
     config_requirements: tuple[RenderInputConfigRequirement, ...]
 
 
-class ApplicationFamilyRenderInput(_ClosedRenderInputModel):
-    """Closed immutable render input for the application-configuration families.
+class _FamilyRenderInputBase(_ClosedRenderInputModel):
+    """Shared identity of every family-local render input.
 
-    Derived data only: the offline materialization owner projects accepted,
-    footprint-pinned payload facts into this snapshot and ties it to the exact
-    source payload digests in ``sources``. Equivalent facts supplied in any
-    order normalize to one canonical snapshot, so identical semantics always
-    produce identical bytes. The model is recursively frozen and rejects every
-    undeclared field — it cannot carry arbitrary metadata, provider state,
-    clocks, or environment.
+    Each input carries only the facts its one family consumes plus the exact
+    source payload digests that produced them. Inputs are normalized to one
+    canonical order so equivalent facts supplied in any order render identical
+    bytes, and they are recursively frozen and closed — no arbitrary metadata,
+    provider state, clocks, or environment can enter.
     """
 
     render_input_schema_version: Literal["mozaiks.app_family_render_input.v1"]
-    application_id: str
-    display_name: str
-    version: str
-    description: str | None
-    default_route: str
-    auth_required: bool
-    pages: tuple[RenderInputPage, ...]
-    #: Application chat startup behavior, resolved by the materialization
-    #: owner only after workflow-selection completeness is proven. A missing
-    #: or contradictory workflow fact never reaches this field: the owner
-    #: fails closed instead of normalizing absence to a mode.
-    chat_startup_mode: Literal["ask", "workflow"]
-    integrations: tuple[RenderInputIntegration, ...]
     sources: tuple[RenderInputSource, ...]
 
     @model_validator(mode="after")
-    def _canonical_order(self) -> ApplicationFamilyRenderInput:
-        pages = tuple(sorted(self.pages, key=lambda p: p.route))
-        routes = [p.route for p in pages]
-        if len(set(routes)) != len(routes):
-            raise ValueError("render input declares duplicate page routes")
-        integrations = tuple(
-            sorted(self.integrations, key=lambda i: i.integration_id)
-        )
-        integration_ids = [i.integration_id for i in integrations]
-        if len(set(integration_ids)) != len(integration_ids):
-            raise ValueError("render input declares duplicate integration ids")
+    def _canonical_sources(self) -> _FamilyRenderInputBase:
         sources = tuple(sorted(self.sources, key=lambda s: s.node_id))
         source_ids = [s.node_id for s in sources]
         if len(set(source_ids)) != len(source_ids):
             raise ValueError("render input declares duplicate source node ids")
         if not sources:
             raise ValueError("render input pins no semantic sources")
-        object.__setattr__(self, "pages", pages)
-        object.__setattr__(self, "integrations", integrations)
         object.__setattr__(self, "sources", sources)
         return self
 
@@ -173,10 +148,78 @@ class ApplicationFamilyRenderInput(_ClosedRenderInputModel):
         return None
 
 
+class AppManifestRenderInput(_FamilyRenderInputBase):
+    """Facts consumed by ``app.json`` only."""
+
+    family: Literal["app_manifest"] = "app_manifest"
+    application_id: str
+    display_name: str
+    version: str
+    description: str | None
+    default_route: str
+    auth_required: bool
+
+
+class RouteManifestRenderInput(_FamilyRenderInputBase):
+    """Facts consumed by ``ui/route_manifest.json`` only."""
+
+    family: Literal["app_ui_route_manifest"] = "app_ui_route_manifest"
+    default_route: str
+    pages: tuple[RenderInputPage, ...]
+
+    @model_validator(mode="after")
+    def _canonical_pages(self) -> RouteManifestRenderInput:
+        pages = tuple(sorted(self.pages, key=lambda p: p.route))
+        routes = [p.route for p in pages]
+        if len(set(routes)) != len(routes):
+            raise ValueError("render input declares duplicate page routes")
+        object.__setattr__(self, "pages", pages)
+        return self
+
+
+class IntegrationsConfigRenderInput(_FamilyRenderInputBase):
+    """Facts consumed by ``config/integrations.yaml`` only."""
+
+    family: Literal["app_integrations_config"] = "app_integrations_config"
+    integrations: tuple[RenderInputIntegration, ...]
+
+    @model_validator(mode="after")
+    def _canonical_integrations(self) -> IntegrationsConfigRenderInput:
+        integrations = tuple(
+            sorted(self.integrations, key=lambda i: i.integration_id)
+        )
+        integration_ids = [i.integration_id for i in integrations]
+        if len(set(integration_ids)) != len(integration_ids):
+            raise ValueError("render input declares duplicate integration ids")
+        object.__setattr__(self, "integrations", integrations)
+        return self
+
+
+class SecretReferencesRenderInput(_FamilyRenderInputBase):
+    """Names-only secret handles consumed by ``security/secrets.yaml``."""
+
+    family: Literal["app_secret_references"] = "app_secret_references"
+    secret_names: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def _canonical_names(self) -> SecretReferencesRenderInput:
+        names = tuple(sorted(set(self.secret_names)))
+        object.__setattr__(self, "secret_names", names)
+        return self
+
+
+AppFamilyRenderInput = (
+    AppManifestRenderInput
+    | RouteManifestRenderInput
+    | IntegrationsConfigRenderInput
+    | SecretReferencesRenderInput
+)
+
+
 def _verify_unit_sources(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+    unit: FamilyInstancePlan, render_input: AppFamilyRenderInput
 ) -> None:
-    """Every unit-pinned source must match the snapshot's exact digest."""
+    """Every unit-pinned source must match the render input's exact digest."""
     for source in unit.sources:
         pinned = render_input.source_digest(source.node_id)
         if pinned is None or pinned != source.payload_digest:
@@ -187,7 +230,7 @@ def _verify_unit_sources(
 
 
 def _app_manifest_document(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+    unit: FamilyInstancePlan, render_input: AppManifestRenderInput
 ) -> dict[str, object]:
     document: dict[str, object] = {
         "appId": render_input.application_id,
@@ -202,7 +245,7 @@ def _app_manifest_document(
 
 
 def _route_manifest_document(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+    unit: FamilyInstancePlan, render_input: RouteManifestRenderInput
 ) -> dict[str, object]:
     entries = [
         {
@@ -220,14 +263,8 @@ def _route_manifest_document(
     return {"pages": entries}
 
 
-def _ai_config_document(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
-) -> dict[str, object]:
-    return {"chat": {"chat_startup_mode": render_input.chat_startup_mode}}
-
-
 def _integrations_document(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+    unit: FamilyInstancePlan, render_input: IntegrationsConfigRenderInput
 ) -> dict[str, object]:
     entries: list[dict[str, object]] = []
     for integration in render_input.integrations:
@@ -252,37 +289,45 @@ def _integrations_document(
 
 
 def _secret_references_document(
-    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+    unit: FamilyInstancePlan, render_input: SecretReferencesRenderInput
 ) -> dict[str, object]:
-    names = {
-        requirement.name
-        for integration in render_input.integrations
-        for requirement in integration.config_requirements
-        if requirement.value_type == "secret"
-    }
-    return {"version": 1, "secrets": sorted(names)}
+    return {"version": 1, "secrets": list(render_input.secret_names)}
 
 
-_DOCUMENT_BUILDERS = {
-    "app.json": (_app_manifest_document, json_decl_bytes),
-    "app/app.json": (_app_manifest_document, json_decl_bytes),
-    "ui/route_manifest.json": (_route_manifest_document, json_decl_bytes),
-    "config/ai.json": (_ai_config_document, json_decl_bytes),
-    "config/integrations.yaml": (_integrations_document, yaml_decl_bytes),
-    "security/secrets.yaml": (_secret_references_document, yaml_decl_bytes),
+_DOCUMENT_BUILDERS: dict[
+    str, tuple[str, Callable[..., dict[str, object]], Callable[..., bytes]]
+] = {
+    "app.json": ("app_manifest", _app_manifest_document, json_decl_bytes),
+    "app/app.json": ("app_manifest", _app_manifest_document, json_decl_bytes),
+    "ui/route_manifest.json": (
+        "app_ui_route_manifest",
+        _route_manifest_document,
+        json_decl_bytes,
+    ),
+    "config/integrations.yaml": (
+        "app_integrations_config",
+        _integrations_document,
+        yaml_decl_bytes,
+    ),
+    "security/secrets.yaml": (
+        "app_secret_references",
+        _secret_references_document,
+        yaml_decl_bytes,
+    ),
 }
 
 
 def render_app_config_unit(
     *,
     unit: FamilyInstancePlan,
-    render_input: ApplicationFamilyRenderInput,
+    render_input: AppFamilyRenderInput,
 ) -> bytes:
     """Render one application-configuration unit's canonical bytes.
 
     The unit's plan-owned output path selects the artifact contract; the
-    renderer never chooses paths and never reads state outside the closed
-    render-input snapshot whose sources cover the unit's pinned footprint.
+    renderer never chooses paths, never reads state outside the family-local
+    render input covering the unit's pinned footprint, and rejects an input
+    variant that belongs to a different family.
     """
     if unit.family_kind not in APP_CONFIG_FAMILIES:
         raise AppConfigMaterializationError(
@@ -304,8 +349,13 @@ def render_app_config_unit(
             f"unit {unit.unit_id!r} output {path!r} has no deterministic "
             "application-config contract in this slice"
         )
+    family, build_document, serialize = builder
+    if unit.family_kind != family or render_input.family != family:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} ({unit.family_kind!r}) does not match the "
+            f"{render_input.family!r} render input for output {path!r}"
+        )
     _verify_unit_sources(unit, render_input)
-    build_document, serialize = builder
     return serialize(build_document(unit, render_input))
 
 
@@ -315,10 +365,14 @@ __all__ = [
     "APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION",
     "APP_FAMILY_RENDER_INPUT_VERSION",
     "AppConfigMaterializationError",
-    "ApplicationFamilyRenderInput",
+    "AppFamilyRenderInput",
+    "AppManifestRenderInput",
+    "IntegrationsConfigRenderInput",
     "RenderInputConfigRequirement",
     "RenderInputIntegration",
     "RenderInputPage",
     "RenderInputSource",
+    "RouteManifestRenderInput",
+    "SecretReferencesRenderInput",
     "render_app_config_unit",
 ]

--- a/mozaiksai/core/semantics/app_config_materialization.py
+++ b/mozaiksai/core/semantics/app_config_materialization.py
@@ -135,7 +135,11 @@ class ApplicationFamilyRenderInput(_ClosedRenderInputModel):
     default_route: str
     auth_required: bool
     pages: tuple[RenderInputPage, ...]
-    has_agent_driven_workflow: bool
+    #: Application chat startup behavior, resolved by the materialization
+    #: owner only after workflow-selection completeness is proven. A missing
+    #: or contradictory workflow fact never reaches this field: the owner
+    #: fails closed instead of normalizing absence to a mode.
+    chat_startup_mode: Literal["ask", "workflow"]
     integrations: tuple[RenderInputIntegration, ...]
     sources: tuple[RenderInputSource, ...]
 
@@ -219,12 +223,7 @@ def _route_manifest_document(
 def _ai_config_document(
     unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
 ) -> dict[str, object]:
-    mode = (
-        "workflow"
-        if render_input.has_agent_driven_workflow
-        else _CHAT_STARTUP_DEFAULT
-    )
-    return {"chat": {"chat_startup_mode": mode}}
+    return {"chat": {"chat_startup_mode": render_input.chat_startup_mode}}
 
 
 def _integrations_document(

--- a/mozaiksai/core/semantics/app_config_materialization.py
+++ b/mozaiksai/core/semantics/app_config_materialization.py
@@ -10,13 +10,14 @@ whose complete input authority exists on accepted semantic payloads:
 - ``app_integrations_config`` -> ``config/integrations.yaml``
 - ``app_secret_references``   -> ``security/secrets.yaml``
 
-Every fact rendered here derives from footprint-pinned payloads
-(ApplicationPayload, AuthPayload, IntegrationPayload, PagePayload,
-WorkflowPayload) or from a deterministic runtime default the normative
-loader already defines (``version`` when unauthored is not one of them —
-version is authored intent; ``chat_startup_mode`` falls back to the
-platform's own ``"ask"`` default only when no agent-driven workflow is
-selected, mirroring ``mozaiksai.hosts.platform``).
+Dependency direction is one-way: the central offline materialization owner
+(``mozaiksai.core.semantics.materialization``) resolves semantic refs,
+validates the graph/plan/binding relationship, and projects the accepted
+payload facts into one closed, immutable :class:`ApplicationFamilyRenderInput`
+snapshot. This module consumes only that snapshot. It imports no semantic
+payload classes, no graph model, and no binding machinery — the snapshot is
+derived data pinned to exact source payload digests, never a second authored
+semantic model.
 
 The renderer is offline substrate: no filesystem, no clocks, no environment,
 no AG2, no AppBuildPlan, no production callers. Families whose facts lack a
@@ -28,33 +29,19 @@ recorded in the slice tests.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from typing import Literal
 
-from mozaiksai.core.runtime.app.layout_registry import MaterializerIdentifier
-from mozaiksai.core.semantics.binding import (
-    ImplementationBinding,
-    RendererSelection,
-    validate_implementation_binding_against_graph,
-)
+from pydantic import BaseModel, ConfigDict, model_validator
+
 from mozaiksai.core.semantics.compilation_plan import FamilyInstancePlan, PlanDisposition
 from mozaiksai.core.semantics.decl_bytes import json_decl_bytes, yaml_decl_bytes
-from mozaiksai.core.semantics.graph import SemanticGraphV2
-from mozaiksai.core.semantics.payloads import (
-    ApplicationPayload,
-    AuthPayload,
-    IntegrationConfigValueKind,
-    IntegrationPayload,
-    OptionalFamilyKind,
-    OptionalFamilySelectionStatus,
-    PagePayload,
-    SemanticPayloadBase,
-    WorkflowPayload,
-    WorkflowStartupMode,
-)
 
 APP_CONFIG_RENDERER_IMPLEMENTATION_ID = "deterministic_app_config_renderer"
 APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION = "1"
+
+APP_FAMILY_RENDER_INPUT_VERSION: Literal["mozaiks.app_family_render_input.v1"] = (
+    "mozaiks.app_family_render_input.v1"
+)
 
 #: The closed family set this renderer implementation may produce.
 APP_CONFIG_FAMILIES: frozenset[str] = frozenset(
@@ -88,160 +75,141 @@ class AppConfigMaterializationError(ValueError):
     """The inputs violate the Slice 5D-0B2A application-family contract."""
 
 
-def resolve_app_config_renderer_selection(
-    binding: ImplementationBinding,
-    *,
-    graph: SemanticGraphV2,
-    layout_registry: Any,
-) -> RendererSelection:
-    """Resolve the accepted app-config renderer through the binding.
+class _ClosedRenderInputModel(BaseModel):
+    """Frozen, unknown-field-rejecting base for every snapshot component."""
 
-    Fails closed when the binding carries no selection covering the
-    application-configuration families, claims a different materializer, or
-    pins any implementation identity/version other than the single accepted
-    deterministic implementation of this slice. There is no fallback to any
-    historical generator path.
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class RenderInputSource(_ClosedRenderInputModel):
+    """One pinned semantic source: exact node identity and payload digest."""
+
+    node_id: str
+    payload_digest: str
+
+
+class RenderInputPage(_ClosedRenderInputModel):
+    """The route-manifest facts of one declared page."""
+
+    page_id: str
+    route: str
+    title: str
+
+
+class RenderInputConfigRequirement(_ClosedRenderInputModel):
+    """One integration configuration requirement, names only — never values."""
+
+    name: str
+    value_type: Literal["text", "url", "secret"]
+    required: bool
+
+
+class RenderInputIntegration(_ClosedRenderInputModel):
+    """The declaration facts of one selected integration."""
+
+    integration_id: str
+    kind: str
+    purpose: str | None
+    required_at: str
+    optional: bool
+    config_requirements: tuple[RenderInputConfigRequirement, ...]
+
+
+class ApplicationFamilyRenderInput(_ClosedRenderInputModel):
+    """Closed immutable render input for the application-configuration families.
+
+    Derived data only: the offline materialization owner projects accepted,
+    footprint-pinned payload facts into this snapshot and ties it to the exact
+    source payload digests in ``sources``. Equivalent facts supplied in any
+    order normalize to one canonical snapshot, so identical semantics always
+    produce identical bytes. The model is recursively frozen and rejects every
+    undeclared field — it cannot carry arbitrary metadata, provider state,
+    clocks, or environment.
     """
-    try:
-        validate_implementation_binding_against_graph(
-            binding, graph, layout_registry=layout_registry
+
+    render_input_schema_version: Literal["mozaiks.app_family_render_input.v1"]
+    application_id: str
+    display_name: str
+    version: str
+    description: str | None
+    default_route: str
+    auth_required: bool
+    pages: tuple[RenderInputPage, ...]
+    has_agent_driven_workflow: bool
+    integrations: tuple[RenderInputIntegration, ...]
+    sources: tuple[RenderInputSource, ...]
+
+    @model_validator(mode="after")
+    def _canonical_order(self) -> ApplicationFamilyRenderInput:
+        pages = tuple(sorted(self.pages, key=lambda p: p.route))
+        routes = [p.route for p in pages]
+        if len(set(routes)) != len(routes):
+            raise ValueError("render input declares duplicate page routes")
+        integrations = tuple(
+            sorted(self.integrations, key=lambda i: i.integration_id)
         )
-    except ValueError as exc:
-        raise AppConfigMaterializationError(
-            f"implementation binding rejected: {exc}"
-        ) from exc
-    matches = [
-        selection
-        for selection in binding.renderer_selections
-        if APP_CONFIG_FAMILIES & set(selection.artifact_families)
-    ]
-    if not matches:
-        raise AppConfigMaterializationError(
-            "binding carries no renderer selection for the application-config families"
-        )
-    selection = matches[0]
-    if selection.materializer_id is not MaterializerIdentifier.APP_CONFIG_EXECUTOR:
-        raise AppConfigMaterializationError(
-            "renderer selection for application-config families pins materializer "
-            f"{selection.materializer_id.value!r}, not the app config executor"
-        )
-    if (
-        selection.implementation_id != APP_CONFIG_RENDERER_IMPLEMENTATION_ID
-        or selection.implementation_version != APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION
-    ):
-        raise AppConfigMaterializationError(
-            "binding pins unaccepted app-config renderer implementation "
-            f"{selection.implementation_id!r}@{selection.implementation_version!r}"
-        )
-    return selection
+        integration_ids = [i.integration_id for i in integrations]
+        if len(set(integration_ids)) != len(integration_ids):
+            raise ValueError("render input declares duplicate integration ids")
+        sources = tuple(sorted(self.sources, key=lambda s: s.node_id))
+        source_ids = [s.node_id for s in sources]
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError("render input declares duplicate source node ids")
+        if not sources:
+            raise ValueError("render input pins no semantic sources")
+        object.__setattr__(self, "pages", pages)
+        object.__setattr__(self, "integrations", integrations)
+        object.__setattr__(self, "sources", sources)
+        return self
+
+    def source_digest(self, node_id: str) -> str | None:
+        for source in self.sources:
+            if source.node_id == node_id:
+                return source.payload_digest
+        return None
 
 
-def _footprint_payloads(
-    unit: FamilyInstancePlan, payload_by_node: Mapping[str, SemanticPayloadBase]
-) -> dict[str, SemanticPayloadBase]:
-    """Return exactly the payloads pinned by the unit's source footprint."""
-    resolved: dict[str, SemanticPayloadBase] = {}
+def _verify_unit_sources(
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> None:
+    """Every unit-pinned source must match the snapshot's exact digest."""
     for source in unit.sources:
-        pinned = payload_by_node.get(source.node_id)
-        if pinned is None or pinned.payload_digest != source.payload_digest:
+        pinned = render_input.source_digest(source.node_id)
+        if pinned is None or pinned != source.payload_digest:
             raise AppConfigMaterializationError(
                 f"unit {unit.unit_id!r} source {source.node_id!r} is missing or does "
                 "not match its pinned payload digest"
             )
-        resolved[source.node_id] = pinned
-    return resolved
-
-
-def _one_of(
-    payloads: Mapping[str, SemanticPayloadBase],
-    payload_type: type,
-    *,
-    unit: FamilyInstancePlan,
-    required: bool,
-) -> Any:
-    matches = [p for p in payloads.values() if isinstance(p, payload_type)]
-    if len(matches) > 1:
-        raise AppConfigMaterializationError(
-            f"unit {unit.unit_id!r} footprint pins more than one "
-            f"{payload_type.__name__}"
-        )
-    if not matches:
-        if required:
-            raise AppConfigMaterializationError(
-                f"unit {unit.unit_id!r} footprint pins no {payload_type.__name__}"
-            )
-        return None
-    return matches[0]
-
-
-def _local_id(node_id: str) -> str:
-    return node_id.rsplit(".", 1)[-1]
-
-
-def _auth_required(
-    application: ApplicationPayload, auth: AuthPayload | None
-) -> bool:
-    if auth is not None:
-        return bool(auth.auth_required)
-    for selection in application.optional_families:
-        if selection.family is OptionalFamilyKind.AUTH:
-            if selection.status is OptionalFamilySelectionStatus.SELECTED:
-                raise AppConfigMaterializationError(
-                    "auth is selected but no AuthPayload is pinned in the footprint"
-                )
-            return False
-    raise AppConfigMaterializationError(
-        "application selection evidence does not state the auth family"
-    )
 
 
 def _app_manifest_document(
-    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
-) -> dict[str, Any]:
-    application: ApplicationPayload = _one_of(
-        payloads, ApplicationPayload, unit=unit, required=True
-    )
-    auth: AuthPayload | None = _one_of(payloads, AuthPayload, unit=unit, required=False)
-    document: dict[str, Any] = {
-        "appId": application.application_id,
-        "appName": application.display_name,
-        "version": application.version,
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> dict[str, object]:
+    document: dict[str, object] = {
+        "appId": render_input.application_id,
+        "appName": render_input.display_name,
+        "version": render_input.version,
     }
-    if application.description is not None:
-        document["description"] = application.description
-    document["authRequired"] = _auth_required(application, auth)
-    document["startup"] = {"landing_spot": application.default_route}
+    if render_input.description is not None:
+        document["description"] = render_input.description
+    document["authRequired"] = render_input.auth_required
+    document["startup"] = {"landing_spot": render_input.default_route}
     return document
 
 
 def _route_manifest_document(
-    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
-) -> dict[str, Any]:
-    application: ApplicationPayload = _one_of(
-        payloads, ApplicationPayload, unit=unit, required=True
-    )
-    pages = sorted(
-        (p for p in payloads.values() if isinstance(p, PagePayload)),
-        key=lambda p: str(p.route or ""),
-    )
-    entries: list[dict[str, Any]] = []
-    declared_routes: set[str] = set()
-    for page in pages:
-        if not page.route or not page.title:
-            raise AppConfigMaterializationError(
-                f"page {page.node_id!r} lacks the route/title facts the route "
-                "manifest requires"
-            )
-        declared_routes.add(page.route)
-        entries.append(
-            {
-                "path": page.route,
-                "component": "SchemaPage",
-                "label": page.title,
-                "schema": page.page_id,
-            }
-        )
-    if application.default_route not in declared_routes:
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> dict[str, object]:
+    entries = [
+        {
+            "path": page.route,
+            "component": "SchemaPage",
+            "label": page.title,
+            "schema": page.page_id,
+        }
+        for page in render_input.pages
+    ]
+    if render_input.default_route not in {page.route for page in render_input.pages}:
         raise AppConfigMaterializationError(
             "application default_route does not resolve to a declared page route"
         )
@@ -249,62 +217,33 @@ def _route_manifest_document(
 
 
 def _ai_config_document(
-    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
-) -> dict[str, Any]:
-    _one_of(payloads, ApplicationPayload, unit=unit, required=True)
-    workflows = [p for p in payloads.values() if isinstance(p, WorkflowPayload)]
-    mode = _CHAT_STARTUP_DEFAULT
-    if any(w.startup_mode is WorkflowStartupMode.AGENT_DRIVEN for w in workflows):
-        mode = "workflow"
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> dict[str, object]:
+    mode = (
+        "workflow"
+        if render_input.has_agent_driven_workflow
+        else _CHAT_STARTUP_DEFAULT
+    )
     return {"chat": {"chat_startup_mode": mode}}
 
 
-def _integration_entries(
-    payloads: Mapping[str, SemanticPayloadBase],
-) -> list[IntegrationPayload]:
-    return sorted(
-        (p for p in payloads.values() if isinstance(p, IntegrationPayload)),
-        key=lambda p: p.integration_id,
-    )
-
-
-_CONFIG_VALUE_TYPES = {
-    IntegrationConfigValueKind.TEXT: "text",
-    IntegrationConfigValueKind.URL: "url",
-    IntegrationConfigValueKind.SECRET: "secret",
-}
-
-
 def _integrations_document(
-    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
-) -> dict[str, Any]:
-    application: ApplicationPayload = _one_of(
-        payloads, ApplicationPayload, unit=unit, required=True
-    )
-    integrations = _integration_entries(payloads)
-    selected = any(
-        s.family is OptionalFamilyKind.INTEGRATIONS
-        and s.status is OptionalFamilySelectionStatus.SELECTED
-        for s in application.optional_families
-    )
-    if selected and not integrations:
-        raise AppConfigMaterializationError(
-            "integrations are selected but no IntegrationPayload is pinned"
-        )
-    entries: list[dict[str, Any]] = []
-    for integration in integrations:
-        entry: dict[str, Any] = {
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> dict[str, object]:
+    entries: list[dict[str, object]] = []
+    for integration in render_input.integrations:
+        entry: dict[str, object] = {
             "service": integration.integration_id,
-            "kind": integration.integration_kind.value,
+            "kind": integration.kind,
         }
         if integration.purpose is not None:
             entry["purpose"] = integration.purpose
-        entry["required_at"] = integration.required_at.value
+        entry["required_at"] = integration.required_at
         entry["optional"] = integration.optional
         entry["required_fields"] = [
             {
                 "name": requirement.name,
-                "type": _CONFIG_VALUE_TYPES[requirement.value_kind],
+                "type": requirement.value_type,
                 "required": requirement.required,
             }
             for requirement in integration.config_requirements
@@ -314,14 +253,14 @@ def _integrations_document(
 
 
 def _secret_references_document(
-    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
-) -> dict[str, Any]:
-    _one_of(payloads, ApplicationPayload, unit=unit, required=True)
-    names: set[str] = set()
-    for integration in _integration_entries(payloads):
-        for requirement in integration.config_requirements:
-            if requirement.value_kind is IntegrationConfigValueKind.SECRET:
-                names.add(requirement.name)
+    unit: FamilyInstancePlan, render_input: ApplicationFamilyRenderInput
+) -> dict[str, object]:
+    names = {
+        requirement.name
+        for integration in render_input.integrations
+        for requirement in integration.config_requirements
+        if requirement.value_type == "secret"
+    }
     return {"version": 1, "secrets": sorted(names)}
 
 
@@ -338,13 +277,13 @@ _DOCUMENT_BUILDERS = {
 def render_app_config_unit(
     *,
     unit: FamilyInstancePlan,
-    payload_by_node: Mapping[str, SemanticPayloadBase],
+    render_input: ApplicationFamilyRenderInput,
 ) -> bytes:
     """Render one application-configuration unit's canonical bytes.
 
     The unit's plan-owned output path selects the artifact contract; the
-    renderer never chooses paths and never reads state outside the unit's
-    pinned source footprint.
+    renderer never chooses paths and never reads state outside the closed
+    render-input snapshot whose sources cover the unit's pinned footprint.
     """
     if unit.family_kind not in APP_CONFIG_FAMILIES:
         raise AppConfigMaterializationError(
@@ -366,16 +305,21 @@ def render_app_config_unit(
             f"unit {unit.unit_id!r} output {path!r} has no deterministic "
             "application-config contract in this slice"
         )
+    _verify_unit_sources(unit, render_input)
     build_document, serialize = builder
-    payloads = _footprint_payloads(unit, payload_by_node)
-    return serialize(build_document(unit, payloads))
+    return serialize(build_document(unit, render_input))
 
 
 __all__ = [
     "APP_CONFIG_FAMILIES",
     "APP_CONFIG_RENDERER_IMPLEMENTATION_ID",
     "APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION",
+    "APP_FAMILY_RENDER_INPUT_VERSION",
     "AppConfigMaterializationError",
+    "ApplicationFamilyRenderInput",
+    "RenderInputConfigRequirement",
+    "RenderInputIntegration",
+    "RenderInputPage",
+    "RenderInputSource",
     "render_app_config_unit",
-    "resolve_app_config_renderer_selection",
 ]

--- a/mozaiksai/core/semantics/app_config_materialization.py
+++ b/mozaiksai/core/semantics/app_config_materialization.py
@@ -219,14 +219,31 @@ AppFamilyRenderInput = (
 def _verify_unit_sources(
     unit: FamilyInstancePlan, render_input: AppFamilyRenderInput
 ) -> None:
-    """Every unit-pinned source must match the render input's exact digest."""
-    for source in unit.sources:
-        pinned = render_input.source_digest(source.node_id)
-        if pinned is None or pinned != source.payload_digest:
-            raise AppConfigMaterializationError(
-                f"unit {unit.unit_id!r} source {source.node_id!r} is missing or does "
-                "not match its pinned payload digest"
-            )
+    """The render input must bind exactly the unit's pinned source set.
+
+    Not a subset, not a superset, not "at least the required sources": after
+    canonical normalization, the (node_id, payload_digest) identity tuples of
+    the render input must equal the PlanUnit's source footprint exactly. A
+    missing source, an additional source, a duplicate, a stale digest, or a
+    substituted identity all fail closed — no unrelated payload can become
+    hidden provenance of a family's bytes.
+    """
+    expected = tuple(
+        sorted((s.node_id, s.payload_digest) for s in unit.sources)
+    )
+    if len({node_id for node_id, _ in expected}) != len(expected):
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} pins duplicate source node ids"
+        )
+    actual = tuple((s.node_id, s.payload_digest) for s in render_input.sources)
+    if actual != expected:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} render input does not bind exactly the "
+            "unit's pinned source set — a source is missing, extra, "
+            "substituted, or does not match its pinned payload digest: "
+            f"expected {[n for n, _ in expected]!r}, "
+            f"got {[n for n, _ in actual]!r}"
+        )
 
 
 def _app_manifest_document(

--- a/mozaiksai/core/semantics/app_config_materialization.py
+++ b/mozaiksai/core/semantics/app_config_materialization.py
@@ -1,0 +1,381 @@
+"""ADR 0007 Slice 5D-0B2A deterministic application-family rendering.
+
+One accepted renderer authority — ``deterministic_app_config_renderer@1`` —
+produces canonical bytes for the closed application-configuration family set
+whose complete input authority exists on accepted semantic payloads:
+
+- ``app_manifest``            -> ``app.json``
+- ``app_ui_route_manifest``   -> ``ui/route_manifest.json``
+- ``app_config``              -> ``config/ai.json``
+- ``app_integrations_config`` -> ``config/integrations.yaml``
+- ``app_secret_references``   -> ``security/secrets.yaml``
+
+Every fact rendered here derives from footprint-pinned payloads
+(ApplicationPayload, AuthPayload, IntegrationPayload, PagePayload,
+WorkflowPayload) or from a deterministic runtime default the normative
+loader already defines (``version`` when unauthored is not one of them —
+version is authored intent; ``chat_startup_mode`` falls back to the
+platform's own ``"ask"`` default only when no agent-driven workflow is
+selected, mirroring ``mozaiksai.hosts.platform``).
+
+The renderer is offline substrate: no filesystem, no clocks, no environment,
+no AG2, no AppBuildPlan, no production callers. Families whose facts lack a
+typed semantic home (subscriptions ``default_plan_id`` and assignment-store
+wiring; data-contract collection->module surface ownership) are NOT rendered
+here — they remain typed plan gaps for 5D-0B2B with their prerequisites
+recorded in the slice tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from mozaiksai.core.runtime.app.layout_registry import MaterializerIdentifier
+from mozaiksai.core.semantics.binding import (
+    ImplementationBinding,
+    RendererSelection,
+    validate_implementation_binding_against_graph,
+)
+from mozaiksai.core.semantics.compilation_plan import FamilyInstancePlan, PlanDisposition
+from mozaiksai.core.semantics.decl_bytes import json_decl_bytes, yaml_decl_bytes
+from mozaiksai.core.semantics.graph import SemanticGraphV2
+from mozaiksai.core.semantics.payloads import (
+    ApplicationPayload,
+    AuthPayload,
+    IntegrationConfigValueKind,
+    IntegrationPayload,
+    OptionalFamilyKind,
+    OptionalFamilySelectionStatus,
+    PagePayload,
+    SemanticPayloadBase,
+    WorkflowPayload,
+    WorkflowStartupMode,
+)
+
+APP_CONFIG_RENDERER_IMPLEMENTATION_ID = "deterministic_app_config_renderer"
+APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION = "1"
+
+#: The closed family set this renderer implementation may produce.
+APP_CONFIG_FAMILIES: frozenset[str] = frozenset(
+    {
+        "app_manifest",
+        "app_ui_route_manifest",
+        "app_config",
+        "app_integrations_config",
+        "app_secret_references",
+    }
+)
+
+#: Output templates this implementation renders. ``config/asset_manifest.json``
+#: shares the ``app_config`` family kind but has no typed semantic source yet;
+#: rendering it fails closed as an explicit 0B2B boundary.
+_RENDERED_TEMPLATES: frozenset[str] = frozenset(
+    {
+        "app.json",
+        "app/app.json",
+        "ui/route_manifest.json",
+        "config/ai.json",
+        "config/integrations.yaml",
+        "security/secrets.yaml",
+    }
+)
+
+_CHAT_STARTUP_DEFAULT = "ask"
+
+
+class AppConfigMaterializationError(ValueError):
+    """The inputs violate the Slice 5D-0B2A application-family contract."""
+
+
+def resolve_app_config_renderer_selection(
+    binding: ImplementationBinding,
+    *,
+    graph: SemanticGraphV2,
+    layout_registry: Any,
+) -> RendererSelection:
+    """Resolve the accepted app-config renderer through the binding.
+
+    Fails closed when the binding carries no selection covering the
+    application-configuration families, claims a different materializer, or
+    pins any implementation identity/version other than the single accepted
+    deterministic implementation of this slice. There is no fallback to any
+    historical generator path.
+    """
+    try:
+        validate_implementation_binding_against_graph(
+            binding, graph, layout_registry=layout_registry
+        )
+    except ValueError as exc:
+        raise AppConfigMaterializationError(
+            f"implementation binding rejected: {exc}"
+        ) from exc
+    matches = [
+        selection
+        for selection in binding.renderer_selections
+        if APP_CONFIG_FAMILIES & set(selection.artifact_families)
+    ]
+    if not matches:
+        raise AppConfigMaterializationError(
+            "binding carries no renderer selection for the application-config families"
+        )
+    selection = matches[0]
+    if selection.materializer_id is not MaterializerIdentifier.APP_CONFIG_EXECUTOR:
+        raise AppConfigMaterializationError(
+            "renderer selection for application-config families pins materializer "
+            f"{selection.materializer_id.value!r}, not the app config executor"
+        )
+    if (
+        selection.implementation_id != APP_CONFIG_RENDERER_IMPLEMENTATION_ID
+        or selection.implementation_version != APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION
+    ):
+        raise AppConfigMaterializationError(
+            "binding pins unaccepted app-config renderer implementation "
+            f"{selection.implementation_id!r}@{selection.implementation_version!r}"
+        )
+    return selection
+
+
+def _footprint_payloads(
+    unit: FamilyInstancePlan, payload_by_node: Mapping[str, SemanticPayloadBase]
+) -> dict[str, SemanticPayloadBase]:
+    """Return exactly the payloads pinned by the unit's source footprint."""
+    resolved: dict[str, SemanticPayloadBase] = {}
+    for source in unit.sources:
+        pinned = payload_by_node.get(source.node_id)
+        if pinned is None or pinned.payload_digest != source.payload_digest:
+            raise AppConfigMaterializationError(
+                f"unit {unit.unit_id!r} source {source.node_id!r} is missing or does "
+                "not match its pinned payload digest"
+            )
+        resolved[source.node_id] = pinned
+    return resolved
+
+
+def _one_of(
+    payloads: Mapping[str, SemanticPayloadBase],
+    payload_type: type,
+    *,
+    unit: FamilyInstancePlan,
+    required: bool,
+) -> Any:
+    matches = [p for p in payloads.values() if isinstance(p, payload_type)]
+    if len(matches) > 1:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} footprint pins more than one "
+            f"{payload_type.__name__}"
+        )
+    if not matches:
+        if required:
+            raise AppConfigMaterializationError(
+                f"unit {unit.unit_id!r} footprint pins no {payload_type.__name__}"
+            )
+        return None
+    return matches[0]
+
+
+def _local_id(node_id: str) -> str:
+    return node_id.rsplit(".", 1)[-1]
+
+
+def _auth_required(
+    application: ApplicationPayload, auth: AuthPayload | None
+) -> bool:
+    if auth is not None:
+        return bool(auth.auth_required)
+    for selection in application.optional_families:
+        if selection.family is OptionalFamilyKind.AUTH:
+            if selection.status is OptionalFamilySelectionStatus.SELECTED:
+                raise AppConfigMaterializationError(
+                    "auth is selected but no AuthPayload is pinned in the footprint"
+                )
+            return False
+    raise AppConfigMaterializationError(
+        "application selection evidence does not state the auth family"
+    )
+
+
+def _app_manifest_document(
+    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
+) -> dict[str, Any]:
+    application: ApplicationPayload = _one_of(
+        payloads, ApplicationPayload, unit=unit, required=True
+    )
+    auth: AuthPayload | None = _one_of(payloads, AuthPayload, unit=unit, required=False)
+    document: dict[str, Any] = {
+        "appId": application.application_id,
+        "appName": application.display_name,
+        "version": application.version,
+    }
+    if application.description is not None:
+        document["description"] = application.description
+    document["authRequired"] = _auth_required(application, auth)
+    document["startup"] = {"landing_spot": application.default_route}
+    return document
+
+
+def _route_manifest_document(
+    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
+) -> dict[str, Any]:
+    application: ApplicationPayload = _one_of(
+        payloads, ApplicationPayload, unit=unit, required=True
+    )
+    pages = sorted(
+        (p for p in payloads.values() if isinstance(p, PagePayload)),
+        key=lambda p: str(p.route or ""),
+    )
+    entries: list[dict[str, Any]] = []
+    declared_routes: set[str] = set()
+    for page in pages:
+        if not page.route or not page.title:
+            raise AppConfigMaterializationError(
+                f"page {page.node_id!r} lacks the route/title facts the route "
+                "manifest requires"
+            )
+        declared_routes.add(page.route)
+        entries.append(
+            {
+                "path": page.route,
+                "component": "SchemaPage",
+                "label": page.title,
+                "schema": page.page_id,
+            }
+        )
+    if application.default_route not in declared_routes:
+        raise AppConfigMaterializationError(
+            "application default_route does not resolve to a declared page route"
+        )
+    return {"pages": entries}
+
+
+def _ai_config_document(
+    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
+) -> dict[str, Any]:
+    _one_of(payloads, ApplicationPayload, unit=unit, required=True)
+    workflows = [p for p in payloads.values() if isinstance(p, WorkflowPayload)]
+    mode = _CHAT_STARTUP_DEFAULT
+    if any(w.startup_mode is WorkflowStartupMode.AGENT_DRIVEN for w in workflows):
+        mode = "workflow"
+    return {"chat": {"chat_startup_mode": mode}}
+
+
+def _integration_entries(
+    payloads: Mapping[str, SemanticPayloadBase],
+) -> list[IntegrationPayload]:
+    return sorted(
+        (p for p in payloads.values() if isinstance(p, IntegrationPayload)),
+        key=lambda p: p.integration_id,
+    )
+
+
+_CONFIG_VALUE_TYPES = {
+    IntegrationConfigValueKind.TEXT: "text",
+    IntegrationConfigValueKind.URL: "url",
+    IntegrationConfigValueKind.SECRET: "secret",
+}
+
+
+def _integrations_document(
+    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
+) -> dict[str, Any]:
+    application: ApplicationPayload = _one_of(
+        payloads, ApplicationPayload, unit=unit, required=True
+    )
+    integrations = _integration_entries(payloads)
+    selected = any(
+        s.family is OptionalFamilyKind.INTEGRATIONS
+        and s.status is OptionalFamilySelectionStatus.SELECTED
+        for s in application.optional_families
+    )
+    if selected and not integrations:
+        raise AppConfigMaterializationError(
+            "integrations are selected but no IntegrationPayload is pinned"
+        )
+    entries: list[dict[str, Any]] = []
+    for integration in integrations:
+        entry: dict[str, Any] = {
+            "service": integration.integration_id,
+            "kind": integration.integration_kind.value,
+        }
+        if integration.purpose is not None:
+            entry["purpose"] = integration.purpose
+        entry["required_at"] = integration.required_at.value
+        entry["optional"] = integration.optional
+        entry["required_fields"] = [
+            {
+                "name": requirement.name,
+                "type": _CONFIG_VALUE_TYPES[requirement.value_kind],
+                "required": requirement.required,
+            }
+            for requirement in integration.config_requirements
+        ]
+        entries.append(entry)
+    return {"integrations": entries}
+
+
+def _secret_references_document(
+    unit: FamilyInstancePlan, payloads: Mapping[str, SemanticPayloadBase]
+) -> dict[str, Any]:
+    _one_of(payloads, ApplicationPayload, unit=unit, required=True)
+    names: set[str] = set()
+    for integration in _integration_entries(payloads):
+        for requirement in integration.config_requirements:
+            if requirement.value_kind is IntegrationConfigValueKind.SECRET:
+                names.add(requirement.name)
+    return {"version": 1, "secrets": sorted(names)}
+
+
+_DOCUMENT_BUILDERS = {
+    "app.json": (_app_manifest_document, json_decl_bytes),
+    "app/app.json": (_app_manifest_document, json_decl_bytes),
+    "ui/route_manifest.json": (_route_manifest_document, json_decl_bytes),
+    "config/ai.json": (_ai_config_document, json_decl_bytes),
+    "config/integrations.yaml": (_integrations_document, yaml_decl_bytes),
+    "security/secrets.yaml": (_secret_references_document, yaml_decl_bytes),
+}
+
+
+def render_app_config_unit(
+    *,
+    unit: FamilyInstancePlan,
+    payload_by_node: Mapping[str, SemanticPayloadBase],
+) -> bytes:
+    """Render one application-configuration unit's canonical bytes.
+
+    The unit's plan-owned output path selects the artifact contract; the
+    renderer never chooses paths and never reads state outside the unit's
+    pinned source footprint.
+    """
+    if unit.family_kind not in APP_CONFIG_FAMILIES:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} family {unit.family_kind!r} is not an "
+            "application-configuration family of this slice"
+        )
+    if unit.disposition is not PlanDisposition.RENDER:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} disposition {unit.disposition.value!r} is not render"
+        )
+    if len(unit.outputs) != 1:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} must own exactly one output path"
+        )
+    path = unit.outputs[0].path
+    builder = _DOCUMENT_BUILDERS.get(path)
+    if builder is None:
+        raise AppConfigMaterializationError(
+            f"unit {unit.unit_id!r} output {path!r} has no deterministic "
+            "application-config contract in this slice"
+        )
+    build_document, serialize = builder
+    payloads = _footprint_payloads(unit, payload_by_node)
+    return serialize(build_document(unit, payloads))
+
+
+__all__ = [
+    "APP_CONFIG_FAMILIES",
+    "APP_CONFIG_RENDERER_IMPLEMENTATION_ID",
+    "APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION",
+    "AppConfigMaterializationError",
+    "render_app_config_unit",
+    "resolve_app_config_renderer_selection",
+]

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -66,6 +66,7 @@ from mozaiksai.core.semantics.payloads import (
     ApplicationPayload,
     ArtifactDeclarationPayload,
     ArtifactDeclarationRole,
+    AuthPayload,
     IntegrationImplementationKind,
     IntegrationPayload,
     LockfileKind,
@@ -94,6 +95,16 @@ from mozaiksai.core.workflow.assignment_kinds import (
 from mozaiksai.core.workflow.structured_output_contracts import (
     StructuredOutputContractRef,
     build_structured_output_contract_ref,
+)
+
+_APP_CONFIG_RENDER_KINDS = frozenset(
+    {
+        "app_manifest",
+        "app_config",
+        "app_integrations_config",
+        "app_secret_references",
+        "app_ui_route_manifest",
+    }
 )
 
 COMPILATION_PLAN_SCHEMA_VERSION: Literal["mozaiks.compilation_plan.v1"] = (
@@ -1311,6 +1322,56 @@ def derive_compilation_plan(
             )
         return value
 
+    def _app_config_inputs_complete(row: RegistryFamilyRow) -> bool:
+        """Slice 5D-0B2A: application-config families with closed inputs.
+
+        Complete only when the accepted authorities can supply every rendered
+        fact for the row's exact output contract; everything else stays a
+        typed gap. ``config/asset_manifest.json`` shares the ``app_config``
+        family but has no typed asset facts yet, so it remains gapped.
+        """
+        applications = [
+            payload
+            for payload in payload_by_node.values()
+            if isinstance(payload, ApplicationPayload)
+        ]
+        if len(applications) != 1:
+            return False
+        application = applications[0]
+        auth_payloads = [
+            payload
+            for payload in payload_by_node.values()
+            if isinstance(payload, AuthPayload)
+        ]
+        auth_selected = any(
+            selection.family is OptionalFamilyKind.AUTH
+            and selection.status is OptionalFamilySelectionStatus.SELECTED
+            for selection in application.optional_families
+        )
+        if auth_selected and len(auth_payloads) != 1:
+            return False
+        if row.kind == "app_manifest":
+            return True
+        if row.kind == "app_config":
+            return row.path_template == "config/ai.json"
+        if row.kind == "app_secret_references":
+            return True
+        if row.kind == "app_integrations_config":
+            return any(
+                isinstance(payload, IntegrationPayload)
+                for payload in payload_by_node.values()
+            )
+        if row.kind == "app_ui_route_manifest":
+            pages = [
+                payload
+                for payload in payload_by_node.values()
+                if isinstance(payload, PagePayload)
+            ]
+            if not pages or any(not page.route or not page.title for page in pages):
+                return False
+            return application.default_route in {page.route for page in pages}
+        return False
+
     def _renderer_inputs_complete(
         row: RegistryFamilyRow, *, root_node_id: str | None
     ) -> bool:
@@ -1321,6 +1382,8 @@ def derive_compilation_plan(
         gaps until a later prerequisite explicitly closes their normative
         source models.
         """
+        if row.kind in _APP_CONFIG_RENDER_KINDS and root_node_id is None:
+            return _app_config_inputs_complete(row)
         if row.kind != "app_ui_page_schema" or root_node_id is None:
             return False
         page = payload_by_node[root_node_id]

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -76,7 +76,6 @@ from mozaiksai.core.semantics.payloads import (
     PagePayload,
     SemanticPayloadBase,
     WorkflowPayload,
-    WorkflowStartupMode,
     parse_semantic_payload,
     validate_semantic_graph_v2_payload_closure,
 )
@@ -1369,36 +1368,22 @@ def derive_compilation_plan(
             # contradictory evidence, which stays a typed gap.
             return not present
 
-        # Auth facts feed app.json's authRequired and the secret-reference
-        # surface; every application-config family shares this gate.
-        if not _facts_honest(OptionalFamilyKind.AUTH, AuthPayload, exactly_one=True):
-            return False
+        # Completion is family-local: each family is gated only by the facts
+        # its own byte contract consumes, so a missing or contradictory input
+        # for one family never blocks another whose closure is complete.
         if row.kind == "app_manifest":
-            return True
+            # app.json consumes application identity/display facts and the
+            # authRequired flag; auth honesty gates only this family.
+            return _facts_honest(
+                OptionalFamilyKind.AUTH, AuthPayload, exactly_one=True
+            )
         if row.kind == "app_config":
-            if row.path_template != "config/ai.json":
-                return False
-            if not _facts_honest(OptionalFamilyKind.WORKFLOWS, WorkflowPayload):
-                return False
-            if _selected(OptionalFamilyKind.WORKFLOWS):
-                workflows = [
-                    payload
-                    for payload in payload_by_node.values()
-                    if isinstance(payload, WorkflowPayload)
-                ]
-                # Startup derivation must be unambiguous: every selected
-                # workflow states its startup mode, and at most one workflow
-                # may claim application startup (agent_driven).
-                if any(workflow.startup_mode is None for workflow in workflows):
-                    return False
-                agent_driven = [
-                    workflow
-                    for workflow in workflows
-                    if workflow.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
-                ]
-                if len(agent_driven) > 1:
-                    return False
-            return True
+            # config/ai.json is deferred: per-workflow startup_mode is not
+            # application-level chat launch authority, and the semantic model
+            # has no application-level AI-launch facts (chat startup mode,
+            # workflow entry point). The family stays a typed gap until that
+            # prerequisite exists — never rendered from inference.
+            return False
         if row.kind == "app_secret_references":
             return _facts_honest(OptionalFamilyKind.INTEGRATIONS, IntegrationPayload)
         if row.kind == "app_integrations_config":

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -76,6 +76,7 @@ from mozaiksai.core.semantics.payloads import (
     PagePayload,
     SemanticPayloadBase,
     WorkflowPayload,
+    WorkflowStartupMode,
     parse_semantic_payload,
     validate_semantic_graph_v2_payload_closure,
 )
@@ -1327,8 +1328,13 @@ def derive_compilation_plan(
 
         Complete only when the accepted authorities can supply every rendered
         fact for the row's exact output contract; everything else stays a
-        typed gap. ``config/asset_manifest.json`` shares the ``app_config``
-        family but has no typed asset facts yet, so it remains gapped.
+        typed gap. Selection honesty is enforced per consuming family: a
+        family whose optional-family selection says SELECTED must have its
+        typed facts present, and a family declared absent must have none —
+        missing selected evidence is never normalized to an empty rendering,
+        and contradictory evidence never renders. ``config/asset_manifest.json``
+        shares the ``app_config`` family but has no typed asset facts yet, so
+        it remains gapped.
         """
         applications = [
             payload
@@ -1338,30 +1344,71 @@ def derive_compilation_plan(
         if len(applications) != 1:
             return False
         application = applications[0]
-        auth_payloads = [
-            payload
-            for payload in payload_by_node.values()
-            if isinstance(payload, AuthPayload)
-        ]
-        auth_selected = any(
-            selection.family is OptionalFamilyKind.AUTH
-            and selection.status is OptionalFamilySelectionStatus.SELECTED
-            for selection in application.optional_families
-        )
-        if auth_selected and len(auth_payloads) != 1:
+
+        def _selected(family: OptionalFamilyKind) -> bool:
+            return any(
+                selection.family is family
+                and selection.status is OptionalFamilySelectionStatus.SELECTED
+                for selection in application.optional_families
+            )
+
+        def _facts_honest(
+            family: OptionalFamilyKind,
+            payload_type: type,
+            *,
+            exactly_one: bool = False,
+        ) -> bool:
+            present = [
+                payload
+                for payload in payload_by_node.values()
+                if isinstance(payload, payload_type)
+            ]
+            if _selected(family):
+                return len(present) == 1 if exactly_one else len(present) >= 1
+            # Declared absent or not applicable: any present fact is
+            # contradictory evidence, which stays a typed gap.
+            return not present
+
+        # Auth facts feed app.json's authRequired and the secret-reference
+        # surface; every application-config family shares this gate.
+        if not _facts_honest(OptionalFamilyKind.AUTH, AuthPayload, exactly_one=True):
             return False
         if row.kind == "app_manifest":
             return True
         if row.kind == "app_config":
-            return row.path_template == "config/ai.json"
-        if row.kind == "app_secret_references":
+            if row.path_template != "config/ai.json":
+                return False
+            if not _facts_honest(OptionalFamilyKind.WORKFLOWS, WorkflowPayload):
+                return False
+            if _selected(OptionalFamilyKind.WORKFLOWS):
+                workflows = [
+                    payload
+                    for payload in payload_by_node.values()
+                    if isinstance(payload, WorkflowPayload)
+                ]
+                # Startup derivation must be unambiguous: every selected
+                # workflow states its startup mode, and at most one workflow
+                # may claim application startup (agent_driven).
+                if any(workflow.startup_mode is None for workflow in workflows):
+                    return False
+                agent_driven = [
+                    workflow
+                    for workflow in workflows
+                    if workflow.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
+                ]
+                if len(agent_driven) > 1:
+                    return False
             return True
+        if row.kind == "app_secret_references":
+            return _facts_honest(OptionalFamilyKind.INTEGRATIONS, IntegrationPayload)
         if row.kind == "app_integrations_config":
-            return any(
-                isinstance(payload, IntegrationPayload)
-                for payload in payload_by_node.values()
-            )
+            return _facts_honest(OptionalFamilyKind.INTEGRATIONS, IntegrationPayload)
         if row.kind == "app_ui_route_manifest":
+            # Selected custom routes are route-manifest inputs this slice
+            # cannot render; the family stays a typed gap rather than
+            # emitting a manifest that silently omits them.
+            if _selected(OptionalFamilyKind.CUSTOM_ROUTES):
+                return False
             pages = [
                 payload
                 for payload in payload_by_node.values()

--- a/mozaiksai/core/semantics/decl_bytes.py
+++ b/mozaiksai/core/semantics/decl_bytes.py
@@ -1,0 +1,79 @@
+"""Named canonical byte contracts for declarative application artifacts.
+
+Two versioned serialization contracts back every deterministic
+application-family artifact:
+
+``mozaiks.json_decl_bytes.v1``
+    UTF-8, LF newlines, two-space indentation, ``ensure_ascii=False``,
+    deterministic declaration order (the caller supplies an ordered
+    document built from closed models — key order is meaning, never
+    re-sorted here), one trailing newline, no timestamps, no host paths.
+
+``mozaiks.yaml_decl_bytes.v1``
+    UTF-8, LF newlines, ``allow_unicode=True``, ``sort_keys=False`` so the
+    closed model's declaration order survives, block style, unbounded line
+    width (no content-dependent wrapping), one trailing newline.
+
+Both contracts parse their own output back and require semantic equality
+with the input document, so a serializer regression can never silently
+change canonical meaning. Neither reads clocks, environment, or the
+filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import yaml
+
+JSON_DECL_BYTES_VERSION: Literal["mozaiks.json_decl_bytes.v1"] = "mozaiks.json_decl_bytes.v1"
+YAML_DECL_BYTES_VERSION: Literal["mozaiks.yaml_decl_bytes.v1"] = "mozaiks.yaml_decl_bytes.v1"
+
+
+class DeclBytesError(ValueError):
+    """The document violates a canonical byte contract."""
+
+
+def json_decl_bytes(document: Mapping[str, Any]) -> bytes:
+    """Serialize one declaration document under ``mozaiks.json_decl_bytes.v1``."""
+    if not isinstance(document, Mapping):
+        raise DeclBytesError("json_decl_bytes requires a mapping document")
+    text = json.dumps(dict(document), indent=2, ensure_ascii=False)
+    text = text.replace("\r\n", "\n")
+    if not text.endswith("\n"):
+        text += "\n"
+    data = text.encode("utf-8")
+    if json.loads(data.decode("utf-8")) != json.loads(json.dumps(dict(document))):
+        raise DeclBytesError("json_decl_bytes round-trip changed document meaning")
+    return data
+
+
+def yaml_decl_bytes(document: Mapping[str, Any]) -> bytes:
+    """Serialize one declaration document under ``mozaiks.yaml_decl_bytes.v1``."""
+    if not isinstance(document, Mapping):
+        raise DeclBytesError("yaml_decl_bytes requires a mapping document")
+    text = yaml.safe_dump(
+        dict(document),
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=2_000_000_000,
+    )
+    text = text.replace("\r\n", "\n")
+    if not text.endswith("\n"):
+        text += "\n"
+    data = text.encode("utf-8")
+    if yaml.safe_load(data.decode("utf-8")) != json.loads(json.dumps(dict(document))):
+        raise DeclBytesError("yaml_decl_bytes round-trip changed document meaning")
+    return data
+
+
+__all__ = [
+    "DeclBytesError",
+    "JSON_DECL_BYTES_VERSION",
+    "YAML_DECL_BYTES_VERSION",
+    "json_decl_bytes",
+    "yaml_decl_bytes",
+]

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -314,7 +314,21 @@ def resolve_app_config_renderer_selection(
         raise AppConfigMaterializationError(
             "binding carries no renderer selection for the application-config families"
         )
+    if len(matches) != 1:
+        raise AppConfigMaterializationError(
+            "application-config families are split across multiple renderer "
+            "selections; deterministic_app_config_renderer@1 requires one "
+            "selection declaring its exact family set"
+        )
     selection = matches[0]
+    declared = set(selection.artifact_families)
+    if declared != APP_CONFIG_FAMILIES:
+        raise AppConfigMaterializationError(
+            "renderer selection is the authorization boundary for "
+            "deterministic_app_config_renderer@1 and must declare exactly its "
+            f"supported family set {sorted(APP_CONFIG_FAMILIES)}; "
+            f"got {sorted(declared)}"
+        )
     if selection.materializer_id is not MaterializerIdentifier.APP_CONFIG_EXECUTOR:
         raise AppConfigMaterializationError(
             "renderer selection for application-config families pins materializer "
@@ -705,11 +719,66 @@ def _match_preserved(
     return by_unit
 
 
+def _assert_app_config_output_closure(
+    plan: CompilationPlan,
+    outputs: Iterable[MaterializedOutput],
+    selection: RendererSelection | None,
+) -> None:
+    """Bijection gate for the application-configuration output set.
+
+    Every emitted app-config output must come from an active, authorized
+    RENDER unit of the validated plan at that unit's plan-owned path; every
+    active authorized unit must have produced exactly one output; and no
+    output may exist for an inactive or unauthorized family. Inactive
+    conditional units are simply absent — never an error, never bytes.
+    """
+    unit_by_id = {unit.unit_id: unit for unit in plan.units}
+    active_expected = {
+        unit.unit_id: unit
+        for unit in plan.units
+        if unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in APP_CONFIG_FAMILIES
+        and any(o.path_scope in _COMPOSABLE_PATH_SCOPES for o in unit.outputs)
+    }
+    emitted_counts: dict[str, int] = {}
+    for output in outputs:
+        unit = unit_by_id.get(output.unit_id)
+        if unit is None or unit.family_kind not in APP_CONFIG_FAMILIES:
+            continue
+        if selection is None or unit.family_kind not in selection.artifact_families:
+            raise AppConfigMaterializationError(
+                f"output {output.path!r} was emitted for unauthorized "
+                f"application-config family {unit.family_kind!r}"
+            )
+        if unit.unit_id not in active_expected:
+            raise AppConfigMaterializationError(
+                f"output {output.path!r} was emitted for inactive "
+                f"application-config unit {output.unit_id!r}"
+            )
+        owned_paths = {
+            o.path for o in unit.outputs if o.path_scope in _COMPOSABLE_PATH_SCOPES
+        }
+        if output.path not in owned_paths:
+            raise AppConfigMaterializationError(
+                f"output {output.path!r} does not equal the plan-owned path of "
+                f"unit {output.unit_id!r}"
+            )
+        emitted_counts[output.unit_id] = emitted_counts.get(output.unit_id, 0) + 1
+    for unit_id, unit in active_expected.items():
+        if emitted_counts.get(unit_id, 0) != 1:
+            raise AppConfigMaterializationError(
+                f"active application-config unit {unit_id!r} "
+                f"({unit.family_kind!r}) must produce exactly one output; "
+                f"produced {emitted_counts.get(unit_id, 0)}"
+            )
+
+
 def _materialize_unit(
     unit: FamilyInstancePlan,
     *,
     payload_by_node: Mapping[str, SemanticPayloadBase],
     app_config_render_input: ApplicationFamilyRenderInput | None,
+    app_config_selection: RendererSelection | None,
     preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
     bundle_outputs: list[MaterializedOutput],
     external: list[str],
@@ -730,10 +799,19 @@ def _materialize_unit(
                 f"render unit {unit.unit_id!r} must own exactly one composable output"
             )
         if unit.family_kind in APP_CONFIG_FAMILIES:
-            if app_config_render_input is None:
+            if app_config_render_input is None or app_config_selection is None:
                 raise MaterializationError(
                     f"render unit {unit.unit_id!r} requires the application-family "
-                    "render input, which was not constructed"
+                    "render input and resolved renderer selection, which were "
+                    "not constructed"
+                )
+            # A renderer selection cannot authorize a family by implication:
+            # the unit's family must be explicitly named by the resolved
+            # selection even though resolution already pinned the exact set.
+            if unit.family_kind not in app_config_selection.artifact_families:
+                raise AppConfigMaterializationError(
+                    f"unit {unit.unit_id!r} family {unit.family_kind!r} is not "
+                    "authorized by the resolved app-config renderer selection"
                 )
             content = render_app_config_unit(
                 unit=unit, render_input=app_config_render_input
@@ -810,12 +888,13 @@ def materialize_plan(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
     app_config_render_input: ApplicationFamilyRenderInput | None = None
+    app_config_selection: RendererSelection | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
         and unit.family_kind in APP_CONFIG_FAMILIES
         for unit in verified_plan.units
     ):
-        resolve_app_config_renderer_selection(
+        app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
         app_config_render_input = build_app_family_render_input(
@@ -834,6 +913,7 @@ def materialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_render_input=app_config_render_input,
+            app_config_selection=app_config_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -843,6 +923,7 @@ def materialize_plan(
             deferred=deferred,
         )
     _assert_output_ownership(verified_plan, outputs)
+    _assert_app_config_output_closure(verified_plan, outputs, app_config_selection)
     return MaterializedBundle(
         plan_digest=verified_plan.plan_digest,
         outputs=tuple(sorted(outputs, key=lambda o: o.path)),
@@ -906,12 +987,13 @@ def rematerialize_plan(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
     app_config_render_input: ApplicationFamilyRenderInput | None = None
+    app_config_selection: RendererSelection | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
         and unit.family_kind in APP_CONFIG_FAMILIES
         for unit in verified_plan.units
     ):
-        resolve_app_config_renderer_selection(
+        app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
         app_config_render_input = build_app_family_render_input(
@@ -974,6 +1056,7 @@ def rematerialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_render_input=app_config_render_input,
+            app_config_selection=app_config_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -983,6 +1066,7 @@ def rematerialize_plan(
             deferred=deferred,
         )
     _assert_output_ownership(verified_plan, outputs)
+    _assert_app_config_output_closure(verified_plan, outputs, app_config_selection)
     return MaterializedBundle(
         plan_digest=verified_plan.plan_digest,
         outputs=tuple(sorted(outputs, key=lambda o: o.path)),

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -409,21 +409,29 @@ def build_app_family_render_input(
             "application-config projection pins more than one AuthPayload"
         )
     auth = auths[0] if auths else None
+
+    def _family_selected(family: OptionalFamilyKind) -> bool:
+        for selection in application.optional_families:
+            if selection.family is family:
+                return selection.status is OptionalFamilySelectionStatus.SELECTED
+        raise AppConfigMaterializationError(
+            f"application selection evidence does not state the {family.value} family"
+        )
+
+    auth_selected = _family_selected(OptionalFamilyKind.AUTH)
     if auth is not None:
+        if not auth_selected:
+            raise AppConfigMaterializationError(
+                "an AuthPayload is pinned while the application declares the "
+                "auth family absent; contradictory evidence cannot render"
+            )
         auth_required = bool(auth.auth_required)
     else:
-        for selection in application.optional_families:
-            if selection.family is OptionalFamilyKind.AUTH:
-                if selection.status is OptionalFamilySelectionStatus.SELECTED:
-                    raise AppConfigMaterializationError(
-                        "auth is selected but no AuthPayload is pinned in the footprint"
-                    )
-                auth_required = False
-                break
-        else:
+        if auth_selected:
             raise AppConfigMaterializationError(
-                "application selection evidence does not state the auth family"
+                "auth is selected but no AuthPayload is pinned in the footprint"
             )
+        auth_required = False
 
     pages: list[RenderInputPage] = []
     for payload in resolved.values():
@@ -470,11 +478,51 @@ def build_app_family_render_input(
         for payload in integration_payloads
     )
 
-    has_agent_driven_workflow = any(
-        isinstance(payload, WorkflowPayload)
-        and payload.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
-        for payload in resolved.values()
-    )
+    # Selection honesty is an application-level fact: evaluate it over the
+    # complete cold-validated payload closure, not only the payloads pinned by
+    # currently-active unit footprints — a gapped config/ai.json unit must not
+    # hide missing, ambiguous, or contradictory workflow evidence.
+    workflow_payloads = [
+        payload
+        for payload in payload_by_node.values()
+        if isinstance(payload, WorkflowPayload)
+    ]
+    if _family_selected(OptionalFamilyKind.WORKFLOWS):
+        if not workflow_payloads:
+            raise AppConfigMaterializationError(
+                "workflows are selected but no WorkflowPayload is pinned in "
+                "the footprint; missing selected evidence cannot render"
+            )
+        if any(payload.startup_mode is None for payload in workflow_payloads):
+            raise AppConfigMaterializationError(
+                "a selected workflow does not state its startup mode; the "
+                "chat startup derivation is ambiguous"
+            )
+        agent_driven = [
+            payload
+            for payload in workflow_payloads
+            if payload.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
+        ]
+        if len(agent_driven) > 1:
+            raise AppConfigMaterializationError(
+                "multiple selected workflows claim agent-driven startup; the "
+                "chat startup derivation is ambiguous"
+            )
+        chat_startup_mode: Literal["ask", "workflow"] = (
+            "workflow" if agent_driven else "ask"
+        )
+    else:
+        if workflow_payloads:
+            raise AppConfigMaterializationError(
+                "WorkflowPayloads are pinned while the application declares "
+                "the workflows family absent; contradictory evidence cannot "
+                "render"
+            )
+        # Proven absence: the platform host itself defaults the chat startup
+        # mode to "ask" when config/ai.json declares none
+        # (mozaiksai.hosts.platform.build_shell_config), so this literal is
+        # the runtime own provider-neutral default, not an invented fact.
+        chat_startup_mode = "ask"
 
     return ApplicationFamilyRenderInput(
         render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
@@ -485,7 +533,7 @@ def build_app_family_render_input(
         default_route=application.default_route,
         auth_required=auth_required,
         pages=tuple(pages),
-        has_agent_driven_workflow=has_agent_driven_workflow,
+        chat_startup_mode=chat_startup_mode,
         integrations=integrations,
         sources=tuple(
             RenderInputSource(node_id=node_id, payload_digest=payload.payload_digest)

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -62,8 +62,16 @@ from mozaiksai.core.runtime.app.page_schema import (
 )
 from mozaiksai.core.semantics.app_config_materialization import (
     APP_CONFIG_FAMILIES,
+    APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+    APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+    APP_FAMILY_RENDER_INPUT_VERSION,
+    AppConfigMaterializationError,
+    ApplicationFamilyRenderInput,
+    RenderInputConfigRequirement,
+    RenderInputIntegration,
+    RenderInputPage,
+    RenderInputSource,
     render_app_config_unit,
-    resolve_app_config_renderer_selection,
 )
 from mozaiksai.core.semantics.binding import (
     ImplementationBinding,
@@ -82,9 +90,17 @@ from mozaiksai.core.semantics.compilation_plan import (
 from mozaiksai.core.semantics.graph import SemanticGraphV2
 from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
 from mozaiksai.core.semantics.payloads import (
+    ApplicationPayload,
+    AuthPayload,
+    IntegrationConfigValueKind,
+    IntegrationPayload,
+    OptionalFamilyKind,
+    OptionalFamilySelectionStatus,
     PagePayload,
     SectionPayload,
     SemanticPayloadBase,
+    WorkflowPayload,
+    WorkflowStartupMode,
     parse_semantic_payload,
 )
 from mozaiksai.core.semantics.portable_path import detect_collisions
@@ -265,6 +281,203 @@ def resolve_page_schema_renderer_selection(
             f"@{PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION!r}"
         )
     return selection
+
+
+def resolve_app_config_renderer_selection(
+    binding: ImplementationBinding,
+    *,
+    graph: SemanticGraphV2,
+    layout_registry: Any,
+) -> RendererSelection:
+    """Resolve the accepted app-config renderer through the binding.
+
+    Fails closed when the binding carries no selection covering the
+    application-configuration families, claims a different materializer, or
+    pins any implementation identity/version other than the single accepted
+    deterministic implementation of this slice. There is no fallback to any
+    historical generator path.
+    """
+    try:
+        validate_implementation_binding_against_graph(
+            binding, graph, layout_registry=layout_registry
+        )
+    except ValueError as exc:
+        raise AppConfigMaterializationError(
+            f"implementation binding rejected: {exc}"
+        ) from exc
+    matches = [
+        selection
+        for selection in binding.renderer_selections
+        if APP_CONFIG_FAMILIES & set(selection.artifact_families)
+    ]
+    if not matches:
+        raise AppConfigMaterializationError(
+            "binding carries no renderer selection for the application-config families"
+        )
+    selection = matches[0]
+    if selection.materializer_id is not MaterializerIdentifier.APP_CONFIG_EXECUTOR:
+        raise AppConfigMaterializationError(
+            "renderer selection for application-config families pins materializer "
+            f"{selection.materializer_id.value!r}, not the app config executor"
+        )
+    if (
+        selection.implementation_id != APP_CONFIG_RENDERER_IMPLEMENTATION_ID
+        or selection.implementation_version != APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION
+    ):
+        raise AppConfigMaterializationError(
+            "binding pins unaccepted app-config renderer implementation "
+            f"{selection.implementation_id!r}@{selection.implementation_version!r}"
+        )
+    return selection
+
+
+# ---------------------------------------------------------------------------
+# Application-family render input (the one payload->renderer boundary)
+# ---------------------------------------------------------------------------
+
+
+_CONFIG_VALUE_TYPES: dict[IntegrationConfigValueKind, Literal["text", "url", "secret"]] = {
+    IntegrationConfigValueKind.TEXT: "text",
+    IntegrationConfigValueKind.URL: "url",
+    IntegrationConfigValueKind.SECRET: "secret",
+}
+
+
+def build_app_family_render_input(
+    *,
+    units: Iterable[FamilyInstancePlan],
+    payload_by_node: Mapping[str, SemanticPayloadBase],
+) -> ApplicationFamilyRenderInput:
+    """Project footprint-pinned payload facts into the closed render input.
+
+    This is the single boundary where semantic payload classes feed the
+    application-family renderer. It resolves exactly the payloads pinned by
+    the app-config units' source footprints, validates their closure, and
+    normalizes the already-authoritative facts into the frozen
+    :class:`ApplicationFamilyRenderInput` snapshot. The renderer never sees a
+    payload object.
+    """
+    app_units = [
+        unit
+        for unit in units
+        if unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in APP_CONFIG_FAMILIES
+    ]
+    if not app_units:
+        raise AppConfigMaterializationError(
+            "no application-configuration render units to project"
+        )
+    resolved: dict[str, SemanticPayloadBase] = {}
+    for unit in app_units:
+        for source in unit.sources:
+            pinned = payload_by_node.get(source.node_id)
+            if pinned is None or pinned.payload_digest != source.payload_digest:
+                raise AppConfigMaterializationError(
+                    f"unit {unit.unit_id!r} source {source.node_id!r} is missing "
+                    "or does not match its pinned payload digest"
+                )
+            resolved[source.node_id] = pinned
+
+    applications = [
+        payload
+        for payload in resolved.values()
+        if isinstance(payload, ApplicationPayload)
+    ]
+    if len(applications) != 1:
+        raise AppConfigMaterializationError(
+            "application-config projection requires exactly one ApplicationPayload"
+        )
+    application = applications[0]
+
+    auths = [payload for payload in resolved.values() if isinstance(payload, AuthPayload)]
+    if len(auths) > 1:
+        raise AppConfigMaterializationError(
+            "application-config projection pins more than one AuthPayload"
+        )
+    auth = auths[0] if auths else None
+    if auth is not None:
+        auth_required = bool(auth.auth_required)
+    else:
+        for selection in application.optional_families:
+            if selection.family is OptionalFamilyKind.AUTH:
+                if selection.status is OptionalFamilySelectionStatus.SELECTED:
+                    raise AppConfigMaterializationError(
+                        "auth is selected but no AuthPayload is pinned in the footprint"
+                    )
+                auth_required = False
+                break
+        else:
+            raise AppConfigMaterializationError(
+                "application selection evidence does not state the auth family"
+            )
+
+    pages: list[RenderInputPage] = []
+    for payload in resolved.values():
+        if isinstance(payload, PagePayload):
+            if not payload.route or not payload.title:
+                raise AppConfigMaterializationError(
+                    f"page {payload.node_id!r} lacks the route/title facts the route "
+                    "manifest requires"
+                )
+            pages.append(
+                RenderInputPage(
+                    page_id=payload.page_id, route=payload.route, title=payload.title
+                )
+            )
+
+    integrations_selected = any(
+        selection.family is OptionalFamilyKind.INTEGRATIONS
+        and selection.status is OptionalFamilySelectionStatus.SELECTED
+        for selection in application.optional_families
+    )
+    integration_payloads = [
+        payload for payload in resolved.values() if isinstance(payload, IntegrationPayload)
+    ]
+    if integrations_selected and not integration_payloads:
+        raise AppConfigMaterializationError(
+            "integrations are selected but no IntegrationPayload is pinned"
+        )
+    integrations = tuple(
+        RenderInputIntegration(
+            integration_id=payload.integration_id,
+            kind=payload.integration_kind.value,
+            purpose=payload.purpose,
+            required_at=payload.required_at.value,
+            optional=payload.optional,
+            config_requirements=tuple(
+                RenderInputConfigRequirement(
+                    name=requirement.name,
+                    value_type=_CONFIG_VALUE_TYPES[requirement.value_kind],
+                    required=requirement.required,
+                )
+                for requirement in payload.config_requirements
+            ),
+        )
+        for payload in integration_payloads
+    )
+
+    has_agent_driven_workflow = any(
+        isinstance(payload, WorkflowPayload)
+        and payload.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
+        for payload in resolved.values()
+    )
+
+    return ApplicationFamilyRenderInput(
+        render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
+        application_id=application.application_id,
+        display_name=application.display_name,
+        version=application.version,
+        description=application.description,
+        default_route=application.default_route,
+        auth_required=auth_required,
+        pages=tuple(pages),
+        has_agent_driven_workflow=has_agent_driven_workflow,
+        integrations=integrations,
+        sources=tuple(
+            RenderInputSource(node_id=node_id, payload_digest=payload.payload_digest)
+            for node_id, payload in resolved.items()
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -496,6 +709,7 @@ def _materialize_unit(
     unit: FamilyInstancePlan,
     *,
     payload_by_node: Mapping[str, SemanticPayloadBase],
+    app_config_render_input: ApplicationFamilyRenderInput | None,
     preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
     bundle_outputs: list[MaterializedOutput],
     external: list[str],
@@ -516,7 +730,14 @@ def _materialize_unit(
                 f"render unit {unit.unit_id!r} must own exactly one composable output"
             )
         if unit.family_kind in APP_CONFIG_FAMILIES:
-            content = render_app_config_unit(unit=unit, payload_by_node=payload_by_node)
+            if app_config_render_input is None:
+                raise MaterializationError(
+                    f"render unit {unit.unit_id!r} requires the application-family "
+                    "render input, which was not constructed"
+                )
+            content = render_app_config_unit(
+                unit=unit, render_input=app_config_render_input
+            )
         else:
             content = render_app_ui_page_schema_unit(unit=unit, payload_by_node=payload_by_node)
         target = composable[0]
@@ -588,6 +809,7 @@ def materialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
+    app_config_render_input: ApplicationFamilyRenderInput | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
         and unit.family_kind in APP_CONFIG_FAMILIES
@@ -595,6 +817,9 @@ def materialize_plan(
     ):
         resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
+        )
+        app_config_render_input = build_app_family_render_input(
+            units=verified_plan.units, payload_by_node=payload_by_node
         )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
 
@@ -608,6 +833,7 @@ def materialize_plan(
         _materialize_unit(
             unit,
             payload_by_node=payload_by_node,
+            app_config_render_input=app_config_render_input,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -679,6 +905,7 @@ def rematerialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
+    app_config_render_input: ApplicationFamilyRenderInput | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
         and unit.family_kind in APP_CONFIG_FAMILIES
@@ -686,6 +913,9 @@ def rematerialize_plan(
     ):
         resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
+        )
+        app_config_render_input = build_app_family_render_input(
+            units=verified_plan.units, payload_by_node=payload_by_node
         )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
     base_by_unit: dict[str, list[MaterializedOutput]] = {}
@@ -743,6 +973,7 @@ def rematerialize_plan(
         _materialize_unit(
             unit,
             payload_by_node=payload_by_node,
+            app_config_render_input=app_config_render_input,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -66,11 +66,15 @@ from mozaiksai.core.semantics.app_config_materialization import (
     APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
     APP_FAMILY_RENDER_INPUT_VERSION,
     AppConfigMaterializationError,
-    ApplicationFamilyRenderInput,
+    AppFamilyRenderInput,
+    AppManifestRenderInput,
+    IntegrationsConfigRenderInput,
     RenderInputConfigRequirement,
     RenderInputIntegration,
     RenderInputPage,
     RenderInputSource,
+    RouteManifestRenderInput,
+    SecretReferencesRenderInput,
     render_app_config_unit,
 )
 from mozaiksai.core.semantics.binding import (
@@ -99,8 +103,6 @@ from mozaiksai.core.semantics.payloads import (
     PagePayload,
     SectionPayload,
     SemanticPayloadBase,
-    WorkflowPayload,
-    WorkflowStartupMode,
     parse_semantic_payload,
 )
 from mozaiksai.core.semantics.portable_path import detect_collisions
@@ -357,60 +359,58 @@ _CONFIG_VALUE_TYPES: dict[IntegrationConfigValueKind, Literal["text", "url", "se
 }
 
 
-def build_app_family_render_input(
+def project_app_family_render_input(
     *,
-    units: Iterable[FamilyInstancePlan],
+    unit: FamilyInstancePlan,
     payload_by_node: Mapping[str, SemanticPayloadBase],
-) -> ApplicationFamilyRenderInput:
-    """Project footprint-pinned payload facts into the closed render input.
+) -> AppFamilyRenderInput:
+    """Project one unit's plan-pinned sources into its family-local input.
 
     This is the single boundary where semantic payload classes feed the
     application-family renderer. It resolves exactly the payloads pinned by
-    the app-config units' source footprints, validates their closure, and
-    normalizes the already-authoritative facts into the frozen
-    :class:`ApplicationFamilyRenderInput` snapshot. The renderer never sees a
-    payload object.
+    THIS unit's source footprint, validates that family's closure, and
+    normalizes the already-authoritative facts into the frozen family-local
+    render input. The renderer never sees a payload object, and missing facts
+    for one family never block another family whose own closure is complete.
     """
-    app_units = [
-        unit
-        for unit in units
-        if unit.disposition is PlanDisposition.RENDER
-        and unit.family_kind in APP_CONFIG_FAMILIES
-    ]
-    if not app_units:
+    if (
+        unit.disposition is not PlanDisposition.RENDER
+        or unit.family_kind not in APP_CONFIG_FAMILIES
+    ):
         raise AppConfigMaterializationError(
-            "no application-configuration render units to project"
+            f"unit {unit.unit_id!r} ({unit.family_kind!r}) is not an active "
+            "application-configuration render unit"
         )
     resolved: dict[str, SemanticPayloadBase] = {}
-    for unit in app_units:
-        for source in unit.sources:
-            pinned = payload_by_node.get(source.node_id)
-            if pinned is None or pinned.payload_digest != source.payload_digest:
-                raise AppConfigMaterializationError(
-                    f"unit {unit.unit_id!r} source {source.node_id!r} is missing "
-                    "or does not match its pinned payload digest"
-                )
-            resolved[source.node_id] = pinned
+    for source in unit.sources:
+        pinned = payload_by_node.get(source.node_id)
+        if pinned is None or pinned.payload_digest != source.payload_digest:
+            raise AppConfigMaterializationError(
+                f"unit {unit.unit_id!r} source {source.node_id!r} is missing "
+                "or does not match its pinned payload digest"
+            )
+        resolved[source.node_id] = pinned
+    sources = tuple(
+        RenderInputSource(node_id=node_id, payload_digest=payload.payload_digest)
+        for node_id, payload in resolved.items()
+    )
 
-    applications = [
-        payload
-        for payload in resolved.values()
-        if isinstance(payload, ApplicationPayload)
-    ]
-    if len(applications) != 1:
-        raise AppConfigMaterializationError(
-            "application-config projection requires exactly one ApplicationPayload"
-        )
-    application = applications[0]
+    def _one_application() -> ApplicationPayload:
+        applications = [
+            payload
+            for payload in resolved.values()
+            if isinstance(payload, ApplicationPayload)
+        ]
+        if len(applications) != 1:
+            raise AppConfigMaterializationError(
+                f"unit {unit.unit_id!r} footprint must pin exactly one "
+                "ApplicationPayload"
+            )
+        return applications[0]
 
-    auths = [payload for payload in resolved.values() if isinstance(payload, AuthPayload)]
-    if len(auths) > 1:
-        raise AppConfigMaterializationError(
-            "application-config projection pins more than one AuthPayload"
-        )
-    auth = auths[0] if auths else None
-
-    def _family_selected(family: OptionalFamilyKind) -> bool:
+    def _family_selected(
+        application: ApplicationPayload, family: OptionalFamilyKind
+    ) -> bool:
         for selection in application.optional_families:
             if selection.family is family:
                 return selection.status is OptionalFamilySelectionStatus.SELECTED
@@ -418,127 +418,136 @@ def build_app_family_render_input(
             f"application selection evidence does not state the {family.value} family"
         )
 
-    auth_selected = _family_selected(OptionalFamilyKind.AUTH)
-    if auth is not None:
-        if not auth_selected:
-            raise AppConfigMaterializationError(
-                "an AuthPayload is pinned while the application declares the "
-                "auth family absent; contradictory evidence cannot render"
-            )
-        auth_required = bool(auth.auth_required)
-    else:
-        if auth_selected:
-            raise AppConfigMaterializationError(
-                "auth is selected but no AuthPayload is pinned in the footprint"
-            )
-        auth_required = False
-
-    pages: list[RenderInputPage] = []
-    for payload in resolved.values():
-        if isinstance(payload, PagePayload):
-            if not payload.route or not payload.title:
-                raise AppConfigMaterializationError(
-                    f"page {payload.node_id!r} lacks the route/title facts the route "
-                    "manifest requires"
-                )
-            pages.append(
-                RenderInputPage(
-                    page_id=payload.page_id, route=payload.route, title=payload.title
-                )
-            )
-
-    integrations_selected = any(
-        selection.family is OptionalFamilyKind.INTEGRATIONS
-        and selection.status is OptionalFamilySelectionStatus.SELECTED
-        for selection in application.optional_families
-    )
-    integration_payloads = [
-        payload for payload in resolved.values() if isinstance(payload, IntegrationPayload)
-    ]
-    if integrations_selected and not integration_payloads:
-        raise AppConfigMaterializationError(
-            "integrations are selected but no IntegrationPayload is pinned"
-        )
-    integrations = tuple(
-        RenderInputIntegration(
-            integration_id=payload.integration_id,
-            kind=payload.integration_kind.value,
-            purpose=payload.purpose,
-            required_at=payload.required_at.value,
-            optional=payload.optional,
-            config_requirements=tuple(
-                RenderInputConfigRequirement(
-                    name=requirement.name,
-                    value_type=_CONFIG_VALUE_TYPES[requirement.value_kind],
-                    required=requirement.required,
-                )
-                for requirement in payload.config_requirements
-            ),
-        )
-        for payload in integration_payloads
-    )
-
-    # Selection honesty is an application-level fact: evaluate it over the
-    # complete cold-validated payload closure, not only the payloads pinned by
-    # currently-active unit footprints — a gapped config/ai.json unit must not
-    # hide missing, ambiguous, or contradictory workflow evidence.
-    workflow_payloads = [
-        payload
-        for payload in payload_by_node.values()
-        if isinstance(payload, WorkflowPayload)
-    ]
-    if _family_selected(OptionalFamilyKind.WORKFLOWS):
-        if not workflow_payloads:
-            raise AppConfigMaterializationError(
-                "workflows are selected but no WorkflowPayload is pinned in "
-                "the footprint; missing selected evidence cannot render"
-            )
-        if any(payload.startup_mode is None for payload in workflow_payloads):
-            raise AppConfigMaterializationError(
-                "a selected workflow does not state its startup mode; the "
-                "chat startup derivation is ambiguous"
-            )
-        agent_driven = [
-            payload
-            for payload in workflow_payloads
-            if payload.startup_mode is WorkflowStartupMode.AGENT_DRIVEN
+    if unit.family_kind == "app_manifest":
+        application = _one_application()
+        auths = [
+            payload for payload in resolved.values() if isinstance(payload, AuthPayload)
         ]
-        if len(agent_driven) > 1:
+        if len(auths) > 1:
             raise AppConfigMaterializationError(
-                "multiple selected workflows claim agent-driven startup; the "
-                "chat startup derivation is ambiguous"
+                "app-manifest projection pins more than one AuthPayload"
             )
-        chat_startup_mode: Literal["ask", "workflow"] = (
-            "workflow" if agent_driven else "ask"
+        auth = auths[0] if auths else None
+        auth_selected = _family_selected(application, OptionalFamilyKind.AUTH)
+        if auth is not None:
+            if not auth_selected:
+                raise AppConfigMaterializationError(
+                    "an AuthPayload is pinned while the application declares "
+                    "the auth family absent; contradictory evidence cannot render"
+                )
+            auth_required = bool(auth.auth_required)
+        else:
+            if auth_selected:
+                raise AppConfigMaterializationError(
+                    "auth is selected but no AuthPayload is pinned in the footprint"
+                )
+            auth_required = False
+        return AppManifestRenderInput(
+            render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
+            application_id=application.application_id,
+            display_name=application.display_name,
+            version=application.version,
+            description=application.description,
+            default_route=application.default_route,
+            auth_required=auth_required,
+            sources=sources,
         )
-    else:
-        if workflow_payloads:
+
+    if unit.family_kind == "app_ui_route_manifest":
+        application = _one_application()
+        pages: list[RenderInputPage] = []
+        for payload in resolved.values():
+            if isinstance(payload, PagePayload):
+                if not payload.route or not payload.title:
+                    raise AppConfigMaterializationError(
+                        f"page {payload.node_id!r} lacks the route/title facts "
+                        "the route manifest requires"
+                    )
+                pages.append(
+                    RenderInputPage(
+                        page_id=payload.page_id,
+                        route=payload.route,
+                        title=payload.title,
+                    )
+                )
+        return RouteManifestRenderInput(
+            render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
+            default_route=application.default_route,
+            pages=tuple(pages),
+            sources=sources,
+        )
+
+    if unit.family_kind == "app_integrations_config":
+        application = _one_application()
+        integration_payloads = [
+            payload
+            for payload in resolved.values()
+            if isinstance(payload, IntegrationPayload)
+        ]
+        if _family_selected(application, OptionalFamilyKind.INTEGRATIONS):
+            if not integration_payloads:
+                raise AppConfigMaterializationError(
+                    "integrations are selected but no IntegrationPayload is pinned"
+                )
+        elif integration_payloads:
             raise AppConfigMaterializationError(
-                "WorkflowPayloads are pinned while the application declares "
-                "the workflows family absent; contradictory evidence cannot "
+                "IntegrationPayloads are pinned while the application declares "
+                "the integrations family absent; contradictory evidence cannot "
                 "render"
             )
-        # Proven absence: the platform host itself defaults the chat startup
-        # mode to "ask" when config/ai.json declares none
-        # (mozaiksai.hosts.platform.build_shell_config), so this literal is
-        # the runtime own provider-neutral default, not an invented fact.
-        chat_startup_mode = "ask"
+        return IntegrationsConfigRenderInput(
+            render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
+            integrations=tuple(
+                RenderInputIntegration(
+                    integration_id=payload.integration_id,
+                    kind=payload.integration_kind.value,
+                    purpose=payload.purpose,
+                    required_at=payload.required_at.value,
+                    optional=payload.optional,
+                    config_requirements=tuple(
+                        RenderInputConfigRequirement(
+                            name=requirement.name,
+                            value_type=_CONFIG_VALUE_TYPES[requirement.value_kind],
+                            required=requirement.required,
+                        )
+                        for requirement in payload.config_requirements
+                    ),
+                )
+                for payload in integration_payloads
+            ),
+            sources=sources,
+        )
 
-    return ApplicationFamilyRenderInput(
-        render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
-        application_id=application.application_id,
-        display_name=application.display_name,
-        version=application.version,
-        description=application.description,
-        default_route=application.default_route,
-        auth_required=auth_required,
-        pages=tuple(pages),
-        chat_startup_mode=chat_startup_mode,
-        integrations=integrations,
-        sources=tuple(
-            RenderInputSource(node_id=node_id, payload_digest=payload.payload_digest)
-            for node_id, payload in resolved.items()
-        ),
+    if unit.family_kind == "app_secret_references":
+        application = _one_application()
+        integration_payloads = [
+            payload
+            for payload in resolved.values()
+            if isinstance(payload, IntegrationPayload)
+        ]
+        if (
+            _family_selected(application, OptionalFamilyKind.INTEGRATIONS)
+            and not integration_payloads
+        ):
+            raise AppConfigMaterializationError(
+                "integrations are selected but no IntegrationPayload is pinned; "
+                "the names-only secret surface cannot render empty output"
+            )
+        names = {
+            requirement.name
+            for payload in integration_payloads
+            for requirement in payload.config_requirements
+            if requirement.value_kind is IntegrationConfigValueKind.SECRET
+        }
+        return SecretReferencesRenderInput(
+            render_input_schema_version=APP_FAMILY_RENDER_INPUT_VERSION,
+            secret_names=tuple(sorted(names)),
+            sources=sources,
+        )
+
+    raise AppConfigMaterializationError(
+        f"unit {unit.unit_id!r} family {unit.family_kind!r} has no family-local "
+        "render-input projection in this slice"
     )
 
 
@@ -825,7 +834,6 @@ def _materialize_unit(
     unit: FamilyInstancePlan,
     *,
     payload_by_node: Mapping[str, SemanticPayloadBase],
-    app_config_render_input: ApplicationFamilyRenderInput | None,
     app_config_selection: RendererSelection | None,
     preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
     bundle_outputs: list[MaterializedOutput],
@@ -847,11 +855,10 @@ def _materialize_unit(
                 f"render unit {unit.unit_id!r} must own exactly one composable output"
             )
         if unit.family_kind in APP_CONFIG_FAMILIES:
-            if app_config_render_input is None or app_config_selection is None:
+            if app_config_selection is None:
                 raise MaterializationError(
-                    f"render unit {unit.unit_id!r} requires the application-family "
-                    "render input and resolved renderer selection, which were "
-                    "not constructed"
+                    f"render unit {unit.unit_id!r} requires the resolved "
+                    "app-config renderer selection, which was not constructed"
                 )
             # A renderer selection cannot authorize a family by implication:
             # the unit's family must be explicitly named by the resolved
@@ -861,8 +868,14 @@ def _materialize_unit(
                     f"unit {unit.unit_id!r} family {unit.family_kind!r} is not "
                     "authorized by the resolved app-config renderer selection"
                 )
+            # Lazy family-local projection: only this unit's plan-pinned
+            # sources feed its closed input, so a typed gap in one family
+            # (e.g. app_config) never blocks another family's rendering.
             content = render_app_config_unit(
-                unit=unit, render_input=app_config_render_input
+                unit=unit,
+                render_input=project_app_family_render_input(
+                    unit=unit, payload_by_node=payload_by_node
+                ),
             )
         else:
             content = render_app_ui_page_schema_unit(unit=unit, payload_by_node=payload_by_node)
@@ -935,7 +948,6 @@ def materialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
-    app_config_render_input: ApplicationFamilyRenderInput | None = None
     app_config_selection: RendererSelection | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
@@ -944,9 +956,6 @@ def materialize_plan(
     ):
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
-        )
-        app_config_render_input = build_app_family_render_input(
-            units=verified_plan.units, payload_by_node=payload_by_node
         )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
 
@@ -960,7 +969,6 @@ def materialize_plan(
         _materialize_unit(
             unit,
             payload_by_node=payload_by_node,
-            app_config_render_input=app_config_render_input,
             app_config_selection=app_config_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
@@ -1034,7 +1042,6 @@ def rematerialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
-    app_config_render_input: ApplicationFamilyRenderInput | None = None
     app_config_selection: RendererSelection | None = None
     if any(
         unit.disposition is PlanDisposition.RENDER
@@ -1043,9 +1050,6 @@ def rematerialize_plan(
     ):
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
-        )
-        app_config_render_input = build_app_family_render_input(
-            units=verified_plan.units, payload_by_node=payload_by_node
         )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
     base_by_unit: dict[str, list[MaterializedOutput]] = {}
@@ -1103,7 +1107,6 @@ def rematerialize_plan(
         _materialize_unit(
             unit,
             payload_by_node=payload_by_node,
-            app_config_render_input=app_config_render_input,
             app_config_selection=app_config_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -105,6 +105,11 @@ from mozaiksai.core.semantics.payloads import (
     SemanticPayloadBase,
     parse_semantic_payload,
 )
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    validate_compilation_plan_against_authority,
+)
 from mozaiksai.core.semantics.portable_path import detect_collisions
 
 PAGE_SCHEMA_FAMILY: Literal["app_ui_page_schema"] = "app_ui_page_schema"
@@ -929,6 +934,7 @@ def _materialize_unit(
 def materialize_plan(
     *,
     plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
     graph: SemanticGraphV2,
     payloads: Iterable[SemanticPayloadBase],
     binding: ImplementationBinding,
@@ -940,10 +946,19 @@ def materialize_plan(
     Renders exactly the renderer-ready page units through the bound accepted
     implementation, places exact preserved bytes for supplied
     ``preserve_unowned`` units, and reports every other unit's disposition
-    explicitly. The registry snapshot identity must match the plan's pinned
-    registry digest — a plan derived from a different registry fails closed.
+    explicitly. Canonical authority inputs are required and the submitted plan
+    must equal the plan re-derived from them. The registry snapshot identity
+    must also match the plan's pinned registry digest.
     """
-    verified_plan, verified_graph, payload_by_node = _cold_validate(plan, graph, payloads)
+    try:
+        canonical_plan = validate_compilation_plan_against_authority(plan, authority_inputs)
+    except PlanAuthorityError as exc:
+        raise MaterializationError(
+            "compilation plan rejected by canonical authority validation"
+        ) from exc
+    verified_plan, verified_graph, payload_by_node = _cold_validate(
+        canonical_plan, graph, payloads
+    )
     _assert_registry_identity(verified_plan, layout_registry)
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
@@ -1016,7 +1031,9 @@ def rematerialize_plan(
     *,
     base_bundle: MaterializedBundle,
     base_plan: CompilationPlan,
+    base_authority_inputs: CompilationPlanAuthorityInputs,
     successor_plan: CompilationPlan,
+    successor_authority_inputs: CompilationPlanAuthorityInputs,
     graph: SemanticGraphV2,
     payloads: Iterable[SemanticPayloadBase],
     binding: ImplementationBinding,
@@ -1029,14 +1046,27 @@ def rematerialize_plan(
     byte-for-byte from the base bundle (preserved reuse re-verifies the
     pinned content digest); removed units' outputs are absent. The closure is
     computed by the 4B authority and attached to the result for inspection.
+    Both plans must first equal the plans re-derived from their respective
+    canonical authority inputs, before any historical bytes can be reused.
     """
-    if base_bundle.plan_digest != base_plan.plan_digest:
+    try:
+        canonical_base_plan = validate_compilation_plan_against_authority(
+            base_plan, base_authority_inputs
+        )
+        canonical_successor_plan = validate_compilation_plan_against_authority(
+            successor_plan, successor_authority_inputs
+        )
+    except PlanAuthorityError as exc:
+        raise MaterializationError(
+            "compilation plan rejected by canonical authority validation"
+        ) from exc
+    if base_bundle.plan_digest != canonical_base_plan.plan_digest:
         raise MaterializationError("base bundle does not correspond to the base plan")
-    closure = plan_regeneration_closure(base_plan, successor_plan)
+    closure = plan_regeneration_closure(canonical_base_plan, canonical_successor_plan)
     reusable_ids = set(closure.reusable)
 
     verified_plan, verified_graph, payload_by_node = _cold_validate(
-        successor_plan, graph, payloads
+        canonical_successor_plan, graph, payloads
     )
     _assert_registry_identity(verified_plan, layout_registry)
     resolve_page_schema_renderer_selection(

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -60,6 +60,11 @@ from mozaiksai.core.runtime.app.page_schema import (
     AppPageSchema,
     AppPageSection,
 )
+from mozaiksai.core.semantics.app_config_materialization import (
+    APP_CONFIG_FAMILIES,
+    render_app_config_unit,
+    resolve_app_config_renderer_selection,
+)
 from mozaiksai.core.semantics.binding import (
     ImplementationBinding,
     RendererSelection,
@@ -412,6 +417,7 @@ class MaterializedBundle:
     external_handoff_units: tuple[str, ...]
     inapplicable_units: tuple[str, ...]
     unsupplied_preserved_units: tuple[str, ...]
+    input_only_units: tuple[str, ...]
     instance_scope_deferred_units: tuple[str, ...]
     gap_count: int
     closure: RegenerationClosure | None = field(default=None)
@@ -495,6 +501,7 @@ def _materialize_unit(
     external: list[str],
     inapplicable: list[str],
     unsupplied: list[str],
+    input_only: list[str],
     deferred: list[str],
 ) -> None:
     composable = [o for o in unit.outputs if o.path_scope in _COMPOSABLE_PATH_SCOPES]
@@ -508,7 +515,10 @@ def _materialize_unit(
             raise MaterializationError(
                 f"render unit {unit.unit_id!r} must own exactly one composable output"
             )
-        content = render_app_ui_page_schema_unit(unit=unit, payload_by_node=payload_by_node)
+        if unit.family_kind in APP_CONFIG_FAMILIES:
+            content = render_app_config_unit(unit=unit, payload_by_node=payload_by_node)
+        else:
+            content = render_app_ui_page_schema_unit(unit=unit, payload_by_node=payload_by_node)
         target = composable[0]
         bundle_outputs.append(
             MaterializedOutput(
@@ -545,6 +555,10 @@ def _materialize_unit(
         external.append(unit.unit_id)
     elif unit.disposition is PlanDisposition.INAPPLICABLE:
         inapplicable.append(unit.unit_id)
+    elif unit.disposition is PlanDisposition.INPUT_ONLY:
+        # Input-only families feed later derivations; they never produce
+        # bundle bytes and are reported explicitly, never silently skipped.
+        input_only.append(unit.unit_id)
     else:
         raise MaterializationError(
             f"unit {unit.unit_id!r} disposition {unit.disposition.value!r} has no "
@@ -574,12 +588,21 @@ def materialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in APP_CONFIG_FAMILIES
+        for unit in verified_plan.units
+    ):
+        resolve_app_config_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
 
     outputs: list[MaterializedOutput] = []
     external: list[str] = []
     inapplicable: list[str] = []
     unsupplied: list[str] = []
+    input_only: list[str] = []
     deferred: list[str] = []
     for unit in verified_plan.units:
         _materialize_unit(
@@ -590,6 +613,7 @@ def materialize_plan(
             external=external,
             inapplicable=inapplicable,
             unsupplied=unsupplied,
+            input_only=input_only,
             deferred=deferred,
         )
     _assert_output_ownership(verified_plan, outputs)
@@ -599,6 +623,7 @@ def materialize_plan(
         external_handoff_units=tuple(sorted(external)),
         inapplicable_units=tuple(sorted(inapplicable)),
         unsupplied_preserved_units=tuple(sorted(unsupplied)),
+        input_only_units=tuple(sorted(input_only)),
         instance_scope_deferred_units=tuple(sorted(set(deferred))),
         gap_count=len(verified_plan.gaps),
     )
@@ -654,6 +679,14 @@ def rematerialize_plan(
     resolve_page_schema_renderer_selection(
         binding, graph=verified_graph, layout_registry=layout_registry
     )
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in APP_CONFIG_FAMILIES
+        for unit in verified_plan.units
+    ):
+        resolve_app_config_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
     base_by_unit: dict[str, list[MaterializedOutput]] = {}
     for output in base_bundle.outputs:
@@ -663,6 +696,7 @@ def rematerialize_plan(
     external: list[str] = []
     inapplicable: list[str] = []
     unsupplied: list[str] = []
+    input_only: list[str] = []
     deferred: list[str] = []
     for unit in verified_plan.units:
         if unit.unit_id in reusable_ids:
@@ -701,6 +735,8 @@ def rematerialize_plan(
                 external.append(unit.unit_id)
             elif unit.disposition is PlanDisposition.INAPPLICABLE:
                 inapplicable.append(unit.unit_id)
+            elif unit.disposition is PlanDisposition.INPUT_ONLY:
+                input_only.append(unit.unit_id)
             if any(o.path_scope not in _COMPOSABLE_PATH_SCOPES for o in unit.outputs):
                 deferred.append(unit.unit_id)
             continue
@@ -712,6 +748,7 @@ def rematerialize_plan(
             external=external,
             inapplicable=inapplicable,
             unsupplied=unsupplied,
+            input_only=input_only,
             deferred=deferred,
         )
     _assert_output_ownership(verified_plan, outputs)
@@ -721,6 +758,7 @@ def rematerialize_plan(
         external_handoff_units=tuple(sorted(external)),
         inapplicable_units=tuple(sorted(inapplicable)),
         unsupplied_preserved_units=tuple(sorted(unsupplied)),
+        input_only_units=tuple(sorted(input_only)),
         instance_scope_deferred_units=tuple(sorted(set(deferred))),
         gap_count=len(verified_plan.gaps),
         closure=closure,

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -210,6 +210,7 @@ def composition_fixture() -> dict[str, object]:
         rendered,
         payload_by_node=payload_by_id,
         app_config_render_input=None,
+        app_config_selection=None,
         preserved_by_unit={},
         bundle_outputs=rendered_outputs,
         external=[],

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -209,6 +209,7 @@ def composition_fixture() -> dict[str, object]:
     _materialize_unit(
         rendered,
         payload_by_node=payload_by_id,
+        app_config_render_input=None,
         preserved_by_unit={},
         bundle_outputs=rendered_outputs,
         external=[],

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -209,7 +209,6 @@ def composition_fixture() -> dict[str, object]:
     _materialize_unit(
         rendered,
         payload_by_node=payload_by_id,
-        app_config_render_input=None,
         app_config_selection=None,
         preserved_by_unit={},
         bundle_outputs=rendered_outputs,

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -214,6 +214,7 @@ def composition_fixture() -> dict[str, object]:
         external=[],
         inapplicable=[],
         unsupplied=[],
+        input_only=[],
         deferred=[],
     )
     preserved_output = _output(preserved, b"agents: []\n", origin="preserved")
@@ -223,6 +224,7 @@ def composition_fixture() -> dict[str, object]:
         external_handoff_units=(handoff.unit_id,),
         inapplicable_units=(inapplicable.unit_id,),
         unsupplied_preserved_units=(),
+        input_only_units=(),
         instance_scope_deferred_units=(preserved.unit_id,),
         gap_count=0,
         closure=closure,

--- a/tests/slice_5c_revision_helpers.py
+++ b/tests/slice_5c_revision_helpers.py
@@ -86,6 +86,7 @@ def revision_fixture() -> dict[str, object]:
         external_handoff_units=(),
         inapplicable_units=(),
         unsupplied_preserved_units=(),
+        input_only_units=(),
         instance_scope_deferred_units=(),
         gap_count=0,
     )
@@ -282,6 +283,7 @@ def executable_revision_fixture() -> dict[str, object]:
         external_handoff_units=materialized_source.external_handoff_units,
         inapplicable_units=materialized_source.inapplicable_units,
         unsupplied_preserved_units=(),
+        input_only_units=(),
         instance_scope_deferred_units=materialized_source.instance_scope_deferred_units,
         gap_count=0,
     )

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -65,6 +65,9 @@ from mozaiksai.core.semantics.payloads import (
     SectionContentEntry,
     SectionEntryKind,
     SectionPayload,
+    SemanticNodeKind,
+    WorkflowPayload,
+    WorkflowStartupMode,
     build_semantic_payload,
     semantic_payload_ref,
 )
@@ -108,18 +111,27 @@ def _extended_fixture(
     default_route: str = "/home",
     auth_selected: bool = True,
     integrations_selected: bool = True,
+    workflows_selected: bool = True,
+    drop_workflow_payload: bool = False,
+    workflow_startup_mode: WorkflowStartupMode | None = WorkflowStartupMode.EVENT_DRIVEN,
+    extra_workflow_startup_mode: WorkflowStartupMode | None = None,
+    custom_routes_selected: bool = False,
     integration_secret_name: str = "EMAIL_API_KEY",
 ):
     """Corpus with explicit product-meaningful optional-family selections."""
     payloads = dict(_corpus_payloads(scope=_SCOPE, home_title=home_title))
 
     def _family_selected(family: OptionalFamilyKind) -> bool:
+        if family is OptionalFamilyKind.CUSTOM_ROUTES:
+            return custom_routes_selected
         if family not in _SELECTED:
             return False
         if family is OptionalFamilyKind.AUTH:
             return auth_selected
         if family is OptionalFamilyKind.INTEGRATIONS:
             return integrations_selected
+        if family is OptionalFamilyKind.WORKFLOWS:
+            return workflows_selected
         return True
 
     application = payloads["application"]
@@ -152,6 +164,31 @@ def _extended_fixture(
         payloads.pop("integration", None)
     if not auth_selected:
         payloads.pop("auth", None)
+    if drop_workflow_payload:
+        payloads.pop(SemanticNodeKind.WORKFLOW, None)
+    elif workflow_startup_mode is not WorkflowStartupMode.EVENT_DRIVEN:
+        workflow = payloads[SemanticNodeKind.WORKFLOW]
+        payloads[SemanticNodeKind.WORKFLOW] = build_semantic_payload(
+            WorkflowPayload,
+            node_id=workflow.node_id,
+            payload_version=workflow.payload_version,
+            scope=_SCOPE,
+            workflow_id=workflow.workflow_id,
+            description=workflow.description,
+            startup_mode=workflow_startup_mode,
+            topology=workflow.topology,
+        )
+    if extra_workflow_startup_mode is not None:
+        payloads["workflow_extra"] = build_semantic_payload(
+            WorkflowPayload,
+            node_id="mozaiks.workflow.assistant",
+            payload_version=1,
+            scope=_SCOPE,
+            workflow_id="assistant",
+            description="Interactive assistant workflow",
+            startup_mode=extra_workflow_startup_mode,
+            topology=None,
+        )
     else:
         auth = payloads["auth"]
         payloads["auth"] = build_semantic_payload(
@@ -1206,6 +1243,347 @@ def test_output_closure_rejects_extra_and_missing_outputs() -> None:
     # No selection at all cannot authorize emitted app-config outputs.
     with pytest.raises(AppConfigMaterializationError, match="unauthorized"):
         _assert_app_config_output_closure(plan, bundle.outputs, None)
+
+
+# ---------------------------------------------------------------------------
+# Selection honesty: a family whose selection says SELECTED must have its
+# typed facts; missing selected evidence stays a typed gap and contradictory
+# evidence never renders. Codex 2's exact attack is preserved first.
+# ---------------------------------------------------------------------------
+
+
+def _gap_paths(plan, family_kind):
+    return {
+        gap.path_template for gap in plan.gaps if gap.family_kind == family_kind
+    }
+
+
+def test_workflows_selected_with_zero_payloads_stays_a_typed_gap() -> None:
+    """Codex 2's exact attack, preserved: WORKFLOWS selected, zero
+    WorkflowPayloads. app_config must not be classified complete from an
+    application-only footprint, and config/ai.json must not be emitted with a
+    normalized chat_startup_mode."""
+    graph, payloads = _extended_fixture(drop_workflow_payload=True)
+    plan = _plan(graph, payloads, with_configs=False)
+    render_units = [
+        u
+        for u in plan.units
+        if u.family_kind == "app_config" and u.disposition is PlanDisposition.RENDER
+    ]
+    assert render_units == []
+    assert "config/ai.json" in _gap_paths(plan, "app_config")
+    with pytest.raises(
+        AppConfigMaterializationError, match="workflows are selected but no"
+    ):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_one_complete_workflow_renders_exact_startup_mode() -> None:
+    ask = _bundle_files()
+    assert json.loads(ask["config/ai.json"]) == {
+        "chat": {"chat_startup_mode": "ask"}
+    }
+    graph, payloads = _extended_fixture(
+        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN
+    )
+    plan = _plan(graph, payloads, with_configs=False)
+    files = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert json.loads(files["config/ai.json"]) == {
+        "chat": {"chat_startup_mode": "workflow"}
+    }
+
+
+def test_two_compatible_workflows_render_deterministically() -> None:
+    graph, payloads = _extended_fixture(
+        extra_workflow_startup_mode=WorkflowStartupMode.ON_DEMAND
+    )
+    plan = _plan(graph, payloads, with_configs=False)
+    files = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert json.loads(files["config/ai.json"]) == {
+        "chat": {"chat_startup_mode": "ask"}
+    }
+    # One agent-driven among on-demand peers is likewise unambiguous.
+    graph2, payloads2 = _extended_fixture(
+        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
+        extra_workflow_startup_mode=WorkflowStartupMode.ON_DEMAND,
+    )
+    plan2 = _plan(graph2, payloads2, with_configs=False)
+    files2 = materialize_plan(
+        plan=plan2,
+        graph=graph2,
+        payloads=payloads2,
+        binding=_binding(graph2),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert json.loads(files2["config/ai.json"]) == {
+        "chat": {"chat_startup_mode": "workflow"}
+    }
+
+
+def test_conflicting_agent_driven_workflows_stay_a_typed_gap() -> None:
+    graph, payloads = _extended_fixture(
+        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
+        extra_workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
+    )
+    plan = _plan(graph, payloads, with_configs=False)
+    assert "config/ai.json" in _gap_paths(plan, "app_config")
+    with pytest.raises(AppConfigMaterializationError, match="ambiguous"):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_workflow_without_startup_mode_stays_a_typed_gap() -> None:
+    graph, payloads = _extended_fixture(workflow_startup_mode=None)
+    plan = _plan(graph, payloads, with_configs=False)
+    assert "config/ai.json" in _gap_paths(plan, "app_config")
+
+
+def test_workflow_node_with_missing_payload_fails_derivation_closed() -> None:
+    from mozaiksai.core.semantics.compilation_plan import CompilationPlanError
+
+    graph, payloads = _extended_fixture()
+    without = [
+        p for p in payloads if p.payload_kind is not SemanticNodeKind.WORKFLOW
+    ]
+    with pytest.raises(CompilationPlanError, match="payload closure failed"):
+        derive_compilation_plan(
+            graph=graph,
+            payloads=without,
+            registry=build_app_layout_registry(()),
+        )
+
+
+def test_workflows_absent_with_payload_present_is_a_contradiction() -> None:
+    graph, payloads = _extended_fixture(workflows_selected=False)
+    plan = _plan(graph, payloads, with_configs=False)
+    assert "config/ai.json" in _gap_paths(plan, "app_config")
+    with pytest.raises(AppConfigMaterializationError, match="declares"):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_workflows_absent_with_zero_payloads_renders_runtime_default() -> None:
+    """Semantically proven absence renders the platform host's own default
+    (mozaiksai.hosts.platform.build_shell_config falls back to "ask" when
+    config/ai.json declares no chat startup mode)."""
+    graph, payloads = _extended_fixture(
+        workflows_selected=False, drop_workflow_payload=True
+    )
+    plan = _plan(graph, payloads, with_configs=False)
+    files = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert json.loads(files["config/ai.json"]) == {
+        "chat": {"chat_startup_mode": "ask"}
+    }
+
+
+def test_workflow_description_mutation_does_not_change_ai_config_bytes() -> None:
+    base = _bundle_files()
+    graph, payloads = _extended_fixture()
+    workflow = next(
+        p for p in payloads if p.payload_kind is SemanticNodeKind.WORKFLOW
+    )
+    mutated = [
+        build_semantic_payload(
+            WorkflowPayload,
+            node_id=p.node_id,
+            payload_version=p.payload_version,
+            scope=_SCOPE,
+            workflow_id=p.workflow_id,
+            description="A different description entirely",
+            startup_mode=p.startup_mode,
+            topology=p.topology,
+        )
+        if p is workflow
+        else p
+        for p in payloads
+    ]
+    nodes = [
+        SemanticNodeV2(
+            node_id=p.node_id, kind=p.payload_kind, payload_ref=semantic_payload_ref(p)
+        )
+        for p in mutated
+    ]
+    edges = list(graph.edges)
+    mutated_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=_SCOPE,
+        nodes=nodes,
+        edges=edges,
+    )
+    plan = _plan(mutated_graph, mutated, with_configs=False)
+    files = materialize_plan(
+        plan=plan,
+        graph=mutated_graph,
+        payloads=mutated,
+        binding=_binding(mutated_graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    # The description is not consumed by config/ai.json: bytes are unchanged
+    # even though the workflow payload digest (and source footprint) changed.
+    assert files["config/ai.json"] == base["config/ai.json"]
+    assert files["app.json"] == base["app.json"]
+
+
+def test_workflow_startup_mode_mutation_changes_only_ai_config() -> None:
+    base = _bundle_files()
+    graph, payloads = _extended_fixture(
+        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN
+    )
+    plan = _plan(graph, payloads, with_configs=False)
+    files = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert files["config/ai.json"] != base["config/ai.json"]
+    for unchanged in (
+        "app.json",
+        "ui/route_manifest.json",
+        "config/integrations.yaml",
+        "security/secrets.yaml",
+    ):
+        assert files[unchanged] == base[unchanged], unchanged
+
+
+def test_forged_render_input_claiming_no_workflow_fails_source_pinning() -> None:
+    plan, payload_by_node, render_input = _valid_render_input()
+    workflow_node_ids = {
+        node_id
+        for node_id, payload in payload_by_node.items()
+        if payload.payload_kind is SemanticNodeKind.WORKFLOW
+    }
+    document = render_input.model_dump()
+    document["chat_startup_mode"] = "ask"
+    document["sources"] = [
+        s for s in document["sources"] if s["node_id"] not in workflow_node_ids
+    ]
+    forged = type(render_input).model_validate(document)
+    ai_unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER and u.family_kind == "app_config"
+    )
+    with pytest.raises(AppConfigMaterializationError, match="missing"):
+        render_app_config_unit(unit=ai_unit, render_input=forged)
+
+
+def test_selected_auth_without_payload_stays_a_typed_gap() -> None:
+    graph, payloads = _extended_fixture(auth_selected=True)
+    without_auth = [
+        p for p in payloads if p.payload_kind is not SemanticNodeKind.AUTH
+    ]
+    nodes = [
+        SemanticNodeV2(
+            node_id=p.node_id, kind=p.payload_kind, payload_ref=semantic_payload_ref(p)
+        )
+        for p in without_auth
+    ]
+    kept_ids = {n.node_id for n in nodes}
+    edges = [
+        e
+        for e in graph.edges
+        if e.source_node_id in kept_ids and e.target_node_id in kept_ids
+    ]
+    stripped_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=_SCOPE,
+        nodes=nodes,
+        edges=edges,
+    )
+    plan = _plan(stripped_graph, without_auth, with_configs=False)
+    for family in (
+        "app_manifest",
+        "app_config",
+        "app_secret_references",
+        "app_ui_route_manifest",
+    ):
+        assert not any(
+            u.family_kind == family and u.disposition is PlanDisposition.RENDER
+            for u in plan.units
+        ), family
+
+
+def test_selected_integrations_without_payload_gap_secret_references() -> None:
+    graph, payloads = _extended_fixture()
+    without = [
+        p for p in payloads if p.payload_kind is not SemanticNodeKind.INTEGRATION
+    ]
+    nodes = [
+        SemanticNodeV2(
+            node_id=p.node_id, kind=p.payload_kind, payload_ref=semantic_payload_ref(p)
+        )
+        for p in without
+    ]
+    kept_ids = {n.node_id for n in nodes}
+    edges = [
+        e
+        for e in graph.edges
+        if e.source_node_id in kept_ids and e.target_node_id in kept_ids
+    ]
+    stripped_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=_SCOPE,
+        nodes=nodes,
+        edges=edges,
+    )
+    plan = _plan(stripped_graph, without, with_configs=False)
+    # Selected integrations with zero payloads: neither the integrations
+    # config nor the names-only secret surface may render empty output.
+    for family in ("app_integrations_config", "app_secret_references"):
+        assert not any(
+            u.family_kind == family and u.disposition is PlanDisposition.RENDER
+            for u in plan.units
+        ), family
+
+
+def test_selected_custom_routes_without_declaration_gap_route_manifest() -> None:
+    graph, payloads = _extended_fixture(custom_routes_selected=True)
+    plan = _plan(graph, payloads, with_configs=False)
+    assert not any(
+        u.family_kind == "app_ui_route_manifest"
+        and u.disposition is PlanDisposition.RENDER
+        for u in plan.units
+    )
+    assert "ui/route_manifest.json" in _gap_paths(plan, "app_ui_route_manifest")
 
 
 def test_payload_mutation_after_snapshot_creation_cannot_change_bytes() -> None:

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -114,6 +114,7 @@ def _extended_fixture(
     home_title: str = "Home",
     default_route: str = "/home",
     auth_selected: bool = True,
+    auth_roles: tuple[str, ...] | None = None,
     integrations_selected: bool = True,
     workflows_selected: bool = True,
     drop_workflow_payload: bool = False,
@@ -202,7 +203,7 @@ def _extended_fixture(
             scope=_SCOPE,
             auth_required=auth.auth_required,
             strategy=auth.strategy,
-            roles=auth.roles,
+            roles=auth.roles if auth_roles is None else auth_roles,
         )
     if integration_secret_name != "EMAIL_API_KEY":
         integration = payloads["integration"]
@@ -1541,3 +1542,267 @@ def test_payload_mutation_after_projection_cannot_change_bytes() -> None:
     before = render_app_config_unit(unit=unit, render_input=render_input)
     payload_by_node.clear()
     assert render_app_config_unit(unit=unit, render_input=render_input) == before
+
+
+# ---------------------------------------------------------------------------
+# Source locality: a family's PlanUnit footprint contains exactly the payload
+# kinds whose facts influence its existence, path, bytes, or validator
+# obligation, and the family render input must bind exactly that footprint —
+# not a subset, not a superset. (Codex 2 attacks preserved below.)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_FAMILY_SOURCE_KINDS = {
+    "app_manifest": {"application", "auth"},
+    "app_ui_route_manifest": {"application", "page"},
+    "app_integrations_config": {"application", "integration"},
+    "app_secret_references": {"application", "integration"},
+}
+
+
+def _unit_for(plan, family):
+    return next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER and u.family_kind == family
+    )
+
+
+def test_auth_roles_mutation_leaves_secret_unit_and_bytes_unchanged() -> None:
+    """Codex 2 Attack A, preserved: security/secrets.yaml consumes no auth
+    fact, so AuthPayload is not a source of app_secret_references. A
+    roles-only auth mutation leaves the secret unit's identity, footprint,
+    reuse, and bytes unchanged."""
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    unit = _unit_for(plan, "app_secret_references")
+    assert {s.node_id.split(".")[1] for s in unit.sources} == {
+        "application",
+        "integration",
+    }
+    mutated_graph, mutated = _extended_fixture(
+        auth_roles=("admin", "viewer", "editor")
+    )
+    mutated_plan = _plan(mutated_graph, mutated, with_configs=False)
+    mutated_unit = _unit_for(mutated_plan, "app_secret_references")
+    assert mutated_unit.unit_digest == unit.unit_digest
+    assert mutated_unit.sources == unit.sources
+    from mozaiksai.core.semantics.compilation_plan import plan_regeneration_closure
+
+    closure = plan_regeneration_closure(plan, mutated_plan)
+    assert unit.unit_id in closure.reusable
+    # app.json DOES consume auth (authRequired): its unit is conservatively
+    # invalidated at payload-level granularity even though roles do not enter
+    # its bytes.
+    manifest_unit = _unit_for(plan, "app_manifest")
+    mutated_manifest = _unit_for(mutated_plan, "app_manifest")
+    assert mutated_manifest.unit_digest != manifest_unit.unit_digest
+    base = _bundle_files()
+    registry = build_app_layout_registry(())
+    changed = materialize_plan(
+        plan=mutated_plan,
+        graph=mutated_graph,
+        payloads=mutated,
+        binding=_binding(mutated_graph),
+        layout_registry=registry,
+    ).files()
+    for path in _RENDERED_PATHS:
+        assert changed[path] == base[path], path
+
+
+def test_extra_unrelated_source_in_valid_render_input_is_rejected() -> None:
+    """Codex 2 Attack B, preserved: a fully valid render input carrying every
+    expected source plus one unrelated valid payload source from the same
+    graph must be rejected — the source set is exact, never 'at least'."""
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    unit = _unit_for(plan, "app_secret_references")
+    valid = project_app_family_render_input(
+        unit=unit, payload_by_node=payload_by_node
+    )
+    page = payload_by_node["mozaiks.page.home"]
+    document = valid.model_dump()
+    document["sources"] = list(document["sources"]) + [
+        {"node_id": page.node_id, "payload_digest": page.payload_digest}
+    ]
+    forged = type(valid).model_validate(document)
+    with pytest.raises(
+        AppConfigMaterializationError, match="does not bind exactly"
+    ):
+        render_app_config_unit(unit=unit, render_input=forged)
+
+
+@pytest.mark.parametrize(
+    ("family", "extra_node"),
+    [
+        pytest.param(
+            "app_secret_references", "mozaiks.auth.corpus", id="auth-into-secrets"
+        ),
+        pytest.param(
+            "app_manifest", "mozaiks.workflow.digest", id="workflow-into-manifest"
+        ),
+        pytest.param(
+            "app_ui_route_manifest",
+            "mozaiks.integration.email",
+            id="integration-into-routes",
+        ),
+        pytest.param(
+            "app_integrations_config",
+            "mozaiks.page.home",
+            id="page-into-integrations",
+        ),
+    ],
+)
+def test_every_family_rejects_an_unrelated_extra_source(family, extra_node) -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    unit = _unit_for(plan, family)
+    valid = project_app_family_render_input(
+        unit=unit, payload_by_node=payload_by_node
+    )
+    extra = payload_by_node[extra_node]
+    document = valid.model_dump()
+    document["sources"] = list(document["sources"]) + [
+        {"node_id": extra.node_id, "payload_digest": extra.payload_digest}
+    ]
+    forged = type(valid).model_validate(document)
+    with pytest.raises(
+        AppConfigMaterializationError, match="does not bind exactly"
+    ):
+        render_app_config_unit(unit=unit, render_input=forged)
+
+
+def test_plan_source_added_to_a_family_is_rejected() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    plan_payload = next(
+        p for p in payloads if p.payload_kind is SemanticNodeKind.PLAN
+    )
+    unit = _unit_for(plan, "app_manifest")
+    valid = project_app_family_render_input(
+        unit=unit, payload_by_node=payload_by_node
+    )
+    document = valid.model_dump()
+    document["sources"] = list(document["sources"]) + [
+        {
+            "node_id": plan_payload.node_id,
+            "payload_digest": plan_payload.payload_digest,
+        }
+    ]
+    forged = type(valid).model_validate(document)
+    with pytest.raises(
+        AppConfigMaterializationError, match="does not bind exactly"
+    ):
+        render_app_config_unit(unit=unit, render_input=forged)
+
+
+def test_omitted_required_source_and_shuffled_exact_set() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    unit = _unit_for(plan, "app_integrations_config")
+    valid = project_app_family_render_input(
+        unit=unit, payload_by_node=payload_by_node
+    )
+    document = valid.model_dump()
+    document["sources"] = list(document["sources"])[:-1]
+    if document["sources"]:
+        trimmed = type(valid).model_validate(document)
+        with pytest.raises(
+            AppConfigMaterializationError, match="does not bind exactly"
+        ):
+            render_app_config_unit(unit=unit, render_input=trimmed)
+    # The exact expected set succeeds in canonical and shuffled input order.
+    document = valid.model_dump()
+    document["sources"] = list(reversed(document["sources"]))
+    shuffled = type(valid).model_validate(document)
+    assert render_app_config_unit(
+        unit=unit, render_input=shuffled
+    ) == render_app_config_unit(unit=unit, render_input=valid)
+
+
+def test_registry_plan_and_render_input_source_kinds_are_consistent() -> None:
+    """Permanent guard: for every renderer-ready family the registry
+    declaration, the derived PlanUnit footprint, and the projected render
+    input agree on exactly the same source kinds."""
+    registry = build_app_layout_registry(())
+    for family in registry.ordered_families():
+        expected = _EXPECTED_FAMILY_SOURCE_KINDS.get(family.kind.value)
+        if expected is None or family.path_template not in _RENDERED_PATHS:
+            continue
+        assert set(family.semantic_input_kinds) == expected, family.kind
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    for family_kind, expected in _EXPECTED_FAMILY_SOURCE_KINDS.items():
+        unit = _unit_for(plan, family_kind)
+        derived_kinds = {
+            payload_by_node[s.node_id].payload_kind.value for s in unit.sources
+        }
+        assert derived_kinds <= expected, (family_kind, derived_kinds)
+        render_input = project_app_family_render_input(
+            unit=unit, payload_by_node=payload_by_node
+        )
+        input_kinds = {
+            payload_by_node[s.node_id].payload_kind.value
+            for s in render_input.sources
+        }
+        assert input_kinds == derived_kinds, family_kind
+
+
+def test_no_family_consumes_graph_edge_identities() -> None:
+    """Edge audit: none of the four family inputs consume edge facts. Adding
+    an unrelated edge changes graph identity but leaves every unit's
+    footprint, identity, and rendered bytes unchanged."""
+    base = _bundle_files()
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    extra_edge = SemanticEdge(
+        kind=SemanticEdgeKind.DEPENDS_ON,
+        source_node_id="mozaiks.module.reports",
+        target_node_id="mozaiks.page.home",
+    )
+    edged_graph = build_semantic_graph_v2(
+        graph_id=graph.graph_id,
+        version=graph.version,
+        scope=_SCOPE,
+        nodes=list(graph.nodes),
+        edges=[*graph.edges, extra_edge],
+    )
+    edged_plan = _plan(edged_graph, payloads, with_configs=False)
+    for family_kind in _EXPECTED_FAMILY_SOURCE_KINDS:
+        assert (
+            _unit_for(edged_plan, family_kind).unit_digest
+            == _unit_for(plan, family_kind).unit_digest
+        ), family_kind
+    files = materialize_plan(
+        plan=edged_plan,
+        graph=edged_graph,
+        payloads=payloads,
+        binding=_binding(edged_graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    for path in _RENDERED_PATHS:
+        assert files[path] == base[path], path
+
+
+def test_unrelated_page_and_workflow_mutations_keep_secret_unit_reusable() -> None:
+    from mozaiksai.core.semantics.compilation_plan import plan_regeneration_closure
+
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    secret_unit = _unit_for(plan, "app_secret_references")
+    for kwargs in (
+        {"home_title": "Console"},
+        {"workflow_startup_mode": WorkflowStartupMode.AGENT_DRIVEN},
+    ):
+        m_graph, m_payloads = _extended_fixture(**kwargs)
+        m_plan = _plan(m_graph, m_payloads, with_configs=False)
+        assert (
+            _unit_for(m_plan, "app_secret_references").unit_digest
+            == secret_unit.unit_digest
+        ), kwargs
+        closure = plan_regeneration_closure(plan, m_plan)
+        assert secret_unit.unit_id in closure.reusable, kwargs

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -107,10 +107,20 @@ def _extended_fixture(
     home_title: str = "Home",
     default_route: str = "/home",
     auth_selected: bool = True,
+    integrations_selected: bool = True,
     integration_secret_name: str = "EMAIL_API_KEY",
 ):
     """Corpus with explicit product-meaningful optional-family selections."""
     payloads = dict(_corpus_payloads(scope=_SCOPE, home_title=home_title))
+
+    def _family_selected(family: OptionalFamilyKind) -> bool:
+        if family not in _SELECTED:
+            return False
+        if family is OptionalFamilyKind.AUTH:
+            return auth_selected
+        if family is OptionalFamilyKind.INTEGRATIONS:
+            return integrations_selected
+        return True
 
     application = payloads["application"]
     selections = tuple(
@@ -118,7 +128,7 @@ def _extended_fixture(
             family=family,
             status=(
                 OptionalFamilySelectionStatus.SELECTED
-                if family in _SELECTED and (family is not OptionalFamilyKind.AUTH or auth_selected)
+                if _family_selected(family)
                 else OptionalFamilySelectionStatus.ABSENT_BY_DECLARATION
             ),
         )
@@ -138,6 +148,8 @@ def _extended_fixture(
         default_route=default_route,
         optional_families=selections,
     )
+    if not integrations_selected:
+        payloads.pop("integration", None)
     if not auth_selected:
         payloads.pop("auth", None)
     else:
@@ -880,6 +892,320 @@ def test_render_input_from_a_different_application_fails_closed() -> None:
     )
     with pytest.raises(AppConfigMaterializationError, match="pinned payload digest"):
         render_app_config_unit(unit=unit, render_input=other_input)
+
+
+# ---------------------------------------------------------------------------
+# Renderer-selection authorization matrix: the ImplementationBinding selection
+# is an authorization/capability boundary, not descriptive metadata. Version 1
+# of deterministic_app_config_renderer supports exactly the five-family set;
+# anything else fails closed at resolution, per-unit dispatch, or output
+# closure.
+# ---------------------------------------------------------------------------
+
+
+def _binding_with_families(
+    graph,
+    families,
+    *,
+    implementation_version: str = APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+    materializer_id: MaterializerIdentifier = MaterializerIdentifier.APP_CONFIG_EXECUTOR,
+):
+    return build_implementation_binding(
+        binding_id="b2a_matrix",
+        version=1,
+        scope=_SCOPE,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id="deterministic_page_schema_renderer",
+                implementation_version="1",
+                artifact_families=("app_ui_page_schema",),
+            ),
+            RendererSelection(
+                materializer_id=materializer_id,
+                implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=implementation_version,
+                artifact_families=tuple(families),
+            ),
+        ),
+    )
+
+
+def _materialize_with(binding, *, graph, payloads, plan):
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    return materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=binding,
+        layout_registry=build_app_layout_registry(()),
+    ), MaterializationError
+
+
+@pytest.mark.parametrize(
+    "families",
+    [
+        pytest.param(("app_manifest",), id="only-app-manifest"),
+        pytest.param(("app_config",), id="only-app-config"),
+        pytest.param(
+            tuple(sorted(APP_CONFIG_FAMILIES - {"app_secret_references"})),
+            id="four-of-five",
+        ),
+        pytest.param(
+            tuple(sorted(APP_CONFIG_FAMILIES | {"app_subscription_config"})),
+            id="five-plus-subscription",
+        ),
+        pytest.param(
+            tuple(sorted(APP_CONFIG_FAMILIES | {"totally_unknown_family"})),
+            id="five-plus-forged",
+        ),
+    ],
+)
+def test_non_exact_family_sets_fail_closed_and_emit_nothing(families) -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    binding = _binding_with_families(graph, families)
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    with pytest.raises((AppConfigMaterializationError, MaterializationError)):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=binding,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_subset_binding_attack_is_rejected_verbatim() -> None:
+    """Codex 2's exact attack, preserved unchanged: an otherwise valid binding
+    whose app-config selection authorizes only app_manifest must fail closed
+    instead of emitting all five application families."""
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    binding = _binding_with_families(graph, ("app_manifest",))
+    with pytest.raises(
+        AppConfigMaterializationError, match="must declare exactly its"
+    ):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=binding,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_empty_and_duplicate_family_sets_fail_at_the_model() -> None:
+    with pytest.raises(ValidationError):
+        RendererSelection(
+            materializer_id=MaterializerIdentifier.APP_CONFIG_EXECUTOR,
+            implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+            implementation_version=APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+            artifact_families=(),
+        )
+    with pytest.raises(ValidationError, match="unique"):
+        RendererSelection(
+            materializer_id=MaterializerIdentifier.APP_CONFIG_EXECUTOR,
+            implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+            implementation_version=APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+            artifact_families=("app_manifest", "app_manifest"),
+        )
+
+
+def test_exact_set_succeeds_in_canonical_and_shuffled_order() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    canonical = _binding_with_families(graph, tuple(sorted(APP_CONFIG_FAMILIES)))
+    shuffled = _binding_with_families(
+        graph, tuple(reversed(sorted(APP_CONFIG_FAMILIES)))
+    )
+    assert canonical.binding_digest == shuffled.binding_digest
+    registry = build_app_layout_registry(())
+    a = materialize_plan(
+        plan=plan, graph=graph, payloads=payloads, binding=canonical,
+        layout_registry=registry,
+    ).files()
+    b = materialize_plan(
+        plan=plan, graph=graph, payloads=payloads, binding=shuffled,
+        layout_registry=registry,
+    ).files()
+    assert a == b
+    assert _RENDERED_PATHS <= set(a)
+
+
+def test_wrong_version_and_wrong_materializer_fail_closed() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    registry = build_app_layout_registry(())
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    wrong_version = _binding_with_families(
+        graph, tuple(sorted(APP_CONFIG_FAMILIES)), implementation_version="2"
+    )
+    with pytest.raises((AppConfigMaterializationError, MaterializationError)):
+        materialize_plan(
+            plan=plan, graph=graph, payloads=payloads, binding=wrong_version,
+            layout_registry=registry,
+        )
+    wrong_materializer = _binding_with_families(
+        graph,
+        tuple(sorted(APP_CONFIG_FAMILIES)),
+        materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+    )
+    with pytest.raises((AppConfigMaterializationError, MaterializationError)):
+        materialize_plan(
+            plan=plan, graph=graph, payloads=payloads, binding=wrong_materializer,
+            layout_registry=registry,
+        )
+
+
+def test_forged_rebuilt_binding_with_recomputed_digest_still_fails() -> None:
+    """Serializing a valid binding, shrinking its family set, and rebuilding a
+    structurally valid document with a freshly computed digest must not
+    restore authorization: the family-set semantics are validated, not the
+    claimed digest."""
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    valid = _binding(graph)
+    document = valid.model_dump(mode="json")
+    forged_families = ("app_manifest",)
+    forged = _binding_with_families(graph, forged_families)
+    assert forged.binding_digest != valid.binding_digest
+    assert document["renderer_selections"][1]["artifact_families"] != list(
+        forged_families
+    )
+    with pytest.raises(AppConfigMaterializationError):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=forged,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_plan_from_another_application_fails_before_authorization() -> None:
+    graph, payloads = _extended_fixture()
+    other_graph, other_payloads = _extended_fixture(default_route="/reports")
+    other_plan = _plan(other_graph, other_payloads, with_configs=False)
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    with pytest.raises(MaterializationError):
+        materialize_plan(
+            plan=other_plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_registry_from_another_snapshot_fails_before_authorization() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+
+    class _MutatedRegistry:
+        """Same schema version, one mutated row -> different snapshot digest."""
+
+        def __init__(self) -> None:
+            source = build_app_layout_registry(())
+            self.schema_version = source.schema_version
+            families = []
+            for family in source.ordered_families():
+                if family.path_template == "app.json":
+                    family = family.model_copy(
+                        update={"path_template": "app_renamed.json"}
+                    )
+                families.append(family)
+            self._families = tuple(families)
+
+        def ordered_families(self):
+            return self._families
+
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    with pytest.raises(MaterializationError):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=_MutatedRegistry(),
+        )
+
+
+def test_inactive_conditional_family_is_absent_without_error() -> None:
+    """The binding pins the renderer's exact five-family capability; the plan
+    decides which of those families are active. An integrations-absent app
+    still binds all five, renders no integrations bytes, and raises no
+    missing-output error."""
+    graph, payloads = _extended_fixture(integrations_selected=False)
+    plan = _plan(graph, payloads, with_configs=False)
+    bundle = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    )
+    files = bundle.files()
+    assert "config/integrations.yaml" not in files
+    for expected in ("app.json", "config/ai.json", "ui/route_manifest.json",
+                     "security/secrets.yaml"):
+        assert expected in files, expected
+    assert yaml.safe_load(files["security/secrets.yaml"]) == {
+        "version": 1,
+        "secrets": [],
+    }
+
+
+def test_output_closure_rejects_extra_and_missing_outputs() -> None:
+    from mozaiksai.core.semantics.materialization import (
+        _assert_app_config_output_closure,
+    )
+
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    binding = _binding(graph)
+    selection = next(
+        s
+        for s in binding.renderer_selections
+        if s.materializer_id is MaterializerIdentifier.APP_CONFIG_EXECUTOR
+    )
+    bundle = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=binding,
+        layout_registry=build_app_layout_registry(()),
+    )
+    app_outputs = [
+        o
+        for o in bundle.outputs
+        if o.path in _RENDERED_PATHS
+    ]
+    # The real bundle passes the closure.
+    _assert_app_config_output_closure(plan, bundle.outputs, selection)
+    # An extra unauthorized duplicate output fails.
+    with pytest.raises(AppConfigMaterializationError, match="exactly one output"):
+        _assert_app_config_output_closure(
+            plan, tuple(bundle.outputs) + (app_outputs[0],), selection
+        )
+    # Omitting one active authorized output fails.
+    dropped = tuple(o for o in bundle.outputs if o is not app_outputs[0])
+    with pytest.raises(AppConfigMaterializationError, match="exactly one output"):
+        _assert_app_config_output_closure(plan, dropped, selection)
+    # No selection at all cannot authorize emitted app-config outputs.
+    with pytest.raises(AppConfigMaterializationError, match="unauthorized"):
+        _assert_app_config_output_closure(plan, bundle.outputs, None)
 
 
 def test_payload_mutation_after_snapshot_creation_cannot_change_bytes() -> None:

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -1,0 +1,734 @@
+"""ADR 0007 Slice 5D-0B2A proof gate: deterministic application-family bytes.
+
+Extends the accepted representative corpus so the reporting-style application
+explicitly SELECTS auth, one integration, and its workflow, then proves the
+closed application-configuration family set renders canonical bytes:
+
+    app.json, ui/route_manifest.json, config/ai.json,
+    config/integrations.yaml, security/secrets.yaml
+
+through the single accepted ``deterministic_app_config_renderer@1`` authority.
+
+Families whose facts still lack a typed semantic home remain typed gaps with
+their exact prerequisites recorded here (see
+``test_blocked_families_remain_typed_with_exact_prerequisites``); nothing in
+this slice claims a complete or runnable application.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    MaterializerIdentifier,
+    build_app_layout_registry,
+)
+from mozaiksai.core.semantics.app_config_materialization import (
+    APP_CONFIG_FAMILIES,
+    APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+    APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+    AppConfigMaterializationError,
+    render_app_config_unit,
+)
+from mozaiksai.core.semantics.binding import (
+    RendererSelection,
+    build_implementation_binding,
+)
+from mozaiksai.core.semantics.compilation_plan import (
+    PlanDisposition,
+    derive_compilation_plan,
+)
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticNodeV2,
+    build_semantic_graph_v2,
+)
+from mozaiksai.core.semantics.materialization import materialize_plan
+from mozaiksai.core.semantics.payloads import (
+    ApplicationPayload,
+    AuthPayload,
+    OptionalFamilyKind,
+    OptionalFamilySelection,
+    OptionalFamilySelectionStatus,
+    PagePayload,
+    SectionContentEntry,
+    SectionEntryKind,
+    SectionPayload,
+    build_semantic_payload,
+    semantic_payload_ref,
+)
+from mozaiksai.core.semantics.refs import SemanticGraphRef
+from tests.test_semantic_payload_graph_v2 import _SCOPE, _corpus_payloads
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SELECTED = {
+    OptionalFamilyKind.AUTH,
+    OptionalFamilyKind.INTEGRATIONS,
+    OptionalFamilyKind.WORKFLOWS,
+}
+
+_RENDERED_PATHS = {
+    "app.json",
+    "ui/route_manifest.json",
+    "config/ai.json",
+    "config/integrations.yaml",
+    "security/secrets.yaml",
+}
+
+
+def _configs() -> dict:
+    return {
+        name: yaml.safe_load(
+            (ROOT / "factory_app" / "workflows" / name / "structured_outputs.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        for name in ("AppGenerator", "AgentGenerator")
+    }
+
+
+CONFIGS = _configs()
+
+
+def _extended_fixture(
+    *,
+    home_title: str = "Home",
+    default_route: str = "/home",
+    auth_selected: bool = True,
+    integration_secret_name: str = "EMAIL_API_KEY",
+):
+    """Corpus with explicit product-meaningful optional-family selections."""
+    payloads = dict(_corpus_payloads(scope=_SCOPE, home_title=home_title))
+
+    application = payloads["application"]
+    selections = tuple(
+        OptionalFamilySelection(
+            family=family,
+            status=(
+                OptionalFamilySelectionStatus.SELECTED
+                if family in _SELECTED and (family is not OptionalFamilyKind.AUTH or auth_selected)
+                else OptionalFamilySelectionStatus.ABSENT_BY_DECLARATION
+            ),
+        )
+        for family in OptionalFamilyKind
+    )
+    payloads["application"] = build_semantic_payload(
+        ApplicationPayload,
+        node_id=application.node_id,
+        payload_version=application.payload_version,
+        scope=_SCOPE,
+        application_id=application.application_id,
+        display_name=application.display_name,
+        description=application.description,
+        tagline=application.tagline,
+        value_proposition=application.value_proposition,
+        version=application.version,
+        default_route=default_route,
+        optional_families=selections,
+    )
+    if not auth_selected:
+        payloads.pop("auth", None)
+    else:
+        auth = payloads["auth"]
+        payloads["auth"] = build_semantic_payload(
+            AuthPayload,
+            node_id=auth.node_id,
+            payload_version=auth.payload_version,
+            scope=_SCOPE,
+            auth_required=auth.auth_required,
+            strategy=auth.strategy,
+            roles=auth.roles,
+        )
+    if integration_secret_name != "EMAIL_API_KEY":
+        integration = payloads["integration"]
+        from mozaiksai.core.semantics.payloads import IntegrationPayload
+
+        payloads["integration"] = build_semantic_payload(
+            IntegrationPayload,
+            node_id=integration.node_id,
+            payload_version=integration.payload_version,
+            scope=_SCOPE,
+            integration_id=integration.integration_id,
+            integration_kind=integration.integration_kind,
+            purpose=integration.purpose,
+            required_at=integration.required_at,
+            optional=integration.optional,
+            config_requirements=tuple(
+                type(req)(
+                    name=(
+                        integration_secret_name
+                        if req.value_kind.value == "secret"
+                        else req.name
+                    ),
+                    value_kind=req.value_kind,
+                    required=req.required,
+                )
+                for req in integration.config_requirements
+            ),
+        )
+
+    # The kind-keyed corpus carries only the hero section payload, yet the
+    # home page declares a second section; close it so the page family's
+    # renderer inputs are byte-complete on this fixture.
+    payloads["section_pricing"] = build_semantic_payload(
+        SectionPayload,
+        node_id="mozaiks.section.pricing",
+        payload_version=1,
+        scope=_SCOPE,
+        section_id="pricing",
+        title="Pricing",
+        intent="Plan comparison",
+        declarative={
+            "id": "pricing",
+            "primitive": "Panel",
+            "config": {"title": "Plans"},
+        },
+        entries=(
+            SectionContentEntry(
+                position=0, entry_kind=SectionEntryKind.TEXT, text="Plans"
+            ),
+        ),
+    )
+
+    ordered = list(payloads.values())
+    nodes = [
+        SemanticNodeV2(
+            node_id=p.node_id,
+            kind=p.payload_kind,
+            payload_ref=semantic_payload_ref(p),
+        )
+        for p in ordered
+    ]
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.RENDERS,
+            source_node_id="mozaiks.page.home",
+            target_node_id="mozaiks.section.hero",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.RENDERS,
+            source_node_id="mozaiks.page.home",
+            target_node_id="mozaiks.section.pricing",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id="mozaiks.action.create_report",
+            target_node_id="mozaiks.event.report_created",
+        ),
+        SemanticEdge(
+            kind=SemanticEdgeKind.OWNS,
+            source_node_id="mozaiks.module.reports",
+            target_node_id="mozaiks.artifact.report_hook",
+        ),
+    ]
+    graph = build_semantic_graph_v2(
+        graph_id="corpus-app",
+        version=1,
+        scope=_SCOPE,
+        nodes=nodes,
+        edges=edges,
+    )
+    return graph, ordered
+
+
+def _plan(graph, payloads, *, with_configs: bool = True):
+    """Derive the aggregate plan.
+
+    Bundle materialization uses ``with_configs=False`` so agent-authored
+    families remain typed ``output_contract_unresolved`` gaps: the 4C
+    materializer intentionally rejects AGENT_AUTHOR units loudly, and B2A
+    does not implement their execution. Gap-closure assertions use the
+    config-full derivation.
+    """
+    return derive_compilation_plan(
+        graph=graph,
+        payloads=payloads,
+        registry=build_app_layout_registry(()),
+        structured_output_configs=CONFIGS if with_configs else None,
+    )
+
+
+def _binding(graph):
+    return build_implementation_binding(
+        binding_id="b2a_binding",
+        version=1,
+        scope=_SCOPE,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id="deterministic_page_schema_renderer",
+                implementation_version="1",
+                artifact_families=("app_ui_page_schema",),
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.APP_CONFIG_EXECUTOR,
+                implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=tuple(sorted(APP_CONFIG_FAMILIES)),
+            ),
+        ),
+    )
+
+
+def _materialize(graph, payloads, plan):
+    return materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry gate: the accepted B1 shape is reproduced, not silently re-pinned.
+# ---------------------------------------------------------------------------
+
+
+def test_accepted_b1_registry_census_is_unchanged() -> None:
+    registry = build_app_layout_registry(())
+    census = Counter(f.disposition.value for f in registry.families)
+    assert dict(census) == {
+        "render": 79,
+        "agent_author": 19,
+        "external_handoff": 11,
+        "input_only": 1,
+        "inapplicable": 13,
+    }
+    assert sum(census.values()) == 123
+
+
+# ---------------------------------------------------------------------------
+# Selected-family closure on the extended fixture
+# ---------------------------------------------------------------------------
+
+
+def _render_units(plan):
+    return {
+        unit.outputs[0].path: unit
+        for unit in plan.units
+        if unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in APP_CONFIG_FAMILIES
+    }
+
+
+def test_extended_fixture_closes_selected_application_families() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads)
+    units = _render_units(plan)
+    assert set(units) == _RENDERED_PATHS
+    for path, unit in units.items():
+        assert unit.sources, path
+    blocked = {
+        gap.path_template
+        for gap in plan.gaps
+        if gap.family_kind in APP_CONFIG_FAMILIES
+    }
+    assert not blocked & _RENDERED_PATHS
+
+
+def test_each_rendered_path_is_owned_by_exactly_one_unit() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads)
+    owners: dict[str, list[str]] = {}
+    for unit in plan.units:
+        for output in unit.outputs:
+            owners.setdefault(output.path, []).append(unit.unit_id)
+    for path in _RENDERED_PATHS:
+        assert len(owners.get(path, [])) == 1, (path, owners.get(path))
+    collisions = {path: ids for path, ids in owners.items() if len(ids) > 1}
+    assert collisions == {}
+
+
+def test_selected_family_gap_count_is_zero_for_b2a_set() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads)
+    b2a_gaps = [
+        gap
+        for gap in plan.gaps
+        if gap.family_kind in APP_CONFIG_FAMILIES
+        and gap.path_template in _RENDERED_PATHS
+    ]
+    assert b2a_gaps == []
+
+
+# ---------------------------------------------------------------------------
+# Canonical bytes + loader equivalence
+# ---------------------------------------------------------------------------
+
+
+def _bundle_files():
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    bundle = _materialize(graph, payloads, plan)
+    return bundle.files()
+
+
+def test_app_manifest_bytes_and_loader_semantics() -> None:
+    files = _bundle_files()
+    data = files["app.json"]
+    assert b"\r" not in data
+    assert data.endswith(b"\n")
+    document = json.loads(data.decode("utf-8"))
+    assert document["appId"] == "corpus-app"
+    assert document["authRequired"] is True
+    assert document["startup"] == {"landing_spot": "/home"}
+    assert set(document) <= {
+        "appId",
+        "appName",
+        "version",
+        "description",
+        "authRequired",
+        "startup",
+    }
+    # Loader name mapping (mozaiksai.core.runtime.app.loader raw parse).
+    assert document.get("appName")
+    # No invented facts: version equals authored payload version.
+    graph, payloads = _extended_fixture()
+    app = next(p for p in payloads if isinstance(p, ApplicationPayload))
+    assert document["version"] == app.version
+
+
+def test_route_manifest_bytes_reference_declared_pages_only() -> None:
+    files = _bundle_files()
+    document = json.loads(files["ui/route_manifest.json"].decode("utf-8"))
+    graph, payloads = _extended_fixture()
+    pages = {p.route: p for p in payloads if isinstance(p, PagePayload)}
+    assert [entry["path"] for entry in document["pages"]] == sorted(pages)
+    for entry in document["pages"]:
+        assert entry["component"] == "SchemaPage"
+        assert entry["schema"] == pages[entry["path"]].page_id
+        assert entry["label"] == pages[entry["path"]].title
+
+
+def test_ai_config_and_integration_and_secret_bytes() -> None:
+    files = _bundle_files()
+    ai_document = json.loads(files["config/ai.json"].decode("utf-8"))
+    assert set(ai_document) == {"chat"}
+    assert ai_document["chat"]["chat_startup_mode"] in {"ask", "workflow"}
+
+    integrations = yaml.safe_load(files["config/integrations.yaml"].decode("utf-8"))
+    assert list(integrations) == ["integrations"]
+    entries = integrations["integrations"]
+    assert [e["service"] for e in entries] == sorted(e["service"] for e in entries)
+    for entry in entries:
+        assert set(entry) <= {
+            "service",
+            "kind",
+            "purpose",
+            "required_at",
+            "optional",
+            "required_fields",
+        }
+        for requirement in entry["required_fields"]:
+            assert set(requirement) == {"name", "type", "required"}
+            assert requirement["type"] in {"text", "url", "secret"}
+
+    secrets = yaml.safe_load(files["security/secrets.yaml"].decode("utf-8"))
+    assert set(secrets) == {"version", "secrets"}
+    assert secrets["version"] == 1
+    secret_names = {
+        requirement["name"]
+        for entry in entries
+        for requirement in entry["required_fields"]
+        if requirement["type"] == "secret"
+    }
+    assert set(secrets["secrets"]) == secret_names
+    # names only — nothing that looks like a value or token
+    blob = files["security/secrets.yaml"].decode("utf-8").lower()
+    for forbidden in ("sk_", "token:", "-----begin", "password:"):
+        assert forbidden not in blob
+
+
+def test_scanner_accepts_rendered_integration_contract() -> None:
+    from factory_app.workflows.AppGenerator.tools.generated_bundle_scanner import (
+        _load_integration_requirements,
+    )
+
+    files = _bundle_files()
+    requirements, errors = _load_integration_requirements(
+        {"config/integrations.yaml": files["config/integrations.yaml"].decode("utf-8")}
+    )
+    assert errors == []
+    assert requirements
+    assert all(isinstance(item, dict) for item in requirements)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_and_shuffled_materialization_is_byte_identical() -> None:
+    first = _bundle_files()
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, list(reversed(payloads)), with_configs=False)
+    bundle = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=tuple(reversed(payloads)),
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    )
+    assert first == bundle.files()
+
+
+def _cross_process_digest() -> str:
+    import hashlib
+
+    files = _bundle_files()
+    joined = b"\x00".join(
+        path.encode("utf-8") + b"\x01" + files[path] for path in sorted(files)
+    )
+    return hashlib.sha256(joined).hexdigest()
+
+
+def test_cross_process_determinism() -> None:
+    local = _cross_process_digest()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tests.test_app_family_materialization_b2a import "
+            "_cross_process_digest; print(_cross_process_digest())",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=300,
+    )
+    assert completed.stdout.strip() == local
+
+
+# ---------------------------------------------------------------------------
+# Mutation footprints
+# ---------------------------------------------------------------------------
+
+
+def test_default_route_mutation_affects_manifest_and_routes_only() -> None:
+    base = _bundle_files()
+    graph, payloads = _extended_fixture(default_route="/home")
+    # a second declared page is required for a different default route; use the
+    # same page set but assert against an equal-route change instead: change
+    # the home page title, which must move the route manifest and nothing else.
+    graph2, payloads2 = _extended_fixture(home_title="Console")
+    plan2 = _plan(graph2, payloads2, with_configs=False)
+    changed = materialize_plan(
+        plan=plan2,
+        graph=graph2,
+        payloads=payloads2,
+        binding=_binding(graph2),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert changed["ui/route_manifest.json"] != base["ui/route_manifest.json"]
+    for unchanged in ("app.json", "config/ai.json", "config/integrations.yaml", "security/secrets.yaml"):
+        assert changed[unchanged] == base[unchanged], unchanged
+
+
+def test_integration_secret_mutation_affects_integrations_and_secrets_only() -> None:
+    base = _bundle_files()
+    graph, payloads = _extended_fixture(integration_secret_name="EMAIL_PROVIDER_KEY")
+    plan = _plan(graph, payloads, with_configs=False)
+    changed = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+    assert changed["config/integrations.yaml"] != base["config/integrations.yaml"]
+    assert changed["security/secrets.yaml"] != base["security/secrets.yaml"]
+    for unchanged in ("app.json", "config/ai.json", "ui/route_manifest.json"):
+        assert changed[unchanged] == base[unchanged], unchanged
+
+
+# ---------------------------------------------------------------------------
+# Ownership, binding, fail-closed behavior
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_rejects_wrong_family_wrong_binding_and_unknown_template() -> None:
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    page_unit = next(
+        u for u in plan.units if u.family_kind == "app_ui_page_schema"
+    )
+    with pytest.raises(AppConfigMaterializationError, match="not an"):
+        render_app_config_unit(unit=page_unit, payload_by_node=payload_by_node)
+
+    from mozaiksai.core.semantics.materialization import MaterializationError
+
+    bad_binding = build_implementation_binding(
+        binding_id="b2a_bad",
+        version=1,
+        scope=_SCOPE,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id="deterministic_page_schema_renderer",
+                implementation_version="1",
+                artifact_families=("app_ui_page_schema",),
+            ),
+        ),
+    )
+    with pytest.raises((MaterializationError, AppConfigMaterializationError)):
+        materialize_plan(
+            plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=bad_binding,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Blocked families stay typed, with exact prerequisites recorded
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_families_remain_typed_with_exact_prerequisites() -> None:
+    """B2A does not render families whose facts have no typed semantic home.
+
+    - ``app_subscription_config``: ``default_plan_id`` and assignment-store
+      wiring have no typed semantic authority (PlanPayload has no default
+      flag; store wiring is runtime configuration). Prerequisite: extend the
+      subscription semantics or accept loader defaults before rendering.
+    - ``app_data_contract``: collection->module surface ownership is edge
+      knowledge, not payload knowledge. Prerequisite: pass typed edge
+      identities into renderer inputs or embed the owner in
+      ``DataCollectionPayload``.
+    - ``config/asset_manifest.json`` (``app_config`` row): assets have
+      selection evidence but no typed asset facts.
+    """
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads)
+    rendered = set(_render_units(plan))
+    assert "config/subscriptions.yaml" not in rendered
+    assert "data/contract.json" not in rendered
+    assert "config/asset_manifest.json" not in rendered
+    # and they are not silently absent: each is a unit or typed gap elsewhere.
+    gap_paths = {g.path_template for g in plan.gaps}
+    unit_families = {u.family_kind for u in plan.units}
+    for path, family in (
+        ("config/subscriptions.yaml", "app_subscription_config"),
+        ("data/contract.json", "app_data_contract"),
+    ):
+        assert path in gap_paths or family in unit_families, path
+
+
+# ---------------------------------------------------------------------------
+# Future-compatibility guards
+# ---------------------------------------------------------------------------
+
+
+def test_mobile_and_evaluation_vocabulary_is_absent_from_renderer_sources() -> None:
+    sources = (
+        (ROOT / "mozaiksai" / "core" / "semantics" / "app_config_materialization.py")
+        .read_text(encoding="utf-8")
+        .lower()
+        + (ROOT / "mozaiksai" / "core" / "semantics" / "decl_bytes.py")
+        .read_text(encoding="utf-8")
+        .lower()
+    )
+    for forbidden in (
+        "react-native",
+        "expo",
+        "swift",
+        "kotlin",
+        "android",
+        "persona",
+        "campaign",
+        "conversion",
+        "revenue",
+        "portfolio",
+    ):
+        assert forbidden not in sources, forbidden
+
+
+def test_renderer_modules_import_no_clock_env_or_filesystem() -> None:
+    import ast
+
+    for module_name in ("app_config_materialization", "decl_bytes"):
+        source = (
+            ROOT / "mozaiksai" / "core" / "semantics" / f"{module_name}.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        for forbidden in ("os", "time", "datetime", "random", "uuid", "pathlib",
+                          "subprocess", "socket"):
+            assert not any(
+                name == forbidden or name.startswith(forbidden + ".")
+                for name in imported
+            ), (module_name, forbidden)
+
+
+# Stage N inventory: the production writers that emit application-configuration
+# artifacts today, via AppBuildPlan. They stay authoritative until the 5D
+# cutover; B2A must not be wired into them and they must not call the B2A
+# renderer.
+_PRODUCTION_APP_CONFIG_WRITERS = (
+    "factory_app/workflows/AppGenerator/tools/materialize_app_config_contracts.py",
+    "factory_app/workflows/AppGenerator/tools/generate_and_download.py",
+    "factory_app/workflows/AppGenerator/tools/save_app_schema.py",
+    "factory_app/workflows/AppGenerator/tools/app_build_plan.py",
+)
+
+_B2A_MODULE_MARKERS = (
+    "app_config_materialization",
+    "decl_bytes",
+)
+
+
+def test_production_writers_exist_and_do_not_call_the_b2a_renderer() -> None:
+    for rel in _PRODUCTION_APP_CONFIG_WRITERS:
+        path = ROOT / Path(rel)
+        assert path.is_file(), f"production writer inventory is stale: {rel}"
+        source = path.read_text(encoding="utf-8")
+        for marker in _B2A_MODULE_MARKERS:
+            assert marker not in source, (rel, marker)
+
+
+def test_b2a_renderer_is_unwired_from_production_code() -> None:
+    """Only the semantics materializer (and tests) may reference the renderer."""
+    allowed = {
+        Path("mozaiksai/core/semantics/app_config_materialization.py"),
+        Path("mozaiksai/core/semantics/decl_bytes.py"),
+        Path("mozaiksai/core/semantics/materialization.py"),
+    }
+    offenders: list[str] = []
+    for root_dir in ("mozaiksai", "factory_app"):
+        for path in (ROOT / root_dir).rglob("*.py"):
+            rel = path.relative_to(ROOT)
+            if rel in allowed:
+                continue
+            source = path.read_text(encoding="utf-8")
+            if any(marker in source for marker in _B2A_MODULE_MARKERS):
+                offenders.append(str(rel))
+    assert offenders == [], offenders

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -4,10 +4,15 @@ Extends the accepted representative corpus so the reporting-style application
 explicitly SELECTS auth, one integration, and its workflow, then proves the
 closed application-configuration family set renders canonical bytes:
 
-    app.json, ui/route_manifest.json, config/ai.json,
+    app.json, ui/route_manifest.json,
     config/integrations.yaml, security/secrets.yaml
 
 through the single accepted ``deterministic_app_config_renderer@1`` authority.
+``config/ai.json`` (``app_config``) is deliberately deferred: per-workflow
+``workflow_startup_mode`` is not application-level chat launch authority, and
+the semantic model has no application-level AI-launch facts yet; the family
+stays a typed gap
+(``test_app_config_stays_a_typed_gap_and_never_blocks_the_four_families``).
 
 Families whose facts still lack a typed semantic home remain typed gaps with
 their exact prerequisites recorded here (see
@@ -52,8 +57,8 @@ from mozaiksai.core.semantics.graph import (
     build_semantic_graph_v2,
 )
 from mozaiksai.core.semantics.materialization import (
-    build_app_family_render_input,
     materialize_plan,
+    project_app_family_render_input,
 )
 from mozaiksai.core.semantics.payloads import (
     ApplicationPayload,
@@ -85,7 +90,6 @@ _SELECTED = {
 _RENDERED_PATHS = {
     "app.json",
     "ui/route_manifest.json",
-    "config/ai.json",
     "config/integrations.yaml",
     "security/secrets.yaml",
 }
@@ -468,11 +472,9 @@ def test_route_manifest_bytes_reference_declared_pages_only() -> None:
         assert entry["label"] == pages[entry["path"]].title
 
 
-def test_ai_config_and_integration_and_secret_bytes() -> None:
+def test_integration_and_secret_bytes() -> None:
     files = _bundle_files()
-    ai_document = json.loads(files["config/ai.json"].decode("utf-8"))
-    assert set(ai_document) == {"chat"}
-    assert ai_document["chat"]["chat_startup_mode"] in {"ask", "workflow"}
+    assert "config/ai.json" not in files
 
     integrations = yaml.safe_load(files["config/integrations.yaml"].decode("utf-8"))
     assert list(integrations) == ["integrations"]
@@ -589,7 +591,7 @@ def test_default_route_mutation_affects_manifest_and_routes_only() -> None:
         layout_registry=build_app_layout_registry(()),
     ).files()
     assert changed["ui/route_manifest.json"] != base["ui/route_manifest.json"]
-    for unchanged in ("app.json", "config/ai.json", "config/integrations.yaml", "security/secrets.yaml"):
+    for unchanged in ("app.json", "config/integrations.yaml", "security/secrets.yaml"):
         assert changed[unchanged] == base[unchanged], unchanged
 
 
@@ -606,7 +608,7 @@ def test_integration_secret_mutation_affects_integrations_and_secrets_only() -> 
     ).files()
     assert changed["config/integrations.yaml"] != base["config/integrations.yaml"]
     assert changed["security/secrets.yaml"] != base["security/secrets.yaml"]
-    for unchanged in ("app.json", "config/ai.json", "ui/route_manifest.json"):
+    for unchanged in ("app.json", "ui/route_manifest.json"):
         assert changed[unchanged] == base[unchanged], unchanged
 
 
@@ -619,14 +621,30 @@ def test_renderer_rejects_wrong_family_wrong_binding_and_unknown_template() -> N
     graph, payloads = _extended_fixture()
     plan = _plan(graph, payloads, with_configs=False)
     payload_by_node = {p.node_id: p for p in payloads}
-    render_input = build_app_family_render_input(
-        units=plan.units, payload_by_node=payload_by_node
+    manifest_unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind == "app_manifest"
+    )
+    render_input = project_app_family_render_input(
+        unit=manifest_unit, payload_by_node=payload_by_node
     )
     page_unit = next(
         u for u in plan.units if u.family_kind == "app_ui_page_schema"
     )
     with pytest.raises(AppConfigMaterializationError, match="not an"):
         render_app_config_unit(unit=page_unit, render_input=render_input)
+    # A family-local input from ANOTHER family's unit is rejected even when
+    # both units are authorized application-configuration units.
+    route_unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind == "app_ui_route_manifest"
+    )
+    with pytest.raises(AppConfigMaterializationError, match="does not match"):
+        render_app_config_unit(unit=route_unit, render_input=render_input)
 
     from mozaiksai.core.semantics.materialization import MaterializationError
 
@@ -677,6 +695,10 @@ def test_blocked_families_remain_typed_with_exact_prerequisites() -> None:
       ``DataCollectionPayload``.
     - ``config/asset_manifest.json`` (``app_config`` row): assets have
       selection evidence but no typed asset facts.
+    - ``config/ai.json`` (``app_config``): per-workflow
+      ``workflow_startup_mode`` is not application-level chat launch
+      authority. Prerequisite: application-level AI-launch facts
+      (chat startup mode, workflow entry point) with typed semantic homes.
     """
     graph, payloads = _extended_fixture()
     plan = _plan(graph, payloads)
@@ -684,6 +706,8 @@ def test_blocked_families_remain_typed_with_exact_prerequisites() -> None:
     assert "config/subscriptions.yaml" not in rendered
     assert "data/contract.json" not in rendered
     assert "config/asset_manifest.json" not in rendered
+    assert "config/ai.json" not in rendered
+    assert "config/ai.json" in {g.path_template for g in plan.gaps}
     # and they are not silently absent: each is a unit or typed gap elsewhere.
     gap_paths = {g.path_template for g in plan.gaps}
     unit_families = {u.family_kind for u in plan.units}
@@ -833,68 +857,67 @@ def test_semantics_package_import_does_not_load_the_renderer() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _valid_render_input():
+def _valid_render_input(family: str = "app_manifest"):
     graph, payloads = _extended_fixture()
     plan = _plan(graph, payloads, with_configs=False)
     payload_by_node = {p.node_id: p for p in payloads}
-    return plan, payload_by_node, build_app_family_render_input(
-        units=plan.units, payload_by_node=payload_by_node
+    unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER and u.family_kind == family
+    )
+    return plan, payload_by_node, unit, project_app_family_render_input(
+        unit=unit, payload_by_node=payload_by_node
     )
 
 
 def test_render_input_is_frozen_and_rejects_undeclared_fields() -> None:
-    _plan_obj, _payloads, render_input = _valid_render_input()
+    _plan_obj, _payloads, _unit, render_input = _valid_render_input()
     with pytest.raises(ValidationError):
         render_input.default_route = "/elsewhere"  # type: ignore[misc]
     document = render_input.model_dump()
     document["arbitrary_metadata"] = {"campaign": "x"}
     with pytest.raises(ValidationError):
         type(render_input).model_validate(document)
-    entry = render_input.integrations[0].model_dump()
+    _p2, _pl2, _u2, integrations_input = _valid_render_input(
+        "app_integrations_config"
+    )
+    entry = integrations_input.integrations[0].model_dump()
     entry["provider_account"] = "acct_123"
     with pytest.raises(ValidationError):
-        type(render_input.integrations[0]).model_validate(entry)
+        type(integrations_input.integrations[0]).model_validate(entry)
 
 
 def test_render_input_normalizes_reordered_equivalent_facts() -> None:
-    plan, payload_by_node, render_input = _valid_render_input()
+    plan, payload_by_node, unit, render_input = _valid_render_input(
+        "app_ui_route_manifest"
+    )
     document = render_input.model_dump()
     document["pages"] = list(reversed(document["pages"]))
-    document["integrations"] = list(reversed(document["integrations"]))
     document["sources"] = list(reversed(document["sources"]))
     reordered = type(render_input).model_validate(document)
     assert reordered == render_input
-    unit = next(
-        u
-        for u in plan.units
-        if u.disposition is PlanDisposition.RENDER
-        and u.family_kind in APP_CONFIG_FAMILIES
-    )
     assert render_app_config_unit(
         unit=unit, render_input=reordered
     ) == render_app_config_unit(unit=unit, render_input=render_input)
 
 
 def test_render_input_rejects_duplicates_and_empty_sources() -> None:
-    _plan_obj, _payloads, render_input = _valid_render_input()
-    document = render_input.model_dump()
+    _plan_obj, _payloads, _unit, route_input = _valid_render_input(
+        "app_ui_route_manifest"
+    )
+    document = route_input.model_dump()
     document["pages"] = document["pages"] + document["pages"][:1]
     with pytest.raises(ValidationError, match="duplicate page routes"):
-        type(render_input).model_validate(document)
-    document = render_input.model_dump()
+        type(route_input).model_validate(document)
+    document = route_input.model_dump()
     document["sources"] = []
     with pytest.raises(ValidationError, match="pins no semantic sources"):
-        type(render_input).model_validate(document)
+        type(route_input).model_validate(document)
 
 
 def test_stale_or_missing_source_digest_fails_closed() -> None:
-    plan, payload_by_node, render_input = _valid_render_input()
-    unit = next(
-        u
-        for u in plan.units
-        if u.disposition is PlanDisposition.RENDER
-        and u.family_kind in APP_CONFIG_FAMILIES
-    )
+    plan, payload_by_node, unit, render_input = _valid_render_input()
     document = render_input.model_dump()
     for source in document["sources"]:
         source["payload_digest"] = "f" * 64
@@ -914,18 +937,18 @@ def test_stale_or_missing_source_digest_fails_closed() -> None:
 
 
 def test_render_input_from_a_different_application_fails_closed() -> None:
-    plan, _payloads, _render_input = _valid_render_input()
+    plan, _payloads, unit, _render_input = _valid_render_input()
     other_graph, other_payloads = _extended_fixture(default_route="/reports")
     other_plan = _plan(other_graph, other_payloads, with_configs=False)
-    other_input = build_app_family_render_input(
-        units=other_plan.units,
-        payload_by_node={p.node_id: p for p in other_payloads},
-    )
-    unit = next(
+    other_unit = next(
         u
-        for u in plan.units
+        for u in other_plan.units
         if u.disposition is PlanDisposition.RENDER
         and u.family_kind == "app_manifest"
+    )
+    other_input = project_app_family_render_input(
+        unit=other_unit,
+        payload_by_node={p.node_id: p for p in other_payloads},
     )
     with pytest.raises(AppConfigMaterializationError, match="pinned payload digest"):
         render_app_config_unit(unit=unit, render_input=other_input)
@@ -993,15 +1016,19 @@ def _materialize_with(binding, *, graph, payloads, plan):
         pytest.param(("app_config",), id="only-app-config"),
         pytest.param(
             tuple(sorted(APP_CONFIG_FAMILIES - {"app_secret_references"})),
-            id="four-of-five",
+            id="three-of-four",
+        ),
+        pytest.param(
+            tuple(sorted(APP_CONFIG_FAMILIES | {"app_config"})),
+            id="four-plus-app-config",
         ),
         pytest.param(
             tuple(sorted(APP_CONFIG_FAMILIES | {"app_subscription_config"})),
-            id="five-plus-subscription",
+            id="four-plus-subscription",
         ),
         pytest.param(
             tuple(sorted(APP_CONFIG_FAMILIES | {"totally_unknown_family"})),
-            id="five-plus-forged",
+            id="four-plus-forged",
         ),
     ],
 )
@@ -1195,7 +1222,8 @@ def test_inactive_conditional_family_is_absent_without_error() -> None:
     )
     files = bundle.files()
     assert "config/integrations.yaml" not in files
-    for expected in ("app.json", "config/ai.json", "ui/route_manifest.json",
+    assert "config/ai.json" not in files
+    for expected in ("app.json", "ui/route_manifest.json",
                      "security/secrets.yaml"):
         assert expected in files, expected
     assert yaml.safe_load(files["security/secrets.yaml"]) == {
@@ -1246,9 +1274,11 @@ def test_output_closure_rejects_extra_and_missing_outputs() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Selection honesty: a family whose selection says SELECTED must have its
-# typed facts; missing selected evidence stays a typed gap and contradictory
-# evidence never renders. Codex 2's exact attack is preserved first.
+# Selection honesty and family-local independence. app_config (config/ai.json)
+# is a deferred prerequisite in EVERY workflow scenario: per-workflow
+# workflow_startup_mode is not application-level chat launch authority, and no
+# application-level AI-launch facts exist. Its typed gap must never block the
+# four renderable families, and no chat startup mode is ever inferred.
 # ---------------------------------------------------------------------------
 
 
@@ -1258,107 +1288,101 @@ def _gap_paths(plan, family_kind):
     }
 
 
+def _materialized_files(graph, payloads, plan):
+    return materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    ).files()
+
+
+def _assert_four_families_render_and_ai_json_absent(graph, payloads, plan):
+    assert "config/ai.json" in _gap_paths(plan, "app_config")
+    assert not any(
+        u.family_kind == "app_config" and u.disposition is PlanDisposition.RENDER
+        for u in plan.units
+    )
+    files = _materialized_files(graph, payloads, plan)
+    assert "config/ai.json" not in files
+    for expected in _RENDERED_PATHS:
+        assert expected in files, expected
+    return files
+
+
 def test_workflows_selected_with_zero_payloads_stays_a_typed_gap() -> None:
-    """Codex 2's exact attack, preserved: WORKFLOWS selected, zero
-    WorkflowPayloads. app_config must not be classified complete from an
-    application-only footprint, and config/ai.json must not be emitted with a
-    normalized chat_startup_mode."""
+    """Codex 2 Attack A, preserved: WORKFLOWS selected, zero WorkflowPayloads.
+
+    app_config stays a typed renderer_input_incomplete gap with no
+    config/ai.json unit or bytes — and the four complete application families
+    render anyway: a missing app_config input must not abort them through a
+    globally coupled snapshot."""
     graph, payloads = _extended_fixture(drop_workflow_payload=True)
     plan = _plan(graph, payloads, with_configs=False)
-    render_units = [
-        u
-        for u in plan.units
-        if u.family_kind == "app_config" and u.disposition is PlanDisposition.RENDER
-    ]
-    assert render_units == []
-    assert "config/ai.json" in _gap_paths(plan, "app_config")
-    with pytest.raises(
-        AppConfigMaterializationError, match="workflows are selected but no"
-    ):
-        materialize_plan(
-            plan=plan,
-            graph=graph,
-            payloads=payloads,
-            binding=_binding(graph),
-            layout_registry=build_app_layout_registry(()),
-        )
+    _assert_four_families_render_and_ai_json_absent(graph, payloads, plan)
 
 
-def test_one_complete_workflow_renders_exact_startup_mode() -> None:
-    ask = _bundle_files()
-    assert json.loads(ask["config/ai.json"]) == {
-        "chat": {"chat_startup_mode": "ask"}
-    }
+def test_two_workflows_without_entry_point_render_no_ai_config() -> None:
+    """Codex 2 Attack B, preserved: one agent_driven and one on_demand
+    workflow with no application-level workflow entry point. Previously
+    chat_startup_mode was inferred as "workflow" from per-workflow facts; now
+    nothing is inferred — app_config stays a typed gap, no config/ai.json and
+    no entry_point are emitted, and the four families render."""
     graph, payloads = _extended_fixture(
-        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN
-    )
-    plan = _plan(graph, payloads, with_configs=False)
-    files = materialize_plan(
-        plan=plan,
-        graph=graph,
-        payloads=payloads,
-        binding=_binding(graph),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    assert json.loads(files["config/ai.json"]) == {
-        "chat": {"chat_startup_mode": "workflow"}
-    }
-
-
-def test_two_compatible_workflows_render_deterministically() -> None:
-    graph, payloads = _extended_fixture(
-        extra_workflow_startup_mode=WorkflowStartupMode.ON_DEMAND
-    )
-    plan = _plan(graph, payloads, with_configs=False)
-    files = materialize_plan(
-        plan=plan,
-        graph=graph,
-        payloads=payloads,
-        binding=_binding(graph),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    assert json.loads(files["config/ai.json"]) == {
-        "chat": {"chat_startup_mode": "ask"}
-    }
-    # One agent-driven among on-demand peers is likewise unambiguous.
-    graph2, payloads2 = _extended_fixture(
         workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
         extra_workflow_startup_mode=WorkflowStartupMode.ON_DEMAND,
     )
-    plan2 = _plan(graph2, payloads2, with_configs=False)
-    files2 = materialize_plan(
-        plan=plan2,
-        graph=graph2,
-        payloads=payloads2,
-        binding=_binding(graph2),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    assert json.loads(files2["config/ai.json"]) == {
-        "chat": {"chat_startup_mode": "workflow"}
-    }
-
-
-def test_conflicting_agent_driven_workflows_stay_a_typed_gap() -> None:
-    graph, payloads = _extended_fixture(
-        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
-        extra_workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN,
-    )
     plan = _plan(graph, payloads, with_configs=False)
-    assert "config/ai.json" in _gap_paths(plan, "app_config")
-    with pytest.raises(AppConfigMaterializationError, match="ambiguous"):
-        materialize_plan(
-            plan=plan,
-            graph=graph,
-            payloads=payloads,
-            binding=_binding(graph),
-            layout_registry=build_app_layout_registry(()),
-        )
+    files = _assert_four_families_render_and_ai_json_absent(graph, payloads, plan)
+    blob = b"".join(files.values())
+    assert b"entry_point" not in blob
+    assert b"chat_startup_mode" not in blob
 
 
-def test_workflow_without_startup_mode_stays_a_typed_gap() -> None:
-    graph, payloads = _extended_fixture(workflow_startup_mode=None)
+@pytest.mark.parametrize(
+    ("kwargs", "case"),
+    [
+        pytest.param({}, "one-complete-workflow", id="one-complete-workflow"),
+        pytest.param(
+            {"workflow_startup_mode": WorkflowStartupMode.AGENT_DRIVEN},
+            "agent-driven",
+            id="one-agent-driven",
+        ),
+        pytest.param(
+            {
+                "workflow_startup_mode": WorkflowStartupMode.AGENT_DRIVEN,
+                "extra_workflow_startup_mode": WorkflowStartupMode.AGENT_DRIVEN,
+            },
+            "two-agent-driven",
+            id="two-agent-driven",
+        ),
+        pytest.param(
+            {"workflow_startup_mode": None},
+            "startup-mode-missing",
+            id="startup-mode-missing",
+        ),
+        pytest.param(
+            {"workflows_selected": False, "drop_workflow_payload": True},
+            "absent-no-payloads",
+            id="absent-no-payloads",
+        ),
+        pytest.param(
+            {"workflows_selected": False},
+            "absent-with-payload",
+            id="absent-with-payload",
+        ),
+    ],
+)
+def test_app_config_stays_a_typed_gap_and_never_blocks_the_four_families(
+    kwargs, case
+) -> None:
+    """Every workflow scenario — complete, ambiguous, missing, absent, or
+    contradictory — leaves app_config a typed gap (no AI-launch authority
+    exists) while the four renderable families materialize independently."""
+    graph, payloads = _extended_fixture(**kwargs)
     plan = _plan(graph, payloads, with_configs=False)
-    assert "config/ai.json" in _gap_paths(plan, "app_config")
+    _assert_four_families_render_and_ai_json_absent(graph, payloads, plan)
 
 
 def test_workflow_node_with_missing_payload_fails_derivation_closed() -> None:
@@ -1376,132 +1400,32 @@ def test_workflow_node_with_missing_payload_fails_derivation_closed() -> None:
         )
 
 
-def test_workflows_absent_with_payload_present_is_a_contradiction() -> None:
-    graph, payloads = _extended_fixture(workflows_selected=False)
-    plan = _plan(graph, payloads, with_configs=False)
-    assert "config/ai.json" in _gap_paths(plan, "app_config")
-    with pytest.raises(AppConfigMaterializationError, match="declares"):
-        materialize_plan(
-            plan=plan,
-            graph=graph,
-            payloads=payloads,
-            binding=_binding(graph),
-            layout_registry=build_app_layout_registry(()),
-        )
-
-
-def test_workflows_absent_with_zero_payloads_renders_runtime_default() -> None:
-    """Semantically proven absence renders the platform host's own default
-    (mozaiksai.hosts.platform.build_shell_config falls back to "ask" when
-    config/ai.json declares no chat startup mode)."""
-    graph, payloads = _extended_fixture(
-        workflows_selected=False, drop_workflow_payload=True
-    )
-    plan = _plan(graph, payloads, with_configs=False)
-    files = materialize_plan(
-        plan=plan,
-        graph=graph,
-        payloads=payloads,
-        binding=_binding(graph),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    assert json.loads(files["config/ai.json"]) == {
-        "chat": {"chat_startup_mode": "ask"}
-    }
-
-
-def test_workflow_description_mutation_does_not_change_ai_config_bytes() -> None:
+def test_workflow_mutations_change_none_of_the_four_outputs() -> None:
+    """No retained family consumes workflow facts: startup-mode and
+    description mutations leave all four outputs byte-identical."""
     base = _bundle_files()
-    graph, payloads = _extended_fixture()
-    workflow = next(
-        p for p in payloads if p.payload_kind is SemanticNodeKind.WORKFLOW
-    )
-    mutated = [
-        build_semantic_payload(
-            WorkflowPayload,
-            node_id=p.node_id,
-            payload_version=p.payload_version,
-            scope=_SCOPE,
-            workflow_id=p.workflow_id,
-            description="A different description entirely",
-            startup_mode=p.startup_mode,
-            topology=p.topology,
-        )
-        if p is workflow
-        else p
-        for p in payloads
-    ]
-    nodes = [
-        SemanticNodeV2(
-            node_id=p.node_id, kind=p.payload_kind, payload_ref=semantic_payload_ref(p)
-        )
-        for p in mutated
-    ]
-    edges = list(graph.edges)
-    mutated_graph = build_semantic_graph_v2(
-        graph_id=graph.graph_id,
-        version=graph.version,
-        scope=_SCOPE,
-        nodes=nodes,
-        edges=edges,
-    )
-    plan = _plan(mutated_graph, mutated, with_configs=False)
-    files = materialize_plan(
-        plan=plan,
-        graph=mutated_graph,
-        payloads=mutated,
-        binding=_binding(mutated_graph),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    # The description is not consumed by config/ai.json: bytes are unchanged
-    # even though the workflow payload digest (and source footprint) changed.
-    assert files["config/ai.json"] == base["config/ai.json"]
-    assert files["app.json"] == base["app.json"]
-
-
-def test_workflow_startup_mode_mutation_changes_only_ai_config() -> None:
-    base = _bundle_files()
-    graph, payloads = _extended_fixture(
-        workflow_startup_mode=WorkflowStartupMode.AGENT_DRIVEN
-    )
-    plan = _plan(graph, payloads, with_configs=False)
-    files = materialize_plan(
-        plan=plan,
-        graph=graph,
-        payloads=payloads,
-        binding=_binding(graph),
-        layout_registry=build_app_layout_registry(()),
-    ).files()
-    assert files["config/ai.json"] != base["config/ai.json"]
-    for unchanged in (
-        "app.json",
-        "ui/route_manifest.json",
-        "config/integrations.yaml",
-        "security/secrets.yaml",
+    for kwargs in (
+        {"workflow_startup_mode": WorkflowStartupMode.AGENT_DRIVEN},
+        {"extra_workflow_startup_mode": WorkflowStartupMode.ON_DEMAND},
     ):
-        assert files[unchanged] == base[unchanged], unchanged
+        graph, payloads = _extended_fixture(**kwargs)
+        plan = _plan(graph, payloads, with_configs=False)
+        files = _materialized_files(graph, payloads, plan)
+        for path in _RENDERED_PATHS:
+            assert files[path] == base[path], (kwargs, path)
 
 
-def test_forged_render_input_claiming_no_workflow_fails_source_pinning() -> None:
-    plan, payload_by_node, render_input = _valid_render_input()
-    workflow_node_ids = {
-        node_id
-        for node_id, payload in payload_by_node.items()
-        if payload.payload_kind is SemanticNodeKind.WORKFLOW
-    }
-    document = render_input.model_dump()
-    document["chat_startup_mode"] = "ask"
-    document["sources"] = [
-        s for s in document["sources"] if s["node_id"] not in workflow_node_ids
-    ]
-    forged = type(render_input).model_validate(document)
-    ai_unit = next(
-        u
-        for u in plan.units
-        if u.disposition is PlanDisposition.RENDER and u.family_kind == "app_config"
-    )
-    with pytest.raises(AppConfigMaterializationError, match="missing"):
-        render_app_config_unit(unit=ai_unit, render_input=forged)
+def test_renderer_cannot_emit_ai_json_even_for_a_forged_unit() -> None:
+    """Attack: hand the renderer a unit whose plan-owned output claims
+    config/ai.json. No deterministic contract exists for that path in this
+    slice, so rendering fails closed instead of inventing AI-launch bytes."""
+    plan, payload_by_node, unit, render_input = _valid_render_input()
+    forged_output = unit.outputs[0].model_copy(update={"path": "config/ai.json"})
+    forged_unit = unit.model_copy(update={"outputs": (forged_output,)})
+    with pytest.raises(
+        AppConfigMaterializationError, match="no deterministic"
+    ):
+        render_app_config_unit(unit=forged_unit, render_input=render_input)
 
 
 def test_selected_auth_without_payload_stays_a_typed_gap() -> None:
@@ -1529,16 +1453,24 @@ def test_selected_auth_without_payload_stays_a_typed_gap() -> None:
         edges=edges,
     )
     plan = _plan(stripped_graph, without_auth, with_configs=False)
-    for family in (
-        "app_manifest",
-        "app_config",
-        "app_secret_references",
-        "app_ui_route_manifest",
-    ):
+    # app.json consumes authRequired: it gaps. app_config stays its deferred
+    # typed gap. The families that do not consume auth facts remain
+    # independently renderable — family-local completion, no shared gate.
+    for gapped in ("app_manifest", "app_config"):
         assert not any(
-            u.family_kind == family and u.disposition is PlanDisposition.RENDER
+            u.family_kind == gapped and u.disposition is PlanDisposition.RENDER
             for u in plan.units
-        ), family
+        ), gapped
+    for renderable in (
+        "app_ui_route_manifest",
+        "app_integrations_config",
+        "app_secret_references",
+    ):
+        assert any(
+            u.family_kind == renderable
+            and u.disposition is PlanDisposition.RENDER
+            for u in plan.units
+        ), renderable
 
 
 def test_selected_integrations_without_payload_gap_secret_references() -> None:
@@ -1573,6 +1505,13 @@ def test_selected_integrations_without_payload_gap_secret_references() -> None:
             u.family_kind == family and u.disposition is PlanDisposition.RENDER
             for u in plan.units
         ), family
+    # Unrelated families remain independently renderable.
+    for renderable in ("app_manifest", "app_ui_route_manifest"):
+        assert any(
+            u.family_kind == renderable
+            and u.disposition is PlanDisposition.RENDER
+            for u in plan.units
+        ), renderable
 
 
 def test_selected_custom_routes_without_declaration_gap_route_manifest() -> None:
@@ -1584,16 +1523,21 @@ def test_selected_custom_routes_without_declaration_gap_route_manifest() -> None
         for u in plan.units
     )
     assert "ui/route_manifest.json" in _gap_paths(plan, "app_ui_route_manifest")
+    # Integrations and the other families remain independently renderable.
+    for renderable in (
+        "app_manifest",
+        "app_integrations_config",
+        "app_secret_references",
+    ):
+        assert any(
+            u.family_kind == renderable
+            and u.disposition is PlanDisposition.RENDER
+            for u in plan.units
+        ), renderable
 
 
-def test_payload_mutation_after_snapshot_creation_cannot_change_bytes() -> None:
-    plan, payload_by_node, render_input = _valid_render_input()
-    unit = next(
-        u
-        for u in plan.units
-        if u.disposition is PlanDisposition.RENDER
-        and u.family_kind in APP_CONFIG_FAMILIES
-    )
+def test_payload_mutation_after_projection_cannot_change_bytes() -> None:
+    plan, payload_by_node, unit, render_input = _valid_render_input()
     before = render_app_config_unit(unit=unit, render_input=render_input)
     payload_by_node.clear()
     assert render_app_config_unit(unit=unit, render_input=render_input) == before

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from mozaiksai.core.runtime.app.layout_registry import (
     MaterializerIdentifier,
@@ -50,7 +51,10 @@ from mozaiksai.core.semantics.graph import (
     SemanticNodeV2,
     build_semantic_graph_v2,
 )
-from mozaiksai.core.semantics.materialization import materialize_plan
+from mozaiksai.core.semantics.materialization import (
+    build_app_family_render_input,
+    materialize_plan,
+)
 from mozaiksai.core.semantics.payloads import (
     ApplicationPayload,
     AuthPayload,
@@ -566,11 +570,14 @@ def test_renderer_rejects_wrong_family_wrong_binding_and_unknown_template() -> N
     graph, payloads = _extended_fixture()
     plan = _plan(graph, payloads, with_configs=False)
     payload_by_node = {p.node_id: p for p in payloads}
+    render_input = build_app_family_render_input(
+        units=plan.units, payload_by_node=payload_by_node
+    )
     page_unit = next(
         u for u in plan.units if u.family_kind == "app_ui_page_schema"
     )
     with pytest.raises(AppConfigMaterializationError, match="not an"):
-        render_app_config_unit(unit=page_unit, payload_by_node=payload_by_node)
+        render_app_config_unit(unit=page_unit, render_input=render_input)
 
     from mozaiksai.core.semantics.materialization import MaterializationError
 
@@ -732,3 +739,157 @@ def test_b2a_renderer_is_unwired_from_production_code() -> None:
             if any(marker in source for marker in _B2A_MODULE_MARKERS):
                 offenders.append(str(rel))
     assert offenders == [], offenders
+
+
+def test_renderer_module_imports_no_payload_or_graph_symbols() -> None:
+    """The renderer consumes only the closed snapshot — never the semantic
+    authoring model. This is the exact dependency direction the architecture
+    scan in test_semantic_payload_graph_v2 enforces repo-wide; asserting it
+    here keeps the boundary explicit at the renderer itself."""
+    for module_name in ("app_config_materialization", "decl_bytes"):
+        source = (
+            ROOT / "mozaiksai" / "core" / "semantics" / f"{module_name}.py"
+        ).read_text(encoding="utf-8")
+        assert "mozaiksai.core.semantics.payloads" not in source, module_name
+        assert "SemanticGraphV2" not in source, module_name
+        assert "semantics.binding" not in source, module_name
+
+
+def test_semantics_package_import_does_not_load_the_renderer() -> None:
+    """Importing the semantics package (the convenience-export surface) must
+    not transitively load the renderer or the offline materializer, so no
+    production module can reach them through the package __init__."""
+    probe = (
+        "import sys\n"
+        "import mozaiksai.core.semantics  # noqa: F401\n"
+        "loaded = [m for m in sys.modules if 'app_config_materialization' in m\n"
+        "          or m.endswith('semantics.materialization')\n"
+        "          or m.endswith('semantics.decl_bytes')]\n"
+        "print(loaded)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "[]"
+
+
+# ---------------------------------------------------------------------------
+# Render-input snapshot attacks: invalid input fails closed; equivalent
+# reordered facts produce identical bytes.
+# ---------------------------------------------------------------------------
+
+
+def _valid_render_input():
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {p.node_id: p for p in payloads}
+    return plan, payload_by_node, build_app_family_render_input(
+        units=plan.units, payload_by_node=payload_by_node
+    )
+
+
+def test_render_input_is_frozen_and_rejects_undeclared_fields() -> None:
+    _plan_obj, _payloads, render_input = _valid_render_input()
+    with pytest.raises(ValidationError):
+        render_input.default_route = "/elsewhere"  # type: ignore[misc]
+    document = render_input.model_dump()
+    document["arbitrary_metadata"] = {"campaign": "x"}
+    with pytest.raises(ValidationError):
+        type(render_input).model_validate(document)
+    entry = render_input.integrations[0].model_dump()
+    entry["provider_account"] = "acct_123"
+    with pytest.raises(ValidationError):
+        type(render_input.integrations[0]).model_validate(entry)
+
+
+def test_render_input_normalizes_reordered_equivalent_facts() -> None:
+    plan, payload_by_node, render_input = _valid_render_input()
+    document = render_input.model_dump()
+    document["pages"] = list(reversed(document["pages"]))
+    document["integrations"] = list(reversed(document["integrations"]))
+    document["sources"] = list(reversed(document["sources"]))
+    reordered = type(render_input).model_validate(document)
+    assert reordered == render_input
+    unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind in APP_CONFIG_FAMILIES
+    )
+    assert render_app_config_unit(
+        unit=unit, render_input=reordered
+    ) == render_app_config_unit(unit=unit, render_input=render_input)
+
+
+def test_render_input_rejects_duplicates_and_empty_sources() -> None:
+    _plan_obj, _payloads, render_input = _valid_render_input()
+    document = render_input.model_dump()
+    document["pages"] = document["pages"] + document["pages"][:1]
+    with pytest.raises(ValidationError, match="duplicate page routes"):
+        type(render_input).model_validate(document)
+    document = render_input.model_dump()
+    document["sources"] = []
+    with pytest.raises(ValidationError, match="pins no semantic sources"):
+        type(render_input).model_validate(document)
+
+
+def test_stale_or_missing_source_digest_fails_closed() -> None:
+    plan, payload_by_node, render_input = _valid_render_input()
+    unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind in APP_CONFIG_FAMILIES
+    )
+    document = render_input.model_dump()
+    for source in document["sources"]:
+        source["payload_digest"] = "f" * 64
+    stale = type(render_input).model_validate(document)
+    with pytest.raises(AppConfigMaterializationError, match="pinned payload digest"):
+        render_app_config_unit(unit=unit, render_input=stale)
+    document = render_input.model_dump()
+    document["sources"] = [
+        s for s in document["sources"] if s["node_id"] not in {
+            src.node_id for src in unit.sources
+        }
+    ]
+    if document["sources"]:
+        missing = type(render_input).model_validate(document)
+        with pytest.raises(AppConfigMaterializationError, match="missing"):
+            render_app_config_unit(unit=unit, render_input=missing)
+
+
+def test_render_input_from_a_different_application_fails_closed() -> None:
+    plan, _payloads, _render_input = _valid_render_input()
+    other_graph, other_payloads = _extended_fixture(default_route="/reports")
+    other_plan = _plan(other_graph, other_payloads, with_configs=False)
+    other_input = build_app_family_render_input(
+        units=other_plan.units,
+        payload_by_node={p.node_id: p for p in other_payloads},
+    )
+    unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind == "app_manifest"
+    )
+    with pytest.raises(AppConfigMaterializationError, match="pinned payload digest"):
+        render_app_config_unit(unit=unit, render_input=other_input)
+
+
+def test_payload_mutation_after_snapshot_creation_cannot_change_bytes() -> None:
+    plan, payload_by_node, render_input = _valid_render_input()
+    unit = next(
+        u
+        for u in plan.units
+        if u.disposition is PlanDisposition.RENDER
+        and u.family_kind in APP_CONFIG_FAMILIES
+    )
+    before = render_app_config_unit(unit=unit, render_input=render_input)
+    payload_by_node.clear()
+    assert render_app_config_unit(unit=unit, render_input=render_input) == before

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -46,7 +46,9 @@ from mozaiksai.core.semantics.binding import (
     RendererSelection,
     build_implementation_binding,
 )
+from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
     PlanDisposition,
     derive_compilation_plan,
 )
@@ -57,8 +59,14 @@ from mozaiksai.core.semantics.graph import (
     build_semantic_graph_v2,
 )
 from mozaiksai.core.semantics.materialization import (
-    materialize_plan,
+    MaterializationError,
     project_app_family_render_input,
+)
+from mozaiksai.core.semantics.materialization import (
+    materialize_plan as _materialize_plan,
+)
+from mozaiksai.core.semantics.materialization import (
+    rematerialize_plan as _rematerialize_plan,
 )
 from mozaiksai.core.semantics.payloads import (
     ApplicationPayload,
@@ -75,6 +83,9 @@ from mozaiksai.core.semantics.payloads import (
     WorkflowStartupMode,
     build_semantic_payload,
     semantic_payload_ref,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    build_compilation_plan_authority_inputs,
 )
 from mozaiksai.core.semantics.refs import SemanticGraphRef
 from tests.test_semantic_payload_graph_v2 import _SCOPE, _corpus_payloads
@@ -312,6 +323,21 @@ def _plan(graph, payloads, *, with_configs: bool = True):
         registry=build_app_layout_registry(()),
         structured_output_configs=CONFIGS if with_configs else None,
     )
+
+
+def _authority_inputs(graph, payloads):
+    return build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=payloads,
+        registry=build_app_layout_registry(()),
+    )
+
+
+def materialize_plan(**kwargs):
+    kwargs["authority_inputs"] = _authority_inputs(
+        kwargs["graph"], kwargs["payloads"]
+    )
+    return _materialize_plan(**kwargs)
 
 
 def _binding(graph):
@@ -1671,6 +1697,99 @@ def test_every_family_rejects_an_unrelated_extra_source(family, extra_node) -> N
         AppConfigMaterializationError, match="does not bind exactly"
     ):
         render_app_config_unit(unit=unit, render_input=forged)
+
+
+def _forge_plan_with_extra_source(plan, family, extra):
+    document = plan.model_dump(mode="json")
+    identity = plan.canonical_payload(include_digest=False)
+    index = next(
+        i
+        for i, unit in enumerate(plan.units)
+        if unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind == family
+    )
+    source = {"node_id": extra.node_id, "payload_digest": extra.payload_digest}
+    for target in (document, identity):
+        target["units"][index]["sources"] = sorted(
+            target["units"][index]["sources"] + [source],
+            key=lambda item: item["node_id"],
+        )
+    document["plan_digest"] = canonical_digest(identity)
+    return CompilationPlan.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    ("family", "extra_node"),
+    [
+        pytest.param(
+            "app_secret_references", "mozaiks.page.home", id="page-into-secrets"
+        ),
+        pytest.param(
+            "app_manifest", "mozaiks.workflow.digest", id="workflow-into-manifest"
+        ),
+        pytest.param(
+            "app_ui_route_manifest",
+            "mozaiks.integration.email",
+            id="integration-into-routes",
+        ),
+        pytest.param(
+            "app_integrations_config",
+            "mozaiks.page.home",
+            id="page-into-integrations",
+        ),
+    ],
+)
+def test_canonical_authority_rejects_forged_family_plan_before_render_or_reuse(
+    family, extra_node, monkeypatch
+) -> None:
+    """A re-digested plan cannot redefine any family's source footprint.
+
+    Canonical authority validation runs before fresh rendering and before
+    rematerialization can copy historical bytes.
+    """
+    graph, payloads = _extended_fixture()
+    plan = _plan(graph, payloads, with_configs=False)
+    payload_by_node = {payload.node_id: payload for payload in payloads}
+    forged = _forge_plan_with_extra_source(plan, family, payload_by_node[extra_node])
+    registry = build_app_layout_registry(())
+    authority_inputs = _authority_inputs(graph, payloads)
+    base_bundle = _materialize_plan(
+        plan=plan,
+        authority_inputs=authority_inputs,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=registry,
+    )
+
+    def _must_not_materialize(*args, **kwargs):
+        raise AssertionError("forged plan reached unit materialization")
+
+    monkeypatch.setattr(
+        "mozaiksai.core.semantics.materialization._materialize_unit",
+        _must_not_materialize,
+    )
+    with pytest.raises(MaterializationError, match="canonical authority"):
+        _materialize_plan(
+            plan=forged,
+            authority_inputs=authority_inputs,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=registry,
+        )
+    with pytest.raises(MaterializationError, match="canonical authority"):
+        _rematerialize_plan(
+            base_bundle=base_bundle,
+            base_plan=plan,
+            base_authority_inputs=authority_inputs,
+            successor_plan=forged,
+            successor_authority_inputs=authority_inputs,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=registry,
+        )
 
 
 def test_plan_source_added_to_a_family_is_rejected() -> None:

--- a/tests/test_app_layout_registry.py
+++ b/tests/test_app_layout_registry.py
@@ -89,7 +89,7 @@ class TestRegistryContract:
             )
         }
         assert {row.semantic_input_kinds for row in by_kind[ArtifactKind.APP_MANIFEST]} == {
-            ("application",)
+            ("application", "auth")
         }
         assert {row.semantic_input_kinds for row in by_kind[ArtifactKind.APP_AUTH_CONFIG]} == {
             ("auth",)
@@ -97,7 +97,7 @@ class TestRegistryContract:
         assert {
             row.semantic_input_kinds
             for row in by_kind[ArtifactKind.APP_INTEGRATIONS_CONFIG]
-        } == {("integration",)}
+        } == {("application", "integration")}
         assert all(
             "workflow" in row.semantic_input_kinds
             for row in by_kind[ArtifactKind.WORKFLOW_MANIFEST]

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -49,13 +49,16 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
 # This corpus declares every optional family ABSENT_BY_DECLARATION while
 # carrying auth/integration/workflow payloads — contradictory selection
-# evidence. Slice 5D-0B2A's selection-honesty completion therefore keeps the
-# application-configuration families as typed gaps here (only the page family
-# renders). Plan identity also includes #475's consulted assignment-contract
-# closure. The honest
-# five-family closure is proven on the selection-consistent fixture in
-# tests/test_app_family_materialization_b2a.py instead.
-_GOLDEN_PLAN_DIGEST = "c95aad3fef6ef3f66c29b1ca5dbd4b38156cb2fbc4afbc89195a4c7d4413e501"
+# evidence. Slice 5D-0B2A's family-local selection-honesty completion keeps
+# app_manifest, app_integrations_config, and app_secret_references as typed
+# gaps here (each consumes the contradicted facts) and defers app_config
+# outright (no application-level AI-launch authority exists). The route
+# manifest consumes none of the contradicted facts — pages and default_route
+# are complete and custom routes are unselected — so it renders alongside the
+# page family. Plan identity also includes #475's consulted assignment-contract
+# closure. The honest four-family closure is proven on the
+# selection-consistent fixture in tests/test_app_family_materialization_b2a.py.
+_GOLDEN_PLAN_DIGEST = "db7ccc1f4d30a3d2621682afb54f8307830eb493beea1e8fb5ffaf2198d46a83"
 
 
 def _registry():

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -47,13 +47,13 @@ _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
-# Re-pinned once for the plan-authority contract: CompilationPlan identity
-# now pins assignment_contracts_digest — the exact assignment-descriptor
-# closure consulted during derivation (empty-consulted for this config-less
-# corpus). Identity-only change: no rendered byte, assignment resolution, or
-# reuse behavior changed; unrelated registry descriptors remain outside plan
-# identity by the locality rule.
-_GOLDEN_PLAN_DIGEST = "df0bebdc10fe304977f6c2828d3410f88366c1763c3f175ac5f891e4bf769314"
+# Re-pinned once for Slice 5D-0B2A: the app-config completion predicate now
+# recognizes the corpus's closed application/auth/page facts, flipping the
+# unconditional application-configuration families (app_manifest, app_config,
+# app_secret_references, app_ui_route_manifest) from typed gaps to RENDER.
+# Plan identity also includes #475's exact consulted assignment-contract
+# closure. No semantic fact was invented; the corpus payloads are unchanged.
+_GOLDEN_PLAN_DIGEST = "9be0e974aeeaa59841ac48d53ef306fd988ec609193de057bbfe6b5a07737e6d"
 
 
 def _registry():
@@ -389,14 +389,12 @@ def test_digest_propagates_payload_to_graph_to_plan() -> None:
         if unit.source_scope is PlanSourceScope.GRAPH_WIDE
     }
     assert graph_wide <= affected
-    # Unsupported route-manifest rendering stays a typed gap rather than a
-    # false dependent renderer unit.
-    assert not any(unit.family_kind == "app_ui_route_manifest" for unit in changed.units)
-    assert any(
-        gap.family_kind == "app_ui_route_manifest"
-            and gap.code.value == "renderer_input_undeclared"
-        for gap in changed.gaps
-    )
+    # Route-manifest rendering now declares typed inputs (5D-0B2A); on this
+    # corpus it either derives a render unit or remains an explicit typed gap —
+    # never a silent omission.
+    route_units = [u for u in changed.units if u.family_kind == "app_ui_route_manifest"]
+    route_gaps = [g for g in changed.gaps if g.family_kind == "app_ui_route_manifest"]
+    assert route_units or route_gaps
     # ...and unrelated declared units with unchanged footprints stay reusable.
     unrelated_units = {
         unit.unit_id
@@ -533,6 +531,8 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
     offenders: list[str] = []
     excluded = {
         Path("mozaiksai/core/semantics/compilation_plan.py"),
+        Path("mozaiksai/core/semantics/decl_bytes.py"),
+        Path("mozaiksai/core/semantics/app_config_materialization.py"),
         Path("mozaiksai/core/semantics/resolver.py"),
         Path("mozaiksai/core/semantics/refs.py"),
         # Slice 4C offline materializer: consumes the plan inside the

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -58,7 +58,15 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # page family. Plan identity also includes #475's consulted assignment-contract
 # closure. The honest four-family closure is proven on the
 # selection-consistent fixture in tests/test_app_family_materialization_b2a.py.
-_GOLDEN_PLAN_DIGEST = "db7ccc1f4d30a3d2621682afb54f8307830eb493beea1e8fb5ffaf2198d46a83"
+# Re-pinned once for the source-locality correction: app_secret_references no
+# longer declares auth as a semantic input (security/secrets.yaml consumes no
+# auth fact), which changes the registry row digest and therefore every plan
+# identity. Proven before re-pinning: the removed source was unconsumed
+# (roles-only auth mutation left secrets bytes identical), all four rendered
+# outputs are byte-identical, selective reuse improved (the secret unit now
+# survives auth mutations), and no required source was dropped (loader and
+# mutation suites green).
+_GOLDEN_PLAN_DIGEST = "c0ef25d66c43710c7a6a967fcfb4fecb8232231050d4e8eb0fda054381389a05"
 
 
 def _registry():

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -47,13 +47,15 @@ _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
-# Re-pinned once for Slice 5D-0B2A: the app-config completion predicate now
-# recognizes the corpus's closed application/auth/page facts, flipping the
-# unconditional application-configuration families (app_manifest, app_config,
-# app_secret_references, app_ui_route_manifest) from typed gaps to RENDER.
-# Plan identity also includes #475's exact consulted assignment-contract
-# closure. No semantic fact was invented; the corpus payloads are unchanged.
-_GOLDEN_PLAN_DIGEST = "9be0e974aeeaa59841ac48d53ef306fd988ec609193de057bbfe6b5a07737e6d"
+# This corpus declares every optional family ABSENT_BY_DECLARATION while
+# carrying auth/integration/workflow payloads — contradictory selection
+# evidence. Slice 5D-0B2A's selection-honesty completion therefore keeps the
+# application-configuration families as typed gaps here (only the page family
+# renders). Plan identity also includes #475's consulted assignment-contract
+# closure. The honest
+# five-family closure is proven on the selection-consistent fixture in
+# tests/test_app_family_materialization_b2a.py instead.
+_GOLDEN_PLAN_DIGEST = "c95aad3fef6ef3f66c29b1ca5dbd4b38156cb2fbc4afbc89195a4c7d4413e501"
 
 
 def _registry():

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -65,8 +65,10 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # (roles-only auth mutation left secrets bytes identical), all four rendered
 # outputs are byte-identical, selective reuse improved (the secret unit now
 # survives auth mutations), and no required source was dropped (loader and
-# mutation suites green).
-_GOLDEN_PLAN_DIGEST = "c0ef25d66c43710c7a6a967fcfb4fecb8232231050d4e8eb0fda054381389a05"
+# mutation suites green). Re-pinned after rebasing onto #475 because the same
+# canonical plan now also pins its consulted assignment-contract closure;
+# rendered bytes and family activation are unchanged.
+_GOLDEN_PLAN_DIGEST = "b751584c87214bf980dd380f8368a459dca0c3569590fe74d8cb80b4f555f4a3"
 
 
 def _registry():

--- a/tests/test_composition_ledger.py
+++ b/tests/test_composition_ledger.py
@@ -77,6 +77,7 @@ def test_missing_extra_duplicate_and_stale_inputs_fail_closed() -> None:
         external_handoff_units=(),
         inapplicable_units=(),
         unsupplied_preserved_units=(),
+        input_only_units=(),
         instance_scope_deferred_units=(),
         gap_count=0,
     )

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 import yaml
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from factory_app.workflows.AppGenerator.tools.app_validation import (
     run_app_bundle_acceptance_gate,
@@ -60,14 +61,21 @@ from mozaiksai.core.semantics.materialization import (
     PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
     MaterializationError,
     compose_bundle,
-    materialize_plan,
-    rematerialize_plan,
     render_app_ui_page_schema_unit,
     resolve_page_schema_renderer_selection,
     validate_page_renderer_input_closure,
 )
+from mozaiksai.core.semantics.materialization import (
+    materialize_plan as _materialize_plan,
+)
+from mozaiksai.core.semantics.materialization import (
+    rematerialize_plan as _rematerialize_plan,
+)
 from mozaiksai.core.semantics.offline_projection import project_semantic_graph
 from mozaiksai.core.semantics.opaque_artifact import PreservedOpaqueArtifact
+from mozaiksai.core.semantics.plan_authority import (
+    build_compilation_plan_authority_inputs,
+)
 from mozaiksai.core.semantics.refs import (
     ChildContractRef,
     ExecutionAccessScopeRef,
@@ -166,6 +174,31 @@ def _source(*, column_label: str = "Order") -> dict:
 
 def _registry():
     return build_app_layout_registry(())
+
+
+def _authority_inputs(graph, payloads, registry=None):
+    return build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=payloads,
+        registry=registry or _registry(),
+    )
+
+
+def materialize_plan(**kwargs):
+    kwargs["authority_inputs"] = _authority_inputs(
+        kwargs["graph"], kwargs["payloads"], kwargs["layout_registry"]
+    )
+    return _materialize_plan(**kwargs)
+
+
+def rematerialize_plan(*, base_graph, base_payloads, **kwargs):
+    kwargs["base_authority_inputs"] = _authority_inputs(
+        base_graph, base_payloads, kwargs["layout_registry"]
+    )
+    kwargs["successor_authority_inputs"] = _authority_inputs(
+        kwargs["graph"], kwargs["payloads"], kwargs["layout_registry"]
+    )
+    return _rematerialize_plan(**kwargs)
 
 
 def _build(source: dict, *, graph_id: str = "slice4c"):
@@ -518,7 +551,7 @@ def test_registry_identity_mismatch_is_rejected() -> None:
 
     snapshot = snapshot_layout_registry(extended)
     forged = snapshot.model_copy(update={"snapshot_digest": "a" * 64})
-    with pytest.raises(MaterializationError):
+    with pytest.raises((MaterializationError, ValidationError)):
         materialize_plan(
             plan=plan,
             graph=result.graph,
@@ -786,6 +819,8 @@ async def test_semantic_page_change_selectively_rematerializes_and_boots(
     successor_bundle = rematerialize_plan(
         base_bundle=base_bundle,
         base_plan=base_plan,
+        base_graph=base_result.graph,
+        base_payloads=base_result.payloads,
         successor_plan=successor_plan,
         graph=successor_result.graph,
         payloads=successor_result.payloads,
@@ -826,6 +861,8 @@ def test_unrelated_semantic_change_keeps_page_reusable() -> None:
     successor_bundle = rematerialize_plan(
         base_bundle=base_bundle,
         base_plan=base_plan,
+        base_graph=base_result.graph,
+        base_payloads=base_result.payloads,
         successor_plan=successor_plan,
         graph=successor_result.graph,
         payloads=successor_result.payloads,

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -430,6 +430,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
             unit,
             payload_by_node={},
             app_config_render_input=None,
+            app_config_selection=None,
             preserved_by_unit={},
             bundle_outputs=[],
             external=[],

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -434,6 +434,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
             external=[],
             inapplicable=[],
             unsupplied=[],
+            input_only=[],
             deferred=[],
         )
 

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -429,8 +429,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
         _materialize_unit(
             unit,
             payload_by_node={},
-            app_config_render_input=None,
-            app_config_selection=None,
+                app_config_selection=None,
             preserved_by_unit={},
             bundle_outputs=[],
             external=[],

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -429,6 +429,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
         _materialize_unit(
             unit,
             payload_by_node={},
+            app_config_render_input=None,
             preserved_by_unit={},
             bundle_outputs=[],
             external=[],

--- a/tests/test_renderer_input_closure.py
+++ b/tests/test_renderer_input_closure.py
@@ -529,10 +529,13 @@ def test_unsupported_renderer_families_remain_explicit_typed_gaps() -> None:
         "app_subscription_config",
         "workflow_manifest",
     } <= renderer_blocked
+    # Slice 5D-0B2A closed app_manifest: the corpus's application/auth facts
+    # are byte-complete, so it renders deterministically instead of gapping.
+    assert "app_manifest" not in renderer_blocked
     assert any(
-        gap.family_kind == "app_manifest"
-        and gap.code is PlanGapCode.RENDERER_INPUT_INCOMPLETE
-        for gap in plan.gaps
+        unit.family_kind == "app_manifest"
+        and unit.disposition is PlanDisposition.RENDER
+        for unit in plan.units
     )
     assert not any(
         unit.disposition is PlanDisposition.AGENT_AUTHOR

--- a/tests/test_renderer_input_closure.py
+++ b/tests/test_renderer_input_closure.py
@@ -529,13 +529,15 @@ def test_unsupported_renderer_families_remain_explicit_typed_gaps() -> None:
         "app_subscription_config",
         "workflow_manifest",
     } <= renderer_blocked
-    # Slice 5D-0B2A closed app_manifest: the corpus's application/auth facts
-    # are byte-complete, so it renders deterministically instead of gapping.
-    assert "app_manifest" not in renderer_blocked
+    # This corpus declares every optional family absent while pinning auth,
+    # integration, and workflow payloads — contradictory selection evidence.
+    # Slice 5D-0B2A selection honesty therefore keeps app_manifest a typed
+    # incomplete gap here; the honest closure renders only on the
+    # selection-consistent B2A fixture.
     assert any(
-        unit.family_kind == "app_manifest"
-        and unit.disposition is PlanDisposition.RENDER
-        for unit in plan.units
+        gap.family_kind == "app_manifest"
+        and gap.code is PlanGapCode.RENDERER_INPUT_INCOMPLETE
+        for gap in plan.gaps
     )
     assert not any(
         unit.disposition is PlanDisposition.AGENT_AUTHOR


### PR DESCRIPTION
## ADR 0007 Slice 5D-0B2A — Deterministic Application-Family Materialization

Answers the slice question for the closed **four-family** application-configuration set: accepted application-level semantic facts deterministically produce the canonical artifact bytes for the families whose input authority actually exists. **This slice renders four families. It does not render `config/ai.json`** — application-level AI-launch semantics (chat startup mode, workflow entry point) have no typed semantic home and remain an explicit typed prerequisite; per-workflow `workflow_startup_mode` is not chat-startup authority and is never used to infer one.

Base: `42803a28da6bc7b2a59048522860178ac9135331` (post-#469 main).

### What this renders

**One renderer authority** — `deterministic_app_config_renderer@1` (`mozaiksai/core/semantics/app_config_materialization.py`), resolved exclusively through an `ImplementationBinding` renderer selection that must declare **exactly** its four-family capability set on the `app_config_executor` materializer. No legacy fallback, no second registry, no dynamic import-by-string.

| Family | Path | Loader-verified against |
|---|---|---|
| `app_manifest` | `app.json` | real app-manifest loader semantics |
| `app_ui_route_manifest` | `ui/route_manifest.json` | declared pages only; default_route must resolve |
| `app_integrations_config` | `config/integrations.yaml` | generated-bundle scanner accepts it |
| `app_secret_references` | `security/secrets.yaml` | names only — never secret values |

**Family-local render inputs** — `AppManifestRenderInput`, `RouteManifestRenderInput`, `IntegrationsConfigRenderInput`, `SecretReferencesRenderInput`: each frozen, `extra="forbid"`, recursively closed, source-digest pinned, carrying only the facts its one family consumes. The offline materialization owner projects them **lazily per active RENDER unit** from that unit's plan-pinned sources, so a typed gap in one family (e.g. `app_config`) never blocks another family whose own closure is complete.

**Selection-honest, family-specific completion** — SELECTED requires the typed facts present (auth exactly one; integrations at least one); a family declared absent must have none (contradictions stay typed gaps); selected custom routes gap the route manifest rather than silently omitting them; selected integrations with zero payloads gap both the integrations config and the names-only secret surface. Missing selected evidence is never normalized to empty output.

**Two named byte contracts** — `mozaiks.json_decl_bytes.v1` / `mozaiks.yaml_decl_bytes.v1` (UTF-8, LF, trailing newline, declaration-order preservation, round-trip equality). The renderer reads no clock, env, filesystem, AppBuildPlan, or Git state, and imports no payload/graph/binding symbols (architecture-guarded).

**Exact source locality** — each family's PlanUnit footprint contains exactly the payload kinds whose facts influence that unit's existence, path, bytes, or validator obligation: `app_manifest` = (application, auth), `app_ui_route_manifest` = (application, page), `app_integrations_config` = (application, integration), `app_secret_references` = (application, integration). `AuthPayload` carries no typed secret handle, so auth is *not* a source of `security/secrets.yaml` — a roles-only auth mutation leaves the secret unit's identity, footprint, reuse, and bytes unchanged, and provider-neutral auth secret declaration remains a separate typed prerequisite. The family render input must bind **exactly** the unit's pinned source set — not a subset, not a superset: a missing, extra, duplicate, substituted, or stale-digest source fails closed, so no unrelated payload can become hidden provenance. A permanent guard proves the registry declaration, derived PlanUnit footprints, and projected render inputs agree; an edge audit proves no family consumes graph-edge identities.

### Deferred, with recorded typed prerequisites

- **`app_config` / `config/ai.json`** — deferred pending application-level AI-launch semantic authority (chat startup mode, workflow entry point). Every workflow scenario — complete, ambiguous, missing, absent, contradictory — leaves it a typed gap; the four families render independently in all of them.
- `app_subscription_config` — default plan + assignment-store wiring untyped
- `app_data_contract` — collection→module ownership edges untyped
- asset manifests — no typed asset facts

Nothing here claims a complete application-configuration closure or a runnable application.

### Production authority unchanged

AppGenerator writers remain the authoritative emitters of these paths until the atomic 5D cutover. Guards prove those production writers do not call the B2A renderer, no production module imports it, and importing the semantics package does not transitively load it.

### Proof (tests)

`tests/test_app_family_materialization_b2a.py` — 66 tests: B1 census unchanged; four-family closure on the selection-consistent fixture; per-artifact byte + loader checks; scanner acceptance; repeated/shuffled/cross-process byte identity; per-path exclusive ownership; exact-family authorization matrix (subset/superset/±app_config/±subscription/forged/duplicate/empty/split/wrong-version/wrong-materializer all fail closed); output bijection; family-local independence attacks (auth/integrations/custom-routes missing gap only their consumers); both Codex-2 reproductions preserved (coupled-snapshot abort; two-workflow startup inference); mutation footprints (workflow mutations change none of the four outputs); render-input snapshot attacks; production-unwired and no-clock/env/fs guards.

The four retained artifacts are byte-identical to the previously reviewed head for identical accepted inputs. Full battery green (see checks); ruff, scoped mypy, strict MkDocs, source hygiene, `git diff --check` clean.

Do not merge — draft for review (reviewer: Codex 2). Do not begin B2B/B2C or the AI-launch prerequisite from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
