### PR TITLE
fix(semantics): define canonical CompilationPlan authority inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,14 @@ This project follows a practical pre-1.0 changelog format:
   rederived plan. No proof object, token, or bearer capability exists:
   possession of nothing establishes validity, serialized authority inputs are
   never trusted without full rederivation, and brownfield plans without a
-  base-input authority are rejected fail-closed. Consumer wiring is a
-  separate enforcement change.
+  base-input authority are rejected fail-closed. CompilationPlan identity
+  now pins `assignment_contracts_digest` — the exact assignment-descriptor
+  closure consulted during derivation, so only descriptors that can affect a
+  plan affect its identity; structured-output enum names are content-derived
+  (sha256) instead of process-salted `hash()`, making config-bearing plan
+  digests deterministic across processes and PYTHONHASHSEED values; and the
+  canonical derivation path no longer reads ambient assignment-registry
+  state. Consumer wiring is a separate enforcement change.
 
 ### Fixed
 - **A present but invalid `config/subscriptions.yaml` now fails application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Added
+
+- **Canonical CompilationPlan authority contract (ADR 0007 lane)**: a plan
+  self-digest proves body integrity, not truthful derivation — a caller can
+  mutate any derived plan fact, recompute the digests, and obtain a
+  structurally cold-valid plan. `CompilationPlanAuthorityInputs` is the one
+  strict immutable authority-input document (semantic graph, complete payload
+  closure, canonical layout-registry snapshot, scope selection,
+  structured-output configuration documents), and
+  `validate_compilation_plan_against_authority` re-derives the candidate
+  through the single canonical `derive_compilation_plan` implementation,
+  requires exact execution-authorizing equality, and returns the canonical
+  rederived plan. No proof object, token, or bearer capability exists:
+  possession of nothing establishes validity, serialized authority inputs are
+  never trusted without full rederivation, and brownfield plans without a
+  base-input authority are rejected fail-closed. Consumer wiring is a
+  separate enforcement change.
+
 ### Fixed
 - **A present but invalid `config/subscriptions.yaml` now fails application
   loading instead of silently disabling entitlement enforcement**: AppLoader

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -732,11 +732,16 @@ class CompilationPlan(SemanticsModel):
     scope_selection: CompilationScopeSelection
     registry_schema_version: str
     registry_digest: str
+    #: Digest of the exact assignment-descriptor closure consulted during
+    #: derivation (descriptor content, or explicit absence, per consulted
+    #: compiler assignment kind). Only descriptors that can affect this plan
+    #: affect this identity; unrelated registry entries never enter it.
+    assignment_contracts_digest: str
     units: tuple[FamilyInstancePlan, ...]
     gaps: tuple[PlanGap, ...] = Field(default_factory=tuple)
     plan_digest: str
 
-    @field_validator("graph_digest", "registry_digest")
+    @field_validator("graph_digest", "registry_digest", "assignment_contracts_digest")
     @classmethod
     def _digests(cls, value: str, info: Any) -> str:
         return _validate_digest(value, field_name=str(info.field_name))
@@ -859,6 +864,7 @@ class CompilationPlan(SemanticsModel):
             "scope_selection": self.scope_selection.model_dump(mode="json"),
             "registry_schema_version": self.registry_schema_version,
             "registry_digest": self.registry_digest,
+            "assignment_contracts_digest": self.assignment_contracts_digest,
             "units": [unit.identity_payload for unit in self.units],
             "gaps": [gap.model_dump(mode="json") for gap in self.gaps],
         }
@@ -968,6 +974,16 @@ def derive_compilation_plan(
         if assignment_descriptors is not None
         else ASSIGNMENT_CONTRACT_DESCRIPTORS
     )
