### PR TITLE
fix(artifacts): establish exact run-bound build persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ This project follows a practical pre-1.0 changelog format:
 ## Unreleased
 
 ### Fixed
+- **Build persistence now records the exact run-to-build relation**: the
+  BuildRecord store enforces its complete index contract before becoming
+  available — retired indexes are dropped only when their full historical
+  definition matches (a same-name index with any other definition fails the
+  store closed), and a partial unique index makes at-most-one CURRENT record
+  per app/family/key storage-enforced with a typed
+  `BuildRecordCurrentConflictError` on concurrent publishes. Every
+  BuildRecord persists the immutable `workflow_run_id`/`build_id` it was
+  created for; a new sealed `RunBuildBinding` (digest-signed, server-owned)
+  captures the exact relation the moment a run establishes its build, and
+  cold verification resolves the persisted records and requires agreement on
+  run, build, app, family/key, version, and bundle digest — chat/session
+  "latest build" fields are never run-to-build authority. Greenfield bundles
+  are created DRAFT and promoted to CURRENT only after the required
+  AppContextVersion lineage registers, and terminal outcomes are strict
+  closed variants: success, revision candidate, build failure with an exact
+  build, or a run-level `WorkflowRunFailure` for runs that failed before
+  establishing any build — no failure ever fabricates a build identity. The
+  run identity, binding, and terminal receipt are server-owned session
+  fields writable only through the privileged persistence seam; generic
+  workflow context updates that try to set them are rejected and logged.
+  Lifecycle event emission is unchanged in this release and cuts over to
+  this authority in a follow-up.
+
 - **A present but invalid `config/subscriptions.yaml` now fails application
   loading instead of silently disabling entitlement enforcement**: AppLoader
   previously caught the subscription contract's load error, logged a warning,

