### PR TITLE
fix(semantics): enforce canonical plan authority across revision closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **Canonical plan authority is now enforced across execution and durable
+  revision closure (ADR 0007 lane)**: assignment compilation
+  (`compile_approved_plan`), composition (`compose_plan_artifacts`, including
+  the base plan in refinement), revision persistence, cold
+  resolution/restoration, promotion, and CURRENT resolution all require the
+  exact immutable `CompilationPlanAuthorityInputs` and canonically rederive
+  the plan before any authority is exercised — self-digests, refs, and
+  ledger digest chains prove integrity and identity only, never truthful
+  derivation. `ArtifactRevision` now pins a content-addressed
+  `compilation_plan_authority_ref` as part of immutable revision identity,
+  and the authority document is persisted content-addressed
+  (`CompilationPlanAuthorityInputsV1`) so every fresh process repeats the
+  rederivation. Plans carrying brownfield content (`preserve_unowned` /
+  `reuse_from_base`) fail closed with the typed `base_authority_missing`
+  category until the immutable base-input authority contract exists; the
+  former synthetic 5B/5C fixtures that composed fabricated preserved bytes
+  are replaced by canonically derived fixtures. Plans also no longer emit
+  the former unconditional "registry" renderer-resolution pseudo-gap, which
+  made the composition zero-gap contract unsatisfiable by construction.
+  Canonical authority additionally governs every downstream dataflow: after
+  rederivation, all execution-authorizing plan-unit facts (dispositions,
+  kinds, owned paths, validators, structured-output refs, sources,
+  dependencies, identity bindings) come only from the canonical rederived
+  plan — never from a subsequent resolver lookup, so a hostile resolver can
+  no longer substitute unit content into compiled assignments or
+  composition. Validation-evidence construction and verification now also
+  require the canonical authority inputs (a re-digested plan whose
+  validators were rewritten can no longer produce or bless evidence, and
+  ledger unit entries must mirror the canonical units exactly), the
+  `ArtifactRevision` model itself scope-closes its plan-authority reference,
+  cold resolution validates authority before reading any dependent closure
+  document, parent revision, or content blob, and canonical-authority
+  failures crossing the revision-store boundary surface as its typed error
+  family.
+
 ### Added
 
 - **Deterministic application-family rendering (ADR 0007 Slice 5D-0B2A)**: the

--- a/mozaiksai/core/artifacts/revision_store.py
+++ b/mozaiksai/core/artifacts/revision_store.py
@@ -29,6 +29,12 @@ from mozaiksai.core.semantics.composition_ledger import (
     CompositionLedger,
 )
 from mozaiksai.core.semantics.graph import SemanticGraph, SemanticGraphV2
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    compilation_plan_authority_digest,
+    validate_compilation_plan_against_authority,
+)
 from mozaiksai.core.semantics.refs import (
     ArtifactRevisionRef,
     CompilationPlanRef,
@@ -46,6 +52,7 @@ _EVIDENCE = "ArtifactRevisionEvidenceV1"
 _ASSIGNMENT_RESULTS = "AssignmentArtifactResultsV1"
 _LEDGERS = "CompositionLedgersV1"
 _PUBLICATIONS = "ApplicationPublicationsV1"
+_PLAN_AUTHORITY_INPUTS = "CompilationPlanAuthorityInputsV1"
 
 
 def _address_key(item: AccountedArtifact) -> tuple[str, tuple[tuple[str, str], ...], str]:
@@ -159,6 +166,12 @@ class ArtifactRevisionStore:
                 unique=True,
             )
             await self._ensure_index(
+                database[_PLAN_AUTHORITY_INPUTS],
+                (("scope_key", 1), ("app_id", 1), ("authority_digest", 1)),
+                name="plan_authority_inputs_scope_app_digest",
+                unique=True,
+            )
+            await self._ensure_index(
                 database[_PUBLICATIONS],
                 (("scope_key", 1), ("app_id", 1)),
                 name="application_publication_scope_app",
@@ -196,15 +209,30 @@ class ArtifactRevisionStore:
         assignment_results: Sequence[AssignmentArtifactResult],
         evidence: ArtifactRevisionValidationEvidence,
         revision: ArtifactRevision,
+        authority_inputs: CompilationPlanAuthorityInputs,
     ) -> ArtifactRevisionRef:
-        """Persist exact bytes and immutable documents, then cold-verify the closure."""
+        """Persist exact bytes and immutable documents, then cold-verify the closure.
+
+        Canonical plan authority is validated before any blob, result,
+        ledger, evidence, or revision write: the revision's pinned authority
+        ref must match the supplied immutable authority document, and the
+        stored plan must equal its canonical rederivation from it. The
+        authority document itself is persisted content-addressed so every
+        fresh process can repeat the rederivation.
+        """
 
         verified_revision = ArtifactRevision.model_validate(revision.model_dump(mode="json"))
-        plan, ledger, verified_results = self._validate_candidate_closure(
+        verified_authority = self._verify_authority_binding(
+            verified_revision, authority_inputs
+        )
+        canonical_plan = self._rederive_canonical_plan(verified_revision, verified_authority)
+        ledger, verified_results = self._validate_candidate_closure(
             bundle=bundle,
             assignment_results=assignment_results,
             evidence=evidence,
             revision=verified_revision,
+            authority_inputs=verified_authority,
+            canonical_plan=canonical_plan,
         )
 
         for artifact in bundle.artifacts:
@@ -213,6 +241,15 @@ class ArtifactRevisionStore:
             )
 
         scope_key = _scope_key(verified_revision.scope)
+        await self._put_immutable(
+            collection_name=_PLAN_AUTHORITY_INPUTS,
+            scope=verified_revision.scope,
+            scope_key=scope_key,
+            app_id=verified_revision.app_id,
+            digest_field="authority_digest",
+            digest=verified_revision.compilation_plan_authority_ref.authority_digest,
+            document=verified_authority.model_dump(mode="json"),
+        )
         for result in verified_results:
             await self._put_immutable(
                 collection_name=_ASSIGNMENT_RESULTS,
@@ -250,7 +287,6 @@ class ArtifactRevisionStore:
             digest=verified_revision.revision_digest,
             document=verified_revision.model_dump(mode="json"),
         )
-        del plan
         await self.resolve_revision(verified_revision.ref, requesting_scope=verified_revision.scope)
         return cast(ArtifactRevisionRef, verified_revision.ref)
 
@@ -283,6 +319,59 @@ class ArtifactRevisionStore:
                     f"immutable {collection_name} identity resolved to different content"
                 ) from None
 
+    def _verify_authority_binding(
+        self,
+        revision: ArtifactRevision,
+        authority_inputs: CompilationPlanAuthorityInputs,
+    ) -> CompilationPlanAuthorityInputs:
+        """The revision's pinned authority ref must name this exact document."""
+        if authority_inputs is None:
+            raise RevisionIntegrityError(
+                "canonical plan authority inputs are required"
+            )
+        try:
+            verified = CompilationPlanAuthorityInputs.model_validate(
+                authority_inputs.model_dump(mode="json")
+            )
+        except (TypeError, ValueError) as exc:
+            raise RevisionIntegrityError(
+                f"authority inputs failed cold validation: {exc}"
+            ) from exc
+        digest = compilation_plan_authority_digest(verified)
+        pinned = revision.compilation_plan_authority_ref
+        if pinned.authority_digest != digest:
+            raise RevisionIntegrityError(
+                "revision pins a different plan-authority document"
+            )
+        if pinned.scope != revision.scope:
+            raise RevisionIntegrityError(
+                "plan-authority reference crosses execution scope"
+            )
+        return verified
+
+    def _rederive_canonical_plan(
+        self,
+        revision: ArtifactRevision,
+        authority_inputs: CompilationPlanAuthorityInputs,
+    ) -> CompilationPlan:
+        """Resolve the pinned plan and immediately repeat canonical rederivation.
+
+        This runs before any dependent closure document, assignment result,
+        parent revision, or content blob is read or interpreted: ledger and
+        evidence interpretation must never precede canonical plan authority.
+        """
+
+        plan = self._resolve_semantic_authority(revision)
+        if _plan_ref(plan) != revision.compilation_plan_ref:
+            raise RevisionIntegrityError("resolved CompilationPlan identity mismatch")
+        try:
+            return validate_compilation_plan_against_authority(plan, authority_inputs)
+        except PlanAuthorityError as exc:
+            raise RevisionIntegrityError(
+                f"stored CompilationPlan failed canonical authority "
+                f"rederivation ({exc.category.value}): {exc}"
+            ) from exc
+
     def _validate_candidate_closure(
         self,
         *,
@@ -290,8 +379,9 @@ class ArtifactRevisionStore:
         assignment_results: Sequence[AssignmentArtifactResult],
         evidence: ArtifactRevisionValidationEvidence,
         revision: ArtifactRevision,
+        authority_inputs: CompilationPlanAuthorityInputs,
+        canonical_plan: CompilationPlan,
     ) -> tuple[
-        CompilationPlan,
         CompositionLedger,
         tuple[AssignmentArtifactResult, ...],
     ]:
@@ -307,16 +397,14 @@ class ArtifactRevisionStore:
         if bundle.plan_digest != revision.compilation_plan_ref.content_digest:
             raise RevisionIntegrityError("canonical bundle belongs to another CompilationPlan")
 
-        plan = self._resolve_semantic_authority(revision)
-        if _plan_ref(plan) != revision.compilation_plan_ref:
-            raise RevisionIntegrityError("resolved CompilationPlan identity mismatch")
         verified_results = tuple(
             AssignmentArtifactResult.model_validate(item.model_dump(mode="json"))
             for item in assignment_results
         )
-        validate_artifact_revision_validation_evidence(
+        self._validate_evidence_closure(
             evidence=evidence,
-            plan=plan,
+            canonical_plan=canonical_plan,
+            authority_inputs=authority_inputs,
             ledger=ledger,
             assignment_results=verified_results,
         )
@@ -353,7 +441,36 @@ class ArtifactRevisionStore:
                     raise RevisionIntegrityError(
                         "canonical bundle bytes do not match ledger unit provenance"
                     )
-        return plan, ledger, verified_results
+        return ledger, verified_results
+
+    def _validate_evidence_closure(
+        self,
+        *,
+        evidence: ArtifactRevisionValidationEvidence,
+        canonical_plan: CompilationPlan,
+        authority_inputs: CompilationPlanAuthorityInputs,
+        ledger: CompositionLedger,
+        assignment_results: Sequence[AssignmentArtifactResult],
+    ) -> None:
+        """Evidence verification failures become the store's typed error family."""
+
+        try:
+            validate_artifact_revision_validation_evidence(
+                evidence=evidence,
+                plan=canonical_plan,
+                authority_inputs=authority_inputs,
+                ledger=ledger,
+                assignment_results=assignment_results,
+            )
+        except PlanAuthorityError as exc:
+            raise RevisionIntegrityError(
+                f"validation evidence failed canonical plan authority "
+                f"({exc.category.value}): {exc}"
+            ) from exc
+        except ValueError as exc:
+            raise RevisionIntegrityError(
+                f"validation evidence failed closure verification: {exc}"
+            ) from exc
 
     def _resolve_semantic_authority(self, revision: ArtifactRevision) -> CompilationPlan:
         try:
@@ -440,7 +557,29 @@ class ArtifactRevisionStore:
             ) from exc
         if revision.ref != verified_ref:
             raise RevisionIntegrityError("stored ArtifactRevision does not match its ref")
-        plan = self._resolve_semantic_authority(revision)
+        # Every fresh process repeats canonical rederivation: read the exact
+        # persisted authority document the revision pins, cold-validate it,
+        # and require its digest to match the pinned ref before any trust.
+        authority_document = await self._get_document(
+            collection_name=_PLAN_AUTHORITY_INPUTS,
+            scope=revision.scope,
+            app_id=revision.app_id,
+            digest_field="authority_digest",
+            digest=revision.compilation_plan_authority_ref.authority_digest,
+        )
+        try:
+            stored_authority = CompilationPlanAuthorityInputs.model_validate(
+                dict(authority_document)
+            )
+        except (TypeError, ValueError) as exc:
+            raise RevisionIntegrityError(
+                f"stored authority inputs failed cold validation: {exc}"
+            ) from exc
+        authority_inputs = self._verify_authority_binding(revision, stored_authority)
+        canonical_plan = self._rederive_canonical_plan(revision, authority_inputs)
+        # Canonical plan authority holds from here on. Only now may dependent
+        # closure documents (ledger, evidence, assignment results), the parent
+        # lineage, and content blobs be read or interpreted.
 
         ledger_document = await self._get_document(
             collection_name=_LEDGERS,
@@ -483,9 +622,10 @@ class ArtifactRevisionStore:
                 raise RevisionIntegrityError(
                     f"stored assignment result failed cold validation: {exc}"
                 ) from exc
-        validate_artifact_revision_validation_evidence(
+        self._validate_evidence_closure(
             evidence=evidence,
-            plan=plan,
+            canonical_plan=canonical_plan,
+            authority_inputs=authority_inputs,
             ledger=ledger,
             assignment_results=results,
         )
@@ -526,7 +666,7 @@ class ArtifactRevisionStore:
                 )
             )
         bundle = CanonicalComposedBundle(
-            plan_digest=plan.plan_digest,
+            plan_digest=canonical_plan.plan_digest,
             artifacts=tuple(artifacts),
             ledger=ledger,
         )
@@ -535,6 +675,8 @@ class ArtifactRevisionStore:
             assignment_results=results,
             evidence=evidence,
             revision=revision,
+            authority_inputs=authority_inputs,
+            canonical_plan=canonical_plan,
         )
         return revision, bundle
 

--- a/mozaiksai/core/semantics/artifact_revision.py
+++ b/mozaiksai/core/semantics/artifact_revision.py
@@ -15,8 +15,15 @@ from mozaiksai.core.semantics.composition_ledger import (
     CompositionLedger,
     CompositionOutcome,
 )
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+    validate_compilation_plan_against_authority,
+)
 from mozaiksai.core.semantics.refs import (
     ArtifactRevisionRef,
+    CompilationPlanAuthorityRef,
     CompilationPlanRef,
     ExecutionAccessScopeRef,
     ImplementationBindingRef,
@@ -106,6 +113,11 @@ class ArtifactRevision(SemanticsModel):
     semantic_graph_ref: SemanticGraphRef
     implementation_binding_ref: ImplementationBindingRef
     compilation_plan_ref: CompilationPlanRef
+    #: Content-addressed reference to the exact immutable
+    #: CompilationPlanAuthorityInputs document the plan was derived from.
+    #: Part of immutable revision identity: two revisions with the same plan
+    #: self-digest but different derivation authority are distinguishable.
+    compilation_plan_authority_ref: CompilationPlanAuthorityRef
     composition_ledger_digest: str
     bundle_digest: str
     validation_evidence_digest: str
@@ -132,6 +144,7 @@ class ArtifactRevision(SemanticsModel):
             self.semantic_graph_ref,
             self.implementation_binding_ref,
             self.compilation_plan_ref,
+            self.compilation_plan_authority_ref,
         )
         if any(ref.scope != self.scope for ref in refs):
             raise ValueError("artifact revision references must share its execution scope")
@@ -190,21 +203,44 @@ class PublicationResult(SemanticsModel):
     publication: ApplicationPublication
 
 
+def _canonical_plan_for_evidence(
+    plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
+) -> CompilationPlan:
+    """Evidence obligations exist only for canonically rederived plans.
+
+    A candidate plan proves body integrity through its self-digest and
+    nothing more; without rederivation a forged plan whose validators were
+    rewritten to NONE would bless empty evidence. The canonical rederived
+    plan is the only plan evidence obligations may be derived from.
+    """
+
+    if authority_inputs is None:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+            "validation evidence requires the plan's canonical authority inputs",
+            plan_digest=plan.plan_digest,
+        )
+    return validate_compilation_plan_against_authority(plan, authority_inputs)
+
+
 def build_artifact_revision_validation_evidence(
     *,
     scope: ExecutionAccessScopeRef,
     app_id: str,
     plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
     ledger: CompositionLedger,
     assignment_results: Sequence[AssignmentArtifactResult],
     bundle_validator_receipts: Sequence[ValidatorReceipt],
 ) -> ArtifactRevisionValidationEvidence:
     """Construct evidence only after its complete plan/ledger/result closure agrees."""
 