+    descriptor_exact_model_ids = frozenset(
+        descriptor.structured_output_model_id
+        for descriptor in descriptor_authority.values()
+    )
+    # The assignment-descriptor authority closure actually consulted by THIS
+    # derivation. Only descriptors that can affect the plan enter its
+    # identity: a consultation records the descriptor content (or its
+    # explicit absence, which produced a gap), and the closure digest is
+    # pinned on the plan. Unrelated registry entries never enter identity.
+    consulted_assignment_contracts: dict[str, dict[str, Any] | None] = {}
     output_configs = dict(structured_output_configs or {})
     verified_scope_selection = CompilationScopeSelection.model_validate(
         scope_selection.model_dump(mode="json")
@@ -1470,6 +1486,24 @@ def derive_compilation_plan(
                 continue
             assignment_kind = compiler_assignment_kinds[0]
             descriptor = descriptor_authority.get(AssignmentKind(assignment_kind))
+            consulted_assignment_contracts[str(assignment_kind)] = (
+                None
+                if descriptor is None
+                else {
+                    "assignment_kind": descriptor.assignment_kind.value,
+                    "workflow_name": descriptor.workflow_name,
+                    "structured_output_model_id": (
+                        descriptor.structured_output_model_id
+                    ),
+                    "owned_artifact_families": list(
+                        descriptor.owned_artifact_families
+                    ),
+                    "validator_ids": list(descriptor.validator_ids),
+                    "identity_bindings": [
+                        list(binding) for binding in descriptor.identity_bindings
+                    ],
+                }
+            )
             if descriptor is None:
                 _gap(row, PlanGapCode.OUTPUT_CONTRACT_UNRESOLVED, adr_slice=5)
                 continue
@@ -1484,6 +1518,7 @@ def derive_compilation_plan(
                     workflow_name=descriptor.workflow_name,
                     model_id=descriptor.structured_output_model_id,
                     configs=output_configs,
+                    exact_model_ids=descriptor_exact_model_ids,
                 )
             except (TypeError, ValueError):
                 _gap(row, PlanGapCode.OUTPUT_CONTRACT_UNRESOLVED, adr_slice=5)
@@ -1695,6 +1730,17 @@ def derive_compilation_plan(
         )
     )
 
+    assignment_contracts_digest = canonical_digest(
+        {
+            "closure_schema_version": "mozaiks.assignment_contract_closure.v1",
+            "consulted": [
+                {"assignment_kind": kind, "descriptor": descriptor}
+                for kind, descriptor in sorted(
+                    consulted_assignment_contracts.items()
+                )
+            ],
+        }
+    )
     payload: dict[str, Any] = {
         "schema_version": COMPILATION_PLAN_SCHEMA_VERSION,
         "graph_id": verified_graph.graph_id,
@@ -1704,6 +1750,7 @@ def derive_compilation_plan(
         "scope_selection": verified_scope_selection.model_dump(mode="json"),
         "registry_schema_version": snapshot.registry_schema_version,
         "registry_digest": snapshot.snapshot_digest,
+        "assignment_contracts_digest": assignment_contracts_digest,
         "units": [unit.identity_payload for unit in sorted_units],
         "gaps": [gap.model_dump(mode="json") for gap in sorted_gaps],
     }
@@ -1715,6 +1762,7 @@ def derive_compilation_plan(
         scope_selection=verified_scope_selection,
         registry_schema_version=snapshot.registry_schema_version,
         registry_digest=snapshot.snapshot_digest,
+        assignment_contracts_digest=assignment_contracts_digest,
         units=sorted_units,
         gaps=sorted_gaps,
         plan_digest=canonical_digest(payload),

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -86,9 +86,10 @@ from mozaiksai.core.semantics.refs import (
     validate_node_id_grammar,
 )
 from mozaiksai.core.workflow.assignment_kinds import (
+    ASSIGNMENT_CONTRACT_DESCRIPTORS,
     COMPILER_ASSIGNMENT_KINDS,
+    AssignmentContractDescriptor,
     AssignmentKind,
-    assignment_contract_descriptor,
 )
 from mozaiksai.core.workflow.structured_output_contracts import (
     StructuredOutputContractRef,
@@ -948,6 +949,8 @@ def derive_compilation_plan(
     registry: Any,
     scope_selection: CompilationScopeSelection = CompilationScopeSelection(),
     structured_output_configs: Mapping[str, Any] | None = None,
+    assignment_descriptors: Mapping[AssignmentKind, AssignmentContractDescriptor]
+    | None = None,
 ) -> CompilationPlan:
     """Derive the single aggregate plan for one immutable graph identity.
 
@@ -957,6 +960,14 @@ def derive_compilation_plan(
     input object is never read.
     """
     verified_graph, payload_by_node = _cold_validate_inputs(graph, payloads)
+    # The descriptor authority is an explicit derivation input; the canonical
+    # module registry is only the default, so validation can supply the exact
+    # snapshot a serialized authority document pinned.
+    descriptor_authority = (
+        assignment_descriptors
+        if assignment_descriptors is not None
+        else ASSIGNMENT_CONTRACT_DESCRIPTORS
+    )
     output_configs = dict(structured_output_configs or {})
     verified_scope_selection = CompilationScopeSelection.model_validate(
         scope_selection.model_dump(mode="json")
@@ -1458,7 +1469,7 @@ def derive_compilation_plan(
                 _gap(row, PlanGapCode.VALIDATOR_UNDECLARED, adr_slice=5)
                 continue
             assignment_kind = compiler_assignment_kinds[0]
-            descriptor = assignment_contract_descriptor(assignment_kind)
+            descriptor = descriptor_authority.get(AssignmentKind(assignment_kind))
             if descriptor is None:
                 _gap(row, PlanGapCode.OUTPUT_CONTRACT_UNRESOLVED, adr_slice=5)
                 continue

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -1,0 +1,296 @@
+"""Canonical CompilationPlan authority contract (offline-only).
+
+A ``CompilationPlan`` self-digest proves body integrity: the digest matches
+the bytes the caller supplied. It does not prove the body was truthfully
+derived. A caller can mutate any derived plan fact — a unit's source
+footprint, disposition, output path, validator, an emitted gap — recompute
+the self-digests, and obtain a structurally cold-valid plan.
+
+This module defines the two halves of the closing rule:
+
+1. :class:`CompilationPlanAuthorityInputs` — the ONE strict immutable
+   authority-input contract: exactly the documents canonical plan derivation
+   consumes (semantic graph, complete payload closure, canonical layout
+   registry snapshot, scope selection, structured-output configuration
+   documents). It is frozen, ``extra="forbid"``, recursively closed over
+   typed models and JSON-safe documents, deterministic, and serializable —
+   serialization is safe precisely because the object is never trusted by
+   possession: every use cold-validates its contents and rederives the plan.
+
+2. :func:`validate_compilation_plan_against_authority` — the one canonical
+   validator. It cold-validates the candidate body and every authority
+   input, re-derives the canonical plan through the single existing
+   :func:`derive_compilation_plan` implementation (no second derivation of
+   source footprints, conditions, paths, assignments, or gaps exists here),
+   requires exact execution-authorizing equality, and returns the CANONICAL
+   REDERIVED plan. There is no proof object, no token, and no bearer
+   capability: possession of nothing establishes validity. The returned plan
+   is safe because it was rederived during that invocation; callers may use
+   it within the current call chain, and durable callers must rederive again
+   after restart.
+
+Authority versus diagnostics: every plan unit fact (family, instance, path,
+disposition, materializer, source and edge footprints, assignment contract,
+validator, dependencies), every emitted gap, and the graph/registry/scope
+identity header are execution authority and are compared exactly (the whole
+canonical body must match). Latent/composite diagnostics live outside the
+plan in ``CompilationGapReport`` and cannot affect rendering, reuse,
+composition, persistence, or promotion — they are not re-verified here.
+
+Brownfield boundary, stated explicitly: canonical derivation has no
+base/brownfield input today, so plans carrying ``preserve_unowned`` (or any
+other non-greenfield-derivable) content cannot be truthfully rederived and
+are REJECTED by this validator — fail-closed, never accepted-unverified.
+The immutable base-input contract that would make them derivable is a
+separate identified prerequisite; no test-only issuance shortcut and no
+self-digest-only fallback exists or may be added.
+
+This is deterministic application-compiler integrity (MOZAIKS_OSS). It
+carries no AG2 runtime concept, no model/provider identity, no prompt
+content, no filesystem paths, and no hosted state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    CompilationScopeSelection,
+    LayoutRegistrySnapshot,
+    derive_compilation_plan,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.graph import SemanticGraphV2
+from mozaiksai.core.semantics.payloads import (
+    SemanticPayload,
+    SemanticPayloadBase,
+)
+
+AUTHORITY_INPUTS_SCHEMA_VERSION = "mozaiks.compilation_plan_authority_inputs.v1"
+
+
+class PlanAuthorityMismatch(StrEnum):
+    """Finite typed categories of plan-authority failure."""
+
+    PLAN_BODY_INVALID = "plan_body_invalid"
+    CANONICAL_DERIVATION_MISMATCH = "canonical_derivation_mismatch"
+    REQUIRED_AUTHORITY_MISSING = "required_authority_missing"
+
+
+class PlanAuthorityError(ValueError):
+    """The candidate plan is not the canonical derivation of its authorities.
+
+    Carries deterministic audit identity only — category, plan digest, and
+    the first mismatching unit identity where known. Never candidate bodies,
+    payload contents, or arbitrary metadata.
+    """
+
+    def __init__(
+        self,
+        category: PlanAuthorityMismatch,
+        message: str,
+        *,
+        plan_digest: str | None = None,
+        unit_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.plan_digest = plan_digest
+        self.unit_id = unit_id
+
+
+class CompilationPlanAuthorityInputs(BaseModel):
+    """The exact immutable inputs canonical plan derivation consumes.
+
+    One instance carries everything :func:`derive_compilation_plan` needs to
+    reproduce a plan: nothing may be silently reconstructed differently at
+    validation time. ``structured_output_configs`` holds the exact immutable
+    configuration documents (JSON-safe mappings keyed by workflow name) the
+    plan was derived with — omitting them for a config-derived plan simply
+    yields a canonical mismatch. The execution scope and optional-family
+    selection travel inside the graph/payload closure and the scope
+    selection; the assignment-contract vocabulary is a closed code-level
+    registry pinned by the layout snapshot's row content. There is no
+    base/brownfield input field because canonical derivation consumes none —
+    see the module docstring for that identified prerequisite.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    authority_schema_version: str = AUTHORITY_INPUTS_SCHEMA_VERSION
+    graph: SemanticGraphV2
+    payloads: tuple[SemanticPayload, ...]
+    registry_snapshot: LayoutRegistrySnapshot
+    scope_selection: CompilationScopeSelection = CompilationScopeSelection()
+    structured_output_configs: Mapping[str, Any] | None = None
+
+    @field_validator("authority_schema_version")
+    @classmethod
+    def _schema_version(cls, value: str) -> str:
+        if value != AUTHORITY_INPUTS_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported authority-inputs schema version "
+                f"{value!r}; expected {AUTHORITY_INPUTS_SCHEMA_VERSION!r}"
+            )
+        return value
+
+    @field_validator("payloads")
+    @classmethod
+    def _payloads(
+        cls, value: tuple[SemanticPayloadBase, ...]
+    ) -> tuple[SemanticPayloadBase, ...]:
+        if not value:
+            raise ValueError("authority inputs require the complete payload closure")
+        return value
+
+
+def build_compilation_plan_authority_inputs(
+    *,
+    graph: SemanticGraphV2,
+    payloads: Any,
+    registry: Any,
+    scope_selection: CompilationScopeSelection | None = None,
+    structured_output_configs: Mapping[str, Any] | None = None,
+) -> CompilationPlanAuthorityInputs:
+    """Snapshot live authority objects into the immutable input contract.
+
+    ``registry`` may be the live ``AppLayoutRegistry`` or an already-built
+    snapshot; the snapshot identity is always recomputed from row content,
+    never taken from a claimed digest.
+    """
+    snapshot = (
+        registry
+        if isinstance(registry, LayoutRegistrySnapshot)
+        else snapshot_layout_registry(registry)
+    )
+    return CompilationPlanAuthorityInputs(
+        graph=graph,
+        payloads=tuple(payloads),
+        registry_snapshot=snapshot,
+        scope_selection=scope_selection or CompilationScopeSelection(),
+        structured_output_configs=structured_output_configs,
+    )
+
+
+def _first_difference(
+    candidate: CompilationPlan, canonical: CompilationPlan
+) -> tuple[str, str | None]:
+    """Locate the first authority difference for the audit identity."""
+    candidate_units = {unit.unit_id: unit for unit in candidate.units}
+    canonical_units = {unit.unit_id: unit for unit in canonical.units}
+    for unit_id in candidate_units.keys() - canonical_units.keys():
+        return ("unit not present in canonical derivation", unit_id)
+    for unit_id in canonical_units.keys() - candidate_units.keys():
+        return ("canonical unit missing from candidate", unit_id)
+    for unit_id, unit in candidate_units.items():
+        if unit.unit_digest != canonical_units[unit_id].unit_digest:
+            return ("unit body differs from canonical derivation", unit_id)
+    if len(candidate.units) != len(canonical.units):
+        return ("duplicate unit identity in candidate", None)
+    if [u.unit_id for u in candidate.units] != [u.unit_id for u in canonical.units]:
+        return ("unit ordering differs from canonical derivation", None)
+    candidate_gaps = [gap.model_dump(mode="json") for gap in candidate.gaps]
+    canonical_gaps = [gap.model_dump(mode="json") for gap in canonical.gaps]
+    if candidate_gaps != canonical_gaps:
+        return ("emitted gap set differs from canonical derivation", None)
+    return ("plan header differs from canonical derivation", None)
+
+
+def validate_compilation_plan_against_authority(
+    candidate_plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
+) -> CompilationPlan:
+    """Verify a candidate plan is exactly its canonical derivation.
+
+    1. Cold-validate the candidate body (self-digests, structural closure).
+    2. Cold-validate every authority input and resolve every reference (the
+       authority contract re-parses its own serialized form; graph/payload
+       closure and registry identity are re-verified by derivation itself).
+    3. Re-derive the canonical plan through the single existing
+       :func:`derive_compilation_plan` implementation.
+    4. Require exact execution-authorizing equality — any added, missing,
+       duplicated, or altered unit; any changed source or edge footprint,
+       path, disposition, materializer, condition, validator, assignment
+       kind, structured-output ref, or dependency; any removed or fabricated
+       emitted gap; any header/scope/registry/graph mutation — rejects.
+    5. Return the CANONICAL REDERIVED plan (never the caller's object, never
+       a proof token). Its safety is the rederivation that just happened;
+       durable callers must rederive again after restart.
+    """
+    if candidate_plan is None:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "no candidate CompilationPlan was supplied",
+        )
+    if authority_inputs is None or not isinstance(
+        authority_inputs, CompilationPlanAuthorityInputs
+    ):
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "CompilationPlanAuthorityInputs are required to verify a plan",
+            plan_digest=getattr(candidate_plan, "plan_digest", None),
+        )
+    try:
+        verified = CompilationPlan.model_validate(
+            candidate_plan.model_dump(mode="json")
+        )
+    except (TypeError, ValueError) as exc:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.PLAN_BODY_INVALID,
+            f"candidate plan failed cold body validation: {exc}",
+            plan_digest=getattr(candidate_plan, "plan_digest", None),
+        ) from exc
+    try:
+        verified_inputs = CompilationPlanAuthorityInputs.model_validate(
+            authority_inputs.model_dump(mode="json")
+        )
+    except (TypeError, ValueError) as exc:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            f"authority inputs failed cold validation: {exc}",
+            plan_digest=verified.plan_digest,
+        ) from exc
+    try:
+        canonical = derive_compilation_plan(
+            graph=verified_inputs.graph,
+            payloads=verified_inputs.payloads,
+            registry=verified_inputs.registry_snapshot,
+            scope_selection=verified_inputs.scope_selection,
+            structured_output_configs=verified_inputs.structured_output_configs,
+        )
+    except (TypeError, ValueError) as exc:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            f"canonical derivation failed for the supplied authorities: {exc}",
+            plan_digest=verified.plan_digest,
+        ) from exc
+    if (
+        verified.plan_digest != canonical.plan_digest
+        or verified.canonical_payload() != canonical.canonical_payload()
+    ):
+        detail, unit_id = _first_difference(verified, canonical)
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH,
+            "candidate plan is not the canonical derivation of its "
+            f"authorities: {detail} "
+            f"(candidate {verified.plan_digest[:12]}, "
+            f"canonical {canonical.plan_digest[:12]})",
+            plan_digest=verified.plan_digest,
+            unit_id=unit_id,
+        )
+    return canonical
+
+
+__all__ = [
+    "AUTHORITY_INPUTS_SCHEMA_VERSION",
+    "CompilationPlanAuthorityInputs",
+    "PlanAuthorityError",
+    "PlanAuthorityMismatch",
+    "build_compilation_plan_authority_inputs",
+    "validate_compilation_plan_against_authority",
+]

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -52,11 +52,21 @@ content, no filesystem paths, and no hosted state.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
 
 from mozaiksai.core.semantics.compilation_plan import (
     CompilationPlan,
@@ -69,6 +79,11 @@ from mozaiksai.core.semantics.graph import SemanticGraphV2
 from mozaiksai.core.semantics.payloads import (
     SemanticPayload,
     SemanticPayloadBase,
+)
+from mozaiksai.core.workflow.assignment_kinds import (
+    AssignmentContractRegistrySnapshot,
+    descriptors_from_snapshot,
+    snapshot_assignment_contract_registry,
 )
 
 AUTHORITY_INPUTS_SCHEMA_VERSION = "mozaiks.compilation_plan_authority_inputs.v1"
@@ -104,6 +119,105 @@ class PlanAuthorityError(ValueError):
         self.unit_id = unit_id
 
 
+class CanonicalJsonEntry(BaseModel):
+    """One key/value pair of a canonical JSON object."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    key: StrictStr
+    value: CanonicalJsonValue
+
+
+class CanonicalJsonObject(BaseModel):
+    """Recursively closed, immutable, deterministic JSON object.
+
+    Entries carry unique string keys in their exact declaration order —
+    declaration order is meaning in structured-output contracts, so the
+    authority pins the document precisely as derivation consumed it; the
+    stored order is itself deterministic and survives serialization. Values
+    are drawn only from the closed JSON algebra: no mutable dict/list
+    survives construction and no non-JSON value can enter.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entries: tuple[CanonicalJsonEntry, ...] = ()
+
+    @model_validator(mode="after")
+    def _unique_keys(self) -> CanonicalJsonObject:
+        keys = [entry.key for entry in self.entries]
+        if len(set(keys)) != len(keys):
+            raise ValueError("canonical JSON object declares duplicate keys")
+        return self
+
+    @classmethod
+    def from_python(cls, value: Mapping[str, Any]) -> CanonicalJsonObject:
+        if not isinstance(value, Mapping):
+            raise ValueError("canonical JSON object requires a mapping")
+        entries = []
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ValueError(
+                    f"canonical JSON object keys must be str, got {type(key).__name__}"
+                )
+            entries.append(CanonicalJsonEntry(key=key, value=_json_value(item)))
+        return cls(entries=tuple(entries))
+
+    def to_python(self) -> dict[str, Any]:
+        return {entry.key: _python_value(entry.value) for entry in self.entries}
+
+
+class CanonicalJsonArray(BaseModel):
+    """Recursively closed, immutable JSON array preserving element order."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    items: tuple[CanonicalJsonValue, ...] = ()
+
+
+CanonicalJsonValue = (
+    None
+    | StrictBool
+    | StrictInt
+    | StrictFloat
+    | StrictStr
+    | CanonicalJsonArray
+    | CanonicalJsonObject
+)
+
+CanonicalJsonEntry.model_rebuild()
+CanonicalJsonArray.model_rebuild()
+CanonicalJsonObject.model_rebuild()
+
+
+def _json_value(value: Any) -> Any:
+    """Normalize one Python value into the closed algebra, failing closed
+    immediately on anything that is not exact JSON."""
+    if value is None or type(value) is bool or type(value) is str:
+        return value
+    if type(value) is int:
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("canonical JSON forbids NaN and infinite floats")
+        return value
+    if isinstance(value, Mapping):
+        return CanonicalJsonObject.from_python(value)
+    if type(value) in (list, tuple):
+        return CanonicalJsonArray(items=tuple(_json_value(item) for item in value))
+    raise ValueError(
+        "canonical JSON forbids values of type " f"{type(value).__name__}"
+    )
+
+
+def _python_value(value: Any) -> Any:
+    if isinstance(value, CanonicalJsonObject):
+        return value.to_python()
+    if isinstance(value, CanonicalJsonArray):
+        return [_python_value(item) for item in value.items]
+    return value
+
+
 class CompilationPlanAuthorityInputs(BaseModel):
     """The exact immutable inputs canonical plan derivation consumes.
 
@@ -127,7 +241,8 @@ class CompilationPlanAuthorityInputs(BaseModel):
     payloads: tuple[SemanticPayload, ...]
     registry_snapshot: LayoutRegistrySnapshot
     scope_selection: CompilationScopeSelection = CompilationScopeSelection()
-    structured_output_configs: Mapping[str, Any] | None = None
+    structured_output_configs: CanonicalJsonObject | None = None
+    assignment_contract_registry: AssignmentContractRegistrySnapshot
 
     @field_validator("authority_schema_version")
     @classmethod
@@ -156,6 +271,7 @@ def build_compilation_plan_authority_inputs(
     registry: Any,
     scope_selection: CompilationScopeSelection | None = None,
     structured_output_configs: Mapping[str, Any] | None = None,
+    assignment_contract_registry: AssignmentContractRegistrySnapshot | None = None,
 ) -> CompilationPlanAuthorityInputs:
     """Snapshot live authority objects into the immutable input contract.
 
@@ -173,7 +289,16 @@ def build_compilation_plan_authority_inputs(
         payloads=tuple(payloads),
         registry_snapshot=snapshot,
         scope_selection=scope_selection or CompilationScopeSelection(),
-        structured_output_configs=structured_output_configs,
+        structured_output_configs=(
+            None
+            if structured_output_configs is None
+            else CanonicalJsonObject.from_python(structured_output_configs)
+        ),
+        assignment_contract_registry=(
+            assignment_contract_registry
+            if assignment_contract_registry is not None
+            else snapshot_assignment_contract_registry()
+        ),
     )
 
 
@@ -261,7 +386,14 @@ def validate_compilation_plan_against_authority(
             payloads=verified_inputs.payloads,
             registry=verified_inputs.registry_snapshot,
             scope_selection=verified_inputs.scope_selection,
-            structured_output_configs=verified_inputs.structured_output_configs,
+            structured_output_configs=(
+                None
+                if verified_inputs.structured_output_configs is None
+                else verified_inputs.structured_output_configs.to_python()
+            ),
+            assignment_descriptors=descriptors_from_snapshot(
+                verified_inputs.assignment_contract_registry
+            ),
         )
     except (TypeError, ValueError) as exc:
         raise PlanAuthorityError(
@@ -288,6 +420,9 @@ def validate_compilation_plan_against_authority(
 
 __all__ = [
     "AUTHORITY_INPUTS_SCHEMA_VERSION",
+    "CanonicalJsonArray",
+    "CanonicalJsonEntry",
+    "CanonicalJsonObject",
     "CompilationPlanAuthorityInputs",
     "PlanAuthorityError",
     "PlanAuthorityMismatch",

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -119,16 +119,47 @@ class PlanAuthorityError(ValueError):
         self.unit_id = unit_id
 
 
-class CanonicalJsonEntry(BaseModel):
-    """One key/value pair of a canonical JSON object."""
+class _AuthorityModel(BaseModel):
+    """Frozen base for authority documents: no unchecked update path exists.
+
+    ``model_copy(update=...)`` bypasses pydantic validation, which would let
+    a raw mutable or non-JSON value masquerade as validated authority state.
+    Authority models therefore refuse update-copies entirely — reconstruct
+    through ``model_validate`` instead. Plain no-update copies stay safe
+    because every field is itself frozen/immutable.
+    """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
+
+    def model_copy(self, *, update=None, deep: bool = False):
+        if update:
+            raise TypeError(
+                f"{type(self).__name__} does not support model_copy(update=...); "
+                "reconstruct through model_validate so authority content is "
+                "always validated"
+            )
+        return super().model_copy(deep=deep)
+
+
+def _reject_nonfinite(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("canonical JSON forbids NaN and infinite floats")
+    return value
+
+
+class CanonicalJsonEntry(_AuthorityModel):
+    """One key/value pair of a canonical JSON object."""
 
     key: StrictStr
     value: CanonicalJsonValue
 
+    @field_validator("value")
+    @classmethod
+    def _finite(cls, value: Any) -> Any:
+        return _reject_nonfinite(value)
 
-class CanonicalJsonObject(BaseModel):
+
+class CanonicalJsonObject(_AuthorityModel):
     """Recursively closed, immutable, deterministic JSON object.
 
     Entries carry unique string keys in their exact declaration order —
@@ -138,8 +169,6 @@ class CanonicalJsonObject(BaseModel):
     are drawn only from the closed JSON algebra: no mutable dict/list
     survives construction and no non-JSON value can enter.
     """
-
-    model_config = ConfigDict(frozen=True, extra="forbid")
 
     entries: tuple[CanonicalJsonEntry, ...] = ()
 
@@ -167,12 +196,17 @@ class CanonicalJsonObject(BaseModel):
         return {entry.key: _python_value(entry.value) for entry in self.entries}
 
 
-class CanonicalJsonArray(BaseModel):
+class CanonicalJsonArray(_AuthorityModel):
     """Recursively closed, immutable JSON array preserving element order."""
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
     items: tuple[CanonicalJsonValue, ...] = ()
+
+    @field_validator("items")
+    @classmethod
+    def _finite_items(cls, value: tuple[Any, ...]) -> tuple[Any, ...]:
+        for item in value:
+            _reject_nonfinite(item)
+        return value
 
 
 CanonicalJsonValue = (
@@ -218,7 +252,7 @@ def _python_value(value: Any) -> Any:
     return value
 
 
-class CompilationPlanAuthorityInputs(BaseModel):
+class CompilationPlanAuthorityInputs(_AuthorityModel):
     """The exact immutable inputs canonical plan derivation consumes.
 
     One instance carries everything :func:`derive_compilation_plan` needs to
@@ -233,8 +267,6 @@ class CompilationPlanAuthorityInputs(BaseModel):
     base/brownfield input field because canonical derivation consumes none —
     see the module docstring for that identified prerequisite.
     """
-
-    model_config = ConfigDict(frozen=True, extra="forbid")
 
     authority_schema_version: str = AUTHORITY_INPUTS_SCHEMA_VERSION
     graph: SemanticGraphV2

--- a/mozaiksai/core/workflow/assignment_kinds.py
+++ b/mozaiksai/core/workflow/assignment_kinds.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from types import MappingProxyType
 
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
 
 class AssignmentKind(StrEnum):
     """Closed assignment vocabulary.
@@ -200,6 +202,119 @@ def registered_assignment_kind_values() -> frozenset[str]:
     return frozenset(kind.value for kind in REGISTERED_ASSIGNMENT_KINDS)
 
 
+ASSIGNMENT_CONTRACT_REGISTRY_SCHEMA_VERSION = (
+    "mozaiks.assignment_contract_registry.v1"
+)
+
+
+class AssignmentContractDescriptorRow(BaseModel):
+    """Serializable identity of one assignment-contract descriptor.
+
+    Describes contract identity only — never runtime behavior: no callable,
+    class object, module, filesystem path, agent, or provider state.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    assignment_kind: AssignmentKind
+    workflow_name: str
+    structured_output_model_id: str
+    owned_artifact_families: tuple[str, ...]
+    validator_ids: tuple[str, ...]
+    identity_bindings: tuple[tuple[str, str], ...]
+
+
+class AssignmentContractRegistrySnapshot(BaseModel):
+    """Deterministic snapshot of the complete descriptor authority.
+
+    Frozen, unknown-field-rejecting, canonically ordered by assignment kind,
+    and digest-identified from canonical content, so a serialized authority
+    document pins exactly the descriptor state canonical plan derivation
+    consumed — ambient module state can never silently change a validation
+    result.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    registry_schema_version: str = ASSIGNMENT_CONTRACT_REGISTRY_SCHEMA_VERSION
+    descriptors: tuple[AssignmentContractDescriptorRow, ...]
+
+    @field_validator("registry_schema_version")
+    @classmethod
+    def _schema_version(cls, value: str) -> str:
+        if value != ASSIGNMENT_CONTRACT_REGISTRY_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported assignment-contract registry schema version "
+                f"{value!r}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _canonical_order(self) -> AssignmentContractRegistrySnapshot:
+        ordered = tuple(
+            sorted(self.descriptors, key=lambda row: row.assignment_kind.value)
+        )
+        kinds = [row.assignment_kind for row in ordered]
+        if len(set(kinds)) != len(kinds):
+            raise ValueError(
+                "assignment-contract registry snapshot declares duplicate kinds"
+            )
+        object.__setattr__(self, "descriptors", ordered)
+        return self
+
+    @property
+    def snapshot_digest(self) -> str:
+        import hashlib
+        import json
+
+        return hashlib.sha256(
+            json.dumps(self.model_dump(mode="json"), sort_keys=True).encode("utf-8")
+        ).hexdigest()
+
+
+def snapshot_assignment_contract_registry() -> AssignmentContractRegistrySnapshot:
+    """Snapshot the canonical descriptor registry as it exists right now."""
+    return AssignmentContractRegistrySnapshot(
+        descriptors=tuple(
+            AssignmentContractDescriptorRow(
+                assignment_kind=descriptor.assignment_kind,
+                workflow_name=descriptor.workflow_name,
+                structured_output_model_id=descriptor.structured_output_model_id,
+                owned_artifact_families=descriptor.owned_artifact_families,
+                validator_ids=descriptor.validator_ids,
+                identity_bindings=descriptor.identity_bindings,
+            )
+            for descriptor in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()
+        )
+    )
+
+
+def descriptors_from_snapshot(
+    snapshot: AssignmentContractRegistrySnapshot,
+) -> Mapping[AssignmentKind, AssignmentContractDescriptor]:
+    """Rebuild the one canonical descriptor type from a validated snapshot.
+
+    This is deserialization, not a second resolution mechanism: the returned
+    mapping holds ordinary :class:`AssignmentContractDescriptor` instances and
+    is consumed by the same derivation code path as the canonical registry.
+    """
+    return MappingProxyType(
+        {
+            row.assignment_kind: AssignmentContractDescriptor(
+                assignment_kind=row.assignment_kind,
+                workflow_name=row.workflow_name,
+                structured_output_model_id=row.structured_output_model_id,
+                owned_artifact_families=tuple(row.owned_artifact_families),
+                validator_ids=tuple(row.validator_ids),
+                identity_bindings=tuple(
+                    (binding[0], binding[1]) for binding in row.identity_bindings
+                ),
+            )
+            for row in snapshot.descriptors
+        }
+    )
+
+
 def app_build_assignment_kind_values() -> frozenset[str]:
     return frozenset(kind.value for kind in APP_BUILD_ASSIGNMENT_KINDS)
 
@@ -207,7 +322,12 @@ def app_build_assignment_kind_values() -> frozenset[str]:
 __all__ = [
     "APP_BUILD_ASSIGNMENT_KINDS",
     "COMPILER_ASSIGNMENT_KINDS",
+    "ASSIGNMENT_CONTRACT_REGISTRY_SCHEMA_VERSION",
+    "AssignmentContractDescriptorRow",
+    "AssignmentContractRegistrySnapshot",
     "REGISTERED_ASSIGNMENT_KINDS",
+    "descriptors_from_snapshot",
+    "snapshot_assignment_contract_registry",
     "AssignmentKind",
     "AssignmentContractDescriptor",
     "ASSIGNMENT_CONTRACT_DESCRIPTORS",

--- a/mozaiksai/core/workflow/outputs/structured.py
+++ b/mozaiksai/core/workflow/outputs/structured.py
@@ -41,7 +41,18 @@ TYPE_MAP = {
 
 
 def _build_literal_enum(name: str, values: list[Any]) -> type[Enum]:
-    enum_name = f"{name}Enum_{abs(hash(tuple(values))) % 10000}"
+    # The enum class name enters the compiled model's JSON schema and
+    # therefore canonical structured-output identity. Python hash() is
+    # process-salted, so the name must be content-derived: a bounded prefix
+    # of the sha256 over the exact ordered value content.
+    import hashlib as _hashlib
+    import json as _json
+
+    content = _json.dumps(
+        values, ensure_ascii=False, separators=(",", ":"), default=repr
+    )
+    digest_prefix = _hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+    enum_name = f"{name}Enum_{digest_prefix}"
     enum_members = {f"VALUE_{i}": value for i, value in enumerate(values)}
     return Enum(enum_name, enum_members)  # type: ignore[return-value]
 

--- a/mozaiksai/core/workflow/structured_output_contracts.py
+++ b/mozaiksai/core/workflow/structured_output_contracts.py
@@ -76,11 +76,28 @@ def structured_output_schema_digest(model: type[BaseModel]) -> str:
     return stable_digest(model.model_json_schema())
 
 
-def _compiled_models(config: Any) -> dict[str, type[BaseModel]]:
+def _default_exact_model_ids() -> frozenset[str]:
+    """The canonical registry's exact-model ids — an explicit default only.
+
+    Canonical plan derivation never uses this default: it passes the exact
+    model ids resolved from its supplied assignment-descriptor authority, so
+    ambient registry state cannot influence a schema digest on the canonical
+    path. Production assignment execution keeps the canonical registry as its
+    natural default.
+    """
+    from .assignment_kinds import ASSIGNMENT_CONTRACT_DESCRIPTORS
+
+    return frozenset(
+        descriptor.structured_output_model_id
+        for descriptor in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()
+    )
+
+
+def _compiled_models(
+    config: Any, *, exact_model_ids: frozenset[str] | None = None
+) -> dict[str, type[BaseModel]]:
     from mozaiksai.core.workflow.declarative.contracts import StructuredOutputsConfig
     from mozaiksai.core.workflow.outputs.structured import build_models_from_config
-
-    from .assignment_kinds import ASSIGNMENT_CONTRACT_DESCRIPTORS
 
     verified = StructuredOutputsConfig.model_validate(config)
     dumped = verified.model_dump(by_alias=True, exclude_unset=True)
@@ -88,11 +105,10 @@ def _compiled_models(config: Any) -> dict[str, type[BaseModel]]:
         dict[str, type[BaseModel]],
         build_models_from_config(dumped.get("models", {})),
     )
-    exact_model_ids = {
-        descriptor.structured_output_model_id
-        for descriptor in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()
-    }
-    for model_id in exact_model_ids & models.keys():
+    resolved_exact_ids = (
+        exact_model_ids if exact_model_ids is not None else _default_exact_model_ids()
+    )
+    for model_id in resolved_exact_ids & models.keys():
         model = models[model_id]
         model.model_config = ConfigDict(**model.model_config, extra="forbid")
         model.model_rebuild(force=True)
@@ -100,14 +116,18 @@ def _compiled_models(config: Any) -> dict[str, type[BaseModel]]:
 
 
 def build_structured_output_contract_ref(
-    *, workflow_name: str, model_id: str, configs: Mapping[str, Any]
+    *,
+    workflow_name: str,
+    model_id: str,
+    configs: Mapping[str, Any],
+    exact_model_ids: frozenset[str] | None = None,
 ) -> StructuredOutputContractRef:
     """Resolve a model through the existing canonical workflow compiler."""
 
     config = configs.get(workflow_name)
     if config is None:
         raise ValueError(f"unknown structured-output workflow {workflow_name!r}")
-    model = _compiled_models(config).get(model_id)
+    model = _compiled_models(config, exact_model_ids=exact_model_ids).get(model_id)
     if model is None:
         raise ValueError(
             f"unknown structured-output model {workflow_name!r}/{model_id!r}"

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -53,6 +53,7 @@ def _plan(
         scope_selection=source.scope_selection,
         registry_schema_version=source.registry_schema_version,
         registry_digest=source.registry_digest,
+        assignment_contracts_digest=source.assignment_contracts_digest,
         units=units,
         gaps=(),
         plan_digest="0" * 64,

--- a/tests/slice_5c_revision_helpers.py
+++ b/tests/slice_5c_revision_helpers.py
@@ -179,6 +179,7 @@ def executable_revision_fixture() -> dict[str, object]:
         scope_selection=source_plan.scope_selection,
         registry_schema_version=source_plan.registry_schema_version,
         registry_digest=source_plan.registry_digest,
+        assignment_contracts_digest=source_plan.assignment_contracts_digest,
         units=source_plan.units,
         gaps=(),
         plan_digest="0" * 64,

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -536,6 +536,10 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
         # Slice 5B offline composition consumes the aggregate plan only
         # after assignment/materialization output has been validated.
             Path("mozaiksai/core/semantics/composition_ledger.py"),
+            # Canonical plan-authority contract: re-derives candidate plans
+            # through the one derivation function; offline-only, and this
+            # same scan proves no production module imports it.
+            Path("mozaiksai/core/semantics/plan_authority.py"),
             # Slice 5C offline immutable revision closure and persistence owner.
             Path("mozaiksai/core/semantics/artifact_revision.py"),
             Path("mozaiksai/core/artifacts/revision_store.py"),

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -47,7 +47,13 @@ _SCOPE = ExecutionAccessScopeRef(tenant_id="tenant1", workspace_id="ws1")
 _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden aggregate digest for the full 2E corpus over the built-in registry.
-_GOLDEN_PLAN_DIGEST = "f69b7f8ce82edab87ad34357a36b500ec12f6f9cf4a502021d566c86299741f4"
+# Re-pinned once for the plan-authority contract: CompilationPlan identity
+# now pins assignment_contracts_digest — the exact assignment-descriptor
+# closure consulted during derivation (empty-consulted for this config-less
+# corpus). Identity-only change: no rendered byte, assignment resolution, or
+# reuse behavior changed; unrelated registry descriptors remain outside plan
+# identity by the locality rule.
+_GOLDEN_PLAN_DIGEST = "df0bebdc10fe304977f6c2828d3410f88366c1763c3f175ac5f891e4bf769314"
 
 
 def _registry():
@@ -626,6 +632,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
             "scope_selection",
             "registry_schema_version",
             "registry_digest",
+            "assignment_contracts_digest",
             "units",
             "gaps",
             "plan_digest",
@@ -1031,6 +1038,7 @@ def test_blocker5_reverse_dependency_and_graph_wide_propagation() -> None:
             "graph_digest": graph_digest,
             "registry_schema_version": "mozaiks.app_layout.v2",
             "registry_digest": canonical_digest("registry"),
+            "assignment_contracts_digest": canonical_digest("no-assignments"),
             "units": units,
             "gaps": [],
         }

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -1,0 +1,625 @@
+"""Canonical CompilationPlan authority-contract proofs (ADR 0007 lane).
+
+A plan self-digest proves body integrity, not truthful derivation: a caller
+can mutate any derived plan fact, recompute the self-digests, and obtain a
+structurally cold-valid plan. These proofs pin the authority contract that
+closes the gap — one immutable authority-input document and one canonical
+validator that re-derives the plan through the single existing derivation
+implementation and returns the canonical rederived plan. No proof object, no
+token, no bearer capability: possession of nothing establishes trust.
+
+PR A defines the contract and validator only; consumer wiring is a separate
+enforcement change.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    derive_compilation_plan,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+    build_compilation_plan_authority_inputs,
+    validate_compilation_plan_against_authority,
+)
+from tests.test_deterministic_page_materialization import (
+    _build,
+    _registry,
+    _source,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _authority():
+    result, plan = _build(_source())
+    inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+    )
+    return inputs, plan
+
+
+def _forge(plan: CompilationPlan, mutate: Callable[[dict], None]) -> CompilationPlan:
+    """Apply one mutation and recompute the outer self-digest.
+
+    The result passes cold model validation whenever the mutation is
+    structurally expressible — exactly the forgery class the canonical
+    validator must reject.
+    """
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    mutate(document)
+    mutate(payload)
+    document["plan_digest"] = canonical_digest(payload)
+    return CompilationPlan.model_validate(document)
+
+
+def _render_unit_index(document: dict) -> int:
+    return next(
+        index
+        for index, unit in enumerate(document["units"])
+        if unit["disposition"] == "render" and unit["sources"]
+    )
+
+
+def _extra_source(inputs, plan):
+    unit = next(u for u in plan.units if u.disposition.value == "render" and u.sources)
+    present = {s.node_id for s in unit.sources}
+    extra = next(p for p in inputs.payloads if p.node_id not in present)
+
+    def mutate(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["sources"] = sorted(
+            list(document["units"][index]["sources"])
+            + [{"node_id": extra.node_id, "payload_digest": extra.payload_digest}],
+            key=lambda s: s["node_id"],
+        )
+
+    return mutate
+
+
+# ---------------------------------------------------------------------------
+# Contract shape: frozen, extra-forbid, closed, serializable-but-untrusted
+# ---------------------------------------------------------------------------
+
+
+def test_authority_inputs_are_frozen_closed_and_versioned() -> None:
+    inputs, _plan_obj = _authority()
+    with pytest.raises(ValidationError):
+        inputs.graph = inputs.graph  # type: ignore[misc]
+    document = inputs.model_dump(mode="json")
+    document["arbitrary_metadata"] = {"campaign": "x"}
+    with pytest.raises(ValidationError):
+        CompilationPlanAuthorityInputs.model_validate(document)
+    document = inputs.model_dump(mode="json")
+    document["authority_schema_version"] = "mozaiks.other.v9"
+    with pytest.raises(ValidationError, match="schema version"):
+        CompilationPlanAuthorityInputs.model_validate(document)
+    document = inputs.model_dump(mode="json")
+    document["payloads"] = []
+    with pytest.raises(ValidationError, match="complete payload closure"):
+        CompilationPlanAuthorityInputs.model_validate(document)
+
+
+def test_authority_inputs_serialization_is_not_trust() -> None:
+    """The contract round-trips losslessly, and a deserialized copy still
+    yields validation only through full rederivation — the same canonical
+    digest, not a remembered claim."""
+    inputs, plan = _authority()
+    revived = CompilationPlanAuthorityInputs.model_validate(
+        json.loads(json.dumps(inputs.model_dump(mode="json")))
+    )
+    canonical = validate_compilation_plan_against_authority(plan, revived)
+    assert canonical.plan_digest == plan.plan_digest
+    # subclass payloads survive the round-trip exactly
+    assert [p.payload_kind for p in revived.payloads] == [
+        p.payload_kind for p in inputs.payloads
+    ]
+    assert [p.payload_digest for p in revived.payloads] == [
+        p.payload_digest for p in inputs.payloads
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The canonical validator: exact acceptance and the forged-candidate matrix
+# ---------------------------------------------------------------------------
+
+
+def test_exact_candidate_returns_the_canonical_rederived_plan() -> None:
+    inputs, plan = _authority()
+    canonical = validate_compilation_plan_against_authority(plan, inputs)
+    assert canonical is not plan  # rederived, never the caller object
+    assert canonical.plan_digest == plan.plan_digest
+    assert canonical.canonical_payload() == plan.canonical_payload()
+
+
+def test_generic_extra_source_forgery_is_rejected() -> None:
+    """The preserved generic reproduction: an unrelated valid same-graph
+    payload source added to one unit, digests recomputed, cold model
+    validation accepting the forgery — the canonical validator rejects it."""
+    inputs, plan = _authority()
+    forged = _forge(plan, _extra_source(inputs, plan))
+    assert (
+        CompilationPlan.model_validate(forged.model_dump(mode="json")).plan_digest
+        == forged.plan_digest
+    )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(forged, inputs)
+    assert (
+        excinfo.value.category is PlanAuthorityMismatch.CANONICAL_DERIVATION_MISMATCH
+    )
+    assert excinfo.value.unit_id is not None
+
+
+def _mutations(inputs, plan):
+    unit = next(u for u in plan.units if u.disposition.value == "render" and u.sources)
+    other_kind = next(
+        p for p in inputs.payloads if p.node_id not in {s.node_id for s in unit.sources}
+    )
+
+    def drop_source(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["sources"] = list(
+            document["units"][index]["sources"]
+        )[:-1]
+
+    def substitute_source(document: dict) -> None:
+        index = _render_unit_index(document)
+        sources = list(document["units"][index]["sources"])
+        sources[0] = {
+            "node_id": other_kind.node_id,
+            "payload_digest": other_kind.payload_digest,
+        }
+        document["units"][index]["sources"] = sorted(
+            sources, key=lambda s: s["node_id"]
+        )
+
+    def stale_digest(document: dict) -> None:
+        index = _render_unit_index(document)
+        sources = [dict(s) for s in document["units"][index]["sources"]]
+        sources[0]["payload_digest"] = "f" * 64
+        document["units"][index]["sources"] = sources
+
+    def extra_edge(document: dict) -> None:
+        index = _render_unit_index(document)
+        edges = [dict(e) for e in document["units"][index]["edge_sources"]]
+        forged_edge = dict(edges[0])
+        forged_edge["target_node_id"] = other_kind.node_id
+        forged_edge["edge_identity"] = "a" * 64
+        document["units"][index]["edge_sources"] = edges + [forged_edge]
+
+    def missing_edge(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["edge_sources"] = list(
+            document["units"][index]["edge_sources"]
+        )[:-1]
+
+    def changed_output_path(document: dict) -> None:
+        index = _render_unit_index(document)
+        outputs = [dict(o) for o in document["units"][index]["outputs"]]
+        outputs[0]["path"] = "ui/pages/hijacked.yaml"
+        document["units"][index]["outputs"] = outputs
+
+    def changed_path_scope(document: dict) -> None:
+        index = _render_unit_index(document)
+        outputs = [dict(o) for o in document["units"][index]["outputs"]]
+        outputs[0]["path_scope"] = "workspace_root"
+        document["units"][index]["outputs"] = outputs
+
+    def changed_disposition(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["disposition"] = "external_handoff"
+
+    def disposition_inapplicable(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["disposition"] = "inapplicable"
+
+    def changed_materializer(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["materializer"] = "app_generator"
+
+    def changed_validator(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["validator"] = "app_paths"
+
+    def changed_assignment(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"][index]["assignment_kind"] = "page_bundle"
+
+    def changed_dependency(document: dict) -> None:
+        index = _render_unit_index(document)
+        other = next(
+            u["unit_id"] for i, u in enumerate(document["units"]) if i != index
+        )
+        document["units"][index]["depends_on_units"] = [other]
+
+    def removed_unit(document: dict) -> None:
+        index = _render_unit_index(document)
+        document["units"] = [u for i, u in enumerate(document["units"]) if i != index]
+
+    def added_unit(document: dict) -> None:
+        index = _render_unit_index(document)
+        clone = copy.deepcopy(document["units"][index])
+        clone["unit_id"] = clone["unit_id"] + "_forged"
+        document["units"] = list(document["units"]) + [clone]
+
+    def removed_gap(document: dict) -> None:
+        document["gaps"] = list(document["gaps"])[:-1]
+
+    def fake_gap(document: dict) -> None:
+        fake = copy.deepcopy(document["gaps"][0])
+        fake["family_kind"] = "app_dashboard"
+        fake["path_template"] = "dashboard/dashboard.yaml"
+        document["gaps"] = list(document["gaps"]) + [fake]
+
+    return {
+        "missing-source": drop_source,
+        "substituted-source": substitute_source,
+        "stale-source-digest": stale_digest,
+        "extra-edge": extra_edge,
+        "missing-edge": missing_edge,
+        "changed-output-path": changed_output_path,
+        "changed-path-scope": changed_path_scope,
+        "disposition-external-handoff": changed_disposition,
+        "disposition-inapplicable": disposition_inapplicable,
+        "changed-materializer": changed_materializer,
+        "changed-validator": changed_validator,
+        "changed-assignment-kind": changed_assignment,
+        "changed-dependency": changed_dependency,
+        "removed-unit": removed_unit,
+        "added-unit": added_unit,
+        "removed-emitted-gap": removed_gap,
+        "fake-emitted-gap": fake_gap,
+    }
+
+
+_MUTATION_IDS = [
+    "missing-source",
+    "substituted-source",
+    "stale-source-digest",
+    "extra-edge",
+    "missing-edge",
+    "changed-output-path",
+    "changed-path-scope",
+    "disposition-external-handoff",
+    "disposition-inapplicable",
+    "changed-materializer",
+    "changed-validator",
+    "changed-assignment-kind",
+    "changed-dependency",
+    "removed-unit",
+    "added-unit",
+    "removed-emitted-gap",
+    "fake-emitted-gap",
+]
+
+
+@pytest.mark.parametrize("mutation_id", _MUTATION_IDS)
+def test_every_forged_plan_fact_is_rejected(mutation_id) -> None:
+    """Every execution-authorizing fact class: forge, recompute self-digests,
+    and prove the validator rejects the candidate — or the body contract
+    itself refuses to express the forgery (also fail-closed)."""
+    inputs, plan = _authority()
+    mutate = _mutations(inputs, plan)[mutation_id]
+    try:
+        forged = _forge(plan, mutate)
+    except (ValueError, TypeError):
+        return  # structurally inexpressible: the body contract already refuses
+    assert forged.plan_digest != plan.plan_digest
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(forged, inputs)
+
+
+def test_changed_structured_output_ref_is_rejected_under_configs() -> None:
+    import yaml as _yaml
+
+    configs = {
+        "AppGenerator": _yaml.safe_load(
+            (
+                ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+            ).read_text(encoding="utf-8")
+        )
+    }
+    result, _ = _build(_source())
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    # the honest config-derived plan validates against config-carrying inputs
+    canonical = validate_compilation_plan_against_authority(plan, inputs)
+    assert canonical.plan_digest == plan.plan_digest
+
+    refs = [
+        u.required_structured_output_ref
+        for u in plan.units
+        if u.required_structured_output_ref is not None
+    ]
+    if len({r.model_dump_json() for r in refs}) < 2:
+        pytest.skip("corpus produced fewer than two distinct structured refs")
+
+    def swap_ref(document: dict) -> None:
+        docs = [
+            u["required_structured_output_ref"]
+            for u in document["units"]
+            if u.get("required_structured_output_ref") is not None
+        ]
+        distinct = next(d for d in docs if d != docs[0])
+        for u in document["units"]:
+            if u.get("required_structured_output_ref") == docs[0]:
+                u["required_structured_output_ref"] = distinct
+                return
+
+    try:
+        forged = _forge(plan, swap_ref)
+    except (ValueError, TypeError):
+        return  # body contract refuses the substitution: fail-closed
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(forged, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Authority mismatches: wrong graph, wrong registry, missing authority,
+# brownfield (no base authority exists), shuffled equivalence, fresh process
+# ---------------------------------------------------------------------------
+
+
+def test_foreign_graph_authorities_reject_the_plan() -> None:
+    inputs, plan = _authority()
+    other_result, other_plan = _build(_source(column_label="Order Number"))
+    other_inputs = build_compilation_plan_authority_inputs(
+        graph=other_result.graph,
+        payloads=other_result.payloads,
+        registry=_registry(),
+    )
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(plan, other_inputs)
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(other_plan, inputs)
+
+
+def test_foreign_registry_authority_rejects_the_plan() -> None:
+    from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+
+    _inputs, plan = _authority()
+    source = build_app_layout_registry(())
+
+    class _MutatedRegistry:
+        def __init__(self) -> None:
+            self.schema_version = source.schema_version
+            families = []
+            for family in source.ordered_families():
+                if family.path_template == "app.json":
+                    family = family.model_copy(
+                        update={"path_template": "app_renamed.json"}
+                    )
+                families.append(family)
+            self._families = tuple(families)
+
+        def ordered_families(self):
+            return self._families
+
+    result, _ = _build(_source())
+    mutated_inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_MutatedRegistry(),
+    )
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(plan, mutated_inputs)
+
+
+def test_missing_authority_fails_explicitly_typed() -> None:
+    inputs, plan = _authority()
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(plan, None)
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(None, inputs)
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(plan, {"graph": None})
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+
+
+def test_brownfield_plan_without_base_authority_is_rejected() -> None:
+    """Canonical derivation consumes no base/brownfield input, so a plan
+    carrying preserve_unowned content cannot be truthfully rederived: the
+    validator rejects it fail-closed rather than accepting it unverified.
+    The immutable base-input contract is the identified prerequisite."""
+    from tests.slice_5b_composition_helpers import composition_fixture
+
+    fixture = composition_fixture()
+    inputs = build_compilation_plan_authority_inputs(
+        graph=fixture["graph"],
+        payloads=fixture["payloads"],
+        registry=_registry(),
+    )
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(fixture["successor"], inputs)
+
+
+def test_shuffled_raw_authority_inputs_derive_the_same_canonical_plan() -> None:
+    inputs, plan = _authority()
+    shuffled = CompilationPlanAuthorityInputs(
+        graph=inputs.graph,
+        payloads=tuple(reversed(inputs.payloads)),
+        registry_snapshot=inputs.registry_snapshot,
+        scope_selection=inputs.scope_selection,
+        structured_output_configs=inputs.structured_output_configs,
+    )
+    canonical = validate_compilation_plan_against_authority(plan, shuffled)
+    assert canonical.plan_digest == plan.plan_digest
+
+
+def test_fresh_process_validation_succeeds() -> None:
+    """Durable callers rederive after restart: a fresh interpreter, fed only
+    the serialized authority inputs and candidate plan, reaches the same
+    canonical acceptance."""
+    inputs, plan = _authority()
+    probe = (
+        "import json, sys\n"
+        "from mozaiksai.core.semantics.compilation_plan import CompilationPlan\n"
+        "from mozaiksai.core.semantics.plan_authority import (\n"
+        "    CompilationPlanAuthorityInputs,\n"
+        "    validate_compilation_plan_against_authority,\n"
+        ")\n"
+        "payload = json.loads(sys.stdin.read())\n"
+        "inputs = CompilationPlanAuthorityInputs.model_validate(payload['inputs'])\n"
+        "plan = CompilationPlan.model_validate(payload['plan'])\n"
+        "canonical = validate_compilation_plan_against_authority(plan, inputs)\n"
+        "print(canonical.plan_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        input=json.dumps(
+            {
+                "inputs": inputs.model_dump(mode="json"),
+                "plan": plan.model_dump(mode="json"),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == plan.plan_digest
+
+
+# ---------------------------------------------------------------------------
+# No bearer authority, no second planner, determinism
+# ---------------------------------------------------------------------------
+
+
+def test_no_bearer_proof_or_token_surface_exists() -> None:
+    source = (ROOT / "mozaiksai/core/semantics/plan_authority.py").read_text(
+        encoding="utf-8"
+    )
+    for forbidden in (
+        "PlanAuthorityProof",
+        "issued_token",
+        "IssuanceToken",
+        "trusted=True",
+        "skip_validation",
+    ):
+        assert forbidden not in source, forbidden
+
+
+def test_no_second_planner_exists() -> None:
+    """The validator calls the one canonical derive_compilation_plan and
+    re-implements none of its derivation vocabulary."""
+    source = (ROOT / "mozaiksai/core/semantics/plan_authority.py").read_text(
+        encoding="utf-8"
+    )
+    assert "derive_compilation_plan(" in source
+    for derivation_internal in (
+        "_condition_state",
+        "_sources_for",
+        "_renderer_footprint",
+        "ConditionIdentifier",
+        "_FAMILY_SOURCE_KINDS",
+        "PathScope",
+        "AssignmentKind",
+    ):
+        assert derivation_internal not in source, derivation_internal
+
+
+def test_validation_is_deterministic_and_bounded() -> None:
+    inputs, plan = _authority()
+    start = time.perf_counter()
+    first = validate_compilation_plan_against_authority(plan, inputs)
+    second = validate_compilation_plan_against_authority(plan, inputs)
+    elapsed = time.perf_counter() - start
+    assert first.plan_digest == second.plan_digest
+    assert first.canonical_payload() == second.canonical_payload()
+    assert elapsed < 60  # offline compiler boundary; generous ceiling only
+
+
+def test_unreferenced_extra_payload_in_authority_inputs_fails_closed() -> None:
+    """Padding the authority inputs with a valid payload no graph node
+    references is rejected by the derivation's own payload-closure
+    validation — extra authority can never ride along unnoticed."""
+    from mozaiksai.core.semantics.payloads import (
+        CapabilityPayload,
+        build_semantic_payload,
+    )
+
+    inputs, plan = _authority()
+    orphan = build_semantic_payload(
+        CapabilityPayload,
+        node_id="mozaiks.capability.orphan",
+        payload_version=1,
+        scope=plan.scope,
+        description="orphan capability payload",
+    )
+    padded = CompilationPlanAuthorityInputs(
+        graph=inputs.graph,
+        payloads=inputs.payloads + (orphan,),
+        registry_snapshot=inputs.registry_snapshot,
+        scope_selection=inputs.scope_selection,
+        structured_output_configs=inputs.structured_output_configs,
+    )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(plan, padded)
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+
+
+def test_scope_selection_is_never_silently_reconstructed() -> None:
+    """A plan derived under a non-default scope selection validates only
+    against inputs carrying that exact selection — no derivation input is
+    silently rebuilt with a different default at validation time."""
+    from mozaiksai.core.runtime.app.layout_registry import PathScope
+    from mozaiksai.core.semantics.compilation_plan import (
+        CompilationScopeSelection,
+    )
+
+    result, _ = _build(_source())
+    selection = CompilationScopeSelection(
+        app_manifest_scope=PathScope.WORKSPACE_ROOT
+    )
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        scope_selection=selection,
+    )
+    matching = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        scope_selection=selection,
+    )
+    canonical = validate_compilation_plan_against_authority(plan, matching)
+    assert canonical.plan_digest == plan.plan_digest
+    default_inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+    )
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(plan, default_inputs)

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -808,16 +808,25 @@ def test_deep_immutability_and_source_mutation_independence() -> None:
 
 
 def test_model_copy_cannot_smuggle_unchecked_open_values() -> None:
-    """model_copy bypasses validators, but the validator's own cold
-    re-validation of the authority document rejects anything that cannot
-    round-trip the closed contract."""
-    inputs, plan = _authority()
-    smuggled = inputs.model_copy(
-        update={"structured_output_configs": {"AppGenerator": object()}}
+    """Authority models refuse model_copy(update=...) outright: the unsafe
+    update path no longer exists, so no raw dict/list or non-JSON object can
+    ever masquerade as validated authority state — no
+    validation-only-later contract."""
+    inputs, _plan_obj = _authority()
+    with pytest.raises(TypeError, match="does not support model_copy"):
+        inputs.model_copy(
+            update={"structured_output_configs": {"AppGenerator": object()}}
+        )
+    from mozaiksai.core.semantics.plan_authority import CanonicalJsonObject
+
+    node = CanonicalJsonObject.from_python({"a": [1, 2]})
+    with pytest.raises(TypeError, match="does not support model_copy"):
+        node.model_copy(update={"entries": ({"key": "a", "value": None},)})
+    # plain no-update copies remain safe and equal
+    assert node.model_copy() == node
+    assert inputs.model_copy().model_dump(mode="json") == inputs.model_dump(
+        mode="json"
     )
-    with pytest.raises(PlanAuthorityError) as excinfo:
-        validate_compilation_plan_against_authority(plan, smuggled)
-    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
 
 
 # ---------------------------------------------------------------------------
@@ -849,3 +858,268 @@ def test_every_derivation_input_is_represented_in_authority_inputs() -> None:
     fields = set(CompilationPlanAuthorityInputs.model_fields)
     for parameter, field in represented.items():
         assert field in fields, (parameter, field)
+
+
+# ---------------------------------------------------------------------------
+# Assignment-descriptor authority locality. The plan pins the digest of the
+# exact descriptor closure CONSULTED during derivation: used-descriptor
+# changes change/reject plan identity; unrelated registry entries never
+# enter it. No "snapshot changed but plan cannot tell" state exists.
+# ---------------------------------------------------------------------------
+
+
+def _config_authority():
+    import yaml as _yaml
+
+    configs = {
+        "AppGenerator": _yaml.safe_load(
+            (
+                ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+            ).read_text(encoding="utf-8")
+        )
+    }
+    result, _ = _build(_source())
+    inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    return inputs, plan
+
+
+def _with_descriptors(inputs, mutate_rows):
+    from mozaiksai.core.workflow.assignment_kinds import (
+        AssignmentContractRegistrySnapshot,
+    )
+
+    rows = [row.model_dump(mode="json") for row in
+            inputs.assignment_contract_registry.descriptors]
+    mutate_rows(rows)
+    snapshot = AssignmentContractRegistrySnapshot.model_validate(
+        {"registry_schema_version": (
+            inputs.assignment_contract_registry.registry_schema_version
+        ), "descriptors": rows}
+    )
+    return CompilationPlanAuthorityInputs.model_validate(
+        {**inputs.model_dump(mode="json"),
+         "assignment_contract_registry": snapshot.model_dump(mode="json")}
+    )
+
+
+def _used_kinds(plan):
+    return {
+        u.assignment_kind
+        for u in plan.units
+        if u.disposition.value == "agent_author" and u.assignment_kind
+    }
+
+
+def test_used_descriptor_mutations_change_or_reject_plan_identity() -> None:
+    inputs, plan = _config_authority()
+    used = _used_kinds(plan)
+    assert used, "config-bearing corpus must consult descriptors"
+    target = sorted(used)[0]
+
+    def _mutate(field, value):
+        def mutate(rows):
+            for row in rows:
+                if row["assignment_kind"] == target:
+                    row[field] = value
+                    return
+        return mutate
+
+    cases = {
+        "changed-workflow": _mutate("workflow_name", "OtherWorkflow"),
+        "changed-model": _mutate(
+            "structured_output_model_id", "SomeOtherModel"
+        ),
+        "changed-owned-family": _mutate(
+            "owned_artifact_families", ["app_dashboard"]
+        ),
+        "changed-validator": _mutate("validator_ids", ["app_paths"]),
+        "changed-identity-binding": _mutate(
+            "identity_bindings", [["module_id", "page_id"]]
+        ),
+    }
+
+    def _removed(rows):
+        rows[:] = [r for r in rows if r["assignment_kind"] != target]
+
+    cases["removed-used-descriptor"] = _removed
+    for case, mutate in cases.items():
+        tampered = _with_descriptors(inputs, mutate)
+        with pytest.raises(PlanAuthorityError) as excinfo:
+            validate_compilation_plan_against_authority(plan, tampered)
+        assert (
+            excinfo.value.category
+            is not PlanAuthorityMismatch.PLAN_BODY_INVALID
+        ), case
+
+
+def test_duplicate_used_descriptor_rejects_at_the_snapshot() -> None:
+    from pydantic import ValidationError as _VE
+
+    inputs, plan = _config_authority()
+    target = sorted(_used_kinds(plan))[0]
+
+    def duplicate(rows):
+        clone = dict(next(r for r in rows if r["assignment_kind"] == target))
+        rows.append(clone)
+
+    with pytest.raises(_VE, match="duplicate"):
+        _with_descriptors(inputs, duplicate)
+
+
+def test_unused_descriptor_mutations_do_not_affect_plan_identity() -> None:
+    """Locality: registry entries outside this plan's consulted closure are
+    normalized out of authority identity — adding, removing, or changing an
+    unused descriptor leaves validation accepting the same canonical plan."""
+    inputs, plan = _config_authority()
+    used = _used_kinds(plan)
+    unused = next(
+        row.assignment_kind.value
+        for row in inputs.assignment_contract_registry.descriptors
+        if row.assignment_kind.value not in used
+    )
+
+    def remove_unused(rows):
+        rows[:] = [r for r in rows if r["assignment_kind"] != unused]
+
+    def change_unused(rows):
+        for row in rows:
+            if row["assignment_kind"] == unused:
+                row["workflow_name"] = "MutatedWorkflow"
+                return
+
+    def reorder(rows):
+        rows.reverse()
+
+    for case, mutate in {
+        "missing-unused": remove_unused,
+        "changed-unused": change_unused,
+        "reordered-equivalent": reorder,
+    }.items():
+        adjusted = _with_descriptors(inputs, mutate)
+        canonical = validate_compilation_plan_against_authority(plan, adjusted)
+        assert canonical.plan_digest == plan.plan_digest, case
+    assert plan.assignment_contracts_digest
+
+
+# ---------------------------------------------------------------------------
+# Ambient structured-output registry independence with config-bearing plans,
+# and cross-process determinism under adversarial PYTHONHASHSEED values with
+# an enum-bearing structured-output contract in play.
+# ---------------------------------------------------------------------------
+
+
+def test_ambient_registry_mutation_cannot_change_config_bearing_plans() -> None:
+    import mozaiksai.core.workflow.assignment_kinds as ak
+
+    inputs, plan = _config_authority()
+    document = json.dumps(
+        {"inputs": inputs.model_dump(mode="json"), "plan": plan.model_dump(mode="json")}
+    )
+    original = ak.ASSIGNMENT_CONTRACT_DESCRIPTORS
+    try:
+        ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = type(original)({})
+        revived = CompilationPlanAuthorityInputs.model_validate(
+            json.loads(document)["inputs"]
+        )
+        canonical = validate_compilation_plan_against_authority(plan, revived)
+    finally:
+        ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = original
+    assert canonical.plan_digest == plan.plan_digest
+
+
+def test_enum_names_are_content_derived_not_process_salted() -> None:
+    from mozaiksai.core.workflow.outputs.structured import _build_literal_enum
+
+    first = _build_literal_enum("Status", ["draft", "published"])
+    second = _build_literal_enum("Status", ["draft", "published"])
+    assert first.__name__ == second.__name__
+    assert first.__name__.startswith("StatusEnum_")
+    suffix = first.__name__.rsplit("_", 1)[1]
+    assert len(suffix) == 12 and int(suffix, 16) >= 0
+    different = _build_literal_enum("Status", ["published", "draft"])
+    assert different.__name__ != first.__name__  # order is content
+
+
+@pytest.mark.parametrize("hash_seed", ["1", "2", "12345"])
+def test_config_bearing_plan_digest_is_hashseed_independent(hash_seed) -> None:
+    """The complete fresh-process proof: the exact same serialized graph,
+    payloads, registry, assignment closure, structured-output configs (with
+    enum-bearing contracts), and candidate plan reproduce the identical
+    canonical digest under adversarial PYTHONHASHSEED values, with the
+    ambient assignment registry emptied."""
+    import os
+
+    inputs, plan = _config_authority()
+    assert any(
+        u.required_structured_output_ref is not None for u in plan.units
+    ), "corpus must exercise structured-output (enum-bearing) contracts"
+    probe = (
+        "import json, sys\n"
+        "import mozaiksai.core.workflow.assignment_kinds as ak\n"
+        "ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = type(ak.ASSIGNMENT_CONTRACT_DESCRIPTORS)({})\n"
+        "from mozaiksai.core.semantics.compilation_plan import CompilationPlan\n"
+        "from mozaiksai.core.semantics.plan_authority import (\n"
+        "    CompilationPlanAuthorityInputs,\n"
+        "    validate_compilation_plan_against_authority,\n"
+        ")\n"
+        "payload = json.loads(sys.stdin.read())\n"
+        "inputs = CompilationPlanAuthorityInputs.model_validate(payload['inputs'])\n"
+        "plan = CompilationPlan.model_validate(payload['plan'])\n"
+        "print(validate_compilation_plan_against_authority(plan, inputs).plan_digest)\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = hash_seed
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        input=json.dumps(
+            {
+                "inputs": inputs.model_dump(mode="json"),
+                "plan": plan.model_dump(mode="json"),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == plan.plan_digest
+
+
+def test_canonical_json_construction_matrix_is_uniform() -> None:
+    """Every supported entry path yields the identical deeply immutable
+    canonical representation or rejects unsafe construction."""
+    from mozaiksai.core.semantics.plan_authority import CanonicalJsonObject
+
+    source = {"a": {"b": [1, 2.5, "x", None, True]}}
+    via_from_python = CanonicalJsonObject.from_python(source)
+    via_validate = CanonicalJsonObject.model_validate(
+        via_from_python.model_dump(mode="json")
+    )
+    via_json = CanonicalJsonObject.model_validate_json(
+        json.dumps(via_from_python.model_dump(mode="json"))
+    )
+    via_copy = via_from_python.model_copy()
+    assert via_from_python == via_validate == via_json == via_copy
+    with pytest.raises(TypeError, match="does not support model_copy"):
+        via_from_python.model_copy(update={"entries": ()})
+    for constructor in (
+        lambda: CanonicalJsonObject.model_validate(
+            {"entries": [{"key": "a", "value": float("nan")}]}
+        ),
+        lambda: CanonicalJsonObject.from_python({"a": float("inf")}),
+    ):
+        with pytest.raises((ValueError, TypeError)):
+            constructor()

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -471,6 +471,7 @@ def test_shuffled_raw_authority_inputs_derive_the_same_canonical_plan() -> None:
         registry_snapshot=inputs.registry_snapshot,
         scope_selection=inputs.scope_selection,
         structured_output_configs=inputs.structured_output_configs,
+        assignment_contract_registry=inputs.assignment_contract_registry,
     )
     canonical = validate_compilation_plan_against_authority(plan, shuffled)
     assert canonical.plan_digest == plan.plan_digest
@@ -583,6 +584,7 @@ def test_unreferenced_extra_payload_in_authority_inputs_fails_closed() -> None:
         registry_snapshot=inputs.registry_snapshot,
         scope_selection=inputs.scope_selection,
         structured_output_configs=inputs.structured_output_configs,
+        assignment_contract_registry=inputs.assignment_contract_registry,
     )
     with pytest.raises(PlanAuthorityError) as excinfo:
         validate_compilation_plan_against_authority(plan, padded)
@@ -623,3 +625,227 @@ def test_scope_selection_is_never_silently_reconstructed() -> None:
     )
     with pytest.raises(PlanAuthorityError):
         validate_compilation_plan_against_authority(plan, default_inputs)
+
+
+# ---------------------------------------------------------------------------
+# Same document / same result: no canonical planner input may remain ambient.
+# Codex 3's exact assignment-registry reproduction is preserved here.
+# ---------------------------------------------------------------------------
+
+
+def test_ambient_assignment_registry_mutation_cannot_change_validation() -> None:
+    """The same serialized authority document yields the same canonical
+    rederived plan even after ambient assignment-descriptor registry state
+    changes — derivation consumes the descriptors resolved from the exact
+    supplied snapshot, never module globals."""
+    import mozaiksai.core.workflow.assignment_kinds as ak
+
+    inputs, plan = _authority()
+    document = json.dumps(
+        {"inputs": inputs.model_dump(mode="json"), "plan": plan.model_dump(mode="json")}
+    )
+    revived = CompilationPlanAuthorityInputs.model_validate(
+        json.loads(document)["inputs"]
+    )
+    before = validate_compilation_plan_against_authority(plan, revived)
+
+    original = ak.ASSIGNMENT_CONTRACT_DESCRIPTORS
+    try:
+        # ambient mutation: rebind the module registry to an empty mapping
+        ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = type(original)({})
+        revived_again = CompilationPlanAuthorityInputs.model_validate(
+            json.loads(document)["inputs"]
+        )
+        after = validate_compilation_plan_against_authority(plan, revived_again)
+    finally:
+        ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = original
+    assert after.plan_digest == before.plan_digest == plan.plan_digest
+    assert after.canonical_payload() == before.canonical_payload()
+
+
+def test_authority_snapshot_pins_descriptor_content() -> None:
+    """A forged descriptor snapshot inside the authority document changes the
+    canonical derivation result — descriptor authority is document state, so
+    tampering yields a typed mismatch rather than silent divergence."""
+    import yaml as _yaml
+
+    configs = {
+        "AppGenerator": _yaml.safe_load(
+            (
+                ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+            ).read_text(encoding="utf-8")
+        )
+    }
+    result, _ = _build(_source())
+    plan = derive_compilation_plan(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    inputs = build_compilation_plan_authority_inputs(
+        graph=result.graph,
+        payloads=result.payloads,
+        registry=_registry(),
+        structured_output_configs=configs,
+    )
+    assert (
+        validate_compilation_plan_against_authority(plan, inputs).plan_digest
+        == plan.plan_digest
+    )
+    document = inputs.model_dump(mode="json")
+    document["assignment_contract_registry"]["descriptors"] = []
+    tampered = CompilationPlanAuthorityInputs.model_validate(document)
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(plan, tampered)
+
+
+def test_fresh_process_ambient_registry_independence() -> None:
+    """A fresh interpreter validating the same serialized document reaches
+    the same canonical digest even with the ambient registry emptied first."""
+    inputs, plan = _authority()
+    probe = (
+        "import json, sys\n"
+        "import mozaiksai.core.workflow.assignment_kinds as ak\n"
+        "ak.ASSIGNMENT_CONTRACT_DESCRIPTORS = type(ak.ASSIGNMENT_CONTRACT_DESCRIPTORS)({})\n"
+        "from mozaiksai.core.semantics.compilation_plan import CompilationPlan\n"
+        "from mozaiksai.core.semantics.plan_authority import (\n"
+        "    CompilationPlanAuthorityInputs,\n"
+        "    validate_compilation_plan_against_authority,\n"
+        ")\n"
+        "payload = json.loads(sys.stdin.read())\n"
+        "inputs = CompilationPlanAuthorityInputs.model_validate(payload['inputs'])\n"
+        "plan = CompilationPlan.model_validate(payload['plan'])\n"
+        "print(validate_compilation_plan_against_authority(plan, inputs).plan_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        input=json.dumps(
+            {
+                "inputs": inputs.model_dump(mode="json"),
+                "plan": plan.model_dump(mode="json"),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == plan.plan_digest
+
+
+# ---------------------------------------------------------------------------
+# Closed structured-output configuration: immediate JSON-safety rejection and
+# deep immutability. "Frozen model containing mutable dict" is not enough.
+# ---------------------------------------------------------------------------
+
+
+def test_non_json_values_reject_immediately_at_construction() -> None:
+    from mozaiksai.core.semantics.plan_authority import CanonicalJsonObject
+
+    class _Custom:
+        pass
+
+    def _fn():
+        return None
+
+    rejects = [
+        {"a": object()},
+        {"a": _Custom()},
+        {"a": _fn},
+        {"a": b"bytes"},
+        {"a": {1, 2}},
+        {"a": float("nan")},
+        {"a": float("inf")},
+        {1: "non-string-key"},
+        {"a": {"nested": object()}},
+        {"a": [1, [2, {"deep": set()}]]},
+    ]
+    for bad in rejects:
+        with pytest.raises((ValueError, TypeError)):
+            CanonicalJsonObject.from_python(bad)
+    good = CanonicalJsonObject.from_python(
+        {"s": "x", "i": 3, "f": 1.5, "b": True, "n": None, "arr": [1, "two", {"k": []}]}
+    )
+    assert good.to_python() == {
+        "s": "x",
+        "i": 3,
+        "f": 1.5,
+        "b": True,
+        "n": None,
+        "arr": [1, "two", {"k": []}],
+    }
+    with pytest.raises((ValueError, TypeError)):
+        CanonicalJsonObject.from_python({"file": open(__file__)})  # noqa: SIM115
+
+
+def test_deep_immutability_and_source_mutation_independence() -> None:
+    from mozaiksai.core.semantics.plan_authority import CanonicalJsonObject
+
+    source = {"a": {"b": [1, 2, 3]}, "c": "keep"}
+    frozen = CanonicalJsonObject.from_python(source)
+    # a source dictionary mutated after construction cannot alter the document
+    source["a"]["b"].append(99)
+    source["c"] = "changed"
+    assert frozen.to_python() == {"a": {"b": [1, 2, 3]}, "c": "keep"}
+    # top-level and nested assignment rejected; entries are tuples
+    with pytest.raises(ValidationError):
+        frozen.entries = ()  # type: ignore[misc]
+    entry = frozen.entries[0]
+    with pytest.raises(ValidationError):
+        entry.value = None  # type: ignore[misc]
+    assert isinstance(frozen.entries, tuple)
+    nested = frozen.to_python()
+    nested["a"]["b"].append(4)  # mutating the EXPORT cannot touch the document
+    assert frozen.to_python() == {"a": {"b": [1, 2, 3]}, "c": "keep"}
+    # serialization -> deserialization yields the identical canonical contract
+    revived = CanonicalJsonObject.model_validate(
+        json.loads(json.dumps(frozen.model_dump(mode="json")))
+    )
+    assert revived == frozen
+    assert revived.to_python() == frozen.to_python()
+
+
+def test_model_copy_cannot_smuggle_unchecked_open_values() -> None:
+    """model_copy bypasses validators, but the validator's own cold
+    re-validation of the authority document rejects anything that cannot
+    round-trip the closed contract."""
+    inputs, plan = _authority()
+    smuggled = inputs.model_copy(
+        update={"structured_output_configs": {"AppGenerator": object()}}
+    )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        validate_compilation_plan_against_authority(plan, smuggled)
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Complete derivation-input identity: every canonical derivation parameter is
+# represented by the authority contract. A new authority-bearing parameter on
+# derive_compilation_plan fails this test until the contract carries it.
+# ---------------------------------------------------------------------------
+
+
+def test_every_derivation_input_is_represented_in_authority_inputs() -> None:
+    import inspect
+
+    parameters = set(
+        inspect.signature(derive_compilation_plan).parameters
+    )
+    represented = {
+        "graph": "graph",
+        "payloads": "payloads",
+        "registry": "registry_snapshot",
+        "scope_selection": "scope_selection",
+        "structured_output_configs": "structured_output_configs",
+        "assignment_descriptors": "assignment_contract_registry",
+    }
+    assert parameters == set(represented), (
+        "derive_compilation_plan gained or lost an authority-bearing "
+        "parameter; CompilationPlanAuthorityInputs must be updated in the "
+        f"same change. parameters={sorted(parameters)}"
+    )
+    fields = set(CompilationPlanAuthorityInputs.model_fields)
+    for parameter, field in represented.items():
+        assert field in fields, (parameter, field)

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -129,6 +129,11 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # Slice 5A: the replacement assignment compiler is an explicitly
         # offline substrate consumer of pinned payload and plan-unit refs.
         Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),
+        # Canonical plan-authority contract: consumes graph/payload authority
+        # as typed inputs and re-derives plans through the one canonical
+        # derivation function. Offline-only; its production non-importability
+        # is proven by the hygiene scan in tests/test_compilation_plan.py.
+        Path("mozaiksai/core/semantics/plan_authority.py"),
         # Slice 5C: the immutable revision store cold-validates the complete
         # graph/plan closure before accepting or restoring application state.
         # Its production non-importability is proven by the Slice 5C guard.


### PR DESCRIPTION
## Define canonical CompilationPlan authority inputs

**Classification: MOZAIKS_OSS — deterministic application-compiler integrity.** Replacement PR A of the two-PR restack superseding #473 (root defect there: bearer-proof authority — `PlanAuthorityProof` was publicly reconstructible and serializable, so possession of an object stood in for validation). Fresh branch from exact main `553b40db`; nothing cherry-picked blindly — only the validator core whose contract remains valid was ported, and every proof/token surface was removed.

### The defect class (regression-pinned)

A `CompilationPlan` self-digest proves body integrity, not truthful derivation: a caller can mutate any derived plan fact — a unit's source footprint, disposition, output path, materializer, validator, assignment kind, structured-output ref, dependencies, edge sources, an emitted gap — recompute the self-digests, and obtain a structurally cold-valid plan.

### The contract (PR A defines; PR B enforces)

**A1 — no bearer authority.** There is no `PlanAuthorityProof`, no token, no issuance seam, no serializable proof-shaped object, and no test-only issuance in production modules. Possession of nothing establishes validity (guard-tested).

**A2 — `CompilationPlanAuthorityInputs`.** One strict immutable authority-input document: semantic graph, complete payload closure (discriminated payload union — subclasses survive serialization exactly), canonical layout-registry snapshot (identity always recomputed from row content), scope selection, and the exact structured-output configuration documents. Frozen, `extra="forbid"`, recursively closed, versioned (`mozaiks.compilation_plan_authority_inputs.v1`), deterministic, and **serializable — because it is never trusted by possession**: every use cold-validates the contents and re-derives the plan. No arbitrary metadata, no filesystem paths, no model/provider/AG2 state.

**A3 — canonical validator.** `validate_compilation_plan_against_authority(candidate_plan, authority_inputs) -> CompilationPlan`: cold-validates the candidate body and every authority input, re-derives through the single existing `derive_compilation_plan` implementation (no second derivation of footprints, conditions, paths, assignments, or gaps — guard-tested), requires exact execution-authorizing equality, and returns the **canonical rederived plan** — never the caller's object, never a proof. Durable callers must rederive after restart (fresh-process test included). Failures are one finite typed `PlanAuthorityError` (`plan_body_invalid` / `canonical_derivation_mismatch` / `required_authority_missing`) carrying audit identity only.

**A4 — full derivation inputs, no silent defaults.** Every `derive_compilation_plan` input is carried explicitly; a plan derived under a non-default scope selection or with structured-output configs validates only against inputs carrying exactly those (tested both ways). Padding the closure with an unreferenced payload fails closed through derivation's own payload-closure validation. **Brownfield boundary stated, not shortcut**: canonical derivation consumes no base/brownfield input today, so `preserve_unowned`-carrying plans are rejected fail-closed (tested against the 5B fixture) — the immutable base-input contract is a separate identified prerequisite; no test-only issuance and no self-digest-only fallback exists.

**A4b — complete derivation-input census (Codex 3 round 2).** Every input read by `derive_compilation_plan` is now explicit and contract-represented — the census found exactly one ambient authority: the module-global assignment-contract descriptor registry, consulted at derivation time. Corrections: (1) `derive_compilation_plan` gained an explicit `assignment_descriptors` parameter (default = the canonical registry, production behavior unchanged); (2) `AssignmentContractRegistrySnapshot` — versioned, frozen, `extra="forbid"`, canonically ordered, digest-identified — snapshots the complete descriptor authority (kind, workflow name, structured-output model id, owned families, validator ids, identity bindings; no callables/modules/paths/provider state), built by `snapshot_assignment_contract_registry()` and rehydrated by `descriptors_from_snapshot()` into the one canonical descriptor type (deserialization, not a second resolution mechanism); (3) `CompilationPlanAuthorityInputs.assignment_contract_registry` is a **required** field, and validation derives from the supplied snapshot — the same serialized authority document yields the same canonical result regardless of process, import order, or global registry mutation (tested in-process and in a fresh ambient-emptied interpreter). A permanent identity test pins `derive_compilation_plan`'s signature to the contract's field coverage, so a new authority-bearing parameter fails tests until the contract carries it.

**A4c — closed structured-output configuration (Codex 3 round 2).** `Mapping[str, Any]` is gone. Configs are stored in a recursively closed JSON value algebra (`CanonicalJsonObject`/`CanonicalJsonArray`/`CanonicalJsonEntry`: None/strict bool/strict int/finite float/str/tuples of frozen models, unique string keys) that rejects `object()`, file objects, functions, custom classes, bytes, sets, NaN/Infinity, and non-string keys **immediately at construction** — nothing survives to fail at dump time. Object keys keep their exact **declaration order** (declaration order is meaning in structured-output contracts — the sibling review caught that sorted keys silently changed schema digests, so the authority pins the document precisely as derivation consumed it). Deep immutability proven: nested mutation impossible, source-dict mutation after construction cannot alter the document, mutating the exported copy cannot either, `model_copy` smuggling of open values is rejected by the validator's cold re-validation, and serialize→deserialize yields the identical contract.

**A5 — authority vs diagnostics.** All plan units and their facts, emitted gaps, and the graph/registry/scope header are execution authority — compared exactly via whole-body canonical equality. Latent/composite diagnostics live outside the plan (`CompilationGapReport`) and cannot affect rendering, reuse, composition, persistence, or promotion.

**A7 — no consumer wiring.** `materialize_plan`, `rematerialize_plan`, `compose_plan_artifacts`, revision persistence, and promotion are untouched in this PR (main has no proof types to deprecate — #473 was never merged). PR B wires every consumer and is stacked after this PR's independent review.

### Proofs

`tests/test_compilation_plan_authority.py` — 40 tests: contract shape (frozen/extra-forbid/versioned/non-empty closure); serialization-is-not-trust round-trip; exact candidate returns the canonical rederived plan; the preserved generic extra-source forgery; a 17-case forged-field matrix (every candidate internally digest-consistent); structured-output-ref substitution under configs; foreign graph and foreign registry authorities; missing authorities typed; brownfield rejection; unreferenced-payload padding rejection; scope-selection never silently reconstructed; shuffled raw authorities deriving the same canonical plan; fresh-process validation via subprocess; no-bearer-surface and no-second-planner guards; determinism/perf record; Codex 3's preserved ambient-registry reproduction (same serialized document, same canonical result under module-global mutation, plus the fresh-process ambient-emptied variant); tampered descriptor-snapshot rejection; the JSON-safety rejection matrix; deep-immutability and model_copy-smuggle proofs; the derivation-input identity census.

Full suite green (see checks); focused battery 295 passed across CompilationPlan/graph/registry/4C/5A/5B/5C/production-guard suites; ruff, scoped mypy, strict MkDocs, `git diff --check` clean.

### Boundaries

No production AppGenerator wiring (AppBuildPlan remains production authority). No AG2 Agent/Task/Resume/Channel/Envelope/event bus, no model/provider IDs, no prompts, no mobile, no evaluation, no hosted state. #471 (frozen `8e5f96cb`) and #473 (frozen `dbf05475`, superseded by this stack) untouched.

Do not merge — draft for independent exact-head review (reviewer: **Codex 3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
