### PR TITLE
feat(semantics): model module-workflow capability bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,26 +16,32 @@ This project follows a practical pre-1.0 changelog format:
 - **Typed module↔workflow capability semantics**: the semantic graph now
   models the relationship between deterministic application capabilities
   (modules, actions, events) and agentic capabilities (workflows) as
-  canonical typed identity instead of stringly convention. Two new node
+  canonical typed identity instead of stringly convention. Three new node
   kinds — `workflow_capability` (the application-semantic identity of one
   workflow capability: a stable `capability_id` owned by exactly one
-  workflow) and `workflow_capability_binding` (one directional, typed
-  relationship per node: `consumes_action`,
-  `commits_result_through_action` with a provider-neutral
-  `workflow_result_id`, or `triggered_by_event`) — plus `ModuleActionRef`,
+  workflow), `workflow_capability_binding` (one directional, typed
+  relationship per node: `consumes_action`, `commits_result_through_action`,
+  or `triggered_by_event`), and `workflow_result` (the typed,
+  capability-owned semantic identity of one workflow output — never a
+  provider schema, model class, or AG2 runtime id) — plus `ModuleActionRef`,
   the exact module/action node identity that carries no HTTP path, handler
-  path, or AG2 tool identity. Payload closure rejects references to
-  nonexistent modules/actions/workflows/capabilities/events, actions the
-  named module does not declare, events no module produces, duplicate
-  binding identities, ambiguous duplicate capability ownership, and
-  missing derived traversal edges; generic BINDS/CONSUMES/DECLARES edges
-  are derived from the typed payloads, never authored as free-standing
-  meaning. AG2 Agent/Task/Network identities stay out of the graph —
-  a Mozaiks workflow capability is application semantics; AG2 runtime
-  objects remain execution implementation details. The new semantics are
-  offline contracts: no module_interface.yaml rendering, no layout-registry
-  families, and no production AppGenerator/AgentGenerator wiring in this
-  change.
+  path, or AG2 tool identity. Typed payloads own application meaning; graph
+  edges are derived projections: every action used through `ModuleActionRef`
+  must have exactly one canonical module owner, event-production authority
+  comes from typed `ActionPayload.emits` joined to the EVENT node's canonical
+  taxonomy identity (a bare EMITS edge can never invent production), commit
+  bindings reference a declared `workflow_result` node owned by their own
+  capability (result fan-out is explicit: several commit bindings referencing
+  the same result node), and each capability/binding/result node must
+  participate in exactly its derived edge set — full edge identity,
+  discriminator included — so payload-unbacked edge mutations fail closed.
+  AG2 Agent/Task/Network identities stay out of the graph — a Mozaiks
+  workflow capability is application semantics; AG2 runtime objects remain
+  execution implementation details. The offline projection now records
+  module-manifest action `emits` into the typed `ActionPayload` it already
+  drew EMITS edges from. The new semantics are offline contracts: no
+  module_interface.yaml rendering, no layout-registry families, and no
+  production AppGenerator/AgentGenerator wiring in this change.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ This project follows a practical pre-1.0 changelog format:
   the same result node), and each capability/binding/result node must
   participate in exactly its derived edge set — full edge identity,
   discriminator included — so payload-unbacked edge mutations fail closed.
+  Every module-declared action forms the canonical ownership family: its
+  complete declarer set must close to exactly one module (contradictory
+  non-module DECLARES edges are never filtered away), every typed emit must
+  resolve to exactly one EVENT node carrying exactly one canonical identity
+  — independent of whether any workflow or trigger consumes the event — and
+  its EMITS edge set must equal the typed projection exactly.
   AG2 Agent/Task/Network identities stay out of the graph — a Mozaiks
   workflow capability is application semantics; AG2 runtime objects remain
   execution implementation details. The offline projection now records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Added
+- **Typed module↔workflow capability semantics**: the semantic graph now
+  models the relationship between deterministic application capabilities
+  (modules, actions, events) and agentic capabilities (workflows) as
+  canonical typed identity instead of stringly convention. Two new node
+  kinds — `workflow_capability` (the application-semantic identity of one
+  workflow capability: a stable `capability_id` owned by exactly one
+  workflow) and `workflow_capability_binding` (one directional, typed
+  relationship per node: `consumes_action`,
+  `commits_result_through_action` with a provider-neutral
+  `workflow_result_id`, or `triggered_by_event`) — plus `ModuleActionRef`,
+  the exact module/action node identity that carries no HTTP path, handler
+  path, or AG2 tool identity. Payload closure rejects references to
+  nonexistent modules/actions/workflows/capabilities/events, actions the
+  named module does not declare, events no module produces, duplicate
+  binding identities, ambiguous duplicate capability ownership, and
+  missing derived traversal edges; generic BINDS/CONSUMES/DECLARES edges
+  are derived from the typed payloads, never authored as free-standing
+  meaning. AG2 Agent/Task/Network identities stay out of the graph —
+  a Mozaiks workflow capability is application semantics; AG2 runtime
+  objects remain execution implementation details. The new semantics are
+  offline contracts: no module_interface.yaml rendering, no layout-registry
+  families, and no production AppGenerator/AgentGenerator wiring in this
+  change.
+
+
 ### Fixed
 
 - **Canonical plan authority is now enforced across execution and durable

--- a/mozaiksai/core/semantics/graph.py
+++ b/mozaiksai/core/semantics/graph.py
@@ -76,6 +76,7 @@ class SemanticNodeKind(StrEnum):
     WORKFLOW = "workflow"
     WORKFLOW_CAPABILITY = "workflow_capability"
     WORKFLOW_CAPABILITY_BINDING = "workflow_capability_binding"
+    WORKFLOW_RESULT = "workflow_result"
     TRIGGER = "trigger"
     PLAN = "plan"
     PRODUCT = "product"

--- a/mozaiksai/core/semantics/graph.py
+++ b/mozaiksai/core/semantics/graph.py
@@ -74,6 +74,8 @@ class SemanticNodeKind(StrEnum):
     DATA_COLLECTION = "data_collection"
     DATA_ALIAS = "data_alias"
     WORKFLOW = "workflow"
+    WORKFLOW_CAPABILITY = "workflow_capability"
+    WORKFLOW_CAPABILITY_BINDING = "workflow_capability_binding"
     TRIGGER = "trigger"
     PLAN = "plan"
     PRODUCT = "product"

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -1469,6 +1469,18 @@ class _Builder:
             for j, raw_action in enumerate(_as_list(manifest.get("actions"))):
                 item = _mapping(raw_action)
                 action = _node_id(SemanticNodeKind.ACTION, f"{module_id}_{item.get('id')}")