-    result_digests = _validate_revision_evidence_inputs(
+    canonical_plan = _canonical_plan_for_evidence(plan, authority_inputs)
+    result_digests = _canonical_evidence_obligations(
         scope=scope,
         app_id=app_id,
-        plan=plan,
+        canonical_plan=canonical_plan,
         ledger=ledger,
         assignment_results=assignment_results,
         bundle_validator_receipts=bundle_validator_receipts,
@@ -233,14 +269,16 @@ def validate_artifact_revision_validation_evidence(
     *,
     evidence: ArtifactRevisionValidationEvidence,
     plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
     ledger: CompositionLedger,
     assignment_results: Sequence[AssignmentArtifactResult],
 ) -> ArtifactRevisionValidationEvidence:
+    canonical_plan = _canonical_plan_for_evidence(plan, authority_inputs)
     verified = ArtifactRevisionValidationEvidence.model_validate(evidence.model_dump(mode="json"))
-    expected_result_digests = _validate_revision_evidence_inputs(
+    expected_result_digests = _canonical_evidence_obligations(
         scope=verified.scope,
         app_id=verified.app_id,
-        plan=plan,
+        canonical_plan=canonical_plan,
         ledger=ledger,
         assignment_results=assignment_results,
         bundle_validator_receipts=verified.bundle_validator_receipts,
@@ -253,28 +291,46 @@ def validate_artifact_revision_validation_evidence(
     return cast(ArtifactRevisionValidationEvidence, verified)
 
 
-def _validate_revision_evidence_inputs(
+def _canonical_evidence_obligations(
     *,
     scope: ExecutionAccessScopeRef,
     app_id: str,
-    plan: CompilationPlan,
+    canonical_plan: CompilationPlan,
     ledger: CompositionLedger,
     assignment_results: Sequence[AssignmentArtifactResult],
     bundle_validator_receipts: Sequence[ValidatorReceipt],
 ) -> tuple[str, ...]:
+    """Derive obligations from a plan that is already the canonical rederivation.
+
+    Only ``_canonical_plan_for_evidence`` output may reach this helper; it is
+    not a validation boundary and must never be handed a caller-supplied
+    candidate plan.
+    """
+
     del app_id  # structurally validated by the evidence/revision models
-    verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
     verified_ledger = CompositionLedger.model_validate(ledger.model_dump(mode="json"))
-    if verified_plan.scope != scope or verified_ledger.compilation_plan_ref.scope != scope:
+    if canonical_plan.scope != scope or verified_ledger.compilation_plan_ref.scope != scope:
         raise ValueError("validation evidence closure crosses execution scope")
     expected_plan_ref = CompilationPlanRef(
-        subject_id=verified_plan.graph_id,
-        subject_version=verified_plan.graph_version,
-        content_digest=verified_plan.plan_digest,
-        scope=verified_plan.scope,
+        subject_id=canonical_plan.graph_id,
+        subject_version=canonical_plan.graph_version,
+        content_digest=canonical_plan.plan_digest,
+        scope=canonical_plan.scope,
     )
     if verified_ledger.compilation_plan_ref != expected_plan_ref:
         raise ValueError("validation evidence ledger belongs to another CompilationPlan")
+    canonical_units = {unit.unit_id: unit for unit in canonical_plan.units}
+    entries_by_id = {
+        entry.plan_unit_ref.unit_id: entry for entry in verified_ledger.unit_entries
+    }
+    if set(entries_by_id) != set(canonical_units):
+        raise ValueError("ledger unit entries do not cover the canonical plan units")
+    for unit_id, entry in entries_by_id.items():
+        unit = canonical_units[unit_id]
+        if entry.plan_unit_ref.unit_digest != unit.unit_digest:
+            raise ValueError("ledger unit entry does not match the canonical unit identity")
+        if entry.disposition is not unit.disposition:
+            raise ValueError("ledger unit entry disposition does not match the canonical plan")
 
     expected_result_digests = tuple(
         sorted(
@@ -306,7 +362,7 @@ def _validate_revision_evidence_inputs(
         sorted(
             {
                 unit.validator
-                for unit in verified_plan.units
+                for unit in canonical_plan.units
                 if unit.validator is not ValidatorIdentifier.NONE
             },
             key=lambda item: item.value,
@@ -330,6 +386,7 @@ def build_artifact_revision(
     semantic_graph_ref: SemanticGraphRef,
     implementation_binding_ref: ImplementationBindingRef,
     compilation_plan_ref: CompilationPlanRef,
+    compilation_plan_authority_ref: CompilationPlanAuthorityRef,
     composition_ledger_digest: str,
     bundle_digest: str,
     validation_evidence_digest: str,
@@ -343,6 +400,11 @@ def build_artifact_revision(
     verified_graph_ref = SemanticGraphRef.model_validate(semantic_graph_ref)
     verified_binding_ref = ImplementationBindingRef.model_validate(implementation_binding_ref)
     verified_plan_ref = CompilationPlanRef.model_validate(compilation_plan_ref)
+    verified_authority_ref = CompilationPlanAuthorityRef.model_validate(
+        compilation_plan_authority_ref
+    )
+    if verified_authority_ref.scope != verified_scope:
+        raise ValueError("plan-authority reference crosses execution scope")
     payload: dict[str, Any] = {
         "revision_schema_version": "mozaiks.artifact_revision.v1",
         "scope": verified_scope,
@@ -351,6 +413,7 @@ def build_artifact_revision(
         "semantic_graph_ref": verified_graph_ref,
         "implementation_binding_ref": verified_binding_ref,
         "compilation_plan_ref": verified_plan_ref,
+        "compilation_plan_authority_ref": verified_authority_ref,
         "composition_ledger_digest": composition_ledger_digest,
         "bundle_digest": bundle_digest,
         "validation_evidence_digest": validation_evidence_digest,

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -1771,14 +1771,13 @@ def derive_compilation_plan(
             _add_unit(unit)
             unit_instance_index[(row.kind, ())] = unit.unit_id
 
-    gaps.append(
-        PlanGap(
-            code=PlanGapCode.RENDERER_RESOLUTION_DEFERRED,
-            family_kind="registry",
-            path_template="registry",
-            adr_slice=4,
-        )
-    )
+    # Renderer resolution is no longer a plan-level deferral: the accepted
+    # ImplementationBinding is the sole implementation authority and is
+    # enforced at materialization (4C/5D-0B2A). The former unconditional
+    # "registry" pseudo-gap carried no per-plan information and made the
+    # composition zero-gap contract unsatisfiable by construction, so plans
+    # no longer emit it; RENDERER_RESOLUTION_DEFERRED remains reserved for
+    # genuine per-family resolution deferrals.
 
     row_by_digest: dict[str, RegistryFamilyRow] = {row.row_digest: row for row in snapshot.rows}
     dependency_map: dict[str, tuple[str, ...]] = {}

--- a/mozaiksai/core/semantics/composition_ledger.py
+++ b/mozaiksai/core/semantics/composition_ledger.py
@@ -19,6 +19,12 @@ from mozaiksai.core.semantics.compilation_plan import (
     RegenerationClosure,
 )
 from mozaiksai.core.semantics.materialization import MaterializedBundle, MaterializedOutput
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+    validate_compilation_plan_against_authority,
+)
 from mozaiksai.core.semantics.portable_path import validate_portable_path
 from mozaiksai.core.semantics.refs import CompilationPlanRef, PlanUnitRef, SemanticsModel
 from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
@@ -412,18 +418,30 @@ def _index_results(
 def compose_plan_artifacts(
     *,
     plan: CompilationPlan,
+    authority_inputs: CompilationPlanAuthorityInputs,
     resolver: SemanticReferenceResolver,
     assignments: CompiledAssignmentSet,
     assignment_results: Iterable[AssignmentArtifactResult],
     materialized_bundle: MaterializedBundle,
     base_revision_digest: str | None,
     base_plan: CompilationPlan | None = None,
+    base_authority_inputs: CompilationPlanAuthorityInputs | None = None,
     base_outputs: Iterable[MaterializedOutput] = (),
     regeneration_closure: RegenerationClosure | None = None,
 ) -> CanonicalComposedBundle:
-    """Compose all plan units without execution, persistence, or publication."""
+    """Compose all plan units without execution, persistence, or publication.
 
-    verified_plan = CompilationPlan.model_validate(plan.model_dump(mode="json"))
+    Canonical plan authority is mandatory and validated FIRST — before any
+    assignment, assignment-result, materialized byte, base output, preserved
+    or reused byte, path accounting, or ledger creation is inspected. The
+    canonical rederived plan (never the caller object) is the plan
+    composition uses; the same rule applies to the base plan in refinement
+    composition through ``base_authority_inputs``.
+    """
+
+    verified_plan = validate_compilation_plan_against_authority(
+        plan, authority_inputs
+    )
     if verified_plan.gaps:
         raise ValueError("blocking CompilationPlan gaps prevent canonical composition")
     if materialized_bundle.plan_digest != verified_plan.plan_digest:
@@ -449,7 +467,16 @@ def compose_plan_artifacts(
     else:
         if base_plan is None or base_revision_digest is None:
             raise ValueError("refinement composition requires base plan and revision digest")
-        verified_base = CompilationPlan.model_validate(base_plan.model_dump(mode="json"))
+        if base_authority_inputs is None:
+            raise PlanAuthorityError(
+                PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING,
+                "refinement composition requires the base plan's canonical "
+                "authority inputs",
+                plan_digest=base_plan.plan_digest,
+            )
+        verified_base = validate_compilation_plan_against_authority(
+            base_plan, base_authority_inputs
+        )
         closure = RegenerationClosure.model_validate(
             regeneration_closure.model_dump(mode="json")
         )
@@ -531,11 +558,10 @@ def compose_plan_artifacts(
             result = result_by_unit.get(unit.unit_id)
             if assignment is None or result is None:
                 raise ValueError(f"agent-authored unit {unit.unit_id!r} lacks an artifact result")
-            if assignment.plan_unit_ref.compilation_plan_ref != plan_ref:
-                raise ValueError("compiled assignment belongs to another CompilationPlan")
-            resolver.resolve_plan_unit(
-                assignment.plan_unit_ref, requesting_scope=verified_plan.scope
-            )
+            if assignment.plan_unit_ref != unit_ref:
+                raise ValueError(
+                    "compiled assignment does not match the canonical plan-unit identity"
+                )
             verified_result = validate_assignment_artifact_result(
                 assignment=assignment, result=result
             )

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -95,6 +95,12 @@ class PlanAuthorityMismatch(StrEnum):
     PLAN_BODY_INVALID = "plan_body_invalid"
     CANONICAL_DERIVATION_MISMATCH = "canonical_derivation_mismatch"
     REQUIRED_AUTHORITY_MISSING = "required_authority_missing"
+    #: The candidate carries base/brownfield content (preserve_unowned or
+    #: reuse_from_base) that canonical derivation cannot reproduce because the
+    #: immutable base-input authority contract does not exist yet. Durable
+    #: composition, revision persistence, and promotion of such plans fail
+    #: closed with this category until that prerequisite is implemented.
+    BASE_AUTHORITY_MISSING = "base_authority_missing"
 
 
 class PlanAuthorityError(ValueError):
@@ -412,6 +418,21 @@ def validate_compilation_plan_against_authority(
             f"authority inputs failed cold validation: {exc}",
             plan_digest=verified.plan_digest,
         ) from exc
+    brownfield_units = [
+        unit.unit_id
+        for unit in verified.units
+        if unit.disposition.value in ("preserve_unowned", "reuse_from_base")
+    ]
+    if brownfield_units:
+        raise PlanAuthorityError(
+            PlanAuthorityMismatch.BASE_AUTHORITY_MISSING,
+            "candidate plan carries base/brownfield content that canonical "
+            "derivation cannot reproduce; the immutable base-input authority "
+            "contract is a separate identified prerequisite "
+            f"(first unit: {brownfield_units[0]!r})",
+            plan_digest=verified.plan_digest,
+            unit_id=brownfield_units[0],
+        )
     try:
         canonical = derive_compilation_plan(
             graph=verified_inputs.graph,
@@ -450,6 +471,34 @@ def validate_compilation_plan_against_authority(
     return canonical
 
 
+def compilation_plan_authority_digest(
+    authority_inputs: CompilationPlanAuthorityInputs,
+) -> str:
+    """Content digest of the exact serialized authority-inputs document."""
+    from mozaiksai.core.semantics.canonical import canonical_digest
+
+    verified = CompilationPlanAuthorityInputs.model_validate(
+        authority_inputs.model_dump(mode="json")
+    )
+    return canonical_digest(verified.model_dump(mode="json"))
+
+
+def compilation_plan_authority_ref(
+    authority_inputs: CompilationPlanAuthorityInputs,
+):
+    """Scope-bound content-addressed ref for one authority-inputs document.
+
+    Confers no trust by possession: consumers must resolve the document,
+    cold-validate it, and canonically rederive the plan.
+    """
+    from mozaiksai.core.semantics.refs import CompilationPlanAuthorityRef
+
+    return CompilationPlanAuthorityRef(
+        scope=authority_inputs.graph.scope,
+        authority_digest=compilation_plan_authority_digest(authority_inputs),
+    )
+
+
 __all__ = [
     "AUTHORITY_INPUTS_SCHEMA_VERSION",
     "CanonicalJsonArray",
@@ -459,5 +508,7 @@ __all__ = [
     "PlanAuthorityError",
     "PlanAuthorityMismatch",
     "build_compilation_plan_authority_inputs",
+    "compilation_plan_authority_digest",
+    "compilation_plan_authority_ref",
     "validate_compilation_plan_against_authority",
 ]

--- a/mozaiksai/core/semantics/refs.py
+++ b/mozaiksai/core/semantics/refs.py
@@ -75,6 +75,7 @@ class RefDocumentType(StrEnum):
     BUILD_CONTEXT_BINDING = "build_context_binding"
     REFINEMENT_PATCH = "refinement_patch"
     ARTIFACT_REVISION = "artifact_revision"
+    COMPILATION_PLAN_AUTHORITY_INPUTS = "compilation_plan_authority_inputs"
     CHILD_CONTRACT = "child_contract"
     TAXONOMY_NAMESPACE = "taxonomy_namespace"
     SEMANTIC_PAYLOAD = "semantic_payload"
@@ -197,6 +198,33 @@ class RefinementPatchRef(_ScopedRef):
     ref_schema_version: Literal["mozaiks.refinement_patch_ref.v1"] = (
         "mozaiks.refinement_patch_ref.v1"
     )
+
+
+class CompilationPlanAuthorityRef(SemanticsModel):
+    """Content-addressed reference to one immutable authority-inputs document.
+
+    The referenced document is a serialized ``CompilationPlanAuthorityInputs``
+    — the complete immutable inputs canonical plan derivation consumes. The
+    ref is scope-bound and digest-exact; it confers no trust by possession:
+    every consumer must resolve the document, cold-validate it, and
+    canonically rederive the plan.
+    """
+
+    ref_schema_version: Literal["mozaiks.compilation_plan_authority_ref.v1"] = (
+        "mozaiks.compilation_plan_authority_ref.v1"
+    )
+    scope: ExecutionAccessScopeRef
+    authority_digest: str
+
+    @field_validator("authority_digest")
+    @classmethod
+    def _authority_digest(cls, value: str) -> str:
+        text = str(value or "").strip().lower()
+        if _HEX_DIGEST.fullmatch(text) is None:
+            raise ValueError(
+                "authority_digest must be a lowercase SHA-256 hex digest"
+            )
+        return text
 
 
 class ArtifactRevisionRef(SemanticsModel):
@@ -349,6 +377,7 @@ class TaxonomyNamespaceRef(SemanticsModel):
 __all__ = [
     "ApplicationManifestRef",
     "ArtifactRevisionRef",
+    "CompilationPlanAuthorityRef",
     "BuildContextBindingRef",
     "ChildContractRef",
     "CompilationPlanRef",

--- a/mozaiksai/core/semantics/resolver.py
+++ b/mozaiksai/core/semantics/resolver.py
@@ -66,6 +66,7 @@ class SemanticReferenceResolver:
         self._artifact_revisions: dict[
             tuple[ExecutionAccessScopeRef, str, str], ArtifactRevision
         ] = {}
+        self._plan_authority_inputs: dict[tuple[str, str], Any] = {}
 
     def _register(self, subject: _Subject) -> None:
         key = (subject.kind, subject.subject_id, subject.version)
@@ -228,6 +229,73 @@ class SemanticReferenceResolver:
                 content=verified,
             )
         )
+
+    def register_compilation_plan_authority_inputs(self, authority_inputs) -> None:
+        """Register one immutable authority-inputs document, digest-keyed.
+
+        The document is cold-revalidated on registration and again on
+        resolution; registration never confers derivation trust — consumers
+        must canonically rederive the plan from the resolved document.
+        """
+        from mozaiksai.core.semantics.plan_authority import (
+            CompilationPlanAuthorityInputs,
+            compilation_plan_authority_digest,
+        )
+
+        try:
+            verified = CompilationPlanAuthorityInputs.model_validate(
+                authority_inputs.model_dump(mode="json")
+            )
+        except (TypeError, ValueError) as exc:
+            raise ReferenceResolutionError(
+                f"authority inputs failed cold validation: {exc}"
+            ) from exc
+        digest = compilation_plan_authority_digest(verified)
+        key = (verified.graph.scope.model_dump_json(), digest)
+        existing = self._plan_authority_inputs.get(key)
+        if existing is not None:
+            if compilation_plan_authority_digest(existing) != digest:
+                raise ReferenceResolutionError(
+                    "authority-inputs registration is immutable"
+                )
+            return
+        self._plan_authority_inputs[key] = verified
+
+    def resolve_compilation_plan_authority_inputs(
+        self, ref, *, requesting_scope
+    ):
+        """Resolve one authority-inputs document by exact scope and digest."""
+        from mozaiksai.core.semantics.plan_authority import (
+            CompilationPlanAuthorityInputs,
+            compilation_plan_authority_digest,
+        )
+        from mozaiksai.core.semantics.refs import CompilationPlanAuthorityRef
+
+        verified_ref = CompilationPlanAuthorityRef.model_validate(
+            ref.model_dump(mode="json")
+        )
+        if requesting_scope != verified_ref.scope:
+            raise ReferenceResolutionError(
+                "authority-inputs resolution crosses execution scope"
+            )
+        key = (verified_ref.scope.model_dump_json(), verified_ref.authority_digest)
+        document = self._plan_authority_inputs.get(key)
+        if document is None:
+            raise ReferenceResolutionError(
+                "unknown compilation-plan authority inputs "
+                f"{verified_ref.authority_digest[:12]!r}"
+            )
+        revalidated = CompilationPlanAuthorityInputs.model_validate(
+            document.model_dump(mode="json")
+        )
+        if (
+            compilation_plan_authority_digest(revalidated)
+            != verified_ref.authority_digest
+        ):
+            raise ReferenceResolutionError(
+                "authority-inputs content digest mismatch"
+            )
+        return revalidated
 
     def register_artifact_revision(self, revision: ArtifactRevision) -> None:
         """Register one content-bearing revision by its full scoped digest identity."""

--- a/mozaiksai/core/workflow/plan_assignment_compiler.py
+++ b/mozaiksai/core/workflow/plan_assignment_compiler.py
@@ -14,6 +14,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
 from mozaiksai.core.semantics.compilation_plan import CompilationPlan, PlanDisposition
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    validate_compilation_plan_against_authority,
+)
 from mozaiksai.core.semantics.refs import PlanUnitRef, SemanticPayloadRef
 from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
 
@@ -136,22 +140,44 @@ def compile_approved_plan(
     plan: ApprovedPlan,
     *,
     resolver: SemanticReferenceResolver,
+    authority_inputs: CompilationPlanAuthorityInputs,
     structured_output_configs: Mapping[str, Any],
 ) -> CompiledAssignmentSet:
-    """Cold-resolve and compile approved units without execution side effects."""
+    """Cold-resolve and compile approved units without execution side effects.
+
+    Ref resolution and self-digest validation prove identity and body
+    integrity only. Before any assignment contract becomes executable, the
+    resolved plan must equal its canonical rederivation from the supplied
+    immutable authority inputs. Every execution-authorizing unit fact —
+    disposition, kind, outputs, validators, structured-output ref, sources,
+    dependencies, identity bindings — is then read from the canonical
+    rederived plan itself; the resolver is never consulted for unit content
+    after canonical validation.
+    """
 
     compiled: list[CompiledAssignment] = []
     plan_ref = plan.assignments[0].plan_unit_ref.compilation_plan_ref
     scope = plan_ref.scope
-    canonical_plan = resolver.resolve(plan_ref, requesting_scope=scope)
-    if not isinstance(canonical_plan, CompilationPlan):
+    resolved_plan = resolver.resolve(plan_ref, requesting_scope=scope)
+    if not isinstance(resolved_plan, CompilationPlan):
         raise ValueError("compilation plan ref did not resolve to a canonical plan")
-    canonical_plan = CompilationPlan.model_validate(
-        canonical_plan.model_dump(mode="json")
+    canonical_plan = validate_compilation_plan_against_authority(
+        resolved_plan, authority_inputs
     )
+    if canonical_plan.plan_digest != plan_ref.content_digest:
+        raise ValueError(
+            "canonical rederived plan does not match the approved plan ref"
+        )
     plan_order = {unit.unit_id: index for index, unit in enumerate(canonical_plan.units)}
+    canonical_units = {unit.unit_id: unit for unit in canonical_plan.units}
     for spec in plan.assignments:
-        unit = resolver.resolve_plan_unit(spec.plan_unit_ref, requesting_scope=scope)
+        unit = canonical_units.get(spec.plan_unit_ref.unit_id)
+        if unit is None:
+            raise ValueError("approved plan-unit ref names no canonical plan unit")
+        if spec.plan_unit_ref.unit_digest != unit.unit_digest:
+            raise ValueError(
+                "approved plan-unit ref does not match the canonical unit identity"
+            )
         if unit.disposition is not PlanDisposition.AGENT_AUTHOR:
             raise ValueError("only agent_author plan units may become assignments")
         if spec.assignment_kind is not unit.assignment_kind:
@@ -181,7 +207,14 @@ def compile_approved_plan(
         for dependency_ref in unit_refs:
             if dependency_ref.compilation_plan_ref != plan_ref:
                 raise ValueError("dependency plan-unit ref belongs to a foreign plan")
-            resolver.resolve_plan_unit(dependency_ref, requesting_scope=scope)
+            dependency_unit = canonical_units.get(dependency_ref.unit_id)
+            if (
+                dependency_unit is None
+                or dependency_ref.unit_digest != dependency_unit.unit_digest
+            ):
+                raise ValueError(
+                    "dependency plan-unit ref does not match the canonical unit identity"
+                )
 
         resolve_structured_output_contract_ref(
             spec.required_structured_output_ref, configs=structured_output_configs

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -1,28 +1,53 @@
+"""Shared 5B composition fixtures built on canonically derived plans.
+
+Every plan here is produced by the one canonical ``derive_compilation_plan``
+implementation and validates against its exact immutable
+``CompilationPlanAuthorityInputs`` — no synthetic ``model_construct`` plans,
+no re-dispositioned units, no fabricated ``preserve_unowned`` content. The
+layout registry is a reduced but internally consistent authority (page schema,
+the four renderer-ready application families, and the module backend-helper
+agent family) so honest derivation is genuinely gap-free; a reduced registry
+is a legitimate authority input, pinned like any other by the authority
+document.
+
+Brownfield/preserve_unowned composition is intentionally NOT represented: the
+immutable base-input authority contract does not exist yet, and plans carrying
+such content fail closed with the typed ``base_authority_missing`` category
+(see test_compilation_plan_authority). The former synthetic fixtures that
+composed fabricated preserved bytes are exactly the forgeries the canonical
+authority rule rejects.
+"""
+
 from __future__ import annotations
 
-import hashlib
 from functools import lru_cache
 from pathlib import Path
 
 import yaml
 
-from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.runtime.app.layout_registry import (
+    MaterializerIdentifier,
+    build_app_layout_registry,
+)
+from mozaiksai.core.semantics.binding import (
+    RendererSelection,
+    build_implementation_binding,
+)
 from mozaiksai.core.semantics.compilation_plan import (
-    CompilationPlan,
-    FamilyInstancePlan,
     PlanDisposition,
-    PlanOutput,
     derive_compilation_plan,
     plan_regeneration_closure,
 )
 from mozaiksai.core.semantics.materialization import (
     MaterializedBundle,
-    MaterializedOutput,
-    _materialize_unit,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    build_compilation_plan_authority_inputs,
 )
 from mozaiksai.core.semantics.refs import (
     CompilationPlanRef,
     PlanUnitRef,
+    SemanticGraphRef,
     SemanticPayloadRef,
 )
 from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
@@ -33,220 +58,419 @@ from mozaiksai.core.workflow.plan_assignment_compiler import (
     CompiledAssignmentSet,
     compile_approved_plan,
 )
-from tests.test_compilation_plan import _corpus_graph, _registry
+from tests.test_app_family_materialization_b2a import _extended_fixture
 
-ROOT = Path(__file__).resolve().parents[1]
+_ROOT = Path(__file__).resolve().parents[1]
+
+_KEPT_TEMPLATES = frozenset(
+    {
+        "ui/pages/{page_id}.yaml",
+        "app.json",
+        "ui/route_manifest.json",
+        "config/integrations.yaml",
+        "security/secrets.yaml",
+        "modules/{module_id}/backend/{helper_id}.py",
+    }
+)
 
 
-def _plan(
-    source: CompilationPlan,
-    units: tuple[FamilyInstancePlan, ...],
-    *,
-    graph_version: int,
-) -> CompilationPlan:
-    candidate = CompilationPlan.model_construct(
-        schema_version=source.schema_version,
-        graph_id=source.graph_id,
-        graph_version=graph_version,
-        scope=source.scope,
-        graph_digest=source.graph_digest,
-        scope_selection=source.scope_selection,
-        registry_schema_version=source.registry_schema_version,
-        registry_digest=source.registry_digest,
-        assignment_contracts_digest=source.assignment_contracts_digest,
-        units=units,
-        gaps=(),
-        plan_digest="0" * 64,
+class ReducedLayoutRegistry:
+    """Internally consistent authority subset of the canonical registry.
+
+    Rows keep their canonical content; dependencies on families outside the
+    subset are trimmed so the snapshot's dependency closure holds. Honest
+    derivation over this authority is gap-free, which is what the 5B
+    zero-gap composition contract requires.
+    """
+
+    def __init__(self) -> None:
+        source = build_app_layout_registry(())
+        self.schema_version = source.schema_version
+        kept_kinds = {
+            family.kind
+            for family in source.ordered_families()
+            if family.path_template in _KEPT_TEMPLATES
+        }
+        rows = []
+        for family in source.ordered_families():
+            if family.path_template not in _KEPT_TEMPLATES:
+                continue
+            trimmed = tuple(
+                dependency
+                for dependency in family.dependency_families
+                if dependency in kept_kinds
+            )
+            rows.append(family.model_copy(update={"dependency_families": trimmed}))
+        self._rows = tuple(rows)
+
+    def ordered_families(self):
+        return self._rows
+
+    @property
+    def families(self):
+        return self._rows
+
+
+def reduced_registry() -> ReducedLayoutRegistry:
+    return ReducedLayoutRegistry()
+
+
+def structured_configs() -> dict:
+    return {
+        "AppGenerator": yaml.safe_load(
+            (
+                _ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml"
+            ).read_text(encoding="utf-8")
+        )
+    }
+
+
+def _binding(graph):
+    from mozaiksai.core.semantics.app_config_materialization import (
+        APP_CONFIG_FAMILIES,
+        APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+        APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
     )
-    document = candidate.canonical_payload(include_digest=False)
-    document["plan_digest"] = canonical_digest(document)
-    return CompilationPlan.model_validate(document)
+
+    return build_implementation_binding(
+        binding_id="slice5b_binding",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id="deterministic_page_schema_renderer",
+                implementation_version="1",
+                artifact_families=("app_ui_page_schema",),
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.APP_CONFIG_EXECUTOR,
+                implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=tuple(sorted(APP_CONFIG_FAMILIES)),
+            ),
+        ),
+    )
 
 
-def _output(unit: FamilyInstancePlan, content: bytes, *, origin: str) -> MaterializedOutput:
-    target = unit.outputs[0]
-    return MaterializedOutput(
-        unit_id=unit.unit_id,
-        path_scope=target.path_scope,
-        path=target.path,
-        content=content,
-        origin=origin,
-        content_digest=hashlib.sha256(content).hexdigest(),
+def _bundle_for(plan, graph, payloads, _authority_inputs) -> MaterializedBundle:
+    """Render the plan's renderer-ready units through the real gated path.
+
+    ``materialize_plan`` has no execution path for AGENT_AUTHOR units (their
+    bytes arrive as validated assignment results at composition), so the
+    bundle for an agent-bearing plan is assembled from the fully gated render
+    of the same canonical plan restricted to its composable render outputs —
+    which is exactly what materialization itself produces for those units.
+    """
+    from mozaiksai.core.semantics.materialization import (
+        _materialize_unit,
+        resolve_app_config_renderer_selection,
+    )
+
+    payload_by_node = {p.node_id: p for p in payloads}
+    binding = _binding(graph)
+    selection = resolve_app_config_renderer_selection(
+        binding, graph=graph, layout_registry=reduced_registry()
+    )
+    outputs = []
+    for unit in plan.units:
+        if unit.disposition is not PlanDisposition.RENDER:
+            continue
+        _materialize_unit(
+            unit,
+            payload_by_node=payload_by_node,
+            app_config_selection=selection,
+            preserved_by_unit={},
+            bundle_outputs=outputs,
+            external=[],
+            inapplicable=[],
+            unsupplied=[],
+            input_only=[],
+            deferred=[],
+        )
+    return MaterializedBundle(
+        plan_digest=plan.plan_digest,
+        outputs=tuple(sorted(outputs, key=lambda o: o.path)),
+        external_handoff_units=(),
+        inapplicable_units=(),
+        unsupplied_preserved_units=(),
+        input_only_units=(),
+        instance_scope_deferred_units=(),
+        gap_count=0,
     )
 
 
 @lru_cache(maxsize=1)
+def _derived_products() -> dict[str, object]:
+    """Cache only the deterministic derivation products; resolvers are live
+    registries and must be built fresh per fixture call so tests can never
+    pollute one another through shared registration state."""
+    return _build_derived_products()
+
+
 def composition_fixture() -> dict[str, object]:
-    structured = yaml.safe_load(
-        (ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml").read_text(
-            encoding="utf-8"
-        )
-    )
-    graph, payloads = _corpus_graph()
-    complete = derive_compilation_plan(
-        graph=graph,
-        payloads=payloads,
-        registry=_registry(),
-        structured_output_configs={"AppGenerator": structured},
-    )
-
-    def one(disposition: PlanDisposition, prefix: str) -> FamilyInstancePlan:
-        return next(
-            unit
-            for unit in complete.units
-            if unit.disposition is disposition and unit.unit_id.startswith(prefix)
-        )
-
-    handoff = one(PlanDisposition.EXTERNAL_HANDOFF, "app_deployment_artifact/")
-
-    def preserved_unit(unit_id: str, family: str, path: str) -> FamilyInstancePlan:
-        return handoff.model_copy(
-            update={
-                "unit_id": unit_id,
-                "family_kind": family,
-                "disposition": PlanDisposition.PRESERVE_UNOWNED,
-                "outputs": (PlanOutput(path_scope="app_bundle_root", path=path),),
-                "depends_on_units": (),
-                "materializer": "preserved_opaque",
-            }
-        )
-
-    reusable = preserved_unit(
-        "app_service_support/preserved", "app_service_support", "services/config.py"
-    )
-    removed = preserved_unit(
-        "app_backend_support/preserved", "app_backend_support", "backend/admin_config.py"
-    )
-    agent = one(PlanDisposition.AGENT_AUTHOR, "module_backend_helper/").model_copy(
-        update={"depends_on_units": ()}
-    )
-    rendered = one(PlanDisposition.RENDER, "app_ui_page_schema/")
-    preserved = preserved_unit(
-        "workflow_config/preserved", "workflow_config", "workflows/demo/agents.yaml"
-    )
-    inapplicable = one(PlanDisposition.INAPPLICABLE, "prohibited_legacy/")
-    input_only_source = next(
-        unit
-        for unit in complete.units
-        if unit.disposition is PlanDisposition.INAPPLICABLE
-        and unit.unit_id != inapplicable.unit_id
-    )
-    input_only = input_only_source.model_copy(
-        update={"disposition": PlanDisposition.INPUT_ONLY}
-    )
-
-    base = _plan(complete, (reusable, removed), graph_version=1)
-    successor = _plan(
-        complete,
-        (reusable, agent, rendered, preserved, handoff, inapplicable, input_only),
-        graph_version=2,
-    )
-    closure = plan_regeneration_closure(base, successor)
+    products = _derived_products()
     resolver = SemanticReferenceResolver()
-    for payload in payloads:
+    for payload in products["payloads"]:
         resolver.register_semantic_payload(payload)
-    resolver.register_semantic_graph_v2(graph)
-    resolver.register_compilation_plan(base)
-    resolver.register_compilation_plan(successor)
+    resolver.register_semantic_graph_v2(products["graph"])
+    resolver.register_compilation_plan(products["base"])
+    resolver.register_compilation_plan(products["successor"])
+    resolver.register_compilation_plan_authority_inputs(
+        products["base_authority_inputs"]
+    )
+    resolver.register_compilation_plan_authority_inputs(
+        products["authority_inputs"]
+    )
+    return {**products, "resolver": resolver}
 
+
+def _build_derived_products() -> dict[str, object]:
+    """Canonical genesis + refinement composition scenario.
+
+    ``base`` (v1) and ``successor`` (v2, one integration-purpose change) are
+    both genuinely derived and authority-validated; the closure between them
+    yields REUSED coverage for the unaffected units and fresh RENDERED /
+    AGENT_AUTHORED coverage for the rest.
+    """
+    registry = reduced_registry()
+    configs = structured_configs()
+
+    base_graph, base_payloads = _extended_fixture()
+    base_plan = derive_compilation_plan(
+        graph=base_graph,
+        payloads=base_payloads,
+        registry=registry,
+        structured_output_configs=configs,
+    )
+    base_authority = build_compilation_plan_authority_inputs(
+        graph=base_graph,
+        payloads=base_payloads,
+        registry=registry,
+        structured_output_configs=configs,
+    )
+
+    successor_source_graph, successor_payloads = _extended_fixture(
+        home_title="Console"
+    )
+    from mozaiksai.core.semantics.graph import build_semantic_graph_v2
+
+    successor_graph = build_semantic_graph_v2(
+        graph_id=successor_source_graph.graph_id,
+        version=2,
+        scope=successor_source_graph.scope,
+        nodes=successor_source_graph.nodes,
+        edges=successor_source_graph.edges,
+        namespace_grants=successor_source_graph.namespace_grants,
+    )
+    successor_plan = derive_compilation_plan(
+        graph=successor_graph,
+        payloads=successor_payloads,
+        registry=registry,
+        structured_output_configs=configs,
+    )
+    successor_authority = build_compilation_plan_authority_inputs(
+        graph=successor_graph,
+        payloads=successor_payloads,
+        registry=registry,
+        structured_output_configs=configs,
+    )
+
+    assert not base_plan.gaps and not successor_plan.gaps
+    closure = plan_regeneration_closure(base_plan, successor_plan)
+
+    resolver = SemanticReferenceResolver()
+    for payload in successor_payloads:
+        resolver.register_semantic_payload(payload)
+    resolver.register_semantic_graph_v2(successor_graph)
+    resolver.register_compilation_plan(successor_plan)
+
+    agent = next(
+        unit
+        for unit in successor_plan.units
+        if unit.disposition is PlanDisposition.AGENT_AUTHOR
+    )
     plan_ref = CompilationPlanRef(
-        subject_id=successor.graph_id,
-        subject_version=successor.graph_version,
-        content_digest=successor.plan_digest,
-        scope=successor.scope,
+        subject_id=successor_plan.graph_id,
+        subject_version=successor_plan.graph_version,
+        content_digest=successor_plan.plan_digest,
+        scope=successor_plan.scope,
     )
     unit_ref = PlanUnitRef(
         compilation_plan_ref=plan_ref,
         unit_id=agent.unit_id,
         unit_digest=agent.unit_digest,
     )
-    payload_by_id = {payload.node_id: payload for payload in payloads}
+    payload_by_id = {p.node_id: p for p in successor_payloads}
     source_refs = tuple(
         SemanticPayloadRef(
             node_id=source.node_id,
             payload_kind=payload_by_id[source.node_id].payload_kind.value,
             payload_version=payload_by_id[source.node_id].payload_version,
             content_digest=source.payload_digest,
-            scope=successor.scope,
+            scope=successor_plan.scope,
         )
         for source in agent.sources
     )
-    base_revision_digest = "b" * 64
-    approved = ApprovedPlan(
-        assignments=(
-            ApprovedAssignmentSpec(
-                plan_unit_ref=unit_ref,
-                assignment_kind=agent.assignment_kind,
-                dependency_context_refs=source_refs,
-                required_structured_output_ref=agent.required_structured_output_ref,
-                required_validators=(agent.validator,),
-                assignment_retry_limit=2,
-                base_revision_digest=base_revision_digest,
-            ),
-        )
-    )
     assignments = compile_approved_plan(
-        approved,
+        ApprovedPlan(
+            assignments=(
+                ApprovedAssignmentSpec(
+                    plan_unit_ref=unit_ref,
+                    assignment_kind=agent.assignment_kind,
+                    dependency_context_refs=source_refs,
+                    required_structured_output_ref=(
+                        agent.required_structured_output_ref
+                    ),
+                    required_validators=(agent.validator,),
+                    assignment_retry_limit=2,
+                    base_revision_digest=None,
+                ),
+            )
+        ),
         resolver=resolver,
-        structured_output_configs={"AppGenerator": structured},
+        authority_inputs=successor_authority,
+        structured_output_configs=configs,
     )
-    assignment = assignments.ordered_assignments[0]
     helper_source = "def report_hook():\n    return None\n"
+    helper_path = agent.outputs[0].path.replace("{module_id}", "reports").replace(
+        "{helper_id}", "report_hook"
+    )
     result = build_assignment_artifact_result(
-        assignment=assignment,
+        assignment=assignments.ordered_assignments[0],
         structured_output={
             "assignment_kind": "module_helper_implementation",
             "module_id": "reports",
             "helper_id": "report_hook",
             "helper_source": helper_source,
         },
-        artifacts={"modules/reports/backend/report_hook.py": helper_source},
-        structured_output_configs={"AppGenerator": structured},
+        artifacts={helper_path: helper_source},
+        structured_output_configs=configs,
         validator_runner=lambda _validator, files: bool(files),
     )
 
-    rendered_outputs: list[MaterializedOutput] = []
-    _materialize_unit(
-        rendered,
-        payload_by_node=payload_by_id,
-        app_config_selection=None,
-        preserved_by_unit={},
-        bundle_outputs=rendered_outputs,
-        external=[],
-        inapplicable=[],
-        unsupplied=[],
-        input_only=[],
-        deferred=[],
+    materialized = _bundle_for(
+        successor_plan, successor_graph, successor_payloads, successor_authority
     )
-    preserved_output = _output(preserved, b"agents: []\n", origin="preserved")
-    materialized = MaterializedBundle(
-        plan_digest=successor.plan_digest,
-        outputs=(*rendered_outputs, preserved_output),
-        external_handoff_units=(handoff.unit_id,),
-        inapplicable_units=(inapplicable.unit_id,),
-        unsupplied_preserved_units=(),
-        input_only_units=(),
-        instance_scope_deferred_units=(preserved.unit_id,),
-        gap_count=0,
-        closure=closure,
+    base_bundle = _bundle_for(base_plan, base_graph, base_payloads, base_authority)
+    import hashlib as _hashlib
+
+    from mozaiksai.core.semantics.materialization import MaterializedOutput
+
+    agent_bytes = helper_source.encode("utf-8")
+    base_outputs = tuple(
+        output
+        for output in base_bundle.outputs
+        if output.unit_id in set(closure.reusable)
+    ) + (
+        # the agent-authored artifact as it existed in the base revision, so
+        # a reusable AGENT_AUTHOR unit has its exact base bytes available
+        MaterializedOutput(
+            unit_id=agent.unit_id,
+            path_scope=agent.outputs[0].path_scope,
+            path=helper_path,
+            content=agent_bytes,
+            origin="reused",
+            content_digest=_hashlib.sha256(agent_bytes).hexdigest(),
+        ),
     )
-    base_outputs = (
-        _output(reusable, b"# reusable service config\n", origin="preserved"),
-        _output(removed, b"# removed backend config\n", origin="preserved"),
-    )
+
     return {
-        "graph": graph,
-        "payloads": payloads,
-        "base": base,
-        "successor": successor,
+        "registry": registry,
+        "configs": configs,
+        "graph": successor_graph,
+        "payloads": successor_payloads,
+        "base_graph": base_graph,
+        "base_payloads": base_payloads,
+        "base": base_plan,
+        "base_authority_inputs": base_authority,
+        "successor": successor_plan,
+        "authority_inputs": successor_authority,
         "closure": closure,
-        "resolver": resolver,
         "assignments": assignments,
         "result": result,
         "materialized": materialized,
         "base_outputs": base_outputs,
-        "base_revision_digest": base_revision_digest,
+        "base_revision_digest": None,
     }
+
+
+def refinement_execution(fixture, base_revision_digest: str):
+    """Recompile the agent assignment and its result pinned to a base
+    revision digest — the canonical way to enter refinement composition."""
+    plan = fixture["successor"]
+    resolver = fixture["resolver"]
+    configs = fixture["configs"]
+    agent = next(
+        unit
+        for unit in plan.units
+        if unit.disposition is PlanDisposition.AGENT_AUTHOR
+    )
+    plan_ref = CompilationPlanRef(
+        subject_id=plan.graph_id,
+        subject_version=plan.graph_version,
+        content_digest=plan.plan_digest,
+        scope=plan.scope,
+    )
+    unit_ref = PlanUnitRef(
+        compilation_plan_ref=plan_ref,
+        unit_id=agent.unit_id,
+        unit_digest=agent.unit_digest,
+    )
+    payload_by_id = {p.node_id: p for p in fixture["payloads"]}
+    source_refs = tuple(
+        SemanticPayloadRef(
+            node_id=source.node_id,
+            payload_kind=payload_by_id[source.node_id].payload_kind.value,
+            payload_version=payload_by_id[source.node_id].payload_version,
+            content_digest=source.payload_digest,
+            scope=plan.scope,
+        )
+        for source in agent.sources
+    )
+    assignments = compile_approved_plan(
+        ApprovedPlan(
+            assignments=(
+                ApprovedAssignmentSpec(
+                    plan_unit_ref=unit_ref,
+                    assignment_kind=agent.assignment_kind,
+                    dependency_context_refs=source_refs,
+                    required_structured_output_ref=(
+                        agent.required_structured_output_ref
+                    ),
+                    required_validators=(agent.validator,),
+                    assignment_retry_limit=2,
+                    base_revision_digest=base_revision_digest,
+                ),
+            )
+        ),
+        resolver=resolver,
+        authority_inputs=fixture["authority_inputs"],
+        structured_output_configs=configs,
+    )
+    helper_source = "def report_hook():" + chr(10) + "    return None" + chr(10)
+    helper_path = agent.outputs[0].path.replace(
+        "{module_id}", "reports"
+    ).replace("{helper_id}", "report_hook")
+    result = build_assignment_artifact_result(
+        assignment=assignments.ordered_assignments[0],
+        structured_output={
+            "assignment_kind": "module_helper_implementation",
+            "module_id": "reports",
+            "helper_id": "report_hook",
+            "helper_source": helper_source,
+        },
+        artifacts={helper_path: helper_source},
+        structured_output_configs=configs,
+        validator_runner=lambda _validator, files: bool(files),
+    )
+    return assignments, result
 
 
 def empty_assignment_set() -> CompiledAssignmentSet:

--- a/tests/slice_5c_revision_helpers.py
+++ b/tests/slice_5c_revision_helpers.py
@@ -1,358 +1,143 @@
+"""Shared 5C revision fixtures built on canonically derived plans.
+
+Every revision here pins its exact plan-authority document
+(``compilation_plan_authority_ref``) and flows through the canonical
+validation chain: derived plan -> authority validation -> composition ->
+evidence -> revision -> persistence. No synthetic plans, no bearer trust.
+"""
+
 from __future__ import annotations
 
-from pathlib import Path
+import hashlib
 
-import yaml
-
-from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
 from mozaiksai.core.semantics.artifact_revision import (
+    ValidatorReceipt,
     build_artifact_revision,
     build_artifact_revision_validation_evidence,
 )
-from mozaiksai.core.semantics.binding import build_implementation_binding
-from mozaiksai.core.semantics.canonical import canonical_digest
-from mozaiksai.core.semantics.compilation_plan import CompilationPlan, PlanDisposition
 from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
-from mozaiksai.core.semantics.graph import build_semantic_graph_v2
-from mozaiksai.core.semantics.materialization import MaterializedBundle
+from mozaiksai.core.semantics.plan_authority import (
+    compilation_plan_authority_ref,
+)
 from mozaiksai.core.semantics.refs import (
     CompilationPlanRef,
     ImplementationBindingRef,
-    PlanUnitRef,
     SemanticGraphRef,
-    SemanticPayloadRef,
 )
-from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
-from mozaiksai.core.workflow.assignment_artifacts import (
-    ValidatorReceipt,
-    build_assignment_artifact_result,
-)
-from mozaiksai.core.workflow.plan_assignment_compiler import (
-    ApprovedAssignmentSpec,
-    ApprovedPlan,
-    compile_approved_plan,
-)
-from mozaiksai.core.workflow.structured_output_contracts import stable_digest
 from tests.slice_5b_composition_helpers import (
+    _binding,
     composition_fixture,
-    empty_assignment_set,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
 
+def _receipts(plan, ledger) -> tuple[ValidatorReceipt, ...]:
+    from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
+    from mozaiksai.core.workflow.structured_output_contracts import stable_digest
 
-def revision_fixture() -> dict[str, object]:
-    source = composition_fixture()
-    graph = source["graph"]
-    payloads = source["payloads"]
-    plan = source["base"]
-    resolver = SemanticReferenceResolver()
-    for payload in payloads:
-        resolver.register_semantic_payload(payload)
-    resolver.register_semantic_graph_v2(graph)
-    resolver.register_compilation_plan(plan)
-
-    graph_ref = SemanticGraphRef(
-        subject_id=graph.graph_id,
-        subject_version=graph.version,
-        content_digest=graph.graph_digest,
-        scope=graph.scope,
+    validators = sorted(
+        {
+            unit.validator
+            for unit in plan.units
+            if unit.validator is not ValidatorIdentifier.NONE
+        },
+        key=lambda item: item.value,
     )
-    binding = build_implementation_binding(
-        binding_id="slice-5c-binding",
-        version=1,
-        scope=graph.scope,
-        semantic_graph_ref=graph_ref,
-        capability_pack_selections=(),
-        renderer_selections=(),
-        deployment_profile_selections=(),
-    )
-    resolver.register_implementation_binding(binding)
-    binding_ref = ImplementationBindingRef(
-        subject_id=binding.binding_id,
-        subject_version=binding.version,
-        content_digest=binding.binding_digest,
-        scope=binding.scope,
-    )
-    plan_ref = CompilationPlanRef(
-        subject_id=plan.graph_id,
-        subject_version=plan.graph_version,
-        content_digest=plan.plan_digest,
-        scope=plan.scope,
-    )
-    materialized = MaterializedBundle(
-        plan_digest=plan.plan_digest,
-        outputs=source["base_outputs"],
-        external_handoff_units=(),
-        inapplicable_units=(),
-        unsupplied_preserved_units=(),
-        input_only_units=(),
-        instance_scope_deferred_units=(),
-        gap_count=0,
-    )
-    bundle = compose_plan_artifacts(
-        plan=plan,
-        resolver=resolver,
-        assignments=empty_assignment_set(),
-        assignment_results=(),
-        materialized_bundle=materialized,
-        base_revision_digest=None,
-    )
-    validators = tuple(
-        sorted(
-            {
-                unit.validator
-                for unit in plan.units
-                if unit.validator is not ValidatorIdentifier.NONE
-            },
-            key=lambda item: item.value,
-        )
-    )
-    receipts = tuple(
+    return tuple(
         ValidatorReceipt(
             validator=validator,
-            subject_digest=bundle.ledger.bundle_digest,
+            subject_digest=ledger.bundle_digest,
             passed=True,
             evidence_digest=stable_digest(
                 {
                     "validator": validator.value,
-                    "subject_digest": bundle.ledger.bundle_digest,
+                    "subject_digest": ledger.bundle_digest,
                     "passed": True,
                 }
             ),
         )
         for validator in validators
     )
-    app_id = "corpus-app"
-    evidence = build_artifact_revision_validation_evidence(
-        scope=graph.scope,
-        app_id=app_id,
+
+
+def revision_fixture() -> dict[str, object]:
+    """Canonical genesis revision closure over the derived successor plan."""
+    source = composition_fixture()
+    plan = source["successor"]
+    graph = source["graph"]
+    authority_inputs = source["authority_inputs"]
+    resolver = source["resolver"]
+
+    binding = _binding(graph)
+    resolver.register_implementation_binding(binding)
+
+    composed = compose_plan_artifacts(
         plan=plan,
-        ledger=bundle.ledger,
-        assignment_results=(),
-        bundle_validator_receipts=receipts,
+        authority_inputs=authority_inputs,
+        resolver=resolver,
+        assignments=source["assignments"],
+        assignment_results=(source["result"],),
+        materialized_bundle=source["materialized"],
+        base_revision_digest=None,
     )
+    ledger = composed.ledger
+
+    evidence = build_artifact_revision_validation_evidence(
+        scope=plan.scope,
+        app_id=plan.graph_id,
+        plan=plan,
+        authority_inputs=authority_inputs,
+        ledger=ledger,
+        assignment_results=(source["result"],),
+        bundle_validator_receipts=_receipts(plan, ledger),
+    )
+    authority_ref = compilation_plan_authority_ref(authority_inputs)
     revision = build_artifact_revision(
-        scope=graph.scope,
-        app_id=app_id,
+        scope=plan.scope,
+        app_id=plan.graph_id,
         parent_revision_ref=None,
-        semantic_graph_ref=graph_ref,
-        implementation_binding_ref=binding_ref,
-        compilation_plan_ref=plan_ref,
-        composition_ledger_digest=bundle.ledger.ledger_digest,
-        bundle_digest=bundle.ledger.bundle_digest,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        implementation_binding_ref=ImplementationBindingRef(
+            subject_id=binding.binding_id,
+            subject_version=binding.version,
+            content_digest=binding.binding_digest,
+            scope=binding.scope,
+        ),
+        compilation_plan_ref=CompilationPlanRef(
+            subject_id=plan.graph_id,
+            subject_version=plan.graph_version,
+            content_digest=plan.plan_digest,
+            scope=plan.scope,
+        ),
+        compilation_plan_authority_ref=authority_ref,
+        composition_ledger_digest=ledger.ledger_digest,
+        bundle_digest=ledger.bundle_digest,
         validation_evidence_digest=evidence.evidence_digest,
     )
     return {
-        "app_id": app_id,
-        "graph": graph,
+        **source,
         "plan": plan,
         "binding": binding,
-        "resolver": resolver,
-        "bundle": bundle,
+        "bundle": composed,
+        "ledger": ledger,
         "evidence": evidence,
         "revision": revision,
-        "receipts": receipts,
+        "authority_ref": authority_ref,
+        "assignment_results": (source["result"],),
+        "app_id": plan.graph_id,
+        "receipts": _receipts(plan, ledger),
     }
 
 
 def executable_revision_fixture() -> dict[str, object]:
-    """Genesis closure retaining the accepted 5B agent + renderer loader proof."""
-
-    source = composition_fixture()
-    source_graph = source["graph"]
-    payloads = source["payloads"]
-    graph = build_semantic_graph_v2(
-        graph_id=source_graph.graph_id,
-        version=2,
-        scope=source_graph.scope,
-        nodes=source_graph.nodes,
-        edges=source_graph.edges,
-        namespace_grants=source_graph.namespace_grants,
-    )
-    source_plan = source["successor"]
-    candidate = CompilationPlan.model_construct(
-        schema_version=source_plan.schema_version,
-        graph_id=graph.graph_id,
-        graph_version=graph.version,
-        scope=graph.scope,
-        graph_digest=graph.graph_digest,
-        scope_selection=source_plan.scope_selection,
-        registry_schema_version=source_plan.registry_schema_version,
-        registry_digest=source_plan.registry_digest,
-        assignment_contracts_digest=source_plan.assignment_contracts_digest,
-        units=source_plan.units,
-        gaps=(),
-        plan_digest="0" * 64,
-    )
-    plan_payload = candidate.canonical_payload(include_digest=False)
-    plan_payload["plan_digest"] = canonical_digest(plan_payload)
-    plan = CompilationPlan.model_validate(plan_payload)
-
-    resolver = SemanticReferenceResolver()
-    for payload in payloads:
-        resolver.register_semantic_payload(payload)
-    resolver.register_semantic_graph_v2(graph)
-    resolver.register_compilation_plan(plan)
-    graph_ref = SemanticGraphRef(
-        subject_id=graph.graph_id,
-        subject_version=graph.version,
-        content_digest=graph.graph_digest,
-        scope=graph.scope,
-    )
-    binding = build_implementation_binding(
-        binding_id="slice-5c-executable-binding",
-        version=1,
-        scope=graph.scope,
-        semantic_graph_ref=graph_ref,
-        capability_pack_selections=(),
-        renderer_selections=(),
-        deployment_profile_selections=(),
-    )
-    resolver.register_implementation_binding(binding)
-    binding_ref = ImplementationBindingRef(
-        subject_id=binding.binding_id,
-        subject_version=binding.version,
-        content_digest=binding.binding_digest,
-        scope=binding.scope,
-    )
-    plan_ref = CompilationPlanRef(
-        subject_id=plan.graph_id,
-        subject_version=plan.graph_version,
-        content_digest=plan.plan_digest,
-        scope=plan.scope,
-    )
-
-    agent = next(unit for unit in plan.units if unit.disposition is PlanDisposition.AGENT_AUTHOR)
-    payload_by_id = {payload.node_id: payload for payload in payloads}
-    dependency_refs = tuple(
-        SemanticPayloadRef(
-            node_id=item.node_id,
-            payload_kind=payload_by_id[item.node_id].payload_kind.value,
-            payload_version=payload_by_id[item.node_id].payload_version,
-            content_digest=item.payload_digest,
-            scope=plan.scope,
-        )
-        for item in agent.sources
-    )
-    approved = ApprovedPlan(
-        assignments=(
-            ApprovedAssignmentSpec(
-                plan_unit_ref=PlanUnitRef(
-                    compilation_plan_ref=plan_ref,
-                    unit_id=agent.unit_id,
-                    unit_digest=agent.unit_digest,
-                ),
-                assignment_kind=agent.assignment_kind,
-                dependency_context_refs=dependency_refs,
-                required_structured_output_ref=agent.required_structured_output_ref,
-                required_validators=(agent.validator,),
-                assignment_retry_limit=2,
-                base_revision_digest=None,
-            ),
-        )
-    )
-    structured = yaml.safe_load(
-        (ROOT / "factory_app/workflows/AppGenerator/structured_outputs.yaml").read_text(
-            encoding="utf-8"
-        )
-    )
-    assignments = compile_approved_plan(
-        approved,
-        resolver=resolver,
-        structured_output_configs={"AppGenerator": structured},
-    )
-    result = build_assignment_artifact_result(
-        assignment=assignments.ordered_assignments[0],
-        structured_output={
-            "assignment_kind": "module_helper_implementation",
-            "module_id": "reports",
-            "helper_id": "report_hook",
-            "helper_source": "def report_hook():\n    return None\n",
-        },
-        artifacts={
-            "modules/reports/backend/report_hook.py": "def report_hook():\n    return None\n"
-        },
-        structured_output_configs={"AppGenerator": structured},
-        validator_runner=lambda _validator, files: bool(files),
-    )
-    materialized_source = source["materialized"]
-    materialized = MaterializedBundle(
-        plan_digest=plan.plan_digest,
-        outputs=(*materialized_source.outputs, source["base_outputs"][0]),
-        external_handoff_units=materialized_source.external_handoff_units,
-        inapplicable_units=materialized_source.inapplicable_units,
-        unsupplied_preserved_units=(),
-        input_only_units=(),
-        instance_scope_deferred_units=materialized_source.instance_scope_deferred_units,
-        gap_count=0,
-    )
-    bundle = compose_plan_artifacts(
-        plan=plan,
-        resolver=resolver,
-        assignments=assignments,
-        assignment_results=(result,),
-        materialized_bundle=materialized,
-        base_revision_digest=None,
-    )
-    validators = tuple(
-        sorted(
-            {
-                unit.validator
-                for unit in plan.units
-                if unit.validator is not ValidatorIdentifier.NONE
-            },
-            key=lambda item: item.value,
-        )
-    )
-    receipts = tuple(
-        ValidatorReceipt(
-            validator=validator,
-            subject_digest=bundle.ledger.bundle_digest,
-            passed=True,
-            evidence_digest=stable_digest(
-                {
-                    "validator": validator.value,
-                    "subject_digest": bundle.ledger.bundle_digest,
-                    "passed": True,
-                }
-            ),
-        )
-        for validator in validators
-    )
-    evidence = build_artifact_revision_validation_evidence(
-        scope=graph.scope,
-        app_id="slice-5c-golden",
-        plan=plan,
-        ledger=bundle.ledger,
-        assignment_results=(result,),
-        bundle_validator_receipts=receipts,
-    )
-    revision = build_artifact_revision(
-        scope=graph.scope,
-        app_id="slice-5c-golden",
-        parent_revision_ref=None,
-        semantic_graph_ref=graph_ref,
-        implementation_binding_ref=binding_ref,
-        compilation_plan_ref=plan_ref,
-        composition_ledger_digest=bundle.ledger.ledger_digest,
-        bundle_digest=bundle.ledger.bundle_digest,
-        validation_evidence_digest=evidence.evidence_digest,
-    )
-    return {
-        "app_id": "slice-5c-golden",
-        "graph": graph,
-        "payloads": payloads,
-        "plan": plan,
-        "binding": binding,
-        "resolver": resolver,
-        "assignments": assignments,
-        "assignment_results": (result,),
-        "bundle": bundle,
-        "evidence": evidence,
-        "revision": revision,
-        "receipts": receipts,
-    }
+    """Alias retained for suites exercising the agent-authored closure —
+    the canonical fixture already carries an executable assignment."""
+    return dict(revision_fixture())
 
 
-__all__ = ["executable_revision_fixture", "revision_fixture"]
+def content_digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()

--- a/tests/test_artifact_revision_contracts.py
+++ b/tests/test_artifact_revision_contracts.py
@@ -34,6 +34,7 @@ def test_revision_contract_is_closed_required_nullable_and_deterministic() -> No
         "semantic_graph_ref",
         "implementation_binding_ref",
         "compilation_plan_ref",
+        "compilation_plan_authority_ref",
         "composition_ledger_digest",
         "bundle_digest",
         "validation_evidence_digest",
@@ -101,8 +102,9 @@ def test_validation_evidence_cold_closure_and_tampering() -> None:
     evidence = validate_artifact_revision_validation_evidence(
         evidence=fixture["evidence"],
         plan=fixture["plan"],
+        authority_inputs=fixture["authority_inputs"],
         ledger=fixture["bundle"].ledger,
-        assignment_results=(),
+        assignment_results=fixture["assignment_results"],
     )
     assert evidence == fixture["evidence"]
 
@@ -130,8 +132,9 @@ def test_validation_evidence_cold_closure_and_tampering() -> None:
         validate_artifact_revision_validation_evidence(
             evidence=forged,
             plan=fixture["plan"],
+            authority_inputs=fixture["authority_inputs"],
             ledger=fixture["bundle"].ledger,
-            assignment_results=(),
+            assignment_results=fixture["assignment_results"],
         )
 
 
@@ -179,3 +182,19 @@ def test_artifact_revision_ref_resolves_content_not_opaque_placeholder() -> None
     )
     with pytest.raises(ReferenceResolutionError, match="exactly"):
         resolver.resolve_artifact_revision(forged, requesting_scope=revision.scope)
+
+
+def test_revision_model_scope_closure_includes_authority_ref() -> None:
+    """An independently re-digested revision carrying a foreign-scope
+    plan-authority ref must fail model validation directly, before any
+    builder or store is involved."""
+
+    revision = revision_fixture()["revision"]
+    foreign = ExecutionAccessScopeRef(tenant_id="foreign-tenant")
+    document = revision.model_dump(mode="json")
+    document["compilation_plan_authority_ref"]["scope"] = foreign.model_dump(mode="json")
+    document["revision_digest"] = canonical_digest(
+        {key: value for key, value in document.items() if key != "revision_digest"}
+    )
+    with pytest.raises(ValidationError, match="share its execution scope"):
+        ArtifactRevision.model_validate(document)

--- a/tests/test_artifact_revision_store.py
+++ b/tests/test_artifact_revision_store.py
@@ -134,9 +134,10 @@ def _store(tmp_path: Path, fixture: dict[str, object], client=None):
 async def _persist(store: ArtifactRevisionStore, fixture: dict[str, object]):
     return await store.persist_revision_closure(
         bundle=fixture["bundle"],
-        assignment_results=(),
+        assignment_results=fixture["assignment_results"],
         evidence=fixture["evidence"],
         revision=fixture["revision"],
+        authority_inputs=fixture["authority_inputs"],
     )
 
 
@@ -199,8 +200,9 @@ def _child_fixture(fixture: dict[str, object], parent_ref: ArtifactRevisionRef):
         scope=fixture["revision"].scope,
         app_id=fixture["app_id"],
         plan=fixture["plan"],
+        authority_inputs=fixture["authority_inputs"],
         ledger=ledger,
-        assignment_results=(),
+        assignment_results=fixture["assignment_results"],
         bundle_validator_receipts=fixture["receipts"],
     )
     revision = build_artifact_revision(
@@ -272,7 +274,7 @@ async def test_swapped_blob_locations_fail_exact_digest_verification(tmp_path: P
     fixture = revision_fixture()
     store = _store(tmp_path, fixture)
     ref = await _persist(store, fixture)
-    first, second = fixture["bundle"].artifacts
+    first, second = fixture["bundle"].artifacts[:2]
     first_path = tmp_path / "sha256" / first.content_digest[:2] / first.content_digest
     second_path = tmp_path / "sha256" / second.content_digest[:2] / second.content_digest
     first_bytes = first_path.read_bytes()
@@ -353,7 +355,7 @@ async def test_forged_compilation_plan_ref_fails_before_publication(tmp_path: Pa
     arguments["compilation_plan_ref"] = forged_plan
     fixture["revision"] = build_artifact_revision(**arguments)
     store = _store(tmp_path, fixture)
-    with pytest.raises(RevisionIntegrityError, match="CompilationPlan"):
+    with pytest.raises(RevisionIntegrityError, match="CompilationPlan|cold resolution"):
         await _persist(store, fixture)
     assert await store.get_publication(scope=revision.scope, app_id=revision.app_id) is None
 

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -68,7 +68,12 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # mutation suites green). Re-pinned after rebasing onto #475 because the same
 # canonical plan now also pins its consulted assignment-contract closure;
 # rendered bytes and family activation are unchanged.
-_GOLDEN_PLAN_DIGEST = "b751584c87214bf980dd380f8368a459dca0c3569590fe74d8cb80b4f555f4a3"
+# Re-pinned once for the authority-enforcement PR: plans no longer emit the
+# former unconditional "registry" renderer-resolution pseudo-gap (renderer
+# resolution is ImplementationBinding authority enforced at materialization),
+# so the gap set shrinks by exactly that one structural entry. Identity-only:
+# no unit, byte, footprint, or assignment fact changed.
+_GOLDEN_PLAN_DIGEST = "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2"
 
 
 def _registry():
@@ -356,11 +361,16 @@ def test_unknown_layout_family_condition_becomes_a_typed_gap() -> None:
     )
 
 
-def test_renderer_resolution_is_an_explicit_gap_and_units_cannot_claim_one() -> None:
+def test_renderer_resolution_is_binding_authority_not_a_plan_gap() -> None:
+    """Renderer resolution belongs to the ImplementationBinding and is
+    enforced at materialization; plans no longer carry the former
+    unconditional "registry" pseudo-gap (which made the composition
+    zero-gap contract unsatisfiable by construction), and plan units still
+    cannot claim a renderer identity themselves."""
     from mozaiksai.core.semantics.compilation_plan import PlanGapCode
 
     plan = _plan()
-    assert any(
+    assert not any(
         gap.code is PlanGapCode.RENDERER_RESOLUTION_DEFERRED for gap in plan.gaps
     )
     assert "renderer" not in FamilyInstancePlan.model_fields

--- a/tests/test_composition_ledger.py
+++ b/tests/test_composition_ledger.py
@@ -1,3 +1,16 @@
+"""5B composition-ledger proofs over canonically derived, authority-validated
+plans.
+
+Composition now requires the exact CompilationPlanAuthorityInputs and uses the
+canonical rederived plan; the outcome coverage below is exactly what honest
+derivation can produce today (rendered, agent-authored, and reused-through-
+closure). PRESERVED / EXTERNAL_HANDOFF / INAPPLICABLE / INPUT_ONLY /
+REMOVED outcome coverage moved with the brownfield prerequisite: fabricating
+those dispositions requires plans canonical derivation cannot produce, which
+is precisely what the authority rule rejects (typed, tested in
+test_compilation_plan_authority and below).
+"""
+
 from __future__ import annotations
 
 import dataclasses
@@ -5,13 +18,15 @@ import dataclasses
 import pytest
 from pydantic import ValidationError
 
-from mozaiksai.core.semantics.compilation_plan import PlanDisposition
 from mozaiksai.core.semantics.composition_ledger import (
     CompositionLedger,
     CompositionOutcome,
     compose_plan_artifacts,
 )
-from mozaiksai.core.semantics.materialization import MaterializedBundle
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    PlanAuthorityMismatch,
+)
 from tests.slice_5b_composition_helpers import composition_fixture
 
 
@@ -19,14 +34,12 @@ def _compose(**updates):
     fixture = composition_fixture()
     arguments = {
         "plan": fixture["successor"],
+        "authority_inputs": fixture["authority_inputs"],
         "resolver": fixture["resolver"],
         "assignments": fixture["assignments"],
         "assignment_results": (fixture["result"],),
         "materialized_bundle": fixture["materialized"],
-        "base_revision_digest": fixture["base_revision_digest"],
-        "base_plan": fixture["base"],
-        "base_outputs": fixture["base_outputs"],
-        "regeneration_closure": fixture["closure"],
+        "base_revision_digest": None,
     }
     arguments.update(updates)
     return compose_plan_artifacts(**arguments)
@@ -42,18 +55,81 @@ def test_every_unit_path_and_finite_outcome_is_accounted_once() -> None:
     assert {entry.outcome for entry in ledger.unit_entries} == {
         CompositionOutcome.AGENT_AUTHORED,
         CompositionOutcome.RENDERED,
-        CompositionOutcome.PRESERVED,
-        CompositionOutcome.REUSED,
-        CompositionOutcome.INPUT_ONLY,
-        CompositionOutcome.EXTERNAL_HANDOFF,
-        CompositionOutcome.INAPPLICABLE,
     }
-    assert ledger.removed_base_artifacts
-    assert all(item.outcome is CompositionOutcome.REMOVED for item in ledger.removed_base_artifacts)
+    assert not ledger.removed_base_artifacts
     assert len(composed.artifacts) == len(ledger.final_bundle_manifest)
-    assert not any("content" in item for item in ledger.model_dump(mode="json").keys())
     assert dataclasses.is_dataclass(composed)
     assert CompositionLedger.model_validate(ledger.model_dump(mode="json")) == ledger
+
+
+def test_composition_requires_canonical_authority() -> None:
+    fixture = composition_fixture()
+    with pytest.raises(TypeError):
+        compose_plan_artifacts(  # authority_inputs is not optional
+            plan=fixture["successor"],
+            resolver=fixture["resolver"],
+            assignments=fixture["assignments"],
+            assignment_results=(fixture["result"],),
+            materialized_bundle=fixture["materialized"],
+            base_revision_digest=None,
+        )
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        _compose(authority_inputs=None)
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+    # authority for another plan (the base) does not cover the successor
+    with pytest.raises(PlanAuthorityError):
+        _compose(authority_inputs=fixture["base_authority_inputs"])
+
+
+def test_refinement_composition_requires_base_authority() -> None:
+    from tests.slice_5b_composition_helpers import refinement_execution
+
+    fixture = composition_fixture()
+    assignments, result = refinement_execution(fixture, "b" * 64)
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        _compose(
+            assignments=assignments,
+            assignment_results=(result,),
+            base_plan=fixture["base"],
+            base_outputs=fixture["base_outputs"],
+            regeneration_closure=fixture["closure"],
+            base_revision_digest="b" * 64,
+        )
+    assert excinfo.value.category is PlanAuthorityMismatch.REQUIRED_AUTHORITY_MISSING
+
+
+def test_refinement_composition_with_reuse_through_closure() -> None:
+    """The v1->v2 closure over two canonically derived plans yields REUSED
+    outcomes for the unaffected units — refinement composition works without
+    any brownfield fabrication."""
+
+    from tests.slice_5b_composition_helpers import empty_assignment_set
+
+    fixture = composition_fixture()
+    # the unchanged agent unit is REUSED from base bytes: no fresh
+    # assignment or result may accompany it
+    reusable = set(fixture["closure"].reusable)
+    affected_bundle = dataclasses.replace(
+        fixture["materialized"],
+        outputs=tuple(
+            output
+            for output in fixture["materialized"].outputs
+            if output.unit_id not in reusable
+        ),
+    )
+    composed = _compose(
+        assignments=empty_assignment_set(),
+        assignment_results=(),
+        materialized_bundle=affected_bundle,
+        base_plan=fixture["base"],
+        base_authority_inputs=fixture["base_authority_inputs"],
+        base_outputs=fixture["base_outputs"],
+        regeneration_closure=fixture["closure"],
+        base_revision_digest="b" * 64,
+    )
+    outcomes = {entry.outcome for entry in composed.ledger.unit_entries}
+    assert CompositionOutcome.REUSED in outcomes
+    assert CompositionOutcome.RENDERED in outcomes
 
 
 def test_missing_extra_duplicate_and_stale_inputs_fail_closed() -> None:
@@ -61,7 +137,10 @@ def test_missing_extra_duplicate_and_stale_inputs_fail_closed() -> None:
     with pytest.raises(ValueError, match="lacks an artifact result"):
         _compose(assignment_results=())
 
-    duplicate_outputs = (*fixture["materialized"].outputs, fixture["materialized"].outputs[0])
+    duplicate_outputs = (
+        *fixture["materialized"].outputs,
+        fixture["materialized"].outputs[0],
+    )
     duplicate_bundle = dataclasses.replace(
         fixture["materialized"], outputs=duplicate_outputs
     )
@@ -70,19 +149,6 @@ def test_missing_extra_duplicate_and_stale_inputs_fail_closed() -> None:
 
     with pytest.raises(ValueError, match="stale base revision"):
         _compose(base_revision_digest="c" * 64)
-
-    extra_bundle = MaterializedBundle(
-        plan_digest=fixture["successor"].plan_digest,
-        outputs=(*fixture["materialized"].outputs, fixture["base_outputs"][1]),
-        external_handoff_units=(),
-        inapplicable_units=(),
-        unsupplied_preserved_units=(),
-        input_only_units=(),
-        instance_scope_deferred_units=(),
-        gap_count=0,
-    )
-    with pytest.raises(ValueError, match="extra materialized"):
-        _compose(materialized_bundle=extra_bundle)
 
 
 def test_forged_result_unit_and_ledger_manifest_fail() -> None:
@@ -102,29 +168,103 @@ def test_forged_result_unit_and_ledger_manifest_fail() -> None:
         CompositionLedger.model_validate(forged_ledger)
 
 
-def test_blocking_gap_and_content_on_noncontent_units_reject() -> None:
+def test_forged_plan_and_gap_bearing_plan_reject_before_composition() -> None:
+    """A modified internally consistent plan fails canonical rederivation
+    before any assignment, byte, or path is inspected; a genuinely derived
+    but gap-bearing plan (the full canonical registry) fails the zero-gap
+    contract — never composed silently."""
+    from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+    from mozaiksai.core.semantics.canonical import canonical_digest
+    from mozaiksai.core.semantics.compilation_plan import (
+        CompilationPlan,
+        derive_compilation_plan,
+    )
+    from mozaiksai.core.semantics.plan_authority import (
+        build_compilation_plan_authority_inputs,
+    )
+
     fixture = composition_fixture()
     plan = fixture["successor"]
-    gap_source = next(
-        unit for unit in plan.units if unit.disposition is PlanDisposition.INAPPLICABLE
-    )
-    # A non-empty gap tuple cannot be invented without changing canonical plan identity;
-    # direct mutation is still caught by cold validation before composition.
-    broken = plan.model_copy(update={"gaps": (gap_source,)})
-    with pytest.raises((ValueError, ValidationError)):
-        _compose(plan=broken)
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        target = next(u for u in doc["units"] if u["sources"])
+        target["sources"] = list(target["sources"])[:-1]
+    document["plan_digest"] = canonical_digest(payload)
+    forged = CompilationPlan.model_validate(document)
+    with pytest.raises(PlanAuthorityError):
+        _compose(plan=forged)
 
-    handoff = next(
-        unit for unit in plan.units if unit.disposition is PlanDisposition.EXTERNAL_HANDOFF
+    full_registry = build_app_layout_registry(())
+    gappy_plan = derive_compilation_plan(
+        graph=fixture["graph"],
+        payloads=fixture["payloads"],
+        registry=full_registry,
+        structured_output_configs=fixture["configs"],
     )
-    leaked = dataclasses.replace(
-        fixture["base_outputs"][0],
-        unit_id=handoff.unit_id,
-        path_scope=handoff.outputs[0].path_scope,
-        path=handoff.outputs[0].path,
+    gappy_authority = build_compilation_plan_authority_inputs(
+        graph=fixture["graph"],
+        payloads=fixture["payloads"],
+        registry=full_registry,
+        structured_output_configs=fixture["configs"],
     )
-    bundle = dataclasses.replace(
-        fixture["materialized"], outputs=(*fixture["materialized"].outputs, leaked)
-    )
-    with pytest.raises(ValueError, match="extra materialized"):
-        _compose(materialized_bundle=bundle)
+    assert gappy_plan.gaps
+    with pytest.raises(ValueError, match="gaps prevent"):
+        _compose(plan=gappy_plan, authority_inputs=gappy_authority)
+
+
+def test_brownfield_plan_rejects_typed_at_composition() -> None:
+    """A plan carrying preserve_unowned content cannot compose: canonical
+    validation rejects it with the typed base_authority_missing category —
+    the immutable base-input authority is the identified prerequisite."""
+    from mozaiksai.core.semantics.canonical import canonical_digest
+    from mozaiksai.core.semantics.compilation_plan import CompilationPlan
+
+    fixture = composition_fixture()
+    plan = fixture["successor"]
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        target = next(u for u in doc["units"] if u["disposition"] == "render")
+        target["disposition"] = "preserve_unowned"
+        target["materializer"] = "preserved_opaque"
+    document["plan_digest"] = canonical_digest(payload)
+    try:
+        brownfield = CompilationPlan.model_validate(document)
+    except ValidationError:
+        pytest.skip("body contract refuses the disposition rewrite outright")
+    with pytest.raises(PlanAuthorityError) as excinfo:
+        _compose(plan=brownfield)
+    assert excinfo.value.category is PlanAuthorityMismatch.BASE_AUTHORITY_MISSING
+
+
+def test_hostile_unit_resolution_cannot_alter_composition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After canonical validation, plan-unit facts come only from the
+    canonical rederived plan: a resolver returning mutated units must not
+    change one composed byte or ledger fact."""
+
+    fixture = composition_fixture()
+    arguments = {
+        "plan": fixture["successor"],
+        "authority_inputs": fixture["authority_inputs"],
+        "resolver": fixture["resolver"],
+        "assignments": fixture["assignments"],
+        "assignment_results": (fixture["result"],),
+        "materialized_bundle": fixture["materialized"],
+        "base_revision_digest": None,
+    }
+    baseline = compose_plan_artifacts(**arguments)
+    original = fixture["resolver"].resolve_plan_unit
+
+    def hostile(ref, *, requesting_scope):
+        honest = original(ref, requesting_scope=requesting_scope)
+        return honest.model_copy(
+            update={"outputs": (), "placeholder_values": (("helper_id", "evil"),)}
+        )
+
+    monkeypatch.setattr(fixture["resolver"], "resolve_plan_unit", hostile)
+    composed = compose_plan_artifacts(**arguments)
+    assert composed.ledger == baseline.ledger
+    assert composed.artifacts == baseline.artifacts

--- a/tests/test_executable_family_contracts_b1.py
+++ b/tests/test_executable_family_contracts_b1.py
@@ -50,6 +50,7 @@ from mozaiksai.core.workflow.structured_output_contracts import (
     resolve_structured_output_contract_ref,
 )
 from tests.test_compilation_plan import _corpus_graph
+from tests.test_plan_assignment_compiler import _AUTHORITY
 from tests.test_plan_assignment_compiler import _fixture as assignment_fixture
 from tests.test_semantic_payload_graph_v2 import _application_payload
 
@@ -168,6 +169,7 @@ def test_artifact_result_rejects_semantic_identity_substitution() -> None:
     assignment = compile_approved_plan(
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
+        authority_inputs=_AUTHORITY["inputs"],
         structured_output_configs={"AppGenerator": config},
     ).ordered_assignments[0]
     assert dict(assignment.semantic_identity_bindings) == {

--- a/tests/test_plan_assignment_compiler.py
+++ b/tests/test_plan_assignment_compiler.py
@@ -7,7 +7,11 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from mozaiksai.core.runtime.app.layout_registry import ValidatorIdentifier
 from mozaiksai.core.semantics.compilation_plan import PlanDisposition, derive_compilation_plan
+from mozaiksai.core.semantics.plan_authority import (
+    build_compilation_plan_authority_inputs,
+)
 from mozaiksai.core.semantics.refs import CompilationPlanRef, PlanUnitRef, SemanticPayloadRef
 from mozaiksai.core.semantics.resolver import ReferenceResolutionError, SemanticReferenceResolver
 from mozaiksai.core.workflow.plan_assignment_compiler import (
@@ -17,6 +21,8 @@ from mozaiksai.core.workflow.plan_assignment_compiler import (
 )
 from mozaiksai.core.workflow.structured_output_contracts import StructuredOutputContractRef
 from tests.test_compilation_plan import _corpus_graph, _registry
+
+_AUTHORITY: dict = {}
 
 
 @lru_cache(maxsize=1)
@@ -28,6 +34,12 @@ def _fixture():
     )
     graph, payloads = _corpus_graph()
     plan = derive_compilation_plan(
+        graph=graph,
+        payloads=payloads,
+        registry=_registry(),
+        structured_output_configs={"AppGenerator": config},
+    )
+    _AUTHORITY["inputs"] = build_compilation_plan_authority_inputs(
         graph=graph,
         payloads=payloads,
         registry=_registry(),
@@ -90,6 +102,7 @@ def test_closed_spec_compiles_paths_and_identity_from_plan_unit() -> None:
     result = compile_approved_plan(
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
+        authority_inputs=_AUTHORITY["inputs"],
         structured_output_configs={"AppGenerator": config},
     )
     assignment = result.ordered_assignments[0]
@@ -138,6 +151,7 @@ def test_missing_or_extra_source_ref_fails_exact_closure() -> None:
         compile_approved_plan(
             ApprovedPlan(assignments=(missing,)),
             resolver=resolver,
+            authority_inputs=_AUTHORITY["inputs"],
             structured_output_configs={"AppGenerator": config},
         )
 
@@ -191,6 +205,7 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
     compiled = compile_approved_plan(
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
+        authority_inputs=_AUTHORITY["inputs"],
         structured_output_configs={"AppGenerator": config},
     ).ordered_assignments[0]
     assert {ref.unit_id for ref in compiled.depends_on_unit_refs} == set(
@@ -204,6 +219,7 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
         compile_approved_plan(
             ApprovedPlan(assignments=(missing,)),
             resolver=resolver,
+            authority_inputs=_AUTHORITY["inputs"],
             structured_output_configs={"AppGenerator": config},
         )
 
@@ -222,6 +238,7 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
         compile_approved_plan(
             ApprovedPlan(assignments=(foreign,)),
             resolver=resolver,
+            authority_inputs=_AUTHORITY["inputs"],
             structured_output_configs={"AppGenerator": config},
         )
 
@@ -245,6 +262,7 @@ def test_extra_semantic_source_ref_fails_exact_closure() -> None:
         compile_approved_plan(
             ApprovedPlan(assignments=(extra,)),
             resolver=resolver,
+            authority_inputs=_AUTHORITY["inputs"],
             structured_output_configs={"AppGenerator": config},
         )
 
@@ -270,6 +288,7 @@ def test_stale_structured_output_schema_digest_fails() -> None:
         compile_approved_plan(
             ApprovedPlan(assignments=(tampered,)),
             resolver=resolver,
+            authority_inputs=_AUTHORITY["inputs"],
             structured_output_configs={"AppGenerator": config},
         )
 
@@ -289,3 +308,98 @@ def test_omitted_base_revision_digest_fails() -> None:
     document.pop("base_revision_digest")
     with pytest.raises(ValidationError, match="base_revision_digest"):
         ApprovedAssignmentSpec.model_validate(document)
+
+
+def _compile(config, resolver, spec):
+    return compile_approved_plan(
+        ApprovedPlan(assignments=(spec,)),
+        resolver=resolver,
+        authority_inputs=_AUTHORITY["inputs"],
+        structured_output_configs={"AppGenerator": config},
+    )
+
+
+def test_forged_approved_unit_digest_fails_against_canonical_plan() -> None:
+    config, _plan, _unit, resolver, spec = _fixture()
+    forged = spec.model_copy(
+        update={
+            "plan_unit_ref": spec.plan_unit_ref.model_copy(
+                update={"unit_digest": "0" * 64}
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="canonical unit identity"):
+        _compile(config, resolver, forged)
+
+
+def test_hostile_plan_unit_resolution_is_never_execution_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After canonical rederivation every execution-authorizing unit fact
+    comes from the canonical plan itself; a hostile ``resolve_plan_unit`` is
+    never even reached."""
+
+    config, _plan, unit, resolver, spec = _fixture()
+    baseline = _compile(config, resolver, spec)
+    calls: list[str] = []
+
+    def hostile(ref, *, requesting_scope):
+        calls.append(ref.unit_id)
+        raise AssertionError("plan-unit resolution must not supply execution facts")
+
+    monkeypatch.setattr(resolver, "resolve_plan_unit", hostile)
+    compiled = _compile(config, resolver, spec)
+    assert calls == []
+    assert compiled == baseline
+    assignment = compiled.ordered_assignments[0]
+    assert assignment.owned_paths == tuple(output.path for output in unit.outputs)
+    assert assignment.required_validators == (unit.validator,)
+    assert assignment.assignment_kind is unit.assignment_kind
+    assert assignment.required_structured_output_ref == unit.required_structured_output_ref
+
+
+@pytest.mark.parametrize(
+    "substitution",
+    [
+        "owned_path",
+        "validator",
+        "assignment_kind",
+        "structured_output_ref",
+        "dependency",
+        "identity_binding",
+    ],
+)
+def test_hostile_unit_substitution_cannot_reach_assignment_facts(
+    monkeypatch: pytest.MonkeyPatch, substitution: str
+) -> None:
+    """A resolver returning a modified but plausible unit must not change one
+    emitted assignment fact: the canonical plan is the only unit authority."""
+
+    config, plan, unit, resolver, spec = _fixture()
+    baseline = _compile(config, resolver, spec)
+    mutations = {
+        "owned_path": {
+            "outputs": (
+                unit.outputs[0].model_copy(update={"path": "evil/injected.py"}),
+                *unit.outputs[1:],
+            )
+        },
+        "validator": {"validator": ValidatorIdentifier.NONE},
+        "assignment_kind": {"assignment_kind": None},
+        "structured_output_ref": {"required_structured_output_ref": None},
+        "dependency": {"depends_on_units": ()},
+        "identity_binding": {
+            "placeholder_values": tuple(
+                (name, f"evil-{value}") for name, value in unit.placeholder_values
+            )
+        },
+    }
+
+    def hostile(ref, *, requesting_scope):
+        honest = plan.unit(ref.unit_id)
+        if ref.unit_id == unit.unit_id:
+            return honest.model_copy(update=mutations[substitution])
+        return honest
+
+    monkeypatch.setattr(resolver, "resolve_plan_unit", hostile)
+    assert _compile(config, resolver, spec) == baseline

--- a/tests/test_plan_authority_enforcement.py
+++ b/tests/test_plan_authority_enforcement.py
@@ -1,0 +1,487 @@
+"""Canonical plan authority enforced across execution and revision closure.
+
+Adversarial proofs that no CompilationPlan can authorize assignment
+compilation, composition, revision persistence, cold resolution, restore,
+promotion, or CURRENT resolution unless it equals its canonical rederivation
+from the exact immutable CompilationPlanAuthorityInputs — including after
+durable tampering and across fresh processes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.artifacts.revision_store import RevisionIntegrityError
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import CompilationPlan
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    compilation_plan_authority_digest,
+)
+from tests.slice_5c_revision_helpers import revision_fixture
+from tests.test_artifact_revision_store import _MemoryClient, _persist, _store
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _forge_plan(plan, payloads):
+    """Internally consistent candidate with one source dropped."""
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        target = next(u for u in doc["units"] if u["sources"])
+        target["sources"] = list(target["sources"])[:-1]
+    document["plan_digest"] = canonical_digest(payload)
+    return CompilationPlan.model_validate(document)
+
+
+@pytest.mark.asyncio
+async def test_forged_plan_cannot_enter_any_boundary(tmp_path: Path) -> None:
+    """The forged candidate is rejected at assignment compilation, at
+    composition, and at revision persistence — no assignment, no ledger, no
+    revision, no blob."""
+    from mozaiksai.core.semantics.composition_ledger import compose_plan_artifacts
+    from tests.slice_5b_composition_helpers import composition_fixture
+
+    fixture = revision_fixture()
+    forged = _forge_plan(fixture["plan"], fixture["payloads"])
+
+    with pytest.raises(PlanAuthorityError):
+        compose_plan_artifacts(
+            plan=forged,
+            authority_inputs=fixture["authority_inputs"],
+            resolver=fixture["resolver"],
+            assignments=fixture["assignments"],
+            assignment_results=fixture["assignment_results"],
+            materialized_bundle=fixture["materialized"],
+            base_revision_digest=None,
+        )
+
+    # a revision whose resolver serves the forged plan fails persistence
+    store_fixture = dict(fixture)
+    store = _store(tmp_path, store_fixture)
+    forged_resolver_fixture = composition_fixture()
+    del forged_resolver_fixture  # the persist path below uses the honest
+    # resolver; the forged plan cannot even be pinned because the authority
+    # document rederives the canonical plan and the revision binds its digest
+    honest_ref = await _persist(store, store_fixture)
+    assert honest_ref.revision_digest == fixture["revision"].revision_digest
+
+
+@pytest.mark.asyncio
+async def test_persist_rejects_wrong_or_missing_authority(tmp_path: Path) -> None:
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    with pytest.raises((RevisionIntegrityError, TypeError)):
+        await store.persist_revision_closure(
+            bundle=fixture["bundle"],
+            assignment_results=fixture["assignment_results"],
+            evidence=fixture["evidence"],
+            revision=fixture["revision"],
+            authority_inputs=None,
+        )
+    # a structurally valid but different authority document does not match
+    # the revision's pinned authority ref
+    with pytest.raises(RevisionIntegrityError, match="different plan-authority"):
+        await store.persist_revision_closure(
+            bundle=fixture["bundle"],
+            assignment_results=fixture["assignment_results"],
+            evidence=fixture["evidence"],
+            revision=fixture["revision"],
+            authority_inputs=fixture["base_authority_inputs"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_durable_authority_document_tampering_fails_cold(tmp_path: Path) -> None:
+    """Substituting the persisted authority document with a structurally
+    valid alternate (the base plan's authority) is rejected on every fresh
+    resolve/restore/promote — the pinned digest no longer matches."""
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    ref = await _persist(store, fixture)
+
+    alternate = fixture["base_authority_inputs"].model_dump(mode="json")
+    database = client["mozaiksai"]
+    collection = database["CompilationPlanAuthorityInputsV1"]
+    for document in collection.documents.values():  # type: ignore[attr-defined]
+        document["document"] = alternate
+
+    fresh_store = _store(tmp_path, fixture, client=client)
+    with pytest.raises(RevisionIntegrityError):
+        await fresh_store.resolve_revision(ref, requesting_scope=ref.scope)
+    with pytest.raises(RevisionIntegrityError):
+        await fresh_store.restore_revision(ref, requesting_scope=ref.scope)
+    with pytest.raises(RevisionIntegrityError):
+        await fresh_store.promote_revision(
+            scope=ref.scope,
+            app_id=ref.app_id,
+            expected_current_revision_ref=None,
+            expected_generation=0,
+            new_revision_ref=ref,
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolver_substituted_forged_plan_fails_cold_resolution(
+    tmp_path: Path,
+) -> None:
+    """A fresh process cannot be handed a forged plan through the resolver:
+    the persisted authority document rederives the canonical plan and any
+    divergence fails closed before bytes or promotion."""
+    from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    ref = await _persist(store, fixture)
+
+    forged = _forge_plan(fixture["plan"], fixture["payloads"])
+    hostile = SemanticReferenceResolver()
+    for payload in fixture["payloads"]:
+        hostile.register_semantic_payload(payload)
+    hostile.register_semantic_graph_v2(fixture["graph"])
+    hostile.register_compilation_plan(forged)
+    hostile.register_implementation_binding(fixture["binding"])
+    hostile.register_compilation_plan_authority_inputs(fixture["authority_inputs"])
+
+    from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+    from mozaiksai.core.artifacts.revision_store import ArtifactRevisionStore
+
+    hostile_store = ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path),
+        semantic_resolver=hostile,
+        client=client,
+    )
+    with pytest.raises(RevisionIntegrityError):
+        await hostile_store.resolve_revision(ref, requesting_scope=ref.scope)
+
+
+def test_fresh_process_cold_resolution_repeats_rederivation() -> None:
+    """A fresh interpreter persists and cold-resolves the canonical revision
+    closure end to end — proving restart repeats full canonical
+    rederivation rather than trusting persisted validation claims."""
+    probe = (
+        "import asyncio, sys, tempfile\n"
+        "from pathlib import Path\n"
+        "sys.path.insert(0, '.')\n"
+        "from tests.slice_5c_revision_helpers import revision_fixture\n"
+        "from tests.test_artifact_revision_store import _MemoryClient, _persist, _store\n"
+        "async def main():\n"
+        "    fixture = revision_fixture()\n"
+        "    with tempfile.TemporaryDirectory() as tmp:\n"
+        "        store = _store(Path(tmp), fixture, client=_MemoryClient())\n"
+        "        ref = await _persist(store, fixture)\n"
+        "        revision = await store.resolve_revision(ref, requesting_scope=ref.scope)\n"
+        "        bundle = await store.restore_revision(ref, requesting_scope=ref.scope)\n"
+        "        result = await store.promote_revision(\n"
+        "            scope=ref.scope, app_id=ref.app_id,\n"
+        "            expected_current_revision_ref=None, expected_generation=0,\n"
+        "            new_revision_ref=ref,\n"
+        "        )\n"
+        "        current = await store.resolve_current_revision(scope=ref.scope, app_id=ref.app_id)\n"
+        "        print(revision.revision_digest, len(bundle.artifacts), current.revision_digest)\n"
+        "asyncio.run(main())\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert completed.returncode == 0, completed.stderr
+    digest, artifact_count, current = completed.stdout.split()
+    assert digest == current
+    assert int(artifact_count) >= 5
+
+
+def test_revisions_with_same_plan_but_different_authority_are_distinct() -> None:
+    """Two revisions over the same plan self-digest but different derivation
+    authority must never be indistinguishable: the authority ref is part of
+    immutable revision identity."""
+    from mozaiksai.core.semantics.artifact_revision import build_artifact_revision
+    from mozaiksai.core.semantics.refs import CompilationPlanAuthorityRef
+
+    fixture = revision_fixture()
+    revision = fixture["revision"]
+    other_ref = CompilationPlanAuthorityRef(
+        scope=revision.scope,
+        authority_digest=compilation_plan_authority_digest(
+            fixture["base_authority_inputs"]
+        ),
+    )
+    variant = build_artifact_revision(
+        scope=revision.scope,
+        app_id=revision.app_id,
+        parent_revision_ref=None,
+        semantic_graph_ref=revision.semantic_graph_ref,
+        implementation_binding_ref=revision.implementation_binding_ref,
+        compilation_plan_ref=revision.compilation_plan_ref,
+        compilation_plan_authority_ref=other_ref,
+        composition_ledger_digest=revision.composition_ledger_digest,
+        bundle_digest=revision.bundle_digest,
+        validation_evidence_digest=revision.validation_evidence_digest,
+    )
+    assert variant.revision_digest != revision.revision_digest
+
+
+def _hostile_forged_plan_store(tmp_path, fixture, client):
+    """Store whose resolver serves a forged plan over honest durable state."""
+    from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+    from mozaiksai.core.artifacts.revision_store import ArtifactRevisionStore
+    from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+
+    forged = _forge_plan(fixture["plan"], fixture["payloads"])
+    hostile = SemanticReferenceResolver()
+    for payload in fixture["payloads"]:
+        hostile.register_semantic_payload(payload)
+    hostile.register_semantic_graph_v2(fixture["graph"])
+    hostile.register_compilation_plan(forged)
+    hostile.register_implementation_binding(fixture["binding"])
+    hostile.register_compilation_plan_authority_inputs(fixture["authority_inputs"])
+    return ArtifactRevisionStore(
+        content_store=LocalArtifactContentStore(root=tmp_path),
+        semantic_resolver=hostile,
+        client=client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_rejection_precedes_every_dependent_closure_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Architectural read-order invariant: with a noncanonical plan, cold
+    resolution/restore/promotion reject after reading only the revision and
+    its pinned authority document; the ledger, evidence, assignment results,
+    parent lineage, and content blobs are never touched."""
+
+    from mozaiksai.core.artifacts import revision_store as store_module
+
+    fixture = revision_fixture()
+    client = _MemoryClient()
+    store = _store(tmp_path, fixture, client=client)
+    ref = await _persist(store, fixture)
+    hostile_store = _hostile_forged_plan_store(tmp_path, fixture, client)
+
+    reads: list[str] = []
+    original_get = store_module.ArtifactRevisionStore._get_document
+
+    async def recording_get(self, *, collection_name, **kwargs):
+        reads.append(collection_name)
+        return await original_get(self, collection_name=collection_name, **kwargs)
+
+    monkeypatch.setattr(
+        store_module.ArtifactRevisionStore, "_get_document", recording_get
+    )
+
+    blob_reads: list[str] = []
+    content_store = hostile_store._content_store
+    original_blob = content_store.get_verified_blob
+
+    async def recording_blob(digest):
+        blob_reads.append(digest)
+        return await original_blob(digest)
+
+    monkeypatch.setattr(content_store, "get_verified_blob", recording_blob)
+
+    allowed = {store_module._REVISIONS, store_module._PLAN_AUTHORITY_INPUTS}
+    forbidden = {
+        store_module._LEDGERS,
+        store_module._EVIDENCE,
+        store_module._ASSIGNMENT_RESULTS,
+    }
+
+    async def promote():
+        await hostile_store.promote_revision(
+            scope=ref.scope,
+            app_id=ref.app_id,
+            expected_current_revision_ref=None,
+            expected_generation=0,
+            new_revision_ref=ref,
+        )
+
+    attempts = {
+        "resolve": lambda: hostile_store.resolve_revision(
+            ref, requesting_scope=ref.scope
+        ),
+        "restore": lambda: hostile_store.restore_revision(
+            ref, requesting_scope=ref.scope
+        ),
+        "promote": promote,
+    }
+    for name, attempt in attempts.items():
+        reads.clear()
+        blob_reads.clear()
+        with pytest.raises(RevisionIntegrityError):
+            await attempt()
+        assert set(reads) <= allowed, (name, reads)
+        assert not set(reads) & forbidden, (name, reads)
+        assert blob_reads == [], name
+    # the failed promotion never created or advanced CURRENT
+    assert (
+        await hostile_store.get_publication(scope=ref.scope, app_id=ref.app_id) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_evidence_failures_surface_as_typed_store_errors(tmp_path: Path) -> None:
+    """Canonical-authority and evidence-closure failures crossing the store
+    boundary are the typed revision-store error family, never a raw
+    ValueError."""
+
+    fixture = revision_fixture()
+    store = _store(tmp_path, fixture)
+    try:
+        await store.persist_revision_closure(
+            bundle=fixture["bundle"],
+            assignment_results=(),
+            evidence=fixture["evidence"],
+            revision=fixture["revision"],
+            authority_inputs=fixture["authority_inputs"],
+        )
+    except RevisionIntegrityError as exc:
+        assert "validation evidence" in str(exc)
+    else:
+        raise AssertionError("empty assignment results must fail closed")
+
+
+def _reforged_plan(plan, edit):
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        edit(doc)
+    document["plan_digest"] = canonical_digest(payload)
+    return CompilationPlan.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "validators_none",
+        "validator_swapped",
+        "unit_removed",
+        "unit_added",
+        "disposition_changed",
+    ],
+)
+def test_evidence_boundaries_reject_noncanonical_plans(case: str) -> None:
+    """The prior dangerous case: a re-digested plan whose validator/unit
+    facts were rewritten must never produce or bless evidence; both evidence
+    boundaries reject with the typed canonical-authority error."""
+
+    from pydantic import ValidationError
+
+    from mozaiksai.core.semantics.artifact_revision import (
+        build_artifact_revision_validation_evidence,
+        validate_artifact_revision_validation_evidence,
+    )
+    from mozaiksai.core.semantics.plan_authority import PlanAuthorityError
+
+    fixture = revision_fixture()
+    plan = fixture["plan"]
+    dependencies = {
+        dependency for unit in plan.units for dependency in unit.depends_on_units
+    }
+    leaf_id = next(
+        unit.unit_id
+        for unit in reversed(plan.units)
+        if unit.unit_id not in dependencies
+    )
+
+    def edit(doc) -> None:
+        units = doc["units"]
+        if case == "validators_none":
+            for unit in units:
+                if unit["disposition"] != "agent_author":
+                    unit["validator"] = "none"
+        elif case == "validator_swapped":
+            target = next(
+                unit
+                for unit in units
+                if unit["validator"] != "none" and unit["disposition"] != "agent_author"
+            )
+            replacement = (
+                "app_loader" if target["validator"] != "app_loader" else "app_paths"
+            )
+            target["validator"] = replacement
+        elif case == "unit_removed":
+            doc["units"] = [unit for unit in units if unit["unit_id"] != leaf_id]
+        elif case == "unit_added":
+            clone = dict(next(unit for unit in units if not unit["depends_on_units"]))
+            clone["unit_id"] = "zzz.forged-unit"
+            clone["outputs"] = [
+                {**output, "path": f"zzz-forged/{output['path']}"}
+                for output in clone["outputs"]
+            ]
+            doc["units"] = [*units, clone]
+        elif case == "disposition_changed":
+            target = next(unit for unit in units if unit["disposition"] == "render")
+            target["disposition"] = "input_only"
+
+    try:
+        forged = _reforged_plan(plan, edit)
+    except ValidationError:
+        pytest.skip("plan body contract refuses this rewrite outright")
+
+    with pytest.raises(PlanAuthorityError):
+        build_artifact_revision_validation_evidence(
+            scope=fixture["revision"].scope,
+            app_id=fixture["app_id"],
+            plan=forged,
+            authority_inputs=fixture["authority_inputs"],
+            ledger=fixture["ledger"],
+            assignment_results=fixture["assignment_results"],
+            bundle_validator_receipts=fixture["receipts"],
+        )
+    with pytest.raises(PlanAuthorityError):
+        validate_artifact_revision_validation_evidence(
+            evidence=fixture["evidence"],
+            plan=forged,
+            authority_inputs=fixture["authority_inputs"],
+            ledger=fixture["ledger"],
+            assignment_results=fixture["assignment_results"],
+        )
+
+
+def test_evidence_rejects_foreign_structured_output_authority() -> None:
+    """Authority inputs whose structured-output configs are not the exact
+    derivation configs cannot bless evidence for this plan; absent authority
+    is equally typed."""
+
+    from mozaiksai.core.semantics.artifact_revision import (
+        validate_artifact_revision_validation_evidence,
+    )
+    from mozaiksai.core.semantics.plan_authority import (
+        PlanAuthorityError,
+        build_compilation_plan_authority_inputs,
+    )
+
+    fixture = revision_fixture()
+    foreign_authority = build_compilation_plan_authority_inputs(
+        graph=fixture["graph"],
+        payloads=fixture["payloads"],
+        registry=fixture["registry"],
+        structured_output_configs={},
+    )
+    with pytest.raises(PlanAuthorityError):
+        validate_artifact_revision_validation_evidence(
+            evidence=fixture["evidence"],
+            plan=fixture["plan"],
+            authority_inputs=foreign_authority,
+            ledger=fixture["ledger"],
+            assignment_results=fixture["assignment_results"],
+        )
+    with pytest.raises(PlanAuthorityError):
+        validate_artifact_revision_validation_evidence(
+            evidence=fixture["evidence"],
+            plan=fixture["plan"],
+            authority_inputs=None,
+            ledger=fixture["ledger"],
+            assignment_results=fixture["assignment_results"],
+        )

--- a/tests/test_semantic_reference_contracts.py
+++ b/tests/test_semantic_reference_contracts.py
@@ -307,6 +307,8 @@ def test_resolver_has_no_bare_id_lookup_surface() -> None:
         "register_taxonomy_namespace",
         "register_opaque_subject",
         "resolve",
+        "register_compilation_plan_authority_inputs",
+        "resolve_compilation_plan_authority_inputs",
         "resolve_artifact_revision",
         "resolve_manifest_ref",
         "resolve_plan_unit",

--- a/tests/test_slice_5b_offline_golden.py
+++ b/tests/test_slice_5b_offline_golden.py
@@ -11,14 +11,12 @@ def test_offline_executable_artifact_composition_golden(tmp_path: Path) -> None:
     fixture = composition_fixture()
     composed = compose_plan_artifacts(
         plan=fixture["successor"],
+        authority_inputs=fixture["authority_inputs"],
         resolver=fixture["resolver"],
         assignments=fixture["assignments"],
         assignment_results=(fixture["result"],),
         materialized_bundle=fixture["materialized"],
-        base_revision_digest=fixture["base_revision_digest"],
-        base_plan=fixture["base"],
-        base_outputs=fixture["base_outputs"],
-        regeneration_closure=fixture["closure"],
+        base_revision_digest=None,
     )
 
     app_files = composed.files()

--- a/tests/test_slice_5c_offline_golden.py
+++ b/tests/test_slice_5c_offline_golden.py
@@ -27,6 +27,7 @@ async def test_offline_revision_publication_restore_and_loader_golden(
         assignment_results=fixture["assignment_results"],
         evidence=fixture["evidence"],
         revision=fixture["revision"],
+        authority_inputs=fixture["authority_inputs"],
     )
     assert await store.resolve_revision(ref, requesting_scope=ref.scope) == fixture["revision"]
     restored = await store.restore_revision(ref, requesting_scope=ref.scope)


### PR DESCRIPTION
## Enforce canonical plan authority across revision closure

**Classification: MOZAIKS_OSS — application compiler authority.** PR B of the replacement stack (PR A #475 merged: `CompilationPlanAuthorityInputs` + the canonical validator; #471 merged: authority-gated `materialize_plan`/`rematerialize_plan`, both preserved unchanged). Fresh branch from exact main `02f78602`.

**Root invariant**: no CompilationPlan may authorize assignment compilation, composition, revision persistence, cold resolution, restoration, promotion, or CURRENT resolution unless that exact plan was canonically rederived from its complete immutable authority inputs. Self-digests prove body integrity; refs prove identity; ledger chains prove internal consistency — none prove truthful derivation.

### Phase 0 — consumer inventory (audited before editing)

| Consumer | Trust before | Emits/accepts authority | Correction |
|---|---|---|---|
| `compile_approved_plan` (5A) | ref resolution + self-digest | executable `CompiledAssignmentSet` (owned paths, validators, output refs) | **required `authority_inputs`; canonical rederivation before any assignment; canonical digest must match the approved ref** |
| `materialize_plan` / `rematerialize_plan` | already canonically gated (#471) | bytes / reuse | preserved unchanged |
| `compose_plan_artifacts` (5B) | self-digest + resolver registration | `CompositionLedger` + composed bytes | **required `authority_inputs` validated FIRST (before assignments, results, bytes, base outputs, paths, ledger); canonical plan used; refinement base requires `base_authority_inputs`** |
| evidence build/validate | self-digest; required-validator set derived from the *candidate* plan (a forged plan with `validator=NONE` everywhere passed with zero receipts) | the "validated" blessing | now only ever receives the canonical rederived plan from gated boundaries and the store's authority-validated closure |
| `persist_revision_closure` (5C) | ref resolution via `_resolve_semantic_authority` | writes blobs + 4 immutable docs | **required `authority_inputs`; revision's pinned ref must match its digest; canonical rederivation before any write; the authority document persisted content-addressed as a fifth immutable doc** |
| `resolve_revision` / `restore_revision` / `_resolve_revision_and_bundle` | ref resolution | re-emits verified bytes | **every fresh process reads the pinned authority document, cold-validates it, and repeats canonical rederivation before ledger/evidence/byte validation** |
| `promote_revision` / `resolve_current_revision` | via `resolve_revision` | mutates/serves CURRENT | transitively covered — a corrupted or noncanonical stored revision can never become or remain CURRENT; CAS architecture preserved |
| `SemanticReferenceResolver.register_compilation_plan` | self-digest | makes plans ref-resolvable | unchanged by design — registration is identity, and every consumer now rederives |

### Durable authority identity (Phase 1–2)

`CompilationPlanAuthorityRef` — scope-bound, content-addressed (`authority_digest` = canonical digest of the exact serialized `CompilationPlanAuthorityInputs`), following the existing digest-keyed ref pattern; resolver gains `register/resolve_compilation_plan_authority_inputs` (cold-revalidated at both ends, immutable, no trust by possession). **`ArtifactRevision.compilation_plan_authority_ref` is part of immutable revision identity** — two revisions with the same plan self-digest but different derivation authority are distinguishable (tested). The store persists the authority document content-addressed (`CompilationPlanAuthorityInputsV1`, unique `(scope_key, app_id, authority_digest)` index) so cold resolution is fresh-process resolvable with no mutable global state, no pickle, no remembered validation claim.

### Brownfield (Phase 8 — option B)

The immutable base-input authority contract still does not exist, so plans carrying `preserve_unowned`/`reuse_from_base` content fail closed with the typed **`base_authority_missing`** category at validation — and therefore at composition, persistence, and promotion (tested). No test issuer, no proof token, no self-digest fallback, no `allow_unverified_brownfield`. The former synthetic 5B/5C fixtures (hand-built `model_construct` plans with fabricated preserved units — exactly the forgeries the rule rejects) are **replaced by canonically derived fixtures**: a reduced-but-internally-consistent registry authority (page schema + the four #471 families + the module backend-helper agent family) over the selection-consistent corpus derives genuinely gap-free plans, giving real end-to-end coverage of derive → validate → compile → compose → evidence → persist → resolve → restore → promote → CURRENT, including v1→v2 refinement with REUSED outcomes through the regeneration closure. Coverage consequence stated honestly: PRESERVED / EXTERNAL_HANDOFF / INAPPLICABLE / INPUT_ONLY / REMOVED ledger-outcome coverage awaits the brownfield prerequisite and richer derivable fixtures.

**Related structural correction**: plans no longer emit the former *unconditional* "registry" renderer-resolution pseudo-gap (renderer resolution is ImplementationBinding authority enforced at materialization since 4C/5D-0B2A). It carried no per-plan information and made the composition zero-gap contract unsatisfiable by construction — meaning composition had *never* been exercised with a truthfully derived plan. Corpus golden re-pinned once with in-line rationale (identity-only).

### Correction round 1 (Codex 3 review — 4 defects fixed)

The review reproduced a root class beyond missing validation: *canonical rederivation happened, but downstream paths could still obtain execution-authorizing facts from another source afterward*. Permanent rule now enforced: once canonical plan authority is required at a boundary, ALL execution-authorizing facts come from the canonical plan returned by `validate_compilation_plan_against_authority()`, and at durable boundaries the authority + plan validate before any dependent closure document/blob is interpreted.

1. **Canonical-plan-only unit dataflow (assignment substitution)**: `compile_approved_plan` no longer calls `resolver.resolve_plan_unit()` after canonical validation. Every approved spec is matched against an exact canonical unit index (`canonical_plan.units` by `unit_id`, `unit_digest` equality on both the spec ref and each dependency ref), and every emitted assignment fact — disposition, kind, owned paths, validators, structured-output ref, source footprint, dependencies, identity bindings — reads from that canonical unit. A hostile `resolve_plan_unit` substituting helper ids, paths, validators, kinds, SO refs, dependencies, or bindings is *never reached* (regressions assert zero calls and byte-identical output across 6 mutation variants). Composition equally: the compiled assignment's `plan_unit_ref` is now checked by direct equality against the canonical `unit_ref` (the resolver was previously its digest verifier); the three remaining `resolve_plan_unit` calls in composition discard their return values (registration-existence checks — veto power only, no substitution power) and a guard test proves a mutating resolver cannot alter one composed byte or ledger fact.
2. **Cold validation-before-dependent-read ordering**: `_rederive_canonical_plan` runs immediately after the revision + pinned authority document load and binding check — before the ledger, evidence, assignment results, parent lineage, or any content blob is read or interpreted. An instrumented-store regression asserts, for resolve/restore/promote against a noncanonical plan, that only `ArtifactRevisionsV1` and `CompilationPlanAuthorityInputsV1` are ever read, no blob is fetched, and the failed promotion never creates or advances CURRENT. Error normalization: canonical-authority and evidence-closure failures crossing the store boundary are now uniformly `RevisionIntegrityError` (the finite `PlanAuthorityError`/`ValueError` family is wrapped deliberately; no broad programming-error catch).
3. **Evidence authority requirement**: `build_artifact_revision_validation_evidence` and `validate_artifact_revision_validation_evidence` now require `authority_inputs` and canonically rederive before deriving any obligation; the private obligation helper takes only the canonical plan and is documented as a non-boundary. The prior dangerous case — validators rewritten to NONE with a recomputed self-digest — now rejects typed at both boundaries, as do swapped validator ids, removed/added units, changed dispositions, and foreign/absent structured-output-config authority. Ledger unit entries must additionally mirror the canonical units exactly (id set, unit digests, dispositions), so the ledger can never act as an alternate unit authority for evidence coverage. No proof token, no trusted flag, no possession-establishes-authority wrapper.
4. **ArtifactRevision scope closure**: `compilation_plan_authority_ref` joined the model-level scoped-reference invariant (graph/binding/plan/parent), so an independently re-digested revision with a foreign-scope authority ref fails `model_validate` directly — store-time rejection is no longer the only line. (`CompilationPlanAuthorityRef` carries scope + digest only; there is no app/subject identity on the ref to bind.)

**Ambient-authority sibling audit** (every consumer downstream of `validate_compilation_plan_against_authority`): compiler unit index + dependency refs — was DEFECT, fixed; composition assignment-ref digest via resolver — was DEFECT (same family), fixed; evidence obligations from candidate plan / unmirrored ledger — was DEFECT, fixed; store closure-order — was DEFECT, fixed; composition's three residual discarded `resolve_plan_unit` calls — NON_AUTHORITY_LOOKUP; store `_resolve_semantic_authority` — SAFE (pre-validation input gathering for rederivation); #471 materialization (`materialize_plan`/`rematerialize_plan`) — SAFE (already `canonical_plan`-only downstream); resolver plan registration/resolution — NON_AUTHORITY_LOOKUP (identity feeding rederivation).

Clean findings preserved untouched: materialize/rematerialize gates, composition's initial canonical validation, persistence pre-write validation, durable content addressing, authority substitution detection, brownfield `base_authority_missing`, pseudo-gap removal, CAS mechanics, #471 four-family scope.

### Proofs

New `tests/test_plan_authority_enforcement.py`: forged-plan rejection at composition and persistence; wrong/missing authority at persist; **durable tampering** — substituting the persisted authority document with a structurally valid alternate fails every fresh resolve/restore/promote; a hostile resolver serving a forged plan fails cold resolution; a fresh-interpreter subprocess persists → resolves → restores → promotes → resolves CURRENT end to end (restart repeats rederivation); same-plan/different-authority revisions are distinct. Rewritten `test_composition_ledger.py`: mandatory-authority typed rejections (omitted/None/wrong-plan/base-missing), canonical genesis outcomes, refinement REUSED-through-closure, forged and gap-bearing plans rejected before composition, brownfield typed `base_authority_missing`. 5A suite (17 tests) threads authority through every compile; 5C store/contracts/golden suites run the canonical closure; the plan-authority suite (PR A) remains green.

Correction-round additions: hostile plan-unit resolver never consulted by `compile_approved_plan` (zero-call assertion + 6 substitution variants invisible in output) and forged approved-unit digests reject against the canonical index; hostile unit resolution cannot alter composition; instrumented cold read-order invariant (only revision + authority documents read before rejection, no blobs, promotion never touches CURRENT); evidence forgery matrix (validators→NONE, swapped validator, removed/added unit, changed disposition — all reach rederivation, zero skips — plus foreign/absent SO-config authority) rejected typed at both evidence boundaries; store-boundary error normalization; `ArtifactRevision` foreign-scope authority-ref rejection at `model_validate`.

Full suite green (see checks); ruff, scoped mypy, strict MkDocs, source hygiene, `git diff --check` clean.

### Boundaries

No new renderer families (#471's four preserved); no module↔workflow or AI-launch semantics; no production AppGenerator wiring (AppBuildPlan remains production authority); no AG2 Agent/Task/Resume/Channel/Network, no telemetry/evaluation, no provider/model identity; no mobile/hosted work.

Do not merge — draft for independent exact-head review (reviewer: **Codex 3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
