### PR TITLE
fix(runtime): close server-owned session and bundle identity boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,29 +12,28 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
-### Added
-
-- **Canonical CompilationPlan authority contract (ADR 0007 lane)**: a plan
-  self-digest proves body integrity, not truthful derivation — a caller can
-  mutate any derived plan fact, recompute the digests, and obtain a
-  structurally cold-valid plan. `CompilationPlanAuthorityInputs` is the one
-  strict immutable authority-input document (semantic graph, complete payload
-  closure, canonical layout-registry snapshot, scope selection,
-  structured-output configuration documents), and
-  `validate_compilation_plan_against_authority` re-derives the candidate
-  through the single canonical `derive_compilation_plan` implementation,
-  requires exact execution-authorizing equality, and returns the canonical
-  rederived plan. No proof object, token, or bearer capability exists:
-  possession of nothing establishes validity, serialized authority inputs are
-  never trusted without full rederivation, and brownfield plans without a
-  base-input authority are rejected fail-closed. CompilationPlan identity
-  now pins `assignment_contracts_digest` — the exact assignment-descriptor
-  closure consulted during derivation, so only descriptors that can affect a
-  plan affect its identity; structured-output enum names are content-derived
-  (sha256) instead of process-salted `hash()`, making config-bearing plan
-  digests deterministic across processes and PYTHONHASHSEED values; and the
-  canonical derivation path no longer reads ambient assignment-registry
-  state. Consumer wiring is a separate enforcement change.
+### Fixed
+- **Server-owned session fields and the canonical bundle entry are closed
+  boundaries**: the chat-session lifecycle authority fields
+  (`workflow_run_id`, `run_build_binding`, `build_terminal_receipt`) are now
+  writable only through a privileged, lease-fenced persistence API — generic
+  session creation with `extra_fields` rejects them deterministically before
+  the idempotent existing-session return (a prohibited request never
+  silently succeeds, whether the session exists or not), generic context
+  persistence drops them with a logged security diagnostic, and the replay
+  merge preserves them past workflow-declared context policy without ever
+  accepting generic writes. A worker that lost its chat execution lease to a
+  successor can no longer replace the successor's lifecycle authority. The
+  app-bundle manifest now has an exact canonical bundle-entry identity: the
+  record must be the canonical `app_bundle`/`app_bundle` BuildRecord, its
+  persisted bundle name must satisfy the closed shared name grammar (ASCII
+  letters/digits/hyphen/underscore), and the single `application/zip` entry
+  must sit at exactly `{bundle_name}/{bundle_name}.zip` — one shared formula
+  used by both the manifest writer and the resolver. A digest may never be
+  validated against "any manifest entry with this digest"; wrong-family
+  records, wrong archive basenames, dot-segment names, duplicate archives,
+  digest-less entries, and mislocated archives all fail the build closed at
+  registration.
 
 ### Fixed
 - **A present but invalid `config/subscriptions.yaml` now fails application

--- a/factory_app/workflows/AppGenerator/tools/generate_and_download.py
+++ b/factory_app/workflows/AppGenerator/tools/generate_and_download.py
@@ -691,9 +691,22 @@ async def _register_app_bundle_artifact_version(
         if app_dir is not None and written_paths
         else []
     )
