### PR TITLE
fix(semantics): cold-verify compilation plans against canonical authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ This project follows a practical pre-1.0 changelog format:
 ## Unreleased
 
 ### Fixed
+
+- **CompilationPlans are now cold-verified against canonical authority before
+  they can authorize byte production or historical reuse**: a plan
+  self-digest proves body integrity, not truthful derivation — a caller
+  could mutate any derived plan fact (a unit's source footprint, disposition,
+  output path, validator, an emitted gap), recompute the digests, and pass a
+  structurally cold-valid forgery into `materialize_plan` or
+  `rematerialize_plan`. Both boundaries now re-derive the candidate from its
+  exact immutable authorities (graph, payload closure, layout registry, and
+  the same optional derivation inputs) through the single canonical
+  derivation function and require exact canonical equality, failing closed
+  with a finite typed `PlanAuthorityError` (`plan_body_invalid`,
+  `canonical_derivation_mismatch`, `required_authority_missing`).
+  Rematerialization additionally pins base-plan lineage (scope and graph
+  identity) and recomputes reuse classification itself; 5B composition can
+  accept the resulting `PlanAuthorityProof` and rejects one that does not
+  cover its plan.
+
 - **A present but invalid `config/subscriptions.yaml` now fails application
   loading instead of silently disabling entitlement enforcement**: AppLoader
   previously caught the subscription contract's load error, logged a warning,

--- a/mozaiksai/core/semantics/composition_ledger.py
+++ b/mozaiksai/core/semantics/composition_ledger.py
@@ -20,9 +20,8 @@ from mozaiksai.core.semantics.compilation_plan import (
 )
 from mozaiksai.core.semantics.materialization import MaterializedBundle, MaterializedOutput
 from mozaiksai.core.semantics.plan_authority import (
-    PlanAuthorityError,
-    PlanAuthorityMismatch,
     PlanAuthorityProof,
+    require_plan_authority_proof,
 )
 from mozaiksai.core.semantics.portable_path import validate_portable_path
 from mozaiksai.core.semantics.refs import CompilationPlanRef, PlanUnitRef, SemanticsModel
@@ -422,37 +421,28 @@ def compose_plan_artifacts(
     assignment_results: Iterable[AssignmentArtifactResult],
     materialized_bundle: MaterializedBundle,
     base_revision_digest: str | None,
+    plan_authority_proof: PlanAuthorityProof,
     base_plan: CompilationPlan | None = None,
     base_outputs: Iterable[MaterializedOutput] = (),
     regeneration_closure: RegenerationClosure | None = None,
-    plan_authority_proof: PlanAuthorityProof | None = None,
 ) -> CanonicalComposedBundle:
     """Compose all plan units without execution, persistence, or publication.
 
-    Composition consumes a ``MaterializedBundle`` whose plan digest is bound
-    to the plan; that bundle's canonical upstream gate
-    (``materialize_plan``/``rematerialize_plan``) verifies the plan against
-    its immutable authorities before any byte exists. This boundary cannot
-    re-derive the plan itself: composed plans legitimately carry
-    ``preserve_unowned`` units that greenfield derivation never selects, and
-    the brownfield base-input contract that would make them derivable is a
-    later, explicitly-identified authority. Callers that hold the plan's
-    authorities may pass the :class:`PlanAuthorityProof` produced by
-    ``validate_compilation_plan_against_authority``; when supplied it must
-    cover exactly this plan or composition fails closed.
+    Plan authority is mandatory: a validator-issued
+    :class:`PlanAuthorityProof` covering exactly this plan must be supplied,
+    and it is verified before any assignment result, preserved byte,
+    materialized output, or path is inspected. ``None`` and non-issued proof
+    documents fail closed. This boundary cannot re-derive the plan itself —
+    composed plans legitimately carry ``preserve_unowned`` units that
+    greenfield derivation never selects; the brownfield base-input contract
+    that would make them derivable is the explicitly identified future
+    authority, and until it exists the validator (or a test fixture
+    simulating that future authority through the private issuance seam) is
+    the only proof source.
     """
 
     verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
-    if plan_authority_proof is not None and not plan_authority_proof.covers(
-        verified_plan
-    ):
-        raise PlanAuthorityError(
-            PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH,
-            "supplied plan-authority proof does not cover the composed plan "
-            f"(proof {plan_authority_proof.plan_digest[:12]}, "
-            f"plan {verified_plan.plan_digest[:12]})",
-            plan_digest=verified_plan.plan_digest,
-        )
+    require_plan_authority_proof(plan_authority_proof, verified_plan)
     if verified_plan.gaps:
         raise ValueError("blocking CompilationPlan gaps prevent canonical composition")
     if materialized_bundle.plan_digest != verified_plan.plan_digest:

--- a/mozaiksai/core/semantics/composition_ledger.py
+++ b/mozaiksai/core/semantics/composition_ledger.py
@@ -19,6 +19,11 @@ from mozaiksai.core.semantics.compilation_plan import (
     RegenerationClosure,
 )
 from mozaiksai.core.semantics.materialization import MaterializedBundle, MaterializedOutput
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+    PlanAuthorityProof,
+)
 from mozaiksai.core.semantics.portable_path import validate_portable_path
 from mozaiksai.core.semantics.refs import CompilationPlanRef, PlanUnitRef, SemanticsModel
 from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
@@ -420,10 +425,34 @@ def compose_plan_artifacts(
     base_plan: CompilationPlan | None = None,
     base_outputs: Iterable[MaterializedOutput] = (),
     regeneration_closure: RegenerationClosure | None = None,
+    plan_authority_proof: PlanAuthorityProof | None = None,
 ) -> CanonicalComposedBundle:
-    """Compose all plan units without execution, persistence, or publication."""
+    """Compose all plan units without execution, persistence, or publication.
+
+    Composition consumes a ``MaterializedBundle`` whose plan digest is bound
+    to the plan; that bundle's canonical upstream gate
+    (``materialize_plan``/``rematerialize_plan``) verifies the plan against
+    its immutable authorities before any byte exists. This boundary cannot
+    re-derive the plan itself: composed plans legitimately carry
+    ``preserve_unowned`` units that greenfield derivation never selects, and
+    the brownfield base-input contract that would make them derivable is a
+    later, explicitly-identified authority. Callers that hold the plan's
+    authorities may pass the :class:`PlanAuthorityProof` produced by
+    ``validate_compilation_plan_against_authority``; when supplied it must
+    cover exactly this plan or composition fails closed.
+    """
 
     verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