+                emitted_event_ids = tuple(
+                    sorted({str(event_type) for event_type in _as_list(item.get("emits"))})
+                )
+                if emitted_event_ids:
+                    # Typed payload authority first: the EMITS edges below are
+                    # projections of this typed fact, never the origin of it.
+                    self.content_field(
+                        action,
+                        "emits",
+                        emitted_event_ids,
+                        f"{base}.manifest.actions[{j}].emits",
+                    )
                 for k, event_type in enumerate(_as_list(item.get("emits"))):
                     self.edge(
                         SemanticEdgeKind.EMITS,

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -37,6 +37,7 @@ from mozaiksai.core.runtime.app.page_schema import (
 )
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
     SemanticEdgeKind,
     SemanticGraphV2,
     SemanticNodeKind,
@@ -282,9 +283,62 @@ class WorkflowTransitionTargetKind(StrEnum):
     TERMINATE = "terminate"
 
 
+class WorkflowCapabilityBindingRole(StrEnum):
+    """Closed semantic roles for one workflow-capability ↔ module relationship.
+
+    Direction is part of the meaning — the graph must know WHAT a binding is,
+    never just that two nodes touch:
+
+    - ``consumes_action``: the workflow capability reads/invokes a declared
+      module action while reasoning.
+    - ``commits_result_through_action``: exactly one named workflow result is
+      intended to be committed through a declared module action.  The module
+      action remains the only thing that mutates durable state.
+    - ``triggered_by_event``: a module-produced domain event launches the
+      workflow capability.
+
+    There is deliberately no ``emits_event`` role: modules own domain-event
+    emission.  A workflow-caused event materializes through the result
+    action's own declared ``emits`` — modeling direct workflow event emission
+    would let the workflow claim module ownership.
+    """
+
+    CONSUMES_ACTION = "consumes_action"
+    COMMITS_RESULT_THROUGH_ACTION = "commits_result_through_action"
+    TRIGGERED_BY_EVENT = "triggered_by_event"
+
+
 # ---------------------------------------------------------------------------
 # Typed sub-shapes
 # ---------------------------------------------------------------------------
+
+
+class ModuleActionRef(SemanticsModel):
+    """Exact identity of one declared module action, in graph-node identity.
+
+    Integrates with the existing semantic identity system: the module and the
+    action are graph nodes, so the ref pins their ``node_id``s rather than
+    inventing a parallel id scheme.  Payload closure requires the module node
+    to be a MODULE, the action node to be an ACTION, and the module to
+    actually declare the action (a DECLARES edge) — a real action under the
+    wrong module never resolves.  The ref carries no HTTP URL, Python method
+    path, handler class, runtime route, or AG2 tool identity: those are
+    implementation projections, not application semantics.
+    """
+
+    module_node_id: str
+    action_node_id: str
+
+    @field_validator("module_node_id", "action_node_id")
+    @classmethod
+    def _node_ids(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @model_validator(mode="after")
+    def _distinct(self) -> ModuleActionRef:
+        if self.module_node_id == self.action_node_id:
+            raise ValueError("module_node_id and action_node_id must differ")
+        return self
 
 
 class OptionalFamilySelection(SemanticsModel):
@@ -1317,6 +1371,200 @@ class TriggerPayload(SemanticPayloadBase):
         return self
 
 
+class WorkflowCapabilityPayload(SemanticPayloadBase):
+    """Application-semantic identity of one workflow capability.
+
+    A workflow capability is a declared, addressable behavior of exactly one
+    workflow — the identity a UI launch, a module-declared reaction, or an
+    orchestrator trigger addresses.  It is NOT an AG2 Agent, Task, Network,
+    or Channel: those are execution implementation details that never enter
+    the semantic graph.  Ownership is directional — the workflow owns its
+    capability identity and reasoning behavior; it does not own module state,
+    module actions, or module-emitted events.
+
+    Payload closure requires ``workflow_node_id`` to resolve to a WORKFLOW
+    node that DECLARES this capability, that no other node declares it, and
+    that ``capability_id`` is unique across the graph — one stable capability
+    identity can never be ambiguously owned by two workflows.
+    """
+
+    payload_kind: Literal[SemanticNodeKind.WORKFLOW_CAPABILITY] = (
+        SemanticNodeKind.WORKFLOW_CAPABILITY
+    )
+    capability_id: str
+    description: str | None
+    workflow_node_id: str
+
+    @field_validator("capability_id")
+    @classmethod
+    def _capability_id(cls, value: str) -> str:
+        return validate_identifier_grammar(SemanticCategory.CAPABILITY, value)
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _text(value, field_name="description")
+
+    @field_validator("workflow_node_id")
+    @classmethod
+    def _workflow_node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+
+class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
+    """One typed, directional relationship between a workflow capability and
+    a deterministic module surface.
+
+    Each binding is its own node so unrelated bindings keep independent
+    semantic identity — a future compilation unit can depend on exactly the
+    binding facts that influence it, and an unrelated module, action, or
+    workflow mutation never moves this binding's digest.
+
+    Role-shape closure (validated here) and referential closure (validated in
+    :func:`validate_semantic_graph_v2_payload_closure`):
+
+    - ``consumes_action`` — requires ``module_action`` only.
+    - ``commits_result_through_action`` — requires ``module_action`` and
+      ``workflow_result_id``: the named workflow result is intended for
+      exactly that module action.  ``workflow_result_id`` is a
+      provider-neutral semantic result identity (snake_case) — never a
+      provider schema or model-class name.
+    - ``triggered_by_event`` — requires ``event_node_id`` only; the event
+      must be a module-produced domain event (an EMITS edge into it).
+
+    A workflow with no result write simply has no
+    ``commits_result_through_action`` binding — truthful absence, no fake
+    result action.
+    """
+
+    payload_kind: Literal[SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING] = (
+        SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING
+    )
+    binding_role: WorkflowCapabilityBindingRole
+    workflow_capability_node_id: str
+    module_action: ModuleActionRef | None = None
+    event_node_id: str | None = None
+    workflow_result_id: str | None = None
+
+    @field_validator("workflow_capability_node_id")
+    @classmethod
+    def _capability_node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("event_node_id")
+    @classmethod
+    def _event_node(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_node_id_grammar(value)
+
+    @field_validator("workflow_result_id")
+    @classmethod
+    def _result_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _field_name(value, field_name="workflow_result_id")
+
+    @model_validator(mode="after")
+    def _role_shape(self) -> WorkflowCapabilityBindingPayload:
+        requirements: dict[WorkflowCapabilityBindingRole, dict[str, bool]] = {
+            WorkflowCapabilityBindingRole.CONSUMES_ACTION: {
+                "module_action": True,
+                "event_node_id": False,
+                "workflow_result_id": False,
+            },
+            WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION: {
+                "module_action": True,
+                "event_node_id": False,
+                "workflow_result_id": True,
+            },
+            WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT: {
+                "module_action": False,
+                "event_node_id": True,
+                "workflow_result_id": False,
+            },
+        }
+        for field_name, required in requirements[self.binding_role].items():
+            value = getattr(self, field_name)
+            if required and value is None:
+                raise ValueError(
+                    f"binding_role {self.binding_role.value!r} requires {field_name}"
+                )
+            if not required and value is not None:
+                raise ValueError(
+                    f"binding_role {self.binding_role.value!r} must not set {field_name}"
+                )
+        return self
+
+    @property
+    def binding_identity(self) -> tuple[str, ...]:
+        """The duplicate-rejection identity: capability, role, and endpoints.
+
+        ``workflow_result_id`` is deliberately excluded — two bindings routing
+        different results into the same action are the same authorized
+        relationship claimed twice, not two relationships.
+        """
+        return (
+            self.workflow_capability_node_id,
+            self.binding_role.value,
+            self.module_action.module_node_id if self.module_action else "",
+            self.module_action.action_node_id if self.module_action else "",
+            self.event_node_id or "",
+        )
+
+
+def derive_workflow_capability_binding_edges(
+    binding: WorkflowCapabilityBindingPayload,
+) -> tuple[SemanticEdge, ...]:
+    """The generic traversal edges one binding node derives (option A).
+
+    The typed payload is the meaning authority; these generic edges exist for
+    graph traversal only and are derived — never authored independently —
+    so payload facts and graph edges cannot drift.  Payload closure requires
+    exactly these edges to be present for every binding node.
+    """
+    edges: list[SemanticEdge] = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=binding.workflow_capability_node_id,
+            target_node_id=binding.node_id,
+        )
+    ]
+    if binding.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT:
+        if binding.event_node_id is None:  # pragma: no cover - model-validated
+            raise SemanticPayloadError("triggered_by_event binding lacks event_node_id")
+        edges.append(
+            SemanticEdge(
+                kind=SemanticEdgeKind.CONSUMES,
+                source_node_id=binding.node_id,
+                target_node_id=binding.event_node_id,
+            )
+        )
+        return tuple(edges)
+    if binding.module_action is None:  # pragma: no cover - model-validated
+        raise SemanticPayloadError("action binding lacks module_action")
+    if binding.binding_role is WorkflowCapabilityBindingRole.CONSUMES_ACTION:
+        edges.append(
+            SemanticEdge(
+                kind=SemanticEdgeKind.CONSUMES,
+                source_node_id=binding.node_id,
+                target_node_id=binding.module_action.action_node_id,
+            )
+        )
+    else:
+        edges.append(
+            SemanticEdge(
+                kind=SemanticEdgeKind.BINDS,
+                source_node_id=binding.node_id,
+                target_node_id=binding.module_action.action_node_id,
+                discriminator=binding.workflow_result_id,
+            )
+        )
+    return tuple(edges)
+
+
 class PlanPayload(SemanticPayloadBase):
     payload_kind: Literal[SemanticNodeKind.PLAN] = SemanticNodeKind.PLAN
     title: str | None
@@ -1465,7 +1713,7 @@ class ArtifactDeclarationPayload(SemanticPayloadBase):
 
 
 SemanticPayload = Annotated[
-    ApplicationPayload | AuthPayload | IntegrationPayload | SurfacePayload | PagePayload | SectionPayload | ModulePayload | ActionPayload | CapabilityPayload | PermissionPayload | EventPayload | ReactionPayload | NotificationPayload | DataCollectionPayload | DataAliasPayload | WorkflowPayload | TriggerPayload | PlanPayload | ProductPayload | MeterPayload | LimitPayload | DeploymentTargetPayload | ArtifactDeclarationPayload,
+    ApplicationPayload | AuthPayload | IntegrationPayload | SurfacePayload | PagePayload | SectionPayload | ModulePayload | ActionPayload | CapabilityPayload | PermissionPayload | EventPayload | ReactionPayload | NotificationPayload | DataCollectionPayload | DataAliasPayload | WorkflowPayload | WorkflowCapabilityPayload | WorkflowCapabilityBindingPayload | TriggerPayload | PlanPayload | ProductPayload | MeterPayload | LimitPayload | DeploymentTargetPayload | ArtifactDeclarationPayload,
     Field(discriminator="payload_kind"),
 ]
 
@@ -1487,6 +1735,8 @@ PAYLOAD_MODEL_BY_KIND: dict[SemanticNodeKind, type[SemanticPayloadBase]] = {
     SemanticNodeKind.DATA_COLLECTION: DataCollectionPayload,
     SemanticNodeKind.DATA_ALIAS: DataAliasPayload,
     SemanticNodeKind.WORKFLOW: WorkflowPayload,
+    SemanticNodeKind.WORKFLOW_CAPABILITY: WorkflowCapabilityPayload,
+    SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING: WorkflowCapabilityBindingPayload,
     SemanticNodeKind.TRIGGER: TriggerPayload,
     SemanticNodeKind.PLAN: PlanPayload,
     SemanticNodeKind.PRODUCT: ProductPayload,
@@ -1657,6 +1907,137 @@ def validate_semantic_graph_v2_payload_closure(
                     f"artifact declaration {payload.node_id!r} lacks its typed page edge"
                 )
 
+    declares_by_target: dict[str, list[str]] = {}
+    for edge in verified_graph.edges:
+        if edge.kind is SemanticEdgeKind.DECLARES:
+            declares_by_target.setdefault(edge.target_node_id, []).append(
+                edge.source_node_id
+            )
+
+    def _kind_of(node_id: str) -> SemanticNodeKind | None:
+        payload = payload_by_node.get(node_id)
+        kind = getattr(payload, "payload_kind", None)
+        return kind if isinstance(kind, SemanticNodeKind) else None
+
+    def _require_sole_declarer(
+        target_node_id: str, expected_kind: SemanticNodeKind, subject: str
+    ) -> str:
+        declarers = declares_by_target.get(target_node_id, [])
+        if len(declarers) != 1:
+            raise SemanticPayloadError(
+                f"{subject} {target_node_id!r} must be declared by exactly one "
+                f"{expected_kind.value} node, found {len(declarers)}"
+            )
+        if _kind_of(declarers[0]) is not expected_kind:
+            raise SemanticPayloadError(
+                f"{subject} {target_node_id!r} is declared by a non-"
+                f"{expected_kind.value} node {declarers[0]!r}"
+            )
+        return declarers[0]
+
+    seen_capability_ids: dict[str, str] = {}
+    for payload in payload_by_node.values():
+        if not isinstance(payload, WorkflowCapabilityPayload):
+            continue
+        if _kind_of(payload.workflow_node_id) is not SemanticNodeKind.WORKFLOW:
+            raise SemanticPayloadError(
+                f"workflow capability {payload.node_id!r} names a missing or "
+                f"non-workflow owner {payload.workflow_node_id!r}"
+            )
+        declarer = _require_sole_declarer(
+            payload.node_id, SemanticNodeKind.WORKFLOW, "workflow capability"
+        )
+        if declarer != payload.workflow_node_id:
+            raise SemanticPayloadError(
+                f"workflow capability {payload.node_id!r} claims owner "
+                f"{payload.workflow_node_id!r} but is declared by {declarer!r}"
+            )
+        previous = seen_capability_ids.get(payload.capability_id)
+        if previous is not None:
+            raise SemanticPayloadError(
+                f"capability_id {payload.capability_id!r} is ambiguously owned "
+                f"by {previous!r} and {payload.node_id!r}"
+            )
+        seen_capability_ids[payload.capability_id] = payload.node_id
+
+    emits_targets = {
+        edge.target_node_id
+        for edge in verified_graph.edges
+        if edge.kind is SemanticEdgeKind.EMITS
+        and _kind_of(edge.source_node_id)
+        in (SemanticNodeKind.MODULE, SemanticNodeKind.ACTION)
+    }
+    seen_bindings: set[tuple[str, ...]] = set()
+    for payload in payload_by_node.values():
+        if not isinstance(payload, WorkflowCapabilityBindingPayload):
+            continue
+        if (
+            _kind_of(payload.workflow_capability_node_id)
+            is not SemanticNodeKind.WORKFLOW_CAPABILITY
+        ):
+            raise SemanticPayloadError(
+                f"binding {payload.node_id!r} names a missing or non-capability "
+                f"subject {payload.workflow_capability_node_id!r}"
+            )
+        declarer = _require_sole_declarer(
+            payload.node_id, SemanticNodeKind.WORKFLOW_CAPABILITY, "capability binding"
+        )
+        if declarer != payload.workflow_capability_node_id:
+            raise SemanticPayloadError(
+                f"binding {payload.node_id!r} claims capability "
+                f"{payload.workflow_capability_node_id!r} but is declared by "
+                f"{declarer!r}"
+            )
+        if payload.module_action is not None:
+            if _kind_of(payload.module_action.module_node_id) is not SemanticNodeKind.MODULE:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references a missing or "
+                    f"non-module node {payload.module_action.module_node_id!r}"
+                )
+            if _kind_of(payload.module_action.action_node_id) is not SemanticNodeKind.ACTION:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references a missing or "
+                    f"non-action node {payload.module_action.action_node_id!r}"
+                )
+            if (
+                SemanticEdgeKind.DECLARES,
+                payload.module_action.module_node_id,
+                payload.module_action.action_node_id,
+            ) not in edge_keys:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references action "
+                    f"{payload.module_action.action_node_id!r} that module "
+                    f"{payload.module_action.module_node_id!r} does not declare"
+                )
+        if payload.event_node_id is not None:
+            if _kind_of(payload.event_node_id) is not SemanticNodeKind.EVENT:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references a missing or "
+                    f"non-event node {payload.event_node_id!r}"
+                )
+            if payload.event_node_id not in emits_targets:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} is triggered by event "
+                    f"{payload.event_node_id!r} that no module or action produces"
+                )
+        binding_key = payload.binding_identity
+        if binding_key in seen_bindings:
+            raise SemanticPayloadError(
+                f"duplicate workflow capability binding identity {binding_key!r}"
+            )
+        seen_bindings.add(binding_key)
+        for required_edge in derive_workflow_capability_binding_edges(payload):
+            if (
+                required_edge.kind,
+                required_edge.source_node_id,
+                required_edge.target_node_id,
+            ) not in edge_keys:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} lacks its derived "
+                    f"{required_edge.kind.value} edge to "
+                    f"{required_edge.target_node_id!r}"
+                )
+
     applications = [
         payload
         for payload in payload_by_node.values()
@@ -1728,6 +2109,7 @@ __all__ = [
     "LimitPayload",
     "LockfileKind",
     "MeterPayload",
+    "ModuleActionRef",
     "ModulePayload",
     "NotificationChannel",
     "NotificationPayload",
@@ -1754,6 +2136,9 @@ __all__ = [
     "TriggerKind",
     "TriggerPayload",
     "TypedFieldSpec",
+    "WorkflowCapabilityBindingPayload",
+    "WorkflowCapabilityBindingRole",
+    "WorkflowCapabilityPayload",
     "WorkflowPayload",
     "WorkflowParticipant",
     "WorkflowStartupMode",
@@ -1762,6 +2147,7 @@ __all__ = [
     "WorkflowTransitionKind",
     "WorkflowTransitionTargetKind",
     "build_semantic_payload",
+    "derive_workflow_capability_binding_edges",
     "parse_semantic_payload",
     "semantic_payload_ref",
     "validate_semantic_graph_v2_payload_closure",

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -1992,12 +1992,10 @@ def validate_semantic_graph_v2_payload_closure(
                     f"artifact declaration {payload.node_id!r} lacks its typed page edge"
                 )
 
-    declares_by_target: dict[str, list[str]] = {}
+    declares_by_target: dict[str, list[SemanticEdge]] = {}
     for edge in verified_graph.edges:
         if edge.kind is SemanticEdgeKind.DECLARES:
-            declares_by_target.setdefault(edge.target_node_id, []).append(
-                edge.source_node_id
-            )
+            declares_by_target.setdefault(edge.target_node_id, []).append(edge)
 
     def _kind_of(node_id: str) -> SemanticNodeKind | None:
         payload = payload_by_node.get(node_id)
@@ -2007,25 +2005,67 @@ def validate_semantic_graph_v2_payload_closure(
     def _require_sole_declarer(
         target_node_id: str, expected_kind: SemanticNodeKind, subject: str
     ) -> str:
-        declarers = declares_by_target.get(target_node_id, [])
-        if len(declarers) != 1:
+        declarer_edges = declares_by_target.get(target_node_id, [])
+        if len(declarer_edges) != 1:
             raise SemanticPayloadError(
                 f"{subject} {target_node_id!r} must be declared by exactly one "
-                f"{expected_kind.value} node, found {len(declarers)}"
+                f"{expected_kind.value} node, found {len(declarer_edges)}"
             )
-        if _kind_of(declarers[0]) is not expected_kind:
+        declarer_node_id = declarer_edges[0].source_node_id
+        if _kind_of(declarer_node_id) is not expected_kind:
             raise SemanticPayloadError(
                 f"{subject} {target_node_id!r} is declared by a non-"
-                f"{expected_kind.value} node {declarers[0]!r}"
+                f"{expected_kind.value} node {declarer_node_id!r}"
             )
-        return declarers[0]
+        return declarer_node_id
 
-    def _module_declarers_of(action_node_id: str) -> list[str]:
-        return [
-            declarer
-            for declarer in declares_by_target.get(action_node_id, [])
-            if _kind_of(declarer) is SemanticNodeKind.MODULE
-        ]
+    def _require_canonical_module_owned_action(
+        action_node_id: str,
+        *,
+        subject: str,
+        expected_module_node_id: str | None = None,
+    ) -> str:
+        """Total declarer closure for one action in the new authority family.
+
+        The COMPLETE declarer set is validated — contradictory non-module
+        declarers are never filtered away before ownership is claimed:
+        exactly one DECLARES edge may target the action, its source must be a
+        MODULE, its projection must carry no discriminator, and when a
+        specific module is expected it must be that module.
+        """
+        declarer_edges = declares_by_target.get(action_node_id, [])
+        if not declarer_edges:
+            raise SemanticPayloadError(
+                f"{subject} action {action_node_id!r} has no module declarer"
+            )
+        if len(declarer_edges) > 1:
+            raise SemanticPayloadError(
+                f"{subject} action {action_node_id!r} has a contradictory "
+                f"declarer set; canonical ownership requires exactly one module "
+                f"declarer, found "
+                f"{sorted(edge.source_node_id for edge in declarer_edges)!r}"
+            )
+        declarer_node_id = declarer_edges[0].source_node_id
+        if _kind_of(declarer_node_id) is not SemanticNodeKind.MODULE:
+            raise SemanticPayloadError(
+                f"{subject} action {action_node_id!r} has a sole declarer "
+                f"{declarer_node_id!r} that is not a module"
+            )
+        if declarer_edges[0].discriminator is not None:
+            raise SemanticPayloadError(
+                f"{subject} action {action_node_id!r} has a declaring edge "
+                f"carrying a discriminator no typed payload backs"
+            )
+        if (
+            expected_module_node_id is not None
+            and declarer_node_id != expected_module_node_id
+        ):
+            raise SemanticPayloadError(
+                f"{subject} action {action_node_id!r} is referenced through "
+                f"module {expected_module_node_id!r} but its canonical module "
+                f"owner is {declarer_node_id!r}"
+            )
+        return declarer_node_id
 
     # --- typed event-production authority -----------------------------------
     # The canonical event identity is the EVENT node's single EVENT-category
@@ -2049,12 +2089,21 @@ def validate_semantic_graph_v2_payload_closure(
         if isinstance(payload, ActionPayload)
     }
     emits_edge_keys: set[tuple[str, str]] = set()
+    emits_edges_by_action: dict[str, list[SemanticEdge]] = {}
     for graph_edge in verified_graph.edges:
         if graph_edge.kind is not SemanticEdgeKind.EMITS:
             continue
         emits_edge_keys.add((graph_edge.source_node_id, graph_edge.target_node_id))
         if _kind_of(graph_edge.source_node_id) is not SemanticNodeKind.ACTION:
             continue
+        emits_edges_by_action.setdefault(graph_edge.source_node_id, []).append(
+            graph_edge
+        )
+        if graph_edge.discriminator is not None:
+            raise SemanticPayloadError(
+                f"EMITS edge from action {graph_edge.source_node_id!r} carries a "
+                f"discriminator no typed payload backs"
+            )
         emitted_ids = action_emits_by_node.get(graph_edge.source_node_id, ())
         if not emitted_ids:
             raise SemanticPayloadError(
@@ -2078,6 +2127,76 @@ def validate_semantic_graph_v2_payload_closure(
     for event_node_id, event_identities in event_identities_by_node.items():
         for event_identity in event_identities:
             event_nodes_by_identity.setdefault(event_identity, []).append(event_node_id)
+
+    # --- the canonical module-ownership family ------------------------------
+    # Every ACTION that any node DECLARES enters the new authority family:
+    # its complete declarer set must close to exactly one module owner, every
+    # typed emits entry must resolve to exactly one EVENT node carrying
+    # exactly one canonical EVENT identity, and the ACTION-sourced EMITS edge
+    # set must equal the typed projection exactly (full SemanticEdge identity,
+    # discriminator included).  This closure holds independently of whether
+    # any workflow, reaction, or trigger consumes the event — a typed emit is
+    # an application-semantic claim in its own right.  Undeclared actions are
+    # historical graph content outside the family: their EMITS edges keep the
+    # floor rules above and confer no event-production authority.
+    module_owned_action_owners: dict[str, str] = {}
+    for family_action_id, family_emitted_ids in action_emits_by_node.items():
+        if not declares_by_target.get(family_action_id):
+            continue
+        module_owned_action_owners[family_action_id] = (
+            _require_canonical_module_owned_action(
+                family_action_id, subject="declared"
+            )
+        )
+        expected_emits_projection: dict[str, SemanticEdge] = {}
+        for family_emitted_id in family_emitted_ids:
+            family_event_nodes = event_nodes_by_identity.get(family_emitted_id, [])
+            if not family_event_nodes:
+                raise SemanticPayloadError(
+                    f"action {family_action_id!r} declares emitted event "
+                    f"{family_emitted_id!r} but no event node carries that "
+                    f"canonical event identity"
+                )
+            if len(family_event_nodes) > 1:
+                raise SemanticPayloadError(
+                    f"canonical event identity {family_emitted_id!r} is carried "
+                    f"by multiple event nodes"
+                )
+            family_event_node_id = family_event_nodes[0]
+            if len(event_identities_by_node.get(family_event_node_id, ())) != 1:
+                raise SemanticPayloadError(
+                    f"event {family_event_node_id!r} carries multiple canonical "
+                    f"event identities"
+                )
+            expected_emits_edge = SemanticEdge(
+                kind=SemanticEdgeKind.EMITS,
+                source_node_id=family_action_id,
+                target_node_id=family_event_node_id,
+            )
+            expected_emits_projection[expected_emits_edge.edge_identity] = (
+                expected_emits_edge
+            )
+        actual_emits_edges = emits_edges_by_action.get(family_action_id, [])
+        for actual_emits_edge in actual_emits_edges:
+            if actual_emits_edge.edge_identity not in expected_emits_projection:
+                raise SemanticPayloadError(
+                    f"EMITS edge {actual_emits_edge.source_node_id!r} -> "
+                    f"{actual_emits_edge.target_node_id!r} (discriminator "
+                    f"{actual_emits_edge.discriminator!r}) is not part of the "
+                    f"typed emits projection of module-owned action "
+                    f"{family_action_id!r}"
+                )
+        actual_emits_identities = {
+            actual_emits_edge.edge_identity
+            for actual_emits_edge in actual_emits_edges
+        }
+        for expected_emits_edge in expected_emits_projection.values():
+            if expected_emits_edge.edge_identity not in actual_emits_identities:
+                raise SemanticPayloadError(
+                    f"action {family_action_id!r} lacks its typed EMITS "
+                    f"projection to {expected_emits_edge.target_node_id!r}"
+                )
+
     for action_node_id, emitted_ids in action_emits_by_node.items():
         for emitted_id in emitted_ids:
             matching_event_nodes = event_nodes_by_identity.get(emitted_id, [])
@@ -2184,26 +2303,11 @@ def validate_semantic_graph_v2_payload_closure(
                     f"binding {payload.node_id!r} references a missing or "
                     f"non-action node {payload.module_action.action_node_id!r}"
                 )
-            module_declarers = _module_declarers_of(payload.module_action.action_node_id)
-            if not module_declarers:
-                raise SemanticPayloadError(
-                    f"binding {payload.node_id!r} references action "
-                    f"{payload.module_action.action_node_id!r} that no module "
-                    f"declares"
-                )
-            if len(module_declarers) > 1:
-                raise SemanticPayloadError(
-                    f"binding {payload.node_id!r} references action "
-                    f"{payload.module_action.action_node_id!r} that is "
-                    f"ambiguously owned by multiple modules"
-                )
-            if module_declarers[0] != payload.module_action.module_node_id:
-                raise SemanticPayloadError(
-                    f"binding {payload.node_id!r} references action "
-                    f"{payload.module_action.action_node_id!r} through module "
-                    f"{payload.module_action.module_node_id!r} but its canonical "
-                    f"module owner is {module_declarers[0]!r}"
-                )
+            _require_canonical_module_owned_action(
+                payload.module_action.action_node_id,
+                subject=f"binding {payload.node_id!r}:",
+                expected_module_node_id=payload.module_action.module_node_id,
+            )
         if payload.event_node_id is not None:
             if _kind_of(payload.event_node_id) is not SemanticNodeKind.EVENT:
                 raise SemanticPayloadError(
@@ -2218,19 +2322,12 @@ def validate_semantic_graph_v2_payload_closure(
                     f"canonical event identity, found {len(trigger_identities)}"
                 )
             trigger_event_id = trigger_identities[0]
-            canonical_producers: list[str] = []
-            for producer_node_id, emitted_ids in action_emits_by_node.items():
-                if trigger_event_id not in emitted_ids:
-                    continue
-                producer_owners = _module_declarers_of(producer_node_id)
-                if len(producer_owners) > 1:
-                    raise SemanticPayloadError(
-                        f"trigger event {payload.event_node_id!r} is produced by "
-                        f"action {producer_node_id!r} with ambiguous module "
-                        f"ownership"
-                    )
-                if len(producer_owners) == 1:
-                    canonical_producers.append(producer_node_id)
+            canonical_producers = [
+                producer_node_id
+                for producer_node_id, produced_ids in action_emits_by_node.items()
+                if trigger_event_id in produced_ids
+                and producer_node_id in module_owned_action_owners
+            ]
             if not canonical_producers:
                 raise SemanticPayloadError(
                     f"binding {payload.node_id!r} is triggered by event "

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -291,9 +291,9 @@ class WorkflowCapabilityBindingRole(StrEnum):
 
     - ``consumes_action``: the workflow capability reads/invokes a declared
       module action while reasoning.
-    - ``commits_result_through_action``: exactly one named workflow result is
-      intended to be committed through a declared module action.  The module
-      action remains the only thing that mutates durable state.
+    - ``commits_result_through_action``: exactly one declared WORKFLOW_RESULT
+      node is intended to be committed through a declared module action.  The
+      module action remains the only thing that mutates durable state.
     - ``triggered_by_event``: a module-produced domain event launches the
       workflow capability.
 
@@ -1413,6 +1413,50 @@ class WorkflowCapabilityPayload(SemanticPayloadBase):
         return validate_node_id_grammar(value)
 
 
+class WorkflowResultPayload(SemanticPayloadBase):
+    """The typed application-semantic identity of one workflow result.
+
+    A workflow result is a declared semantic output of exactly one workflow
+    capability — result identity stays local to the capability that produces
+    it, because one workflow may expose several capabilities with different
+    semantic outputs.  ``result_id`` is unique within the owning capability
+    only; two unrelated capabilities may both truthfully produce ``summary``.
+
+    Identity is the node plus capability ownership — never a provider id,
+    model id, Python class, Pydantic/structured-output implementation class,
+    prompt name, or AG2 runtime result id.  Schema compatibility between the
+    workflow output contract and a module action input contract is deferred;
+    this node establishes only what the result IS and who owns it.
+
+    Payload closure requires ``workflow_capability_node_id`` to resolve to a
+    WORKFLOW_CAPABILITY node that is the sole DECLARES owner of this node.
+    """
+
+    payload_kind: Literal[SemanticNodeKind.WORKFLOW_RESULT] = (
+        SemanticNodeKind.WORKFLOW_RESULT
+    )
+    result_id: str
+    description: str | None
+    workflow_capability_node_id: str
+
+    @field_validator("result_id")
+    @classmethod
+    def _result_id(cls, value: str) -> str:
+        return _field_name(value, field_name="result_id")
+
+    @field_validator("description")
+    @classmethod
+    def _description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _text(value, field_name="description")
+
+    @field_validator("workflow_capability_node_id")
+    @classmethod
+    def _capability_node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+
 class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
     """One typed, directional relationship between a workflow capability and
     a deterministic module surface.
@@ -1427,12 +1471,19 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
 
     - ``consumes_action`` — requires ``module_action`` only.
     - ``commits_result_through_action`` — requires ``module_action`` and
-      ``workflow_result_id``: the named workflow result is intended for
-      exactly that module action.  ``workflow_result_id`` is a
-      provider-neutral semantic result identity (snake_case) — never a
-      provider schema or model-class name.
-    - ``triggered_by_event`` — requires ``event_node_id`` only; the event
-      must be a module-produced domain event (an EMITS edge into it).
+      ``workflow_result_node_id``: an exact reference to a declared
+      WORKFLOW_RESULT node owned by this binding's own capability.  A free
+      result string can never establish result identity, and a capability
+      can never commit another capability's result.
+    - ``triggered_by_event`` — requires ``event_node_id`` only; closure
+      requires a canonical module-owned action whose typed
+      ``ActionPayload.emits`` truthfully produces the event.
+
+    Result fan-out policy: intentional fan-out is expressed only through
+    multiple explicit ``commits_result_through_action`` binding nodes that
+    all reference the SAME WORKFLOW_RESULT node — one declared result
+    committed through more than one deterministic module action, never a
+    hidden coincidence through repeated strings.
 
     A workflow with no result write simply has no
     ``commits_result_through_action`` binding — truthful absence, no fake
@@ -1446,7 +1497,7 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
     workflow_capability_node_id: str
     module_action: ModuleActionRef | None = None
     event_node_id: str | None = None
-    workflow_result_id: str | None = None
+    workflow_result_node_id: str | None = None
 
     @field_validator("workflow_capability_node_id")
     @classmethod
@@ -1460,12 +1511,12 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
             return None
         return validate_node_id_grammar(value)
 
-    @field_validator("workflow_result_id")
+    @field_validator("workflow_result_node_id")
     @classmethod
-    def _result_id(cls, value: str | None) -> str | None:
+    def _result_node(cls, value: str | None) -> str | None:
         if value is None:
             return None
-        return _field_name(value, field_name="workflow_result_id")
+        return validate_node_id_grammar(value)
 
     @model_validator(mode="after")
     def _role_shape(self) -> WorkflowCapabilityBindingPayload:
@@ -1473,17 +1524,17 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
             WorkflowCapabilityBindingRole.CONSUMES_ACTION: {
                 "module_action": True,
                 "event_node_id": False,
-                "workflow_result_id": False,
+                "workflow_result_node_id": False,
             },
             WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION: {
                 "module_action": True,
                 "event_node_id": False,
-                "workflow_result_id": True,
+                "workflow_result_node_id": True,
             },
             WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT: {
                 "module_action": False,
                 "event_node_id": True,
-                "workflow_result_id": False,
+                "workflow_result_node_id": False,
             },
         }
         for field_name, required in requirements[self.binding_role].items():
@@ -1502,9 +1553,11 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
     def binding_identity(self) -> tuple[str, ...]:
         """The duplicate-rejection identity: capability, role, and endpoints.
 
-        ``workflow_result_id`` is deliberately excluded — two bindings routing
-        different results into the same action are the same authorized
-        relationship claimed twice, not two relationships.
+        ``workflow_result_node_id`` is part of the identity: committing the
+        same declared result through the same action twice is one relationship
+        claimed twice (rejected), while committing a DIFFERENT declared result
+        through the same action, or the same result through a different action
+        (explicit fan-out), are distinct typed relationships.
         """
         return (
             self.workflow_capability_node_id,
@@ -1512,18 +1565,22 @@ class WorkflowCapabilityBindingPayload(SemanticPayloadBase):
             self.module_action.module_node_id if self.module_action else "",
             self.module_action.action_node_id if self.module_action else "",
             self.event_node_id or "",
+            self.workflow_result_node_id or "",
         )
 
 
 def derive_workflow_capability_binding_edges(
     binding: WorkflowCapabilityBindingPayload,
 ) -> tuple[SemanticEdge, ...]:
-    """The generic traversal edges one binding node derives (option A).
+    """The complete meaning-bearing graph projection of one binding node.
 
     The typed payload is the meaning authority; these generic edges exist for
     graph traversal only and are derived — never authored independently —
     so payload facts and graph edges cannot drift.  Payload closure requires
-    exactly these edges to be present for every binding node.
+    the actual edge set touching every binding node to equal this derived set
+    EXACTLY (full :class:`SemanticEdge` identity including ``discriminator``),
+    so a forged, extra, or discriminator-mutated generic edge can never alter
+    application meaning independently of the payload.
     """
     edges: list[SemanticEdge] = [
         SemanticEdge(
@@ -1553,16 +1610,43 @@ def derive_workflow_capability_binding_edges(
                 target_node_id=binding.module_action.action_node_id,
             )
         )
-    else:
-        edges.append(
-            SemanticEdge(
-                kind=SemanticEdgeKind.BINDS,
-                source_node_id=binding.node_id,
-                target_node_id=binding.module_action.action_node_id,
-                discriminator=binding.workflow_result_id,
-            )
+        return tuple(edges)
+    if binding.workflow_result_node_id is None:  # pragma: no cover - model-validated
+        raise SemanticPayloadError("commit binding lacks workflow_result_node_id")
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=binding.node_id,
+            target_node_id=binding.module_action.action_node_id,
+            discriminator=binding.workflow_result_node_id,
         )
+    )
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.CONSUMES,
+            source_node_id=binding.node_id,
+            target_node_id=binding.workflow_result_node_id,
+        )
+    )
     return tuple(edges)
+
+
+def derive_workflow_result_edges(
+    result: WorkflowResultPayload,
+) -> tuple[SemanticEdge, ...]:
+    """The ownership projection of one WORKFLOW_RESULT node.
+
+    The owning capability DECLARES its result; commit bindings referencing the
+    result contribute their own derived CONSUMES edges.  Together those form
+    the exact edge participation payload closure requires for result nodes.
+    """
+    return (
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=result.workflow_capability_node_id,
+            target_node_id=result.node_id,
+        ),
+    )
 
 
 class PlanPayload(SemanticPayloadBase):
@@ -1713,7 +1797,7 @@ class ArtifactDeclarationPayload(SemanticPayloadBase):
 
 
 SemanticPayload = Annotated[
-    ApplicationPayload | AuthPayload | IntegrationPayload | SurfacePayload | PagePayload | SectionPayload | ModulePayload | ActionPayload | CapabilityPayload | PermissionPayload | EventPayload | ReactionPayload | NotificationPayload | DataCollectionPayload | DataAliasPayload | WorkflowPayload | WorkflowCapabilityPayload | WorkflowCapabilityBindingPayload | TriggerPayload | PlanPayload | ProductPayload | MeterPayload | LimitPayload | DeploymentTargetPayload | ArtifactDeclarationPayload,
+    ApplicationPayload | AuthPayload | IntegrationPayload | SurfacePayload | PagePayload | SectionPayload | ModulePayload | ActionPayload | CapabilityPayload | PermissionPayload | EventPayload | ReactionPayload | NotificationPayload | DataCollectionPayload | DataAliasPayload | WorkflowPayload | WorkflowCapabilityPayload | WorkflowCapabilityBindingPayload | WorkflowResultPayload | TriggerPayload | PlanPayload | ProductPayload | MeterPayload | LimitPayload | DeploymentTargetPayload | ArtifactDeclarationPayload,
     Field(discriminator="payload_kind"),
 ]
 
@@ -1737,6 +1821,7 @@ PAYLOAD_MODEL_BY_KIND: dict[SemanticNodeKind, type[SemanticPayloadBase]] = {
     SemanticNodeKind.WORKFLOW: WorkflowPayload,
     SemanticNodeKind.WORKFLOW_CAPABILITY: WorkflowCapabilityPayload,
     SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING: WorkflowCapabilityBindingPayload,
+    SemanticNodeKind.WORKFLOW_RESULT: WorkflowResultPayload,
     SemanticNodeKind.TRIGGER: TriggerPayload,
     SemanticNodeKind.PLAN: PlanPayload,
     SemanticNodeKind.PRODUCT: ProductPayload,
@@ -1935,6 +2020,82 @@ def validate_semantic_graph_v2_payload_closure(
             )
         return declarers[0]
 
+    def _module_declarers_of(action_node_id: str) -> list[str]:
+        return [
+            declarer
+            for declarer in declares_by_target.get(action_node_id, [])
+            if _kind_of(declarer) is SemanticNodeKind.MODULE
+        ]
+
+    # --- typed event-production authority -----------------------------------
+    # The canonical event identity is the EVENT node's single EVENT-category
+    # taxonomy reference; ``ActionPayload.emits`` entries join through that
+    # identity.  A generic EMITS edge is a projection of the typed relation,
+    # never its origin: an edge an action's typed emits does not back is a
+    # forgery, and a typed emit whose unique event node lacks the projection
+    # is an incomplete graph.
+    event_identities_by_node: dict[str, tuple[str, ...]] = {}
+    for graph_node in verified_graph.nodes:
+        if graph_node.kind is not SemanticNodeKind.EVENT:
+            continue
+        event_identities_by_node[graph_node.node_id] = tuple(
+            reference.identifier
+            for reference in graph_node.taxonomy_references
+            if reference.category is SemanticCategory.EVENT
+        )
+    action_emits_by_node = {
+        payload.node_id: payload.emits
+        for payload in payload_by_node.values()
+        if isinstance(payload, ActionPayload)
+    }
+    emits_edge_keys: set[tuple[str, str]] = set()
+    for graph_edge in verified_graph.edges:
+        if graph_edge.kind is not SemanticEdgeKind.EMITS:
+            continue
+        emits_edge_keys.add((graph_edge.source_node_id, graph_edge.target_node_id))
+        if _kind_of(graph_edge.source_node_id) is not SemanticNodeKind.ACTION:
+            continue
+        emitted_ids = action_emits_by_node.get(graph_edge.source_node_id, ())
+        if not emitted_ids:
+            raise SemanticPayloadError(
+                f"EMITS edge from action {graph_edge.source_node_id!r} is not "
+                f"backed by typed ActionPayload.emits — a generic edge cannot "
+                f"invent event production"
+            )
+        target_identities = event_identities_by_node.get(graph_edge.target_node_id, ())
+        if len(target_identities) > 1:
+            raise SemanticPayloadError(
+                f"event {graph_edge.target_node_id!r} carries multiple canonical "
+                f"event identities"
+            )
+        if len(target_identities) == 1 and target_identities[0] not in emitted_ids:
+            raise SemanticPayloadError(
+                f"EMITS edge from action {graph_edge.source_node_id!r} targets "
+                f"event {graph_edge.target_node_id!r} whose canonical identity "
+                f"{target_identities[0]!r} the action's typed emits does not declare"
+            )
+    event_nodes_by_identity: dict[str, list[str]] = {}
+    for event_node_id, event_identities in event_identities_by_node.items():
+        for event_identity in event_identities:
+            event_nodes_by_identity.setdefault(event_identity, []).append(event_node_id)
+    for action_node_id, emitted_ids in action_emits_by_node.items():
+        for emitted_id in emitted_ids:
+            matching_event_nodes = event_nodes_by_identity.get(emitted_id, [])
+            if len(matching_event_nodes) > 1:
+                raise SemanticPayloadError(
+                    f"canonical event identity {emitted_id!r} is carried by "
+                    f"multiple event nodes"
+                )
+            if (
+                len(matching_event_nodes) == 1
+                and (action_node_id, matching_event_nodes[0]) not in emits_edge_keys
+            ):
+                raise SemanticPayloadError(
+                    f"action {action_node_id!r} declares emitted event "
+                    f"{emitted_id!r} but lacks the required EMITS projection to "
+                    f"{matching_event_nodes[0]!r}"
+                )
+
     seen_capability_ids: dict[str, str] = {}
     for payload in payload_by_node.values():
         if not isinstance(payload, WorkflowCapabilityPayload):
@@ -1960,13 +2121,37 @@ def validate_semantic_graph_v2_payload_closure(
             )
         seen_capability_ids[payload.capability_id] = payload.node_id
 
-    emits_targets = {
-        edge.target_node_id
-        for edge in verified_graph.edges
-        if edge.kind is SemanticEdgeKind.EMITS
-        and _kind_of(edge.source_node_id)
-        in (SemanticNodeKind.MODULE, SemanticNodeKind.ACTION)
-    }
+    result_owner_by_node: dict[str, str] = {}
+    seen_result_ids: dict[tuple[str, str], str] = {}
+    for payload in payload_by_node.values():
+        if not isinstance(payload, WorkflowResultPayload):
+            continue
+        if (
+            _kind_of(payload.workflow_capability_node_id)
+            is not SemanticNodeKind.WORKFLOW_CAPABILITY
+        ):
+            raise SemanticPayloadError(
+                f"workflow result {payload.node_id!r} names a missing or "
+                f"non-capability owner {payload.workflow_capability_node_id!r}"
+            )
+        result_declarer = _require_sole_declarer(
+            payload.node_id, SemanticNodeKind.WORKFLOW_CAPABILITY, "workflow result"
+        )
+        if result_declarer != payload.workflow_capability_node_id:
+            raise SemanticPayloadError(
+                f"workflow result {payload.node_id!r} claims owner "
+                f"{payload.workflow_capability_node_id!r} but is declared by "
+                f"{result_declarer!r}"
+            )
+        result_scope_key = (payload.workflow_capability_node_id, payload.result_id)
+        if result_scope_key in seen_result_ids:
+            raise SemanticPayloadError(
+                f"result_id {payload.result_id!r} is declared twice by capability "
+                f"{payload.workflow_capability_node_id!r}"
+            )
+        seen_result_ids[result_scope_key] = payload.node_id
+        result_owner_by_node[payload.node_id] = payload.workflow_capability_node_id
+
     seen_bindings: set[tuple[str, ...]] = set()
     for payload in payload_by_node.values():
         if not isinstance(payload, WorkflowCapabilityBindingPayload):
@@ -1999,15 +2184,25 @@ def validate_semantic_graph_v2_payload_closure(
                     f"binding {payload.node_id!r} references a missing or "
                     f"non-action node {payload.module_action.action_node_id!r}"
                 )
-            if (
-                SemanticEdgeKind.DECLARES,
-                payload.module_action.module_node_id,
-                payload.module_action.action_node_id,
-            ) not in edge_keys:
+            module_declarers = _module_declarers_of(payload.module_action.action_node_id)
+            if not module_declarers:
                 raise SemanticPayloadError(
                     f"binding {payload.node_id!r} references action "
-                    f"{payload.module_action.action_node_id!r} that module "
-                    f"{payload.module_action.module_node_id!r} does not declare"
+                    f"{payload.module_action.action_node_id!r} that no module "
+                    f"declares"
+                )
+            if len(module_declarers) > 1:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references action "
+                    f"{payload.module_action.action_node_id!r} that is "
+                    f"ambiguously owned by multiple modules"
+                )
+            if module_declarers[0] != payload.module_action.module_node_id:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references action "
+                    f"{payload.module_action.action_node_id!r} through module "
+                    f"{payload.module_action.module_node_id!r} but its canonical "
+                    f"module owner is {module_declarers[0]!r}"
                 )
         if payload.event_node_id is not None:
             if _kind_of(payload.event_node_id) is not SemanticNodeKind.EVENT:
@@ -2015,10 +2210,51 @@ def validate_semantic_graph_v2_payload_closure(
                     f"binding {payload.node_id!r} references a missing or "
                     f"non-event node {payload.event_node_id!r}"
                 )
-            if payload.event_node_id not in emits_targets:
+            trigger_identities = event_identities_by_node.get(payload.event_node_id, ())
+            if len(trigger_identities) != 1:
                 raise SemanticPayloadError(
                     f"binding {payload.node_id!r} is triggered by event "
-                    f"{payload.event_node_id!r} that no module or action produces"
+                    f"{payload.event_node_id!r} which must carry exactly one "
+                    f"canonical event identity, found {len(trigger_identities)}"
+                )
+            trigger_event_id = trigger_identities[0]
+            canonical_producers: list[str] = []
+            for producer_node_id, emitted_ids in action_emits_by_node.items():
+                if trigger_event_id not in emitted_ids:
+                    continue
+                producer_owners = _module_declarers_of(producer_node_id)
+                if len(producer_owners) > 1:
+                    raise SemanticPayloadError(
+                        f"trigger event {payload.event_node_id!r} is produced by "
+                        f"action {producer_node_id!r} with ambiguous module "
+                        f"ownership"
+                    )
+                if len(producer_owners) == 1:
+                    canonical_producers.append(producer_node_id)
+            if not canonical_producers:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} is triggered by event "
+                    f"{payload.event_node_id!r} that no canonical module-owned "
+                    f"action produces"
+                )
+        if payload.workflow_result_node_id is not None:
+            if (
+                _kind_of(payload.workflow_result_node_id)
+                is not SemanticNodeKind.WORKFLOW_RESULT
+            ):
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} references a missing or "
+                    f"non-workflow-result node {payload.workflow_result_node_id!r}"
+                )
+            committed_result_owner = result_owner_by_node.get(
+                payload.workflow_result_node_id
+            )
+            if committed_result_owner != payload.workflow_capability_node_id:
+                raise SemanticPayloadError(
+                    f"binding {payload.node_id!r} commits result "
+                    f"{payload.workflow_result_node_id!r} owned by capability "
+                    f"{committed_result_owner!r} — a capability cannot commit "
+                    f"another capability's result"
                 )
         binding_key = payload.binding_identity
         if binding_key in seen_bindings:
@@ -2026,16 +2262,69 @@ def validate_semantic_graph_v2_payload_closure(
                 f"duplicate workflow capability binding identity {binding_key!r}"
             )
         seen_bindings.add(binding_key)
-        for required_edge in derive_workflow_capability_binding_edges(payload):
-            if (
-                required_edge.kind,
-                required_edge.source_node_id,
-                required_edge.target_node_id,
-            ) not in edge_keys:
+
+    # --- exact derived projection ownership ---------------------------------
+    # Workflow-capability semantics nodes participate ONLY in the canonical
+    # derived edges their typed payloads define.  The actual edge set touching
+    # each such node must equal the derived set exactly — full SemanticEdge
+    # identity, discriminator included — so a payload-unbacked edge mutation
+    # can never add, remove, or reshape application meaning.
+    exact_projection_kinds = {
+        SemanticNodeKind.WORKFLOW_CAPABILITY,
+        SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING,
+        SemanticNodeKind.WORKFLOW_RESULT,
+    }
+    expected_participation: dict[str, dict[str, SemanticEdge]] = {
+        node_id: {}
+        for node_id, payload in payload_by_node.items()
+        if getattr(payload, "payload_kind", None) in exact_projection_kinds
+    }
+
+    def _expect_participation(derived_edge: SemanticEdge) -> None:
+        for endpoint in (derived_edge.source_node_id, derived_edge.target_node_id):
+            expected_here = expected_participation.get(endpoint)
+            if expected_here is not None:
+                expected_here[derived_edge.edge_identity] = derived_edge
+
+    for payload in payload_by_node.values():
+        if isinstance(payload, WorkflowCapabilityBindingPayload):
+            for derived_edge in derive_workflow_capability_binding_edges(payload):
+                _expect_participation(derived_edge)
+        elif isinstance(payload, WorkflowResultPayload):
+            for derived_edge in derive_workflow_result_edges(payload):
+                _expect_participation(derived_edge)
+        elif isinstance(payload, WorkflowCapabilityPayload):
+            _expect_participation(
+                SemanticEdge(
+                    kind=SemanticEdgeKind.DECLARES,
+                    source_node_id=payload.workflow_node_id,
+                    target_node_id=payload.node_id,
+                )
+            )
+
+    for graph_edge in verified_graph.edges:
+        for endpoint in (graph_edge.source_node_id, graph_edge.target_node_id):
+            expected_here = expected_participation.get(endpoint)
+            if expected_here is None:
+                continue
+            if graph_edge.edge_identity not in expected_here:
                 raise SemanticPayloadError(
-                    f"binding {payload.node_id!r} lacks its derived "
-                    f"{required_edge.kind.value} edge to "
-                    f"{required_edge.target_node_id!r}"
+                    f"edge {graph_edge.kind.value} "
+                    f"{graph_edge.source_node_id!r} -> "
+                    f"{graph_edge.target_node_id!r} (discriminator "
+                    f"{graph_edge.discriminator!r}) is not part of the canonical "
+                    f"derived projection of {endpoint!r}"
+                )
+    actual_edge_identities = {edge.edge_identity for edge in verified_graph.edges}
+    for projection_node_id, expected_here in expected_participation.items():
+        for derived_edge in expected_here.values():
+            if derived_edge.edge_identity not in actual_edge_identities:
+                raise SemanticPayloadError(
+                    f"node {projection_node_id!r} lacks its derived "
+                    f"{derived_edge.kind.value} edge "
+                    f"{derived_edge.source_node_id!r} -> "
+                    f"{derived_edge.target_node_id!r} (discriminator "
+                    f"{derived_edge.discriminator!r})"
                 )
 
     applications = [
@@ -2141,6 +2430,7 @@ __all__ = [
     "WorkflowCapabilityPayload",
     "WorkflowPayload",
     "WorkflowParticipant",
+    "WorkflowResultPayload",
     "WorkflowStartupMode",
     "WorkflowTopology",
     "WorkflowTransition",
@@ -2148,6 +2438,7 @@ __all__ = [
     "WorkflowTransitionTargetKind",
     "build_semantic_payload",
     "derive_workflow_capability_binding_edges",
+    "derive_workflow_result_edges",
     "parse_semantic_payload",
     "semantic_payload_ref",
     "validate_semantic_graph_v2_payload_closure",

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -59,6 +59,7 @@ from mozaiksai.core.semantics.payloads import (
     IntegrationRequirementPhase,
     LimitPayload,
     MeterPayload,
+    ModuleActionRef,
     ModulePayload,
     NotificationChannel,
     NotificationPayload,
@@ -81,6 +82,9 @@ from mozaiksai.core.semantics.payloads import (
     TriggerKind,
     TriggerPayload,
     TypedFieldSpec,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityBindingRole,
+    WorkflowCapabilityPayload,
     WorkflowParticipant,
     WorkflowPayload,
     WorkflowStartupMode,
@@ -514,6 +518,42 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
     }
 
 
+def _extended_kind_payloads(
+    *, scope: ExecutionAccessScopeRef = _SCOPE
+) -> dict[SemanticNodeKind, SemanticPayloadBase]:
+    """Corpus plus the module-workflow binding kinds.
+
+    The shared corpus graph is a pinned golden consumed by the compilation
+    plan and materialization suites, so the binding kinds get full graph
+    closure coverage in tests/test_workflow_capability_semantics.py instead
+    of being appended there; this map keeps per-kind round-trip coverage
+    complete for the whole enum.
+    """
+    payloads = dict(_corpus_payloads(scope=scope))
+    payloads[SemanticNodeKind.WORKFLOW_CAPABILITY] = build_semantic_payload(
+        WorkflowCapabilityPayload,
+        node_id="mozaiks.workflow_capability.digest_reporting",
+        payload_version=1,
+        scope=scope,
+        capability_id="reports.generate_digest",
+        description="User-launchable weekly digest generation",
+        workflow_node_id="mozaiks.workflow.digest",
+    )
+    payloads[SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING] = build_semantic_payload(
+        WorkflowCapabilityBindingPayload,
+        node_id="mozaiks.workflow_capability_binding.digest_reads_reports",
+        payload_version=1,
+        scope=scope,
+        binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+        workflow_capability_node_id="mozaiks.workflow_capability.digest_reporting",
+        module_action=ModuleActionRef(
+            module_node_id="mozaiks.module.reports",
+            action_node_id="mozaiks.action.create_report",
+        ),
+    )
+    return payloads
+
+
 def _pricing_section(scope: ExecutionAccessScopeRef = _SCOPE) -> SectionPayload:
     return build_semantic_payload(
         SectionPayload,
@@ -938,7 +978,7 @@ def test_every_node_kind_has_exactly_one_payload_variant() -> None:
 def test_each_kind_round_trips_through_the_discriminated_union(
     kind: SemanticNodeKind,
 ) -> None:
-    payload = _corpus_payloads()[kind]
+    payload = _extended_kind_payloads()[kind]
     parsed = parse_semantic_payload(json.loads(json.dumps(payload.model_dump(mode="json"))))
     assert type(parsed) is PAYLOAD_MODEL_BY_KIND[kind]
     assert parsed == payload
@@ -969,6 +1009,7 @@ def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
         DataCollectionPayload: ("description", "fields"),
         DataAliasPayload: ("alias", "collection", "owner_node_id"),
         WorkflowPayload: ("description", "startup_mode", "topology"),
+        WorkflowCapabilityPayload: ("description",),
         TriggerPayload: ("description", "trigger_kind"),
         PlanPayload: ("title", "prices"),
         ProductPayload: ("title", "description", "prices"),

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -87,6 +87,7 @@ from mozaiksai.core.semantics.payloads import (
     WorkflowCapabilityPayload,
     WorkflowParticipant,
     WorkflowPayload,
+    WorkflowResultPayload,
     WorkflowStartupMode,
     WorkflowTopology,
     WorkflowTransition,
@@ -551,6 +552,15 @@ def _extended_kind_payloads(
             action_node_id="mozaiks.action.create_report",
         ),
     )
+    payloads[SemanticNodeKind.WORKFLOW_RESULT] = build_semantic_payload(
+        WorkflowResultPayload,
+        node_id="mozaiks.workflow_result.weekly_digest",
+        payload_version=1,
+        scope=scope,
+        result_id="weekly_digest",
+        description="The rendered weekly digest",
+        workflow_capability_node_id="mozaiks.workflow_capability.digest_reporting",
+    )
     return payloads
 
 
@@ -1010,6 +1020,7 @@ def test_truthful_absence_is_explicit_and_distinct_from_empty() -> None:
         DataAliasPayload: ("alias", "collection", "owner_node_id"),
         WorkflowPayload: ("description", "startup_mode", "topology"),
         WorkflowCapabilityPayload: ("description",),
+        WorkflowResultPayload: ("description",),
         TriggerPayload: ("description", "trigger_kind"),
         PlanPayload: ("title", "prices"),
         ProductPayload: ("title", "description", "prices"),

--- a/tests/test_workflow_capability_semantics.py
+++ b/tests/test_workflow_capability_semantics.py
@@ -278,14 +278,19 @@ def _build_graph(
     edges: list[SemanticEdge] | None = None,
     graph_id: str = "documents-analysis",
     event_identity: str | None = _EVENT_ID,
+    extra_event_identities: dict[str, str] | None = None,
 ) -> SemanticGraphV2:
+    identities: dict[str, str] = dict(extra_event_identities or {})
+    if event_identity is not None:
+        identities[_EVENT] = event_identity
     nodes = []
     for payload in payloads.values():
         taxonomy_references: tuple[TaxonomyReference, ...] = ()
-        if payload.node_id == _EVENT and event_identity is not None:
+        if payload.node_id in identities:
             taxonomy_references = (
                 TaxonomyReference(
-                    category=SemanticCategory.EVENT, identifier=event_identity
+                    category=SemanticCategory.EVENT,
+                    identifier=identities[payload.node_id],
                 ),
             )
         nodes.append(
@@ -571,7 +576,7 @@ def test_action_declared_by_two_modules_rejects() -> None:
             target_node_id=_ACTION_GET,
         )
     )
-    _expect_rejection(payloads, "ambiguously owned by multiple modules", edges=edges)
+    _expect_rejection(payloads, "contradictory\\s+declarer set", edges=edges)
 
 
 def test_action_with_no_module_declarer_rejects() -> None:
@@ -585,7 +590,70 @@ def test_action_with_no_module_declarer_rejects() -> None:
             and edge.target_node_id == _ACTION_GET
         )
     ]
-    _expect_rejection(payloads, "that no module\\s+declares", edges=edges)
+    _expect_rejection(payloads, "has no module declarer", edges=edges)
+
+
+def test_action_with_module_and_nonmodule_declarers_rejects() -> None:
+    """Codex reproduction: MODULE + WORKFLOW both declare one action.
+
+    The complete declarer set is validated — a contradictory non-module
+    DECLARES edge is never filtered away before ownership is claimed.  The
+    same closure covers the ModuleActionRef target (get_content) and the
+    event-producing action (create).
+    """
+    for contradicted_action in (_ACTION_GET, _ACTION_CREATE):
+        payloads = _fixture_payloads()
+        edges = _fixture_edges(payloads)
+        edges.append(
+            SemanticEdge(
+                kind=SemanticEdgeKind.DECLARES,
+                source_node_id=_WORKFLOW,
+                target_node_id=contradicted_action,
+            )
+        )
+        _expect_rejection(payloads, "contradictory\\s+declarer set", edges=edges)
+
+
+def test_action_with_only_a_nonmodule_declarer_rejects() -> None:
+    payloads = _fixture_payloads()
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_WORKFLOW,
+            target_node_id=_ACTION_GET,
+        )
+        if (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _MODULE
+            and edge.target_node_id == _ACTION_GET
+        )
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(payloads, "sole declarer.*is not a module", edges=edges)
+
+
+def test_discriminated_module_declares_edge_rejects() -> None:
+    """A payload-unbacked discriminator on the ownership projection rejects."""
+    payloads = _fixture_payloads()
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_MODULE,
+            target_node_id=_ACTION_GET,
+            discriminator="uninvited",
+        )
+        if (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _MODULE
+            and edge.target_node_id == _ACTION_GET
+        )
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(
+        payloads, "declaring edge\\s+carrying a discriminator", edges=edges
+    )
 
 
 def test_removed_action_rejects() -> None:
@@ -643,7 +711,165 @@ def test_typed_emits_without_projection_edge_rejects() -> None:
         for edge in _fixture_edges(payloads)
         if edge.kind is not SemanticEdgeKind.EMITS
     ]