+    # The archive identity comes from the one shared canonical formula: the
+    # manifest records the bundle archive at exactly
+    # {bundle_name}/{bundle_name}.zip, and a zip whose on-disk name disagrees
+    # with the canonical archive name fails the build closed instead of
+    # persisting a manifest that cannot be resolved.
+    from mozaiksai.core.artifacts.models import canonical_bundle_archive_path
+
+    canonical_archive_path = canonical_bundle_archive_path(bundle_name)
+    if zip_path.name != f"{bundle_name}.zip":
+        raise RuntimeError(
+            f"bundle archive {zip_path.name!r} does not match the canonical "
+            f"archive name {bundle_name}.zip"
+        )
     files_manifest = [
         {
-            "path": f"{bundle_name}/{zip_path.name}",
+            "path": canonical_archive_path,
             "sha256": sha,
             "size_bytes": zip_path.stat().st_size,
             "content_type": "application/zip",
@@ -782,6 +795,20 @@ async def _register_app_bundle_artifact_version(
             "metadata": bundle_content_metadata,
         },
     )
+    # The persisted record must identify exactly one canonical bundle archive
+    # entry (unique application/zip entry under the persisted bundle_name
+    # path) — the only manifest digest that may ever serve as bundle-digest
+    # authority. A manifest that fails this resolves to no verifiable bundle,
+    # so the build fails closed here instead of persisting an ambiguous record.
+    from mozaiksai.core.artifacts.models import resolve_canonical_bundle_entry
+
+    canonical_bundle_entry = resolve_canonical_bundle_entry(artifact_version)
+    if canonical_bundle_entry.sha256 != sha:
+        raise RuntimeError(
+            "canonical bundle entry digest does not match the archive just "
+            f"written for record {artifact_version.id!r}"
+        )
+
     if context_variables is not None and hasattr(context_variables, "set"):
         try:
             context_variables.set("artifact_version_id", artifact_version.id)
@@ -983,7 +1010,17 @@ async def generate_and_download(
         pass
 
     # Normalize bundle name to a safe folder name
-    bundle_name = "".join(ch for ch in bundle_name if ch.isalnum() or ch in {"-", "_"}).strip() or "GeneratedApp"
+    # Derivation from the display name, constrained to the closed shared
+    # bundle-name grammar (ASCII letters/digits/hyphen/underscore) that
+    # validate_canonical_bundle_name enforces at read time.
+    bundle_name = (
+        "".join(
+            ch
+            for ch in bundle_name
+            if ch.isascii() and (ch.isalnum() or ch in {"-", "_"})
+        ).strip()
+        or "GeneratedApp"
+    )
 
     app_dir = _resolve_app_output_dir(app_id=app_id, build_id=build_id or chat_id)
     base_dir = app_dir.parent

--- a/mozaiksai/core/artifacts/models.py
+++ b/mozaiksai/core/artifacts/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
@@ -232,6 +233,137 @@ class RefinementSessionDoc(BaseModel):
     @property
     def result_artifact_version_id(self) -> str | None:
         return self.result_build_record_id
+
+
+# --------------------------------------------------------------------------
+# Canonical app-bundle manifest entry identity
+# --------------------------------------------------------------------------
+
+# The canonical bundle archive entry is identified by its closed writer
+# contract, never by digest equality: the app_bundle manifest writer stamps
+# exactly one entry with this content type (the generated-file mapper can
+# never produce it), at exactly the canonical archive path
+# "{bundle_name}/{bundle_name}.zip" with bundle_name persisted in
+# commit_metadata.metadata["bundle_name"].
+CANONICAL_BUNDLE_CONTENT_TYPE = "application/zip"
+
+CANONICAL_APP_BUNDLE_FAMILY = "app_bundle"
+CANONICAL_APP_BUNDLE_KEY = "app_bundle"
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# The closed bundle-name grammar shared by the writer (name derivation) and
+# the resolver (identity verification): ASCII letters, digits, hyphen,
+# underscore only. This structurally excludes path separators, dot segments,
+# traversal, absolute/drive-qualified paths, and control characters.
+_CANONICAL_BUNDLE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class CanonicalBundleEntryError(ValueError):
+    """The record does not identify exactly one canonical bundle entry.
+
+    Raised when the record is not the canonical app_bundle record, when its
+    persisted bundle name violates the closed grammar, and for zero
+    candidates, multiple candidates, a missing/malformed digest, or a path
+    that is not exactly the canonical archive path. Consumers treat this as
+    "no verifiable bundle" and fail closed — in particular, a digest may
+    never be validated against "any manifest entry with this digest": only
+    the uniquely identified canonical entry's digest is bundle authority.
+    """
+
+
+def validate_canonical_bundle_name(bundle_name: Any) -> str:
+    """Validate a bundle name against the closed shared grammar.
+
+    Returns the exact name, or raises :class:`CanonicalBundleEntryError`.
+    Never normalizes: an invalid name fails closed, it is not repaired.
+    """
+    name = str(bundle_name or "")
+    if not _CANONICAL_BUNDLE_NAME_RE.match(name):
+        raise CanonicalBundleEntryError(
+            f"bundle name {name!r} violates the canonical bundle-name grammar "
+            "(ASCII letters, digits, hyphen, underscore only)"
+        )
+    return name
+
+
+def canonical_bundle_archive_path(bundle_name: str) -> str:
+    """The one canonical archive path formula: ``{bundle_name}/{bundle_name}.zip``.
+
+    Both the manifest writer and the resolver derive the archive identity
+    from this helper, so writer and resolver cannot drift independently.
+    """
+    name = validate_canonical_bundle_name(bundle_name)
+    return f"{name}/{name}.zip"
+
+
+def resolve_canonical_bundle_entry(record: BuildRecord) -> BuildRecordFileEntry:
+    """Resolve the single canonical bundle archive entry of an app_bundle record.
+
+    Exact contract (closed writer identity — no heuristics, no basename
+    inference, no suffix search, no digest membership search, no first-ZIP
+    wins, no path normalization):
+
+    1. the record itself is the canonical application-bundle record:
+       ``build_family == build_key == "app_bundle"`` — another family/key is
+       never accepted merely because its manifest looks bundle-shaped;
+    2. the persisted ``commit_metadata.metadata["bundle_name"]`` exists and
+       satisfies the closed shared bundle-name grammar;
+    3. the manifest contains exactly one ``application/zip`` candidate;
+    4. that candidate's path equals exactly
+       ``{bundle_name}/{bundle_name}.zip``;
+    5. the candidate's ``sha256`` is a lowercase 64-hex digest.
+
+    Anything else raises :class:`CanonicalBundleEntryError` and can never
+    become bundle-digest authority.
+    """
+    if (
+        record.build_family != CANONICAL_APP_BUNDLE_FAMILY
+        or record.build_key != CANONICAL_APP_BUNDLE_KEY
+    ):
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} family/key "
+            f"{record.build_family!r}/{record.build_key!r} is not the "
+            "canonical app_bundle record"
+        )
+
+    bundle_name = str(record.commit_metadata.metadata.get("bundle_name") or "")
+    if not bundle_name.strip():
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} carries no persisted bundle_name identity"
+        )
+    expected_path = canonical_bundle_archive_path(bundle_name)
+
+    candidates = [
+        entry
+        for entry in record.files_manifest
+        if entry.content_type == CANONICAL_BUNDLE_CONTENT_TYPE
+    ]
+    if not candidates:
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} manifest has no canonical bundle entry "
+            f"(content_type={CANONICAL_BUNDLE_CONTENT_TYPE!r})"
+        )
+    if len(candidates) > 1:
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} manifest has {len(candidates)} canonical "
+            "bundle entries; exactly one is required"
+        )
+    entry = candidates[0]
+
+    if str(entry.path or "") != expected_path:
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} canonical bundle entry path {entry.path!r} "
+            f"is not the exact canonical archive path {expected_path!r}"
+        )
+
+    digest = str(entry.sha256 or "").strip()
+    if not _SHA256_HEX_RE.match(digest):
+        raise CanonicalBundleEntryError(
+            f"record {record.id!r} canonical bundle entry {entry.path!r} has "
+            "no valid lowercase sha256 digest"
+        )
+    return entry
 
 
 # Prior-api class aliases -- kept so callers that import the old names still work

--- a/mozaiksai/core/data/persistence/persistence_manager.py
+++ b/mozaiksai/core/data/persistence/persistence_manager.py
@@ -130,6 +130,22 @@ def _context_authority_policy_for_workflow(workflow_name: str):
     )
 
 