+    if plan_authority_proof is not None and not plan_authority_proof.covers(
+        verified_plan
+    ):
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH,
+            "supplied plan-authority proof does not cover the composed plan "
+            f"(proof {plan_authority_proof.plan_digest[:12]}, "
+            f"plan {verified_plan.plan_digest[:12]})",
+            plan_digest=verified_plan.plan_digest,
+        )
     if verified_plan.gaps:
         raise ValueError("blocking CompilationPlan gaps prevent canonical composition")
     if materialized_bundle.plan_digest != verified_plan.plan_digest:

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -67,6 +67,7 @@ from mozaiksai.core.semantics.binding import (
 )
 from mozaiksai.core.semantics.compilation_plan import (
     CompilationPlan,
+    CompilationScopeSelection,
     FamilyInstancePlan,
     LayoutRegistrySnapshot,
     PlanDisposition,
@@ -81,6 +82,9 @@ from mozaiksai.core.semantics.payloads import (
     SectionPayload,
     SemanticPayloadBase,
     parse_semantic_payload,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    validate_compilation_plan_against_authority,
 )
 from mozaiksai.core.semantics.portable_path import detect_collisions
 
@@ -560,6 +564,8 @@ def materialize_plan(
     binding: ImplementationBinding,
     layout_registry: Any,
     preserved_artifacts: Iterable[PreservedOpaqueArtifact] = (),
+    scope_selection: CompilationScopeSelection | None = None,
+    structured_output_configs: Any = None,
 ) -> MaterializedBundle:
     """Materialize every plan-authorized output for one CompilationPlan.
 
@@ -569,6 +575,17 @@ def materialize_plan(
     explicitly. The registry snapshot identity must match the plan's pinned
     registry digest — a plan derived from a different registry fails closed.
     """
+    # A self-digest proves body integrity, not truthful derivation: the plan
+    # must equal its canonical rederivation from the supplied authorities
+    # before it may authorize any byte production.
+    validate_compilation_plan_against_authority(
+        plan,
+        graph=graph,
+        payloads=payloads,
+        registry=layout_registry,
+        scope_selection=scope_selection,
+        structured_output_configs=structured_output_configs,
+    )
     verified_plan, verified_graph, payload_by_node = _cold_validate(plan, graph, payloads)
     _assert_registry_identity(verified_plan, layout_registry)
     resolve_page_schema_renderer_selection(
@@ -634,6 +651,8 @@ def rematerialize_plan(
     binding: ImplementationBinding,
     layout_registry: Any,
     preserved_artifacts: Iterable[PreservedOpaqueArtifact] = (),
+    scope_selection: CompilationScopeSelection | None = None,
+    structured_output_configs: Any = None,
 ) -> MaterializedBundle:
     """Selectively rematerialize a successor plan against a base bundle.
 
@@ -644,6 +663,26 @@ def rematerialize_plan(
     """
     if base_bundle.plan_digest != base_plan.plan_digest:
         raise MaterializationError("base bundle does not correspond to the base plan")
+    # The successor plan authorizes every fresh byte and every reuse
+    # decision: verify it against canonical derivation before any
+    # historical output is consulted. The base plan authorities are not
+    # present at this boundary; the base is anchored by cold body
+    # validation, the exact digest tie to the base bundle, and
+    # same-scope/same-graph lineage, and the reuse classification is
+    # recomputed here from both plans, never taken from the caller.
+    validate_compilation_plan_against_authority(
+        successor_plan,
+        graph=graph,
+        payloads=payloads,
+        registry=layout_registry,
+        scope_selection=scope_selection,
+        structured_output_configs=structured_output_configs,
+    )
+    verified_base = CompilationPlan.model_validate(base_plan.model_dump(mode="json"))
+    if verified_base.scope != successor_plan.scope:
+        raise MaterializationError("base plan belongs to another execution scope")
+    if verified_base.graph_id != successor_plan.graph_id:
+        raise MaterializationError("base plan belongs to another application graph")
     closure = plan_regeneration_closure(base_plan, successor_plan)
     reusable_ids = set(closure.reusable)
 

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -36,7 +36,7 @@ base-input contract exists) may accept it in place of re-deriving.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
@@ -78,24 +78,97 @@ class PlanAuthorityError(ValueError):
         self.unit_id = unit_id
 
 
+class _IssuanceToken:
+    """Module-private issuance capability binding one exact plan digest.
+
+    TRUST MODEL — explicit and bounded: this is an in-process fail-closed API
+    contract, not cryptography. A ``PlanAuthorityProof`` is meaningful only
+    when its token was created by :func:`validate_compilation_plan_against_authority`
+    at issuance time for the exact digests the proof names. Ordinary callers
+    cannot obtain a token through any public path: proofs are not
+    serializable documents, ``dataclasses.replace`` keeps the original token
+    (whose bound digest then mismatches), and constructing ``_IssuanceToken``
+    requires reaching into this module's private namespace — which no
+    production module does (guard-tested). Test fixtures that must compose
+    not-yet-derivable brownfield plans may simulate the future base-input
+    authority through this private seam, and only there.
+    """
+
+    __slots__ = ("_plan_digest",)
+
+    def __init__(self, plan_digest: str) -> None:
+        self._plan_digest = plan_digest
+
+
 @dataclass(frozen=True)
 class PlanAuthorityProof:
     """Attestation that one exact plan was verified against exact authorities.
 
-    Produced only by :func:`validate_compilation_plan_against_authority`.
-    Immutable, scope-free of payload content, and valid only for the exact
-    plan digest it names — there is no ambient trusted-plan set and no TTL.
+    Issued only by :func:`validate_compilation_plan_against_authority` (or a
+    test fixture explicitly simulating a future authority through the private
+    issuance seam). Immutable, free of payload content, non-serializable, and
+    valid only for the exact plan/graph/registry/scope identity it names —
+    there is no ambient trusted-plan set and no TTL.
     """
 
     plan_digest: str
     graph_digest: str
     registry_digest: str
+    scope_key: str
+    issued_token: _IssuanceToken = field(repr=False, compare=False)
 
     def covers(self, plan: CompilationPlan) -> bool:
         return (
-            self.plan_digest == plan.plan_digest
+            isinstance(self.issued_token, _IssuanceToken)
+            and self.issued_token._plan_digest == self.plan_digest
+            and self.plan_digest == plan.plan_digest
             and self.graph_digest == plan.graph_digest
             and self.registry_digest == plan.registry_digest
+            and self.scope_key == _scope_key(plan)
+        )
+
+
+def _scope_key(plan: CompilationPlan) -> str:
+    scope = plan.scope
+    return "|".join(
+        str(getattr(scope, name, "") or "")
+        for name in ("tenant_id", "workspace_id", "pre_app_scope_id")
+    )
+
+
+def require_plan_authority_proof(
+    proof: PlanAuthorityProof | None, plan: CompilationPlan
+) -> None:
+    """Fail closed unless ``proof`` is a validator-issued proof for ``plan``.
+
+    ``None``, a foreign object, a proof whose token was not bound to its own
+    plan digest at issuance, or a proof for another plan/graph/registry/scope
+    all reject with the finite typed :class:`PlanAuthorityError` before any
+    downstream authority is exercised.
+    """
+    if proof is None or not isinstance(proof, PlanAuthorityProof):
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "a validator-issued PlanAuthorityProof is required; None or a "
+            "foreign object cannot authorize plan consumption",
+            plan_digest=getattr(plan, "plan_digest", None),
+        )
+    if (
+        not isinstance(proof.issued_token, _IssuanceToken)
+        or proof.issued_token._plan_digest != proof.plan_digest
+    ):
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "the supplied proof was not issued by the canonical validator "
+            "for the digests it names",
+            plan_digest=plan.plan_digest,
+        )
+    if not proof.covers(plan):
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH,
+            "the supplied proof does not cover this exact plan "
+            f"(proof {proof.plan_digest[:12]}, plan {plan.plan_digest[:12]})",
+            plan_digest=plan.plan_digest,
         )
 
 
@@ -201,6 +274,8 @@ def validate_compilation_plan_against_authority(
         plan_digest=canonical.plan_digest,
         graph_digest=canonical.graph_digest,
         registry_digest=canonical.registry_digest,
+        scope_key=_scope_key(canonical),
+        issued_token=_IssuanceToken(canonical.plan_digest),
     )
 
 