-    _expect_rejection(payloads, "lacks the required EMITS projection", edges=edges)
+    _expect_rejection(payloads, "lacks its typed EMITS\\s+projection", edges=edges)
+
+
+def test_typed_emit_without_any_event_node_rejects_even_without_trigger() -> None:
+    """Codex reproduction TYPED_EMIT_MISSING_EVENT_NODE.
+
+    The typed emit is an application-semantic claim in its own right: it must
+    close even when no trigger binding (and no consumer at all) exists.
+    """
+    payloads = _fixture_payloads()
+    del payloads[_EVENT]
+    del payloads[_BINDING_TRIGGER]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if _EVENT not in (edge.source_node_id, edge.target_node_id)
+        and _BINDING_TRIGGER not in (edge.source_node_id, edge.target_node_id)
+    ]
+    _expect_rejection(
+        payloads,
+        "no event node carries that\\s+canonical event identity",
+        edges=edges,
+    )
+
+
+def test_typed_emit_event_without_taxonomy_identity_rejects() -> None:
+    """Codex reproduction TYPED_EMIT_EVENT_WITHOUT_TAXONOMY.
+
+    An EVENT node with no canonical EVENT-category identity cannot satisfy a
+    typed emit — with or without any trigger binding downstream.
+    """
+    with_trigger = _fixture_payloads()
+    _expect_rejection(
+        with_trigger,
+        "no event node carries that\\s+canonical event identity",
+        event_identity=None,
+    )
+
+    without_trigger = _fixture_payloads()
+    del without_trigger[_BINDING_TRIGGER]
+    edges = [
+        edge
+        for edge in _fixture_edges(without_trigger)
+        if _BINDING_TRIGGER not in (edge.source_node_id, edge.target_node_id)
+    ]
+    _expect_rejection(
+        without_trigger,
+        "no event node carries that\\s+canonical event identity",
+        edges=edges,
+        event_identity=None,
+    )
+
+
+def test_two_event_nodes_with_same_canonical_identity_reject() -> None:
+    payloads = _fixture_payloads()
+    payloads["mozaiks.event.documents_created_alt"] = build_semantic_payload(
+        EventPayload,
+        node_id="mozaiks.event.documents_created_alt",
+        payload_version=1,
+        scope=_SCOPE,
+        description="A rival claim to the same event identity",
+    )
+    _expect_rejection(
+        payloads,
+        "carried\\s+by multiple event nodes",
+        extra_event_identities={"mozaiks.event.documents_created_alt": _EVENT_ID},
+    )
+
+
+def test_typed_event_without_any_trigger_still_validates() -> None:
+    """A complete typed emit closure needs no consumer to be truthful."""
+    payloads = _fixture_payloads()
+    del payloads[_BINDING_TRIGGER]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if _BINDING_TRIGGER not in (edge.source_node_id, edge.target_node_id)
+    ]
+    graph = _build_graph(payloads, edges=edges)
+    validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+
+
+def test_emits_discriminator_mutations_reject() -> None:
+    """Codex reproductions EMITS_WRONG_EXTRA_DISCRIMINATOR and
+    EMITS_EXTRA_DISCRIMINATED_DUPLICATE: the ACTION EMITS projection is
+    compared with full SemanticEdge identity, discriminator included."""
+    payloads = _fixture_payloads()
+
+    # A discriminated ACTION EMITS edge rejects at the floor (no typed payload
+    # backs any such discriminator) and would fail exact projection beneath.
+    discriminator_rejections = (
+        "carries a\\s+discriminator no typed payload backs"
+        "|not part of the\\s+typed emits projection"
+    )
+
+    # The only projection carries a forged discriminator.
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_CREATE,
+            target_node_id=_EVENT,
+            discriminator="evil",
+        )
+        if edge.kind is SemanticEdgeKind.EMITS
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(payloads, discriminator_rejections, edges=edges)
+
+    # The exact projection exists, plus a discriminated duplicate.
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_CREATE,
+            target_node_id=_EVENT,
+            discriminator="evil",
+        )
+    )
+    _expect_rejection(payloads, discriminator_rejections, edges=edges)
+
+
+def test_emits_projection_to_wrong_or_extra_event_rejects() -> None:
+    payloads = _fixture_payloads()
+    payloads["mozaiks.event.decoy"] = build_semantic_payload(
+        EventPayload,
+        node_id="mozaiks.event.decoy",
+        payload_version=1,
+        scope=_SCOPE,
+        description="An event the action never declared",
+    )
+
+    # The projection targets the wrong event node entirely.
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_CREATE,
+            target_node_id="mozaiks.event.decoy",
+        )
+        if edge.kind is SemanticEdgeKind.EMITS
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(
+        payloads, "not part of the\\s+typed emits projection", edges=edges
+    )
+
+    # The exact projection exists, plus an extra edge to another event.
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_CREATE,
+            target_node_id="mozaiks.event.decoy",
+        )
+    )
+    _expect_rejection(
+        payloads, "not part of the\\s+typed emits projection", edges=edges
+    )
 
 
 def test_event_without_canonical_producer_rejects() -> None:
@@ -694,19 +920,31 @@ def test_event_producer_with_ambiguous_module_ownership_rejects() -> None:
             target_node_id=_ACTION_CREATE,
         )
     )
-    _expect_rejection(payloads, "ambiguous module\\s+ownership", edges=edges)
+    _expect_rejection(payloads, "contradictory\\s+declarer set", edges=edges)
 
 
-def test_trigger_event_without_canonical_identity_rejects() -> None:
+def test_trigger_to_orphan_identity_less_event_rejects() -> None:
+    """No typed emit claims the event and it carries no canonical identity —
+    the trigger-authority check still fails closed."""
     payloads = _fixture_payloads()
+    payloads[_ACTION_CREATE] = _rebuilt_action(payloads, _ACTION_CREATE, emits=())
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if edge.kind is not SemanticEdgeKind.EMITS
+    ]
     _expect_rejection(
-        payloads, "exactly one\\s+canonical event identity", event_identity=None
+        payloads,
+        "exactly one\\s+canonical event identity",
+        edges=edges,
+        event_identity=None,
     )
 
 
 def test_removed_event_rejects() -> None:
     payloads = _fixture_payloads()
     del payloads[_EVENT]
+    payloads[_ACTION_CREATE] = _rebuilt_action(payloads, _ACTION_CREATE, emits=())
     edges = [
         edge
         for edge in _fixture_edges(payloads)

--- a/tests/test_workflow_capability_semantics.py
+++ b/tests/test_workflow_capability_semantics.py
@@ -5,14 +5,21 @@ workflow linkage lived in seven mutually-unaware string namespaces (module
 capability rows, reaction targets, orchestrator trigger ids, kebab slugs,
 plan lists, synthesized envelope ids, page workflow_ids).  These tests prove:
 
+- typed semantic payloads own application meaning; generic graph edges are
+  derived projections that can never invent ownership, event production,
+  binding meaning, or result identity;
+- module actions used through :class:`ModuleActionRef` have exactly one
+  canonical module owner;
+- event production authority comes from typed ``ActionPayload.emits`` joined
+  to the EVENT node's canonical taxonomy identity, never from a bare EMITS
+  edge;
+- each binding/capability/result node participates in EXACTLY its derived
+  edge set (full edge identity, discriminator included);
+- workflow results are typed, capability-owned WORKFLOW_RESULT nodes; fan-out
+  is explicit (several commit bindings referencing the same result node);
 - the canonical fixture (documents / AnalyzeDocument) validates and is
-  byte-deterministic across processes;
-- every single-axis mutation either changes canonical semantic identity or is
-  rejected by validation;
-- unrelated module/action/workflow additions never move a binding's identity;
-- referential integrity fails closed on every dangling or foreign reference;
-- the three App Zero patterns (user-launched, event-triggered, no-result
-  answer) are expressible with zero hosted/provider policy.
+  byte-deterministic across processes, and unrelated additions never move a
+  binding or result identity.
 """
 from __future__ import annotations
 
@@ -28,6 +35,7 @@ from mozaiksai.core.semantics.graph import (
     SemanticEdgeKind,
     SemanticGraphV2,
     SemanticNodeV2,
+    TaxonomyReference,
     build_semantic_graph_v2,
 )
 from mozaiksai.core.semantics.payloads import (
@@ -41,13 +49,16 @@ from mozaiksai.core.semantics.payloads import (
     WorkflowCapabilityBindingRole,
     WorkflowCapabilityPayload,
     WorkflowPayload,
+    WorkflowResultPayload,
     build_semantic_payload,
     derive_workflow_capability_binding_edges,
+    derive_workflow_result_edges,
     parse_semantic_payload,
     semantic_payload_ref,
     validate_semantic_graph_v2_payload_closure,
 )
 from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+from mozaiksai.core.taxonomy import SemanticCategory
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -59,11 +70,17 @@ _ACTION_CREATE = "mozaiks.action.documents_create"
 _ACTION_GET = "mozaiks.action.documents_get_content"
 _ACTION_STORE = "mozaiks.action.documents_store_analysis"
 _EVENT = "mozaiks.event.documents_created"
+_EVENT_ID = "domain.documents.created"
 _WORKFLOW = "mozaiks.workflow.analyze_document"
 _CAPABILITY = "mozaiks.workflow_capability.documents_analysis"
+_RESULT = "mozaiks.workflow_result.analysis_result"
+_RESULT_ALT = "mozaiks.workflow_result.analysis_summary"
 _BINDING_TRIGGER = "mozaiks.workflow_capability_binding.analysis_on_created"
 _BINDING_READ = "mozaiks.workflow_capability_binding.analysis_reads_content"
 _BINDING_RESULT = "mozaiks.workflow_capability_binding.analysis_stores_result"
+
+_RIVAL_WORKFLOW = "mozaiks.workflow.rival"
+_RIVAL_CAPABILITY = "mozaiks.workflow_capability.rival_analysis"
 
 
 def _action(node_id: str, *, description: str, emits: tuple[str, ...] = ()) -> ActionPayload:
@@ -77,13 +94,55 @@ def _action(node_id: str, *, description: str, emits: tuple[str, ...] = ()) -> A
     )
 
 
+def _result(
+    node_id: str,
+    *,
+    result_id: str,
+    capability_node_id: str = _CAPABILITY,
+    description: str | None = "One analysis of one document",
+) -> WorkflowResultPayload:
+    return build_semantic_payload(
+        WorkflowResultPayload,
+        node_id=node_id,
+        payload_version=1,
+        scope=_SCOPE,
+        result_id=result_id,
+        description=description,
+        workflow_capability_node_id=capability_node_id,
+    )
+
+
+def _rival_workflow_and_capability() -> tuple[WorkflowPayload, WorkflowCapabilityPayload]:
+    workflow = build_semantic_payload(
+        WorkflowPayload,
+        node_id=_RIVAL_WORKFLOW,
+        payload_version=1,
+        scope=_SCOPE,
+        workflow_id="rival",
+        description="Competing workflow",
+        startup_mode=None,
+        topology=None,
+    )
+    capability = build_semantic_payload(
+        WorkflowCapabilityPayload,
+        node_id=_RIVAL_CAPABILITY,
+        payload_version=1,
+        scope=_SCOPE,
+        capability_id="documents.rival_analysis",
+        description="A different capability",
+        workflow_node_id=_RIVAL_WORKFLOW,
+    )
+    return workflow, capability
+
+
 def _fixture_payloads() -> dict[str, SemanticPayloadBase]:
     """The canonical fixture: documents module + AnalyzeDocument workflow.
 
-    module documents { create, get_content, store_analysis } emits
-    domain.documents.created; workflow AnalyzeDocument declares capability
-    documents.analysis with three bindings: triggered by the event, consumes
-    get_content, commits result analysis_result through store_analysis.
+    module documents { create, get_content, store_analysis }; create truthfully
+    emits domain.documents.created; workflow AnalyzeDocument declares
+    capability documents.analysis, which declares workflow result
+    analysis_result and three bindings: triggered by the event, consumes
+    get_content, commits the declared result through store_analysis.
     """
     payloads: dict[str, SemanticPayloadBase] = {}
 
@@ -104,7 +163,7 @@ def _fixture_payloads() -> dict[str, SemanticPayloadBase]:
         _action(
             _ACTION_CREATE,
             description="Create one document",
-            emits=("domain.documents.created",),
+            emits=(_EVENT_ID,),
         )
     )
     _add(_action(_ACTION_GET, description="Read one document's content"))
@@ -141,6 +200,7 @@ def _fixture_payloads() -> dict[str, SemanticPayloadBase]:
             workflow_node_id=_WORKFLOW,
         )
     )
+    _add(_result(_RESULT, result_id="analysis_result"))
     _add(
         build_semantic_payload(
             WorkflowCapabilityBindingPayload,
@@ -176,7 +236,7 @@ def _fixture_payloads() -> dict[str, SemanticPayloadBase]:
             module_action=ModuleActionRef(
                 module_node_id=_MODULE, action_node_id=_ACTION_STORE
             ),
-            workflow_result_id="analysis_result",
+            workflow_result_node_id=_RESULT,
         )
     )
     return payloads
@@ -196,15 +256,18 @@ def _fixture_edges(payloads: dict[str, SemanticPayloadBase]) -> list[SemanticEdg
             target_node_id=_EVENT,
         )
     )
-    edges.append(
-        SemanticEdge(
-            kind=SemanticEdgeKind.DECLARES,
-            source_node_id=_WORKFLOW,
-            target_node_id=_CAPABILITY,
-        )
-    )
     for payload in payloads.values():
-        if isinstance(payload, WorkflowCapabilityBindingPayload):
+        if isinstance(payload, WorkflowCapabilityPayload):
+            edges.append(
+                SemanticEdge(
+                    kind=SemanticEdgeKind.DECLARES,
+                    source_node_id=payload.workflow_node_id,
+                    target_node_id=payload.node_id,
+                )
+            )
+        elif isinstance(payload, WorkflowResultPayload):
+            edges.extend(derive_workflow_result_edges(payload))
+        elif isinstance(payload, WorkflowCapabilityBindingPayload):
             edges.extend(derive_workflow_capability_binding_edges(payload))
     return edges
 
@@ -214,19 +277,30 @@ def _build_graph(
     *,
     edges: list[SemanticEdge] | None = None,
     graph_id: str = "documents-analysis",
+    event_identity: str | None = _EVENT_ID,
 ) -> SemanticGraphV2:
+    nodes = []
+    for payload in payloads.values():
+        taxonomy_references: tuple[TaxonomyReference, ...] = ()
+        if payload.node_id == _EVENT and event_identity is not None:
+            taxonomy_references = (
+                TaxonomyReference(
+                    category=SemanticCategory.EVENT, identifier=event_identity
+                ),
+            )
+        nodes.append(
+            SemanticNodeV2(
+                node_id=payload.node_id,
+                kind=payload.payload_kind,
+                taxonomy_references=taxonomy_references,
+                payload_ref=semantic_payload_ref(payload),
+            )
+        )
     return build_semantic_graph_v2(
         graph_id=graph_id,
         version=1,
         scope=_SCOPE,
-        nodes=[
-            SemanticNodeV2(
-                node_id=payload.node_id,
-                kind=payload.payload_kind,
-                payload_ref=semantic_payload_ref(payload),
-            )
-            for payload in payloads.values()
-        ],
+        nodes=nodes,
         edges=_fixture_edges(payloads) if edges is None else edges,
     )
 
@@ -235,6 +309,41 @@ def _validate(payloads: dict[str, SemanticPayloadBase], **kwargs) -> SemanticGra
     graph = _build_graph(payloads, **kwargs)
     validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
     return graph
+
+
+def _expect_rejection(payloads: dict[str, SemanticPayloadBase], match: str, **kwargs) -> None:
+    graph = _build_graph(payloads, **kwargs)
+    with pytest.raises(SemanticPayloadError, match=match):
+        validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+
+
+def _rebuilt_binding(payloads: dict[str, SemanticPayloadBase], source_node_id: str, **overrides):
+    base = payloads[source_node_id]
+    fields = {
+        "node_id": base.node_id,
+        "payload_version": base.payload_version,
+        "scope": base.scope,
+        "binding_role": base.binding_role,
+        "workflow_capability_node_id": base.workflow_capability_node_id,
+        "module_action": base.module_action,
+        "event_node_id": base.event_node_id,
+        "workflow_result_node_id": base.workflow_result_node_id,
+    }
+    fields.update(overrides)
+    return build_semantic_payload(WorkflowCapabilityBindingPayload, **fields)
+
+
+def _rebuilt_action(payloads: dict[str, SemanticPayloadBase], node_id: str, **overrides):
+    base = payloads[node_id]
+    fields = {
+        "node_id": base.node_id,
+        "payload_version": base.payload_version,
+        "scope": base.scope,
+        "description": base.description,
+        "emits": base.emits,
+    }
+    fields.update(overrides)
+    return build_semantic_payload(ActionPayload, **fields)
 
 
 # ---------------------------------------------------------------------------
@@ -274,26 +383,12 @@ def test_fixture_digest_is_identical_in_a_fresh_process() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _rebuilt_binding(payloads: dict[str, SemanticPayloadBase], source_node_id: str, **overrides):
-    base = payloads[source_node_id]
-    fields = {
-        "node_id": base.node_id,
-        "payload_version": base.payload_version,
-        "scope": base.scope,
-        "binding_role": base.binding_role,
-        "workflow_capability_node_id": base.workflow_capability_node_id,
-        "module_action": base.module_action,
-        "event_node_id": base.event_node_id,
-        "workflow_result_id": base.workflow_result_id,
-    }
-    fields.update(overrides)
-    return build_semantic_payload(WorkflowCapabilityBindingPayload, **fields)
-
-
 def test_each_bound_axis_mutation_changes_canonical_identity() -> None:
     baseline = _fixture_payloads()
     baseline_graph = _validate(baseline)
     read_binding_digest = baseline[_BINDING_READ].payload_digest
+    commit_binding_digest = baseline[_BINDING_RESULT].payload_digest
+    result_digest = baseline[_RESULT].payload_digest
 
     # Input action mutated: get_content -> create.
     mutated = _fixture_payloads()
@@ -319,13 +414,14 @@ def test_each_bound_axis_mutation_changes_canonical_identity() -> None:
     )
     assert _validate(mutated).graph_digest != baseline_graph.graph_digest
 
-    # Binding role/direction mutated on the same endpoints.
+    # Binding role/direction mutated on the same endpoints (explicit fan-out
+    # of the declared result through a second action, so it still validates).
     mutated = _fixture_payloads()
     mutated[_BINDING_READ] = _rebuilt_binding(
         mutated,
         _BINDING_READ,
         binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
-        workflow_result_id="content_projection",
+        workflow_result_node_id=_RESULT,
     )
     assert _validate(mutated).graph_digest != baseline_graph.graph_digest
 
@@ -343,20 +439,40 @@ def test_each_bound_axis_mutation_changes_canonical_identity() -> None:
     )
     assert _validate(mutated).graph_digest != baseline_graph.graph_digest
 
-    # Workflow result id mutated.
+    # Committed result reference mutated: point at a second declared result.
     mutated = _fixture_payloads()
+    mutated[_RESULT_ALT] = _result(_RESULT_ALT, result_id="analysis_summary")
     mutated[_BINDING_RESULT] = _rebuilt_binding(
-        mutated, _BINDING_RESULT, workflow_result_id="analysis_summary"
+        mutated, _BINDING_RESULT, workflow_result_node_id=_RESULT_ALT
     )
+    graph = _validate(mutated)
+    assert mutated[_BINDING_RESULT].payload_digest != commit_binding_digest
+    assert graph.graph_digest != baseline_graph.graph_digest
+
+    # Result node's own result_id mutated: result identity moves, the binding
+    # keeps pinning the same node (identity via node + ownership, not string).
+    mutated = _fixture_payloads()
+    mutated[_RESULT] = _result(_RESULT, result_id="analysis_summary")
+    graph = _validate(mutated)
+    assert mutated[_RESULT].payload_digest != result_digest
+    assert mutated[_BINDING_RESULT].payload_digest == commit_binding_digest
+    assert graph.graph_digest != baseline_graph.graph_digest
+
+    # Result description is identity-bearing payload content.
+    mutated = _fixture_payloads()
+    mutated[_RESULT] = _result(
+        _RESULT, result_id="analysis_result", description="Deeper analysis"
+    )
+    assert mutated[_RESULT].payload_digest != result_digest
     assert _validate(mutated).graph_digest != baseline_graph.graph_digest
 
 
-def test_unrelated_additions_never_move_a_binding_identity() -> None:
+def test_unrelated_additions_never_move_binding_or_result_identity() -> None:
     baseline = _fixture_payloads()
-    binding_digests = {
+    tracked_digests = {
         node_id: payload.payload_digest
         for node_id, payload in baseline.items()
-        if isinstance(payload, WorkflowCapabilityBindingPayload)
+        if isinstance(payload, WorkflowCapabilityBindingPayload | WorkflowResultPayload)
     }
 
     extended = _fixture_payloads()
@@ -371,15 +487,27 @@ def test_unrelated_additions_never_move_a_binding_identity() -> None:
     extended["mozaiks.action.archive_store"] = _action(
         "mozaiks.action.archive_store", description="Unrelated action"
     )
-    extended["mozaiks.workflow.unrelated"] = build_semantic_payload(
-        WorkflowPayload,
-        node_id="mozaiks.workflow.unrelated",
-        payload_version=1,
-        scope=_SCOPE,
-        workflow_id="unrelated",
-        description="Unrelated workflow",
-        startup_mode=None,
-        topology=None,
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    extended[rival_workflow.node_id] = rival_workflow
+    extended[rival_capability.node_id] = rival_capability
+    extended["mozaiks.workflow_result.rival_summary"] = _result(
+        "mozaiks.workflow_result.rival_summary",
+        result_id="summary",
+        capability_node_id=_RIVAL_CAPABILITY,
+    )
+    extended["mozaiks.workflow_capability_binding.rival_reads_archive"] = (
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id="mozaiks.workflow_capability_binding.rival_reads_archive",
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            workflow_capability_node_id=_RIVAL_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id="mozaiks.module.archive",
+                action_node_id="mozaiks.action.archive_store",
+            ),
+        )
     )
     edges = _fixture_edges(extended)
     edges.append(
@@ -392,21 +520,72 @@ def test_unrelated_additions_never_move_a_binding_identity() -> None:
     graph = _build_graph(extended, edges=edges)
     validate_semantic_graph_v2_payload_closure(graph, list(extended.values()))
 
-    for node_id, digest in binding_digests.items():
+    for node_id, digest in tracked_digests.items():
         assert extended[node_id].payload_digest == digest, (
-            f"unrelated mutation moved binding identity {node_id}"
+            f"unrelated mutation moved semantic identity {node_id}"
         )
 
 
 # ---------------------------------------------------------------------------
-# Referential integrity: every dangling/foreign reference fails closed
+# Canonical module action ownership
 # ---------------------------------------------------------------------------
 
 
-def _expect_rejection(payloads: dict[str, SemanticPayloadBase], match: str, **kwargs) -> None:
-    graph = _build_graph(payloads, **kwargs)
-    with pytest.raises(SemanticPayloadError, match=match):
-        validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+def test_action_under_wrong_module_rejects() -> None:
+    """A real action referenced through a module that is not its canonical owner."""
+    payloads = _fixture_payloads()
+    payloads["mozaiks.module.other"] = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.other",
+        payload_version=1,
+        scope=_SCOPE,
+        module_id="other",
+        description="Another module",
+    )
+    payloads[_BINDING_READ] = _rebuilt_binding(
+        payloads,
+        _BINDING_READ,
+        module_action=ModuleActionRef(
+            module_node_id="mozaiks.module.other", action_node_id=_ACTION_GET
+        ),
+    )
+    _expect_rejection(payloads, "canonical module owner is")
+
+
+def test_action_declared_by_two_modules_rejects() -> None:
+    """Codex reproduction: two modules DECLARE the same action."""
+    payloads = _fixture_payloads()
+    payloads["mozaiks.module.other"] = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.other",
+        payload_version=1,
+        scope=_SCOPE,
+        module_id="other",
+        description="Another module",
+    )
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.module.other",
+            target_node_id=_ACTION_GET,
+        )
+    )
+    _expect_rejection(payloads, "ambiguously owned by multiple modules", edges=edges)
+
+
+def test_action_with_no_module_declarer_rejects() -> None:
+    payloads = _fixture_payloads()
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if not (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _MODULE
+            and edge.target_node_id == _ACTION_GET
+        )
+    ]
+    _expect_rejection(payloads, "that no module\\s+declares", edges=edges)
 
 
 def test_removed_action_rejects() -> None:
@@ -431,6 +610,100 @@ def test_removed_workflow_rejects() -> None:
     _expect_rejection(payloads, "missing or non-workflow", edges=edges)
 
 
+# ---------------------------------------------------------------------------
+# Typed event production authority
+# ---------------------------------------------------------------------------
+
+
+def test_forged_emits_edge_without_typed_backing_rejects() -> None:
+    """Codex reproduction: ActionPayload.emits == () plus a generic EMITS edge."""
+    payloads = _fixture_payloads()
+    payloads[_ACTION_CREATE] = _rebuilt_action(payloads, _ACTION_CREATE, emits=())
+    _expect_rejection(payloads, "not\\s+backed by typed ActionPayload.emits")
+
+
+def test_forged_emits_edge_from_unrelated_action_rejects() -> None:
+    """A generic EMITS edge from an action that declares no emitted events."""
+    payloads = _fixture_payloads()
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_GET,
+            target_node_id=_EVENT,
+        )
+    )
+    _expect_rejection(payloads, "not\\s+backed by typed ActionPayload.emits", edges=edges)
+
+
+def test_typed_emits_without_projection_edge_rejects() -> None:
+    payloads = _fixture_payloads()
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if edge.kind is not SemanticEdgeKind.EMITS
+    ]
+    _expect_rejection(payloads, "lacks the required EMITS projection", edges=edges)
+
+
+def test_event_without_canonical_producer_rejects() -> None:
+    payloads = _fixture_payloads()
+    payloads[_ACTION_CREATE] = _rebuilt_action(payloads, _ACTION_CREATE, emits=())
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if edge.kind is not SemanticEdgeKind.EMITS
+    ]
+    _expect_rejection(
+        payloads, "no canonical module-owned\\s+action produces", edges=edges
+    )
+
+
+def test_event_producer_without_module_owner_rejects() -> None:
+    """Codex reproduction: the only producer action has no module owner."""
+    payloads = _fixture_payloads()
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if not (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _MODULE
+            and edge.target_node_id == _ACTION_CREATE
+        )
+    ]
+    _expect_rejection(
+        payloads, "no canonical module-owned\\s+action produces", edges=edges
+    )
+
+
+def test_event_producer_with_ambiguous_module_ownership_rejects() -> None:
+    payloads = _fixture_payloads()
+    payloads["mozaiks.module.other"] = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.other",
+        payload_version=1,
+        scope=_SCOPE,
+        module_id="other",
+        description="Another module",
+    )
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.module.other",
+            target_node_id=_ACTION_CREATE,
+        )
+    )
+    _expect_rejection(payloads, "ambiguous module\\s+ownership", edges=edges)
+
+
+def test_trigger_event_without_canonical_identity_rejects() -> None:
+    payloads = _fixture_payloads()
+    _expect_rejection(
+        payloads, "exactly one\\s+canonical event identity", event_identity=None
+    )
+
+
 def test_removed_event_rejects() -> None:
     payloads = _fixture_payloads()
     del payloads[_EVENT]
@@ -442,96 +715,200 @@ def test_removed_event_rejects() -> None:
     _expect_rejection(payloads, "missing or non-event", edges=edges)
 
 
-def test_action_under_wrong_module_rejects() -> None:
-    """A real action referenced through a module that does not declare it."""
-    payloads = _fixture_payloads()
-    payloads["mozaiks.module.other"] = build_semantic_payload(
-        ModulePayload,
-        node_id="mozaiks.module.other",
-        payload_version=1,
-        scope=_SCOPE,
-        module_id="other",
-        description="Another module",
-    )
-    payloads[_BINDING_READ] = _rebuilt_binding(
-        payloads,
-        _BINDING_READ,
-        module_action=ModuleActionRef(
-            module_node_id="mozaiks.module.other", action_node_id=_ACTION_GET
-        ),
-    )
-    _expect_rejection(payloads, "does not declare")
+# ---------------------------------------------------------------------------
+# Typed workflow result identity and ownership
+# ---------------------------------------------------------------------------
 
 
-def test_event_without_module_producer_rejects() -> None:
+def test_missing_result_node_rejects() -> None:
+    """A free/unanchored workflow result is impossible: the commit binding must
+    reference a declared WORKFLOW_RESULT node."""
     payloads = _fixture_payloads()
+    del payloads[_RESULT]
     edges = [
         edge
         for edge in _fixture_edges(payloads)
-        if edge.kind is not SemanticEdgeKind.EMITS
+        if _RESULT not in (edge.source_node_id, edge.target_node_id)
     ]
-    _expect_rejection(payloads, "no module or action produces", edges=edges)
+    _expect_rejection(payloads, "missing or\\s+non-workflow-result", edges=edges)
+
+
+def test_result_node_must_be_workflow_result_kind() -> None:
+    payloads = _fixture_payloads()
+    payloads[_BINDING_RESULT] = _rebuilt_binding(
+        payloads, _BINDING_RESULT, workflow_result_node_id=_EVENT
+    )
+    _expect_rejection(payloads, "missing or\\s+non-workflow-result")
+
+
+def test_result_owned_by_foreign_capability_rejects() -> None:
+    """A capability cannot commit another capability's result."""
+    payloads = _fixture_payloads()
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[rival_capability.node_id] = rival_capability
+    payloads["mozaiks.workflow_result.rival_summary"] = _result(
+        "mozaiks.workflow_result.rival_summary",
+        result_id="summary",
+        capability_node_id=_RIVAL_CAPABILITY,
+    )
+    payloads[_BINDING_RESULT] = _rebuilt_binding(
+        payloads,
+        _BINDING_RESULT,
+        workflow_result_node_id="mozaiks.workflow_result.rival_summary",
+    )
+    _expect_rejection(payloads, "cannot commit\\s+another capability's result")
+
+
+def test_result_owner_and_declarer_must_agree() -> None:
+    payloads = _fixture_payloads()
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[rival_capability.node_id] = rival_capability
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_RIVAL_CAPABILITY,
+            target_node_id=_RESULT,
+        )
+        if (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _CAPABILITY
+            and edge.target_node_id == _RESULT
+        )
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(payloads, "claims owner", edges=edges)
+
+
+def test_result_declared_by_two_capabilities_rejects() -> None:
+    payloads = _fixture_payloads()
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[rival_capability.node_id] = rival_capability
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_RIVAL_CAPABILITY,
+            target_node_id=_RESULT,
+        )
+    )
+    _expect_rejection(payloads, "declared by exactly one", edges=edges)
+
+
+def test_duplicate_result_id_within_one_capability_rejects() -> None:
+    payloads = _fixture_payloads()
+    payloads[_RESULT_ALT] = _result(_RESULT_ALT, result_id="analysis_result")
+    _expect_rejection(payloads, "declared twice by capability")
+
+
+def test_same_result_id_in_unrelated_capabilities_accepts() -> None:
+    payloads = _fixture_payloads()
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[rival_capability.node_id] = rival_capability
+    payloads["mozaiks.workflow_result.rival_analysis_result"] = _result(
+        "mozaiks.workflow_result.rival_analysis_result",
+        result_id="analysis_result",
+        capability_node_id=_RIVAL_CAPABILITY,
+    )
+    _validate(payloads)
+
+
+def test_result_identity_is_provider_neutral() -> None:
+    """A provider schema / model-class / runtime name is not result identity."""
+    for provider_shaped in ("PlanCatalogProposal", "AnalyzeDocumentOutput", "gpt-result"):
+        with pytest.raises(ValidationError, match="result_id"):
+            _result(_RESULT, result_id=provider_shaped)
+
+
+# ---------------------------------------------------------------------------
+# Explicit result fan-out policy
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_fan_out_of_one_result_through_two_actions_accepts() -> None:
+    """Intentional fan-out: multiple commit bindings, one WORKFLOW_RESULT node."""
+    payloads = _fixture_payloads()
+    payloads["mozaiks.workflow_capability_binding.analysis_also_creates"] = (
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id="mozaiks.workflow_capability_binding.analysis_also_creates",
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id=_MODULE, action_node_id=_ACTION_CREATE
+            ),
+            workflow_result_node_id=_RESULT,
+        )
+    )
+    _validate(payloads)
+
+
+def test_two_results_through_the_same_action_are_distinct_relationships() -> None:
+    payloads = _fixture_payloads()
+    payloads[_RESULT_ALT] = _result(_RESULT_ALT, result_id="analysis_summary")
+    payloads["mozaiks.workflow_capability_binding.analysis_stores_summary"] = (
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id="mozaiks.workflow_capability_binding.analysis_stores_summary",
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id=_MODULE, action_node_id=_ACTION_STORE
+            ),
+            workflow_result_node_id=_RESULT_ALT,
+        )
+    )
+    _validate(payloads)
 
 
 def test_duplicate_binding_identity_rejects() -> None:
     payloads = _fixture_payloads()
     duplicate = _rebuilt_binding(
         payloads,
-        _BINDING_READ,
-        node_id="mozaiks.workflow_capability_binding.analysis_reads_content_again",
+        _BINDING_RESULT,
+        node_id="mozaiks.workflow_capability_binding.analysis_stores_result_again",
     )
     payloads[duplicate.node_id] = duplicate
     _expect_rejection(payloads, "duplicate workflow capability binding identity")
 
 