+# Server-owned session fields: lifecycle authority facts minted by the
+# runtime (immutable run identity, the run-to-build binding, the terminal
+# build receipt). They are writable ONLY through
+# AG2PersistenceManager.persist_server_owned_session_fields — the privileged,
+# lease-fenced write point. Every generic session write path (create with
+# extra_fields, context persistence, replay merge) must either reject them
+# (direct caller writes) or drop them with an explicit security diagnostic
+# (model/tool-authored context), so an injected value can never reach the
+# session document through a generic API.
+SERVER_OWNED_SESSION_FIELDS = frozenset({
+    "build_terminal_receipt",
+    "run_build_binding",
+    "workflow_run_id",
+})
+
+
 class PersistenceManager:
     """Mongo connection holder for runtime persistence."""
 
@@ -402,6 +418,29 @@ class AG2PersistenceManager:
         resolved_app_id = coalesce_app_id(app_id=app_id)
         if not resolved_app_id:
             raise ValueError("app_id is required")
+        # Server-owned lifecycle authority fields are never accepted from a
+        # direct caller. This is pure input validation and must run BEFORE
+        # the idempotent existing-session return: a request carrying a
+        # reserved key is invalid whether the session does not exist, already
+        # exists, or races into existence — deterministic rejection, zero
+        # mutation, never a silent success.
+        if isinstance(extra_fields, dict) and extra_fields:
+            injected_server_owned = sorted(
+                k for k in extra_fields if k in SERVER_OWNED_SESSION_FIELDS
+            )
+            if injected_server_owned:
+                logger.warning(
+                    "[CREATE_CHAT_SESSION] Rejected creation with "
+                    "server-owned session fields %s (chat_id=%s app_id=%s): "
+                    "only persist_server_owned_session_fields may write them",
+                    injected_server_owned,
+                    chat_id,
+                    resolved_app_id,
+                )
+                raise ValueError(
+                    "extra_fields may not contain server-owned session "
+                    f"fields: {injected_server_owned}"
+                )
         assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
         try:
             coll = await self._coll()
@@ -542,6 +581,14 @@ class AG2PersistenceManager:
                 f"context_authority.policy_unavailable workflow={clean_workflow_name} op=replay"
             ) from e
 
+        # Server-owned lifecycle fields are runtime infrastructure, not
+        # workflow-declared context: they bypass the declared-variable replay
+        # policy (which would drop them as unknown) but are only ever written
+        # through the privileged setter, never by workflow context updates.
+        server_owned = {
+            key: extra.pop(key) for key in list(extra) if key in SERVER_OWNED_SESSION_FIELDS
+        }
+
         replay_diagnostics: list[str] = []
         filtered = policy.filter_for_replay(
             extra,
@@ -555,6 +602,7 @@ class AG2PersistenceManager:
                 chat_id,
                 replay_diagnostics,
             )