@@ -208,5 +283,6 @@ __all__ = [
     "PlanAuthorityError",
     "PlanAuthorityMismatch",
     "PlanAuthorityProof",
+    "require_plan_authority_proof",
     "validate_compilation_plan_against_authority",
 ]

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -1,0 +1,212 @@
+"""Canonical-authority validation for CompilationPlans (offline-only).
+
+A ``CompilationPlan`` self-digest proves body integrity: the digest matches
+the bytes the caller supplied. It does not prove the body was truthfully
+derived. A caller can mutate any derived plan fact — a unit's source
+footprint, disposition, output path, validator, an emitted gap — recompute
+the self-digest, and obtain a structurally cold-valid plan.
+
+This module establishes the one canonical validation rule closing that trust
+boundary: before a plan may authorize materialization, rematerialization,
+historical-output reuse, or composition, the candidate is re-derived from its
+exact immutable authorities — the semantic graph, the complete payload
+closure, the canonical layout registry, and the same optional derivation
+inputs (scope selection, structured-output configs) — through the ONE
+existing canonical derivation function, and compared for exact canonical
+equality. There is no second derivation implementation here and no partial
+field-by-field re-derivation: every execution-authorizing fact (units, source
+footprints, paths, dispositions, materializers, conditions, validators,
+assignment contracts, structured-output refs, dependencies, emitted gaps) is
+covered because the whole plan must match.
+
+Diagnostics versus authority: ``CompilationPlan.gaps`` is the literal emitted
+first-blocker set and IS execution authority — it is part of the compared
+canonical body. Latent/composite diagnostics live outside the plan (in
+``CompilationGapReport``) and never enter materialization or reuse, so they
+are not re-verified here.
+
+The returned :class:`PlanAuthorityProof` is a bounded in-process attestation
+that one exact plan digest was verified against one exact graph/registry
+identity. It carries no mutable state and no global cache; downstream offline
+boundaries that cannot hold the full authorities (5B composition, whose
+preserve-unowned inputs are not greenfield-derivable until the brownfield
+base-input contract exists) may accept it in place of re-deriving.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    CompilationScopeSelection,
+    derive_compilation_plan,
+)
+from mozaiksai.core.semantics.graph import SemanticGraphV2
+
+
+class PlanAuthorityMismatch(StrEnum):
+    """Finite typed categories of plan-authority failure."""
+
+    PLAN_BODY_INVALID = "plan_body_invalid"
+    CANONICAL_DERIVATION_MISMATCH = "canonical_derivation_mismatch"
+    REQUIRED_AUTHORITY_MISSING = "required_authority_missing"
+
+
+class PlanAuthorityError(ValueError):
+    """The candidate plan is not the canonical derivation of its authorities.
+
+    Carries deterministic audit identity only — category, plan digest, and
+    the first mismatching unit/gap identity where known. Never candidate
+    bodies, payload contents, or arbitrary metadata.
+    """
+
+    def __init__(
+        self,
+        category: PlanAuthorityMismatch,
+        message: str,
+        *,
+        plan_digest: str | None = None,
+        unit_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.plan_digest = plan_digest
+        self.unit_id = unit_id
+
+
+@dataclass(frozen=True)
+class PlanAuthorityProof:
+    """Attestation that one exact plan was verified against exact authorities.
+
+    Produced only by :func:`validate_compilation_plan_against_authority`.
+    Immutable, scope-free of payload content, and valid only for the exact
+    plan digest it names — there is no ambient trusted-plan set and no TTL.
+    """
+
+    plan_digest: str
+    graph_digest: str
+    registry_digest: str
+
+    def covers(self, plan: CompilationPlan) -> bool:
+        return (
+            self.plan_digest == plan.plan_digest
+            and self.graph_digest == plan.graph_digest
+            and self.registry_digest == plan.registry_digest
+        )
+
+
+def _first_difference(
+    candidate: CompilationPlan, canonical: CompilationPlan
+) -> tuple[str, str | None]:
+    """Locate the first authority difference for the audit identity."""
+    candidate_units = {unit.unit_id: unit for unit in candidate.units}
+    canonical_units = {unit.unit_id: unit for unit in canonical.units}
+    for unit_id in candidate_units.keys() - canonical_units.keys():
+        return ("unit not present in canonical derivation", unit_id)
+    for unit_id in canonical_units.keys() - candidate_units.keys():
+        return ("canonical unit missing from candidate", unit_id)
+    for unit_id, unit in candidate_units.items():
+        if unit.unit_digest != canonical_units[unit_id].unit_digest:
+            return ("unit body differs from canonical derivation", unit_id)
+    if len(candidate.units) != len(canonical.units):
+        return ("duplicate unit identity in candidate", None)
+    if [u.unit_id for u in candidate.units] != [u.unit_id for u in canonical.units]:
+        return ("unit ordering differs from canonical derivation", None)
+    candidate_gaps = [gap.model_dump(mode="json") for gap in candidate.gaps]
+    canonical_gaps = [gap.model_dump(mode="json") for gap in canonical.gaps]
+    if candidate_gaps != canonical_gaps:
+        return ("emitted gap set differs from canonical derivation", None)
+    return ("plan header differs from canonical derivation", None)
+
+
+def validate_compilation_plan_against_authority(
+    candidate: CompilationPlan,
+    *,
+    graph: SemanticGraphV2,
+    payloads: Any,
+    registry: Any,
+    scope_selection: CompilationScopeSelection | None = None,
+    structured_output_configs: Mapping[str, Any] | None = None,
+) -> PlanAuthorityProof:
+    """Verify a candidate plan is exactly its canonical derivation.
+
+    1. Cold-validate the candidate body (self-digest and structural closure).
+    2. Re-derive the canonical plan from the supplied immutable authorities
+       through :func:`derive_compilation_plan` — the single derivation
+       implementation; nothing is re-implemented here.
+    3. Require exact canonical equality. Any difference — an added, missing,
+       duplicated, or altered unit; a changed source footprint, path,
+       disposition, materializer, condition, validator, assignment kind,
+       structured-output ref, or dependency; a removed or fabricated emitted
+       gap; a header mutation — rejects before any output or historical
+       reuse is consulted.
+
+    The same optional derivation inputs the plan was created with must be
+    supplied (``scope_selection``, ``structured_output_configs``); they are
+    part of the plan's authority, and omitting them simply yields a canonical
+    mismatch for plans that required them.
+    """
+    if candidate is None:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "no candidate CompilationPlan was supplied",
+        )
+    if graph is None or registry is None:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "graph and registry authorities are required to verify a plan",
+            plan_digest=candidate.plan_digest,
+        )
+    try:
+        verified = CompilationPlan.model_validate(candidate.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.PLAN_BODY_INVALID,
+            f"candidate plan failed cold body validation: {exc}",
+            plan_digest=getattr(candidate, "plan_digest", None),
+        ) from exc
+    try:
+        canonical = derive_compilation_plan(
+            graph=graph,
+            payloads=payloads,
+            registry=registry,
+            scope_selection=scope_selection or CompilationScopeSelection(),
+            structured_output_configs=structured_output_configs,
+        )
+    except (TypeError, ValueError) as exc:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            f"canonical derivation failed for the supplied authorities: {exc}",
+            plan_digest=verified.plan_digest,
+        ) from exc
+    if (
+        verified.plan_digest != canonical.plan_digest
+        or verified.canonical_payload() != canonical.canonical_payload()
+    ):
+        detail, unit_id = _first_difference(verified, canonical)
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH,
+            "candidate plan is not the canonical derivation of its "
+            f"authorities: {detail} "
+            f"(candidate {verified.plan_digest[:12]}, "
+            f"canonical {canonical.plan_digest[:12]})",
+            plan_digest=verified.plan_digest,
+            unit_id=unit_id,
+        )
+    return PlanAuthorityProof(
+        plan_digest=canonical.plan_digest,
+        graph_digest=canonical.graph_digest,
+        registry_digest=canonical.registry_digest,
+    )
+
+
+__all__ = [
+    "PlanAuthorityError",
+    "PlanAuthorityMismatch",
+    "PlanAuthorityProof",
+    "validate_compilation_plan_against_authority",
+]

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import yaml
 
+from mozaiksai.core.semantics import plan_authority as _plan_authority
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.compilation_plan import (
     CompilationPlan,
@@ -20,6 +21,7 @@ from mozaiksai.core.semantics.materialization import (
     MaterializedOutput,
     _materialize_unit,
 )
+from mozaiksai.core.semantics.plan_authority import PlanAuthorityProof
 from mozaiksai.core.semantics.refs import (
     CompilationPlanRef,
     PlanUnitRef,
@@ -75,6 +77,25 @@ def _output(unit: FamilyInstancePlan, content: bytes, *, origin: str) -> Materia
 
 
 @lru_cache(maxsize=1)
+def issue_test_authority_proof(plan) -> PlanAuthorityProof:
+    """Issue a proof for a synthetic test plan through the PRIVATE seam.
+
+    These fixtures deliberately compose plans (preserve_unowned, fabricated
+    refinement units) that greenfield derivation cannot produce yet — the
+    brownfield base-input contract is the identified future authority. Until
+    it exists, tests simulate that authority by reaching into the
+    plan_authority module's private issuance token. No production module
+    references this seam (guard-tested in test_compilation_plan_authority).
+    """
+    return PlanAuthorityProof(
+        plan_digest=plan.plan_digest,
+        graph_digest=plan.graph_digest,
+        registry_digest=plan.registry_digest,
+        scope_key=_plan_authority._scope_key(plan),
+        issued_token=_plan_authority._IssuanceToken(plan.plan_digest),
+    )
+
+
 def composition_fixture() -> dict[str, object]:
     structured = yaml.safe_load(
         (ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml").read_text(
@@ -235,6 +256,7 @@ def composition_fixture() -> dict[str, object]:
         "payloads": payloads,
         "base": base,
         "successor": successor,
+        "plan_authority_proof": issue_test_authority_proof(successor),
         "closure": closure,
         "resolver": resolver,
         "assignments": assignments,

--- a/tests/slice_5c_revision_helpers.py
+++ b/tests/slice_5c_revision_helpers.py
@@ -36,6 +36,7 @@ from mozaiksai.core.workflow.structured_output_contracts import stable_digest
 from tests.slice_5b_composition_helpers import (
     composition_fixture,
     empty_assignment_set,
+    issue_test_authority_proof,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -95,6 +96,7 @@ def revision_fixture() -> dict[str, object]:
         assignments=empty_assignment_set(),
         assignment_results=(),
         materialized_bundle=materialized,
+        plan_authority_proof=issue_test_authority_proof(plan),
         base_revision_digest=None,
     )
     validators = tuple(
@@ -290,6 +292,7 @@ def executable_revision_fixture() -> dict[str, object]:
         assignments=assignments,
         assignment_results=(result,),
         materialized_bundle=materialized,
+        plan_authority_proof=issue_test_authority_proof(plan),
         base_revision_digest=None,
     )
     validators = tuple(

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -536,6 +536,10 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
         # Slice 5B offline composition consumes the aggregate plan only
         # after assignment/materialization output has been validated.
             Path("mozaiksai/core/semantics/composition_ledger.py"),
+            # Canonical-authority verifier: re-derives candidate plans through
+            # the one derivation function; offline-only, and this same scan
+            # proves no production module imports it.
+            Path("mozaiksai/core/semantics/plan_authority.py"),
             # Slice 5C offline immutable revision closure and persistence owner.
             Path("mozaiksai/core/semantics/artifact_revision.py"),
             Path("mozaiksai/core/artifacts/revision_store.py"),

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -431,25 +431,274 @@ def test_missing_authorities_fail_typed() -> None:
     assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
 
 
-def test_composition_rejects_a_non_covering_proof() -> None:
+# ---------------------------------------------------------------------------
+# Public composition boundary: plan authority is mandatory. Codex 3's exact
+# reproduction is preserved — an internally consistent forged plan (rejected
+# by the canonical validator) with the entire supporting chain publicly
+# recomputed (closure, resolver, assignments, result, bundle) must not be
+# composable, and no None/omitted/forged-proof path may exist.
+# ---------------------------------------------------------------------------
+
+
+def _forged_composition_scenario():
+    import dataclasses
+    from pathlib import Path as _Path
+
+    import yaml as _yaml
+
+    from mozaiksai.core.semantics.compilation_plan import (
+        plan_regeneration_closure,
+    )
+    from mozaiksai.core.semantics.refs import (
+        CompilationPlanRef,
+        PlanUnitRef,
+        SemanticPayloadRef,
+    )
+    from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+    from mozaiksai.core.workflow.assignment_artifacts import (
+        build_assignment_artifact_result,
+    )
+    from mozaiksai.core.workflow.plan_assignment_compiler import (
+        ApprovedAssignmentSpec,
+        ApprovedPlan,
+        compile_approved_plan,
+    )
+    from tests.slice_5b_composition_helpers import composition_fixture
+
+    root = _Path(__file__).resolve().parents[1]
+    structured = _yaml.safe_load(
+        (
+            root / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    fixture = composition_fixture()
+    successor = fixture["successor"]
+    base = fixture["base"]
+    base_ids = {u.unit_id for u in base.units}
+    unit = next(
+        u for u in successor.units if u.sources and u.unit_id not in base_ids
+    )
+    present = {s.node_id for s in unit.sources}
+    extra = next(p for p in fixture["payloads"] if p.node_id not in present)
+    document = successor.model_dump(mode="json")
+    payload = successor.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        for u in doc["units"]:
+            if u["unit_id"] == unit.unit_id:
+                u["sources"] = sorted(
+                    list(u["sources"])
+                    + [
+                        {
+                            "node_id": extra.node_id,
+                            "payload_digest": extra.payload_digest,
+                        }
+                    ],
+                    key=lambda s: s["node_id"],
+                )
+    document["plan_digest"] = canonical_digest(payload)
+    forged = CompilationPlan.model_validate(document)
+
+    resolver = SemanticReferenceResolver()
+    for item in fixture["payloads"]:
+        resolver.register_semantic_payload(item)
+    resolver.register_semantic_graph_v2(fixture["graph"])
+    resolver.register_compilation_plan(base)
+    resolver.register_compilation_plan(forged)
+
+    agent = next(
+        u for u in forged.units if u.disposition.value == "agent_author"
+    )
+    plan_ref = CompilationPlanRef(
+        subject_id=forged.graph_id,
+        subject_version=forged.graph_version,
+        content_digest=forged.plan_digest,
+        scope=forged.scope,
+    )
+    unit_ref = PlanUnitRef(
+        compilation_plan_ref=plan_ref,
+        unit_id=agent.unit_id,
+        unit_digest=agent.unit_digest,
+    )
+    payload_by_id = {p.node_id: p for p in fixture["payloads"]}
+    source_refs = tuple(
+        SemanticPayloadRef(
+            node_id=s.node_id,
+            payload_kind=payload_by_id[s.node_id].payload_kind.value,
+            payload_version=payload_by_id[s.node_id].payload_version,
+            content_digest=s.payload_digest,
+            scope=forged.scope,
+        )
+        for s in agent.sources
+    )
+    assignments = compile_approved_plan(
+        ApprovedPlan(
+            assignments=(
+                ApprovedAssignmentSpec(
+                    plan_unit_ref=unit_ref,
+                    assignment_kind=agent.assignment_kind,
+                    dependency_context_refs=source_refs,
+                    required_structured_output_ref=(
+                        agent.required_structured_output_ref
+                    ),
+                    required_validators=(agent.validator,),
+                    assignment_retry_limit=2,
+                    base_revision_digest=fixture["base_revision_digest"],
+                ),
+            )
+        ),
+        resolver=resolver,
+        structured_output_configs={"AppGenerator": structured},
+    )
+    helper_source = "def report_hook():\n    return None\n"
+    result = build_assignment_artifact_result(
+        assignment=assignments.ordered_assignments[0],
+        structured_output={
+            "assignment_kind": "module_helper_implementation",
+            "module_id": "reports",
+            "helper_id": "report_hook",
+            "helper_source": helper_source,
+        },
+        artifacts={"modules/reports/backend/report_hook.py": helper_source},
+        structured_output_configs={"AppGenerator": structured},
+        validator_runner=lambda _validator, files: bool(files),
+    )
+    bundle = dataclasses.replace(
+        fixture["materialized"], plan_digest=forged.plan_digest
+    )
+    return {
+        "fixture": fixture,
+        "forged": forged,
+        "resolver": resolver,
+        "assignments": assignments,
+        "result": result,
+        "bundle": bundle,
+        "closure": plan_regeneration_closure(base, forged),
+    }
+
+
+def _compose_forged(scenario, proof):
     from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
 
-    graph, payloads, plan = _authority()
-    wrong = PlanAuthorityProof(
-        plan_digest="a" * 64,
-        graph_digest=plan.graph_digest,
-        registry_digest=plan.registry_digest,
+    return compose_plan_artifacts(
+        plan=scenario["forged"],
+        resolver=scenario["resolver"],
+        assignments=scenario["assignments"],
+        assignment_results=(scenario["result"],),
+        materialized_bundle=scenario["bundle"],
+        plan_authority_proof=proof,
+        base_revision_digest=scenario["fixture"]["base_revision_digest"],
+        base_plan=scenario["fixture"]["base"],
+        base_outputs=scenario["fixture"]["base_outputs"],
+        regeneration_closure=scenario["closure"],
+    )
+
+
+def test_codex3_public_composition_forgery_is_rejected() -> None:
+    """Preserved reproduction: the internally consistent forged plan whose
+    supporting chain was fully recomputed through public APIs cannot compose —
+    proof=None fails typed, and no validator will issue a covering proof."""
+    scenario = _forged_composition_scenario()
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        _compose_forged(scenario, None)
+    assert (
+        excinfo.value.category
+        is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+    )
+
+
+def test_composition_requires_the_proof_argument_entirely() -> None:
+    from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
+
+    scenario = _forged_composition_scenario()
+    with pytest.raises(TypeError):
+        compose_plan_artifacts(
+            plan=scenario["forged"],
+            resolver=scenario["resolver"],
+            assignments=scenario["assignments"],
+            assignment_results=(scenario["result"],),
+            materialized_bundle=scenario["bundle"],
+            base_revision_digest=scenario["fixture"]["base_revision_digest"],
+            base_plan=scenario["fixture"]["base"],
+            base_outputs=scenario["fixture"]["base_outputs"],
+            regeneration_closure=scenario["closure"],
+        )
+
+
+def test_forged_or_foreign_proofs_cannot_authorize_composition() -> None:
+    import dataclasses
+
+
+    scenario = _forged_composition_scenario()
+    forged = scenario["forged"]
+    honest = scenario["fixture"]["plan_authority_proof"]
+    # proof for another plan (the honest successor) does not cover the forgery
+    with pytest.raises(PlanAuthorityError):
+        _compose_forged(scenario, honest)
+    # dataclasses.replace with substituted digests keeps the original token,
+    # whose issuance-bound digest then mismatches — rejected as non-issued
+    replaced = dataclasses.replace(
+        honest,
+        plan_digest=forged.plan_digest,
+        graph_digest=forged.graph_digest,
+        registry_digest=forged.registry_digest,
+    )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        _compose_forged(scenario, replaced)
+    assert (
+        excinfo.value.category
+        is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+    )
+    # direct public construction cannot mint a token
+    with pytest.raises(TypeError):
+        PlanAuthorityProof(
+            plan_digest=forged.plan_digest,
+            graph_digest=forged.graph_digest,
+            registry_digest=forged.registry_digest,
+            scope_key="tenant1|ws1|",
+        )
+    # a caller-created token-shaped object is a foreign object
+    class _FakeToken:
+        _plan_digest = forged.plan_digest
+
+    fake = PlanAuthorityProof(
+        plan_digest=forged.plan_digest,
+        graph_digest=forged.graph_digest,
+        registry_digest=forged.registry_digest,
+        scope_key="tenant1|ws1|",
+        issued_token=_FakeToken(),
     )
     with pytest.raises(PlanAuthorityError):
-        compose_plan_artifacts(
-            plan=plan,
-            resolver=None,  # rejected before any resolver use
-            assignments=None,
-            assignment_results=(),
-            materialized_bundle=None,
-            base_revision_digest=None,
-            plan_authority_proof=wrong,
-        )
+        _compose_forged(scenario, fake)
+    # proofs are not serializable documents: no pydantic surface exists
+    assert not hasattr(PlanAuthorityProof, "model_validate")
+    # a wrong-scope proof for an identical body does not cover the plan
+    graph, payloads, plan = _authority()
+    issued = validate_compilation_plan_against_authority(
+        plan, graph=graph, payloads=payloads, registry=_registry()
+    )
+    wrong_scope = dataclasses.replace(issued, scope_key="other|scope|")
+    from mozaiksai.core.semantics.plan_authority import (
+        require_plan_authority_proof,
+    )
+
+    with pytest.raises(PlanAuthorityError):
+        require_plan_authority_proof(wrong_scope, plan)
+    # the untouched validator-issued proof covers its exact plan
+    require_plan_authority_proof(issued, plan)
+
+
+def test_no_production_module_reaches_the_private_issuance_seam() -> None:
+    from pathlib import Path as _Path
+
+    root = _Path(__file__).resolve().parents[1]
+    offenders = []
+    for base_dir in ("mozaiksai", "factory_app"):
+        for path in (root / base_dir).rglob("*.py"):
+            if path.name == "plan_authority.py":
+                continue
+            if "_IssuanceToken" in path.read_text(encoding="utf-8"):
+                offenders.append(str(path.relative_to(root)))
+    assert offenders == []
 
 
 def test_base_plan_foreign_scope_and_graph_are_rejected() -> None:

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -1,0 +1,494 @@
+"""Canonical-authority validation proofs for CompilationPlans.
+
+A plan self-digest proves body integrity, not truthful derivation: a caller
+can mutate any derived plan fact, recompute the self-digest, and obtain a
+structurally cold-valid plan. These proofs pin the closing rule — before a
+plan authorizes materialization, rematerialization, or historical reuse, it
+must equal its exact canonical rederivation from immutable authorities — and
+attack every execution-authorizing field class.
+
+Codex 2's original generic reproduction is preserved first: an unrelated but
+valid same-graph payload source added to one unit, digests recomputed, cold
+model validation accepting the forgery.
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from collections.abc import Callable
+
+import pytest
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    derive_compilation_plan,
+)
+from mozaiksai.core.semantics.materialization import (
+    MaterializationError,
+    materialize_plan,
+    rematerialize_plan,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+    PlanAuthorityProof,
+    validate_compilation_plan_against_authority,
+)
+from tests.test_deterministic_page_materialization import (
+    _binding,
+    _build,
+    _registry,
+    _source,
+)
+
+
+def _authority():
+    result, plan = _build(_source())
+    return result.graph, result.payloads, plan
+
+
+def _forge(plan: CompilationPlan, mutate: Callable[[dict], None]) -> CompilationPlan:
+    """Apply one mutation and recompute the outer self-digest.
+
+    The result passes cold model validation whenever the mutation is
+    structurally expressible — exactly the forgery class the authority
+    verifier must reject.
+    """
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    mutate(document)
+    mutate(payload)
+    document["plan_digest"] = canonical_digest(payload)
+    return CompilationPlan.model_validate(document)
+
+
+def _render_unit_index(document: dict) -> int:
+    return next(
+        index
+        for index, unit in enumerate(document["units"])
+        if unit["disposition"] == "render" and unit["sources"]
+    )
+
+
+def _extra_source(graph, payloads, plan):
+    unit = next(u for u in plan.units if u.disposition.value == "render" and u.sources)
+    present = {s.node_id for s in unit.sources}
+    extra = next(p for p in payloads if p.node_id not in present)
+
+    def mutate(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["sources"] = sorted(
+            list(document["units"][index]["sources"])
+            + [{"node_id": extra.node_id, "payload_digest": extra.payload_digest}],
+            key=lambda s: s["node_id"],
+        )
+
+    return mutate
+
+
+def test_codex2_generic_extra_source_forgery_is_preserved_and_rejected() -> None:
+    """The exact reproduction: cold model validation accepts the forgery;
+    canonical-authority validation rejects it before any consumer trusts the
+    forged footprint."""
+    graph, payloads, plan = _authority()
+    forged = _forge(plan, _extra_source(graph, payloads, plan))
+    # cold model path accepts the recomputed self-digest — body integrity only
+    assert (
+        CompilationPlan.model_validate(forged.model_dump(mode="json")).plan_digest
+        == forged.plan_digest
+    )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(
+            forged, graph=graph, payloads=payloads, registry=_registry()
+        )
+    assert (
+        excinfo.value.category is PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH
+    )
+    assert excinfo.value.unit_id is not None
+
+
+def _mutations(graph, payloads, plan):
+    unit = next(u for u in plan.units if u.disposition.value == "render" and u.sources)
+    other_kind = next(
+        p for p in payloads if p.node_id not in {s.node_id for s in unit.sources}
+    )
+
+    def drop_source(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["sources"] = list(
+            document["units"][index]["sources"]
+        )[:-1]
+
+    def substitute_source(document: dict) -> None:
+        index = _render_unit_index(document)
+        sources = list(document["units"][index]["sources"])
+        sources[0] = {
+            "node_id": other_kind.node_id,
+            "payload_digest": other_kind.payload_digest,
+        }
+        document["units"][index]["sources"] = sorted(
+            sources, key=lambda s: s["node_id"]
+        )
+
+    def stale_digest(document: dict) -> None:
+        index = _render_unit_index(document)
+        sources = [dict(s) for s in document["units"][index]["sources"]]
+        sources[0]["payload_digest"] = "f" * 64
+        document["units"][index]["sources"] = sources
+
+    def extra_edge(document: dict) -> None:
+        index = _render_unit_index(document)
+        edges = [dict(e) for e in document["units"][index]["edge_sources"]]
+        forged_edge = dict(edges[0])
+        forged_edge["target_node_id"] = other_kind.node_id
+        forged_edge["edge_identity"] = "a" * 64
+        document["units"][index]["edge_sources"] = edges + [forged_edge]
+
+    def missing_edge(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["edge_sources"] = list(
+            document["units"][index]["edge_sources"]
+        )[:-1]
+
+    def changed_output_path(document: dict) -> None:
+        index = _render_unit_index(document)
+        outputs = [dict(o) for o in document["units"][index]["outputs"]]
+        outputs[0]["path"] = "ui/pages/hijacked.yaml"
+        document["units"][index]["outputs"] = outputs
+
+    def changed_path_scope(document: dict) -> None:
+        index = _render_unit_index(document)
+        outputs = [dict(o) for o in document["units"][index]["outputs"]]
+        outputs[0]["path_scope"] = "workspace_root"
+        document["units"][index]["outputs"] = outputs
+
+    def changed_disposition(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["disposition"] = "external_handoff"
+
+    def disposition_inapplicable(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["disposition"] = "inapplicable"
+
+    def changed_materializer(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["materializer"] = "app_generator"
+
+    def changed_validator(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["validator"] = "app_paths"
+
+    def changed_assignment(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["assignment_kind"] = "page_bundle"
+
+    def changed_dependency(document: dict) -> None:
+        index = _render_unit_index(document)
+        other = next(
+            u["unit_id"]
+            for i, u in enumerate(document["units"])
+            if i != index
+        )
+        document["units"][index]["depends_on_units"] = [other]
+
+    def removed_unit(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"] = [
+            u for i, u in enumerate(document["units"]) if i != index
+        ]
+
+    def added_unit(document: dict) -> None:
+        index = _render_unit_index(document)
+        clone = copy.deepcopy(document["units"][index])
+        clone["unit_id"] = clone["unit_id"] + "_forged"
+        document["units"] = list(document["units"]) + [clone]
+
+    def removed_gap(document: dict) -> None:
+        document["gaps"] = list(document["gaps"])[:-1]
+
+    def fake_gap(document: dict) -> None:
+        fake = copy.deepcopy(document["gaps"][0])
+        fake["family_kind"] = "app_dashboard"
+        fake["path_template"] = "dashboard/dashboard.yaml"
+        document["gaps"] = list(document["gaps"]) + [fake]
+
+    return {
+        "missing-source": drop_source,
+        "substituted-source": substitute_source,
+        "stale-source-digest": stale_digest,
+        "extra-edge": extra_edge,
+        "missing-edge": missing_edge,
+        "changed-output-path": changed_output_path,
+        "changed-path-scope": changed_path_scope,
+        "disposition-external-handoff": changed_disposition,
+        "disposition-inapplicable": disposition_inapplicable,
+        "changed-materializer": changed_materializer,
+        "changed-validator": changed_validator,
+        "changed-assignment-kind": changed_assignment,
+        "changed-dependency": changed_dependency,
+        "removed-unit": removed_unit,
+        "added-unit": added_unit,
+        "removed-emitted-gap": removed_gap,
+        "fake-emitted-gap": fake_gap,
+    }
+
+
+_MUTATION_IDS = [
+    "missing-source",
+    "substituted-source",
+    "stale-source-digest",
+    "extra-edge",
+    "missing-edge",
+    "changed-output-path",
+    "changed-path-scope",
+    "disposition-external-handoff",
+    "disposition-inapplicable",
+    "changed-materializer",
+    "changed-validator",
+    "changed-assignment-kind",
+    "changed-dependency",
+    "removed-unit",
+    "added-unit",
+    "removed-emitted-gap",
+    "fake-emitted-gap",
+]
+
+
+@pytest.mark.parametrize("mutation_id", _MUTATION_IDS)
+def test_every_forged_plan_fact_is_rejected(mutation_id) -> None:
+    """Every execution-authorizing fact class: forge, recompute self-digests,
+    and prove the authority verifier rejects the candidate — or the body
+    contract itself refuses to express the forgery (also fail-closed)."""
+    graph, payloads, plan = _authority()
+    mutate = _mutations(graph, payloads, plan)[mutation_id]
+    try:
+        forged = _forge(plan, mutate)
+    except (ValueError, TypeError):
+        return  # structurally inexpressible: the body contract already refuses
+    assert forged.plan_digest != plan.plan_digest
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(
+            forged, graph=graph, payloads=payloads, registry=_registry()
+        )
+
+
+def test_changed_structured_output_ref_is_rejected() -> None:
+    from pathlib import Path as _Path
+
+    import yaml as _yaml
+
+    root = _Path(__file__).resolve().parents[1]
+    configs = {
+        "AppGenerator": _yaml.safe_load(
+            (
+                root / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+            ).read_text(encoding="utf-8")
+        )
+    }
+    from mozaiksai.core.semantics.offline_projection import (  # noqa: F401
+        project_semantic_graph,
+    )
+    from tests.test_deterministic_page_materialization import (
+        _build as _build_4c,
+    )
+    from tests.test_deterministic_page_materialization import (
+        _source as _source_4c,
+    )
+
+    result, _ = _build_4c(_source_4c())
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    if not any(u.required_structured_output_ref is not None for u in plan.units):
+        pytest.skip("corpus produced no structured-output refs")
+
+    def swap_ref(document: dict) -> None:
+        refs = [
+            unit["required_structured_output_ref"]
+            for unit in document["units"]
+            if unit.get("required_structured_output_ref") is not None
+        ]
+        distinct = [r for r in refs if r != refs[0]]
+        if not distinct:
+            pytest.skip("corpus produced a single structured-output ref")
+        for unit in document["units"]:
+            if unit.get("required_structured_output_ref") == refs[0]:
+                unit["required_structured_output_ref"] = distinct[0]
+                return
+
+    # Either the body contract refuses the substitution outright, or the
+    # authority verifier rejects the cold-valid forgery — both fail closed.
+    try:
+        forged = _forge(plan, swap_ref)
+    except (ValueError, TypeError):
+        forged = None
+    if forged is not None:
+        with pytest.raises(PlanAuthorityError):
+            validate_compilation_plan_against_authority(
+                forged,
+                graph=result.graph,
+                payloads=result.payloads,
+                registry=_registry(),
+                structured_output_configs=configs,
+            )
+    # the same authorities WITH configs accept the honest plan
+    proof = validate_compilation_plan_against_authority(
+        plan,
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    assert proof.covers(plan)
+
+
+def test_materialize_plan_rejects_forged_plan_before_bytes() -> None:
+    graph, payloads, plan = _authority()
+    forged = _forge(plan, _extra_source(graph, payloads, plan))
+    with pytest.raises(PlanAuthorityError):
+        materialize_plan(
+            plan=forged,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=_registry(),
+        )
+
+
+def test_rematerialize_plan_rejects_forged_successor_before_reuse() -> None:
+    graph, payloads, plan = _authority()
+    base_bundle = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=_registry(),
+    )
+    forged = _forge(plan, _extra_source(graph, payloads, plan))
+    with pytest.raises(MaterializationError):
+        rematerialize_plan(
+            base_bundle=base_bundle,
+            base_plan=forged,  # wrong base digest: bundle tie rejects first
+            successor_plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=_registry(),
+        )
+    with pytest.raises(PlanAuthorityError):
+        rematerialize_plan(
+            base_bundle=base_bundle,
+            base_plan=plan,
+            successor_plan=forged,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=_registry(),
+        )
+
+
+def test_foreign_graph_plan_and_shuffled_authorities() -> None:
+    graph, payloads, plan = _authority()
+    other_result, other_plan = _build(_source(column_label="Order Number"))
+    # foreign plan against these authorities: canonical mismatch
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(
+            other_plan, graph=graph, payloads=payloads, registry=_registry()
+        )
+    # shuffled raw authority input derives the same canonical plan
+    proof = validate_compilation_plan_against_authority(
+        plan,
+        graph=graph,
+        payloads=tuple(reversed(tuple(payloads))),
+        registry=_registry(),
+    )
+    assert proof.covers(plan)
+
+
+def test_exact_canonical_plan_is_accepted_with_proof() -> None:
+    graph, payloads, plan = _authority()
+    proof = validate_compilation_plan_against_authority(
+        plan, graph=graph, payloads=payloads, registry=_registry()
+    )
+    assert proof.covers(plan)
+    assert proof.plan_digest == plan.plan_digest
+    assert not proof.covers(
+        _forge(plan, _extra_source(graph, payloads, plan))
+    )
+
+
+def test_missing_authorities_fail_typed() -> None:
+    graph, payloads, plan = _authority()
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(
+            plan, graph=None, payloads=payloads, registry=_registry()
+        )
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+
+
+def test_composition_rejects_a_non_covering_proof() -> None:
+    from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
+
+    graph, payloads, plan = _authority()
+    wrong = PlanAuthorityProof(
+        plan_digest="a" * 64,
+        graph_digest=plan.graph_digest,
+        registry_digest=plan.registry_digest,
+    )
+    with pytest.raises(PlanAuthorityError):
+        compose_plan_artifacts(
+            plan=plan,
+            resolver=None,  # rejected before any resolver use
+            assignments=None,
+            assignment_results=(),
+            materialized_bundle=None,
+            base_revision_digest=None,
+            plan_authority_proof=wrong,
+        )
+
+
+def test_base_plan_foreign_scope_and_graph_are_rejected() -> None:
+    graph, payloads, plan = _authority()
+    bundle = materialize_plan(
+        plan=plan,
+        graph=graph,
+        payloads=payloads,
+        binding=_binding(graph),
+        layout_registry=_registry(),
+    )
+    other_result, other_plan = _build(_source(), graph_id="slice4c_other")
+    forged_base = other_plan.model_copy(
+        update={"plan_digest": plan.plan_digest}
+    )
+    with pytest.raises((MaterializationError, ValueError)):
+        rematerialize_plan(
+            base_bundle=bundle,
+            base_plan=forged_base,
+            successor_plan=plan,
+            graph=graph,
+            payloads=payloads,
+            binding=_binding(graph),
+            layout_registry=_registry(),
+        )
+
+
+def test_verification_is_deterministic_and_bounded() -> None:
+    """Determinism and a coarse performance record for the representative
+    corpus: repeated verification yields identical proofs; duration is
+    recorded, not asserted against a brittle budget."""
+    graph, payloads, plan = _authority()
+    start = time.perf_counter()
+    first = validate_compilation_plan_against_authority(
+        plan, graph=graph, payloads=payloads, registry=_registry()
+    )
+    second = validate_compilation_plan_against_authority(
+        plan, graph=graph, payloads=payloads, registry=_registry()
+    )
+    elapsed = time.perf_counter() - start
+    assert first == second
+    assert elapsed < 60  # offline compiler boundary; generous ceiling only

--- a/tests/test_composition_ledger.py
+++ b/tests/test_composition_ledger.py
@@ -23,6 +23,7 @@ def _compose(**updates):
         "assignments": fixture["assignments"],
         "assignment_results": (fixture["result"],),
         "materialized_bundle": fixture["materialized"],
+        "plan_authority_proof": fixture["plan_authority_proof"],
         "base_revision_digest": fixture["base_revision_digest"],
         "base_plan": fixture["base"],
         "base_outputs": fixture["base_outputs"],

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -518,7 +518,9 @@ def test_registry_identity_mismatch_is_rejected() -> None:
 
     snapshot = snapshot_layout_registry(extended)
     forged = snapshot.model_copy(update={"snapshot_digest": "a" * 64})
-    with pytest.raises(MaterializationError):
+    from mozaiksai.core.semantics.plan_authority import PlanAuthorityError
+
+    with pytest.raises((MaterializationError, PlanAuthorityError)):
         materialize_plan(
             plan=plan,
             graph=result.graph,

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -129,6 +129,11 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # Slice 5A: the replacement assignment compiler is an explicitly
         # offline substrate consumer of pinned payload and plan-unit refs.
         Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),
+        # Canonical plan-authority verifier: consumes the graph authority as
+        # an input type and re-derives plans through the one canonical
+        # derivation function. Offline-only; its production non-importability
+        # is proven by the hygiene scan in tests/test_compilation_plan.py.
+        Path("mozaiksai/core/semantics/plan_authority.py"),
         # Slice 5C: the immutable revision store cold-validates the complete
         # graph/plan closure before accepting or restoring application state.
         # Its production non-importability is proven by the Slice 5C guard.

--- a/tests/test_slice_5b_offline_golden.py
+++ b/tests/test_slice_5b_offline_golden.py
@@ -15,6 +15,7 @@ def test_offline_executable_artifact_composition_golden(tmp_path: Path) -> None:
         assignments=fixture["assignments"],
         assignment_results=(fixture["result"],),
         materialized_bundle=fixture["materialized"],
+        plan_authority_proof=fixture["plan_authority_proof"],
         base_revision_digest=fixture["base_revision_digest"],
         base_plan=fixture["base"],
         base_outputs=fixture["base_outputs"],


### PR DESCRIPTION
## Cold-verify CompilationPlans against canonical authority

**Classification: MOZAIKS_OSS — application compiler integrity.** Prerequisite PR from exact main `553b40db`, independent of frozen #471 (nothing imported or cherry-picked from it; provable on current-main plan families).

### The defect (reproduced verbatim on main, preserved as a regression)

A `CompilationPlan` self-digest proves body integrity, not truthful derivation. The committed reproduction takes a canonical 4C plan, adds one **unrelated but valid same-graph payload source** to a render unit's footprint, recomputes the unit and plan digests, and:

- cold model validation **accepts** the forged plan;
- `materialize_plan` **accepts** it and renders bytes — the unrelated source becomes hidden provenance/invalidation authority.

The same class covers removed/substituted sources, flipped dispositions, redirected output paths, swapped validators/materializers/assignment kinds/structured-output refs/dependencies, forged edge sources, added/removed units, and removed/fabricated emitted gaps — every one expressible with correct self-digests.

### The canonical validation rule

`validate_compilation_plan_against_authority` (`mozaiksai/core/semantics/plan_authority.py`):

1. cold-validate the candidate body;
2. **re-derive the canonical plan from the exact immutable authorities** — graph, complete payload closure, canonical layout registry, and the same optional derivation inputs (`scope_selection`, `structured_output_configs`) — through the one existing `derive_compilation_plan` implementation (no second derivation of footprints, conditions, paths, assignments, or gaps);
3. require **exact canonical equality** before any output or historical reuse is consulted.

Failures are one finite typed `PlanAuthorityError` — `plan_body_invalid` / `canonical_derivation_mismatch` / `required_authority_missing` — carrying audit identity only (plan digest, first mismatching unit id, category); never candidate bodies or payload contents.

**Identity vs diagnostics**: `CompilationPlan.gaps` is the emitted first-blocker set and is execution authority — compared exactly. Latent/composite diagnostics live outside the plan (`CompilationGapReport`) and never enter materialization or reuse.

### Wiring

- **`materialize_plan`** and **`rematerialize_plan`** validate before any byte production or reuse. Both gained the two missing authoritative inputs (`scope_selection`, `structured_output_configs`) identified at their boundaries, so config-derived plans stay verifiable.
- **Rematerialization**: the successor plan is fully verified; the base plan is cold-body-validated, pinned to the base bundle by exact digest tie, lineage-checked (same scope, same graph identity), and reuse classification is recomputed from both plans — never taken from the caller. Reused bytes still re-verify their content digests.
- **5B `compose_plan_artifacts`**: plan authority is **mandatory** — `plan_authority_proof: PlanAuthorityProof` is a required keyword with no default; `None` and non-issued proof documents fail typed **before** any assignment result, preserved byte, output, or path is inspected. There is no wrapper, overload, or helper that supplies `None`.
- **Proof issuance/trust model** (explicit, in-process, not cryptographic): a proof is meaningful only when issued by `validate_compilation_plan_against_authority` — issuance binds a module-private token to the exact plan digest, and `require_plan_authority_proof` verifies token binding plus exact plan/graph/registry/**scope** coverage. Direct public construction cannot mint a token; proofs are not serializable documents; `dataclasses.replace` keeps the original token whose bound digest then mismatches; a caller-created token-shaped object is rejected as foreign. Full rederivation at composition is architecturally impossible today (composed plans legitimately carry `preserve_unowned` units greenfield derivation never selects — the identified missing authority is the future brownfield base-input contract); until it exists, test fixtures composing such plans simulate that future authority through the private issuance seam, and a guard test proves no production module reaches it. 5C revision persistence consumes the composed bundle through this chain (ledger/digest closure over the proof-gated composition).
- No mutable global cache, no memoization, no TTL, no ambient trusted-plan set. Verification is deterministic across runs (tested) and adds one derivation per boundary call on this offline path (~seconds on the representative corpus, generous ceiling asserted only).

### Proofs

`tests/test_compilation_plan_authority.py` — 30 tests: the preserved generic reproduction; a 17-case forged-field matrix (sources, edges, paths, scopes, dispositions, materializers, validators, assignment kinds, dependencies, unit add/remove, gap remove/fabricate — every candidate with correct self-digests); structured-output-ref substitution under configs; `materialize_plan` rejection before bytes; `rematerialize_plan` rejection before reuse plus base-lineage attacks; foreign-graph plan rejection; shuffled-authority equivalence; exact-canonical acceptance with proof coverage; missing-authority typed failure; composition proof-mismatch rejection; determinism/perf record; Codex 3's preserved public-composition reproduction (forged plan + fully recomputed public chain: closure, resolver, recompiled assignments, rebuilt result, re-tied bundle) rejected typed with proof omitted/None/foreign/replaced; private-seam guard.

Full suite: 14,317 passed / 0 failed; focused battery 245 passed (post-correction) plus the original 417 across CompilationPlan/registry/graph/binding/4C/5A/5B/5C/materialization/composition/revision-store/production-guard suites; ruff, scoped mypy, strict MkDocs, `git diff --check` clean.

### Boundaries

No production AppGenerator wiring (AppBuildPlan remains production authority — guard suites re-run green). No AG2 Agent/Task/Resume/Channel/Envelope, no event system, no provider/model IDs, no prompts, no mobile, no evidence/evaluation, no hosted state. #471 remains frozen and untouched.

Do not merge — draft for independent exact-head review (reviewer: **Codex 3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