+# ---------------------------------------------------------------------------
+# Capability ownership (carried forward clean)
+# ---------------------------------------------------------------------------
+
+
 def test_ambiguous_capability_ownership_rejects() -> None:
     payloads = _fixture_payloads()
-    payloads["mozaiks.workflow.rival"] = build_semantic_payload(
-        WorkflowPayload,
-        node_id="mozaiks.workflow.rival",
-        payload_version=1,
-        scope=_SCOPE,
-        workflow_id="rival",
-        description="Competing workflow",
-        startup_mode=None,
-        topology=None,
-    )
-    payloads["mozaiks.workflow_capability.rival_analysis"] = build_semantic_payload(
+    rival_workflow, _unused = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[_RIVAL_CAPABILITY] = build_semantic_payload(
         WorkflowCapabilityPayload,
-        node_id="mozaiks.workflow_capability.rival_analysis",
+        node_id=_RIVAL_CAPABILITY,
         payload_version=1,
         scope=_SCOPE,
         capability_id="documents.analysis",
         description="Same capability id, different workflow",
-        workflow_node_id="mozaiks.workflow.rival",
+        workflow_node_id=_RIVAL_WORKFLOW,
     )
-    edges = _fixture_edges(payloads)
-    edges.append(
-        SemanticEdge(
-            kind=SemanticEdgeKind.DECLARES,
-            source_node_id="mozaiks.workflow.rival",
-            target_node_id="mozaiks.workflow_capability.rival_analysis",
-        )
-    )
-    _expect_rejection(payloads, "ambiguously owned", edges=edges)
+    _expect_rejection(payloads, "ambiguously owned")
 
 
 def test_capability_owner_and_declarer_must_agree() -> None:
     payloads = _fixture_payloads()
-    payloads["mozaiks.workflow.rival"] = build_semantic_payload(
-        WorkflowPayload,
-        node_id="mozaiks.workflow.rival",
-        payload_version=1,
-        scope=_SCOPE,
-        workflow_id="rival",
-        description="Competing workflow",
-        startup_mode=None,
-        topology=None,
-    )
+    rival_workflow, _unused = _rival_workflow_and_capability()
+    payloads[rival_workflow.node_id] = rival_workflow
     edges = [
         SemanticEdge(
             kind=SemanticEdgeKind.DECLARES,
-            source_node_id="mozaiks.workflow.rival",
+            source_node_id=_RIVAL_WORKFLOW,
             target_node_id=_CAPABILITY,
         )
         if (
@@ -545,6 +922,11 @@ def test_capability_owner_and_declarer_must_agree() -> None:
     _expect_rejection(payloads, "declared by", edges=edges)
 
 
+# ---------------------------------------------------------------------------
+# Exact derived-edge projection (full identity, discriminator included)
+# ---------------------------------------------------------------------------
+
+
 def test_missing_derived_edge_rejects() -> None:
     payloads = _fixture_payloads()
     edges = [
@@ -556,6 +938,133 @@ def test_missing_derived_edge_rejects() -> None:
         )
     ]
     _expect_rejection(payloads, "lacks its derived", edges=edges)
+
+
+def test_forged_extra_edges_on_binding_nodes_reject() -> None:
+    """Codex reproduction: extra meaning-bearing edges beyond the derived set."""
+    payloads = _fixture_payloads()
+    forged_edges = (
+        # Extra BINDS from the consumes binding to another action.
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=_BINDING_READ,
+            target_node_id=_ACTION_STORE,
+        ),
+        # Extra CONSUMES from the commit binding to another action.
+        SemanticEdge(
+            kind=SemanticEdgeKind.CONSUMES,
+            source_node_id=_BINDING_RESULT,
+            target_node_id=_ACTION_GET,
+        ),
+        # Extra edge from the trigger binding to an action.
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=_BINDING_TRIGGER,
+            target_node_id=_ACTION_STORE,
+        ),
+        # Forged inbound DECLARES onto a binding from a module.
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_MODULE,
+            target_node_id=_BINDING_READ,
+        ),
+        # Forged inbound edge onto the declared result node.
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=_WORKFLOW,
+            target_node_id=_RESULT,
+        ),
+    )
+    for forged in forged_edges:
+        edges = _fixture_edges(payloads)
+        edges.append(forged)
+        # A forged inbound DECLARES is caught by the sole-declarer rule before
+        # the exact-projection scan; every other forgery falls through to it.
+        _expect_rejection(
+            payloads,
+            "not part of the canonical\\s+derived projection"
+            "|declared by exactly one",
+            edges=edges,
+        )
+
+
+def test_discriminator_mutations_on_derived_edges_reject() -> None:
+    """Codex reproduction: edge identity must include the discriminator."""
+    payloads = _fixture_payloads()
+
+    def _mutate(match_kind: SemanticEdgeKind, source: str, replacement: SemanticEdge) -> list[SemanticEdge]:
+        return [
+            replacement
+            if (edge.kind is match_kind and edge.source_node_id == source)
+            else edge
+            for edge in _fixture_edges(payloads)
+        ]
+
+    # Wrong result discriminator on the commit projection.
+    edges = _mutate(
+        SemanticEdgeKind.BINDS,
+        _BINDING_RESULT,
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=_BINDING_RESULT,
+            target_node_id=_ACTION_STORE,
+            discriminator=_RESULT_ALT,
+        ),
+    )
+    _expect_rejection(
+        payloads, "not part of the canonical\\s+derived projection", edges=edges
+    )
+
+    # Missing result discriminator on the commit projection.
+    edges = _mutate(
+        SemanticEdgeKind.BINDS,
+        _BINDING_RESULT,
+        SemanticEdge(
+            kind=SemanticEdgeKind.BINDS,
+            source_node_id=_BINDING_RESULT,
+            target_node_id=_ACTION_STORE,
+        ),
+    )
+    _expect_rejection(
+        payloads, "not part of the canonical\\s+derived projection", edges=edges
+    )
+
+    # Extra discriminator on the consumes projection.
+    edges = _mutate(
+        SemanticEdgeKind.CONSUMES,
+        _BINDING_READ,
+        SemanticEdge(
+            kind=SemanticEdgeKind.CONSUMES,
+            source_node_id=_BINDING_READ,
+            target_node_id=_ACTION_GET,
+            discriminator="uninvited",
+        ),
+    )
+    _expect_rejection(
+        payloads, "not part of the canonical\\s+derived projection", edges=edges
+    )
+
+
+def test_edge_only_mutation_never_changes_meaning_silently() -> None:
+    """Payloads unchanged + a meaning-bearing edge mutation must reject."""
+    payloads = _fixture_payloads()
+    baseline_digests = {
+        node_id: payload.payload_digest for node_id, payload in payloads.items()
+    }
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.CONSUMES,
+            source_node_id=_BINDING_READ,
+            target_node_id=_ACTION_STORE,
+        )
+    )
+    graph = _build_graph(payloads, edges=edges)
+    with pytest.raises(SemanticPayloadError):
+        validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+    assert baseline_digests == {
+        node_id: payload.payload_digest for node_id, payload in payloads.items()
+    }
 
 
 def test_foreign_scope_binding_rejects() -> None:
