### PR TITLE
fix(subscriptions): fail closed on invalid present contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ This project follows a practical pre-1.0 changelog format:
 ## Unreleased
 
 ### Fixed
+- **A present but invalid `config/subscriptions.yaml` now fails application
+  loading instead of silently disabling entitlement enforcement**: AppLoader
+  previously caught the subscription contract's load error, logged a warning,
+  and continued with no subscription config — which wired
+  `NoOpEntitlementAdapter` and granted every `entitlement_gate`
+  unconditionally. An invalid present contract (malformed YAML, unknown
+  fields, wrong schema version, broken plan/default/product/wallet
+  references) now raises `AppLoadError` and the platform host refuses to
+  start. An absent file is unchanged: a valid non-SaaS app with no
+  enforcement configured. Both `mozaiks.subscriptions.v1` and
+  `mozaiks.subscriptions.v2` remain accepted, unchanged —
+  `load_subscriptions_config` stays the sole schema authority.
 
 - **Generated Mongo documents no longer break HTTP responses**: module action
   results are normalized at the ModuleExecutor boundary so BSON `ObjectId`

--- a/docs/architecture/app/app-bundle-declaratives.md
+++ b/docs/architecture/app/app-bundle-declaratives.md
@@ -54,8 +54,10 @@ grants. When the app also declares `assignment_store`, the platform loads it at
 startup and wires the OSS `ConfiguredEntitlementAdapter` into
 `ModuleExecutor`; the adapter reads the configured app data alias for active
 subscription assignment state. Non-SaaS apps omit this file; all entitlement
-gates pass unconditionally via `NoOpEntitlementAdapter`. Schema:
-`mozaiks.subscriptions.v1`.
+gates pass unconditionally via `NoOpEntitlementAdapter`. A file that is
+present but invalid fails application loading — it is never downgraded to
+disabled enforcement, so a malformed contract can never silently grant gated
+actions. Schema: `mozaiks.subscriptions.v1`.
 Assignment stores may declare `tenant_id_field`, `workspace_id_field`, and
 `user_id_field`; the configured adapter checks exact scoped assignments before
 falling back to broader tenant, workspace, user, or app-level records.

--- a/mozaiksai/core/runtime/app/loader.py
+++ b/mozaiksai/core/runtime/app/loader.py
@@ -153,16 +153,23 @@ class AppLoader:
         except AppProvenanceLoadError as exc:
             raise AppLoadError(f"Invalid provenance.yaml: {exc}") from exc
 
+        # Fail closed: an app that DECLARES a subscription contract must load
+        # it or not load at all. Downgrading an invalid present config to
+        # subscriptions_config=None would wire NoOpEntitlementAdapter and
+        # silently grant every entitlement gate. Only an absent file means a
+        # valid non-SaaS app. load_subscriptions_config remains the sole
+        # schema authority (v1 and v2 both accepted, unchanged).
         subscriptions_config: SubscriptionsConfig | None = None
         try:
             subscriptions_config = load_subscriptions_config(base_path)
-            if subscriptions_config is not None:
-                logger.info(
-                    "SUBSCRIPTIONS_LOADED: %s plans (%s)",
-                    len(subscriptions_config.plans), [p.plan_id for p in subscriptions_config.plans])
         except SubscriptionsLoadError as exc:
-            logger.warning(
-                "SUBSCRIPTIONS_CONFIG_INVALID: %s — entitlement enforcement disabled", exc)
+            raise AppLoadError(f"Invalid config/subscriptions.yaml: {exc}") from exc
+        if subscriptions_config is not None:
+            logger.info(
+                "SUBSCRIPTIONS_LOADED: schema=%s root_plans=%s products=%s",
+                subscriptions_config.schema_version,
+                [p.plan_id for p in subscriptions_config.plans],
+                [p.product_id for p in subscriptions_config.products])
 
         logger.info(
             "APP_LOADED: name=%s version=%s mode=%s workflows=%s modules=%s",

--- a/tests/test_subscriptions_fail_closed_app_loading.py
+++ b/tests/test_subscriptions_fail_closed_app_loading.py
@@ -1,0 +1,272 @@
+"""Fail-closed app loading for present-but-invalid subscription contracts.
+
+The security contract:
+
+- ABSENT ``config/subscriptions.yaml`` → valid non-SaaS app, config None,
+  NoOpEntitlementAdapter permitted.
+- PRESENT AND VALID (v1 or v2) → app loads, ConfiguredEntitlementAdapter.
+- PRESENT BUT INVALID (malformed YAML, wrong schema, unknown field, broken
+  reference, invalid default, invalid product/plan or wallet/top-up
+  relationship) → ``AppLoadError``; the app never boots with entitlement
+  enforcement silently disabled.
+
+Previously an invalid present contract was downgraded to ``None`` with a
+warning, which wired NoOpEntitlementAdapter and granted every
+``entitlement_gate`` unconditionally.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.ports.entitlement import NoOpEntitlementAdapter
+from mozaiksai.core.runtime.app.entitlements import ConfiguredEntitlementAdapter
+from mozaiksai.core.runtime.app.loader import AppLoader, AppLoadError
+from mozaiksai.core.runtime.app.subscriptions_loader import (
+    SubscriptionsLoadError,
+    load_subscriptions_config,
+)
+
+_VALID_V1 = """schema_version: mozaiks.subscriptions.v1
+label: Test Plans
+default_plan_id: free
+plans:
+  - plan_id: free
+    label: Free
+    capabilities: []
+  - plan_id: pro
+    label: Pro
+    capabilities:
+      - reports.export
+"""
+
+# Generic v2 structure exercising exactly the shape the hosted product (App
+# Zero) depends on — multi-product, default_product_id, per-product
+# assignment stores/plans, root wallets/top-ups/pricing catalog — with no
+# proprietary plan data.
+_VALID_V2 = """schema_version: mozaiks.subscriptions.v2
+label: Test Multi-Product Plans
+default_product_id: platform
+products:
+  - product_id: platform
+    label: Platform
+    default_plan_id: starter
+    assignment_store:
+      data_alias: billing.platform_subscriptions
+    plans:
+      - plan_id: starter
+        label: Starter
+        capabilities: []
+      - plan_id: builder
+        label: Builder
+        capabilities:
+          - reports.export
+    pricing_catalog_group:
+      group_id: platform
+      label: Platform
+      plan_ids: [starter, builder]
+  - product_id: ai
+    label: AI
+    default_plan_id: ai_starter
+    assignment_store:
+      data_alias: billing.ai_subscriptions
+    plans:
+      - plan_id: ai_starter
+        label: AI Starter
+        capabilities: []
+token_wallets:
+  - wallet_id: ai_tokens
+    unit: tokens
+    usage_meter_id: ai_tokens
+    scope: user
+    auto_debit_usage: true
+top_up_products:
+  - product_id: tokens_10k
+    label: 10K tokens
+    wallet_id: ai_tokens
+    token_amount: 10000
+    price:
+      amount_cents: 500
+      currency: usd
+"""
+
+_INVALID_CONFIGS = {
+    "malformed_yaml": "schema_version: [unclosed\nplans:\n  - {",
+    "wrong_schema_version": (
+        "schema_version: mozaiks.subscriptions.v99\nlabel: X\n"
+        "default_plan_id: free\nplans:\n  - plan_id: free\n    label: Free\n"
+    ),
+    "unknown_root_field": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "default_plan_id: free\nsurprise_field: true\n"
+        "plans:\n  - plan_id: free\n    label: Free\n"
+    ),
+    "broken_default_reference": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "default_plan_id: nonexistent\nplans:\n  - plan_id: free\n    label: Free\n"
+    ),
+    "missing_default": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "plans:\n  - plan_id: free\n    label: Free\n"
+    ),
+    "duplicate_plan_ids": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "default_plan_id: free\nplans:\n"
+        "  - plan_id: free\n    label: Free\n"
+        "  - plan_id: free\n    label: Also Free\n"
+    ),
+    "invalid_product_relationship": (
+        "schema_version: mozaiks.subscriptions.v2\nlabel: X\n"
+        "products:\n  - product_id: platform\n    label: Platform\n"
+        "    default_plan_id: nonexistent\n"
+        "    plans:\n      - plan_id: starter\n        label: Starter\n"
+    ),
+    "v1_with_products": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "default_plan_id: free\nplans:\n  - plan_id: free\n    label: Free\n"
+        "products:\n  - product_id: p\n    label: P\n    default_plan_id: a\n"
+        "    plans:\n      - plan_id: a\n        label: A\n"
+    ),
+    "invalid_wallet_topup_relationship": (
+        "schema_version: mozaiks.subscriptions.v1\nlabel: X\n"
+        "default_plan_id: free\nplans:\n  - plan_id: free\n    label: Free\n"
+        "token_wallets:\n  - wallet_id: ai_tokens\n"
+        "top_up_products:\n"
+        "  - product_id: pack\n    label: Pack\n    wallet_id: unknown_wallet\n"
+        "    token_amount: 100\n    price:\n      amount_cents: 100\n"
+    ),
+}
+
+
+def _write_app(root: Path, subscriptions_yaml: str | None) -> Path:
+    (root / "app.json").write_text('{"appName": "Fail Closed App"}', encoding="utf-8")
+    if subscriptions_yaml is not None:
+        config_dir = root / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "subscriptions.yaml").write_text(subscriptions_yaml, encoding="utf-8")
+    return root
+
+
+def _write_gated_module(root: Path) -> None:
+    module_dir = root / "modules" / "reports"
+    backend = module_dir / "backend"
+    backend.mkdir(parents=True, exist_ok=True)
+    (module_dir / "module.yaml").write_text(
+        """schema_version: mozaiks.module.v1
+module:
+  id: reports
+  display_name: Reports
+  version: 1.0.0
+  description: Gated reports
+  handler: backend.handler:ReportsHandler
+actions:
+  - id: export_report
+    description: Export a report.
+    handler_method: export_report
+    entitlement_gate: reports.export
+    input_schema: {type: object, properties: {}}
+    output_schema: {type: object}
+""",
+        encoding="utf-8",
+    )
+    (backend / "__init__.py").write_text("", encoding="utf-8")
+    (backend / "handler.py").write_text(
+        "class ReportsHandler:\n"
+        "    async def export_report(self, ctx, **params):\n"
+        "        return {\"exported\": True}\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Absent / valid v1 / valid v2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_absent_config_is_a_valid_non_saas_app(tmp_path: Path) -> None:
+    _write_app(tmp_path, None)
+    result = await AppLoader.load(str(tmp_path))
+    assert result.subscriptions_config is None
+    # NoOp is permitted only for genuinely non-SaaS apps.
+    adapter = NoOpEntitlementAdapter()
+    granted = await adapter.check("anything", app_id="app-x")
+    assert granted.granted is True
+
+
+@pytest.mark.asyncio
+async def test_valid_v1_loads_and_configures_enforcement(tmp_path: Path) -> None:
+    _write_app(tmp_path, _VALID_V1)
+    result = await AppLoader.load(str(tmp_path))
+    assert result.subscriptions_config is not None
+    assert result.subscriptions_config.schema_version == "mozaiks.subscriptions.v1"
+    adapter = ConfiguredEntitlementAdapter(config=result.subscriptions_config)
+    denied = await adapter.check("reports.export", app_id="app-x")
+    assert denied.granted is False  # default plan grants nothing
+
+
+@pytest.mark.asyncio
+async def test_valid_v2_loads_and_configures_enforcement(tmp_path: Path) -> None:
+    _write_app(tmp_path, _VALID_V2)
+    result = await AppLoader.load(str(tmp_path))
+    assert result.subscriptions_config is not None
+    assert result.subscriptions_config.schema_version == "mozaiks.subscriptions.v2"
+    assert [p.product_id for p in result.subscriptions_config.products] == ["platform", "ai"]
+    adapter = ConfiguredEntitlementAdapter(
+        config=result.subscriptions_config,
+        collection_resolver=lambda _alias: None,  # no store hits in this test
+    )
+    assert isinstance(adapter, ConfiguredEntitlementAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Present but invalid → AppLoadError, never NoOp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", sorted(_INVALID_CONFIGS))
+async def test_invalid_present_config_fails_app_loading(tmp_path: Path, case: str) -> None:
+    _write_app(tmp_path, _INVALID_CONFIGS[case])
+    with pytest.raises(AppLoadError, match="Invalid config/subscriptions.yaml"):
+        await AppLoader.load(str(tmp_path))
+
+
+@pytest.mark.parametrize("case", sorted(_INVALID_CONFIGS))
+def test_loader_remains_sole_schema_authority(tmp_path: Path, case: str) -> None:
+    """AppLoader adds no second parser: the same inputs fail the one loader."""
+    _write_app(tmp_path, _INVALID_CONFIGS[case])
+    with pytest.raises(SubscriptionsLoadError):
+        load_subscriptions_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Security regression: gated action + malformed config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gated_action_never_exposed_under_disabled_enforcement(tmp_path: Path) -> None:
+    """The core security proof. An app declares an entitlement-gated action
+    and ships a present-but-malformed subscriptions.yaml.
+
+    Before this correction: the config became None, NoOpEntitlementAdapter
+    was wired, and the gated action was granted to everyone. After: the
+    application fails loading — the gated action is never exposed under
+    disabled enforcement.
+    """
+    _write_app(tmp_path, _INVALID_CONFIGS["malformed_yaml"])
+    _write_gated_module(tmp_path)
+
+    with pytest.raises(AppLoadError, match="Invalid config/subscriptions.yaml"):
+        await AppLoader.load(str(tmp_path))
+
+    # Control: the same app with a VALID config loads, and enforcement is
+    # configured (the gate denies without an active grant).
+    (tmp_path / "config" / "subscriptions.yaml").write_text(_VALID_V1, encoding="utf-8")
+    result = await AppLoader.load(str(tmp_path))
+    assert result.subscriptions_config is not None
+    adapter = ConfiguredEntitlementAdapter(config=result.subscriptions_config)
+    outcome = await adapter.check("reports.export", app_id="app-x")
+    assert outcome.granted is False


### PR DESCRIPTION
## Defect (fail-open authorization)

`AppLoader` caught `SubscriptionsLoadError` from a **present but invalid** `config/subscriptions.yaml`, logged `SUBSCRIPTIONS_CONFIG_INVALID … entitlement enforcement disabled`, and continued with `subscriptions_config=None`. The platform then wired `NoOpEntitlementAdapter`, which grants **every** `entitlement_gate` unconditionally — a malformed contract silently disabled all paid-feature enforcement.

## Correction — one loader, fail closed, no schema change

- `AppLoader` now wraps `SubscriptionsLoadError` as `AppLoadError`: an app that declares a subscription contract must load it or not load at all; platform startup/readiness fails.
- **Absent file unchanged**: valid non-SaaS app, `subscriptions_config=None`, `NoOpEntitlementAdapter` permitted.
- **Both `mozaiks.subscriptions.v1` and `mozaiks.subscriptions.v2` remain accepted, unchanged.** `load_subscriptions_config` stays the sole schema authority — no second parser, no v1/v2 conversion, no permissive fallback, no hosted overlay, no renderer code, no `ProductDef` change.

## Security regression (core proof)

`test_gated_action_never_exposed_under_disabled_enforcement`: an app declaring an `entitlement_gate`d action plus a malformed `subscriptions.yaml`. **Before** (verified against unmodified main by stashing the fix): the app loaded with `DID NOT RAISE` — enforcement disabled, gated action granted to everyone. **After**: `AppLoadError` — the action is never exposed under disabled enforcement. Control case: the same app with a valid config loads and the gate denies without a grant.

## App Zero compatibility

Read-only check (no mozaiks-app edits): the hosted product's live `app/config/subscriptions.yaml` (`mozaiks.subscriptions.v2`, products platform/ai/hosting/marketplace) loads unchanged through this loader. A **generic** multi-product v2 fixture — multi-product, `default_product_id`, per-product assignment stores/plans, root wallets/top-ups/pricing groups, no proprietary plan data — is part of the committed matrix.

## Test matrix

`tests/test_subscriptions_fail_closed_app_loading.py` (22 tests): absent → non-SaaS boot; valid v1 → configured enforcement; valid v2 → configured enforcement; invalid matrix (malformed YAML, wrong schema version, unknown root field, broken default reference, missing default, duplicate plan ids, invalid product/plan relationship, v1-with-products, invalid wallet/top-up relationship) → `AppLoadError`, each also proven to fail the one loader directly (no second schema authority); the security regression + control.

## Validation

Full suite **14288 passed / 83 skipped / 0 failed**; focused battery 213 passed across subscriptions loader, AppLoader, entitlement adapter/helpers/drift, token guard/ingest, billing fulfillment, profile usage, SubscriptionContractDesigner, canonical example apps, and generated-app functional acceptance; ruff clean; scoped mypy clean; strict MkDocs build clean (one doc sentence added documenting the fail-closed behavior); `git diff --check` clean.

## Boundaries

No v1/v2 canonicalization or removal, no factory output migration, no semantic payload/renderer/data-contract work, no provider fields, no mozaiks-app edits. The stashed v1-only convergence direction (`subs-convergence-halted-v2-stop-condition`) was **not** used — it remains a rejected direction that must never be applied.

## OSS Change Impact

- Layer changed: runtime app loading (`mozaiksai/core/runtime/app/loader.py`).
- Build workflow impact: none.
- Runtime/platform impact: invalid present subscription contracts fail startup instead of disabling enforcement.
- App workspace impact: apps shipping invalid contracts now surface the error at load; valid and absent contracts unchanged.
- Tests run: listed above.
- Docs updated: `docs/architecture/app/app-bundle-declaratives.md`, CHANGELOG.
- Compatibility risk: none for valid or absent configs; intentionally breaking only for configs that were already invalid.

Preferred independent reviewer: **Codex 2**, after the #471 review/integration completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)