--- a/factory_app/refinement_harness/tools/get_stale_artifact_families.py
+++ b/factory_app/refinement_harness/tools/get_stale_artifact_families.py
@@ -33,7 +33,7 @@ async def get_stale_artifact_families(
         return {"stale_families": [], "all_current": True}
 
     store = artifact_store or get_artifact_store()
-    stale = await store.get_stale_artifact_families(app_id=app_id)
+    stale = await store.get_stale_build_families(app_id=app_id)
     return {
         "stale_families": stale,
         "all_current": len(stale) == 0,

--- a/factory_app/workflows/AppGenerator/tools/generate_and_download.py
+++ b/factory_app/workflows/AppGenerator/tools/generate_and_download.py
@@ -579,46 +579,225 @@ async def _register_greenfield_app_context_for_bundle(
     files_manifest: list[dict[str, Any]],
     workflow_name: str,
     chat_id: str | None,
+    workflow_run_id: str | None = None,
+    build_id: str | None = None,
     context_variables: Any | None,
-    raise_on_contract_error: bool = False,
-) -> Any | None:
-    try:
-        registered = await register_greenfield_app_context_version(
-            app_bundle_artifact=app_bundle_artifact,
-            artifact_store=artifact_store,
-            files_manifest=files_manifest,
-            source_workflow=workflow_name,
-            source_chat_id=chat_id,
-            make_current=True,
-        )
-    except (TypeError, ValueError) as exc:
-        if raise_on_contract_error:
-            raise
-        wf_logger = get_workflow_logger(
-            workflow_name=workflow_name,
-            chat_id=chat_id,
-            app_id=getattr(app_bundle_artifact, "app_id", None),
-        )
-        wf_logger.warning("Greenfield app-context registration skipped: %s", exc)
-        _context_set(context_variables, "app_context_registration_warning", str(exc))
-        return None
-    except Exception as exc:
-        wf_logger = get_workflow_logger(
-            workflow_name=workflow_name,
-            chat_id=chat_id,
-            app_id=getattr(app_bundle_artifact, "app_id", None),
-        )
-        wf_logger.warning("Greenfield app-context registration failed: %s", exc)
-        _context_set(context_variables, "app_context_registration_warning", str(exc))
-        return None
+) -> Any:
+    """Register the CURRENT AppContextVersion lineage for a generated bundle.
 
+    This registration is required publication lineage: hosting and refinement
+    resolve the CURRENT AppContextVersion, so a failure here must fail the
+    build instead of returning a downloadable bundle whose lineage does not
+    exist.
+    """
+    registered = await register_greenfield_app_context_version(
+        app_bundle_artifact=app_bundle_artifact,
+        artifact_store=artifact_store,
+        files_manifest=files_manifest,
+        source_workflow=workflow_name,
+        source_chat_id=chat_id,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
+        make_current=True,
+    )
     _context_set(context_variables, "app_context_version_id", registered.context_version.context_version_id)
     _context_set(context_variables, "app_context_artifact_version_id", registered.artifact_version.id)
     _context_set(context_variables, "greenfield_app_context_registered", True)
     return registered
 
 
+def _terminal_run_identity(context_variables: Any | None) -> tuple[str, str]:
+    """Resolve the immutable (workflow_run_id, build_id) pair for receipts.
+
+    The workflow_run_id is minted by the bridge at run launch and threaded
+    through the persisted run context. The build identity is the journey's
+    build_id when one exists, otherwise it is derived from the run identity —
+    never from the chat, so two runs in one chat always carry distinct
+    terminal identities.
+    """
+    workflow_run_id = str(_context_get(context_variables, "workflow_run_id") or "").strip()
+    build_id = str(_context_get(context_variables, "build_id") or "").strip()
+    if not build_id and workflow_run_id:
+        build_id = f"build_{workflow_run_id}"
+    return workflow_run_id, build_id
+
+
+async def _persist_terminal_receipt(
+    *,
+    receipt_payload: dict[str, Any],
+    app_id: str,
+    chat_id: str | None,
+    workflow_name: str,
+    context_variables: Any | None,
+    best_effort: bool = False,
+) -> None:
+    """Persist the terminal receipt through the server-owned session channel.
+
+    Generic context persistence strips the reserved receipt key, so the only
+    durable write path is this privileged call; the in-memory context copy is
+    kept for in-run visibility only.
+    """
+    _context_set(context_variables, "build_terminal_receipt", receipt_payload)
+    resolved_chat_id = str(chat_id or "").strip()
+    if not resolved_chat_id:
+        return
+    pm = _ag2_persistence_manager()
+    try:
+        await pm.persist_server_owned_session_fields(
+            chat_id=resolved_chat_id,
+            app_id=str(app_id),
+            workflow_name=str(workflow_name),
+            fields={"build_terminal_receipt": receipt_payload},
+        )
+    except Exception:
+        if not best_effort:
+            raise
+        # Failure receipts ride the original exception path: a durable-write
+        # problem must not mask the build failure being reported. The absent
+        # receipt then simply claims nothing (fail closed).
+        get_workflow_logger(workflow_name=str(workflow_name), app_id=str(app_id)).warning(
+            "Failure receipt durable write failed; completion will claim nothing for this run"
+        )
+
+
+async def _persist_run_build_binding(
+    *,
+    binding_payload: dict[str, Any],
+    app_id: str,
+    chat_id: str | None,
+    workflow_name: str,
+    context_variables: Any | None,
+) -> None:
+    """Persist the run-to-build binding through the server-owned session channel.
+
+    The binding is authority persistence, not telemetry: a durable-write
+    failure fails the build closed rather than leaving a build whose exact
+    run relation cannot be cold-resolved later. Headless runs (no chat
+    session) keep the in-memory copy only — there is no session document to
+    bind to and no bridge lifecycle that would consume it.
+    """
+    _context_set(context_variables, "run_build_binding", binding_payload)
+    resolved_chat_id = str(chat_id or "").strip()
+    if not resolved_chat_id:
+        return
+    pm = _ag2_persistence_manager()
+    await pm.persist_server_owned_session_fields(
+        chat_id=resolved_chat_id,
+        app_id=str(app_id),
+        workflow_name=str(workflow_name),
+        fields={"run_build_binding": binding_payload},
+    )
+
+
+async def _write_failure_receipt(
+    *,
+    context_variables: Any | None,
+    app_id: str,
+    chat_id: str | None,
+    workflow_name: str,
+    error_code: str,
+) -> None:
+    from mozaiksai.core.artifacts.build_receipt import (
+        BuildFailureReceipt,
+        WorkflowRunFailure,
+        issue_failure_receipt,
+        issue_run_failure,
+    )
+    from mozaiksai.core.artifacts.run_build_binding import (
+        BindingValidationError,
+        parse_run_build_binding,
+    )
+
+    workflow_run_id = str(_context_get(context_variables, "workflow_run_id") or "").strip()
+    if not workflow_run_id:
+        # Without an immutable run identity no receipt can bind the failure;
+        # the completion hook then claims nothing for this run (fail closed).
+        return
+
+    # A build-specific failure receipt requires the exact build this run
+    # established — the sealed run/build binding written at record creation.
+    # A run that failed before establishing any build gets the run-level
+    # WorkflowRunFailure instead: a failure receipt never fabricates a build.
+    binding = None
+    raw_binding = _context_get(context_variables, "run_build_binding")
+    if raw_binding is not None:
+        try:
+            binding = parse_run_build_binding(raw_binding)
+        except BindingValidationError:
+            binding = None
+    receipt: BuildFailureReceipt | WorkflowRunFailure
+    if binding is not None and binding.workflow_run_id == workflow_run_id:
+        receipt = issue_failure_receipt(
+            app_id=str(app_id),
+            workflow_name=str(workflow_name),
+            workflow_run_id=workflow_run_id,
+            build_id=binding.build_id,
+            error_code=error_code,  # type: ignore[arg-type]
+        )
+    else:
+        receipt = issue_run_failure(
+            app_id=str(app_id),
+            workflow_name=str(workflow_name),
+            workflow_run_id=workflow_run_id,
+            error_code="run_failed_before_build",
+        )
+    await _persist_terminal_receipt(
+        receipt_payload=receipt.model_dump(mode="json"),
+        app_id=str(app_id),
+        chat_id=chat_id,
+        workflow_name=str(workflow_name),
+        context_variables=context_variables,
+        best_effort=True,
+    )
+
+
 async def _register_app_bundle_artifact_version(
+    *,
+    app_id: str,
+    user_id: str | None,
+    workflow_name: str,
+    chat_id: str | None,
+    bundle_name: str,
+    zip_path: Path,
+    app_dir: Path | None = None,
+    written_paths: list[str] | None = None,
+    context_variables: Any | None,
+):
+    """Register the bundle's BuildRecord and required lineage.
+
+    Owns the terminal receipt boundary: success writes the run-bound success
+    receipt only after the complete persistence closure inside the steps
+    function; any registration failure writes the run-bound failure receipt
+    before re-raising, so the completion hook emits the typed build-failed
+    outcome for exactly this run instead of claiming completion. The
+    ``download_status`` markers remain UI projections only.
+    """
+    try:
+        return await _register_app_bundle_artifact_version_steps(
+            app_id=app_id,
+            user_id=user_id,
+            workflow_name=workflow_name,
+            chat_id=chat_id,
+            bundle_name=bundle_name,
+            zip_path=zip_path,
+            app_dir=app_dir,
+            written_paths=written_paths,
+            context_variables=context_variables,
+        )
+    except Exception:
+        await _write_failure_receipt(
+            context_variables=context_variables,
+            app_id=str(app_id),
+            chat_id=chat_id,
+            workflow_name=str(workflow_name),
+            error_code="lineage_registration_failed",
+        )
+        _context_set(context_variables, "download_status", "failed")
+        _context_set(context_variables, "app_download_ready", False)
+        raise
+
+
+async def _register_app_bundle_artifact_version_steps(
     *,
     app_id: str,
     user_id: str | None,
@@ -667,11 +846,11 @@ async def _register_app_bundle_artifact_version(
             parent_version_id = None
             validation_status_raw = None
 
-    lifecycle_status = (
-        ArtifactLifecycleStatus.DRAFT
-        if parent_version_id
-        else ArtifactLifecycleStatus.CURRENT
-    )
+    # Every bundle record starts as DRAFT: a greenfield record becomes CURRENT
+    # only after its required AppContextVersion lineage registered, so a
+    # failed registration can never leave a published-looking record behind.
+    lifecycle_status = ArtifactLifecycleStatus.DRAFT
+    promote_after_lineage = not parent_version_id
 
     normalized_status = str(validation_status_raw or "").strip().lower()
     validation_status = ArtifactValidationStatus.PENDING
@@ -753,6 +932,8 @@ async def _register_app_bundle_artifact_version(
             wf_logger = get_workflow_logger(workflow_name=workflow_name, app_id=app_id)
             wf_logger.warning("Content store put_bundle failed; falling back to local path: %s", cs_exc)
 
+    # The immutable run binding is stamped on every record in this closure.
+    run_binding_workflow_run_id, run_binding_build_id = _terminal_run_identity(context_variables)
     artifact_store = get_artifact_store()
     canonical_inputs_version = await resolve_latest_artifact_version_refs(
         app_id=str(app_id),
@@ -768,6 +949,8 @@ async def _register_app_bundle_artifact_version(
         files_manifest=files_manifest,
         source_workflow=workflow_name,
         source_chat_id=chat_id,
+        workflow_run_id=run_binding_workflow_run_id or None,
+        build_id=run_binding_build_id or None,
         lifecycle_status=lifecycle_status,
         validation_status=validation_status,
         app_validation_status=str(app_validation_status) if app_validation_status else None,
@@ -787,12 +970,134 @@ async def _register_app_bundle_artifact_version(
             context_variables.set("artifact_version_id", artifact_version.id)
         except Exception:
             pass
-    await _register_greenfield_app_context_for_bundle(
+
+    # The run just established its build: issue and durably persist the sealed
+    # run-to-build binding through the server-owned session seam. This is the
+    # only creation point — the binding is never derived from chat identity or
+    # latest-session build fields, and a pre-build run never has one.
+    if run_binding_workflow_run_id and run_binding_build_id:
+        from mozaiksai.core.artifacts.run_build_binding import issue_run_build_binding
+
+        run_build_binding = issue_run_build_binding(
+            app_id=str(app_id),
+            workflow_name=str(workflow_name),
+            workflow_run_id=run_binding_workflow_run_id,
+            build_id=run_binding_build_id,
+            build_record_id=str(artifact_version.id),
+            build_family=str(artifact_version.build_family),
+            build_key=str(artifact_version.build_key),
+            version_number=int(artifact_version.version_number),
+            bundle_digest=sha,
+        )
+        await _persist_run_build_binding(
+            binding_payload=run_build_binding.model_dump(mode="json"),
+            app_id=str(app_id),
+            chat_id=chat_id,
+            workflow_name=str(workflow_name),
+            context_variables=context_variables,
+        )
+
+    registered_context = await _register_greenfield_app_context_for_bundle(
         app_bundle_artifact=artifact_version,
         artifact_store=artifact_store,
         files_manifest=files_manifest,
         workflow_name=workflow_name,
         chat_id=chat_id,
+        workflow_run_id=run_binding_workflow_run_id or None,
+        build_id=run_binding_build_id or None,
+        context_variables=context_variables,
+    )
+    if promote_after_lineage:
+        accepted = await artifact_store.accept_build_record(
+            app_id=str(app_id),
+            build_record_id=artifact_version.id,
+        )
+        if accepted is None:
+            raise RuntimeError(
+                "app_bundle promotion failed: record vanished before acceptance"
+            )
+        artifact_version = accepted
+
+    workflow_run_id, terminal_build_id = _terminal_run_identity(context_variables)
+    if not workflow_run_id or not terminal_build_id:
+        # Launched outside the bridge (no minted run identity): the build
+        # artifacts persist normally, but no receipt is issued, so the bridge
+        # can never claim lifecycle completion for an unidentified run.
+        get_workflow_logger(workflow_name=workflow_name, app_id=str(app_id)).warning(
+            "No workflow_run_id in run context; terminal receipt skipped — "
+            "bridge lifecycle completion will not claim this build"
+        )
+        return artifact_version
+
+    # Acceptance/receipt requires the exact persisted run binding: the receipt
+    # is constructed from the persisted verified records, and any disagreement
+    # between the persisted binding and this run fails the build closed.
+    persisted_run_id = str(getattr(artifact_version, "workflow_run_id", "") or "").strip()
+    persisted_build_id = str(getattr(artifact_version, "build_id", "") or "").strip()
+    if persisted_run_id != workflow_run_id or persisted_build_id != terminal_build_id:
+        raise RuntimeError(
+            "terminal receipt refused: persisted BuildRecord run binding "
+            f"({persisted_run_id!r}/{persisted_build_id!r}) does not match this run "
+            f"({workflow_run_id!r}/{terminal_build_id!r})"
+        )
+    context_record = registered_context.artifact_version
+    context_run_id = str(getattr(context_record, "workflow_run_id", "") or "").strip()
+    context_build_id = str(getattr(context_record, "build_id", "") or "").strip()
+    if context_run_id != workflow_run_id or context_build_id != terminal_build_id:
+        raise RuntimeError(
+            "terminal receipt refused: persisted AppContextVersion run binding "
+            "does not match this run"
+        )
+    persisted_digests = {
+        str(getattr(entry, "sha256", "") or "") for entry in artifact_version.files_manifest
+    }
+    if sha not in persisted_digests:
+        raise RuntimeError(
+            "terminal receipt refused: bundle digest is not present in the "
+            "persisted BuildRecord manifest"
+        )
+
+    from mozaiksai.core.artifacts.build_receipt import (
+        BuildRevisionCandidateReceipt,
+        BuildSuccessReceipt,
+        issue_revision_candidate_receipt,
+        issue_success_receipt,
+    )
+
+    record_lifecycle = str(
+        getattr(artifact_version.lifecycle_status, "value", artifact_version.lifecycle_status)
+    )
+    receipt_kwargs = {
+        "app_id": str(app_id),
+        "workflow_name": str(workflow_name),
+        "workflow_run_id": persisted_run_id,
+        "build_id": persisted_build_id,
+        "build_record_id": str(artifact_version.id),
+        "app_context_version_id": str(registered_context.context_version.context_version_id),
+        "app_context_record_id": str(context_record.id),
+        "bundle_digest": sha,
+    }
+    receipt: BuildSuccessReceipt | BuildRevisionCandidateReceipt
+    if promote_after_lineage:
+        if record_lifecycle != "current":
+            raise RuntimeError(
+                "terminal receipt refused: greenfield record is not CURRENT after acceptance"
+            )
+        receipt = issue_success_receipt(**receipt_kwargs)
+    else:
+        # Refinement produces a non-current candidate deliberately; it gets
+        # the distinct closed candidate variant, never an ambiguous success.
+        if record_lifecycle != "draft" or not artifact_version.parent_build_record_id:
+            raise RuntimeError(
+                "terminal receipt refused: revision candidate must be a draft with parent lineage"
+            )
+        receipt = issue_revision_candidate_receipt(**receipt_kwargs)
+
+    await _persist_terminal_receipt(
+        receipt_payload=receipt.model_dump(mode="json"),
+        app_id=str(app_id),
+        chat_id=chat_id,
+        workflow_name=str(workflow_name),
         context_variables=context_variables,
     )
     return artifact_version

--- a/mozaiksai/control_plane/implementations/refinement_router.py
+++ b/mozaiksai/control_plane/implementations/refinement_router.py
@@ -1385,7 +1385,7 @@ class RefinementTriggerRouteResolver:
                 ArtifactStore,  # local import avoids circular dep
             )
             store = ArtifactStore()
-            stale = await store.get_stale_artifact_families(app_id=request.app_id)
+            stale = await store.get_stale_build_families(app_id=request.app_id)
         except Exception as exc:
             _logger.debug("STALE_ARTIFACT_LOOKUP_FAILED app=%s: %s", request.app_id, exc)
             return None

--- a/mozaiksai/control_plane/invalidation.py
+++ b/mozaiksai/control_plane/invalidation.py
@@ -121,7 +121,7 @@ class ArtifactInvalidationService:
             invalidated_build_record_ids = await resolved_store.invalidate_artifact_version_refs(
                 app_id=app_id,
                 artifact_version_refs=artifact_version_refs,
-                affected_artifact_kinds=affected_build_families,
+                affected_build_families=affected_build_families,
                 reason=reason,
             )
 
@@ -142,8 +142,7 @@ class ArtifactInvalidationService:
                 for family in sorted(downstream):
                     count = await resolved_store.invalidate_artifact_family(
                         app_id=app_id,
-                        artifact_kind=family,
-                        artifact_key=family,
+                        build_family=family,
                         reason=reason,
                     )
                     if count:

--- a/mozaiksai/core/app_context/store.py
+++ b/mozaiksai/core/app_context/store.py
@@ -285,6 +285,8 @@ async def register_greenfield_app_context_version(
     files_manifest: list[dict[str, Any]] | None = None,
     source_workflow: str | None = None,
     source_chat_id: str | None = None,
+    workflow_run_id: str | None = None,
+    build_id: str | None = None,
     make_current: bool = True,
 ) -> RegisteredAppContextVersion:
     """Persist greenfield app-context artifacts and register a current AppContextVersion."""
@@ -385,6 +387,8 @@ async def register_greenfield_app_context_version(
         artifact_store=store,
         source_workflow=source_workflow,
         source_chat_id=source_chat_id,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
         make_current=make_current,
     )
 
@@ -468,6 +472,8 @@ async def register_app_context_version(
     artifact_store: BuildRecordStore | None = None,
     source_workflow: str | None = None,
     source_chat_id: str | None = None,
+    workflow_run_id: str | None = None,
+    build_id: str | None = None,
     make_current: bool = False,
 ) -> RegisteredAppContextVersion:
     """Persist an AppContextVersion as an ArtifactVersion."""
@@ -489,6 +495,8 @@ async def register_app_context_version(
         ],
         source_workflow=source_workflow,
         source_chat_id=source_chat_id,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
         lifecycle_status=BuildRecordStatus.DRAFT,
         validation_status=BuildRecordValidationStatus.PENDING,
         commit_metadata={

--- a/mozaiksai/core/artifacts/build_receipt.py
+++ b/mozaiksai/core/artifacts/build_receipt.py
@@ -1,0 +1,404 @@
+"""Immutable run-bound terminal build receipts.
+
+A workflow run that reaches its terminal build outcome writes exactly one
+closed receipt binding the outcome to the run's immutable identity and to the
+persisted lineage it produced. Chat-scoped progress markers (for example
+``download_status``) remain UI projections only — a receipt is the sole
+success/failure authority the completion bridge may act on, and a receipt for
+one run can never complete another run even inside the same chat.
+
+The receipt is deliberately minimal and cold-verifiable: identity fields plus
+persisted-lineage references plus a content digest over those fields. It
+carries no chat history, prompts, agent objects, provider/channel identity,
+free-form metadata, timestamps-as-identity, Git state, or hosted state.
+
+This is temporary current-product hardening: the BuildRecord references here
+follow the temporary pre-5D publication authority, which ADR 0007 Slice 5D
+will later replace with the ArtifactRevision/ApplicationPublication authority.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+TERMINAL_RECEIPT_CONTEXT_KEY = "build_terminal_receipt"
+
+RECEIPT_SCHEMA_VERSION = "mozaiks.build_receipt.v1"
+
+BuildFailureCode = Literal[
+    "bundle_generation_failed",
+    "lineage_registration_failed",
+    "bundle_acceptance_failed",
+]
+
+WorkflowRunFailureCode = Literal[
+    "run_failed_before_build",
+    "run_cancelled_before_build",
+]
+
+
+class ReceiptValidationError(ValueError):
+    """A terminal receipt is malformed, mistyped, or fails digest verification."""
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _digest_payload(data: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {key: value for key, value in data.items() if key != "receipt_digest"},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class _SealedRunBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["mozaiks.build_receipt.v1"]
+    scope: Literal["server"]
+    app_id: str
+    workflow_name: str
+    workflow_run_id: str
+    receipt_digest: str
+
+    @field_validator("app_id", "workflow_name", "workflow_run_id")
+    @classmethod
+    def _run_identity_non_empty(cls, value: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            raise ValueError("receipt identity fields must be non-empty")
+        return value
+
+    def verify_digest(self) -> None:
+        expected = _digest_payload(self.model_dump(mode="json"))
+        if expected != self.receipt_digest:
+            raise ReceiptValidationError(
+                "terminal receipt digest mismatch: receipt was altered after issue"
+            )
+
+
+class _ReceiptBase(_SealedRunBase):
+    build_id: str
+
+    @field_validator("build_id")
+    @classmethod
+    def _build_identity_non_empty(cls, value: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            raise ValueError("receipt identity fields must be non-empty")
+        return value
+
+
+class _LineageReceipt(_ReceiptBase):
+    """Shared required lineage fields for terminal receipts that reference
+    persisted build closure. No optional fields — absence means invalid."""
+
+    build_record_id: str
+    app_context_version_id: str
+    app_context_record_id: str
+    bundle_digest: str
+
+    @field_validator("build_record_id", "app_context_version_id", "app_context_record_id")
+    @classmethod
+    def _refs_non_empty(cls, value: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            raise ValueError("terminal receipt lineage references must be non-empty")
+        return value
+
+    @field_validator("bundle_digest")
+    @classmethod
+    def _digest_shape(cls, value: str) -> str:
+        value = str(value or "").strip()
+        if not _SHA256_RE.match(value):
+            raise ValueError("bundle_digest must be a lowercase 64-hex sha256 digest")
+        return value
+
+
+class BuildSuccessReceipt(_LineageReceipt):
+    """Genesis terminal success: the complete CURRENT lineage for exactly one run.
+
+    Every field is required — there is no nullable half-success shape. The
+    referenced app-bundle BuildRecord must be CURRENT and carry this exact
+    run/build binding; the referenced AppContextVersion record must be
+    CURRENT, carry the same binding, and its logical version and bundle
+    cross-reference must agree. ``bundle_digest`` is the required lowercase
+    SHA-256 of the bundle zip and must agree with the persisted manifest.
+    """
+
+    kind: Literal["success"]
+    status: Literal["succeeded"]
+
+
+class BuildRevisionCandidateReceipt(_LineageReceipt):
+    """Refinement terminal outcome: a persisted non-current revision candidate.
+
+    A distinct closed variant so a refinement candidate can never be confused
+    with a Genesis CURRENT success. The referenced BuildRecord must be a
+    DRAFT that carries parent lineage plus this exact run/build binding; all
+    lineage and digest requirements match the success receipt otherwise.
+    """
+
+    kind: Literal["revision_candidate"]
+    status: Literal["candidate"]
+
+
+class BuildFailureReceipt(_ReceiptBase):
+    """Terminal failure of a run whose exact build exists.
+
+    Requires the exact run/build identity plus a finite failure code, and
+    carries no lineage references — a failed run has no accepted lineage and
+    the receipt must not fabricate one. A run that failed before establishing
+    any build gets :class:`WorkflowRunFailure` instead: a failure receipt may
+    never fabricate a build.
+    """
+
+    kind: Literal["failure"]
+    status: Literal["failed"]
+    error_code: BuildFailureCode
+
+
+class WorkflowRunFailure(_SealedRunBase):
+    """Terminal failure of a run that established no build.
+
+    Carries the run identity only — no build_id, no lineage, no fabricated
+    references. This is the truthful terminal shape for pre-build failures:
+    consumers may report the run-level failure, but no build-specific
+    lifecycle event can ever be derived from it.
+    """
+
+    kind: Literal["run_failure"]
+    status: Literal["failed"]
+    error_code: WorkflowRunFailureCode
+
+
+TerminalBuildReceipt = Annotated[
+    BuildSuccessReceipt | BuildRevisionCandidateReceipt | BuildFailureReceipt,
+    Field(discriminator="kind"),
+]
+
+TerminalRunOutcome = Annotated[
+    BuildSuccessReceipt
+    | BuildRevisionCandidateReceipt
+    | BuildFailureReceipt
+    | WorkflowRunFailure,
+    Field(discriminator="kind"),
+]
+
+
+def _issue_lineage_receipt(
+    model_cls: type[_LineageReceipt],
+    *,
+    kind: str,
+    status: str,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    build_id: str,
+    build_record_id: str,
+    app_context_version_id: str,
+    app_context_record_id: str,
+    bundle_digest: str,
+) -> Any:
+    payload: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": kind,
+        "scope": "server",
+        "status": status,
+        "app_id": app_id,
+        "workflow_name": workflow_name,
+        "workflow_run_id": workflow_run_id,
+        "build_id": build_id,
+        "build_record_id": build_record_id,
+        "app_context_version_id": app_context_version_id,
+        "app_context_record_id": app_context_record_id,
+        "bundle_digest": bundle_digest,
+        "receipt_digest": "",
+    }
+    model = model_cls.model_validate(
+        {**payload, "receipt_digest": _digest_payload({**payload, "receipt_digest": ""})}
+    )
+    # Recompute over the validated/normalized dump so verification is stable.
+    dumped = model.model_dump(mode="json")
+    return model_cls.model_validate({**dumped, "receipt_digest": _digest_payload(dumped)})
+
+
+def issue_success_receipt(
+    *,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    build_id: str,
+    build_record_id: str,
+    app_context_version_id: str,
+    app_context_record_id: str,
+    bundle_digest: str,
+) -> BuildSuccessReceipt:
+    receipt: BuildSuccessReceipt = _issue_lineage_receipt(
+        BuildSuccessReceipt,
+        kind="success",
+        status="succeeded",
+        app_id=app_id,
+        workflow_name=workflow_name,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
+        build_record_id=build_record_id,
+        app_context_version_id=app_context_version_id,
+        app_context_record_id=app_context_record_id,
+        bundle_digest=bundle_digest,
+    )
+    return receipt
+
+
+def issue_revision_candidate_receipt(
+    *,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    build_id: str,
+    build_record_id: str,
+    app_context_version_id: str,
+    app_context_record_id: str,
+    bundle_digest: str,
+) -> BuildRevisionCandidateReceipt:
+    receipt: BuildRevisionCandidateReceipt = _issue_lineage_receipt(
+        BuildRevisionCandidateReceipt,
+        kind="revision_candidate",
+        status="candidate",
+        app_id=app_id,
+        workflow_name=workflow_name,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
+        build_record_id=build_record_id,
+        app_context_version_id=app_context_version_id,
+        app_context_record_id=app_context_record_id,
+        bundle_digest=bundle_digest,
+    )
+    return receipt
+
+
+def issue_failure_receipt(
+    *,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    build_id: str,
+    error_code: BuildFailureCode,
+) -> BuildFailureReceipt:
+    payload: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": "failure",
+        "scope": "server",
+        "status": "failed",
+        "app_id": app_id,
+        "workflow_name": workflow_name,
+        "workflow_run_id": workflow_run_id,
+        "build_id": build_id,
+        "error_code": error_code,
+        "receipt_digest": "",
+    }
+    model = BuildFailureReceipt.model_validate(
+        {**payload, "receipt_digest": _digest_payload({**payload, "receipt_digest": ""})}
+    )
+    dumped = model.model_dump(mode="json")
+    signed: BuildFailureReceipt = BuildFailureReceipt.model_validate(
+        {**dumped, "receipt_digest": _digest_payload(dumped)}
+    )
+    return signed
+
+
+def issue_run_failure(
+    *,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    error_code: WorkflowRunFailureCode,
+) -> WorkflowRunFailure:
+    """Issue the run-level terminal failure for a run that built nothing.
+
+    Deliberately has no ``build_id`` parameter: a pre-build failure must not
+    fabricate a build identity from chat, journey, or session state.
+    """
+    payload: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": "run_failure",
+        "scope": "server",
+        "status": "failed",
+        "app_id": app_id,
+        "workflow_name": workflow_name,
+        "workflow_run_id": workflow_run_id,
+        "error_code": error_code,
+        "receipt_digest": "",
+    }
+    model = WorkflowRunFailure.model_validate(
+        {**payload, "receipt_digest": _digest_payload({**payload, "receipt_digest": ""})}
+    )
+    dumped = model.model_dump(mode="json")
+    signed: WorkflowRunFailure = WorkflowRunFailure.model_validate(
+        {**dumped, "receipt_digest": _digest_payload(dumped)}
+    )
+    return signed
+
+
+def parse_terminal_receipt(
+    raw: Any,
+) -> BuildSuccessReceipt | BuildRevisionCandidateReceipt | BuildFailureReceipt | WorkflowRunFailure:
+    """Parse and digest-verify a persisted terminal receipt.
+
+    Raises :class:`ReceiptValidationError` for anything that is not a valid,
+    unaltered receipt. Callers treat that as "no usable receipt" and fail
+    closed — a malformed receipt never authorizes a lifecycle claim.
+    """
+    if not isinstance(raw, dict):
+        raise ReceiptValidationError("terminal receipt must be a mapping")
+    kind = raw.get("kind")
+    try:
+        receipt: (
+            BuildSuccessReceipt
+            | BuildRevisionCandidateReceipt
+            | BuildFailureReceipt
+            | WorkflowRunFailure
+        )
+        if kind == "success":
+            receipt = BuildSuccessReceipt.model_validate(raw)
+        elif kind == "revision_candidate":
+            receipt = BuildRevisionCandidateReceipt.model_validate(raw)
+        elif kind == "failure":
+            receipt = BuildFailureReceipt.model_validate(raw)
+        elif kind == "run_failure":
+            receipt = WorkflowRunFailure.model_validate(raw)
+        else:
+            raise ReceiptValidationError(f"unknown terminal receipt kind: {kind!r}")
+    except ReceiptValidationError:
+        raise
+    except Exception as exc:
+        raise ReceiptValidationError(f"invalid terminal receipt: {type(exc).__name__}") from exc
+    receipt.verify_digest()
+    return receipt
+
+
+__all__ = [
+    "TERMINAL_RECEIPT_CONTEXT_KEY",
+    "RECEIPT_SCHEMA_VERSION",
+    "BuildFailureCode",
+    "BuildFailureReceipt",
+    "BuildRevisionCandidateReceipt",
+    "BuildSuccessReceipt",
+    "ReceiptValidationError",
+    "TerminalBuildReceipt",
+    "TerminalRunOutcome",
+    "WorkflowRunFailure",
+    "WorkflowRunFailureCode",
+    "issue_failure_receipt",
+    "issue_revision_candidate_receipt",
+    "issue_run_failure",
+    "issue_success_receipt",
+    "parse_terminal_receipt",
+]

--- a/mozaiksai/core/artifacts/closure.py
+++ b/mozaiksai/core/artifacts/closure.py
@@ -1,0 +1,298 @@
+"""Cold verification of run-bound build authority against persisted records.
+
+Self-digests on receipts and bindings prove body integrity only — they are
+never authorization. Authorization requires resolving the exact persisted
+records the claim references and requiring agreement on every canonical
+dimension: app scope, family/key vocabulary, run/build binding, lifecycle
+state, logical AppContextVersion identity, the AppContextVersion-to-
+BuildRecord cross-reference, and the bundle digest. Any missing or
+disagreeing value fails closed; a real but unrelated CURRENT record is
+never sufficient, and records without a persisted run binding can never
+satisfy a run-bound claim.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from logs.logging_config import get_core_logger
+from mozaiksai.core.artifacts.build_receipt import (
+    BuildFailureReceipt,
+    BuildRevisionCandidateReceipt,
+    BuildSuccessReceipt,
+)
+from mozaiksai.core.artifacts.run_build_binding import RunBuildBinding
+
+logger = get_core_logger("build_closure_verification")
+
+
+def _refuse(reason: str, *args: Any) -> bool:
+    logger.error("BUILD_CLOSURE_VERIFICATION_FAILED: " + reason, *args)
+    return False
+
+
+def _resolve_store(store: Any | None) -> Any:
+    if store is not None:
+        return store
+    from mozaiksai.core.artifacts import get_artifact_store
+
+    return get_artifact_store()
+
+
+async def verify_run_build_binding_closure(
+    binding: RunBuildBinding,
+    *,
+    workflow_run_id: str,
+    app_id: str,
+    workflow_name: str,
+    store: Any | None = None,
+) -> bool:
+    """Cold-verify that a binding is the exact current run's build relation.
+
+    The binding must name the exact caller-supplied run/app/workflow, and the
+    persisted BuildRecord it references must exist under that app scope and
+    carry the identical run/build binding, family, key, and version stamped
+    at creation. When the binding carries a bundle digest, that digest must
+    be present in the persisted record manifest. Anything else fails closed:
+    a binding for another run, another app, an unbound record, or a record
+    whose stored identity disagrees never authorizes a build-specific claim.
+    """
+    expected_run = str(workflow_run_id or "").strip()
+    if not expected_run or binding.workflow_run_id != expected_run:
+        return _refuse(
+            "binding run %r does not match current run %r",
+            binding.workflow_run_id,
+            expected_run or "<missing>",
+        )
+    if binding.app_id != str(app_id) or binding.workflow_name != str(workflow_name):
+        return _refuse(
+            "binding scope %s/%s does not match current %s/%s",
+            binding.app_id,
+            binding.workflow_name,
+            app_id,
+            workflow_name,
+        )
+
+    resolved_store = _resolve_store(store)
+    record = await resolved_store.get_build_record(
+        app_id=str(app_id), build_record_id=binding.build_record_id
+    )
+    if record is None:
+        return _refuse(
+            "build record %s not found for app %s", binding.build_record_id, app_id
+        )
+
+    record_run_id = str(getattr(record, "workflow_run_id", "") or "").strip()
+    record_build_id = str(getattr(record, "build_id", "") or "").strip()
+    if not record_run_id or record_run_id != binding.workflow_run_id:
+        return _refuse(
+            "record %s run binding %r does not match binding run %r",
+            record.id,
+            record_run_id or "<unbound>",
+            binding.workflow_run_id,
+        )
+    if not record_build_id or record_build_id != binding.build_id:
+        return _refuse(
+            "record %s build binding %r does not match binding build %r",
+            record.id,
+            record_build_id or "<unbound>",
+            binding.build_id,
+        )
+    if record.build_family != binding.build_family or record.build_key != binding.build_key:
+        return _refuse(
+            "record %s family/key %s/%s does not match binding %s/%s",
+            record.id,
+            record.build_family,
+            record.build_key,
+            binding.build_family,
+            binding.build_key,
+        )
+    if int(record.version_number) != int(binding.version_number):
+        return _refuse(
+            "record %s version %s does not match binding version %s",
+            record.id,
+            record.version_number,
+            binding.version_number,
+        )
+    if binding.bundle_digest is not None:
+        manifest_digests = {
+            str(getattr(entry, "sha256", "") or "") for entry in record.files_manifest
+        }
+        manifest_digests.discard("")
+        if binding.bundle_digest not in manifest_digests:
+            return _refuse(
+                "binding bundle digest %s absent from record %s manifest",
+                binding.bundle_digest,
+                record.id,
+            )
+    return True
+
+
+async def verify_terminal_receipt_closure(
+    receipt: BuildSuccessReceipt | BuildRevisionCandidateReceipt,
+    *,
+    app_id: str,
+    store: Any | None = None,
+) -> bool:
+    """Cold-verify a lineage receipt against the exact persisted closure.
+
+    The referenced records must be the exact records persisted for this run
+    and build, on every canonical dimension: server-owned app scope,
+    family/key vocabulary, run/build binding, lifecycle state, logical
+    AppContextVersion identity, the AppContextVersion-to-BuildRecord
+    cross-reference, and the required bundle digest. Failure receipts carry
+    no lineage and are never closure-verifiable.
+    """
+    if isinstance(receipt, BuildFailureReceipt):
+        return _refuse("failure receipts carry no lineage closure to verify")
+
+    resolved_store = _resolve_store(store)
+    record = await resolved_store.get_build_record(
+        app_id=str(app_id), build_record_id=receipt.build_record_id
+    )
+    if record is None:
+        return _refuse(
+            "build record %s not found for app %s", receipt.build_record_id, app_id
+        )
+    if record.build_family != "app_bundle" or record.build_key != "app_bundle":
+        return _refuse(
+            "record %s family/key %s/%s is not the canonical app_bundle vocabulary",
+            record.id,
+            record.build_family,
+            record.build_key,
+        )
+
+    # Exact run/build binding: the record must have been created FOR this
+    # run and build. Records without a persisted binding can never satisfy a
+    # lineage receipt — there is no fallback for unbound records.
+    record_run_id = str(getattr(record, "workflow_run_id", "") or "").strip()
+    record_build_id = str(getattr(record, "build_id", "") or "").strip()
+    if not record_run_id or record_run_id != receipt.workflow_run_id:
+        return _refuse(
+            "record %s run binding %r does not match receipt run %r",
+            record.id,
+            record_run_id or "<unbound>",
+            receipt.workflow_run_id,
+        )
+    if not record_build_id or record_build_id != receipt.build_id:
+        return _refuse(
+            "record %s build binding %r does not match receipt build %r",
+            record.id,
+            record_build_id or "<unbound>",
+            receipt.build_id,
+        )
+
+    lifecycle = str(getattr(record.lifecycle_status, "value", record.lifecycle_status))
+    if isinstance(receipt, BuildRevisionCandidateReceipt):
+        if lifecycle != "draft" or not record.parent_build_record_id:
+            return _refuse(
+                "revision candidate record %s must be a draft with parent lineage (lifecycle=%s)",
+                record.id,
+                lifecycle,
+            )
+    else:
+        if lifecycle != "current":
+            return _refuse(
+                "success record %s lifecycle=%s is not CURRENT", record.id, lifecycle
+            )
+
+    # Required bundle digest agreement with the persisted manifest authority.
+    manifest_digests = {
+        str(getattr(entry, "sha256", "") or "") for entry in record.files_manifest
+    }
+    manifest_digests.discard("")
+    if receipt.bundle_digest not in manifest_digests:
+        return _refuse(
+            "bundle digest %s absent from record %s manifest",
+            receipt.bundle_digest,
+            record.id,
+        )
+
+    context_record = await resolved_store.get_build_record(
+        app_id=str(app_id), build_record_id=receipt.app_context_record_id
+    )
+    if context_record is None:
+        return _refuse(
+            "AppContextVersion record %s not found", receipt.app_context_record_id
+        )
+    if (
+        context_record.build_family != "app_context_version"
+        or context_record.build_key != "app_context_version"
+    ):
+        return _refuse(
+            "record %s family/key %s/%s is not the canonical app_context_version vocabulary",
+            context_record.id,
+            context_record.build_family,
+            context_record.build_key,
+        )
+    context_lifecycle = str(
+        getattr(context_record.lifecycle_status, "value", context_record.lifecycle_status)
+    )
+    if context_lifecycle != "current":
+        return _refuse(
+            "AppContextVersion record %s lifecycle=%s is not current",
+            context_record.id,
+            context_lifecycle,
+        )
+    context_run_id = str(getattr(context_record, "workflow_run_id", "") or "").strip()
+    context_build_id = str(getattr(context_record, "build_id", "") or "").strip()
+    if not context_run_id or context_run_id != receipt.workflow_run_id:
+        return _refuse(
+            "AppContextVersion record %s run binding %r does not match receipt run %r",
+            context_record.id,
+            context_run_id or "<unbound>",
+            receipt.workflow_run_id,
+        )
+    if not context_build_id or context_build_id != receipt.build_id:
+        return _refuse(
+            "AppContextVersion record %s build binding %r does not match receipt build %r",
+            context_record.id,
+            context_build_id or "<unbound>",
+            receipt.build_id,
+        )
+
+    # Logical AppContextVersion identity and the exact cross-reference back to
+    # the receipt's BuildRecord, read from the persisted summary payload.
+    summary = getattr(getattr(context_record, "commit_metadata", None), "metadata", None)
+    payload = summary.get("summary_payload") if isinstance(summary, dict) else None
+    if not isinstance(payload, dict):
+        return _refuse(
+            "AppContextVersion record %s carries no persisted summary payload",
+            context_record.id,
+        )
+    logical_id = str(payload.get("context_version_id") or "").strip()
+    if not logical_id or logical_id != receipt.app_context_version_id:
+        return _refuse(
+            "AppContextVersion record %s logical id %r does not match receipt %r",
+            context_record.id,
+            logical_id or "<missing>",
+            receipt.app_context_version_id,
+        )
+    payload_app_id = str(payload.get("app_id") or "").strip()
+    if payload_app_id != str(app_id):
+        return _refuse(
+            "AppContextVersion record %s app scope %r does not match %r",
+            context_record.id,
+            payload_app_id,
+            app_id,
+        )
+    bundle_refs = [
+        ref
+        for ref in (payload.get("artifact_refs") or [])
+        if isinstance(ref, dict) and ref.get("artifact_kind") == "app_bundle"
+    ]
+    if not any(
+        str(ref.get("artifact_version_id") or "").strip() == receipt.build_record_id
+        for ref in bundle_refs
+    ):
+        return _refuse(
+            "AppContextVersion record %s does not cross-reference BuildRecord %s",
+            context_record.id,
+            receipt.build_record_id,
+        )
+    return True
+
+
+__all__ = [
+    "verify_run_build_binding_closure",
+    "verify_terminal_receipt_closure",
+]

--- a/mozaiksai/core/artifacts/models.py
+++ b/mozaiksai/core/artifacts/models.py
@@ -128,6 +128,12 @@ class BuildRecord(BaseModel):
     lineage_root_id: str
     source_workflow: str | None = None
     source_chat_id: str | None = None
+    # Immutable run binding: the server-minted workflow run and build this
+    # record was created for. Written once at creation; terminal receipts are
+    # verified against these exact values (no fallback for unbound records —
+    # a record without a binding can never satisfy a success receipt).
+    workflow_run_id: str | None = None
+    build_id: str | None = None
     canonical_inputs_version: dict[str, str] = Field(default_factory=dict)
     lifecycle_status: BuildRecordStatus = BuildRecordStatus.DRAFT
     validation_status: BuildRecordValidationStatus = BuildRecordValidationStatus.PENDING

--- a/mozaiksai/core/artifacts/run_build_binding.py
+++ b/mozaiksai/core/artifacts/run_build_binding.py
@@ -1,0 +1,184 @@
+"""Server-owned run-to-build binding.
+
+A build-specific lifecycle claim requires the exact server-owned relation
+``workflow_run_id -> build_id`` established by the same run. This module
+defines that relation as one closed, digest-sealed object: the binding is
+created only at the moment the current run establishes its build (the
+terminal build tool persisting the BuildRecord), and it names the exact
+persisted BuildRecord identity it was established for.
+
+Chat/session "latest build" fields (``build_registry_id``,
+``journey_instance_id``, latest ``build_id``, most-recent CURRENT record)
+are presentation and workflow context. They are never run-to-build
+authority and can never produce a binding.
+
+The binding is persisted through the existing server-owned session seam
+(:data:`~mozaiksai.core.data.persistence.persistence_manager.SERVER_OWNED_SESSION_FIELDS`)
+— the same session document and authority as the terminal receipt. There is
+no second build store: the authoritative relation also lives on the
+BuildRecord itself (``workflow_run_id``/``build_id`` stamped at creation),
+and cold verification resolves the persisted record and requires exact
+agreement on every dimension.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+RUN_BUILD_BINDING_CONTEXT_KEY = "run_build_binding"
+
+BINDING_SCHEMA_VERSION = "mozaiks.run_build_binding.v1"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class BindingValidationError(ValueError):
+    """A run/build binding is malformed, mistyped, or fails digest verification."""
+
+
+def _digest_payload(data: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {key: value for key, value in data.items() if key != "binding_digest"},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class RunBuildBinding(BaseModel):
+    """The exact server-owned relation between one run and the build it established.
+
+    Every identity field is required: the binding names the run, the build,
+    and the exact persisted BuildRecord identity (record id, family, key,
+    version). ``bundle_digest`` carries the bundle content digest when the
+    build established one. The binding proves body integrity through
+    ``binding_digest`` only — authorization always requires cold
+    verification against the persisted BuildRecord.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["mozaiks.run_build_binding.v1"]
+    scope: Literal["server"]
+    app_id: str
+    workflow_name: str
+    workflow_run_id: str
+    build_id: str
+    build_record_id: str
+    build_family: str
+    build_key: str
+    version_number: int = Field(ge=1)
+    bundle_digest: str | None = None
+    binding_digest: str
+
+    @field_validator(
+        "app_id",
+        "workflow_name",
+        "workflow_run_id",
+        "build_id",
+        "build_record_id",
+        "build_family",
+        "build_key",
+    )
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            raise ValueError("run/build binding identity fields must be non-empty")
+        return value
+
+    @field_validator("bundle_digest")
+    @classmethod
+    def _digest_shape(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = str(value or "").strip()
+        if not _SHA256_RE.match(value):
+            raise ValueError("bundle_digest must be a lowercase 64-hex sha256 digest")
+        return value
+
+    def verify_digest(self) -> None:
+        expected = _digest_payload(self.model_dump(mode="json"))
+        if expected != self.binding_digest:
+            raise BindingValidationError(
+                "run/build binding digest mismatch: binding was altered after issue"
+            )
+
+
+def issue_run_build_binding(
+    *,
+    app_id: str,
+    workflow_name: str,
+    workflow_run_id: str,
+    build_id: str,
+    build_record_id: str,
+    build_family: str,
+    build_key: str,
+    version_number: int,
+    bundle_digest: str | None = None,
+) -> RunBuildBinding:
+    """Issue the sealed binding for a build the current run just established.
+
+    Callable only from the server-owned write point that persisted the
+    BuildRecord for this run. Never derive the inputs from chat identity,
+    latest-session build fields, journey state, timestamps, or a
+    most-recent CURRENT record.
+    """
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "scope": "server",
+        "app_id": app_id,
+        "workflow_name": workflow_name,
+        "workflow_run_id": workflow_run_id,
+        "build_id": build_id,
+        "build_record_id": build_record_id,
+        "build_family": build_family,
+        "build_key": build_key,
+        "version_number": version_number,
+        "bundle_digest": bundle_digest,
+        "binding_digest": "",
+    }
+    model = RunBuildBinding.model_validate(
+        {**payload, "binding_digest": _digest_payload({**payload, "binding_digest": ""})}
+    )
+    # Recompute over the validated/normalized dump so verification is stable.
+    dumped = model.model_dump(mode="json")
+    return RunBuildBinding.model_validate(
+        {**dumped, "binding_digest": _digest_payload(dumped)}
+    )
+
+
+def parse_run_build_binding(raw: Any) -> RunBuildBinding:
+    """Parse and digest-verify a persisted run/build binding.
+
+    Raises :class:`BindingValidationError` for anything that is not a valid,
+    unaltered binding. Callers treat that as "no binding" and fail closed —
+    a malformed binding never authorizes a build-specific claim.
+    """
+    if not isinstance(raw, dict):
+        raise BindingValidationError("run/build binding must be a mapping")
+    try:
+        binding = RunBuildBinding.model_validate(raw)
+    except BindingValidationError:
+        raise
+    except Exception as exc:
+        raise BindingValidationError(
+            f"invalid run/build binding: {type(exc).__name__}"
+        ) from exc
+    binding.verify_digest()
+    return binding
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "RUN_BUILD_BINDING_CONTEXT_KEY",
+    "BindingValidationError",
+    "RunBuildBinding",
+    "issue_run_build_binding",
+    "parse_run_build_binding",
+]

--- a/mozaiksai/core/artifacts/store.py
+++ b/mozaiksai/core/artifacts/store.py
@@ -7,6 +7,7 @@ from typing import Any
 from uuid import uuid4
 
 from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
 
 from logs.logging_config import get_workflow_logger
 from mozaiksai.core.core_config import get_mongo_client
@@ -34,9 +35,33 @@ ArtifactValidationStatus = BuildRecordValidationStatus
 
 logger = get_workflow_logger("artifact_store")
 
+_DATABASE_NAME = "mozaiksai"
+
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
+
+
+class BuildRecordCurrentConflictError(RuntimeError):
+    """A concurrent writer published a different CURRENT record for the same target.
+
+    Raised when the storage-level uniqueness guard (partial unique index on
+    CURRENT records per app_id/build_family/build_key) rejects a publication
+    because another record became CURRENT between the supersede step and the
+    publish step. The caller's record was NOT published; the concurrent
+    winner's CURRENT record stands.
+    """
+
+    def __init__(self, *, app_id: str, build_family: str, build_key: str, build_record_id: str) -> None:
+        self.app_id = app_id
+        self.build_family = build_family
+        self.build_key = build_key
+        self.build_record_id = build_record_id
+        super().__init__(
+            f"Concurrent CURRENT publication conflict for app_id={app_id!r} "
+            f"build_family={build_family!r} build_key={build_key!r}: "
+            f"record {build_record_id!r} was not published"
+        )
 
 
 class BuildRecordStore:
@@ -52,61 +77,170 @@ class BuildRecordStore:
         async with self._init_lock:
             if self.client is not None:
                 return
-            self.client = get_mongo_client()
-            await self._ensure_indexes()
+            candidate = get_mongo_client()
+            # The store becomes available only after the complete index
+            # contract verifies; a failed migration must not leave a client
+            # behind that skips verification on the next call.
+            await self._ensure_indexes(client=candidate)
+            self.client = candidate
 
-    async def _ensure_indexes(self) -> None:
-        versions = await self._coll("ArtifactVersions")
-        await versions.create_index(
-            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
-            name="av_app_kind_key_version",
-            unique=True,
-        )
-        await versions.create_index(
-            [("app_id", 1), ("lineage_root_id", 1), ("created_at", -1)],
-            name="av_app_lineage_created",
-        )
-        await versions.create_index(
-            [("app_id", 1), ("lifecycle_status", 1), ("updated_at", -1)],
-            name="av_app_status_updated",
+    # Retired unique indexes keyed on fields BuildRecord documents never carry
+    # (every record produced null tuples, so distinct build families collided
+    # with E11000). Each retired index is identified by its COMPLETE historical
+    # definition, never by name alone: dropping is destructive DDL, and an
+    # unrelated operator index that merely reuses a retired name must fail the
+    # store closed instead of being deleted.
+    _RETIRED_INDEX_CONTRACT: dict[str, list[dict[str, Any]]] = {
+        "ArtifactVersions": [
+            {
+                "name": "av_app_kind_key_version",
+                "keys": [
+                    ("app_id", 1),
+                    ("artifact_kind", 1),
+                    ("artifact_key", 1),
+                    ("version_number", -1),
+                ],
+                "unique": True,
+            },
+        ],
+        "ArtifactVersionCounters": [
+            {
+                "name": "avc_app_kind_key",
+                "keys": [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
+                "unique": True,
+            },
+        ],
+    }
+
+    # BuildRecord identity is (app_id, build_family, build_key, version_number);
+    # the model carries app scope as app_id only (build_app_scope_filter).
+    _INDEX_CONTRACT: dict[str, list[dict[str, Any]]] = {
+        "ArtifactVersions": [
+            {
+                "name": "av_app_family_key_version",
+                "keys": [
+                    ("app_id", 1),
+                    ("build_family", 1),
+                    ("build_key", 1),
+                    ("version_number", -1),
+                ],
+                "unique": True,
+            },
+            {
+                "name": "av_app_lineage_created",
+                "keys": [("app_id", 1), ("lineage_root_id", 1), ("created_at", -1)],
+            },
+            {
+                "name": "av_app_status_updated",
+                "keys": [("app_id", 1), ("lifecycle_status", 1), ("updated_at", -1)],
+            },
+            {
+                # Storage-level invariant: at most one CURRENT record per
+                # (app_id, build_family, build_key). Concurrent independent
+                # clients racing supersede-then-publish cannot both land
+                # CURRENT — the second publish fails with DuplicateKeyError,
+                # which the store translates into a typed conflict.
+                "name": "av_unique_current",
+                "keys": [("app_id", 1), ("build_family", 1), ("build_key", 1)],
+                "unique": True,
+                "partialFilterExpression": {"lifecycle_status": "current"},
+            },
+        ],
+        "ArtifactVersionCounters": [
+            {
+                "name": "avc_app_family_key",
+                "keys": [("app_id", 1), ("build_family", 1), ("build_key", 1)],
+                "unique": True,
+            },
+        ],
+        "ChangeRequests": [
+            {
+                "name": "cr_app_record_created",
+                "keys": [("app_id", 1), ("build_record_id", 1), ("created_at", -1)],
+            },
+            {
+                "name": "cr_app_class_created",
+                "keys": [("app_id", 1), ("classification", 1), ("created_at", -1)],
+            },
+        ],
+        "RefinementSessions": [
+            {
+                "name": "rs_app_record_started",
+                "keys": [("app_id", 1), ("build_record_id", 1), ("started_at", -1)],
+            },
+            {
+                "name": "rs_app_result_record_started",
+                "keys": [("app_id", 1), ("result_build_record_id", 1), ("started_at", -1)],
+                "sparse": True,
+            },
+            {
+                "name": "rs_app_sandbox",
+                "keys": [("app_id", 1), ("sandbox_id", 1)],
+                "sparse": True,
+            },
+        ],
+    }
+
+    async def _ensure_indexes(self, *, client: Any) -> None:
+        """Verify and materialize the store's complete index contract.
+
+        Runs as a full preflight before any destructive action: every present
+        retired-name candidate is compared against its exact historical
+        definition first. Only exact matches are dropped; a same-name index
+        with any other definition fails the store closed with a typed
+        index-contract error, and no unrelated index is ever deleted. The
+        canonical indexes are then installed/verified through the canonical
+        runtime index verifier; a same-name canonical index with a different
+        definition also fails closed.
+        """
+        from mozaiksai.core.runtime.persistence.indexes import (
+            DatabaseIndexApplyError,
+            _ensure_raw_collection_indexes,
+            _index_mismatches,
+            _normalize_index_spec,
         )
 
-        counters = await self._coll("ArtifactVersionCounters")
-        await counters.create_index(
-            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
-            name="avc_app_kind_key",
-            unique=True,
-        )
+        database = client[_DATABASE_NAME]
 
-        change_requests = await self._coll("ChangeRequests")
-        await change_requests.create_index(
-            [("app_id", 1), ("build_record_id", 1), ("created_at", -1)],
-            name="cr_app_record_created",
-        )
-        await change_requests.create_index(
-            [("app_id", 1), ("classification", 1), ("created_at", -1)],
-            name="cr_app_class_created",
-        )
+        # Preflight: verify every retired-name candidate everywhere before
+        # executing a single drop.
+        verified_drops: list[tuple[Any, str]] = []
+        for collection_name, retired_specs in self._RETIRED_INDEX_CONTRACT.items():
+            collection = database[collection_name]
+            existing_rows = {
+                str(row.get("name") or ""): dict(row)
+                for row in await collection.list_indexes().to_list(length=None)
+            }
+            for raw_spec in retired_specs:
+                spec = _normalize_index_spec(
+                    dict(raw_spec), f"{collection_name}.retired[{raw_spec['name']}]"
+                )
+                present = existing_rows.get(spec.name)
+                if present is None:
+                    continue
+                mismatch = "; ".join(_index_mismatches(present, spec))
+                if mismatch:
+                    raise DatabaseIndexApplyError(
+                        f"Refusing to drop index {spec.name!r} on "
+                        f"{collection_name!r}: existing definition does not "
+                        f"match the retired contract ({mismatch}). Resolve the "
+                        "conflicting index manually; the store fails closed."
+                    )
+                verified_drops.append((collection, spec.name))
 
-        refinement_sessions = await self._coll("RefinementSessions")
-        await refinement_sessions.create_index(
-            [("app_id", 1), ("build_record_id", 1), ("started_at", -1)],
-            name="rs_app_record_started",
-        )
-        await refinement_sessions.create_index(
-            [("app_id", 1), ("result_build_record_id", 1), ("started_at", -1)],
-            name="rs_app_result_record_started",
-            sparse=True,
-        )
-        await refinement_sessions.create_index(
-            [("app_id", 1), ("sandbox_id", 1)],
-            name="rs_app_sandbox",
-            sparse=True,
-        )
+        for collection, index_name in verified_drops:
+            await collection.drop_index(index_name)
+
+        for collection_name, specs in self._INDEX_CONTRACT.items():
+            await _ensure_raw_collection_indexes(
+                database[collection_name],
+                specs,
+                collection_label=collection_name,
+            )
 
     async def _coll(self, name: str):
         await self._ensure_client()
-        return self.client["mozaiksai"][name]  # type: ignore[index]
+        return self.client[_DATABASE_NAME][name]  # type: ignore[index]
 
     async def _next_build_record_version_number(self, *, app_id: str, build_family: str, build_key: str) -> int:
         counters = await self._coll("ArtifactVersionCounters")
@@ -165,8 +299,8 @@ class BuildRecordStore:
         self,
         *,
         app_id: str,
-        artifact_kind: str,
-        artifact_key: str,
+        build_family: str,
+        build_key: str | None = None,
         reason: str,
         invalidated_by_version_id: str | None = None,
         exclude_version_id: str | None = None,
@@ -176,10 +310,11 @@ class BuildRecordStore:
             raise ValueError("app_id is required")
         query: dict[str, Any] = {
             "app_id": resolved_app_id,
-            "artifact_kind": artifact_kind,
-            "artifact_key": artifact_key,
+            "build_family": build_family,
             "lifecycle_status": {"$nin": [ArtifactLifecycleStatus.ARCHIVED.value, ArtifactLifecycleStatus.DELETED.value, ArtifactLifecycleStatus.STALE.value]},
         }
+        if build_key is not None:
+            query["build_key"] = build_key
         if exclude_version_id:
             query["_id"] = {"$ne": exclude_version_id}
         versions = await self._coll("ArtifactVersions")
@@ -203,7 +338,7 @@ class BuildRecordStore:
         *,
         app_id: str,
         artifact_version_refs: dict[str, str],
-        affected_artifact_kinds: Iterable[str] | None = None,
+        affected_build_families: Iterable[str] | None = None,
         reason: str,
         invalidated_by_version_id: str | None = None,
     ) -> list[str]:
@@ -212,23 +347,23 @@ class BuildRecordStore:
             raise ValueError("app_id is required")
 
         normalized_refs: dict[str, str] = {}
-        for raw_kind, raw_version_id in dict(artifact_version_refs or {}).items():
-            artifact_kind = str(raw_kind or "").strip()
+        for raw_family, raw_version_id in dict(artifact_version_refs or {}).items():
+            build_family = str(raw_family or "").strip()
             artifact_version_id = str(raw_version_id or "").strip()
-            if artifact_kind and artifact_version_id:
-                normalized_refs[artifact_kind] = artifact_version_id
+            if build_family and artifact_version_id:
+                normalized_refs[build_family] = artifact_version_id
 
-        target_kinds: list[str] = []
-        raw_target_kinds = list(affected_artifact_kinds or normalized_refs.keys())
-        for raw_kind in raw_target_kinds:
-            artifact_kind = str(raw_kind or "").strip()
-            if artifact_kind and artifact_kind not in target_kinds:
-                target_kinds.append(artifact_kind)
+        target_families: list[str] = []
+        raw_target_families = list(affected_build_families or normalized_refs.keys())
+        for raw_family in raw_target_families:
+            build_family = str(raw_family or "").strip()
+            if build_family and build_family not in target_families:
+                target_families.append(build_family)
 
         invalidated_ids: list[str] = []
         seen_version_ids: set[str] = set()
-        for artifact_kind in target_kinds:
-            artifact_version_id = normalized_refs.get(artifact_kind)  # type: ignore[assignment]
+        for build_family in target_families:
+            artifact_version_id = normalized_refs.get(build_family)  # type: ignore[assignment]
             if not artifact_version_id or artifact_version_id in seen_version_ids:
                 continue
             seen_version_ids.add(artifact_version_id)
@@ -519,31 +654,6 @@ class BuildRecordStore:
         rows = await cursor.to_list(length=max(1, int(limit)))
         return [RefinementSessionDoc.model_validate(row) for row in rows]
 
-    async def get_current_artifact_version_refs(self, *, app_id: str) -> dict[str, str]:
-        """Return a mapping of artifact_kind → artifact_version_id for all CURRENT versions."""
-        resolved_app_id = str(coalesce_app_id(app_id=app_id) or "").strip()
-        if not resolved_app_id:
-            return {}
-        await self._ensure_client()
-        versions = await self._coll("ArtifactVersions")
-        try:
-            scope = build_app_scope_filter(resolved_app_id)
-            cursor = versions.find(
-                {**scope, "lifecycle_status": ArtifactLifecycleStatus.CURRENT.value},
-                projection={"artifact_kind": 1, "build_family": 1, "_id": 1, "version_number": 1},
-            ).sort("version_number", -1)
-            rows = await cursor.to_list(length=200)
-            refs: dict[str, str] = {}
-            for row in rows:
-                kind = str(row.get("artifact_kind") or row.get("build_family") or "").strip()
-                version_id = str(row.get("_id") or "").strip()
-                if kind and version_id and kind not in refs:
-                    refs[kind] = version_id
-            return refs
-        except Exception as exc:
-            logger.warning("get_current_artifact_version_refs failed for app %s: %s", resolved_app_id, exc)
-            return {}
-
     async def get_current_build_record_refs(self, *, app_id: str) -> dict[str, str]:
         """Return a mapping of build_family → build_record_id for all CURRENT build records."""
         resolved_app_id = str(coalesce_app_id(app_id=app_id) or "").strip()
@@ -555,12 +665,12 @@ class BuildRecordStore:
             scope = build_app_scope_filter(resolved_app_id)
             cursor = versions.find(
                 {**scope, "lifecycle_status": ArtifactLifecycleStatus.CURRENT.value},
-                projection={"build_family": 1, "artifact_kind": 1, "_id": 1, "version_number": 1},
+                projection={"build_family": 1, "_id": 1, "version_number": 1},
             ).sort("version_number", -1)
             rows = await cursor.to_list(length=200)
             refs: dict[str, str] = {}
             for row in rows:
-                family = str(row.get("build_family") or row.get("artifact_kind") or "").strip()
+                family = str(row.get("build_family") or "").strip()
                 record_id = str(row.get("_id") or "").strip()
                 if family and record_id and family not in refs:
                     refs[family] = record_id
@@ -568,34 +678,6 @@ class BuildRecordStore:
         except Exception as exc:
             logger.warning("get_current_build_record_refs failed for app %s: %s", resolved_app_id, exc)
             return {}
-
-    async def get_stale_artifact_families(self, *, app_id: str) -> list[str]:
-        """Return artifact family names that are genuinely stale (STALE but no CURRENT)."""
-        resolved_app_id = str(coalesce_app_id(app_id=app_id) or "").strip()
-        if not resolved_app_id:
-            return []
-        await self._ensure_client()
-        versions = await self._coll("ArtifactVersions")
-        try:
-            scope = build_app_scope_filter(resolved_app_id)
-            stale_kinds: set[str] = set(
-                await versions.distinct(
-                    "artifact_kind",
-                    {**scope, "lifecycle_status": ArtifactLifecycleStatus.STALE.value},
-                )
-            )
-            if not stale_kinds:
-                return []
-            current_kinds: set[str] = set(
-                await versions.distinct(
-                    "artifact_kind",
-                    {**scope, "lifecycle_status": ArtifactLifecycleStatus.CURRENT.value},
-                )
-            )
-            return sorted(str(k) for k in (stale_kinds - current_kinds) if k)
-        except Exception as exc:
-            logger.warning("get_stale_artifact_families failed for app %s: %s", resolved_app_id, exc)
-            return []
 
     async def get_stale_build_families(self, *, app_id: str) -> list[str]:
         """Return build family names that are genuinely stale (STALE but no CURRENT)."""
@@ -636,6 +718,8 @@ class BuildRecordStore:
         files_manifest: Iterable[dict[str, Any] | ArtifactFileManifestEntry] | None = None,
         source_workflow: str | None = None,
         source_chat_id: str | None = None,
+        workflow_run_id: str | None = None,
+        build_id: str | None = None,
         parent_build_record_id: str | None = None,
         canonical_inputs_version: dict[str, str] | None = None,
         lifecycle_status: ArtifactLifecycleStatus = ArtifactLifecycleStatus.CURRENT,
@@ -687,6 +771,8 @@ class BuildRecordStore:
             lineage_root_id=lineage_root_id,
             source_workflow=source_workflow,
             source_chat_id=source_chat_id,
+            workflow_run_id=str(workflow_run_id).strip() or None if workflow_run_id else None,
+            build_id=str(build_id).strip() or None if build_id else None,
             canonical_inputs_version=dict(canonical_inputs_version or {}),
             lifecycle_status=lifecycle_status,
             validation_status=validation_status,
@@ -716,7 +802,20 @@ class BuildRecordStore:
                 },
             )
 
-        await versions.insert_one(record.model_dump(by_alias=True, mode="python"))
+        try:
+            await versions.insert_one(record.model_dump(by_alias=True, mode="python"))
+        except DuplicateKeyError as exc:
+            if lifecycle_status == ArtifactLifecycleStatus.CURRENT:
+                # A concurrent writer made another record CURRENT between this
+                # call's supersede step and its insert; the partial unique
+                # index keeps the invariant and this record was not created.
+                raise BuildRecordCurrentConflictError(
+                    app_id=resolved_app_id,
+                    build_family=build_family,
+                    build_key=build_key,
+                    build_record_id=build_record_id,
+                ) from exc
+            raise
         return record
 
     async def get_build_record(
@@ -920,10 +1019,23 @@ class BuildRecordStore:
                 }
             },
         )
-        await versions.update_one(
-            {"_id": target.id, **build_app_scope_filter(resolved_app_id)},
-            {"$set": updates},
-        )
+        try:
+            await versions.update_one(
+                {"_id": target.id, **build_app_scope_filter(resolved_app_id)},
+                {"$set": updates},
+            )
+        except DuplicateKeyError as exc:
+            # The av_unique_current partial unique index rejected the publish:
+            # a concurrent independent client made a different record CURRENT
+            # after this accept's supersede step ran. Re-accepting the record
+            # that already IS current never conflicts (same document), so a
+            # duplicate here always means a different-target winner.
+            raise BuildRecordCurrentConflictError(
+                app_id=resolved_app_id,
+                build_family=target.build_family,
+                build_key=target.build_key,
+                build_record_id=target.id,
+            ) from exc
         refreshed = await versions.find_one({"_id": target.id, **build_app_scope_filter(resolved_app_id)})
         return BuildRecord.model_validate(refreshed) if isinstance(refreshed, dict) else target
 

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -130,6 +130,18 @@ def _context_authority_policy_for_workflow(workflow_name: str):
     )
 
 
+# Server-owned session fields: written only through
+# AG2PersistenceManager.persist_server_owned_session_fields by trusted runtime
+# write points (the workflow bridge's run-identity mint and the terminal
+# receipt boundary). Generic context persistence rejects them with a logged
+# warning so model/tool-authored installs or replacements are detectable.
+SERVER_OWNED_SESSION_FIELDS = frozenset({
+    "build_terminal_receipt",
+    "run_build_binding",
+    "workflow_run_id",
+})
+
+
 class PersistenceManager:
     """Mongo connection holder for runtime persistence."""
 
@@ -542,6 +554,14 @@ class AG2PersistenceManager:
                 f"context_authority.policy_unavailable workflow={clean_workflow_name} op=replay"
             ) from e
 
+        # Server-owned lifecycle fields are runtime infrastructure, not
+        # workflow-declared context: they bypass the declared-variable replay
+        # policy (which would drop them as unknown) but are only ever written
+        # through the privileged setter, never by workflow context updates.
+        server_owned = {
+            key: extra.pop(key) for key in list(extra) if key in SERVER_OWNED_SESSION_FIELDS
+        }
+
         replay_diagnostics: list[str] = []
         filtered = policy.filter_for_replay(
             extra,
@@ -555,6 +575,7 @@ class AG2PersistenceManager:
                 chat_id,
                 replay_diagnostics,
             )
+        filtered.update(server_owned)
         return filtered
 
     async def persist_context_variables(
@@ -619,6 +640,19 @@ class AG2PersistenceManager:
         for key, value in variables.items():
             if not isinstance(key, str) or not key.strip() or key in protected:
                 continue
+            if key in SERVER_OWNED_SESSION_FIELDS:
+                # Server-owned lifecycle authority fields are never writable
+                # through generic context persistence: a model/tool-authored
+                # context update must not install or replace them. The
+                # rejection is logged so tampering attempts are detectable.
+                logger.warning(
+                    "[PERSIST_CONTEXT_VARIABLES] Rejected write to server-owned "
+                    "session field %r (chat_id=%s workflow=%s)",
+                    key,
+                    chat_id,
+                    clean_workflow_name,
+                )
+                continue
             candidate_updates[key] = value
         if not candidate_updates:
             return
@@ -662,6 +696,62 @@ class AG2PersistenceManager:
         if matched_count is not None and matched_count == 0:
             raise RuntimeError(
                 f"failed to persist workflow context for chat_id={chat_id}: scoped session was not found"
+            )
+
+    async def persist_server_owned_session_fields(
+        self,
+        *,
+        chat_id: str,
+        app_id: str | None = None,
+        workflow_name: str | None = None,
+        fields: dict[str, Any] | None = None,
+    ) -> None:
+        """Write server-owned lifecycle authority fields for a chat session.
+
+        This is the only durable write path for SERVER_OWNED_SESSION_FIELDS
+        (run identity, terminal build receipt). It bypasses workflow-declared
+        context policy because these are runtime infrastructure facts, not
+        workflow context variables — but it writes into the same session
+        document through the same authority; there is no second context
+        store. Keys outside the reserved set are rejected.
+        """
+        resolved_app_id = coalesce_app_id(app_id=app_id)
+        if not resolved_app_id:
+            raise ValueError("app_id is required")
+        clean_workflow_name = str(workflow_name or "").strip()
+        updates: dict[str, Any] = {}
+        for key, value in (fields or {}).items():
+            if key not in SERVER_OWNED_SESSION_FIELDS:
+                raise ValueError(
+                    f"{key!r} is not a server-owned session field; use "
+                    "persist_context_variables for workflow context"
+                )
+            updates[key] = deepcopy(value)
+        if not updates:
+            return
+        updates["last_updated_at"] = datetime.now(UTC)
+
+        scope: dict[str, Any] = {
+            "_id": chat_id,
+            **build_app_scope_filter(str(resolved_app_id)),
+        }
+        if clean_workflow_name:
+            scope["workflow_name"] = clean_workflow_name
+        coll = await self._coll()
+        result = await coll.update_one(
+            scope,
+            {"$set": updates, "$inc": {"session_version": 1}},
+        )
+        if getattr(result, "acknowledged", True) is False:
+            raise RuntimeError(
+                f"failed to persist server-owned session fields for chat_id={chat_id}: "
+                "write was not acknowledged"
+            )
+        matched_count = getattr(result, "matched_count", None)
+        if matched_count is not None and matched_count == 0:
+            raise RuntimeError(
+                f"failed to persist server-owned session fields for chat_id={chat_id}: "
+                "scoped session was not found"
             )
 
     async def create_general_chat_session(

--- a/tests/test_appgenerator_generate_and_download_persistence.py
+++ b/tests/test_appgenerator_generate_and_download_persistence.py
@@ -58,10 +58,15 @@ class _FakeStore:
 class _FakeArtifactStore:
     def __init__(self) -> None:
         self.calls = []
+        self.accepted_ids = []
 
     async def create_build_record(self, **kwargs):
         self.calls.append(dict(kwargs))
         return type("ArtifactVersion", (), {"id": "av_bundle_1"})()
+
+    async def accept_build_record(self, *, app_id, build_record_id, commit_metadata=None):
+        self.accepted_ids.append(build_record_id)
+        return type("ArtifactVersion", (), {"id": build_record_id})()
 
 
 def test_generate_and_download_merges_accepted_bundle_persisted_additions_and_deletions() -> None:
@@ -127,7 +132,25 @@ def test_persist_pending_schema_migration_records_staged_history(monkeypatch, tm
     assert (tmp_path / "data" / "migrations" / "m_1.json").exists()
 
 
+class _StubGreenfieldRegistration:
+    def __init__(self) -> None:
+        self.context_version = type("ContextVersion", (), {"context_version_id": "acv_1"})()
+        self.artifact_version = type("ArtifactVersion", (), {"id": "av_context_1"})()
+
+
+def _stub_greenfield_registration(monkeypatch) -> None:
+    async def _register(**_kwargs):
+        return _StubGreenfieldRegistration()
+
+    monkeypatch.setattr(
+        generate_and_download_module,
+        "register_greenfield_app_context_version",
+        _register,
+    )
+
+
 def test_register_app_bundle_artifact_version_sets_context_and_parent(monkeypatch, tmp_path: Path) -> None:
+    _stub_greenfield_registration(monkeypatch)
     fake_artifact_store = _FakeArtifactStore()
     artifacts_mod = importlib.import_module("mozaiksai.core.artifacts")
     monkeypatch.setattr(artifacts_mod, "get_artifact_store", lambda: fake_artifact_store)
@@ -191,6 +214,7 @@ def test_register_app_bundle_artifact_version_sets_context_and_parent(monkeypatc
 
 
 def test_register_app_bundle_artifact_version_marks_failed_acceptance(monkeypatch, tmp_path: Path) -> None:
+    _stub_greenfield_registration(monkeypatch)
     fake_artifact_store = _FakeArtifactStore()
     artifacts_mod = importlib.import_module("mozaiksai.core.artifacts")
     monkeypatch.setattr(artifacts_mod, "get_artifact_store", lambda: fake_artifact_store)

--- a/tests/test_appgenerator_greenfield_app_context_registration.py
+++ b/tests/test_appgenerator_greenfield_app_context_registration.py
@@ -81,6 +81,8 @@ class _MemoryArtifactStore:
             source_workflow=kwargs.get("source_workflow"),
             source_chat_id=kwargs.get("source_chat_id"),
             canonical_inputs_version=kwargs.get("canonical_inputs_version") or {},
+            workflow_run_id=kwargs.get("workflow_run_id"),
+            build_id=kwargs.get("build_id"),
             lifecycle_status=kwargs.get("lifecycle_status", ArtifactLifecycleStatus.DRAFT),
             validation_status=kwargs.get("validation_status", ArtifactValidationStatus.PENDING),
             files_manifest=kwargs.get("files_manifest") or [],
@@ -152,9 +154,26 @@ class _MemoryArtifactStore:
                 doc.lifecycle_status = ArtifactLifecycleStatus.SUPERSEDED
 
 
-def _patch_artifact_store(monkeypatch, store: _MemoryArtifactStore) -> None:
+class _FakeSessionPM:
+    """Server-owned session-field sink for terminal receipt persistence."""
+
+    def __init__(self) -> None:
+        self.server_owned: dict[str, Any] = {}
+
+    async def persist_server_owned_session_fields(
+        self, *, chat_id: str, app_id: str | None = None,
+        workflow_name: str | None = None, fields: dict[str, Any] | None = None,
+    ) -> None:
+        self.server_owned.update(fields or {})
+
+
+def _patch_artifact_store(monkeypatch, store: _MemoryArtifactStore) -> _FakeSessionPM:
     artifacts_mod = importlib.import_module("mozaiksai.core.artifacts")
     monkeypatch.setattr(artifacts_mod, "get_artifact_store", lambda: store)
+    session_pm = _FakeSessionPM()
+    monkeypatch.setattr(
+        generate_and_download_module, "_ag2_persistence_manager", lambda: session_pm
+    )
     monkeypatch.setattr(
         artifacts_mod,
         "resolve_latest_artifact_version_refs",
@@ -168,6 +187,7 @@ def _patch_artifact_store(monkeypatch, store: _MemoryArtifactStore) -> None:
             },
         ),
     )
+    return session_pm
 
 
 def _write_generated_app(app_dir: Path) -> list[str]:
@@ -283,12 +303,17 @@ async def test_appgenerator_app_bundle_save_registers_greenfield_context(
         assert (app_dir / rel_path).read_text(encoding="utf-8") == content
 
 
-async def test_appgenerator_greenfield_context_registration_failure_is_nonfatal(
+async def test_appgenerator_greenfield_context_registration_failure_fails_the_build(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
+    """Required CURRENT lineage persistence failure must fail bundle registration.
+
+    Hosting and refinement resolve the CURRENT AppContextVersion; the build
+    must not claim success while that lineage does not exist.
+    """
     store = _MemoryArtifactStore()
-    _patch_artifact_store(monkeypatch, store)
+    session_pm = _patch_artifact_store(monkeypatch, store)
 
     async def _fail_registration(**_kwargs: Any) -> None:
         raise RuntimeError("context store unavailable")
@@ -305,25 +330,28 @@ async def test_appgenerator_greenfield_context_registration_failure_is_nonfatal(
     zip_path.write_bytes(b"fake bundle bytes")
     context = _Context({"app_bundle_acceptance_status": "passed"})
 
-    app_bundle = await generate_and_download_module._register_app_bundle_artifact_version(
-        app_id="field_service",
-        user_id="user_123",
-        workflow_name="AppGenerator",
-        chat_id="chat_greenfield",
-        bundle_name="GeneratedApp",
-        zip_path=zip_path,
-        app_dir=app_dir,
-        written_paths=written_paths,
-        context_variables=context,
-    )
+    with pytest.raises(RuntimeError, match="context store unavailable"):
+        await generate_and_download_module._register_app_bundle_artifact_version(
+            app_id="field_service",
+            user_id="user_123",
+            workflow_name="AppGenerator",
+            chat_id="chat_greenfield",
+            bundle_name="GeneratedApp",
+            zip_path=zip_path,
+            app_dir=app_dir,
+            written_paths=written_paths,
+            context_variables=context,
+        )
 
-    assert app_bundle.id == "av_app_bundle_1"
-    assert context.data["artifact_version_id"] == "av_app_bundle_1"
-    assert "context store unavailable" in context.data["app_context_registration_warning"]
-    assert {call["build_family"] for call in store.create_calls} == {"app_bundle"}
+    assert context.data.get("greenfield_app_context_registered") is not True
+    assert context.data.get("download_status") != "ready"
+    assert context.data.get("app_download_ready") is not True
+    # An unidentified run (no minted workflow_run_id) never persists
+    # server-owned run/build authority.
+    assert session_pm.server_owned == {}
 
 
-async def test_appgenerator_greenfield_context_contract_errors_can_be_strict() -> None:
+async def test_appgenerator_greenfield_context_contract_errors_fail_closed() -> None:
     store = _MemoryArtifactStore()
 
     with pytest.raises(ValueError, match="app_id is required"):
@@ -334,7 +362,6 @@ async def test_appgenerator_greenfield_context_contract_errors_can_be_strict() -
             workflow_name="AppGenerator",
             chat_id="chat_greenfield",
             context_variables=_Context(),
-            raise_on_contract_error=True,
         )
 
 
@@ -356,3 +383,173 @@ def test_appgenerator_context_registration_has_no_graph_database_or_proprietary_
         for term in forbidden_terms:
             assert term.lower() not in text
 
+
+async def test_auto_tool_failure_traversal_never_claims_completion(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Full path: auto-tool catch -> error result -> run-bound failure receipt.
+
+    The auto-tool handler converts the raised required-lineage failure into an
+    error tool result; the registration boundary must persist the typed
+    run-bound failure receipt, and no partial state may look like a
+    successful CURRENT lineage.
+    """
+    from types import SimpleNamespace
+
+    from mozaiksai.core.events.auto_tool_handler import AutoToolEventHandler
+
+    store = _MemoryArtifactStore()
+    session_pm = _patch_artifact_store(monkeypatch, store)
+
+    async def _fail_registration(**_kwargs: Any) -> None:
+        raise RuntimeError("context store unavailable")
+
+    monkeypatch.setattr(
+        generate_and_download_module,
+        "register_greenfield_app_context_version",
+        _fail_registration,
+    )
+
+    app_dir = tmp_path / "GeneratedApp"
+    written_paths = _write_generated_app(app_dir)
+    zip_path = tmp_path / "GeneratedApp.zip"
+    zip_path.write_bytes(b"fake bundle bytes")
+    run_id = "wfrun_greenfield_traversal"
+    context = _Context(
+        {"app_bundle_acceptance_status": "passed", "workflow_run_id": run_id}
+    )
+
+    async def _terminal_tool(**kwargs: Any) -> dict[str, Any]:
+        await generate_and_download_module._register_app_bundle_artifact_version(
+            app_id="field_service",
+            user_id="user_123",
+            workflow_name="AppGenerator",
+            chat_id="chat_greenfield",
+            bundle_name="GeneratedApp",
+            zip_path=zip_path,
+            app_dir=app_dir,
+            written_paths=written_paths,
+            context_variables=kwargs["context_variables"],
+        )
+        return {"status": "success"}
+
+    handler = AutoToolEventHandler.__new__(AutoToolEventHandler)
+    binding = SimpleNamespace(
+        function=_terminal_tool, agent_name="DownloadAgent", tool_name="generate_and_download"
+    )
+    result, status = await handler._invoke_tool(binding, {"context_variables": context})
+
+    # The real shared catch converted the failure into an error tool result.
+    assert status == "error"
+    assert result == {"status": "error", "message": "tool_execution_failed"}
+
+    # The registration boundary issued the run-bound failure receipt; markers
+    # remain UI projections and no success/ready claim exists anywhere.
+    from mozaiksai.core.artifacts.build_receipt import (
+        TERMINAL_RECEIPT_CONTEXT_KEY,
+        parse_terminal_receipt,
+    )
+
+    receipt = parse_terminal_receipt(context.data.get(TERMINAL_RECEIPT_CONTEXT_KEY))
+    assert receipt.kind == "failure"
+    assert receipt.workflow_run_id == run_id
+    assert receipt.error_code == "lineage_registration_failed"
+    assert context.data.get("download_status") == "failed"
+    assert context.data.get("app_download_ready") is False
+    assert context.data.get("greenfield_app_context_registered") is not True
+
+    # The run established its build before the lineage failure, so the sealed
+    # run/build binding exists, the failure receipt carries exactly that
+    # build, and the binding cold-verifies against the persisted record.
+    from mozaiksai.core.artifacts.closure import verify_run_build_binding_closure
+    from mozaiksai.core.artifacts.run_build_binding import parse_run_build_binding
+
+    run_binding = parse_run_build_binding(context.data.get("run_build_binding"))
+    assert run_binding.workflow_run_id == run_id
+    assert run_binding.build_id == f"build_{run_id}"
+    assert receipt.build_id == run_binding.build_id
+    assert session_pm.server_owned.get("run_build_binding") == run_binding.model_dump(
+        mode="json"
+    )
+    assert await verify_run_build_binding_closure(
+        run_binding,
+        workflow_run_id=run_id,
+        app_id="field_service",
+        workflow_name="AppGenerator",
+        store=store,
+    )
+
+    # Lifecycle event consumption of this receipt is the run-bound lifecycle
+    # cutover (the follow-up PR); this contract PR proves the persisted
+    # authority is exact and truthful for that consumer.
+
+    # Partial state: the bundle record exists only as a non-current draft and
+    # no CURRENT AppContextVersion lineage was created.
+    bundle_calls = [c for c in store.create_calls if c["build_family"] == "app_bundle"]
+    assert bundle_calls and all(
+        str(getattr(c["lifecycle_status"], "value", c["lifecycle_status"])) == "draft"
+        for c in bundle_calls
+    )
+    assert not [c for c in store.create_calls if c["build_family"] == "app_context_version"]
+
+    # Retry is deterministic: it fails identically and cannot mint CURRENT state.
+    result2, status2 = await handler._invoke_tool(binding, {"context_variables": context})
+    assert status2 == "error" and result2["status"] == "error"
+    assert not [c for c in store.create_calls if c["build_family"] == "app_context_version"]
+
+
+async def test_pre_build_failure_issues_run_level_failure_not_build_receipt(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A run that fails before establishing any build gets WorkflowRunFailure.
+
+    No BuildRecord was created, so there is no run/build binding, no
+    build-specific failure receipt, and no fabricated build identity — the
+    persisted terminal outcome is the run-level failure only.
+    """
+    from mozaiksai.core.artifacts.build_receipt import (
+        TERMINAL_RECEIPT_CONTEXT_KEY,
+        parse_terminal_receipt,
+    )
+
+    store = _MemoryArtifactStore()
+    session_pm = _patch_artifact_store(monkeypatch, store)
+
+    app_dir = tmp_path / "GeneratedApp"
+    written_paths = _write_generated_app(app_dir)
+    missing_zip = tmp_path / "never_written.zip"
+    run_id = "wfrun_prebuild_failure"
+    context = _Context(
+        {"app_bundle_acceptance_status": "passed", "workflow_run_id": run_id}
+    )
+
+    with pytest.raises(FileNotFoundError):
+        await generate_and_download_module._register_app_bundle_artifact_version(
+            app_id="field_service",
+            user_id="user_123",
+            workflow_name="AppGenerator",
+            chat_id="chat_greenfield",
+            bundle_name="GeneratedApp",
+            zip_path=missing_zip,
+            app_dir=app_dir,
+            written_paths=written_paths,
+            context_variables=context,
+        )
+
+    # No build was established: no record, no binding, anywhere.
+    assert store.create_calls == []
+    assert "run_build_binding" not in context.data
+    assert "run_build_binding" not in session_pm.server_owned
+
+    # The persisted terminal outcome is the run-level failure with the exact
+    # run identity and no build fields at all.
+    receipt = parse_terminal_receipt(context.data.get(TERMINAL_RECEIPT_CONTEXT_KEY))
+    assert receipt.kind == "run_failure"
+    assert receipt.workflow_run_id == run_id
+    assert receipt.error_code == "run_failed_before_build"
+    assert "build_id" not in type(receipt).model_fields
+    assert session_pm.server_owned.get("build_terminal_receipt") == receipt.model_dump(
+        mode="json"
+    )

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -84,8 +84,8 @@ async def test_invalidate_artifact_family_marks_versions_stale() -> None:
 
     modified = await store.invalidate_artifact_family(
         app_id="app-1",
-        artifact_kind="app_bundle",
-        artifact_key="primary",
+        build_family="app_bundle",
+        build_key="primary",
         reason="design changed upstream",
         invalidated_by_version_id="av_new",
         exclude_version_id="av_keep",
@@ -94,8 +94,8 @@ async def test_invalidate_artifact_family_marks_versions_stale() -> None:
     assert modified == 2
     query, update = versions_coll.update_many.await_args.args
     assert query["app_id"] == "app-1"
-    assert query["artifact_kind"] == "app_bundle"
-    assert query["artifact_key"] == "primary"
+    assert query["build_family"] == "app_bundle"
+    assert query["build_key"] == "primary"
     assert query["_id"] == {"$ne": "av_keep"}
     assert update["$set"]["lifecycle_status"] == ArtifactLifecycleStatus.STALE.value
     assert update["$set"]["invalidated_by_version_id"] == "av_new"
@@ -115,7 +115,7 @@ async def test_invalidate_artifact_version_refs_marks_only_targeted_known_versio
             "app_bundle": "av_bundle_1",
             "workflow_bundle": "av_workflow_1",
         },
-        affected_artifact_kinds=["concept", "missing", "app_bundle", "workflow_bundle"],
+        affected_build_families=["concept", "missing", "app_bundle", "workflow_bundle"],
         reason="change_request:cr_123",
     )
 
@@ -352,7 +352,7 @@ async def test_list_refinement_sessions_filters_by_result_build_record_id() -> N
 
 
 @pytest.mark.asyncio
-async def test_get_stale_artifact_families_returns_stale_without_current() -> None:
+async def test_get_stale_build_families_returns_stale_without_current() -> None:
     """Families with a STALE version but no CURRENT version are returned."""
     store = BuildRecordStore.__new__(BuildRecordStore)
     versions_coll = MagicMock()
@@ -365,17 +365,19 @@ async def test_get_stale_artifact_families_returns_stale_without_current() -> No
     store._coll = AsyncMock(return_value=versions_coll)
     store._ensure_client = AsyncMock()
 
-    result = await store.get_stale_artifact_families(app_id="app-1")
+    result = await store.get_stale_build_families(app_id="app-1")
 
     # workflow_bundle has a CURRENT version, so it is not stale
     # design_docs has no CURRENT version, so it remains stale
     assert result == ["design_docs"]
     assert versions_coll.distinct.await_count == 2
+    for call in versions_coll.distinct.await_args_list:
+        assert call.args[0] == "build_family"
 
 
 @pytest.mark.asyncio
-async def test_get_current_artifact_version_refs_returns_highest_current_per_kind() -> None:
-    """Returns the highest-versioned CURRENT artifact_version_id for each kind."""
+async def test_get_current_build_record_refs_returns_highest_current_per_family() -> None:
+    """Returns the highest-versioned CURRENT build_record_id for each build family."""
     store = BuildRecordStore.__new__(BuildRecordStore)
     versions_coll = MagicMock()
     cursor = MagicMock()
@@ -383,16 +385,16 @@ async def test_get_current_artifact_version_refs_returns_highest_current_per_kin
     cursor.sort.return_value = cursor
     cursor.to_list = AsyncMock(
         return_value=[
-            {"_id": "av_concept_2", "artifact_kind": "concept", "version_number": 2},
-            {"_id": "av_concept_1", "artifact_kind": "concept", "version_number": 1},
-            {"_id": "av_design_1", "artifact_kind": "design_docs", "version_number": 1},
+            {"_id": "av_concept_2", "build_family": "concept", "version_number": 2},
+            {"_id": "av_concept_1", "build_family": "concept", "version_number": 1},
+            {"_id": "av_design_1", "build_family": "design_docs", "version_number": 1},
         ]
     )
     versions_coll.find.return_value = cursor
     store._coll = AsyncMock(return_value=versions_coll)
     store._ensure_client = AsyncMock()
 
-    refs = await store.get_current_artifact_version_refs(app_id="app-1")
+    refs = await store.get_current_build_record_refs(app_id="app-1")
 
     # concept -> highest version (av_concept_2); design_docs -> only version
     assert refs == {"concept": "av_concept_2", "design_docs": "av_design_1"}
@@ -403,8 +405,8 @@ async def test_get_current_artifact_version_refs_returns_highest_current_per_kin
 
 
 @pytest.mark.asyncio
-async def test_get_current_artifact_version_refs_returns_empty_when_no_current() -> None:
-    """Returns empty dict when no CURRENT artifact versions exist."""
+async def test_get_current_build_record_refs_returns_empty_when_no_current() -> None:
+    """Returns empty dict when no CURRENT build records exist."""
     store = BuildRecordStore.__new__(BuildRecordStore)
     versions_coll = MagicMock()
     cursor = MagicMock()
@@ -414,13 +416,13 @@ async def test_get_current_artifact_version_refs_returns_empty_when_no_current()
     store._coll = AsyncMock(return_value=versions_coll)
     store._ensure_client = AsyncMock()
 
-    refs = await store.get_current_artifact_version_refs(app_id="app-1")
+    refs = await store.get_current_build_record_refs(app_id="app-1")
 
     assert refs == {}
 
 
 @pytest.mark.asyncio
-async def test_get_stale_artifact_families_clears_when_all_rebuilt() -> None:
+async def test_get_stale_build_families_clears_when_all_rebuilt() -> None:
     """If every stale family has a CURRENT version, the list is empty."""
     store = BuildRecordStore.__new__(BuildRecordStore)
     versions_coll = MagicMock()
@@ -433,6 +435,6 @@ async def test_get_stale_artifact_families_clears_when_all_rebuilt() -> None:
     store._coll = AsyncMock(return_value=versions_coll)
     store._ensure_client = AsyncMock()
 
-    result = await store.get_stale_artifact_families(app_id="app-1")
+    result = await store.get_stale_build_families(app_id="app-1")
 
     assert result == []

--- a/tests/test_build_record_store_real_mongo.py
+++ b/tests/test_build_record_store_real_mongo.py
@@ -1,0 +1,532 @@
+"""Real-Mongo proofs for canonical BuildRecord identity indexes.
+
+BuildRecord documents carry (app_id, build_family, build_key, version_number);
+the store's unique indexes must use those same fields. The retired indexes on
+fields no record carries made every record contribute a null identity tuple,
+so the second build family for an app collided with E11000.
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo.errors import DuplicateKeyError
+
+from mozaiksai.core.artifacts.store import (
+    ArtifactLifecycleStatus,
+    BuildRecordCurrentConflictError,
+    BuildRecordStore,
+)
+from mozaiksai.core.runtime.persistence.indexes import DatabaseIndexApplyError
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real Mongo BuildRecord index tests",
+)
+
+_MONGO_URI = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+
+
+class _TestDatabaseClient:
+    """Route the store's fixed database name to one disposable test database."""
+
+    def __init__(self, client: AsyncIOMotorClient, database_name: str) -> None:
+        self._client = client
+        self._database_name = database_name
+
+    def __getitem__(self, _name: str):
+        return self._client[self._database_name]
+
+
+def _store(client: AsyncIOMotorClient, database_name: str) -> BuildRecordStore:
+    store = BuildRecordStore()
+    store.client = _TestDatabaseClient(client, database_name)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_two_build_families_do_not_collide_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+
+        first = await store.create_build_record(
+            app_id="app-families",
+            build_family="app_bundle",
+            build_key="primary",
+        )
+        second = await store.create_build_record(
+            app_id="app-families",
+            build_family="workflow_bundle",
+            build_key="primary",
+        )
+
+        assert first.build_family == "app_bundle"
+        assert second.build_family == "workflow_bundle"
+        assert first.version_number == 1
+        assert second.version_number == 1
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_canonical_identity_rejects_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+        record = await store.create_build_record(
+            app_id="app-dup",
+            build_family="app_bundle",
+            build_key="primary",
+        )
+
+        versions = client[database_name]["ArtifactVersions"]
+        duplicate = {
+            "_id": f"av_{uuid4().hex[:24]}",
+            "app_id": "app-dup",
+            "build_family": record.build_family,
+            "build_key": record.build_key,
+            "version_number": record.version_number,
+        }
+        with pytest.raises(DuplicateKeyError):
+            await versions.insert_one(duplicate)
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_retired_obsolete_indexes_are_dropped_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        versions = client[database_name]["ArtifactVersions"]
+        counters = client[database_name]["ArtifactVersionCounters"]
+        await versions.create_index(
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
+            name="av_app_kind_key_version",
+            unique=True,
+        )
+        await counters.create_index(
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
+            name="avc_app_kind_key",
+            unique=True,
+        )
+
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+
+        version_indexes = {
+            str(row["name"]): row
+            for row in await versions.list_indexes().to_list(length=None)
+        }
+        counter_indexes = {
+            str(row["name"]): row
+            for row in await counters.list_indexes().to_list(length=None)
+        }
+        assert "av_app_kind_key_version" not in version_indexes
+        assert "avc_app_kind_key" not in counter_indexes
+        assert list(version_indexes["av_app_family_key_version"]["key"].items()) == [
+            ("app_id", 1),
+            ("build_family", 1),
+            ("build_key", 1),
+            ("version_number", -1),
+        ]
+        assert version_indexes["av_app_family_key_version"].get("unique") is True
+        assert list(counter_indexes["avc_app_family_key"]["key"].items()) == [
+            ("app_id", 1),
+            ("build_family", 1),
+            ("build_key", 1),
+        ]
+        assert counter_indexes["avc_app_family_key"].get("unique") is True
+
+        # The corrected indexes now allow distinct families for one app.
+        await store.create_build_record(
+            app_id="app-migrated", build_family="app_bundle", build_key="k"
+        )
+        await store.create_build_record(
+            app_id="app-migrated", build_family="workflow_bundle", build_key="k"
+        )
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_unrelated_same_name_index_survives_and_store_fails_closed_real_mongo() -> None:
+    """A foreign index reusing a retired name must never be dropped."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        versions = client[database_name]["ArtifactVersions"]
+        await versions.create_index(
+            [("security_boundary", 1)],
+            name="av_app_kind_key_version",
+        )
+
+        store = _store(client, database_name)
+        with pytest.raises(DatabaseIndexApplyError, match="Refusing to drop"):
+            await store._ensure_indexes(client=store.client)
+
+        surviving = {
+            str(row["name"]): row
+            for row in await versions.list_indexes().to_list(length=None)
+        }
+        assert "av_app_kind_key_version" in surviving
+        assert list(surviving["av_app_kind_key_version"]["key"].items()) == [
+            ("security_boundary", 1)
+        ]
+        # Initialization failed before installing anything canonical.
+        assert "av_app_family_key_version" not in surviving
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("keys", "options", "reason"),
+    [
+        (
+            [("app_id", 1), ("artifact_kind", 1)],
+            {"unique": True},
+            "partial key match",
+        ),
+        (
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
+            {},
+            "same keys wrong unique",
+        ),
+        (
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
+            {"unique": True, "sparse": True},
+            "same keys wrong option",
+        ),
+    ],
+)
+async def test_retired_name_with_divergent_definition_fails_closed_real_mongo(
+    keys, options, reason
+) -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        versions = client[database_name]["ArtifactVersions"]
+        await versions.create_index(keys, name="av_app_kind_key_version", **options)
+
+        store = _store(client, database_name)
+        with pytest.raises(DatabaseIndexApplyError, match="Refusing to drop"):
+            await store._ensure_indexes(client=store.client)
+
+        surviving = {
+            str(row["name"]) for row in await versions.list_indexes().to_list(length=None)
+        }
+        assert "av_app_kind_key_version" in surviving, reason
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_initialization_is_idempotent_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+        await store._ensure_indexes(client=store.client)
+        versions = client[database_name]["ArtifactVersions"]
+        names = {
+            str(row["name"]) for row in await versions.list_indexes().to_list(length=None)
+        }
+        assert "av_app_family_key_version" in names
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+class _NoSupersedeCollectionProxy:
+    """Delegate to the real ArtifactVersions collection but skip supersede.
+
+    Freezes an accept/create between its supersede step and its publish step,
+    reproducing the interleaving where a concurrent independent client
+    published CURRENT in that window. The uniqueness rejection itself comes
+    from the real Mongo partial unique index, never from this proxy.
+    """
+
+    def __init__(self, collection) -> None:
+        self._collection = collection
+
+    def __getattr__(self, name: str):
+        return getattr(self._collection, name)
+
+    async def update_many(self, *_args, **_kwargs):
+        return None
+
+
+class _NoSupersedeStore(BuildRecordStore):
+    async def _coll(self, name: str):
+        collection = await super()._coll(name)
+        if name == "ArtifactVersions":
+            return _NoSupersedeCollectionProxy(collection)
+        return collection
+
+
+async def _current_records(client: AsyncIOMotorClient, database_name: str, *, app_id: str, build_family: str, build_key: str) -> list[dict]:
+    versions = client[database_name]["ArtifactVersions"]
+    return await versions.find(
+        {
+            "app_id": app_id,
+            "build_family": build_family,
+            "build_key": build_key,
+            "lifecycle_status": "current",
+        }
+    ).to_list(length=None)
+
+
+@pytest.mark.asyncio
+async def test_storage_rejects_second_current_bypassing_store_real_mongo() -> None:
+    """The invariant holds even for writers that bypass store code entirely."""
+    client_a = AsyncIOMotorClient(_MONGO_URI)
+    client_b = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client_a, database_name)
+        await store._ensure_indexes(client=store.client)
+
+        r1 = await store.create_build_record(
+            app_id="app-race",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        r2 = await store.create_build_record(
+            app_id="app-race",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        accepted = await store.accept_build_record(app_id="app-race", build_record_id=r1.id)
+        assert accepted is not None and accepted.lifecycle_status == ArtifactLifecycleStatus.CURRENT
+
+        # Independent client, raw driver write: try to mint a second CURRENT.
+        raw_versions = client_b[database_name]["ArtifactVersions"]
+        with pytest.raises(DuplicateKeyError):
+            await raw_versions.update_one(
+                {"_id": r2.id}, {"$set": {"lifecycle_status": "current"}}
+            )
+
+        current = await _current_records(
+            client_b, database_name, app_id="app-race", build_family="app_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in current] == [r1.id]
+    finally:
+        await client_a.drop_database(database_name)
+        client_a.close()
+        client_b.close()
+
+
+@pytest.mark.asyncio
+async def test_interleaved_accept_conflict_is_typed_and_keeps_one_current_real_mongo() -> None:
+    """Codex 1's race: independent clients interleaving supersede/publish."""
+    client_a = AsyncIOMotorClient(_MONGO_URI)
+    client_b = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store_a = _store(client_a, database_name)
+        await store_a._ensure_indexes(client=store_a.client)
+        store_b = _NoSupersedeStore()
+        store_b.client = _TestDatabaseClient(client_b, database_name)
+
+        r1 = await store_a.create_build_record(
+            app_id="app-race",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        r2 = await store_a.create_build_record(
+            app_id="app-race",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        unrelated = await store_a.create_build_record(
+            app_id="app-race",
+            build_family="workflow_bundle",
+            build_key="primary",
+        )
+
+        # Client A publishes r1 in the window after client B's supersede step
+        # already ran (store_b skips supersede to freeze that interleaving).
+        accepted = await store_a.accept_build_record(app_id="app-race", build_record_id=r1.id)
+        assert accepted is not None and accepted.lifecycle_status == ArtifactLifecycleStatus.CURRENT
+
+        with pytest.raises(BuildRecordCurrentConflictError) as conflict:
+            await store_b.accept_build_record(app_id="app-race", build_record_id=r2.id)
+        assert conflict.value.build_record_id == r2.id
+        assert conflict.value.build_family == "app_bundle"
+
+        current = await _current_records(
+            client_a, database_name, app_id="app-race", build_family="app_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in current] == [r1.id]
+
+        # The losing record was not published and unrelated families are untouched.
+        r2_doc = await client_a[database_name]["ArtifactVersions"].find_one({"_id": r2.id})
+        assert r2_doc is not None and r2_doc["lifecycle_status"] == "draft"
+        unrelated_current = await _current_records(
+            client_a, database_name, app_id="app-race", build_family="workflow_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in unrelated_current] == [unrelated.id]
+    finally:
+        await client_a.drop_database(database_name)
+        client_a.close()
+        client_b.close()
+
+
+@pytest.mark.asyncio
+async def test_interleaved_create_current_conflict_is_typed_real_mongo() -> None:
+    client_a = AsyncIOMotorClient(_MONGO_URI)
+    client_b = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store_a = _store(client_a, database_name)
+        await store_a._ensure_indexes(client=store_a.client)
+        store_b = _NoSupersedeStore()
+        store_b.client = _TestDatabaseClient(client_b, database_name)
+
+        first = await store_a.create_build_record(
+            app_id="app-race",
+            build_family="app_bundle",
+            build_key="primary",
+        )
+        assert first.lifecycle_status == ArtifactLifecycleStatus.CURRENT
+
+        with pytest.raises(BuildRecordCurrentConflictError):
+            await store_b.create_build_record(
+                app_id="app-race",
+                build_family="app_bundle",
+                build_key="primary",
+            )
+
+        current = await _current_records(
+            client_a, database_name, app_id="app-race", build_family="app_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in current] == [first.id]
+    finally:
+        await client_a.drop_database(database_name)
+        client_a.close()
+        client_b.close()
+
+
+@pytest.mark.asyncio
+async def test_same_target_accept_retry_is_idempotent_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+
+        r1 = await store.create_build_record(
+            app_id="app-retry",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        first = await store.accept_build_record(app_id="app-retry", build_record_id=r1.id)
+        retried = await store.accept_build_record(app_id="app-retry", build_record_id=r1.id)
+        assert first is not None and retried is not None
+        assert first.lifecycle_status == ArtifactLifecycleStatus.CURRENT
+        assert retried.lifecycle_status == ArtifactLifecycleStatus.CURRENT
+
+        current = await _current_records(
+            client, database_name, app_id="app-retry", build_family="app_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in current] == [r1.id]
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_sequential_different_target_accept_supersedes_real_mongo() -> None:
+    """Non-interleaved publication is last-writer-wins, never two CURRENT."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        store = _store(client, database_name)
+        await store._ensure_indexes(client=store.client)
+
+        r1 = await store.create_build_record(
+            app_id="app-seq",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        r2 = await store.create_build_record(
+            app_id="app-seq",
+            build_family="app_bundle",
+            build_key="primary",
+            lifecycle_status=ArtifactLifecycleStatus.DRAFT,
+        )
+        await store.accept_build_record(app_id="app-seq", build_record_id=r1.id)
+        await store.accept_build_record(app_id="app-seq", build_record_id=r2.id)
+
+        current = await _current_records(
+            client, database_name, app_id="app-seq", build_family="app_bundle", build_key="primary"
+        )
+        assert [row["_id"] for row in current] == [r2.id]
+        r1_doc = await client[database_name]["ArtifactVersions"].find_one({"_id": r1.id})
+        assert r1_doc is not None and r1_doc["lifecycle_status"] == "superseded"
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_unique_current_index_mismatch_fails_closed_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        versions = client[database_name]["ArtifactVersions"]
+        # Same canonical name, weaker filter: verifier must reject, not adopt.
+        await versions.create_index(
+            [("app_id", 1), ("build_family", 1), ("build_key", 1)],
+            name="av_unique_current",
+            unique=True,
+            partialFilterExpression={"lifecycle_status": "draft"},
+        )
+
+        store = _store(client, database_name)
+        with pytest.raises(DatabaseIndexApplyError):
+            await store._ensure_indexes(client=store.client)
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_mismatched_canonical_definition_fails_closed_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_build_record_test_{uuid4().hex}"
+    try:
+        versions = client[database_name]["ArtifactVersions"]
+        # Same canonical name, different definition: the verifier must reject
+        # rather than accept the index by name.
+        await versions.create_index(
+            [("app_id", 1), ("build_family", 1)],
+            name="av_app_family_key_version",
+        )
+
+        store = _store(client, database_name)
+        with pytest.raises(DatabaseIndexApplyError):
+            await store._ensure_indexes(client=store.client)
+    finally:
+        await client.drop_database(database_name)
+        client.close()

--- a/tests/test_control_plane_invalidation.py
+++ b/tests/test_control_plane_invalidation.py
@@ -115,7 +115,7 @@ async def test_artifact_invalidation_service_uses_session_refs_and_affected_fami
                 "workflow_bundle": "av_workflow_1",
                 "app_bundle": "av_app_1",
             },
-            "affected_artifact_kinds": ["design_docs", "app_bundle"],
+            "affected_build_families": ["design_docs", "app_bundle"],
             "reason": "change_request:cr_123",
         }
     ]
@@ -123,14 +123,12 @@ async def test_artifact_invalidation_service_uses_session_refs_and_affected_fami
     assert artifact_store.family_calls == [
         {
             "app_id": "app_1",
-            "artifact_kind": "subscription_contract",
-            "artifact_key": "subscription_contract",
+            "build_family": "subscription_contract",
             "reason": "change_request:cr_123",
         },
         {
             "app_id": "app_1",
-            "artifact_kind": "workflow_bundle",
-            "artifact_key": "workflow_bundle",
+            "build_family": "workflow_bundle",
             "reason": "change_request:cr_123",
         }
     ]

--- a/tests/test_refinement_router.py
+++ b/tests/test_refinement_router.py
@@ -1408,7 +1408,7 @@ def _patch_artifact_store(monkeypatch: pytest.MonkeyPatch, stale_families: list)
     import importlib
     store_mod = importlib.import_module("mozaiksai.core.artifacts.store")
     monkeypatch.setattr(store_mod.ArtifactStore, "__init__", lambda self: None)
-    monkeypatch.setattr(store_mod.ArtifactStore, "get_stale_artifact_families", AsyncMock(return_value=stale_families))
+    monkeypatch.setattr(store_mod.ArtifactStore, "get_stale_build_families", AsyncMock(return_value=stale_families))
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_build_binding.py
+++ b/tests/test_run_build_binding.py
@@ -1,0 +1,490 @@
+"""RunBuildBinding contract and cold-verification matrix.
+
+The exact server-owned relation ``workflow_run_id -> build_id`` is the only
+authority for build-specific claims. These tests prove the sealed binding
+contract (issue/parse/digest), the run-level WorkflowRunFailure terminal
+shape, and cold verification against persisted BuildRecords: run A binds
+build A, run B binds build B, a pre-build run has no binding, and a foreign
+build, wrong run, wrong app, wrong family/key, wrong version, or stale
+digest never verifies.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.artifacts.build_receipt import (
+    BuildFailureReceipt,
+    ReceiptValidationError,
+    WorkflowRunFailure,
+    issue_failure_receipt,
+    issue_run_failure,
+    issue_success_receipt,
+    parse_terminal_receipt,
+)
+from mozaiksai.core.artifacts.closure import (
+    verify_run_build_binding_closure,
+    verify_terminal_receipt_closure,
+)
+from mozaiksai.core.artifacts.models import (
+    ArtifactCommitMetadata,
+    BuildRecord,
+    BuildRecordFileEntry,
+    BuildRecordStatus,
+)
+from mozaiksai.core.artifacts.run_build_binding import (
+    BindingValidationError,
+    RunBuildBinding,
+    issue_run_build_binding,
+    parse_run_build_binding,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_APP = "app_field_service"
+_WF = "AppGenerator"
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+
+
+class _FakeStore:
+    """Minimal persisted-record resolver for cold verification."""
+
+    def __init__(self) -> None:
+        self.records: dict[tuple[str, str], BuildRecord] = {}
+
+    def add(self, record: BuildRecord) -> BuildRecord:
+        self.records[(record.app_id, record.id)] = record
+        return record
+
+    async def get_build_record(
+        self, *, app_id: str, build_record_id: str
+    ) -> BuildRecord | None:
+        return self.records.get((str(app_id), str(build_record_id)))
+
+
+def _record(
+    *,
+    record_id: str,
+    workflow_run_id: str | None,
+    build_id: str | None,
+    app_id: str = _APP,
+    build_family: str = "app_bundle",
+    build_key: str = "app_bundle",
+    version_number: int = 1,
+    bundle_digest: str | None = _DIGEST_A,
+    lifecycle_status: BuildRecordStatus = BuildRecordStatus.CURRENT,
+    parent_build_record_id: str | None = None,
+    summary_payload: dict[str, Any] | None = None,
+) -> BuildRecord:
+    manifest = (
+        [BuildRecordFileEntry(path="bundle.zip", sha256=bundle_digest)]
+        if bundle_digest
+        else []
+    )
+    metadata: dict[str, Any] = {}
+    if summary_payload is not None:
+        metadata["summary_payload"] = summary_payload
+    return BuildRecord(
+        _id=record_id,
+        app_id=app_id,
+        build_family=build_family,
+        build_key=build_key,
+        version_number=version_number,
+        parent_build_record_id=parent_build_record_id,
+        lineage_root_id=record_id,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
+        lifecycle_status=lifecycle_status,
+        files_manifest=manifest,
+        commit_metadata=ArtifactCommitMetadata(metadata=metadata),
+    )
+
+
+def _binding(
+    *,
+    workflow_run_id: str,
+    build_id: str,
+    record_id: str,
+    app_id: str = _APP,
+    workflow_name: str = _WF,
+    build_family: str = "app_bundle",
+    build_key: str = "app_bundle",
+    version_number: int = 1,
+    bundle_digest: str | None = _DIGEST_A,
+) -> RunBuildBinding:
+    return issue_run_build_binding(
+        app_id=app_id,
+        workflow_name=workflow_name,
+        workflow_run_id=workflow_run_id,
+        build_id=build_id,
+        build_record_id=record_id,
+        build_family=build_family,
+        build_key=build_key,
+        version_number=version_number,
+        bundle_digest=bundle_digest,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sealed contract: issue / parse / digest
+# ---------------------------------------------------------------------------
+
+
+async def test_binding_round_trips_through_persistence_and_seals_its_body() -> None:
+    binding = _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_a")
+
+    # Cold resolution: the binding survives a JSON persistence round trip
+    # (restart) and parses back to the identical sealed object.
+    persisted = json.loads(json.dumps(binding.model_dump(mode="json")))
+    restored = parse_run_build_binding(persisted)
+    assert restored == binding
+    assert restored.workflow_run_id == "wfrun_a"
+    assert restored.build_id == "build_a"
+    assert restored.build_record_id == "rec_a"
+
+    # Any altered field fails digest verification — the seal covers the body.
+    tampered = dict(persisted)
+    tampered["build_id"] = "build_of_another_run"
+    with pytest.raises(BindingValidationError):
+        parse_run_build_binding(tampered)
+
+    with pytest.raises(BindingValidationError):
+        parse_run_build_binding({**persisted, "binding_digest": "0" * 64})
+
+    with pytest.raises(BindingValidationError):
+        parse_run_build_binding("not-a-mapping")
+
+    with pytest.raises(BindingValidationError):
+        parse_run_build_binding({**persisted, "extra_claim": True})
+
+
+async def test_binding_requires_complete_closed_identity() -> None:
+    for missing in (
+        "app_id",
+        "workflow_name",
+        "workflow_run_id",
+        "build_id",
+        "build_record_id",
+        "build_family",
+        "build_key",
+    ):
+        kwargs = dict(
+            app_id=_APP,
+            workflow_name=_WF,
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            build_record_id="rec_a",
+            build_family="app_bundle",
+            build_key="app_bundle",
+            version_number=1,
+        )
+        kwargs[missing] = "  "
+        with pytest.raises(ValidationError):
+            issue_run_build_binding(**kwargs)  # type: ignore[arg-type]
+
+    with pytest.raises(ValidationError):
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            version_number=0,
+        )
+    with pytest.raises(ValidationError):
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            bundle_digest="not-a-sha",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run-level terminal failure: no build, no fabrication
+# ---------------------------------------------------------------------------
+
+
+async def test_workflow_run_failure_carries_no_build_identity() -> None:
+    outcome = issue_run_failure(
+        app_id=_APP,
+        workflow_name=_WF,
+        workflow_run_id="wfrun_prebuild",
+        error_code="run_failed_before_build",
+    )
+    assert isinstance(outcome, WorkflowRunFailure)
+    assert "build_id" not in type(outcome).model_fields
+
+    parsed = parse_terminal_receipt(outcome.model_dump(mode="json"))
+    assert isinstance(parsed, WorkflowRunFailure)
+    assert parsed.workflow_run_id == "wfrun_prebuild"
+    assert parsed.error_code == "run_failed_before_build"
+
+    # Injecting a build claim into the run-level shape is rejected outright.
+    forged = {**outcome.model_dump(mode="json"), "build_id": "build_stolen"}
+    with pytest.raises(ReceiptValidationError):
+        parse_terminal_receipt(forged)
+
+
+async def test_build_failure_receipt_requires_exact_build_identity() -> None:
+    receipt = issue_failure_receipt(
+        app_id=_APP,
+        workflow_name=_WF,
+        workflow_run_id="wfrun_b",
+        build_id="build_b",
+        error_code="lineage_registration_failed",
+    )
+    assert isinstance(receipt, BuildFailureReceipt)
+    assert receipt.build_id == "build_b"
+
+    with pytest.raises(ValidationError):
+        issue_failure_receipt(
+            app_id=_APP,
+            workflow_name=_WF,
+            workflow_run_id="wfrun_b",
+            build_id="  ",
+            error_code="lineage_registration_failed",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cold verification against persisted records
+# ---------------------------------------------------------------------------
+
+
+async def test_run_a_and_run_b_each_verify_only_their_own_build() -> None:
+    store = _FakeStore()
+    store.add(
+        _record(record_id="rec_a", workflow_run_id="wfrun_a", build_id="build_a")
+    )
+    store.add(
+        _record(
+            record_id="rec_b",
+            workflow_run_id="wfrun_b",
+            build_id="build_b",
+            version_number=2,
+            bundle_digest=_DIGEST_B,
+        )
+    )
+    binding_a = _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_a")
+    binding_b = _binding(
+        workflow_run_id="wfrun_b",
+        build_id="build_b",
+        record_id="rec_b",
+        version_number=2,
+        bundle_digest=_DIGEST_B,
+    )
+
+    assert await verify_run_build_binding_closure(
+        binding_a, workflow_run_id="wfrun_a", app_id=_APP, workflow_name=_WF, store=store
+    )
+    assert await verify_run_build_binding_closure(
+        binding_b, workflow_run_id="wfrun_b", app_id=_APP, workflow_name=_WF, store=store
+    )
+
+    # Foreign build: run B presenting run A's binding (and vice versa) never
+    # verifies — the relation belongs to exactly one run.
+    assert not await verify_run_build_binding_closure(
+        binding_a, workflow_run_id="wfrun_b", app_id=_APP, workflow_name=_WF, store=store
+    )
+    assert not await verify_run_build_binding_closure(
+        binding_b, workflow_run_id="wfrun_a", app_id=_APP, workflow_name=_WF, store=store
+    )
+
+
+async def test_binding_closure_fails_closed_on_every_disagreement() -> None:
+    store = _FakeStore()
+    store.add(
+        _record(record_id="rec_a", workflow_run_id="wfrun_a", build_id="build_a")
+    )
+
+    async def _verifies(binding: RunBuildBinding, **overrides: Any) -> bool:
+        kwargs = dict(
+            workflow_run_id="wfrun_a", app_id=_APP, workflow_name=_WF, store=store
+        )
+        kwargs.update(overrides)
+        return await verify_run_build_binding_closure(binding, **kwargs)
+
+    good = _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_a")
+    assert await _verifies(good)
+
+    # Wrong current run / app / workflow scope.
+    assert not await _verifies(good, workflow_run_id="wfrun_other")
+    assert not await _verifies(good, workflow_run_id="")
+    assert not await _verifies(good, app_id="other_app")
+    assert not await _verifies(good, workflow_name="OtherWorkflow")
+
+    # Referenced record does not exist (or exists under another app only).
+    assert not await _verifies(
+        _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_missing")
+    )
+
+    # Unbound record: persisted without any run binding can never satisfy one.
+    store.add(_record(record_id="rec_unbound", workflow_run_id=None, build_id=None))
+    assert not await _verifies(
+        _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_unbound")
+    )
+
+    # Record stamped for a different run or different build.
+    store.add(
+        _record(record_id="rec_other_run", workflow_run_id="wfrun_z", build_id="build_a")
+    )
+    assert not await _verifies(
+        _binding(workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_other_run")
+    )
+    store.add(
+        _record(
+            record_id="rec_other_build", workflow_run_id="wfrun_a", build_id="build_z"
+        )
+    )
+    assert not await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a", build_id="build_a", record_id="rec_other_build"
+        )
+    )
+
+    # Family/key/version vocabulary disagreement.
+    assert not await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            build_family="workflow_bundle",
+        )
+    )
+    assert not await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            build_key="other_key",
+        )
+    )
+    assert not await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            version_number=7,
+        )
+    )
+
+    # Stale digest: the binding's bundle digest is absent from the persisted
+    # manifest authority.
+    assert not await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            bundle_digest=_DIGEST_B,
+        )
+    )
+
+    # A binding without an established digest still verifies on identity.
+    assert await _verifies(
+        _binding(
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            record_id="rec_a",
+            bundle_digest=None,
+        )
+    )
+
+
+async def test_pre_build_run_resolves_no_binding() -> None:
+    """A run that never established a build has nothing to parse — absence is
+    the truthful state, never an invitation to derive one from session data."""
+    for absent in (None, {}, ""):
+        with pytest.raises(BindingValidationError):
+            parse_run_build_binding(absent)
+
+
+# ---------------------------------------------------------------------------
+# Terminal receipt closure through the OSS verifier
+# ---------------------------------------------------------------------------
+
+
+def _closure_fixture() -> tuple[_FakeStore, Any]:
+    store = _FakeStore()
+    store.add(
+        _record(record_id="rec_bundle", workflow_run_id="wfrun_a", build_id="build_a")
+    )
+    store.add(
+        _record(
+            record_id="rec_acv",
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            build_family="app_context_version",
+            build_key="app_context_version",
+            bundle_digest=None,
+            summary_payload={
+                "context_version_id": "acv_logical_1",
+                "app_id": _APP,
+                "artifact_refs": [
+                    {"artifact_kind": "app_bundle", "artifact_version_id": "rec_bundle"}
+                ],
+            },
+        )
+    )
+    receipt = issue_success_receipt(
+        app_id=_APP,
+        workflow_name=_WF,
+        workflow_run_id="wfrun_a",
+        build_id="build_a",
+        build_record_id="rec_bundle",
+        app_context_version_id="acv_logical_1",
+        app_context_record_id="rec_acv",
+        bundle_digest=_DIGEST_A,
+    )
+    return store, receipt
+
+
+async def test_success_receipt_closure_verifies_exact_persisted_lineage() -> None:
+    store, receipt = _closure_fixture()
+    assert await verify_terminal_receipt_closure(receipt, app_id=_APP, store=store)
+
+
+async def test_success_receipt_closure_fails_closed_on_substitution() -> None:
+    store, receipt = _closure_fixture()
+
+    # A real but unrelated CURRENT record under another run never suffices.
+    store.add(
+        _record(record_id="rec_bundle", workflow_run_id="wfrun_z", build_id="build_z")
+    )
+    assert not await verify_terminal_receipt_closure(receipt, app_id=_APP, store=store)
+
+    # Restore, then break the AppContextVersion cross-reference.
+    store, receipt = _closure_fixture()
+    store.add(
+        _record(
+            record_id="rec_acv",
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            build_family="app_context_version",
+            build_key="app_context_version",
+            bundle_digest=None,
+            summary_payload={
+                "context_version_id": "acv_logical_1",
+                "app_id": _APP,
+                "artifact_refs": [
+                    {"artifact_kind": "app_bundle", "artifact_version_id": "rec_other"}
+                ],
+            },
+        )
+    )
+    assert not await verify_terminal_receipt_closure(receipt, app_id=_APP, store=store)
+
+    # Restore, then demote the bundle record: a non-CURRENT record cannot
+    # satisfy a success receipt.
+    store, receipt = _closure_fixture()
+    store.add(
+        _record(
+            record_id="rec_bundle",
+            workflow_run_id="wfrun_a",
+            build_id="build_a",
+            lifecycle_status=BuildRecordStatus.DRAFT,
+        )
+    )
+    assert not await verify_terminal_receipt_closure(receipt, app_id=_APP, store=store)

--- a/tests/test_server_owned_session_fields_real_mongo.py
+++ b/tests/test_server_owned_session_fields_real_mongo.py
@@ -1,0 +1,182 @@
+"""Real-Mongo proofs for server-owned session field protection.
+
+The terminal build receipt and the workflow run identity are lifecycle
+authority: only the privileged server write path may install or replace them.
+Generic context persistence — the path every model/tool-authored context
+update flows through — must reject writes to those keys with detection, so an
+injected receipt can never become the persisted claim the completion bridge
+reads.
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from mozaiksai.core.data.persistence.persistence_manager import (
+    SERVER_OWNED_SESSION_FIELDS,
+    AG2PersistenceManager,
+    PersistenceManager,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real Mongo session-field tests",
+)
+
+_MONGO_URI = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+_APP_ID = "app-server-owned"
+_WORKFLOW = "AppGenerator"
+
+
+class _TestDatabaseClient:
+    def __init__(self, client: AsyncIOMotorClient, database_name: str) -> None:
+        self._client = client
+        self._database_name = database_name
+
+    def __getitem__(self, _name: str):
+        return self._client[self._database_name]
+
+
+def _pm(client: AsyncIOMotorClient, database_name: str) -> AG2PersistenceManager:
+    pm = AG2PersistenceManager()
+    pm.persistence = PersistenceManager()
+    pm.persistence.client = _TestDatabaseClient(client, database_name)
+    return pm
+
+
+async def _seed_session(pm: AG2PersistenceManager, chat_id: str) -> None:
+    coll = await pm._coll()
+    await coll.insert_one(
+        {
+            "_id": chat_id,
+            "chat_id": chat_id,
+            "app_id": _APP_ID,
+            "workflow_name": _WORKFLOW,
+            "user_id": "user-1",
+            "status": "active",
+            "messages": [],
+            "session_version": 1,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_context_persistence_rejects_server_owned_fields_real_mongo() -> None:
+    """Attack 17: a receipt injected through the model-accessible context
+    update path never reaches the persisted session document."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_server_owned_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+
+        await pm.persist_context_variables(
+            chat_id=chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            variables={
+                "build_terminal_receipt": {"kind": "success", "forged": True},
+                "workflow_run_id": "wfrun_attacker",
+                "run_build_binding": {"build_id": "stolen", "forged": True},
+                "app_download_ready": True,
+            },
+        )
+
+        doc = await (await pm._coll()).find_one({"_id": chat_id})
+        assert doc is not None
+        assert "build_terminal_receipt" not in doc
+        assert "workflow_run_id" not in doc
+        assert "run_build_binding" not in doc
+
+        fetched = await pm.fetch_chat_session_extra_context(
+            chat_id=chat_id, app_id=_APP_ID, workflow_name=_WORKFLOW
+        )
+        assert "build_terminal_receipt" not in fetched
+        assert "workflow_run_id" not in fetched
+        assert "run_build_binding" not in fetched
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_writes_and_fetch_returns_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_server_owned_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+
+        receipt = {"kind": "failure", "workflow_run_id": "wfrun_legit"}
+        binding = {"workflow_run_id": "wfrun_legit", "build_id": "build_wfrun_legit"}
+        await pm.persist_server_owned_session_fields(
+            chat_id=chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            fields={
+                "workflow_run_id": "wfrun_legit",
+                "build_terminal_receipt": receipt,
+                "run_build_binding": binding,
+            },
+        )
+
+        fetched = await pm.fetch_chat_session_extra_context(
+            chat_id=chat_id, app_id=_APP_ID, workflow_name=_WORKFLOW
+        )
+        assert fetched.get("workflow_run_id") == "wfrun_legit"
+        assert fetched.get("build_terminal_receipt") == receipt
+        assert fetched.get("run_build_binding") == binding
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_rejects_non_reserved_keys_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_server_owned_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+        with pytest.raises(ValueError, match="not a server-owned session field"):
+            await pm.persist_server_owned_session_fields(
+                chat_id=chat_id,
+                app_id=_APP_ID,
+                workflow_name=_WORKFLOW,
+                fields={"download_status": "ready"},
+            )
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_fails_closed_on_missing_session_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_server_owned_test_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        with pytest.raises(RuntimeError, match="scoped session was not found"):
+            await pm.persist_server_owned_session_fields(
+                chat_id="chat_missing",
+                app_id=_APP_ID,
+                workflow_name=_WORKFLOW,
+                fields={"workflow_run_id": "wfrun_x"},
+            )
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+def test_reserved_key_set_is_exactly_the_lifecycle_authority_fields() -> None:
+    assert SERVER_OWNED_SESSION_FIELDS == {
+        "build_terminal_receipt",
+        "run_build_binding",
+        "workflow_run_id",
+    }

--- a/tests/test_studio_workflow_trigger.py
+++ b/tests/test_studio_workflow_trigger.py
@@ -381,7 +381,7 @@ def test_studio_trigger_endpoint_accepts_refinement_trigger_payload(monkeypatch)
         {
             "app_id": captured_prepare["app_id"],
             "artifact_version_refs": {"app_bundle": "av_123"},
-            "affected_artifact_kinds": ["app_bundle"],
+            "affected_build_families": ["app_bundle"],
             "reason": "change_request:cr_123",
         }
     ]


### PR DESCRIPTION
## Replacement PR A — run/build persistence contract

First of two bounded PRs restacking #468 (superseded, will be closed once both replacements are published). This PR **defines and persists the authority**: the exact server-owned relation `workflow_run_id -> build_id` and the persisted records that prove it. It contains **no workflow bridge code and no lifecycle emitter wiring** — `build.started`/`build.completed`/`build.failed` cut over to this authority in replacement PR B (`cc/run-bound-build-lifecycle`), created only after this PR reviews clean and merges.

## A1. BuildRecord identity and index safety

- Canonical identity `(app_id, build_family, build_key, version_number)` with matching counter identity, materialized through the canonical runtime index verifier before the store becomes available — a failed migration leaves no client behind that skips verification.
- Retired indexes are identified by their **complete historical definitions**, verified everywhere as a preflight before any drop executes. A same-name index with any other definition fails the store closed; no name-only deletion, ever.
- `av_unique_current` (partial unique on CURRENT per app/family/key) makes at-most-one-CURRENT **storage-enforced**; concurrent independent-client publishes get a typed `BuildRecordCurrentConflictError` (idempotent same-target retries unaffected). Proven on real Mongo including raw-driver bypass writers (20 tests).

## A2. RunBuildBinding

- One closed, digest-sealed `RunBuildBinding` (`mozaiks.run_build_binding.v1`, `mozaiksai/core/artifacts/run_build_binding.py`): schema version, server scope, app_id, workflow name, immutable `workflow_run_id`, canonical `build_id`, exact BuildRecord identity (record id, family, key, version), `bundle_digest` when established, and a sealing `binding_digest`.
- Created at exactly one point: the terminal build tool, at the moment the current run establishes its build (BuildRecord creation). **Never** derived from chat ID, latest session build, latest journey build, latest CURRENT record, or caller strings — a pre-build run has no binding, and absence is the truthful state.
- The relation is persisted twice by design and with one authority: stamped immutably on the BuildRecord at creation, and projected as the sealed binding through the existing server-owned session seam. No second build store.

## A3. AppContext lineage

- Bundle and AppContextVersion BuildRecords persist the identical run/build binding; the AppContextVersion carries its logical version identity and the `artifact_refs` cross-reference back to the bundle record; bundle digest agreement is required. All of it cold-verified in the OSS closure verifier (`mozaiksai/core/artifacts/closure.py`) — receipt/binding self-digests prove body integrity only, never authorization.
- Required AppContextVersion persistence remains fail closed: a lineage failure fails the build instead of returning a bundle whose lineage does not exist.
- Greenfield order: **DRAFT bundle → required AppContextVersion → exact linkage → CURRENT acceptance.** No user-visible completion is wired in this PR.

## A4. Terminal contracts

Strict closed variants, no nullable half-success shape:

- `BuildSuccessReceipt` — complete CURRENT lineage for exactly one run; every field required.
- `BuildRevisionCandidateReceipt` — distinct closed variant; a draft-with-parent candidate can never be confused with a Genesis success.
- `BuildFailureReceipt` — requires the **exact established build** (taken from the run's own binding), plus a finite error code; carries no lineage and fabricates none.
- `WorkflowRunFailure` — the run-level terminal failure for runs that established **no** build: run identity only, no build fields at all. The terminal tool now issues this (not a derived-build failure receipt) when a run fails before record creation.

No bearer-token trust anywhere: cold verification resolves the persisted records.

## A5. Server-owned persistence

`workflow_run_id`, `run_build_binding`, and `build_terminal_receipt` are writable only through the privileged `persist_server_owned_session_fields` seam. Generic model/tool context updates that attempt to set them are rejected with logged detection; replay preserves them past workflow-declared context policy. Same session document, same authority — no second context store.

## A6. Proofs

- Binding contract matrix (`tests/test_run_build_binding.py`): sealed round-trip through JSON persistence (restart/cold resolution), tamper/digest attacks, complete-identity enforcement; run A/build A and run B/build B verify independently and cross-run presentation fails both directions (foreign build); wrong run/app/workflow/record/family/key/version, unbound record, and stale digest all fail closed; a pre-build run resolves no binding; success-receipt closure verifies the exact persisted lineage and fails closed on record substitution, broken cross-reference, and non-CURRENT lifecycle.
- Terminal-tool traversals (greenfield registration suite): established-build failure carries the binding's exact build in its failure receipt and the binding cold-verifies; pre-build failure creates no record, no binding, and a run-level `WorkflowRunFailure` with no build fields; unidentified runs persist no server-owned authority.
- Real Mongo: BuildRecord concurrency/race matrix (20 tests incl. retired-index attacks, raw-driver bypass, `av_unique_current`), server-owned session-field protection incl. the new binding key (injected bindings never reach the store; privileged writes round-trip).
- Full suite green locally; ruff clean; source-hygiene gate green.

## Boundaries

No workflow bridge code, no lifecycle emitter wiring, no SemanticGraph/CompilationPlan wiring, no ArtifactRevision production cutover, no new AG2 primitives (AG2 keeps agent execution, tasks, resume, channels; this is Mozaiks build-artifact identity and persistence), no hosted/subscription/mobile/evaluation scope, no second build or context store.

## OSS Change Impact

- Layer changed: runtime artifacts (store, models, receipts, new binding + closure verifier), app-context store threading, persistence manager (server-owned seam), control-plane rename consumers, AppGenerator terminal tool persistence ordering + receipt/binding issuance.
- Build workflow impact: AppGenerator `generate_and_download` registers greenfield bundles DRAFT-first, promotes after lineage, issues bindings/receipts. No emitter behavior changes.
- Runtime/platform impact: BuildRecord store fails closed on index-contract violations; concurrent CURRENT publishes are typed conflicts.
- App workspace impact: none for generated apps' own runtime behavior.
- Tests run: suites above + full `pytest -q --no-cov`.
- Docs updated: CHANGELOG.
- Compatibility risk: pre-production internal contracts only.

Reviewer: Codex 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