@@ -580,7 +1089,7 @@ def test_foreign_scope_binding_rejects() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Role shape and provider neutrality
+# Role shape closure
 # ---------------------------------------------------------------------------
 
 
@@ -607,7 +1116,7 @@ def test_role_shapes_are_closed() -> None:
             event_node_id=_EVENT,
             **common,
         )
-    with pytest.raises(ValidationError, match="requires workflow_result_id"):
+    with pytest.raises(ValidationError, match="requires workflow_result_node_id"):
         build_semantic_payload(
             WorkflowCapabilityBindingPayload,
             binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
@@ -622,32 +1131,14 @@ def test_role_shapes_are_closed() -> None:
             event_node_id=_EVENT,
             **common,
         )
-    with pytest.raises(ValidationError, match="must not set workflow_result_id"):
+    with pytest.raises(ValidationError, match="must not set workflow_result_node_id"):
         build_semantic_payload(
             WorkflowCapabilityBindingPayload,
             binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
             module_action=action,
-            workflow_result_id="analysis_result",
+            workflow_result_node_id=_RESULT,
             **common,
         )
-
-
-def test_workflow_result_identity_is_provider_neutral() -> None:
-    """A provider schema / model-class name is not durable application meaning."""
-    for provider_shaped in ("PlanCatalogProposal", "AnalyzeDocumentOutput", "gpt-result"):
-        with pytest.raises(ValidationError, match="workflow_result_id"):
-            build_semantic_payload(
-                WorkflowCapabilityBindingPayload,
-                node_id="mozaiks.workflow_capability_binding.neutrality_probe",
-                payload_version=1,
-                scope=_SCOPE,
-                binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
-                workflow_capability_node_id=_CAPABILITY,
-                module_action=ModuleActionRef(
-                    module_node_id=_MODULE, action_node_id=_ACTION_STORE
-                ),
-                workflow_result_id=provider_shaped,
-            )
 
 
 def test_module_action_ref_is_exact() -> None:
@@ -663,7 +1154,7 @@ def test_module_action_ref_is_exact() -> None:
 
 
 def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
-    """UI -> research.generate_report -> reads source data -> stores report."""
+    """UI -> research.generate_report -> reads sources -> declared result -> store."""
     payloads: dict[str, SemanticPayloadBase] = {}
 
     def _add(payload: SemanticPayloadBase) -> None:
@@ -680,20 +1171,14 @@ def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
         )
     )
     _add(
-        build_semantic_payload(
-            ActionPayload,
-            node_id="mozaiks.action.reports_get_source_data",
-            payload_version=1,
-            scope=_SCOPE,
+        _action(
+            "mozaiks.action.reports_get_source_data",
             description="Read report source data",
         )
     )
     _add(
-        build_semantic_payload(
-            ActionPayload,
-            node_id="mozaiks.action.reports_store_report",
-            payload_version=1,
-            scope=_SCOPE,
+        _action(
+            "mozaiks.action.reports_store_report",
             description="Persist a generated report",
         )
     )
@@ -718,6 +1203,14 @@ def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
             capability_id="research.generate_report",
             description="User-launched report generation",
             workflow_node_id="mozaiks.workflow.report_generator",
+        )
+    )
+    _add(
+        _result(
+            "mozaiks.workflow_result.generated_report",
+            result_id="generated_report",
+            capability_node_id="mozaiks.workflow_capability.generate_report",
+            description="The finished report",
         )
     )
     _add(
@@ -746,7 +1239,7 @@ def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
                 module_node_id="mozaiks.module.reports",
                 action_node_id="mozaiks.action.reports_store_report",
             ),