+        filtered.update(server_owned)
         return filtered
 
     async def persist_context_variables(
@@ -619,6 +667,19 @@ class AG2PersistenceManager:
         for key, value in variables.items():
             if not isinstance(key, str) or not key.strip() or key in protected:
                 continue
+            if key in SERVER_OWNED_SESSION_FIELDS:
+                # Server-owned lifecycle authority fields are never writable
+                # through generic context persistence: a model/tool-authored
+                # context update must not install or replace them. The
+                # rejection is logged so tampering attempts are detectable.
+                logger.warning(
+                    "[PERSIST_CONTEXT_VARIABLES] Rejected write to server-owned "
+                    "session field %r (chat_id=%s workflow=%s)",
+                    key,
+                    chat_id,
+                    clean_workflow_name,
+                )
+                continue
             candidate_updates[key] = value
         if not candidate_updates:
             return
@@ -662,6 +723,66 @@ class AG2PersistenceManager:
         if matched_count is not None and matched_count == 0:
             raise RuntimeError(
                 f"failed to persist workflow context for chat_id={chat_id}: scoped session was not found"
+            )
+
+    async def persist_server_owned_session_fields(
+        self,
+        *,
+        chat_id: str,
+        app_id: str | None = None,
+        workflow_name: str | None = None,
+        fields: dict[str, Any] | None = None,
+    ) -> None:
+        """Write server-owned lifecycle authority fields for a chat session.
+
+        This is the only durable write path for SERVER_OWNED_SESSION_FIELDS
+        (run identity, run/build binding, terminal build receipt). It bypasses
+        workflow-declared context policy because these are runtime
+        infrastructure facts, not workflow context variables — but it writes
+        into the same session document through the same authority; there is
+        no second context store. Keys outside the reserved set are rejected,
+        and the write is lease-fenced: a worker that has lost its chat
+        execution lease to a successor cannot replace the successor run's
+        lifecycle authority.
+        """
+        resolved_app_id = coalesce_app_id(app_id=app_id)
+        if not resolved_app_id:
+            raise ValueError("app_id is required")
+        assert_chat_mutable(app_id=resolved_app_id, chat_id=chat_id)
+        clean_workflow_name = str(workflow_name or "").strip()
+        updates: dict[str, Any] = {}
+        for key, value in (fields or {}).items():
+            if key not in SERVER_OWNED_SESSION_FIELDS:
+                raise ValueError(
+                    f"{key!r} is not a server-owned session field; use "
+                    "persist_context_variables for workflow context"
+                )
+            updates[key] = deepcopy(value)
+        if not updates:
+            return
+        updates["last_updated_at"] = datetime.now(UTC)
+
+        scope: dict[str, Any] = {
+            "_id": chat_id,
+            **build_app_scope_filter(str(resolved_app_id)),
+        }
+        if clean_workflow_name:
+            scope["workflow_name"] = clean_workflow_name
+        coll = await self._coll()
+        result = await coll.update_one(
+            scope,
+            {"$set": updates, "$inc": {"session_version": 1}},
+        )
+        if getattr(result, "acknowledged", True) is False:
+            raise RuntimeError(
+                f"failed to persist server-owned session fields for chat_id={chat_id}: "
+                "write was not acknowledged"
+            )
+        matched_count = getattr(result, "matched_count", None)
+        if matched_count is not None and matched_count == 0:
+            raise RuntimeError(
+                f"failed to persist server-owned session fields for chat_id={chat_id}: "
+                "scoped session was not found"
             )
 
     async def create_general_chat_session(

--- a/tests/test_appgenerator_generate_and_download_persistence.py
+++ b/tests/test_appgenerator_generate_and_download_persistence.py
@@ -61,7 +61,18 @@ class _FakeArtifactStore:
 
     async def create_build_record(self, **kwargs):
         self.calls.append(dict(kwargs))
-        return type("ArtifactVersion", (), {"id": "av_bundle_1"})()
+        from mozaiksai.core.artifacts.models import BuildRecord
+
+        return BuildRecord(
+            _id="av_bundle_1",
+            app_id=kwargs["app_id"],
+            build_family=kwargs["build_family"],
+            build_key=kwargs["build_key"],
+            version_number=1,
+            lineage_root_id="av_bundle_1",
+            files_manifest=kwargs.get("files_manifest") or [],
+            commit_metadata=kwargs.get("commit_metadata") or {},
+        )
 
 
 def test_generate_and_download_merges_accepted_bundle_persisted_additions_and_deletions() -> None:

--- a/tests/test_appgenerator_greenfield_app_context_registration.py
+++ b/tests/test_appgenerator_greenfield_app_context_registration.py
@@ -266,6 +266,19 @@ async def test_appgenerator_app_bundle_save_registers_greenfield_context(
     }
     assert file_ownership == {OwnershipClass.GENERATED_OVERLAY.value}
 
+    # Writer/resolver equivalence: the record the real writer just persisted
+    # resolves through the canonical resolver, and the resolved entry sits at
+    # exactly the shared canonical archive path. If the writer ever changes
+    # archive naming without the resolver contract changing, this fails.
+    from mozaiksai.core.artifacts.models import (
+        canonical_bundle_archive_path,
+        resolve_canonical_bundle_entry,
+    )
+
+    canonical_entry = resolve_canonical_bundle_entry(store.versions["av_app_bundle_1"])
+    assert canonical_entry.path == canonical_bundle_archive_path("GeneratedApp")
+    assert canonical_entry.content_type == "application/zip"
+
     app_bundle_manifest_paths = {
         entry.path for entry in store.versions["av_app_bundle_1"].files_manifest
     }
@@ -356,3 +369,34 @@ def test_appgenerator_context_registration_has_no_graph_database_or_proprietary_
         for term in forbidden_terms:
             assert term.lower() not in text
 
+
+
+async def test_writer_rejects_archive_name_disagreeing_with_bundle_identity(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """The real writer fails closed when the on-disk archive name does not
+    match the canonical {bundle_name}.zip identity, instead of persisting a
+    manifest that could never resolve."""
+    store = _MemoryArtifactStore()
+    _patch_artifact_store(monkeypatch, store)
+
+    app_dir = tmp_path / "GeneratedApp"
+    written_paths = _write_generated_app(app_dir)
+    zip_path = tmp_path / "SomethingElse.zip"
+    zip_path.write_bytes(b"fake bundle bytes")
+    context = _Context({"app_bundle_acceptance_status": "passed"})
+
+    with pytest.raises(RuntimeError, match="canonical archive name"):
+        await generate_and_download_module._register_app_bundle_artifact_version(
+            app_id="field_service",
+            user_id="user_123",
+            workflow_name="AppGenerator",
+            chat_id="chat_greenfield",
+            bundle_name="GeneratedApp",
+            zip_path=zip_path,
+            app_dir=app_dir,
+            written_paths=written_paths,
+            context_variables=context,
+        )
+    assert store.create_calls == []

--- a/tests/test_canonical_bundle_entry.py
+++ b/tests/test_canonical_bundle_entry.py
@@ -1,0 +1,218 @@
+"""Exact canonical bundle-entry identity for app-bundle manifests.
+
+The bundle digest authority is the digest of the uniquely identified
+canonical bundle archive entry — never "any manifest entry with this
+digest". These tests prove the closed identity rule: exactly one
+``application/zip`` entry, a valid digest, and the exact
+``{bundle_name}/{archive}`` path persisted with the record.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from mozaiksai.core.artifacts.models import (
+    ArtifactCommitMetadata,
+    BuildRecord,
+    BuildRecordFileEntry,
+    CanonicalBundleEntryError,
+    resolve_canonical_bundle_entry,
+)
+
+_ZIP_DIGEST = hashlib.sha256(b"bundle zip bytes").hexdigest()
+_JSON_DIGEST = hashlib.sha256(b'{"app_id": "field_service"}').hexdigest()
+
+
+def _record(
+    *,
+    manifest: list[BuildRecordFileEntry],
+    bundle_name: str | None = "GeneratedApp",
+    build_family: str = "app_bundle",
+    build_key: str = "app_bundle",
+) -> BuildRecord:
+    metadata: dict = {"artifact_path": "/tmp/GeneratedApp.zip"}
+    if bundle_name is not None:
+        metadata["bundle_name"] = bundle_name
+    return BuildRecord(
+        _id="av_app_bundle_1",
+        app_id="field_service",
+        build_family=build_family,
+        build_key=build_key,
+        version_number=1,
+        lineage_root_id="av_app_bundle_1",
+        files_manifest=manifest,
+        commit_metadata=ArtifactCommitMetadata(metadata=metadata),
+    )
+
+
+def _zip_entry(
+    *,
+    path: str = "GeneratedApp/GeneratedApp.zip",
+    sha256: str | None = _ZIP_DIGEST,
+    content_type: str = "application/zip",
+) -> BuildRecordFileEntry:
+    return BuildRecordFileEntry(path=path, sha256=sha256, content_type=content_type)
+
+
+def _app_json_entry(sha256: str = _JSON_DIGEST) -> BuildRecordFileEntry:
+    return BuildRecordFileEntry(
+        path="GeneratedApp/app/app.json", sha256=sha256, content_type="application/json"
+    )
+
+
+def test_valid_manifest_resolves_exactly_the_bundle_archive() -> None:
+    record = _record(manifest=[_zip_entry(), _app_json_entry()])
+    entry = resolve_canonical_bundle_entry(record)
+    assert entry.path == "GeneratedApp/GeneratedApp.zip"
+    assert entry.sha256 == _ZIP_DIGEST
+    # Identity is the entry, never digest equality: another file's digest is
+    # not bundle authority even if a caller presents it.
+    assert entry.sha256 != _JSON_DIGEST
+
+
+def test_zero_bundle_entries_fail_closed() -> None:
+    record = _record(manifest=[_app_json_entry()])
+    with pytest.raises(CanonicalBundleEntryError, match="no canonical bundle entry"):
+        resolve_canonical_bundle_entry(record)
+    with pytest.raises(CanonicalBundleEntryError):
+        resolve_canonical_bundle_entry(_record(manifest=[]))
+
+
+def test_multiple_bundle_entries_fail_closed() -> None:
+    record = _record(
+        manifest=[
+            _zip_entry(),
+            _zip_entry(path="GeneratedApp/second-archive.zip", sha256="b" * 64),
+        ]
+    )
+    with pytest.raises(CanonicalBundleEntryError, match="exactly one is required"):
+        resolve_canonical_bundle_entry(record)
+
+
+def test_missing_or_malformed_digest_fails_closed() -> None:
+    for bad in (None, "", "not-a-sha", "B" * 64):
+        record = _record(manifest=[_zip_entry(sha256=bad)])
+        with pytest.raises(CanonicalBundleEntryError, match="sha256"):
+            resolve_canonical_bundle_entry(record)
+
+
+def test_record_identity_requires_canonical_family_and_key() -> None:
+    """A record is never accepted as the app bundle merely because its
+    manifest looks bundle-shaped: build_family/build_key must both be exactly
+    "app_bundle"."""
+    for family, key in (
+        ("workflow_bundle", "app_bundle"),
+        ("app_bundle", "workflow_bundle"),
+        ("app_context_version", "app_context_version"),
+    ):
+        record = _record(
+            manifest=[_zip_entry()], build_family=family, build_key=key
+        )
+        with pytest.raises(
+            CanonicalBundleEntryError, match="not the canonical app_bundle record"
+        ):
+            resolve_canonical_bundle_entry(record)
+
+    # Correct family/key resolves (positive control).
+    entry = resolve_canonical_bundle_entry(_record(manifest=[_zip_entry()]))
+    assert entry.path == "GeneratedApp/GeneratedApp.zip"
+
+
+def test_archive_path_requires_exact_canonical_equality() -> None:
+    """Only {bundle_name}/{bundle_name}.zip is the archive identity — never
+    two-segments, non-empty basename, .zip suffix, or application/zip alone.
+    The exact digest under a wrong path is still rejected."""
+    for bad_path in (
+        "GeneratedApp/other.zip",
+        "GeneratedApp/evil.zip",
+        "GeneratedApp/not-a-zip",
+        "GeneratedApp/.",
+        "GeneratedApp/..",
+        "GeneratedApp/subdir/file.zip",
+        "other/GeneratedApp.zip",
+        "GeneratedApp/app/assets/copy.zip",
+        "OtherBundle/GeneratedApp.zip",
+        "GeneratedApp.zip",
+        "GeneratedApp//",
+        "GeneratedApp/GeneratedApp.ZIP",
+        "GeneratedApp/GeneratedApp.zip/",
+    ):
+        record = _record(manifest=[_zip_entry(path=bad_path)])
+        with pytest.raises(
+            CanonicalBundleEntryError, match="exact canonical archive path"
+        ):
+            resolve_canonical_bundle_entry(record)
+
+
+def test_same_digest_under_noncanonical_path_is_not_bundle_authority() -> None:
+    """A copy of the archive bytes parked under a noncanonical path (not
+    typed as the bundle archive) never resolves — identity is the entry,
+    never digest membership."""
+    record = _record(
+        manifest=[
+            _app_json_entry(),
+            BuildRecordFileEntry(
+                path="GeneratedApp/app/assets/copy.zip",
+                sha256=_ZIP_DIGEST,
+                content_type="application/octet-stream",
+            ),
+        ]
+    )
+    with pytest.raises(CanonicalBundleEntryError, match="no canonical bundle entry"):
+        resolve_canonical_bundle_entry(record)
+
+
+def test_bundle_name_grammar_fails_closed() -> None:
+    """The persisted bundle name must satisfy the closed shared grammar;
+    invalid names are rejected, never normalized into valid ones."""
+    from mozaiksai.core.artifacts.models import validate_canonical_bundle_name
+
+    for bad_name in (
+        ".",
+        "..",
+        "a/b",
+        "a\\b",
+        "../escape",
+        "/absolute",
+        "C:\\drive",
+        "C:drive",
+        "name\x00null",
+        "name\nnewline",
+        "with space",
+        "dotted.name",
+        "unicode\u00e9",
+    ):
+        with pytest.raises(CanonicalBundleEntryError, match="grammar"):
+            validate_canonical_bundle_name(bad_name)
+        record = _record(
+            manifest=[_zip_entry(path=f"{bad_name}/{bad_name}.zip")],
+            bundle_name=bad_name,
+        )
+        with pytest.raises(CanonicalBundleEntryError):
+            resolve_canonical_bundle_entry(record)
+
+    assert validate_canonical_bundle_name("Generated-App_2") == "Generated-App_2"
+
+
+def test_record_without_bundle_name_identity_fails_closed() -> None:
+    record = _record(manifest=[_zip_entry()], bundle_name=None)
+    with pytest.raises(CanonicalBundleEntryError, match="bundle_name"):
+        resolve_canonical_bundle_entry(record)
+    record = _record(manifest=[_zip_entry()], bundle_name="")
+    with pytest.raises(CanonicalBundleEntryError, match="bundle_name"):
+        resolve_canonical_bundle_entry(record)
+
+
+def test_shared_archive_path_formula_is_the_resolver_requirement() -> None:
+    """One shared helper defines the archive identity for writer and
+    resolver: the formula and the resolver requirement cannot drift."""
+    from mozaiksai.core.artifacts.models import canonical_bundle_archive_path
+
+    assert canonical_bundle_archive_path("GeneratedApp") == "GeneratedApp/GeneratedApp.zip"
+    entry = resolve_canonical_bundle_entry(
+        _record(manifest=[_zip_entry(path=canonical_bundle_archive_path("GeneratedApp"))])
+    )
+    assert entry.sha256 == _ZIP_DIGEST
+    with pytest.raises(CanonicalBundleEntryError, match="grammar"):
+        canonical_bundle_archive_path("../escape")

--- a/tests/test_server_owned_session_fields_real_mongo.py
+++ b/tests/test_server_owned_session_fields_real_mongo.py
@@ -1,0 +1,342 @@
+"""Real-Mongo proofs for the server-owned session field boundary.
+
+The immutable run identity, the run/build binding, and the terminal build
+receipt are lifecycle authority: only the privileged, lease-fenced server
+write path may install or replace them. Every generic session write path —
+creation with extra_fields, model/tool-authored context persistence, and the
+replay merge — must reject or drop them with detection, so an injected value
+can never reach the persisted session document through a generic API.
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+import mozaiksai.core.runtime.persistence.distributed_lock as dl
+from mozaiksai.core.data.persistence.persistence_manager import (
+    SERVER_OWNED_SESSION_FIELDS,
+    AG2PersistenceManager,
+    PersistenceManager,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOZAIKS_RUN_REAL_MONGO_TESTS") != "1",
+    reason="set MOZAIKS_RUN_REAL_MONGO_TESTS=1 for real Mongo session-field tests",
+)
+
+_MONGO_URI = os.environ.get("MONGO_URI", "mongodb://127.0.0.1:27017")
+_APP_ID = "app-server-owned"
+_WORKFLOW = "AppGenerator"
+
+_INJECTED = {
+    "workflow_run_id": "wfrun_attacker",
+    "run_build_binding": {"build_id": "stolen", "forged": True},
+    "build_terminal_receipt": {"kind": "success", "forged": True},
+}
+
+
+class _TestDatabaseClient:
+    def __init__(self, client: AsyncIOMotorClient, database_name: str) -> None:
+        self._client = client
+        self._database_name = database_name
+
+    def __getitem__(self, _name: str):
+        return self._client[self._database_name]
+
+
+def _pm(client: AsyncIOMotorClient, database_name: str) -> AG2PersistenceManager:
+    pm = AG2PersistenceManager()
+    pm.persistence = PersistenceManager()
+    pm.persistence.client = _TestDatabaseClient(client, database_name)
+    return pm
+
+
+async def _seed_session(pm: AG2PersistenceManager, chat_id: str) -> None:
+    coll = await pm._coll()
+    await coll.insert_one(
+        {
+            "_id": chat_id,
+            "chat_id": chat_id,
+            "app_id": _APP_ID,
+            "workflow_name": _WORKFLOW,
+            "user_id": "user-1",
+            "status": "active",
+            "messages": [],
+            "session_version": 1,
+        }
+    )
+
+
+def _assert_clean(doc: dict) -> None:
+    for key in SERVER_OWNED_SESSION_FIELDS:
+        assert key not in doc, f"server-owned field {key!r} leaked into storage"
+
+
+@pytest.mark.asyncio
+async def test_create_chat_session_rejects_server_owned_extra_fields_real_mongo() -> None:
+    """Generic creation is a direct caller write: injection is rejected
+    outright and no session document is created at all (fail closed)."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        for key, value in _INJECTED.items():
+            with pytest.raises(ValueError, match="server-owned"):
+                await pm.create_chat_session(
+                    chat_id,
+                    app_id=_APP_ID,
+                    workflow_name=_WORKFLOW,
+                    user_id="user-1",
+                    extra_fields={"parent_chat_id": "ok", key: value},
+                )
+            assert await (await pm._coll()).find_one({"_id": chat_id}) is None
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_chat_session_rejects_reserved_fields_for_existing_session_real_mongo() -> None:
+    """A request carrying a reserved key is invalid independent of session
+    existence: against an existing session it must reject deterministically,
+    never return the idempotent success, and must leave the existing document
+    byte-equivalent."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await pm.create_chat_session(
+            chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            user_id="user-1",
+            extra_fields={"parent_chat_id": "chat_parent"},
+        )
+        before = await (await pm._coll()).find_one({"_id": chat_id})
+        assert before is not None
+
+        # Reserved only, and benign + reserved: both reject against the
+        # existing session with zero mutation.
+        for fields in (
+            {"workflow_run_id": "wfrun_attacker"},
+            {"journey_key": "genesis", "run_build_binding": {"forged": True}},
+        ):
+            with pytest.raises(ValueError, match="server-owned"):
+                await pm.create_chat_session(
+                    chat_id,
+                    app_id=_APP_ID,
+                    workflow_name=_WORKFLOW,
+                    user_id="user-1",
+                    extra_fields=fields,
+                )
+            after = await (await pm._coll()).find_one({"_id": chat_id})
+            assert after == before
+
+        # Benign-only against the existing session keeps the idempotent
+        # early-return behavior: success, zero mutation.
+        await pm.create_chat_session(
+            chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            user_id="user-1",
+            extra_fields={"journey_key": "genesis"},
+        )
+        after = await (await pm._coll()).find_one({"_id": chat_id})
+        assert after == before
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_chat_session_benign_extra_fields_unaffected_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await pm.create_chat_session(
+            chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            user_id="user-1",
+            extra_fields={"parent_chat_id": "chat_parent", "journey_key": "genesis"},
+        )
+        doc = await (await pm._coll()).find_one({"_id": chat_id})
+        assert doc is not None
+        assert doc["parent_chat_id"] == "chat_parent"
+        assert doc["journey_key"] == "genesis"
+        _assert_clean(doc)
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_generic_context_persistence_drops_server_owned_fields_real_mongo() -> None:
+    """Model/tool-authored context updates flow through persist_context_variables:
+    reserved keys are dropped with detection and never reach the document."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+
+        await pm.persist_context_variables(
+            chat_id=chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            variables={**_INJECTED, "app_download_ready": True},
+        )
+        # Dotted variants of reserved keys are undeclared context variables:
+        # the workflow-declared persistence policy drops them, so they can
+        # never materialize or mutate a reserved field through nesting.
+        await pm.persist_context_variables(
+            chat_id=chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            variables={"workflow_run_id.nested": "x", "run_build_binding.build_id": "y"},
+        )
+
+        doc = await (await pm._coll()).find_one({"_id": chat_id})
+        assert doc is not None
+        _assert_clean(doc)
+        assert "workflow_run_id.nested" not in doc
+        assert "run_build_binding.build_id" not in doc
+
+        fetched = await pm.fetch_chat_session_extra_context(
+            chat_id=chat_id, app_id=_APP_ID, workflow_name=_WORKFLOW
+        )
+        _assert_clean(fetched)
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_writes_and_replay_returns_real_mongo() -> None:
+    """The privileged writer is the single durable path; the replay merge
+    preserves server-owned fields past workflow-declared context policy."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+
+        receipt = {"kind": "failure", "workflow_run_id": "wfrun_legit"}
+        binding = {"workflow_run_id": "wfrun_legit", "build_id": "build_wfrun_legit"}
+        await pm.persist_server_owned_session_fields(
+            chat_id=chat_id,
+            app_id=_APP_ID,
+            workflow_name=_WORKFLOW,
+            fields={
+                "workflow_run_id": "wfrun_legit",
+                "build_terminal_receipt": receipt,
+                "run_build_binding": binding,
+            },
+        )
+
+        fetched = await pm.fetch_chat_session_extra_context(
+            chat_id=chat_id, app_id=_APP_ID, workflow_name=_WORKFLOW
+        )
+        assert fetched.get("workflow_run_id") == "wfrun_legit"
+        assert fetched.get("build_terminal_receipt") == receipt
+        assert fetched.get("run_build_binding") == binding
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_rejects_non_reserved_keys_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+        with pytest.raises(ValueError, match="not a server-owned session field"):
+            await pm.persist_server_owned_session_fields(
+                chat_id=chat_id,
+                app_id=_APP_ID,
+                workflow_name=_WORKFLOW,
+                fields={"app_download_ready": True},
+            )
+        doc = await (await pm._coll()).find_one({"_id": chat_id})
+        assert doc is not None
+        assert "app_download_ready" not in doc
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_fails_closed_on_missing_session_real_mongo() -> None:
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    try:
+        pm = _pm(client, database_name)
+        with pytest.raises(RuntimeError, match="scoped session was not found"):
+            await pm.persist_server_owned_session_fields(
+                chat_id=f"chat_missing_{uuid4().hex}",
+                app_id=_APP_ID,
+                workflow_name=_WORKFLOW,
+                fields={"workflow_run_id": "wfrun_x"},
+            )
+    finally:
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_privileged_setter_is_lease_fenced_real_mongo() -> None:
+    """A worker whose chat execution lease was lost to a successor cannot
+    replace the successor run's lifecycle authority through the privileged
+    writer — the write is refused before touching Mongo."""
+    client = AsyncIOMotorClient(_MONGO_URI)
+    database_name = f"mozaiks_boundary_test_{uuid4().hex}"
+    chat_id = f"chat_{uuid4().hex}"
+    resource = dl.chat_lock_resource(_APP_ID, chat_id)
+    try:
+        pm = _pm(client, database_name)
+        await _seed_session(pm, chat_id)
+
+        lease = dl.ChatLease(
+            resource=resource,
+            holder_id="stale-worker",
+            mode=dl.ChatLockMode.REQUIRED,
+            collection=None,
+            ttl_seconds=60,
+        )
+        lease._mark_lost("superseded by successor")
+        dl._process_leases[resource] = lease
+
+        with pytest.raises(dl.ChatLeaseLostError):
+            await pm.persist_server_owned_session_fields(
+                chat_id=chat_id,
+                app_id=_APP_ID,
+                workflow_name=_WORKFLOW,
+                fields={"workflow_run_id": "wfrun_stale_takeover"},
+            )
+        doc = await (await pm._coll()).find_one({"_id": chat_id})
+        assert doc is not None
+        _assert_clean(doc)
+    finally:
+        dl._process_leases.pop(resource, None)
+        await client.drop_database(database_name)
+        client.close()
+
+
+def test_reserved_key_set_is_exactly_the_lifecycle_authority_fields() -> None:
+    assert SERVER_OWNED_SESSION_FIELDS == {
+        "build_terminal_receipt",
+        "run_build_binding",
+        "workflow_run_id",
+    }


### PR DESCRIPTION
## Independent boundary hardening (valid before and after 5D)

Small hardening extracted from the frozen #474 review round. Both fixes are independent of publication sequencing and remain valid before and after the 5D ArtifactRevision/ApplicationPublication cutover. This PR contains **no** CURRENT bundle/AppContext publication redesign, no transaction/CAS publication, no run/build lifecycle emitters, and no ArtifactRevision/ApplicationPublication production wiring.

## A. Server-owned session field protection

`SERVER_OWNED_SESSION_FIELDS = {workflow_run_id, run_build_binding, build_terminal_receipt}` — the chat-session lifecycle authority fields — now have exactly one durable write path: the new privileged `persist_server_owned_session_fields` API, which is **lease-fenced** with `assert_chat_mutable` so a worker whose chat execution lease was lost to a successor cannot replace the successor run's lifecycle authority (this closes the fencing gap Codex 1 flagged on the frozen #474 seam at its introduction point).

Every generic session write path was audited and closed:

| Path | Behavior |
|---|---|
| `create_chat_session(extra_fields=...)` | **Rejects** reserved keys deterministically, and the validation runs **before** the idempotent existing-session return: a prohibited request never silently succeeds, whether the session does not exist, already exists, or races into existence — logged security diagnostic + `ValueError`, zero mutation (existing documents stay byte-equivalent). |
| `persist_context_variables` | **Drops** reserved keys with a logged security diagnostic (model/tool-authored context must not crash the run, matching existing protected-key policy). |
| `fetch_chat_session_extra_context` (replay merge) | Preserves privileged values past workflow-declared context policy without ever accepting generic writes. |
| `mark_chat_completed`, `update_last_artifact`, pending-input request save/clear, tool-call state, general-chat upsert, ui-state backfill | Audited: fixed non-reserved field names only — no caller-controlled keys reach `$set`. |
| Raw factory session writers (`_record_chat_session_build_registry_id`, journey seeding in the platform build_lifecycle helpers) | Audited: fixed non-reserved field names (`build_registry_id`, journey fields) only. |
| `app_registry` module | Audited: reads chat sessions only, never writes them. |

No second session store; the privileged path writes the same session document through the same authority.

## B. Exact canonical bundle-entry identity

The writer's contract was independently confirmed: the archive is created as `{bundle_name}.zip` and recorded in the manifest at `{bundle_name}/{bundle_name}.zip`; `bundle_name` is derived through a closed character filter and persisted in `commit_metadata.metadata["bundle_name"]`; the generated-file mapper can never produce `application/zip`. No new "is_bundle" boolean was needed.

`resolve_canonical_bundle_entry(record)` (in `mozaiksai/core/artifacts/models.py`) enforces the exact contract:

1. the record itself is the canonical application-bundle record — `build_family == build_key == "app_bundle"` (another family/key is never accepted because its manifest looks bundle-shaped);
2. the persisted `bundle_name` satisfies the **closed shared grammar** (`validate_canonical_bundle_name`: ASCII letters/digits/hyphen/underscore only — structurally excludes path separators, dot segments, traversal, absolute/drive paths, control characters; invalid names fail closed, never normalized);
3. exactly one `application/zip` candidate exists;
4. its path equals **exactly** `canonical_bundle_archive_path(bundle_name)` = `{bundle_name}/{bundle_name}.zip` — no two-segment shape check, no basename inference, no suffix search, no digest membership search, no first-ZIP-wins, no normalization fallback;
5. its `sha256` is a lowercase 64-hex digest.

`GeneratedApp/other.zip`, `GeneratedApp/evil.zip`, `GeneratedApp/not-a-zip`, `GeneratedApp/.`, `GeneratedApp/..`, `GeneratedApp/subdir/file.zip`, `other/GeneratedApp.zip`, the correct digest under a wrong path, wrong-family/key records, and duplicate canonical-looking entries all raise typed `CanonicalBundleEntryError`.

**Writer/resolver equivalence**: the writer's name derivation is now ASCII-constrained to the same grammar, the manifest archive path is produced through the same shared `canonical_bundle_archive_path` helper, and the writer refuses an on-disk archive whose name disagrees with `{bundle_name}.zip`. A permanent regression resolves a real writer-produced record and asserts writer path == resolver requirement, so archive naming cannot drift without the contract changing. The AppGenerator terminal tool still fails the build closed at registration on any digest mismatch.

## Proofs

- Real Mongo (`tests/test_server_owned_session_fields_real_mongo.py`): create-with-injection rejected with no document created; benign extra_fields unaffected; generic context injection dropped and never stored; privileged write + replay round-trip; non-reserved key rejection; missing-session fail-closed; **lease-fence: a lost-lease worker's privileged write raises `ChatLeaseLostError` before touching Mongo**; reserved-set exactness.
- Bundle identity (`tests/test_canonical_bundle_entry.py`): exact valid case; wrong family/key/both; the full exact-path attack list (evil.zip, not-a-zip, dot segments, subdir archives, wrong first segment, case variants); zero/duplicate/malformed-digest candidates; same digest under noncanonical paths; the closed name-grammar matrix (slashes, backslashes, traversal, absolute/drive paths, control characters, spaces, dots, non-ASCII); shared-formula equivalence; plus the real-writer equivalence and archive-name fail-closed regressions in the greenfield suite.
- Session creation matrix (real Mongo): new+reserved rejected with no document; new benign+reserved rejected atomically; **existing session + reserved (only and mixed) rejected with the existing document byte-equivalent**; existing + benign keeps the idempotent early return; privileged setter with valid lease succeeds; lost lease rejects before mutation; dotted reserved-key variants cannot materialize.
- Regressions: Genesis persistence suite (greenfield registration + generate_and_download persistence), #472 subscription fail-closed suite, #469 transport/BSON suites, chat-lease unit + real-Mongo suites, source-hygiene gate — all green.
- Full `pytest -q --no-cov`: **14,299 passed, 0 failed**. Ruff clean. `git diff --check` clean. Scoped mypy blocked locally only by the known environmental numpy-stub artifact (CI is the arbiter).

## Boundaries

Untouched: BuildRecord CURRENT promotion sequencing, AppContextVersion promotion sequencing, publication CAS, ArtifactRevision production authority, lifecycle event emitters, semantic compiler, AG2, subscriptions, hosted, mobile, evaluation.

## OSS Change Impact

- Layer changed: runtime persistence (session write boundary) + artifacts model layer (canonical bundle entry) + AppGenerator terminal tool (registration-time verification).
- Build workflow impact: AppGenerator bundle registration now fails closed on an ambiguous manifest.
- Runtime/platform impact: server-owned session fields are closed to generic writes; privileged writes are lease-fenced.
- App workspace impact: none.
- Tests run: listed above + full suite.
- Docs updated: CHANGELOG.
- Compatibility risk: pre-production internal contracts only.

Reviewer: Codex 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