-            workflow_result_id="generated_report",
+            workflow_result_node_id="mozaiks.workflow_result.generated_report",
         )
     )
     edges = [
@@ -770,6 +1263,8 @@ def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
     for payload in list(payloads.values()):
         if isinstance(payload, WorkflowCapabilityBindingPayload):
             edges.extend(derive_workflow_capability_binding_edges(payload))
+        elif isinstance(payload, WorkflowResultPayload):
+            edges.extend(derive_workflow_result_edges(payload))
     graph = build_semantic_graph_v2(
         graph_id="pattern-a",
         version=1,
@@ -798,9 +1293,15 @@ def test_app_zero_pattern_b_event_triggered_analysis() -> None:
     trigger = payloads[_BINDING_TRIGGER]
     assert trigger.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT
     assert trigger.event_node_id == _EVENT
-    result = payloads[_BINDING_RESULT]
-    assert result.module_action.action_node_id == _ACTION_STORE
-    assert result.workflow_result_id == "analysis_result"
+    # Typed production authority: the trigger event is produced by the
+    # module-owned create action's own typed emits.
+    assert payloads[_ACTION_CREATE].emits == (_EVENT_ID,)
+    commit = payloads[_BINDING_RESULT]
+    assert commit.module_action.action_node_id == _ACTION_STORE
+    assert commit.workflow_result_node_id == _RESULT
+    declared_result = payloads[_RESULT]
+    assert declared_result.result_id == "analysis_result"
+    assert declared_result.workflow_capability_node_id == _CAPABILITY
     # Directional authority: the workflow capability owns neither the module
     # actions nor the event — its bindings reference them, and the module
     # remains the sole declarer of both.
@@ -809,11 +1310,12 @@ def test_app_zero_pattern_b_event_triggered_analysis() -> None:
 
 
 def test_app_zero_pattern_c_no_module_result_write() -> None:
-    """Event-triggered advisory workflow with a user-facing answer only.
+    """Event-triggered advisory capability whose proposal is its only output.
 
-    Genericized proposal/brief pattern: the workflow proposes; a human later
-    invokes the module commit action.  No commits_result_through_action
-    binding exists and none is fabricated — truthful absence validates.
+    Genericized proposal/brief pattern: the declared workflow result IS the
+    semantic output, and a human later invokes the module commit action, so
+    there is no commits_result_through_action binding and none is fabricated
+    — truthful absence validates.
     """
     payloads = _fixture_payloads()
     del payloads[_BINDING_RESULT]
@@ -832,3 +1334,5 @@ def test_app_zero_pattern_c_no_module_result_write() -> None:
         if isinstance(payload, WorkflowCapabilityBindingPayload)
     }
     assert remaining_roles == {WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT}
+    # The declared result stays: the proposal itself is the semantic output.
+    assert isinstance(payloads[_RESULT], WorkflowResultPayload)

--- a/tests/test_workflow_capability_semantics.py
+++ b/tests/test_workflow_capability_semantics.py
@@ -1,0 +1,834 @@
+"""Module↔workflow capability binding semantics: contract, closure, mutation matrix.
+
+The typed vocabulary under test replaces the stringly seam where module and
+workflow linkage lived in seven mutually-unaware string namespaces (module
+capability rows, reaction targets, orchestrator trigger ids, kebab slugs,
+plan lists, synthesized envelope ids, page workflow_ids).  These tests prove:
+
+- the canonical fixture (documents / AnalyzeDocument) validates and is
+  byte-deterministic across processes;
+- every single-axis mutation either changes canonical semantic identity or is
+  rejected by validation;
+- unrelated module/action/workflow additions never move a binding's identity;
+- referential integrity fails closed on every dangling or foreign reference;
+- the three App Zero patterns (user-launched, event-triggered, no-result
+  answer) are expressible with zero hosted/provider policy.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticGraphV2,
+    SemanticNodeV2,
+    build_semantic_graph_v2,
+)
+from mozaiksai.core.semantics.payloads import (
+    ActionPayload,
+    EventPayload,
+    ModuleActionRef,
+    ModulePayload,
+    SemanticPayloadBase,
+    SemanticPayloadError,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityBindingRole,
+    WorkflowCapabilityPayload,
+    WorkflowPayload,
+    build_semantic_payload,
+    derive_workflow_capability_binding_edges,
+    parse_semantic_payload,
+    semantic_payload_ref,
+    validate_semantic_graph_v2_payload_closure,
+)
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-docs", workspace_id="ws-docs")
+_FOREIGN_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant-other")
+
+_MODULE = "mozaiks.module.documents"
+_ACTION_CREATE = "mozaiks.action.documents_create"
+_ACTION_GET = "mozaiks.action.documents_get_content"
+_ACTION_STORE = "mozaiks.action.documents_store_analysis"
+_EVENT = "mozaiks.event.documents_created"
+_WORKFLOW = "mozaiks.workflow.analyze_document"
+_CAPABILITY = "mozaiks.workflow_capability.documents_analysis"
+_BINDING_TRIGGER = "mozaiks.workflow_capability_binding.analysis_on_created"
+_BINDING_READ = "mozaiks.workflow_capability_binding.analysis_reads_content"
+_BINDING_RESULT = "mozaiks.workflow_capability_binding.analysis_stores_result"
+
+
+def _action(node_id: str, *, description: str, emits: tuple[str, ...] = ()) -> ActionPayload:
+    return build_semantic_payload(
+        ActionPayload,
+        node_id=node_id,
+        payload_version=1,
+        scope=_SCOPE,
+        description=description,
+        emits=emits,
+    )
+
+
+def _fixture_payloads() -> dict[str, SemanticPayloadBase]:
+    """The canonical fixture: documents module + AnalyzeDocument workflow.
+
+    module documents { create, get_content, store_analysis } emits
+    domain.documents.created; workflow AnalyzeDocument declares capability
+    documents.analysis with three bindings: triggered by the event, consumes
+    get_content, commits result analysis_result through store_analysis.
+    """
+    payloads: dict[str, SemanticPayloadBase] = {}
+
+    def _add(payload: SemanticPayloadBase) -> None:
+        payloads[payload.node_id] = payload
+
+    _add(
+        build_semantic_payload(
+            ModulePayload,
+            node_id=_MODULE,
+            payload_version=1,
+            scope=_SCOPE,
+            module_id="documents",
+            description="Durable document facts",
+        )
+    )
+    _add(
+        _action(
+            _ACTION_CREATE,
+            description="Create one document",
+            emits=("domain.documents.created",),
+        )
+    )
+    _add(_action(_ACTION_GET, description="Read one document's content"))
+    _add(_action(_ACTION_STORE, description="Persist one analysis result"))
+    _add(
+        build_semantic_payload(
+            EventPayload,
+            node_id=_EVENT,
+            payload_version=1,
+            scope=_SCOPE,
+            description="A document was created",
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowPayload,
+            node_id=_WORKFLOW,
+            payload_version=1,
+            scope=_SCOPE,
+            workflow_id="analyze_document",
+            description="Reason over a new document",
+            startup_mode=None,
+            topology=None,
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityPayload,
+            node_id=_CAPABILITY,
+            payload_version=1,
+            scope=_SCOPE,
+            capability_id="documents.analysis",
+            description="Analyze a created document",
+            workflow_node_id=_WORKFLOW,
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id=_BINDING_TRIGGER,
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT,
+            workflow_capability_node_id=_CAPABILITY,
+            event_node_id=_EVENT,
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id=_BINDING_READ,
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id=_MODULE, action_node_id=_ACTION_GET
+            ),
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id=_BINDING_RESULT,
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id=_MODULE, action_node_id=_ACTION_STORE
+            ),
+            workflow_result_id="analysis_result",
+        )
+    )
+    return payloads
+
+
+def _fixture_edges(payloads: dict[str, SemanticPayloadBase]) -> list[SemanticEdge]:
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES, source_node_id=_MODULE, target_node_id=action
+        )
+        for action in (_ACTION_CREATE, _ACTION_GET, _ACTION_STORE)
+    ]
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.EMITS,
+            source_node_id=_ACTION_CREATE,
+            target_node_id=_EVENT,
+        )
+    )
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id=_WORKFLOW,
+            target_node_id=_CAPABILITY,
+        )
+    )
+    for payload in payloads.values():
+        if isinstance(payload, WorkflowCapabilityBindingPayload):
+            edges.extend(derive_workflow_capability_binding_edges(payload))
+    return edges
+
+
+def _build_graph(
+    payloads: dict[str, SemanticPayloadBase],
+    *,
+    edges: list[SemanticEdge] | None = None,
+    graph_id: str = "documents-analysis",
+) -> SemanticGraphV2:
+    return build_semantic_graph_v2(
+        graph_id=graph_id,
+        version=1,
+        scope=_SCOPE,
+        nodes=[
+            SemanticNodeV2(
+                node_id=payload.node_id,
+                kind=payload.payload_kind,
+                payload_ref=semantic_payload_ref(payload),
+            )
+            for payload in payloads.values()
+        ],
+        edges=_fixture_edges(payloads) if edges is None else edges,
+    )
+
+
+def _validate(payloads: dict[str, SemanticPayloadBase], **kwargs) -> SemanticGraphV2:
+    graph = _build_graph(payloads, **kwargs)
+    validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Canonical fixture: valid, deterministic across processes
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_fixture_validates_and_round_trips() -> None:
+    payloads = _fixture_payloads()
+    graph = _validate(payloads)
+    for payload in payloads.values():
+        parsed = parse_semantic_payload(payload.model_dump(mode="json"))
+        assert parsed == payload
+    assert graph.graph_digest == _build_graph(_fixture_payloads()).graph_digest
+
+
+def test_fixture_digest_is_identical_in_a_fresh_process() -> None:
+    expected = _build_graph(_fixture_payloads()).graph_digest
+    probe = (
+        "from tests.test_workflow_capability_semantics import (\n"
+        "    _build_graph, _fixture_payloads)\n"
+        "print(_build_graph(_fixture_payloads()).graph_digest)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == expected
+
+
+# ---------------------------------------------------------------------------
+# Mutation matrix: one axis at a time
+# ---------------------------------------------------------------------------
+
+
+def _rebuilt_binding(payloads: dict[str, SemanticPayloadBase], source_node_id: str, **overrides):
+    base = payloads[source_node_id]
+    fields = {
+        "node_id": base.node_id,
+        "payload_version": base.payload_version,
+        "scope": base.scope,
+        "binding_role": base.binding_role,
+        "workflow_capability_node_id": base.workflow_capability_node_id,
+        "module_action": base.module_action,
+        "event_node_id": base.event_node_id,
+        "workflow_result_id": base.workflow_result_id,
+    }
+    fields.update(overrides)
+    return build_semantic_payload(WorkflowCapabilityBindingPayload, **fields)
+
+
+def test_each_bound_axis_mutation_changes_canonical_identity() -> None:
+    baseline = _fixture_payloads()
+    baseline_graph = _validate(baseline)
+    read_binding_digest = baseline[_BINDING_READ].payload_digest
+
+    # Input action mutated: get_content -> create.
+    mutated = _fixture_payloads()
+    mutated[_BINDING_READ] = _rebuilt_binding(
+        mutated,
+        _BINDING_READ,
+        module_action=ModuleActionRef(
+            module_node_id=_MODULE, action_node_id=_ACTION_CREATE
+        ),
+    )
+    graph = _validate(mutated)
+    assert mutated[_BINDING_READ].payload_digest != read_binding_digest
+    assert graph.graph_digest != baseline_graph.graph_digest
+
+    # Result action mutated: store_analysis -> create.
+    mutated = _fixture_payloads()
+    mutated[_BINDING_RESULT] = _rebuilt_binding(
+        mutated,
+        _BINDING_RESULT,
+        module_action=ModuleActionRef(
+            module_node_id=_MODULE, action_node_id=_ACTION_CREATE
+        ),
+    )
+    assert _validate(mutated).graph_digest != baseline_graph.graph_digest
+
+    # Binding role/direction mutated on the same endpoints.
+    mutated = _fixture_payloads()
+    mutated[_BINDING_READ] = _rebuilt_binding(
+        mutated,
+        _BINDING_READ,
+        binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+        workflow_result_id="content_projection",
+    )
+    assert _validate(mutated).graph_digest != baseline_graph.graph_digest
+
+    # Capability id mutated.
+    mutated = _fixture_payloads()
+    base_cap = mutated[_CAPABILITY]
+    mutated[_CAPABILITY] = build_semantic_payload(
+        WorkflowCapabilityPayload,
+        node_id=base_cap.node_id,
+        payload_version=1,
+        scope=_SCOPE,
+        capability_id="documents.deep_analysis",
+        description=base_cap.description,
+        workflow_node_id=base_cap.workflow_node_id,
+    )
+    assert _validate(mutated).graph_digest != baseline_graph.graph_digest
+
+    # Workflow result id mutated.
+    mutated = _fixture_payloads()
+    mutated[_BINDING_RESULT] = _rebuilt_binding(
+        mutated, _BINDING_RESULT, workflow_result_id="analysis_summary"
+    )
+    assert _validate(mutated).graph_digest != baseline_graph.graph_digest
+
+
+def test_unrelated_additions_never_move_a_binding_identity() -> None:
+    baseline = _fixture_payloads()
+    binding_digests = {
+        node_id: payload.payload_digest
+        for node_id, payload in baseline.items()
+        if isinstance(payload, WorkflowCapabilityBindingPayload)
+    }
+
+    extended = _fixture_payloads()
+    extended["mozaiks.module.archive"] = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.archive",
+        payload_version=1,
+        scope=_SCOPE,
+        module_id="archive",
+        description="Unrelated module",
+    )
+    extended["mozaiks.action.archive_store"] = _action(
+        "mozaiks.action.archive_store", description="Unrelated action"
+    )
+    extended["mozaiks.workflow.unrelated"] = build_semantic_payload(
+        WorkflowPayload,
+        node_id="mozaiks.workflow.unrelated",
+        payload_version=1,
+        scope=_SCOPE,
+        workflow_id="unrelated",
+        description="Unrelated workflow",
+        startup_mode=None,
+        topology=None,
+    )
+    edges = _fixture_edges(extended)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.module.archive",
+            target_node_id="mozaiks.action.archive_store",
+        )
+    )
+    graph = _build_graph(extended, edges=edges)
+    validate_semantic_graph_v2_payload_closure(graph, list(extended.values()))
+
+    for node_id, digest in binding_digests.items():
+        assert extended[node_id].payload_digest == digest, (
+            f"unrelated mutation moved binding identity {node_id}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Referential integrity: every dangling/foreign reference fails closed
+# ---------------------------------------------------------------------------
+
+
+def _expect_rejection(payloads: dict[str, SemanticPayloadBase], match: str, **kwargs) -> None:
+    graph = _build_graph(payloads, **kwargs)
+    with pytest.raises(SemanticPayloadError, match=match):
+        validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+
+
+def test_removed_action_rejects() -> None:
+    payloads = _fixture_payloads()
+    del payloads[_ACTION_GET]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if _ACTION_GET not in (edge.source_node_id, edge.target_node_id)
+    ]
+    _expect_rejection(payloads, "missing or non-action", edges=edges)
+
+
+def test_removed_workflow_rejects() -> None:
+    payloads = _fixture_payloads()
+    del payloads[_WORKFLOW]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if _WORKFLOW not in (edge.source_node_id, edge.target_node_id)
+    ]
+    _expect_rejection(payloads, "missing or non-workflow", edges=edges)
+
+
+def test_removed_event_rejects() -> None:
+    payloads = _fixture_payloads()
+    del payloads[_EVENT]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if _EVENT not in (edge.source_node_id, edge.target_node_id)
+    ]
+    _expect_rejection(payloads, "missing or non-event", edges=edges)
+
+
+def test_action_under_wrong_module_rejects() -> None:
+    """A real action referenced through a module that does not declare it."""
+    payloads = _fixture_payloads()
+    payloads["mozaiks.module.other"] = build_semantic_payload(
+        ModulePayload,
+        node_id="mozaiks.module.other",
+        payload_version=1,
+        scope=_SCOPE,
+        module_id="other",
+        description="Another module",
+    )
+    payloads[_BINDING_READ] = _rebuilt_binding(
+        payloads,
+        _BINDING_READ,
+        module_action=ModuleActionRef(
+            module_node_id="mozaiks.module.other", action_node_id=_ACTION_GET
+        ),
+    )
+    _expect_rejection(payloads, "does not declare")
+
+
+def test_event_without_module_producer_rejects() -> None:
+    payloads = _fixture_payloads()
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if edge.kind is not SemanticEdgeKind.EMITS
+    ]
+    _expect_rejection(payloads, "no module or action produces", edges=edges)
+
+
+def test_duplicate_binding_identity_rejects() -> None:
+    payloads = _fixture_payloads()
+    duplicate = _rebuilt_binding(
+        payloads,
+        _BINDING_READ,
+        node_id="mozaiks.workflow_capability_binding.analysis_reads_content_again",
+    )
+    payloads[duplicate.node_id] = duplicate
+    _expect_rejection(payloads, "duplicate workflow capability binding identity")
+
+
+def test_ambiguous_capability_ownership_rejects() -> None:
+    payloads = _fixture_payloads()
+    payloads["mozaiks.workflow.rival"] = build_semantic_payload(
+        WorkflowPayload,
+        node_id="mozaiks.workflow.rival",
+        payload_version=1,
+        scope=_SCOPE,
+        workflow_id="rival",
+        description="Competing workflow",
+        startup_mode=None,
+        topology=None,
+    )
+    payloads["mozaiks.workflow_capability.rival_analysis"] = build_semantic_payload(
+        WorkflowCapabilityPayload,
+        node_id="mozaiks.workflow_capability.rival_analysis",
+        payload_version=1,
+        scope=_SCOPE,
+        capability_id="documents.analysis",
+        description="Same capability id, different workflow",
+        workflow_node_id="mozaiks.workflow.rival",
+    )
+    edges = _fixture_edges(payloads)
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.workflow.rival",
+            target_node_id="mozaiks.workflow_capability.rival_analysis",
+        )
+    )
+    _expect_rejection(payloads, "ambiguously owned", edges=edges)
+
+
+def test_capability_owner_and_declarer_must_agree() -> None:
+    payloads = _fixture_payloads()
+    payloads["mozaiks.workflow.rival"] = build_semantic_payload(
+        WorkflowPayload,
+        node_id="mozaiks.workflow.rival",
+        payload_version=1,
+        scope=_SCOPE,
+        workflow_id="rival",
+        description="Competing workflow",
+        startup_mode=None,
+        topology=None,
+    )
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.workflow.rival",
+            target_node_id=_CAPABILITY,
+        )
+        if (
+            edge.kind is SemanticEdgeKind.DECLARES
+            and edge.source_node_id == _WORKFLOW
+            and edge.target_node_id == _CAPABILITY
+        )
+        else edge
+        for edge in _fixture_edges(payloads)
+    ]
+    _expect_rejection(payloads, "declared by", edges=edges)
+
+
+def test_missing_derived_edge_rejects() -> None:
+    payloads = _fixture_payloads()
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if not (
+            edge.kind is SemanticEdgeKind.CONSUMES
+            and edge.source_node_id == _BINDING_READ
+        )
+    ]
+    _expect_rejection(payloads, "lacks its derived", edges=edges)
+
+
+def test_foreign_scope_binding_rejects() -> None:
+    foreign = build_semantic_payload(
+        WorkflowCapabilityBindingPayload,
+        node_id=_BINDING_READ,
+        payload_version=1,
+        scope=_FOREIGN_SCOPE,
+        binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+        workflow_capability_node_id=_CAPABILITY,
+        module_action=ModuleActionRef(
+            module_node_id=_MODULE, action_node_id=_ACTION_GET
+        ),
+    )
+    graph = _build_graph(_fixture_payloads())
+    supplied = [
+        foreign if payload.node_id == _BINDING_READ else payload
+        for payload in _fixture_payloads().values()
+    ]
+    with pytest.raises(SemanticPayloadError):
+        validate_semantic_graph_v2_payload_closure(graph, supplied)
+
+
+# ---------------------------------------------------------------------------
+# Role shape and provider neutrality
+# ---------------------------------------------------------------------------
+
+
+def test_role_shapes_are_closed() -> None:
+    common = {
+        "node_id": "mozaiks.workflow_capability_binding.shape_probe",
+        "payload_version": 1,
+        "scope": _SCOPE,
+        "workflow_capability_node_id": _CAPABILITY,
+    }
+    action = ModuleActionRef(module_node_id=_MODULE, action_node_id=_ACTION_GET)
+
+    with pytest.raises(ValidationError, match="requires module_action"):
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            **common,
+        )
+    with pytest.raises(ValidationError, match="must not set event_node_id"):
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            module_action=action,
+            event_node_id=_EVENT,
+            **common,
+        )
+    with pytest.raises(ValidationError, match="requires workflow_result_id"):
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+            module_action=action,
+            **common,
+        )
+    with pytest.raises(ValidationError, match="must not set module_action"):
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            binding_role=WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT,
+            module_action=action,
+            event_node_id=_EVENT,
+            **common,
+        )
+    with pytest.raises(ValidationError, match="must not set workflow_result_id"):
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            module_action=action,
+            workflow_result_id="analysis_result",
+            **common,
+        )
+
+
+def test_workflow_result_identity_is_provider_neutral() -> None:
+    """A provider schema / model-class name is not durable application meaning."""
+    for provider_shaped in ("PlanCatalogProposal", "AnalyzeDocumentOutput", "gpt-result"):
+        with pytest.raises(ValidationError, match="workflow_result_id"):
+            build_semantic_payload(
+                WorkflowCapabilityBindingPayload,
+                node_id="mozaiks.workflow_capability_binding.neutrality_probe",
+                payload_version=1,
+                scope=_SCOPE,
+                binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+                workflow_capability_node_id=_CAPABILITY,
+                module_action=ModuleActionRef(
+                    module_node_id=_MODULE, action_node_id=_ACTION_STORE
+                ),
+                workflow_result_id=provider_shaped,
+            )
+
+
+def test_module_action_ref_is_exact() -> None:
+    with pytest.raises(ValidationError, match="must differ"):
+        ModuleActionRef(module_node_id=_MODULE, action_node_id=_MODULE)
+    with pytest.raises(ValidationError):
+        ModuleActionRef(module_node_id="documents", action_node_id=_ACTION_GET)
+
+
+# ---------------------------------------------------------------------------
+# App Zero proofs (genericized; zero hosted/provider policy)
+# ---------------------------------------------------------------------------
+
+
+def test_app_zero_pattern_a_user_launched_report_workflow() -> None:
+    """UI -> research.generate_report -> reads source data -> stores report."""
+    payloads: dict[str, SemanticPayloadBase] = {}
+
+    def _add(payload: SemanticPayloadBase) -> None:
+        payloads[payload.node_id] = payload
+
+    _add(
+        build_semantic_payload(
+            ModulePayload,
+            node_id="mozaiks.module.reports",
+            payload_version=1,
+            scope=_SCOPE,
+            module_id="reports",
+            description="Durable report facts",
+        )
+    )
+    _add(
+        build_semantic_payload(
+            ActionPayload,
+            node_id="mozaiks.action.reports_get_source_data",
+            payload_version=1,
+            scope=_SCOPE,
+            description="Read report source data",
+        )
+    )
+    _add(
+        build_semantic_payload(
+            ActionPayload,
+            node_id="mozaiks.action.reports_store_report",
+            payload_version=1,
+            scope=_SCOPE,
+            description="Persist a generated report",
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowPayload,
+            node_id="mozaiks.workflow.report_generator",
+            payload_version=1,
+            scope=_SCOPE,
+            workflow_id="report_generator",
+            description="Generate a research report",
+            startup_mode=None,
+            topology=None,
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityPayload,
+            node_id="mozaiks.workflow_capability.generate_report",
+            payload_version=1,
+            scope=_SCOPE,
+            capability_id="research.generate_report",
+            description="User-launched report generation",
+            workflow_node_id="mozaiks.workflow.report_generator",
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id="mozaiks.workflow_capability_binding.report_reads_sources",
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.CONSUMES_ACTION,
+            workflow_capability_node_id="mozaiks.workflow_capability.generate_report",
+            module_action=ModuleActionRef(
+                module_node_id="mozaiks.module.reports",
+                action_node_id="mozaiks.action.reports_get_source_data",
+            ),
+        )
+    )
+    _add(
+        build_semantic_payload(
+            WorkflowCapabilityBindingPayload,
+            node_id="mozaiks.workflow_capability_binding.report_commits_report",
+            payload_version=1,
+            scope=_SCOPE,
+            binding_role=WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION,
+            workflow_capability_node_id="mozaiks.workflow_capability.generate_report",
+            module_action=ModuleActionRef(
+                module_node_id="mozaiks.module.reports",
+                action_node_id="mozaiks.action.reports_store_report",
+            ),
+            workflow_result_id="generated_report",
+        )
+    )
+    edges = [
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.module.reports",
+            target_node_id=action,
+        )
+        for action in (
+            "mozaiks.action.reports_get_source_data",
+            "mozaiks.action.reports_store_report",
+        )
+    ]
+    edges.append(
+        SemanticEdge(
+            kind=SemanticEdgeKind.DECLARES,
+            source_node_id="mozaiks.workflow.report_generator",
+            target_node_id="mozaiks.workflow_capability.generate_report",
+        )
+    )
+    for payload in list(payloads.values()):
+        if isinstance(payload, WorkflowCapabilityBindingPayload):
+            edges.extend(derive_workflow_capability_binding_edges(payload))
+    graph = build_semantic_graph_v2(
+        graph_id="pattern-a",
+        version=1,
+        scope=_SCOPE,
+        nodes=[
+            SemanticNodeV2(
+                node_id=payload.node_id,
+                kind=payload.payload_kind,
+                payload_ref=semantic_payload_ref(payload),
+            )
+            for payload in payloads.values()
+        ],
+        edges=edges,
+    )
+    validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+
+
+def test_app_zero_pattern_b_event_triggered_analysis() -> None:
+    """documents.create -> domain.documents.created -> analysis -> store.
+
+    The canonical fixture IS Pattern B; assert the semantic facts read back.
+    """
+    payloads = _fixture_payloads()
+    _validate(payloads)
+
+    trigger = payloads[_BINDING_TRIGGER]
+    assert trigger.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT
+    assert trigger.event_node_id == _EVENT
+    result = payloads[_BINDING_RESULT]
+    assert result.module_action.action_node_id == _ACTION_STORE
+    assert result.workflow_result_id == "analysis_result"
+    # Directional authority: the workflow capability owns neither the module
+    # actions nor the event — its bindings reference them, and the module
+    # remains the sole declarer of both.
+    capability = payloads[_CAPABILITY]
+    assert capability.workflow_node_id == _WORKFLOW
+
+
+def test_app_zero_pattern_c_no_module_result_write() -> None:
+    """Event-triggered advisory workflow with a user-facing answer only.
+
+    Genericized proposal/brief pattern: the workflow proposes; a human later
+    invokes the module commit action.  No commits_result_through_action
+    binding exists and none is fabricated — truthful absence validates.
+    """
+    payloads = _fixture_payloads()
+    del payloads[_BINDING_RESULT]
+    del payloads[_BINDING_READ]
+    edges = [
+        edge
+        for edge in _fixture_edges(payloads)
+        if edge.source_node_id not in (_BINDING_RESULT, _BINDING_READ)
+        and edge.target_node_id not in (_BINDING_RESULT, _BINDING_READ)
+    ]
+    graph = _build_graph(payloads, edges=edges)
+    validate_semantic_graph_v2_payload_closure(graph, list(payloads.values()))
+    remaining_roles = {
+        payload.binding_role
+        for payload in payloads.values()
+        if isinstance(payload, WorkflowCapabilityBindingPayload)
+    }
+    assert remaining_roles == {WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT}


### PR DESCRIPTION
## What this is

First redesign slice after the Canonical Application Architecture Audit (**partial redesign, not restart**). **Semantics only**: the relationship between deterministic application capabilities (modules, actions, durable events) and agentic capabilities (workflows) becomes one canonical typed identity inside `SemanticGraph`.

**Correction round 1 (current head)** applies Codex 3's four material findings under one root rule: **typed semantic payloads own application meaning; graph edges are derived projections**. Generic DECLARES cannot invent ownership, generic EMITS cannot invent event production, generic BINDS/CONSUMES cannot invent binding meaning, and a free result string cannot invent workflow-result identity.

Deliberately absent — next slices own them: no `module_interface.yaml` rendering or canonicalization, no layout-registry families, no renderers, no app-local `extension_registry.json` workflow registry, no production AppGenerator/AgentGenerator wiring, no controller layer, no ArtifactRevision/ApplicationPublication change, no AG2 surface.

## Why (inventory findings)

The pre-edit inventory found the module↔workflow relationship living in **seven mutually-unaware string namespaces**, none of them canonical:

1. `module.yaml capabilities[]` with `kind: workflow` — typed at load but `target` unvalidated, and `kind`/`target` are **dead at runtime** (the router keeps only a bare `capability_id` set);
2. `contracts/reactions.yaml target.capability_id` — the actual module→workflow edge, checked only for membership in that bare set;
3. `orchestrator.yaml triggers[].capability_id` — the actual runtime route key, read by a raw-YAML loader that also accepts an undeclared `capability_ids` plural the typed contract forbids;
4. `workflow_name_to_capability_id()` kebab slugs — the de-facto build-time identity, which **violates the taxonomy CAPABILITY grammar** (hyphens are illegal), so generated ids can never be registered or expressed in `TriggerPayload`;
5. `AppBuildPlan event_flows[].workflow_capability_ids[]` — planning-only, uncross-checked;
6. `f"{module}.{action}"` synthesized into event envelopes as `source.capability_id`;
7. page-launch `workflow_id` (PascalCase folder names).

**No code path ever compares a module's reaction `capability_id` against the target workflow's orchestrator trigger `capability_id` — the exact pair the runtime joins on**; a mismatch degrades to a silent `{"status": "unresolved"}` log line. `module_interface.yaml` is generated (from JSON smuggled through string context variables) and **read by nothing**. App Zero corroborates: five separate workflow tools hand-validate `module_id.action_id` / workflow-name strings with private allowlists, and zero `kind: workflow` capabilities exist in the entire hosted product.

## The typed model (option A: dedicated payloads + derived generic edges)

- **`SemanticNodeKind.WORKFLOW_CAPABILITY` + `WorkflowCapabilityPayload`** — the application-semantic identity of one workflow capability: a stable taxonomy-grammar `capability_id`, owned by exactly one WORKFLOW node (`workflow_node_id` + a required sole DECLARES edge; graph-wide `capability_id` uniqueness). Not an AG2 Agent/Task/Network/Channel — AG2 runtime identities never enter the graph. *(Reviewed CLEAN in round 1; carried forward unchanged.)*
- **`SemanticNodeKind.WORKFLOW_CAPABILITY_BINDING` + `WorkflowCapabilityBindingPayload`** — one directional, typed relationship per node with a closed role enum (`consumes_action`, `commits_result_through_action`, `triggered_by_event`; role-shape exclusivity; deliberately **no workflow-emits-event role** — reviewed CLEAN).
- **`SemanticNodeKind.WORKFLOW_RESULT` + `WorkflowResultPayload`** *(new in correction round)* — the typed, capability-owned semantic identity of one workflow output: `result_id` (snake_case, unique **within the owning capability only** — two unrelated capabilities may both produce `summary`), required-nullable `description`, and `workflow_capability_node_id` with a required sole DECLARES owner. Never a provider id, model id, Python/Pydantic class, structured-output implementation class, prompt name, or AG2 runtime result id. Schema compatibility stays deferred.
- **`ModuleActionRef`** — exact module/action node identity; carries no HTTP URL, Python method path, handler class, runtime route, or AG2 tool identity.
- **Event identity is reused** — EVENT nodes; no duplicate event model, no second event-id system.

## Correction round 1 — the four fixes

1. **Canonical sole module-action ownership.** For every action used through `ModuleActionRef`, closure now requires exactly ONE MODULE node to declare that action, and that sole declarer to equal `module_node_id`. Two modules declaring the same action reject; the right action through the wrong module rejects; zero module declarers reject. (Scoped to actions the new semantics reference — the pinned corpus contains module-undeclared actions, so this PR does not redefine unrelated historical action semantics.)
2. **Typed ActionPayload-backed event production.** Event-production authority is built from typed payloads: `ActionPayload.emits` (taxonomy EVENT ids) joined to the EVENT node's canonical identity — its single EVENT-category `TaxonomyReference` (the existing Slice-1 mechanism; no new id system). Globally, an ACTION-sourced EMITS edge unbacked by the action's typed emits rejects (`emits == ()` + forged edge is Codex reproduction 1), an edge into an identity-carrying event the action's emits does not declare rejects, and a typed emit whose unique identity-carrying event node lacks the EMITS projection rejects. A `triggered_by_event` binding requires its event to carry exactly one canonical identity and to be produced by at least one **canonical module-owned** action's typed emits — multiple legitimate producers stay allowed; module-/surface-sourced EMITS edges are traversal-only and confer no trigger authority. Same-family projection fix: `offline_projection` now records module-manifest action `emits` into the typed `ActionPayload` it already drew EMITS edges from (its output previously exhibited exactly this defect and is closure-validated).
3. **Exact derived-edge projection, discriminator included.** `derive_workflow_capability_binding_edges` defines each binding's ENTIRE meaning-bearing projection, and closure compares using full `SemanticEdge.edge_identity` (kind, source, target, **discriminator**) — the actual edge set touching every WORKFLOW_CAPABILITY / WORKFLOW_CAPABILITY_BINDING / WORKFLOW_RESULT node must equal the derived set **exactly** (`expected == actual`, not `expected ⊆ actual`). Extra forged BINDS/CONSUMES edges, wrong/missing/extra discriminators, and payload-unchanged edge-only mutations all reject. No open-ended "harmless extra edge" class exists for these nodes.
4. **Typed workflow-result identity + explicit fan-out.** `commits_result_through_action` now requires `workflow_result_node_id` — an exact reference to a declared WORKFLOW_RESULT node — replacing the free `workflow_result_id` string (no lexical provider blacklist; the grammar plus node-plus-ownership identity is the authority). Closure requires the result node to exist with kind WORKFLOW_RESULT, exactly one WORKFLOW_CAPABILITY declarer equal to the payload owner, `result_id` uniqueness within that capability only, and `binding.workflow_capability_node_id == result.workflow_capability_node_id` — **a capability cannot commit another capability's result**. The commit projection is BINDS binding→action with `discriminator = workflow_result_node_id` plus CONSUMES binding→result. **Fan-out policy (documented, chosen deliberately): intentional fan-out is ALLOWED only as multiple explicit commit binding nodes all referencing the SAME result node** — real workflows legitimately commit one produced result through more than one deterministic action, and the node reference makes that explicit rather than a string coincidence. `binding_identity` now includes the result node: same capability+role+action+result duplicates reject; a different result through the same action, and the same result through different actions, are distinct typed relationships.

## Correction Round 2 — final bounded closure (current head)

Three remaining closure defects fixed; the reviewed-clean architecture (capability/result ownership, fan-out, binding projections, source locality, plan isolation) is untouched.

1. **Exact typed-emitted-event identity closure.** The canonical module-ownership family — every ACTION any node DECLARES — now closes its typed emits unconditionally: each `ActionPayload.emits` entry must resolve to **exactly one** EVENT node carrying **exactly one** canonical EVENT-category taxonomy identity. Zero matching nodes reject (`TYPED_EMIT_MISSING_EVENT_NODE`), identity-less events cannot satisfy an emit (`TYPED_EMIT_EVENT_WITHOUT_TAXONOMY`), duplicate identity claims reject as ambiguous — and none of this is keyed off trigger bindings: a typed emit is an application-semantic claim that must close even when nothing consumes the event (tested with the trigger binding removed, both rejecting and accepting directions). The identity mechanism is the existing EVENT taxonomy reference — no second id field, aliases, or name-derived fallback. Undeclared actions (the pinned historical corpus shape) remain outside the family under the round-1 floor rules and confer no authority.
2. **Full SemanticEdge identity for ACTION EMITS projections.** The family's expected EMITS projection (one `ACTION → EMITS → EVENT` edge per typed emit, `discriminator=None`) is compared against the actual ACTION-sourced EMITS edge set using canonical `SemanticEdge.edge_identity` — `expected == actual`, discriminator included. Wrong-discriminator edges, discriminated duplicates (`EMITS_WRONG_EXTRA_DISCRIMINATOR`, `EMITS_EXTRA_DISCRIMINATED_DUPLICATE`), wrong-target and extra-target projections, missing projections, and payload-unchanged edge-only mutations all reject. A global floor additionally rejects any discriminated ACTION-sourced EMITS edge (no typed payload backs one anywhere). Module/surface EMITS edges stay classified as traversal-only, exactly as previously accepted.
3. **Total ACTION declarer closure.** One shared primitive, `_require_canonical_module_owned_action`, now serves both ModuleActionRef validation and event-producer authority: it collects **ALL** DECLARES edges targeting the action — never filtering non-module declarers away first — and requires exactly one declarer, of MODULE kind, with an undiscriminated declaring edge, optionally the exact expected module. MODULE+WORKFLOW co-declaration (`ACTION_MODULE_OWNER_PLUS_NONMODULE_DECLARER`), workflow-only declarers, multi-module declarers, zero declarers, and discriminated ownership edges all reject, for both ref targets and event producers. Scope stays bounded to actions entering the new authority family (the historical corpus keeps its undeclared action untouched).

## Referential integrity (all fail closed)

Missing/non-module, missing/non-action, missing/non-workflow, missing/non-capability, missing/non-event, missing/non-workflow-result references; ambiguous or wrong module ownership of a referenced action; forged or missing EMITS projections; trigger events without canonical identity or without a canonical module-owned typed producer; results declared by zero, two, or the wrong capability; duplicate `result_id` within one capability; cross-capability result commits; duplicate binding identity; ambiguous duplicate capability ownership; owner/declarer disagreement; missing derived edges; forged extra edges and discriminator mutations; foreign scope. No string coincidence establishes identity anywhere.

## Patterns proven (App Zero, genericized, zero hosted/provider policy)

- **A — user-launched**: `research.generate_report` → consumes `reports.get_source_data` → declared result `generated_report` → committed through `reports.store_report`.
- **B — event-triggered**: module-owned `documents.create` typed-emits `domain.documents.created` (canonical EVENT identity) → `documents.analysis` capability → declared result `analysis_result` → committed through `documents.store_analysis` (the canonical mutation-matrix fixture).
- **C — no module result write**: event-triggered advisory capability whose **declared result is the proposal itself** — trigger binding only, no `commits_result_through_action` binding and no fake result action; truthful absence validates.

## Identity / determinism

Frozen, extra-forbid, canonical-digest payloads; no clock/random/`hash()`/provider IDs/filesystem paths. Fresh-process determinism proven by subprocess digest equality. Source locality preserved: unrelated module/action/workflow/capability/result/binding additions move **no** existing binding or result digest, while every bound-axis mutation (input action, result action, role, capability id, committed result node, result_id, result description) changes canonical identity or rejects. Closure is validated relationally — no whole-graph hash inside any payload.

## CompilationPlan impact

None: plan derivation is payload-kind-triggered and references no edge kinds; the new/changed kinds are safely ignored. The shared plan/materialization golden corpus is **byte-identical** (enum-completeness round-trip uses the isolated extended kind map; full closure coverage lives in the dedicated suite). Verified by running the #475/#477 plan-authority, #471 four-family materialization, executable family contracts, and revision/publication suites unchanged.

## Tests

- `tests/test_workflow_capability_semantics.py` (49): canonical fixture + round-trip, subprocess determinism, full mutation matrix, total-declarer closure matrix (zero/two-module/module+workflow/workflow-only/discriminated-DECLARES, ref targets and event producers), typed event-identity matrix (missing node, identity-less node, duplicate identity, no-trigger independence both directions), exact EMITS projection matrix (wrong/duplicate discriminator, wrong/extra target, missing projection), all round-1 and round-2 Codex reproductions, workflow-result mutation matrix, explicit fan-out accept + duplicate reject, binding edge attack matrix, role-shape closure, provider-neutral `result_id` grammar, App Zero patterns A/B/C.
- `tests/test_semantic_payload_graph_v2.py` — enum-completeness and per-kind round-trip extended to WORKFLOW_RESULT; required-nullable map; shared corpus and goldens untouched.
- Regressions green: graph v2 (97), offline projection (59 — now closure-valid under the typed-emits rules), CompilationPlan derivation + authority, #471 four-family materialization, executable family contracts, revision contracts/store, semantic graph/serialization/taxonomy (307 across the battery), AG2/OSS hygiene, ruff, `git diff --check`, full `pytest -q --no-cov`.
- Scoped mypy blocked locally only by the known environmental numpy-stub artifact; a `--no-site-packages` pass over the changed modules shows no new-code findings; the CI lint job's mypy step is the arbiter.

## OSS Change Impact

- Layer changed: `mozaiksai/core/semantics/` (graph node kinds, payload catalog, closure validation, offline projection emits content) + tests + CHANGELOG.
- Build workflow impact: none in this PR (generators untouched; next PR — `feat(compiler): plan workflow module interfaces and app workflow registries` — owns family planning).
- Runtime/platform impact: none (offline contracts; no production importer changes).
- App workspace impact: none.
- Compatibility risk: pre-production semantic architecture; no unreleased stringly semantics preserved, no production execution path broken.

Reviewer: Codex 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
