### PR TITLE
feat(compiler): plan workflow module interfaces and app workflow registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ This project follows a practical pre-1.0 changelog format:
 ## Unreleased
 
 ### Added
+
+- **Deterministic workflow module interfaces and app workflow registries
+  (ADR 0007 compiler slice)**: the offline semantic compiler now plans and
+  renders two new families from the module-workflow capability semantics —
+  `workflows/{workflow_id}/module_interface.yaml`
+  (`mozaiks.module_interface.v2`, an exact projection of one workflow's
+  capabilities, every capability-owned workflow result — committed or
+  advisory — typed module-action/result bindings, and canonical trigger
+  events; a validation and diff surface, never runtime input) and
+  `workflows/workflow_registry.json` (`mozaiks.app_workflow_registry.v1`,
+  the app-local registry of workflows, capability ownership, and event
+  triggers — distinct from the factory `extension_registry.json`; journey,
+  sequencing, entrypoint, and AI-launch facts remain deferred until their
+  semantics exist). Both render through a new binding-resolved authority,
+  `deterministic_workflow_interface_renderer@1`, under the existing
+  canonical byte contracts. Source locality is payload-driven — unrelated
+  module, action-body, or event-payload changes never reprint an interface
+  that does not depend on them — and node-level canonical event identity is
+  pinned into plan-unit identity through new conditional `taxonomy_sources`
+  (every pre-existing unit digest is unchanged).
+
+### Added
 - **Typed module↔workflow capability semantics**: the semantic graph now
   models the relationship between deterministic application capabilities
   (modules, actions, events) and agentic capabilities (workflows) as

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -352,6 +352,28 @@ authoritative emitters of these paths until the atomic 5D cutover; hygiene
 guards prove they do not call the B2A renderer and that no production module
 imports it.
 
+The workflow-interface slice extends the deterministic corpus with two
+families rendered by a second binding-resolved authority,
+`deterministic_workflow_interface_renderer@1` on the
+`workflow_interface_executor` materializer: `workflow_module_interface`
+(`workflows/{workflow_id}/module_interface.yaml`, one exact projection of a
+workflow's module-capability closure — capabilities, every capability-owned
+workflow result whether committed or advisory, typed action/result bindings,
+canonical trigger events — a validation and diff surface, never
+runtime input) and `app_workflow_registry`
+(`workflows/workflow_registry.json`, the app-local list of workflows, their
+capability surface, and event triggers; deliberately not the factory
+`extension_registry.json` — journeys, transitions, entrypoints, and AI-launch
+facts stay deferred until their semantics exist). Source locality is
+payload-driven: selection follows typed payload references, ACTION payload
+bodies are never pinned (action identity is the node id inside the binding
+payload), and the registry excludes module/action/result facts entirely.
+Because canonical event identity lives on the EVENT node's taxonomy
+reference rather than any payload, plan units gain `taxonomy_sources` —
+pinned `(node, category, identifier)` triples that enter unit identity and
+serialization only when non-empty, so every payload-only unit's digest and
+serialized form are unchanged.
+
 ## ApplicationManifest
 
 `ApplicationManifest` is the minimal root identity and reference document,

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -103,6 +103,8 @@ class ArtifactKind(StrEnum):
     WORKFLOW_TOOL = "workflow_tool"
     WORKFLOW_UI = "workflow_ui"
     WORKFLOW_TASK_BATCH = "workflow_task_batch"
+    WORKFLOW_MODULE_INTERFACE = "workflow_module_interface"
+    APP_WORKFLOW_REGISTRY = "app_workflow_registry"
     BUILD_CONTEXT_REGISTRY = "build_context_registry"
     BUILD_CONTEXT_ASSET = "build_context_asset"
     CAPABILITY_PACK_OUTPUT = "capability_pack_output"
@@ -174,6 +176,7 @@ class MaterializerIdentifier(StrEnum):
     PAGE_SCHEMA_EXECUTOR = "page_schema_executor"
     APP_CONFIG_EXECUTOR = "app_config_executor"
     WORKFLOW_GENERATOR = "workflow_generator"
+    WORKFLOW_INTERFACE_EXECUTOR = "workflow_interface_executor"
     CAPABILITY_PACK_MATERIALIZER = "capability_pack_materializer"
     DOWNLOAD_DEPLOYMENT_RENDERER = "download_deployment_renderer"
     PRESERVED_OPAQUE = "preserved_opaque"
@@ -723,6 +726,17 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "ui_config.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,), stubs=(StubKind.JS_FRONTEND,), inputs=("artifact_declaration", "workflow")),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "middleware.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=workflow_inputs),
         _family(ArtifactKind.WORKFLOW_TASK_BATCH, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "extended_orchestration/task_batches.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
+        # module_interface.yaml is a deterministic projection of the workflow's
+        # module-capability closure (#478 semantics) — a validation and diff
+        # surface, never runtime input and never independent authority.
+        _family(ArtifactKind.WORKFLOW_MODULE_INTERFACE, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workspace, "workflows/{workflow_id}/module_interface.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.NONE, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, multiplicity=Multiplicity.MANY, materializer=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
+        _family(ArtifactKind.WORKFLOW_MODULE_INTERFACE, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workflow, "module_interface.yaml", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.NONE, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, materializer=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
+        # workflows/workflow_registry.json is the app-local workflow registry:
+        # workflows, their capabilities, and event triggers. It is NOT the
+        # factory extension_registry.json (journeys/transitions stay deferred
+        # until sequencing semantics exist) and declares no runtime consumer
+        # until the platform migrates onto it.
+        _family(ArtifactKind.APP_WORKFLOW_REGISTRY, LayoutOwner.APP_WORKSPACE, Requirement.CONDITIONAL, workspace, "workflows/workflow_registry.json", ValidatorIdentifier.APP_PATHS, RuntimeConsumerIdentifier.NONE, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, materializer=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,)),
         _family(ArtifactKind.WORKFLOW_TOOL, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "tools/{tool_id}.py", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_TOOL_DECLARED, multiplicity=Multiplicity.MANY, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.WORKFLOW_TOOL_IMPLEMENTATION,), deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=("artifact_declaration", "workflow")),
         _family(ArtifactKind.WORKFLOW_UI, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "ui/{workflow_id}/{component_id}.jsx", ValidatorIdentifier.GENERATED_APP_VALIDATOR, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_COMPONENT_DECLARED, multiplicity=Multiplicity.MANY, security=SecurityClass.EXECUTABLE_STUB, assignment=(AssignmentKind.WORKFLOW_UI_IMPLEMENTATION,), deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=("artifact_declaration", "workflow")),
         _family(ArtifactKind.MODULE_MANIFEST, LayoutOwner.MODULE, Requirement.REQUIRED, module, "module.yaml", ValidatorIdentifier.MODULE_LOADER, RuntimeConsumerIdentifier.MODULE_LOADER, condition=ConditionIdentifier.WHEN_MODULE_DECLARED, assignment=(AssignmentKind.MODULE_CONTRACT,), stubs=(StubKind.PYTHON_BACKEND,)),
@@ -1129,6 +1143,25 @@ def _semantic_inputs_for_family(kind: ArtifactKind) -> tuple[str, ...]:
             "trigger",
             "event",
             "capability",
+        ),
+        # module_interface.yaml renders the #478 capability-binding closure of
+        # one workflow. ACTION is deliberately absent: action identity is the
+        # node id pinned inside the binding payload, so unrelated action body
+        # changes never invalidate an interface.
+        ArtifactKind.WORKFLOW_MODULE_INTERFACE: (
+            "workflow",
+            "workflow_capability",
+            "workflow_capability_binding",
+            "workflow_result",
+            "module",
+        ),
+        # workflow_registry.json spans every workflow's capability surface and
+        # event triggers only; MODULE/ACTION/RESULT facts stay out so module
+        # churn never reprints the registry.
+        ArtifactKind.APP_WORKFLOW_REGISTRY: (
+            "workflow",
+            "workflow_capability",
+            "workflow_capability_binding",
         ),
         ArtifactKind.APP_DEPLOYMENT_ARTIFACT: (
             "deployment_target",

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -48,7 +48,7 @@ from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_serializer, model_validator
 
 from mozaiksai.core.runtime.app.layout_registry import (
     ArtifactDisposition,
@@ -75,7 +75,11 @@ from mozaiksai.core.semantics.payloads import (
     OptionalFamilySelectionStatus,
     PagePayload,
     SemanticPayloadBase,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityBindingRole,
+    WorkflowCapabilityPayload,
     WorkflowPayload,
+    WorkflowResultPayload,
     parse_semantic_payload,
     validate_semantic_graph_v2_payload_closure,
 )
@@ -86,6 +90,7 @@ from mozaiksai.core.semantics.refs import (
     _validate_digest,
     validate_node_id_grammar,
 )
+from mozaiksai.core.taxonomy import SemanticCategory
 from mozaiksai.core.workflow.assignment_kinds import (
     ASSIGNMENT_CONTRACT_DESCRIPTORS,
     COMPILER_ASSIGNMENT_KINDS,
@@ -106,6 +111,41 @@ _APP_CONFIG_RENDER_KINDS = frozenset(
         "app_ui_route_manifest",
     }
 )
+
+_WORKFLOW_INTERFACE_FAMILY = "workflow_module_interface"
+_APP_WORKFLOW_REGISTRY_FAMILY = "app_workflow_registry"
+_WORKFLOW_INTERFACE_RENDER_KINDS = frozenset(
+    {_WORKFLOW_INTERFACE_FAMILY, _APP_WORKFLOW_REGISTRY_FAMILY}
+)
+
+
+def canonical_instance_identity_value(value: str) -> str:
+    """Validate one canonical renderer instance-identity value.
+
+    The single closed grammar for placeholder identity values; derivation and
+    any renderer that re-verifies instance identity share this exact rule.
+    """
+    text = str(value or "").strip()
+    if _VALUE_RE.fullmatch(text) is None:
+        raise ValueError(f"instance identity value {value!r} is outside the closed domain")
+    return text
+
+
+def canonical_instance_unit_id(
+    family_kind: str, instance_identity: str, row_digest: str
+) -> str:
+    """The exact canonical unit id of one per-instance family unit.
+
+    This is THE unit-id derivation rule — extracted so a renderer verifying
+    a supplied unit against its canonical layout row uses the identical
+    construction the planner used, never a second permissive parse.
+    """
+    return f"{family_kind}/{instance_identity}/{row_digest[:12]}"
+
+
+def canonical_single_unit_id(family_kind: str, row_digest: str) -> str:
+    """The exact canonical unit id of one single-instance family unit."""
+    return f"{family_kind}/{row_digest[:12]}"
 
 COMPILATION_PLAN_SCHEMA_VERSION: Literal["mozaiks.compilation_plan.v1"] = (
     "mozaiks.compilation_plan.v1"
@@ -496,6 +536,39 @@ class PlanSource(SemanticsModel):
         return _validate_digest(value, field_name="payload_digest")
 
 
+class PlanTaxonomySource(SemanticsModel):
+    """One node-level canonical taxonomy identity a unit's bytes depend on.
+
+    Some canonical identities live on the graph node, not on any typed
+    payload — the canonical event identity is the EVENT node's single
+    EVENT-category taxonomy reference.  Payload digests cannot pin such a
+    fact, so a unit that renders it pins the exact ``(node, category,
+    identifier)`` triple here.  Changing the node's canonical identity then
+    changes the unit's reuse signature exactly like a payload change would.
+    """
+
+    node_id: str
+    category: str
+    identifier: str
+
+    @field_validator("node_id")
+    @classmethod
+    def _node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("category")
+    @classmethod
+    def _category(cls, value: str) -> str:
+        return SemanticCategory(str(value or "").strip()).value
+
+    @model_validator(mode="after")
+    def _grammar(self) -> PlanTaxonomySource:
+        from mozaiksai.core.taxonomy import validate_identifier_grammar
+
+        validate_identifier_grammar(self.category, self.identifier)
+        return self
+
+
 class PlanEdgeSource(SemanticsModel):
     """One complete graph relationship whose facts can affect rendered bytes."""
 
@@ -577,6 +650,10 @@ class FamilyInstancePlan(SemanticsModel):
     outputs: tuple[PlanOutput, ...] = Field(default_factory=tuple)
     sources: tuple[PlanSource, ...] = Field(default_factory=tuple)
     edge_sources: tuple[PlanEdgeSource, ...] = Field(default_factory=tuple)
+    #: Node-level canonical taxonomy identities this unit's bytes consume.
+    #: Empty for every family whose facts are fully payload-pinned; entering
+    #: identity only when non-empty keeps all such units' digests stable.
+    taxonomy_sources: tuple[PlanTaxonomySource, ...] = Field(default_factory=tuple)
     depends_on_units: tuple[str, ...] = Field(default_factory=tuple)
     materializer: str
     assignment_kind: AssignmentKind | None = None
@@ -652,6 +729,19 @@ class FamilyInstancePlan(SemanticsModel):
             raise ValueError("duplicate edge source identities in one unit")
         return ordered
 
+    @field_validator("taxonomy_sources")
+    @classmethod
+    def _taxonomy_sources(
+        cls, value: tuple[PlanTaxonomySource, ...]
+    ) -> tuple[PlanTaxonomySource, ...]:
+        ordered = tuple(
+            sorted(value, key=lambda item: (item.node_id, item.category, item.identifier))
+        )
+        keys = [(item.node_id, item.category) for item in ordered]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate taxonomy source identities in one unit")
+        return ordered
+
     @field_validator("depends_on_units")
     @classmethod
     def _deps(cls, value: tuple[str, ...]) -> tuple[str, ...]:
@@ -659,6 +749,21 @@ class FamilyInstancePlan(SemanticsModel):
         if len(ordered) != len(set(ordered)):
             raise ValueError("duplicate unit dependencies")
         return ordered
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: Any) -> Any:
+        """Serialize with the exact identity representation.
+
+        ``taxonomy_sources`` is omitted when empty so the serialized unit,
+        the identity payload, and the unit digest all state the same claim
+        ("no node-level identity feeds these bytes") in the same shape —
+        every pre-existing payload-only unit keeps its exact serialized form
+        and digest.
+        """
+        data = handler(self)
+        if isinstance(data, dict) and not data.get("taxonomy_sources"):
+            data.pop("taxonomy_sources", None)
+        return data
 
     @model_validator(mode="after")
     def _shape(self) -> FamilyInstancePlan:
@@ -699,7 +804,7 @@ class FamilyInstancePlan(SemanticsModel):
 
     @property
     def identity_payload(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "unit_id": self.unit_id,
             "family_kind": self.family_kind,
             "family_identity_digest": self.family_identity_digest,
@@ -726,6 +831,20 @@ class FamilyInstancePlan(SemanticsModel):
             ),
             "base_plan_digest": self.base_plan_digest,
         }
+        # Node-level taxonomy identity enters unit identity only when this
+        # unit actually pins one: absence and emptiness are the same claim
+        # ("no node-level identity feeds these bytes"), and conditional
+        # inclusion keeps every pre-existing payload-only unit digest stable.
+        if self.taxonomy_sources:
+            payload["taxonomy_sources"] = [
+                {
+                    "node_id": item.node_id,
+                    "category": item.category,
+                    "identifier": item.identifier,
+                }
+                for item in self.taxonomy_sources
+            ]
+        return payload
 
     @property
     def unit_digest(self) -> str:
@@ -1242,12 +1361,158 @@ def derive_compilation_plan(
             return tuple(sorted(instances))
         return None
 
+    def _footprint_parts(
+        selected: set[str],
+    ) -> tuple[tuple[PlanSource, ...], tuple[PlanEdgeSource, ...]]:
+        sources = tuple(
+            PlanSource(
+                node_id=node_id,
+                payload_digest=payload_by_node[node_id].payload_digest,
+            )
+            for node_id in sorted(selected)
+        )
+        edge_sources = tuple(
+            PlanEdgeSource(
+                kind=edge.kind,
+                source_node_id=edge.source_node_id,
+                target_node_id=edge.target_node_id,
+                discriminator=edge.discriminator,
+                edge_identity=edge.edge_identity,
+            )
+            for edge in verified_graph.edges
+            if edge.source_node_id in selected and edge.target_node_id in selected
+        )
+        return sources, edge_sources
+
+    workflow_footprint_memo: dict[
+        tuple[str, str | None],
+        tuple[
+            tuple[PlanSource, ...],
+            tuple[PlanEdgeSource, ...],
+            tuple[PlanTaxonomySource, ...],
+        ]
+        | None,
+    ] = {}
+
+    def _workflow_family_footprint(
+        row_kind: str, root_node_id: str | None
+    ) -> tuple[
+        tuple[PlanSource, ...],
+        tuple[PlanEdgeSource, ...],
+        tuple[PlanTaxonomySource, ...],
+    ] | None:
+        """Payload-driven closure selection for the workflow-interface corpus.
+
+        Typed payloads own meaning, so selection follows payload references
+        (never generic edge hops): capabilities owned by the in-scope
+        workflows, their binding nodes, EVERY workflow result each included
+        capability canonically owns (committed or advisory — delivery is a
+        separate relation), the module payloads action bindings name, and the
+        node-level canonical EVENT identity of every bound trigger event.
+        ACTION payloads are deliberately NOT selected — the semantic identity
+        of an action is its node id (pinned inside the binding payload), so
+        unrelated action body changes never move these units.  ``None`` means
+        a bound event lacks exactly one canonical identity; the caller
+        records a typed renderer-input gap.
+        """
+        memo_key = (row_kind, root_node_id)
+        if memo_key in workflow_footprint_memo:
+            return workflow_footprint_memo[memo_key]
+        include_action_bindings = row_kind == _WORKFLOW_INTERFACE_FAMILY
+        if root_node_id is None:
+            workflow_node_ids = {
+                node.node_id
+                for node in verified_graph.nodes
+                if node.kind is SemanticNodeKind.WORKFLOW
+            }
+        else:
+            workflow_node_ids = {root_node_id}
+        selected = set(workflow_node_ids)
+        capability_ids: set[str] = set()
+        for payload in payload_by_node.values():
+            if (
+                isinstance(payload, WorkflowCapabilityPayload)
+                and payload.workflow_node_id in workflow_node_ids
+            ):
+                selected.add(payload.node_id)
+                capability_ids.add(payload.node_id)
+        taxonomy: dict[str, PlanTaxonomySource] = {}
+        result: tuple[
+            tuple[PlanSource, ...],
+            tuple[PlanEdgeSource, ...],
+            tuple[PlanTaxonomySource, ...],
+        ] | None
+        if include_action_bindings:
+            # Result ownership is the capability's DECLARES closure, never a
+            # commit binding: every capability-owned WORKFLOW_RESULT belongs
+            # to the interface whether or not delivery through a module
+            # action exists (advisory results are valid application
+            # semantics).  Commit bindings are a separate delivery relation.
+            for payload in payload_by_node.values():
+                if (
+                    isinstance(payload, WorkflowResultPayload)
+                    and payload.workflow_capability_node_id in capability_ids
+                ):
+                    selected.add(payload.node_id)
+        for payload in payload_by_node.values():
+            if not isinstance(payload, WorkflowCapabilityBindingPayload):
+                continue
+            if payload.workflow_capability_node_id not in capability_ids:
+                continue
+            is_trigger = (
+                payload.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT
+            )
+            if not include_action_bindings and not is_trigger:
+                continue
+            selected.add(payload.node_id)
+            if include_action_bindings and payload.module_action is not None:
+                selected.add(payload.module_action.module_node_id)
+            if is_trigger and payload.event_node_id is not None:
+                identifiers = tuple(
+                    reference.identifier
+                    for reference in node_by_id[payload.event_node_id].taxonomy_references
+                    if reference.category is SemanticCategory.EVENT
+                )
+                if len(identifiers) != 1:
+                    workflow_footprint_memo[memo_key] = None
+                    return None
+                taxonomy[payload.event_node_id] = PlanTaxonomySource(
+                    node_id=payload.event_node_id,
+                    category=SemanticCategory.EVENT.value,
+                    identifier=identifiers[0],
+                )
+        sources, edge_sources = _footprint_parts(selected)
+        result = (
+            sources,
+            edge_sources,
+            tuple(
+                sorted(
+                    taxonomy.values(),
+                    key=lambda item: (item.node_id, item.category, item.identifier),
+                )
+            ),
+        )
+        workflow_footprint_memo[memo_key] = result
+        return result
+
     def _renderer_footprint(
         row: RegistryFamilyRow, *, root_node_id: str | None = None
-    ) -> tuple[tuple[PlanSource, ...], tuple[PlanEdgeSource, ...]]:
+    ) -> tuple[
+        tuple[PlanSource, ...],
+        tuple[PlanEdgeSource, ...],
+        tuple[PlanTaxonomySource, ...],
+    ]:
+        if row.kind in _WORKFLOW_INTERFACE_RENDER_KINDS:
+            footprint = _workflow_family_footprint(row.kind, root_node_id)
+            if footprint is None:
+                raise CompilationPlanError(
+                    f"family {row.kind!r} footprint requested for a closure its "
+                    "completeness check must have rejected"
+                )
+            return footprint
         allowed = {SemanticNodeKind(kind) for kind in row.semantic_input_kinds}
         if not allowed:
-            return (), ()
+            return (), (), ()
         if root_node_id is None:
             selected = {
                 node.node_id for node in verified_graph.nodes if node.kind in allowed
@@ -1288,25 +1553,8 @@ def derive_compilation_plan(
                         continue
                     if node_by_id[other].kind in allowed:
                         selected.add(other)
-        sources = tuple(
-            PlanSource(
-                node_id=node_id,
-                payload_digest=payload_by_node[node_id].payload_digest,
-            )
-            for node_id in sorted(selected)
-        )
-        edge_sources = tuple(
-            PlanEdgeSource(
-                kind=edge.kind,
-                source_node_id=edge.source_node_id,
-                target_node_id=edge.target_node_id,
-                discriminator=edge.discriminator,
-                edge_identity=edge.edge_identity,
-            )
-            for edge in verified_graph.edges
-            if edge.source_node_id in selected and edge.target_node_id in selected
-        )
-        return sources, edge_sources
+        sources, edge_sources = _footprint_parts(selected)
+        return sources, edge_sources, ()
 
     def _placeholder_value(placeholder: str, node_id: str) -> str:
         identity_fields = {
@@ -1416,6 +1664,20 @@ def derive_compilation_plan(
         """
         if row.kind in _APP_CONFIG_RENDER_KINDS and root_node_id is None:
             return _app_config_inputs_complete(row)
+        if row.kind in _WORKFLOW_INTERFACE_RENDER_KINDS:
+            # Complete exactly when the payload-driven closure resolves: the
+            # interface family roots at one WORKFLOW payload, the registry
+            # spans all of them, and every bound trigger event must carry
+            # exactly one canonical EVENT identity to pin. A workflow with no
+            # capabilities is a truthful empty projection, not a gap.
+            if row.kind == _WORKFLOW_INTERFACE_FAMILY:
+                if root_node_id is None or not isinstance(
+                    payload_by_node.get(root_node_id), WorkflowPayload
+                ):
+                    return False
+            elif root_node_id is not None:
+                return False
+            return _workflow_family_footprint(row.kind, root_node_id) is not None
         if row.kind != "app_ui_page_schema" or root_node_id is None:
             return False
         page = payload_by_node[root_node_id]
@@ -1480,7 +1742,7 @@ def derive_compilation_plan(
             PathScope.MODULE_RELATIVE.value,
         }:
             selected_scope = verified_scope_selection.module_scope
-        elif row.kind == "workflow_manifest":
+        elif row.kind in {"workflow_manifest", _WORKFLOW_INTERFACE_FAMILY}:
             selected_scope = verified_scope_selection.workflow_manifest_scope
         if selected_scope is not None and row.path_scope != selected_scope.value:
             _add_unit(
@@ -1645,8 +1907,8 @@ def derive_compilation_plan(
                         adr_slice=4,
                     )
                     continue
-                unit_sources, unit_edge_sources = _renderer_footprint(
-                    row, root_node_id=root_node_id
+                unit_sources, unit_edge_sources, unit_taxonomy_sources = (
+                    _renderer_footprint(row, root_node_id=root_node_id)
                 )
                 resolved_sources = unit_sources or (
                     PlanSource(
@@ -1656,7 +1918,7 @@ def derive_compilation_plan(
                 )
                 identity = "-".join(value for _name, value in values)
                 unit = FamilyInstancePlan(
-                    unit_id=f"{row.kind}/{identity}/{row_digest[:12]}",
+                    unit_id=canonical_instance_unit_id(row.kind, identity, row_digest),
                     family_kind=row.kind,
                     family_identity_digest=row_digest,
                     disposition=disposition,
@@ -1665,6 +1927,7 @@ def derive_compilation_plan(
                     outputs=(PlanOutput(path_scope=row.path_scope, path=path),),
                     sources=resolved_sources,
                     edge_sources=unit_edge_sources,
+                    taxonomy_sources=unit_taxonomy_sources,
                     materializer=row.materializer,
                     validator=row.validator,
                     assignment_kind=assignment_kind,
@@ -1701,8 +1964,8 @@ def derive_compilation_plan(
                 # their instance identity lives in placeholder_values and the
                 # collision domain, not the relative path.
 
-                unit_sources, unit_edge_sources = _renderer_footprint(
-                    row, root_node_id=node.node_id
+                unit_sources, unit_edge_sources, unit_taxonomy_sources = (
+                    _renderer_footprint(row, root_node_id=node.node_id)
                 )
                 resolved_sources = unit_sources or (
                     PlanSource(
@@ -1719,7 +1982,7 @@ def derive_compilation_plan(
                     )
                     continue
                 unit = FamilyInstancePlan(
-                    unit_id=f"{row.kind}/{local}/{row_digest[:12]}",
+                    unit_id=canonical_instance_unit_id(row.kind, local, row_digest),
                     family_kind=row.kind,
                     family_identity_digest=row_digest,
                     disposition=disposition,
@@ -1728,6 +1991,7 @@ def derive_compilation_plan(
                     outputs=(PlanOutput(path_scope=row.path_scope, path=path),),
                     sources=resolved_sources,
                     edge_sources=unit_edge_sources,
+                    taxonomy_sources=unit_taxonomy_sources,
                     materializer=row.materializer,
                     validator=row.validator,
                     assignment_kind=assignment_kind,
@@ -1742,7 +2006,9 @@ def derive_compilation_plan(
                 _gap(row, PlanGapCode.RENDERER_INPUT_INCOMPLETE, adr_slice=4)
                 continue
             source_kinds = _FAMILY_SOURCE_KINDS.get(row.condition, ())
-            declared_sources, declared_edge_sources = _renderer_footprint(row)
+            declared_sources, declared_edge_sources, declared_taxonomy_sources = (
+                _renderer_footprint(row)
+            )
             graph_wide = not trigger_kinds and not source_kinds and not row.semantic_input_kinds
             resolved_sources = (
                 () if graph_wide else declared_sources or _sources_for(source_kinds)
@@ -1753,7 +2019,7 @@ def derive_compilation_plan(
                 _gap(row, PlanGapCode.SOURCE_FOOTPRINT_INCOMPLETE, adr_slice=5)
                 continue
             unit = FamilyInstancePlan(
-                unit_id=f"{row.kind}/{row_digest[:12]}",
+                unit_id=canonical_single_unit_id(row.kind, row_digest),
                 family_kind=row.kind,
                 family_identity_digest=row_digest,
                 disposition=disposition,
@@ -1763,6 +2029,7 @@ def derive_compilation_plan(
                 outputs=(PlanOutput(path_scope=row.path_scope, path=row.path_template),),
                 sources=resolved_sources,
                 edge_sources=() if graph_wide else declared_edge_sources,
+                taxonomy_sources=() if graph_wide else declared_taxonomy_sources,
                 materializer=row.materializer,
                 validator=row.validator,
                 assignment_kind=assignment_kind,
@@ -2016,6 +2283,10 @@ __all__ = [
     "PlanEdgeSource",
     "PlanOutput",
     "PlanSource",
+    "PlanTaxonomySource",
+    "canonical_instance_identity_value",
+    "canonical_instance_unit_id",
+    "canonical_single_unit_id",
     "PlanSourceScope",
     "RegenerationClosure",
     "RegistryFamilyRow",

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -98,11 +98,17 @@ from mozaiksai.core.semantics.payloads import (
     AuthPayload,
     IntegrationConfigValueKind,
     IntegrationPayload,
+    ModulePayload,
     OptionalFamilyKind,
     OptionalFamilySelectionStatus,
     PagePayload,
     SectionPayload,
     SemanticPayloadBase,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityBindingRole,
+    WorkflowCapabilityPayload,
+    WorkflowPayload,
+    WorkflowResultPayload,
     parse_semantic_payload,
 )
 from mozaiksai.core.semantics.plan_authority import (
@@ -111,6 +117,29 @@ from mozaiksai.core.semantics.plan_authority import (
     validate_compilation_plan_against_authority,
 )
 from mozaiksai.core.semantics.portable_path import detect_collisions
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_INTERFACE_FAMILIES,
+    WORKFLOW_INTERFACE_RENDER_INPUT_VERSION,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+    ModuleInterfaceRenderInput,
+    RenderInputCapability,
+    RenderInputCapabilityBinding,
+    RenderInputCapabilityResult,
+    RenderInputRegistryCapability,
+    RenderInputRegistryWorkflow,
+    WorkflowInterfaceMaterializationError,
+    WorkflowInterfaceRenderInput,
+    WorkflowRegistryRenderInput,
+    render_workflow_interface_unit,
+)
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    RenderInputSource as WorkflowRenderInputSource,
+)
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    RenderInputTaxonomySource as WorkflowRenderInputTaxonomySource,
+)
+from mozaiksai.core.taxonomy import SemanticCategory
 
 PAGE_SCHEMA_FAMILY: Literal["app_ui_page_schema"] = "app_ui_page_schema"
 PAGE_BYTES_SCHEMA_VERSION: Literal["mozaiks.page_bytes.v1"] = "mozaiks.page_bytes.v1"
@@ -556,6 +585,281 @@ def project_app_family_render_input(
     )
 
 
+def resolve_workflow_interface_renderer_selection(
+    binding: ImplementationBinding,
+    *,
+    graph: SemanticGraphV2,
+    layout_registry: Any,
+) -> RendererSelection:
+    """Resolve the accepted workflow-interface renderer through the binding.
+
+    Fails closed when the binding carries no selection covering the
+    workflow-interface families, claims a different materializer, or pins any
+    implementation identity/version other than the single accepted
+    deterministic implementation of this slice.
+    """
+    try:
+        validate_implementation_binding_against_graph(
+            binding, graph, layout_registry=layout_registry
+        )
+    except ValueError as exc:
+        raise WorkflowInterfaceMaterializationError(
+            f"implementation binding rejected: {exc}"
+        ) from exc
+    matches = [
+        selection
+        for selection in binding.renderer_selections
+        if WORKFLOW_INTERFACE_FAMILIES & set(selection.artifact_families)
+    ]
+    if not matches:
+        raise WorkflowInterfaceMaterializationError(
+            "binding carries no renderer selection for the workflow-interface families"
+        )
+    if len(matches) != 1:
+        raise WorkflowInterfaceMaterializationError(
+            "workflow-interface families are split across multiple renderer "
+            "selections; deterministic_workflow_interface_renderer@1 requires "
+            "one selection declaring its exact family set"
+        )
+    selection = matches[0]
+    declared = set(selection.artifact_families)
+    if declared != WORKFLOW_INTERFACE_FAMILIES:
+        raise WorkflowInterfaceMaterializationError(
+            "renderer selection is the authorization boundary for "
+            "deterministic_workflow_interface_renderer@1 and must declare "
+            f"exactly its supported family set {sorted(WORKFLOW_INTERFACE_FAMILIES)}; "
+            f"got {sorted(declared)}"
+        )
+    if selection.materializer_id is not MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR:
+        raise WorkflowInterfaceMaterializationError(
+            "renderer selection for workflow-interface families pins materializer "
+            f"{selection.materializer_id.value!r}, not the workflow interface executor"
+        )
+    if (
+        selection.implementation_id != WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID
+        or selection.implementation_version
+        != WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION
+    ):
+        raise WorkflowInterfaceMaterializationError(
+            "renderer selection pins implementation "
+            f"{selection.implementation_id!r}@{selection.implementation_version!r}; "
+            "the only accepted workflow-interface implementation is "
+            f"{WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID!r}@"
+            f"{WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION!r}"
+        )
+    return selection
+
+
+def project_workflow_interface_render_input(
+    *,
+    unit: FamilyInstancePlan,
+    payload_by_node: Mapping[str, SemanticPayloadBase],
+) -> WorkflowInterfaceRenderInput:
+    """Project one unit's plan-pinned sources into its family-local input.
+
+    This is the single boundary where semantic payload classes feed the
+    workflow-interface renderer. Every rendered fact is derived from a
+    payload pinned by THIS unit's source footprint or from the unit's pinned
+    node-level taxonomy identities — the renderer never sees a payload
+    object, and no fact outside the unit's reuse signature can reach bytes.
+    """
+    if (
+        unit.disposition is not PlanDisposition.RENDER
+        or unit.family_kind not in WORKFLOW_INTERFACE_FAMILIES
+    ):
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} ({unit.family_kind!r}) is not an active "
+            "workflow-interface render unit"
+        )
+    resolved: dict[str, SemanticPayloadBase] = {}
+    for source in unit.sources:
+        pinned = payload_by_node.get(source.node_id)
+        if pinned is None or pinned.payload_digest != source.payload_digest:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} source {source.node_id!r} is missing "
+                "or does not match its pinned payload digest"
+            )
+        resolved[source.node_id] = pinned
+    sources = tuple(
+        WorkflowRenderInputSource(node_id=node_id, payload_digest=payload.payload_digest)
+        for node_id, payload in resolved.items()
+    )
+    taxonomy_sources = tuple(
+        WorkflowRenderInputTaxonomySource(
+            node_id=item.node_id, category=item.category, identifier=item.identifier
+        )
+        for item in unit.taxonomy_sources
+    )
+    event_identity_by_node = {
+        item.node_id: item.identifier
+        for item in unit.taxonomy_sources
+        if item.category == SemanticCategory.EVENT.value
+    }
+    workflows = {
+        node_id: payload
+        for node_id, payload in resolved.items()
+        if isinstance(payload, WorkflowPayload)
+    }
+    capabilities = {
+        node_id: payload
+        for node_id, payload in resolved.items()
+        if isinstance(payload, WorkflowCapabilityPayload)
+    }
+    bindings = [
+        payload
+        for payload in resolved.values()
+        if isinstance(payload, WorkflowCapabilityBindingPayload)
+    ]
+    results = {
+        node_id: payload
+        for node_id, payload in resolved.items()
+        if isinstance(payload, WorkflowResultPayload)
+    }
+    modules = {
+        node_id: payload
+        for node_id, payload in resolved.items()
+        if isinstance(payload, ModulePayload)
+    }
+
+    def _trigger_event_type(binding: WorkflowCapabilityBindingPayload) -> str:
+        event_node_id = binding.event_node_id
+        if event_node_id is None or event_node_id not in event_identity_by_node:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} binding {binding.node_id!r} references "
+                "a trigger event whose canonical identity is not pinned"
+            )
+        return event_identity_by_node[event_node_id]
+
+    def _binding_input(
+        binding: WorkflowCapabilityBindingPayload,
+    ) -> RenderInputCapabilityBinding:
+        if binding.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT:
+            return RenderInputCapabilityBinding(
+                role=binding.binding_role.value,
+                event_type=_trigger_event_type(binding),
+            )
+        if binding.module_action is None:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} binding {binding.node_id!r} lacks its "
+                "module action identity"
+            )
+        module = modules.get(binding.module_action.module_node_id)
+        if module is None:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} binding {binding.node_id!r} references "
+                f"module {binding.module_action.module_node_id!r} outside the "
+                "unit's pinned footprint"
+            )
+        workflow_result_id: str | None = None
+        if binding.binding_role is WorkflowCapabilityBindingRole.COMMITS_RESULT_THROUGH_ACTION:
+            result = (
+                None
+                if binding.workflow_result_node_id is None
+                else results.get(binding.workflow_result_node_id)
+            )
+            if result is None:
+                raise WorkflowInterfaceMaterializationError(
+                    f"unit {unit.unit_id!r} binding {binding.node_id!r} references "
+                    "a workflow result outside the unit's pinned footprint"
+                )
+            workflow_result_id = result.result_id
+        return RenderInputCapabilityBinding(
+            role=binding.binding_role.value,
+            module_id=module.module_id,
+            action_node_id=binding.module_action.action_node_id,
+            workflow_result_id=workflow_result_id,
+        )
+
+    def _capability_inputs(
+        owned_capability_ids: set[str],
+    ) -> tuple[RenderInputCapability, ...]:
+        # Result membership is ownership, never delivery: every pinned
+        # WORKFLOW_RESULT owned by the capability is projected whether or
+        # not a commit binding references it.
+        return tuple(
+            RenderInputCapability(
+                capability_id=capability.capability_id,
+                description=capability.description,
+                results=tuple(
+                    RenderInputCapabilityResult(
+                        result_id=result.result_id,
+                        description=result.description,
+                    )
+                    for result in results.values()
+                    if result.workflow_capability_node_id == node_id
+                ),
+                bindings=tuple(
+                    _binding_input(binding)
+                    for binding in bindings
+                    if binding.workflow_capability_node_id == node_id
+                ),
+            )
+            for node_id, capability in capabilities.items()
+            if node_id in owned_capability_ids
+        )
+
+    if unit.family_kind == "workflow_module_interface":
+        if len(workflows) != 1:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} footprint must pin exactly one "
+                "WorkflowPayload"
+            )
+        workflow_node_id, workflow = next(iter(workflows.items()))
+        foreign = [
+            node_id
+            for node_id, capability in capabilities.items()
+            if capability.workflow_node_id != workflow_node_id
+        ]
+        if foreign:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} pins capabilities owned by another "
+                f"workflow: {sorted(foreign)!r}"
+            )
+        return ModuleInterfaceRenderInput(
+            render_input_schema_version=WORKFLOW_INTERFACE_RENDER_INPUT_VERSION,
+            workflow_id=workflow.workflow_id,
+            capabilities=_capability_inputs(set(capabilities)),
+            sources=sources,
+            taxonomy_sources=taxonomy_sources,
+        )
+
+    workflow_inputs: list[RenderInputRegistryWorkflow] = []
+    for workflow_node_id, workflow in workflows.items():
+        owned = {
+            node_id
+            for node_id, capability in capabilities.items()
+            if capability.workflow_node_id == workflow_node_id
+        }
+        registry_capabilities = tuple(
+            RenderInputRegistryCapability(
+                capability_id=capabilities[node_id].capability_id,
+                event_triggers=tuple(
+                    _trigger_event_type(binding)
+                    for binding in bindings
+                    if binding.workflow_capability_node_id == node_id
+                    and binding.binding_role
+                    is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT
+                ),
+            )
+            for node_id in owned
+        )
+        workflow_inputs.append(
+            RenderInputRegistryWorkflow(
+                workflow_id=workflow.workflow_id,
+                startup_mode=(
+                    None if workflow.startup_mode is None else workflow.startup_mode.value
+                ),
+                capabilities=registry_capabilities,
+            )
+        )
+    return WorkflowRegistryRenderInput(
+        render_input_schema_version=WORKFLOW_INTERFACE_RENDER_INPUT_VERSION,
+        workflows=tuple(workflow_inputs),
+        sources=sources,
+        taxonomy_sources=taxonomy_sources,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Canonical page bytes
 # ---------------------------------------------------------------------------
@@ -835,11 +1139,65 @@ def _assert_app_config_output_closure(
             )
 
 
+def _assert_workflow_interface_output_closure(
+    plan: CompilationPlan,
+    outputs: list[MaterializedOutput],
+    selection: RendererSelection | None,
+) -> None:
+    """Exact output closure for the workflow-interface families.
+
+    Every emitted workflow-interface output must come from an active,
+    authorized RENDER unit at that unit's plan-owned composable path; every
+    active authorized composable unit must produce exactly one output; and no
+    output may exist for an inactive or unauthorized family.
+    """
+    unit_by_id = {unit.unit_id: unit for unit in plan.units}
+    active_expected = {
+        unit.unit_id: unit
+        for unit in plan.units
+        if unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in WORKFLOW_INTERFACE_FAMILIES
+        and any(o.path_scope in _COMPOSABLE_PATH_SCOPES for o in unit.outputs)
+    }
+    emitted_counts: dict[str, int] = {}
+    for output in outputs:
+        unit = unit_by_id.get(output.unit_id)
+        if unit is None or unit.family_kind not in WORKFLOW_INTERFACE_FAMILIES:
+            continue
+        if selection is None or unit.family_kind not in selection.artifact_families:
+            raise WorkflowInterfaceMaterializationError(
+                f"output {output.path!r} was emitted for unauthorized "
+                f"workflow-interface family {unit.family_kind!r}"
+            )
+        if unit.unit_id not in active_expected:
+            raise WorkflowInterfaceMaterializationError(
+                f"output {output.path!r} was emitted for inactive "
+                f"workflow-interface unit {output.unit_id!r}"
+            )
+        owned_paths = {
+            o.path for o in unit.outputs if o.path_scope in _COMPOSABLE_PATH_SCOPES
+        }
+        if output.path not in owned_paths:
+            raise WorkflowInterfaceMaterializationError(
+                f"output {output.path!r} does not equal the plan-owned path of "
+                f"unit {output.unit_id!r}"
+            )
+        emitted_counts[output.unit_id] = emitted_counts.get(output.unit_id, 0) + 1
+    for unit_id, unit in active_expected.items():
+        if emitted_counts.get(unit_id, 0) != 1:
+            raise WorkflowInterfaceMaterializationError(
+                f"active workflow-interface unit {unit_id!r} "
+                f"({unit.family_kind!r}) must produce exactly one output; "
+                f"produced {emitted_counts.get(unit_id, 0)}"
+            )
+
+
 def _materialize_unit(
     unit: FamilyInstancePlan,
     *,
     payload_by_node: Mapping[str, SemanticPayloadBase],
     app_config_selection: RendererSelection | None,
+    workflow_interface_selection: RendererSelection | None,
     preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
     bundle_outputs: list[MaterializedOutput],
     external: list[str],
@@ -879,6 +1237,23 @@ def _materialize_unit(
             content = render_app_config_unit(
                 unit=unit,
                 render_input=project_app_family_render_input(
+                    unit=unit, payload_by_node=payload_by_node
+                ),
+            )
+        elif unit.family_kind in WORKFLOW_INTERFACE_FAMILIES:
+            if workflow_interface_selection is None:
+                raise MaterializationError(
+                    f"render unit {unit.unit_id!r} requires the resolved "
+                    "workflow-interface renderer selection, which was not constructed"
+                )
+            if unit.family_kind not in workflow_interface_selection.artifact_families:
+                raise WorkflowInterfaceMaterializationError(
+                    f"unit {unit.unit_id!r} family {unit.family_kind!r} is not "
+                    "authorized by the resolved workflow-interface renderer selection"
+                )
+            content = render_workflow_interface_unit(
+                unit=unit,
+                render_input=project_workflow_interface_render_input(
                     unit=unit, payload_by_node=payload_by_node
                 ),
             )
@@ -972,6 +1347,15 @@ def materialize_plan(
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
+    workflow_interface_selection: RendererSelection | None = None
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in WORKFLOW_INTERFACE_FAMILIES
+        for unit in verified_plan.units
+    ):
+        workflow_interface_selection = resolve_workflow_interface_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
 
     outputs: list[MaterializedOutput] = []
@@ -985,6 +1369,7 @@ def materialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=app_config_selection,
+            workflow_interface_selection=workflow_interface_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -995,6 +1380,9 @@ def materialize_plan(
         )
     _assert_output_ownership(verified_plan, outputs)
     _assert_app_config_output_closure(verified_plan, outputs, app_config_selection)
+    _assert_workflow_interface_output_closure(
+        verified_plan, outputs, workflow_interface_selection
+    )
     return MaterializedBundle(
         plan_digest=verified_plan.plan_digest,
         outputs=tuple(sorted(outputs, key=lambda o: o.path)),
@@ -1081,6 +1469,15 @@ def rematerialize_plan(
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
+    workflow_interface_selection: RendererSelection | None = None
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind in WORKFLOW_INTERFACE_FAMILIES
+        for unit in verified_plan.units
+    ):
+        workflow_interface_selection = resolve_workflow_interface_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
     base_by_unit: dict[str, list[MaterializedOutput]] = {}
     for output in base_bundle.outputs:
@@ -1138,6 +1535,7 @@ def rematerialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=app_config_selection,
+            workflow_interface_selection=workflow_interface_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -1148,6 +1546,9 @@ def rematerialize_plan(
         )
     _assert_output_ownership(verified_plan, outputs)
     _assert_app_config_output_closure(verified_plan, outputs, app_config_selection)
+    _assert_workflow_interface_output_closure(
+        verified_plan, outputs, workflow_interface_selection
+    )
     return MaterializedBundle(
         plan_digest=verified_plan.plan_digest,
         outputs=tuple(sorted(outputs, key=lambda o: o.path)),

--- a/mozaiksai/core/semantics/workflow_interface_materialization.py
+++ b/mozaiksai/core/semantics/workflow_interface_materialization.py
@@ -1,0 +1,571 @@
+"""Deterministic workflow-interface family rendering.
+
+One accepted renderer authority — ``deterministic_workflow_interface_renderer@1``
+— produces canonical bytes for the two workflow-interface families whose
+complete input authority exists on accepted semantic payloads plus pinned
+node-level canonical event identities:
+
+- ``workflow_module_interface`` -> ``module_interface.yaml`` (one per workflow)
+- ``app_workflow_registry``     -> ``workflows/workflow_registry.json``
+
+``module_interface.yaml`` is an exact projection of one workflow's
+module-capability closure (workflow capabilities, EVERY workflow result each
+capability canonically owns — committed or advisory — their typed bindings to
+declared module actions, and canonical trigger events). It is a validation
+and diff surface for authored workflow bundles —
+never runtime input and never independent authority. The registry lists every
+workflow's capability surface and event triggers so a future platform
+consumer can stop re-parsing orchestrator files; it deliberately carries no
+journey, sequencing, entrypoint, or AI-launch facts (those semantics do not
+exist yet) and is NOT the factory ``extension_registry.json``.
+
+Action identity is the semantic node id: the module and the action are graph
+nodes and ``ModuleActionRef`` pins their node ids rather than inventing a
+parallel id scheme, so the projection renders ``module_id`` (a typed module
+fact) plus ``action_node_id`` — lossless under the sole-declarer closure.
+Canonical event identity lives on the EVENT node's taxonomy reference, so it
+reaches the renderer only through the unit's pinned ``taxonomy_sources``.
+
+Each family consumes its own closed, frozen, family-local render input
+projected by the central offline materialization owner from exactly that
+unit's plan-pinned sources. Dependency direction stays one-way: this module
+imports no semantic payload classes, no graph model, and no binding
+machinery — only the canonical layout-row contract (the same
+``RegistryFamilyRow`` snapshot machinery the planner uses) so the renderer
+can bind every supplied unit to the exact canonical row identity it claims.
+The renderer is offline substrate: no filesystem, no clocks, no
+environment, no AG2, no AppBuildPlan, no production callers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+from mozaiksai.core.semantics.compilation_plan import (
+    FamilyInstancePlan,
+    PlanDisposition,
+    RegistryFamilyRow,
+    canonical_instance_identity_value,
+    canonical_instance_unit_id,
+    canonical_single_unit_id,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.decl_bytes import json_decl_bytes, yaml_decl_bytes
+
+WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID = "deterministic_workflow_interface_renderer"
+WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION = "1"
+
+WORKFLOW_INTERFACE_RENDER_INPUT_VERSION: Literal[
+    "mozaiks.workflow_interface_render_input.v1"
+] = "mozaiks.workflow_interface_render_input.v1"
+
+MODULE_INTERFACE_SCHEMA_VERSION = "mozaiks.module_interface.v2"
+APP_WORKFLOW_REGISTRY_SCHEMA_VERSION = "mozaiks.app_workflow_registry.v1"
+
+#: The closed family set this renderer implementation may produce.
+WORKFLOW_INTERFACE_FAMILIES: frozenset[str] = frozenset(
+    {
+        "workflow_module_interface",
+        "app_workflow_registry",
+    }
+)
+
+@lru_cache(maxsize=1)
+def _canonical_rows_by_digest() -> Mapping[str, RegistryFamilyRow]:
+    """The exact canonical layout rows this renderer version owns.
+
+    Resolution direction is the invariant: a supplied unit's
+    ``family_identity_digest`` names — or fails to name — one of these
+    content-addressed canonical rows, and every other unit fact (family
+    kind, unit id, placeholder set, output scope, output path) must then
+    equal what THAT row canonically derives. The renderer never selects a
+    profile from caller-supplied ``path_scope`` or ``path``.
+
+    Pure construction from the one canonical core registry definition — the
+    same ``RegistryFamilyRow`` machinery the planner snapshots — so the
+    compiler and renderer cannot carry independently authored layout facts
+    that drift. No filesystem, environment, runtime app layout, or dynamic
+    row discovery is consulted; a mutated or extended row simply has a
+    digest this renderer does not know and is rejected.
+    """
+    snapshot = snapshot_layout_registry(build_app_layout_registry(()))
+    return {
+        row.row_digest: row
+        for row in snapshot.rows
+        if row.kind in WORKFLOW_INTERFACE_FAMILIES
+    }
+
+
+def _canonical_unit_identity(
+    unit: FamilyInstancePlan, row: RegistryFamilyRow
+) -> tuple[str, str, str | None]:
+    """Derive (expected_unit_id, expected_path, workflow_id) from the row.
+
+    Uses the planner's own derivation rules — the shared unit-id helpers and
+    the row's own path-template expansion — never a second path convention.
+    Placeholder exactness is the instance-identity contract: the interface
+    rows require EXACTLY ``(("workflow_id", <id>),)`` (the workflow-relative
+    twin carries the same scope-implied identity even though its template
+    has no placeholder), and the registry row requires EXACTLY ``()``.
+    Surplus, missing, or substituted identity axes reject.
+    """
+    if row.kind == "workflow_module_interface":
+        values = unit.placeholder_values
+        if len(values) != 1 or values[0][0] != "workflow_id":
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} must carry exactly the canonical "
+                f"workflow instance identity; got {values!r}"
+            )
+        try:
+            workflow_id = canonical_instance_identity_value(values[0][1])
+        except ValueError as exc:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} workflow instance identity is not "
+                f"canonical: {exc}"
+            ) from exc
+        expected_unit_id = canonical_instance_unit_id(
+            row.kind, workflow_id, row.row_digest
+        )
+        expected_path = row.path_template.replace("{workflow_id}", workflow_id)
+    else:
+        if unit.placeholder_values != ():
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} must carry no instance identity; "
+                f"got {unit.placeholder_values!r}"
+            )
+        workflow_id = None
+        expected_unit_id = canonical_single_unit_id(row.kind, row.row_digest)
+        expected_path = row.path_template
+    if "{" in expected_path or "}" in expected_path:
+        raise WorkflowInterfaceMaterializationError(
+            f"canonical row {row.kind!r} template did not expand completely"
+        )
+    return expected_unit_id, expected_path, workflow_id
+
+_BINDING_ROLES: frozenset[str] = frozenset(
+    {
+        "consumes_action",
+        "commits_result_through_action",
+        "triggered_by_event",
+    }
+)
+
+
+class WorkflowInterfaceMaterializationError(ValueError):
+    """The inputs violate the workflow-interface family contract."""
+
+
+class _ClosedRenderInputModel(BaseModel):
+    """Frozen, unknown-field-rejecting base for every render-input component."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class RenderInputSource(_ClosedRenderInputModel):
+    """One pinned semantic source: exact node identity and payload digest."""
+
+    node_id: str
+    payload_digest: str
+
+
+class RenderInputTaxonomySource(_ClosedRenderInputModel):
+    """One pinned node-level canonical taxonomy identity."""
+
+    node_id: str
+    category: str
+    identifier: str
+
+
+class RenderInputCapabilityBinding(_ClosedRenderInputModel):
+    """The projection facts of one typed capability binding."""
+
+    role: str
+    module_id: str | None = None
+    action_node_id: str | None = None
+    event_type: str | None = None
+    workflow_result_id: str | None = None
+
+    @model_validator(mode="after")
+    def _role_shape(self) -> RenderInputCapabilityBinding:
+        if self.role not in _BINDING_ROLES:
+            raise ValueError(f"unknown binding role {self.role!r}")
+        action_role = self.role in {"consumes_action", "commits_result_through_action"}
+        if action_role != (self.module_id is not None and self.action_node_id is not None):
+            raise ValueError(
+                f"binding role {self.role!r} requires exactly its action identity"
+            )
+        if (self.role == "triggered_by_event") != (self.event_type is not None):
+            raise ValueError(
+                f"binding role {self.role!r} requires exactly its event identity"
+            )
+        if (self.role == "commits_result_through_action") != (
+            self.workflow_result_id is not None
+        ):
+            raise ValueError(
+                f"binding role {self.role!r} requires exactly its result identity"
+            )
+        return self
+
+    @property
+    def sort_key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.role,
+            self.module_id or "",
+            self.action_node_id or "",
+            self.event_type or "",
+            self.workflow_result_id or "",
+        )
+
+
+class RenderInputCapabilityResult(_ClosedRenderInputModel):
+    """One capability-owned workflow result: semantic identity only.
+
+    A result belongs to the interface because its capability declares it —
+    whether or not any commit binding delivers it. Advisory results are valid
+    application semantics; no provider, model, structured-output class,
+    prompt, runtime, route, or handler identity ever enters this shape.
+    """
+
+    result_id: str
+    description: str | None
+
+
+class RenderInputCapability(_ClosedRenderInputModel):
+    """One workflow capability with its complete result and binding projection."""
+
+    capability_id: str
+    description: str | None
+    results: tuple[RenderInputCapabilityResult, ...] = ()
+    bindings: tuple[RenderInputCapabilityBinding, ...]
+
+    @model_validator(mode="after")
+    def _canonical_members(self) -> RenderInputCapability:
+        results = tuple(sorted(self.results, key=lambda r: r.result_id))
+        result_ids = [r.result_id for r in results]
+        if len(result_ids) != len(set(result_ids)):
+            raise ValueError(
+                f"capability {self.capability_id!r} declares duplicate result ids"
+            )
+        object.__setattr__(self, "results", results)
+        ordered = tuple(sorted(self.bindings, key=lambda b: b.sort_key))
+        keys = [b.sort_key for b in ordered]
+        if len(keys) != len(set(keys)):
+            raise ValueError(
+                f"capability {self.capability_id!r} declares duplicate bindings"
+            )
+        object.__setattr__(self, "bindings", ordered)
+        return self
+
+
+class RenderInputRegistryCapability(_ClosedRenderInputModel):
+    """The registry projection of one capability: identity and triggers."""
+
+    capability_id: str
+    event_triggers: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def _canonical_triggers(self) -> RenderInputRegistryCapability:
+        ordered = tuple(sorted(set(self.event_triggers)))
+        object.__setattr__(self, "event_triggers", ordered)
+        return self
+
+
+class RenderInputRegistryWorkflow(_ClosedRenderInputModel):
+    """The registry projection of one workflow."""
+
+    workflow_id: str
+    startup_mode: str | None
+    capabilities: tuple[RenderInputRegistryCapability, ...]
+
+    @model_validator(mode="after")
+    def _canonical_capabilities(self) -> RenderInputRegistryWorkflow:
+        ordered = tuple(sorted(self.capabilities, key=lambda c: c.capability_id))
+        capability_ids = [c.capability_id for c in ordered]
+        if len(capability_ids) != len(set(capability_ids)):
+            raise ValueError(
+                f"workflow {self.workflow_id!r} declares duplicate capability ids"
+            )
+        object.__setattr__(self, "capabilities", ordered)
+        return self
+
+
+class _FamilyRenderInputBase(_ClosedRenderInputModel):
+    """Shared identity of every family-local render input.
+
+    Each input carries only the facts its one family consumes plus the exact
+    pinned source payload digests and node-level taxonomy identities that
+    produced them, normalized to one canonical order.
+    """
+
+    render_input_schema_version: Literal["mozaiks.workflow_interface_render_input.v1"]
+    sources: tuple[RenderInputSource, ...]
+    taxonomy_sources: tuple[RenderInputTaxonomySource, ...] = ()
+
+    @model_validator(mode="after")
+    def _canonical_sources(self) -> _FamilyRenderInputBase:
+        sources = tuple(sorted(self.sources, key=lambda s: s.node_id))
+        source_ids = [s.node_id for s in sources]
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError("render input declares duplicate source node ids")
+        if not sources:
+            raise ValueError("render input pins no semantic sources")
+        object.__setattr__(self, "sources", sources)
+        taxonomy = tuple(
+            sorted(
+                self.taxonomy_sources,
+                key=lambda t: (t.node_id, t.category, t.identifier),
+            )
+        )
+        taxonomy_keys = [(t.node_id, t.category) for t in taxonomy]
+        if len(taxonomy_keys) != len(set(taxonomy_keys)):
+            raise ValueError("render input declares duplicate taxonomy identities")
+        object.__setattr__(self, "taxonomy_sources", taxonomy)
+        return self
+
+
+class ModuleInterfaceRenderInput(_FamilyRenderInputBase):
+    """Facts consumed by one workflow's ``module_interface.yaml`` only."""
+
+    family: Literal["workflow_module_interface"] = "workflow_module_interface"
+    workflow_id: str
+    capabilities: tuple[RenderInputCapability, ...]
+
+    @model_validator(mode="after")
+    def _canonical_capabilities(self) -> ModuleInterfaceRenderInput:
+        ordered = tuple(sorted(self.capabilities, key=lambda c: c.capability_id))
+        capability_ids = [c.capability_id for c in ordered]
+        if len(capability_ids) != len(set(capability_ids)):
+            raise ValueError("render input declares duplicate capability ids")
+        object.__setattr__(self, "capabilities", ordered)
+        return self
+
+
+class WorkflowRegistryRenderInput(_FamilyRenderInputBase):
+    """Facts consumed by ``workflows/workflow_registry.json`` only."""
+
+    family: Literal["app_workflow_registry"] = "app_workflow_registry"
+    workflows: tuple[RenderInputRegistryWorkflow, ...]
+
+    @model_validator(mode="after")
+    def _canonical_workflows(self) -> WorkflowRegistryRenderInput:
+        ordered = tuple(sorted(self.workflows, key=lambda w: w.workflow_id))
+        workflow_ids = [w.workflow_id for w in ordered]
+        if len(workflow_ids) != len(set(workflow_ids)):
+            raise ValueError("render input declares duplicate workflow ids")
+        object.__setattr__(self, "workflows", ordered)
+        return self
+
+
+WorkflowInterfaceRenderInput = ModuleInterfaceRenderInput | WorkflowRegistryRenderInput
+
+
+def _verify_unit_binding(
+    unit: FamilyInstancePlan, render_input: WorkflowInterfaceRenderInput
+) -> None:
+    """The render input must bind exactly the unit's pinned identity sets.
+
+    After canonical normalization, both the ``(node_id, payload_digest)``
+    source tuples and the ``(node_id, category, identifier)`` taxonomy
+    tuples must equal the plan unit's pinned sets exactly — a missing,
+    extra, duplicate, stale, or substituted identity fails closed.
+    """
+    expected_sources = tuple(
+        sorted((s.node_id, s.payload_digest) for s in unit.sources)
+    )
+    if len({node_id for node_id, _ in expected_sources}) != len(expected_sources):
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} pins duplicate source node ids"
+        )
+    actual_sources = tuple((s.node_id, s.payload_digest) for s in render_input.sources)
+    if actual_sources != expected_sources:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} render input does not bind exactly the "
+            "unit's pinned source set: "
+            f"expected {[n for n, _ in expected_sources]!r}, "
+            f"got {[n for n, _ in actual_sources]!r}"
+        )
+    expected_taxonomy = tuple(
+        sorted((t.node_id, t.category, t.identifier) for t in unit.taxonomy_sources)
+    )
+    actual_taxonomy = tuple(
+        (t.node_id, t.category, t.identifier) for t in render_input.taxonomy_sources
+    )
+    if actual_taxonomy != expected_taxonomy:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} render input does not bind exactly the "
+            "unit's pinned taxonomy identities: "
+            f"expected {expected_taxonomy!r}, got {actual_taxonomy!r}"
+        )
+
+
+def _binding_document(binding: RenderInputCapabilityBinding) -> dict[str, object]:
+    document: dict[str, object] = {"role": binding.role}
+    if binding.module_id is not None:
+        document["module_id"] = binding.module_id
+    if binding.action_node_id is not None:
+        document["action_node_id"] = binding.action_node_id
+    if binding.event_type is not None:
+        document["event_type"] = binding.event_type
+    if binding.workflow_result_id is not None:
+        document["workflow_result_id"] = binding.workflow_result_id
+    return document
+
+
+def _module_interface_document(
+    render_input: ModuleInterfaceRenderInput,
+) -> dict[str, object]:
+    return {
+        "schema_version": MODULE_INTERFACE_SCHEMA_VERSION,
+        "workflow_id": render_input.workflow_id,
+        "capabilities": [
+            {
+                "capability_id": capability.capability_id,
+                **(
+                    {"description": capability.description}
+                    if capability.description is not None
+                    else {}
+                ),
+                "results": [
+                    {
+                        "result_id": result.result_id,
+                        **(
+                            {"description": result.description}
+                            if result.description is not None
+                            else {}
+                        ),
+                    }
+                    for result in capability.results
+                ],
+                "bindings": [
+                    _binding_document(binding) for binding in capability.bindings
+                ],
+            }
+            for capability in render_input.capabilities
+        ],
+    }
+
+
+def _workflow_registry_document(
+    render_input: WorkflowRegistryRenderInput,
+) -> dict[str, object]:
+    return {
+        "schema_version": APP_WORKFLOW_REGISTRY_SCHEMA_VERSION,
+        "workflows": [
+            {
+                "workflow_id": workflow.workflow_id,
+                "startup_mode": workflow.startup_mode,
+                "capabilities": [
+                    {
+                        "capability_id": capability.capability_id,
+                        "event_triggers": list(capability.event_triggers),
+                    }
+                    for capability in workflow.capabilities
+                ],
+            }
+            for workflow in render_input.workflows
+        ],
+    }
+
+
+def render_workflow_interface_unit(
+    unit: FamilyInstancePlan,
+    render_input: WorkflowInterfaceRenderInput,
+) -> bytes:
+    """Render one workflow-interface family unit to canonical bytes.
+
+    The unit must be an active RENDER unit of this renderer's closed family
+    set, its output template must be one this implementation declares, and
+    the render input must bind exactly the unit's pinned source and taxonomy
+    identity sets.
+    """
+    if (
+        unit.disposition is not PlanDisposition.RENDER
+        or unit.family_kind not in WORKFLOW_INTERFACE_FAMILIES
+    ):
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} ({unit.family_kind!r}) is not an active "
+            "workflow-interface render unit"
+        )
+    if unit.family_kind != render_input.family:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} family does not match render input "
+            f"family {render_input.family!r}"
+        )
+    if len(unit.outputs) != 1:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} must own exactly one output path"
+        )
+    target = unit.outputs[0]
+    # Complete canonical layout-row/instance identity binding. Direction is
+    # the invariant: family_identity_digest resolves the exact canonical row
+    # this renderer owns, that row derives the exact instance placeholder
+    # set, unit id, path scope, and expanded path, and every supplied unit
+    # fact must equal that canonical result — the renderer never chooses a
+    # profile from caller-supplied scope or path. This is the direct-renderer
+    # responsibility ("is this unit exactly one canonical unit shape this
+    # renderer owns?"); whether that canonical unit belongs to the current
+    # CompilationPlan is #475/#477 plan authority, deliberately not
+    # re-implemented here.
+    row = _canonical_rows_by_digest().get(unit.family_identity_digest)
+    if row is None:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} family identity digest does not name a "
+            "canonical layout row this renderer owns"
+        )
+    if unit.family_kind != row.kind:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} family {unit.family_kind!r} does not match "
+            f"its canonical layout row {row.kind!r}"
+        )
+    expected_unit_id, expected_path, unit_workflow_id = _canonical_unit_identity(
+        unit, row
+    )
+    if unit.unit_id != expected_unit_id:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit id {unit.unit_id!r} does not equal the exact canonical unit "
+            f"identity {expected_unit_id!r} of its layout row"
+        )
+    if isinstance(render_input, ModuleInterfaceRenderInput):
+        if render_input.workflow_id != unit_workflow_id:
+            raise WorkflowInterfaceMaterializationError(
+                f"unit {unit.unit_id!r} render input names workflow "
+                f"{render_input.workflow_id!r} but the unit's exact workflow "
+                f"identity is {unit_workflow_id!r}"
+            )
+    if target.path_scope != row.path_scope or target.path != expected_path:
+        raise WorkflowInterfaceMaterializationError(
+            f"unit {unit.unit_id!r} output ({target.path_scope!r}, "
+            f"{target.path!r}) does not equal the exact canonical path "
+            f"({row.path_scope!r}, {expected_path!r}) of its layout row"
+        )
+    _verify_unit_binding(unit, render_input)
+    if isinstance(render_input, ModuleInterfaceRenderInput):
+        return yaml_decl_bytes(_module_interface_document(render_input))
+    return json_decl_bytes(_workflow_registry_document(render_input))
+
+
+__all__ = [
+    "APP_WORKFLOW_REGISTRY_SCHEMA_VERSION",
+    "MODULE_INTERFACE_SCHEMA_VERSION",
+    "ModuleInterfaceRenderInput",
+    "RenderInputCapability",
+    "RenderInputCapabilityBinding",
+    "RenderInputCapabilityResult",
+    "RenderInputRegistryCapability",
+    "RenderInputRegistryWorkflow",
+    "RenderInputSource",
+    "RenderInputTaxonomySource",
+    "WORKFLOW_INTERFACE_FAMILIES",
+    "WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID",
+    "WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION",
+    "WORKFLOW_INTERFACE_RENDER_INPUT_VERSION",
+    "WorkflowInterfaceMaterializationError",
+    "WorkflowInterfaceRenderInput",
+    "WorkflowRegistryRenderInput",
+    "render_workflow_interface_unit",
+]

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -186,6 +186,7 @@ def _bundle_for(plan, graph, payloads, _authority_inputs) -> MaterializedBundle:
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=selection,
+            workflow_interface_selection=None,
             preserved_by_unit={},
             bundle_outputs=outputs,
             external=[],

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -88,6 +88,11 @@ from mozaiksai.core.semantics.plan_authority import (
     build_compilation_plan_authority_inputs,
 )
 from mozaiksai.core.semantics.refs import SemanticGraphRef
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_INTERFACE_FAMILIES,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+)
 from tests.test_semantic_payload_graph_v2 import _SCOPE, _corpus_payloads
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -364,6 +369,12 @@ def _binding(graph):
                 implementation_version=APP_CONFIG_RENDERER_IMPLEMENTATION_VERSION,
                 artifact_families=tuple(sorted(APP_CONFIG_FAMILIES)),
             ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                implementation_id=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=tuple(sorted(WORKFLOW_INTERFACE_FAMILIES)),
+            ),
         ),
     )
 
@@ -387,13 +398,13 @@ def test_accepted_b1_registry_census_is_unchanged() -> None:
     registry = build_app_layout_registry(())
     census = Counter(f.disposition.value for f in registry.families)
     assert dict(census) == {
-        "render": 79,
+        "render": 82,
         "agent_author": 19,
         "external_handoff": 11,
         "input_only": 1,
         "inapplicable": 13,
     }
-    assert sum(census.values()) == 123
+    assert sum(census.values()) == 126
 
 
 # ---------------------------------------------------------------------------
@@ -828,6 +839,9 @@ def test_b2a_renderer_is_unwired_from_production_code() -> None:
         Path("mozaiksai/core/semantics/app_config_materialization.py"),
         Path("mozaiksai/core/semantics/decl_bytes.py"),
         Path("mozaiksai/core/semantics/materialization.py"),
+        # The workflow-interface renderer shares the decl-bytes contracts and
+        # is equally offline-only; the same scan keeps it out of production.
+        Path("mozaiksai/core/semantics/workflow_interface_materialization.py"),
     }
     offenders: list[str] = []
     for root_dir in ("mozaiksai", "factory_app"):
@@ -1019,6 +1033,12 @@ def _binding_with_families(
                 implementation_id=APP_CONFIG_RENDERER_IMPLEMENTATION_ID,
                 implementation_version=implementation_version,
                 artifact_families=tuple(families),
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                implementation_id=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=tuple(sorted(WORKFLOW_INTERFACE_FAMILIES)),
             ),
         ),
     )

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -73,7 +73,13 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # resolution is ImplementationBinding authority enforced at materialization),
 # so the gap set shrinks by exactly that one structural entry. Identity-only:
 # no unit, byte, footprint, or assignment fact changed.
-_GOLDEN_PLAN_DIGEST = "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2"
+# Re-pinned once for the workflow-interface-families PR: the registry gains
+# the workflow_module_interface twin rows and the app_workflow_registry row
+# (registry identity), and the corpus plan gains their derived units (the
+# corpus workflow has no capability bindings, so both render as truthful
+# empty projections). Every pre-existing unit digest is unchanged — empty
+# taxonomy_sources is omitted from unit identity and serialization alike.
+_GOLDEN_PLAN_DIGEST = "0969d4e804e007add764224f1f6d6d5e71c1f743551d02c047dfb9a2ca4ca8c1"
 
 
 def _registry():
@@ -558,6 +564,10 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
         Path("mozaiksai/core/semantics/compilation_plan.py"),
         Path("mozaiksai/core/semantics/decl_bytes.py"),
         Path("mozaiksai/core/semantics/app_config_materialization.py"),
+        # Workflow-interface families: deterministic module_interface.yaml /
+        # workflow_registry.json renderer; offline-only like its app-config
+        # sibling, consumed solely through the semantics materialization owner.
+        Path("mozaiksai/core/semantics/workflow_interface_materialization.py"),
         Path("mozaiksai/core/semantics/resolver.py"),
         Path("mozaiksai/core/semantics/refs.py"),
         # Slice 4C offline materializer: consumes the plan inside the
@@ -644,6 +654,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         PlanGap,
         PlanOutput,
         PlanSource,
+        PlanTaxonomySource,
         RegenerationClosure,
     )
 
@@ -672,6 +683,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
             "outputs",
             "sources",
             "edge_sources",
+            "taxonomy_sources",
             "depends_on_units",
             "materializer",
             "assignment_kind",
@@ -681,6 +693,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         },
         PlanOutput: {"path_scope", "path"},
         PlanSource: {"node_id", "payload_digest"},
+        PlanTaxonomySource: {"node_id", "category", "identifier"},
         PlanEdgeSource: {
             "kind",
             "source_node_id",
@@ -753,6 +766,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         | allowed_fields[FamilyInstancePlan]
         | allowed_fields[PlanOutput]
         | allowed_fields[PlanSource]
+        | allowed_fields[PlanTaxonomySource]
         | allowed_fields[PlanEdgeSource]
         | allowed_fields[PlanGap]
             | {"ref_schema_version", "tenant_id", "workspace_id", "pre_app_scope_id"}

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -430,6 +430,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
             unit,
             payload_by_node={},
                 app_config_selection=None,
+                workflow_interface_selection=None,
             preserved_by_unit={},
             bundle_outputs=[],
             external=[],

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -131,6 +131,10 @@ _SEMANTICS_OWNER_FILES = frozenset(
         # and non-importability are proven by its own proof suite and the
         # hygiene scan in tests/test_compilation_plan.py.
         Path("mozaiksai/core/semantics/materialization.py"),
+        # Workflow-interface families: deterministic module_interface.yaml /
+        # workflow_registry.json renderer, offline-only like its app-config
+        # sibling; covered by the same hygiene scan.
+        Path("mozaiksai/core/semantics/workflow_interface_materialization.py"),
         # Slice 5A: the replacement assignment compiler is an explicitly
         # offline substrate consumer of pinned payload and plan-unit refs.
         Path("mozaiksai/core/workflow/plan_assignment_compiler.py"),

--- a/tests/test_workflow_interface_families.py
+++ b/tests/test_workflow_interface_families.py
@@ -1,0 +1,1425 @@
+"""Workflow-interface compilation families: module_interface.yaml + workflow_registry.json.
+
+Proofs that the two new families are exact deterministic projections of the
+#478 module-workflow capability semantics: payload-driven source locality,
+node-level canonical event identity pinned through ``taxonomy_sources``,
+binding-authorized deterministic rendering, canonical plan-authority
+integration, and byte-for-byte reuse across refinement when nothing a unit
+depends on changed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    MaterializerIdentifier,
+    PathScope,
+    build_app_layout_registry,
+)
+from mozaiksai.core.semantics.binding import (
+    RendererSelection,
+    build_implementation_binding,
+)
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    CompilationScopeSelection,
+    derive_compilation_plan,
+    plan_regeneration_closure,
+)
+from mozaiksai.core.semantics.materialization import (
+    PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+    PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+    materialize_plan,
+    rematerialize_plan,
+)
+from mozaiksai.core.semantics.payloads import (
+    ModuleActionRef,
+    SemanticPayloadBase,
+    build_semantic_payload,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    build_compilation_plan_authority_inputs,
+    validate_compilation_plan_against_authority,
+)
+from mozaiksai.core.semantics.refs import SemanticGraphRef
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_INTERFACE_FAMILIES,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+    WorkflowInterfaceMaterializationError,
+)
+from tests.test_workflow_capability_semantics import (
+    _ACTION_CREATE,
+    _ACTION_GET,
+    _BINDING_RESULT,
+    _CAPABILITY,
+    _EVENT,
+    _MODULE,
+    _RESULT,
+    _RESULT_ALT,
+    _WORKFLOW,
+    _build_graph,
+    _fixture_payloads,
+    _rebuilt_action,
+    _result,
+    _rival_workflow_and_capability,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_INTERFACE_FAMILY = "workflow_module_interface"
+_REGISTRY_FAMILY = "app_workflow_registry"
+
+# Golden re-pinned once in correction round 1: capability-owned results were
+# previously omitted unless a commit binding referenced them — the interface
+# now projects EVERY capability-owned WORKFLOW_RESULT (committed or advisory)
+# in an explicit `results` block. This re-pin fixes missing semantic output
+# projection; no unrelated plan/unit identity was re-pinned.
+_GOLDEN_MODULE_INTERFACE = """schema_version: mozaiks.module_interface.v2
+workflow_id: analyze_document
+capabilities:
+- capability_id: documents.analysis
+  description: Analyze a created document
+  results:
+  - result_id: analysis_result
+    description: One analysis of one document
+  bindings:
+  - role: commits_result_through_action
+    module_id: documents
+    action_node_id: mozaiks.action.documents_store_analysis
+    workflow_result_id: analysis_result
+  - role: consumes_action
+    module_id: documents
+    action_node_id: mozaiks.action.documents_get_content
+  - role: triggered_by_event
+    event_type: domain.documents.created
+"""
+
+_GOLDEN_WORKFLOW_REGISTRY = """{
+  "schema_version": "mozaiks.app_workflow_registry.v1",
+  "workflows": [
+    {
+      "workflow_id": "analyze_document",
+      "startup_mode": null,
+      "capabilities": [
+        {
+          "capability_id": "documents.analysis",
+          "event_triggers": [
+            "domain.documents.created"
+          ]
+        }
+      ]
+    }
+  ]
+}
+"""
+
+
+def _scope_selection() -> CompilationScopeSelection:
+    return CompilationScopeSelection(workflow_manifest_scope=PathScope.WORKSPACE_ROOT)
+
+
+def _derive(payloads: dict[str, SemanticPayloadBase], *, graph=None):
+    resolved_graph = _build_graph(payloads) if graph is None else graph
+    plan = derive_compilation_plan(
+        graph=resolved_graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    return resolved_graph, plan
+
+
+def _family_units(plan: CompilationPlan) -> dict[str, object]:
+    units = {}
+    for unit in plan.units:
+        if unit.family_kind in WORKFLOW_INTERFACE_FAMILIES and unit.sources:
+            units[unit.family_kind] = unit
+    return units
+
+
+def _binding(graph):
+    return build_implementation_binding(
+        binding_id="wi_families",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=("app_ui_page_schema",),
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                implementation_id=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=tuple(sorted(WORKFLOW_INTERFACE_FAMILIES)),
+            ),
+        ),
+    )
+
+
+def _materialize(payloads: dict[str, SemanticPayloadBase]):
+    graph, plan = _derive(payloads)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    bundle = materialize_plan(
+        plan=plan,
+        authority_inputs=authority,
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    )
+    return graph, plan, authority, bundle
+
+
+def test_capability_closure_derives_exact_payload_driven_footprints() -> None:
+    """Interface and registry units pin exactly the payload closure their
+    bytes consume — never edge-hop spillover, never ACTION payload bodies —
+    plus the bound event's canonical node-level identity."""
+
+    _graph, plan = _derive(_fixture_payloads())
+    units = _family_units(plan)
+    interface = units[_INTERFACE_FAMILY]
+    registry = units[_REGISTRY_FAMILY]
+
+    assert [s.node_id for s in interface.sources] == sorted(
+        [
+            _MODULE,
+            _WORKFLOW,
+            _CAPABILITY,
+            "mozaiks.workflow_capability_binding.analysis_on_created",
+            "mozaiks.workflow_capability_binding.analysis_reads_content",
+            _BINDING_RESULT,
+            _RESULT,
+        ]
+    )
+    assert [(t.node_id, t.category, t.identifier) for t in interface.taxonomy_sources] == [
+        (_EVENT, "event", "domain.documents.created")
+    ]
+    # The registry excludes module/action/result facts entirely: module churn
+    # can never reprint it.
+    assert [s.node_id for s in registry.sources] == sorted(
+        [
+            _WORKFLOW,
+            _CAPABILITY,
+            "mozaiks.workflow_capability_binding.analysis_on_created",
+        ]
+    )
+    assert [(t.node_id, t.identifier) for t in registry.taxonomy_sources] == [
+        (_EVENT, "domain.documents.created")
+    ]
+    assert not [g for g in plan.gaps if g.family_kind in WORKFLOW_INTERFACE_FAMILIES]
+    assert interface.outputs[0].path == "workflows/analyze_document/module_interface.yaml"
+    assert registry.outputs[0].path == "workflows/workflow_registry.json"
+
+
+def test_rendered_bytes_are_the_exact_golden_projections() -> None:
+    _graph, _plan, _authority, bundle = _materialize(_fixture_payloads())
+    by_path = {output.path: output for output in bundle.outputs}
+    interface = by_path["workflows/analyze_document/module_interface.yaml"]
+    registry = by_path["workflows/workflow_registry.json"]
+    assert interface.content.decode("utf-8") == _GOLDEN_MODULE_INTERFACE
+    assert registry.content.decode("utf-8") == _GOLDEN_WORKFLOW_REGISTRY
+    assert interface.origin == "rendered"
+    assert registry.origin == "rendered"
+
+
+def test_unrelated_payload_mutations_never_move_unit_digests() -> None:
+    """Action bodies and producer descriptions are NOT interface authority:
+    the binding payload pins action identity as node ids, so unrelated
+    action/producer changes leave both units' reuse signatures untouched."""
+
+    base_payloads = _fixture_payloads()
+    _graph, base_plan = _derive(base_payloads)
+    base_units = _family_units(base_plan)
+
+    for mutated_action, overrides in (
+        (_ACTION_GET, {"description": "Read one document's content, verbatim"}),
+        (_ACTION_CREATE, {"description": "Create exactly one document"}),
+    ):
+        payloads = dict(base_payloads)
+        payloads[mutated_action] = _rebuilt_action(payloads, mutated_action, **overrides)
+        _mutated_graph, plan = _derive(payloads)
+        units = _family_units(plan)
+        for family in (_INTERFACE_FAMILY, _REGISTRY_FAMILY):
+            assert units[family].unit_digest == base_units[family].unit_digest, (
+                mutated_action,
+                family,
+            )
+
+
+def test_meaningful_mutations_move_exactly_the_dependent_units() -> None:
+    """Capability facts move both units; module identity and committed
+    results move only the interface; the registry never sees them."""
+
+    base_payloads = _fixture_payloads()
+    _graph, base_plan = _derive(base_payloads)
+    base_units = _family_units(base_plan)
+
+    # Capability description is pinned by both families.
+    payloads = dict(base_payloads)
+    capability = payloads[_CAPABILITY]
+    payloads[_CAPABILITY] = build_semantic_payload(
+        type(capability),
+        node_id=capability.node_id,
+        payload_version=capability.payload_version,
+        scope=capability.scope,
+        capability_id=capability.capability_id,
+        description="Analyze a created document, thoroughly",
+        workflow_node_id=capability.workflow_node_id,
+    )
+    _mutated, plan = _derive(payloads)
+    units = _family_units(plan)
+    assert units[_INTERFACE_FAMILY].unit_digest != base_units[_INTERFACE_FAMILY].unit_digest
+    assert units[_REGISTRY_FAMILY].unit_digest != base_units[_REGISTRY_FAMILY].unit_digest
+
+    # The committed result is interface authority only.
+    payloads = dict(base_payloads)
+    result = payloads[_RESULT]
+    payloads[_RESULT] = build_semantic_payload(
+        type(result),
+        node_id=result.node_id,
+        payload_version=result.payload_version,
+        scope=result.scope,
+        result_id="analysis_verdict",
+        description=result.description,
+        workflow_capability_node_id=result.workflow_capability_node_id,
+    )
+    _mutated, plan = _derive(payloads)
+    units = _family_units(plan)
+    assert units[_INTERFACE_FAMILY].unit_digest != base_units[_INTERFACE_FAMILY].unit_digest
+    assert units[_REGISTRY_FAMILY].unit_digest == base_units[_REGISTRY_FAMILY].unit_digest
+
+    # The module's typed identity is interface authority only.
+    payloads = dict(base_payloads)
+    module = payloads[_MODULE]
+    payloads[_MODULE] = build_semantic_payload(
+        type(module),
+        node_id=module.node_id,
+        payload_version=module.payload_version,
+        scope=module.scope,
+        module_id="document_store",
+        description=module.description,
+    )
+    _mutated, plan = _derive(payloads)
+    units = _family_units(plan)
+    assert units[_INTERFACE_FAMILY].unit_digest != base_units[_INTERFACE_FAMILY].unit_digest
+    assert units[_REGISTRY_FAMILY].unit_digest == base_units[_REGISTRY_FAMILY].unit_digest
+
+
+def test_canonical_event_identity_change_moves_both_units() -> None:
+    """The trigger event's node-level canonical identity is pinned unit
+    identity: renaming it moves both reuse signatures even though no payload
+    digest changed."""
+
+    payloads = _fixture_payloads()
+    base_graph = _build_graph(payloads)
+    renamed_payloads = dict(payloads)
+    renamed_payloads[_ACTION_CREATE] = _rebuilt_action(
+        renamed_payloads, _ACTION_CREATE, emits=("domain.documents.registered",)
+    )
+    renamed_graph = _build_graph(
+        renamed_payloads, event_identity="domain.documents.registered"
+    )
+    _same, base_plan = _derive(payloads, graph=base_graph)
+    _same2, renamed_plan = _derive(renamed_payloads, graph=renamed_graph)
+    base_units = _family_units(base_plan)
+    renamed_units = _family_units(renamed_plan)
+    for family in (_INTERFACE_FAMILY, _REGISTRY_FAMILY):
+        assert renamed_units[family].unit_digest != base_units[family].unit_digest
+        assert renamed_units[family].taxonomy_sources[0].identifier == (
+            "domain.documents.registered"
+        )
+
+
+def test_workflow_without_capabilities_renders_truthful_empty_projections() -> None:
+    payloads = {
+        node_id: payload
+        for node_id, payload in _fixture_payloads().items()
+        if not node_id.startswith(
+            ("mozaiks.workflow_capability", "mozaiks.workflow_result")
+        )
+    }
+    _graph, _plan, _authority, bundle = _materialize(payloads)
+    by_path = {output.path: output for output in bundle.outputs}
+    interface = by_path["workflows/analyze_document/module_interface.yaml"].content
+    registry = by_path["workflows/workflow_registry.json"].content
+    assert b"capabilities: []" in interface
+    assert b'"capabilities": []' in registry
+
+
+def test_materialization_requires_the_exact_renderer_selection() -> None:
+    payloads = _fixture_payloads()
+    graph, plan = _derive(payloads)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    without_selection = build_implementation_binding(
+        binding_id="wi_missing",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=("app_ui_page_schema",),
+            ),
+        ),
+    )
+    with pytest.raises(
+        WorkflowInterfaceMaterializationError, match="no renderer selection"
+    ):
+        materialize_plan(
+            plan=plan,
+            authority_inputs=authority,
+            graph=graph,
+            payloads=tuple(payloads.values()),
+            binding=without_selection,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+    partial = build_implementation_binding(
+        binding_id="wi_partial",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                implementation_id=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=("app_ui_page_schema",),
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                implementation_id=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+                artifact_families=("app_workflow_registry",),
+            ),
+        ),
+    )
+    with pytest.raises(
+        WorkflowInterfaceMaterializationError, match="exactly its supported family set"
+    ):
+        materialize_plan(
+            plan=plan,
+            authority_inputs=authority,
+            graph=graph,
+            payloads=tuple(payloads.values()),
+            binding=partial,
+            layout_registry=build_app_layout_registry(()),
+        )
+
+
+def test_rematerialize_reuses_untouched_interface_bytes() -> None:
+    """An unrelated action-body change between revisions leaves both units
+    reusable: refinement copies the exact prior bytes instead of re-rendering."""
+
+    base_payloads = _fixture_payloads()
+    base_graph, base_plan, base_authority, base_bundle = _materialize(base_payloads)
+
+    successor_payloads = dict(base_payloads)
+    successor_payloads[_ACTION_GET] = _rebuilt_action(
+        successor_payloads, _ACTION_GET, description="Read one document, cold"
+    )
+    successor_graph = _build_graph(successor_payloads)
+    successor_plan = derive_compilation_plan(
+        graph=successor_graph,
+        payloads=tuple(successor_payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    successor_authority = build_compilation_plan_authority_inputs(
+        graph=successor_graph,
+        payloads=tuple(successor_payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    closure = plan_regeneration_closure(base_plan, successor_plan)
+    interface_unit = _family_units(successor_plan)[_INTERFACE_FAMILY]
+    registry_unit = _family_units(successor_plan)[_REGISTRY_FAMILY]
+    assert interface_unit.unit_id in closure.reusable
+    assert registry_unit.unit_id in closure.reusable
+
+    bundle = rematerialize_plan(
+        base_plan=base_plan,
+        base_authority_inputs=base_authority,
+        successor_plan=successor_plan,
+        successor_authority_inputs=successor_authority,
+        graph=successor_graph,
+        payloads=tuple(successor_payloads.values()),
+        binding=_binding(successor_graph),
+        layout_registry=build_app_layout_registry(()),
+        base_bundle=base_bundle,
+    )
+    by_path = {output.path: output for output in bundle.outputs}
+    for path in (
+        "workflows/analyze_document/module_interface.yaml",
+        "workflows/workflow_registry.json",
+    ):
+        assert by_path[path].origin == "reused"
+        base_output = next(o for o in base_bundle.outputs if o.path == path)
+        assert by_path[path].content == base_output.content
+
+
+def test_forged_taxonomy_identity_rejects_against_canonical_authority() -> None:
+    """A plan whose pinned canonical event identity was rewritten (and
+    re-digested) is not the canonical derivation of its authorities."""
+
+    payloads = _fixture_payloads()
+    graph, plan = _derive(payloads)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    validate_compilation_plan_against_authority(plan, authority)
+
+    from mozaiksai.core.semantics.canonical import canonical_digest
+
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        for unit in doc["units"]:
+            for taxonomy in unit.get("taxonomy_sources", ()):
+                taxonomy["identifier"] = "domain.documents.hijacked"
+    document["plan_digest"] = canonical_digest(payload)
+    forged = CompilationPlan.model_validate(document)
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(forged, authority)
+
+
+def test_cross_process_bytes_and_digests_are_identical() -> None:
+    probe = (
+        "from tests.test_workflow_interface_families import (\n"
+        "    _fixture_payloads, _materialize)\n"
+        "import hashlib\n"
+        "_g, plan, _a, bundle = _materialize(_fixture_payloads())\n"
+        "digest = hashlib.sha256()\n"
+        "for output in bundle.outputs:\n"
+        "    if 'workflow' in output.path:\n"
+        "        digest.update(output.content)\n"
+        "print(plan.plan_digest, digest.hexdigest())\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert completed.returncode == 0, completed.stderr
+    import hashlib
+
+    _graph, plan, _authority, bundle = _materialize(_fixture_payloads())
+    digest = hashlib.sha256()
+    for output in bundle.outputs:
+        if "workflow" in output.path:
+            digest.update(output.content)
+    assert completed.stdout.split() == [plan.plan_digest, digest.hexdigest()]
+
+
+# ---------------------------------------------------------------------------
+# Correction round 1 — defect 1: ALL capability-owned results are interface
+# semantics, whether or not a commit binding delivers them.
+# ---------------------------------------------------------------------------
+
+
+def _rebuilt_result(payloads, node_id, **overrides):
+    base = payloads[node_id]
+    fields = {
+        "node_id": base.node_id,
+        "payload_version": base.payload_version,
+        "scope": base.scope,
+        "result_id": base.result_id,
+        "description": base.description,
+        "workflow_capability_node_id": base.workflow_capability_node_id,
+    }
+    fields.update(overrides)
+    return build_semantic_payload(type(base), **fields)
+
+
+def _advisory_result_payloads() -> dict[str, SemanticPayloadBase]:
+    """Canonical fixture plus one advisory (uncommitted) result R2."""
+    payloads = dict(_fixture_payloads())
+    payloads[_RESULT_ALT] = _result(_RESULT_ALT, result_id="analysis_summary")
+    return payloads
+
+
+def _interface_state(payloads):
+    graph, plan = _derive(payloads)
+    units = _family_units(plan)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    bundle = materialize_plan(
+        plan=plan,
+        authority_inputs=authority,
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        binding=_binding(graph),
+        layout_registry=build_app_layout_registry(()),
+    )
+    interface_bytes = next(
+        o.content
+        for o in bundle.outputs
+        if o.path == "workflows/analyze_document/module_interface.yaml"
+    )
+    return units, interface_bytes
+
+
+def test_advisory_result_is_projected_without_any_commit_binding() -> None:
+    """An uncommitted capability-owned result appears in the interface, is
+    pinned in the unit footprint, and stays absent from the registry."""
+
+    payloads = _advisory_result_payloads()
+    _graph, plan = _derive(payloads)
+    units = _family_units(plan)
+    interface = units[_INTERFACE_FAMILY]
+    registry = units[_REGISTRY_FAMILY]
+    assert _RESULT_ALT in {s.node_id for s in interface.sources}
+    assert _RESULT_ALT not in {s.node_id for s in registry.sources}
+
+    _units, interface_bytes = _interface_state(payloads)
+    text = interface_bytes.decode("utf-8")
+    assert "result_id: analysis_summary" in text
+    assert text.index("results:") < text.index("bindings:")
+
+
+def test_result_locality_matrix() -> None:
+    """The complete advisory-result mutation matrix: every owned-result fact
+    moves the interface (digest AND bytes); nothing else does, and the
+    registry never moves for any result-only change."""
+
+    base_payloads = _advisory_result_payloads()
+    base_units, base_bytes = _interface_state(base_payloads)
+
+    def _changed(payloads, *, registry_must_hold: bool = True):
+        units, rendered = _interface_state(payloads)
+        assert (
+            units[_INTERFACE_FAMILY].unit_digest
+            != base_units[_INTERFACE_FAMILY].unit_digest
+        )
+        assert rendered != base_bytes
+        if registry_must_hold:
+            assert (
+                units[_REGISTRY_FAMILY].unit_digest
+                == base_units[_REGISTRY_FAMILY].unit_digest
+            )
+        return rendered
+
+    # 2. advisory result_id rename
+    payloads = dict(base_payloads)
+    payloads[_RESULT_ALT] = _rebuilt_result(
+        payloads, _RESULT_ALT, result_id="analysis_digest"
+    )
+    rendered = _changed(payloads)
+    assert b"analysis_digest" in rendered
+
+    # 3. advisory description change (description is rendered)
+    payloads = dict(base_payloads)
+    payloads[_RESULT_ALT] = _rebuilt_result(
+        payloads, _RESULT_ALT, description="One short summary"
+    )
+    rendered = _changed(payloads)
+    assert b"One short summary" in rendered
+
+    # 4. advisory result deletion
+    payloads = {k: v for k, v in base_payloads.items() if k != _RESULT_ALT}
+    rendered = _changed(payloads)
+    assert b"analysis_summary" not in rendered
+
+    # 5. add another uncommitted result R3
+    payloads = dict(base_payloads)
+    payloads["mozaiks.workflow_result.analysis_notes"] = _result(
+        "mozaiks.workflow_result.analysis_notes", result_id="analysis_notes"
+    )
+    rendered = _changed(payloads)
+    assert b"analysis_notes" in rendered
+
+    # 6. a result owned by an unrelated workflow's capability leaves this
+    # workflow's interface untouched
+    rival_workflow, rival_capability = _rival_workflow_and_capability()
+    payloads = dict(base_payloads)
+    payloads[rival_workflow.node_id] = rival_workflow
+    payloads[rival_capability.node_id] = rival_capability
+    payloads["mozaiks.workflow_result.rival_verdict"] = _result(
+        "mozaiks.workflow_result.rival_verdict",
+        result_id="rival_verdict",
+        capability_node_id=rival_capability.node_id,
+    )
+    _graph, rival_plan = _derive(payloads)
+    analyze_unit = next(
+        u
+        for u in rival_plan.units
+        if u.family_kind == _INTERFACE_FAMILY
+        and ("workflow_id", "analyze_document") in u.placeholder_values
+    )
+    assert analyze_unit.unit_digest == base_units[_INTERFACE_FAMILY].unit_digest
+
+    # 7. removing R1's commit binding keeps R1 listed; only bindings change
+    payloads = {k: v for k, v in base_payloads.items() if k != _BINDING_RESULT}
+    rendered = _changed(payloads)
+    text = rendered.decode("utf-8")
+    assert "result_id: analysis_result" in text
+    assert "commits_result_through_action" not in text
+
+    # 8. committing the advisory result changes bindings, not result identity
+    payloads = dict(base_payloads)
+    payloads["mozaiks.workflow_capability_binding.analysis_stores_summary"] = (
+        build_semantic_payload(
+            type(payloads[_BINDING_RESULT]),
+            node_id="mozaiks.workflow_capability_binding.analysis_stores_summary",
+            payload_version=1,
+            scope=payloads[_BINDING_RESULT].scope,
+            binding_role=payloads[_BINDING_RESULT].binding_role,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=payloads[_BINDING_RESULT].module_action,
+            workflow_result_node_id=_RESULT_ALT,
+        )
+    )
+    rendered = _changed(payloads)
+    text = rendered.decode("utf-8")
+    assert text.count("- result_id: analysis_summary") == 1
+    assert "workflow_result_id: analysis_summary" in text
+
+    # 9. fan-out: one result committed through two actions appears once in
+    # results with two explicit commit bindings
+    payloads = dict(base_payloads)
+    payloads["mozaiks.workflow_capability_binding.analysis_stores_twice"] = (
+        build_semantic_payload(
+            type(payloads[_BINDING_RESULT]),
+            node_id="mozaiks.workflow_capability_binding.analysis_stores_twice",
+            payload_version=1,
+            scope=payloads[_BINDING_RESULT].scope,
+            binding_role=payloads[_BINDING_RESULT].binding_role,
+            workflow_capability_node_id=_CAPABILITY,
+            module_action=ModuleActionRef(
+                module_node_id=_MODULE, action_node_id=_ACTION_CREATE
+            ),
+            workflow_result_node_id=_RESULT,
+        )
+    )
+    rendered = _changed(payloads)
+    text = rendered.decode("utf-8")
+    assert text.count("- result_id: analysis_result") == 1
+    assert text.count("workflow_result_id: analysis_result") == 2
+
+
+def test_result_footprint_forgeries_reject_against_authority() -> None:
+    """Removing, adding, or substituting a result source (re-digested) is not
+    the canonical derivation; removing the advisory result from the graph
+    truthfully produces a NEW canonical interface identity."""
+
+    from mozaiksai.core.semantics.canonical import canonical_digest
+
+    payloads = _advisory_result_payloads()
+    graph, plan = _derive(payloads)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+    validate_compilation_plan_against_authority(plan, authority)
+    interface_unit_id = _family_units(plan)[_INTERFACE_FAMILY].unit_id
+    rival_digest = payloads[_RESULT].payload_digest
+
+    def _forge(edit) -> CompilationPlan:
+        document = plan.model_dump(mode="json")
+        payload = plan.canonical_payload(include_digest=False)
+        for doc in (document, payload):
+            unit = next(u for u in doc["units"] if u["unit_id"] == interface_unit_id)
+            edit(unit)
+        document["plan_digest"] = canonical_digest(payload)
+        return CompilationPlan.model_validate(document)
+
+    def _drop_advisory(unit) -> None:
+        unit["sources"] = [s for s in unit["sources"] if s["node_id"] != _RESULT_ALT]
+
+    def _add_unrelated(unit) -> None:
+        unit["sources"] = sorted(
+            [*unit["sources"], {"node_id": "mozaiks.event.documents_created",
+                                "payload_digest": rival_digest}],
+            key=lambda s: s["node_id"],
+        )
+
+    def _substitute(unit) -> None:
+        for source in unit["sources"]:
+            if source["node_id"] == _RESULT_ALT:
+                source["payload_digest"] = rival_digest
+
+    for edit in (_drop_advisory, _add_unrelated, _substitute):
+        with pytest.raises(PlanAuthorityError):
+            validate_compilation_plan_against_authority(_forge(edit), authority)
+
+    # Truthful removal: the canonical rederivation without the advisory
+    # result is a different interface identity, not a rejection.
+    without = {k: v for k, v in payloads.items() if k != _RESULT_ALT}
+    _g2, plan_without = _derive(without)
+    assert (
+        _family_units(plan_without)[_INTERFACE_FAMILY].unit_digest
+        != _family_units(plan)[_INTERFACE_FAMILY].unit_digest
+    )
+
+
+def test_advisory_result_changes_rematerialize_interface_and_reuse_registry() -> None:
+    """Advisory-result mutation, deletion, and addition each re-render the
+    interface while the registry (and an unrelated workflow change keeps the
+    interface) reuse exact prior bytes."""
+
+    base_payloads = _advisory_result_payloads()
+    base_graph, base_plan, base_authority, base_bundle = _materialize(base_payloads)
+
+    def _successors():
+        mutated = dict(base_payloads)
+        mutated[_RESULT_ALT] = _rebuilt_result(
+            mutated, _RESULT_ALT, description="One revised summary"
+        )
+        deleted = {k: v for k, v in base_payloads.items() if k != _RESULT_ALT}
+        added = dict(base_payloads)
+        added["mozaiks.workflow_result.analysis_notes"] = _result(
+            "mozaiks.workflow_result.analysis_notes", result_id="analysis_notes"
+        )
+        return {"mutated": mutated, "deleted": deleted, "added": added}
+
+    for label, successor_payloads in _successors().items():
+        successor_graph = _build_graph(successor_payloads)
+        successor_plan = derive_compilation_plan(
+            graph=successor_graph,
+            payloads=tuple(successor_payloads.values()),
+            registry=build_app_layout_registry(()),
+            scope_selection=_scope_selection(),
+        )
+        successor_authority = build_compilation_plan_authority_inputs(
+            graph=successor_graph,
+            payloads=tuple(successor_payloads.values()),
+            registry=build_app_layout_registry(()),
+            scope_selection=_scope_selection(),
+        )
+        bundle = rematerialize_plan(
+            base_plan=base_plan,
+            base_authority_inputs=base_authority,
+            successor_plan=successor_plan,
+            successor_authority_inputs=successor_authority,
+            graph=successor_graph,
+            payloads=tuple(successor_payloads.values()),
+            binding=_binding(successor_graph),
+            layout_registry=build_app_layout_registry(()),
+            base_bundle=base_bundle,
+        )
+        by_path = {o.path: o for o in bundle.outputs}
+        interface = by_path["workflows/analyze_document/module_interface.yaml"]
+        registry = by_path["workflows/workflow_registry.json"]
+        assert interface.origin == "rendered", label
+        base_interface = next(
+            o
+            for o in base_bundle.outputs
+            if o.path == "workflows/analyze_document/module_interface.yaml"
+        )
+        assert interface.content != base_interface.content, label
+        assert registry.origin == "reused", label
+
+
+# ---------------------------------------------------------------------------
+# Correction round 1 — defect 2: exact workflow/path identity binding at the
+# renderer itself, independent of canonical plan authority and output closure.
+# ---------------------------------------------------------------------------
+
+
+def _projected_interface_unit_and_input():
+    from mozaiksai.core.semantics.materialization import (
+        project_workflow_interface_render_input,
+    )
+
+    payloads = _fixture_payloads()
+    _graph, plan = _derive(payloads)
+    unit = _family_units(plan)[_INTERFACE_FAMILY]
+    render_input = project_workflow_interface_render_input(
+        unit=unit, payload_by_node={p.node_id: p for p in payloads.values()}
+    )
+    return payloads, plan, unit, render_input
+
+
+def test_renderer_binds_unit_input_and_path_to_one_exact_workflow() -> None:
+    """Direct-renderer attack matrix: only the exact canonical path of the
+    unit's exact workflow renders; every contradictory identity fails closed."""
+
+    from mozaiksai.core.semantics.compilation_plan import PlanOutput
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        render_workflow_interface_unit,
+    )
+
+    _payloads, _plan, unit, render_input = _projected_interface_unit_and_input()
+    assert render_workflow_interface_unit(unit=unit, render_input=render_input)
+
+    hostile_paths = (
+        "workflows/other_workflow/module_interface.yaml",
+        "workflows/analyze_document/../other_workflow/module_interface.yaml",
+        "workflows//analyze_document/module_interface.yaml",
+        "workflows/analyze_document/workflow_registry.json",
+        "workflows/Analyze_Document/module_interface.yaml",
+        "module_interface.yaml",  # workspace-scoped unit, relative path
+    )
+    for path in hostile_paths:
+        forged = unit.model_copy(
+            update={
+                "outputs": (
+                    PlanOutput.model_construct(
+                        path_scope=unit.outputs[0].path_scope, path=path
+                    ),
+                )
+            }
+        )
+        with pytest.raises(
+            WorkflowInterfaceMaterializationError, match="exact canonical path"
+        ):
+            render_workflow_interface_unit(unit=forged, render_input=render_input)
+
+    # A render input naming a different workflow than the unit's exact
+    # identity fails before any path comparison.
+    renamed_input = render_input.model_copy(update={"workflow_id": "other_workflow"})
+    with pytest.raises(
+        WorkflowInterfaceMaterializationError, match="exact workflow identity"
+    ):
+        render_workflow_interface_unit(unit=unit, render_input=renamed_input)
+
+    # A unit stripped of its workflow identity cannot render at all.
+    anonymous = unit.model_copy(update={"placeholder_values": ()})
+    with pytest.raises(
+        WorkflowInterfaceMaterializationError,
+        match="canonical workflow instance identity",
+    ):
+        render_workflow_interface_unit(unit=anonymous, render_input=render_input)
+
+
+def test_renderer_rejects_foreign_workflow_sources_and_keeps_twin_row() -> None:
+    """Workflow B's projected facts cannot enter workflow A's unit, and the
+    legitimate workflow-relative twin row still renders."""
+
+    from mozaiksai.core.semantics.materialization import (
+        project_workflow_interface_render_input,
+    )
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        render_workflow_interface_unit,
+    )
+
+    payloads, _plan, unit, _render_input = _projected_interface_unit_and_input()
+
+    # Workflow B: rename the workflow and re-derive; its projected input does
+    # not bind workflow A's pinned sources.
+    foreign_payloads = dict(payloads)
+    workflow = foreign_payloads[_WORKFLOW]
+    foreign_payloads[_WORKFLOW] = build_semantic_payload(
+        type(workflow),
+        node_id=workflow.node_id,
+        payload_version=workflow.payload_version,
+        scope=workflow.scope,
+        workflow_id="other_workflow",
+        description=workflow.description,
+        startup_mode=workflow.startup_mode,
+        topology=workflow.topology,
+    )
+    _foreign_graph, foreign_plan = _derive(foreign_payloads)
+    foreign_unit = _family_units(foreign_plan)[_INTERFACE_FAMILY]
+    foreign_input = project_workflow_interface_render_input(
+        unit=foreign_unit,
+        payload_by_node={p.node_id: p for p in foreign_payloads.values()},
+    )
+    with pytest.raises(WorkflowInterfaceMaterializationError):
+        render_workflow_interface_unit(unit=unit, render_input=foreign_input)
+
+    # The workflow-relative twin row remains a legitimate rendering target.
+    relative_plan = derive_compilation_plan(
+        graph=_build_graph(payloads),
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=CompilationScopeSelection(
+            workflow_manifest_scope=PathScope.WORKFLOW_RELATIVE
+        ),
+    )
+    relative_unit = next(
+        u
+        for u in relative_plan.units
+        if u.family_kind == _INTERFACE_FAMILY and u.sources
+    )
+    assert relative_unit.outputs[0].path == "module_interface.yaml"
+    relative_input = project_workflow_interface_render_input(
+        unit=relative_unit,
+        payload_by_node={p.node_id: p for p in payloads.values()},
+    )
+    content = render_workflow_interface_unit(
+        unit=relative_unit, render_input=relative_input
+    )
+    assert b"workflow_id: analyze_document" in content
+
+
+def test_output_closure_and_authority_protect_paths_independently() -> None:
+    """Three distinct protections: the renderer's exact-path contract (tested
+    above), canonical plan authority on a path-forged plan, and the output
+    closure on missing/extra/duplicate/foreign outputs."""
+
+    from mozaiksai.core.semantics.canonical import canonical_digest
+    from mozaiksai.core.semantics.materialization import (
+        MaterializationError,
+        MaterializedOutput,
+        _assert_workflow_interface_output_closure,
+    )
+
+    payloads = _fixture_payloads()
+    graph, plan = _derive(payloads)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph,
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=_scope_selection(),
+    )
+
+    # Canonical authority rejects a plan whose interface output path was
+    # rewritten (and re-digested) before materialization even begins.
+    interface_unit_id = _family_units(plan)[_INTERFACE_FAMILY].unit_id
+    document = plan.model_dump(mode="json")
+    payload = plan.canonical_payload(include_digest=False)
+    for doc in (document, payload):
+        unit = next(u for u in doc["units"] if u["unit_id"] == interface_unit_id)
+        unit["outputs"][0]["path"] = "workflows/other_workflow/module_interface.yaml"
+    document["plan_digest"] = canonical_digest(payload)
+    forged_plan = CompilationPlan.model_validate(document)
+    with pytest.raises(MaterializationError, match="canonical authority"):
+        materialize_plan(
+            plan=forged_plan,
+            authority_inputs=authority,
+            graph=graph,
+            payloads=tuple(payloads.values()),
+            binding=_binding(graph),
+            layout_registry=build_app_layout_registry(()),
+        )
+
+    # Output closure: missing, duplicate, and foreign-family outputs each
+    # fail independently of the renderer.
+    _g, _p, _a, bundle = _materialize(payloads)
+    selection = next(
+        s
+        for s in _binding(graph).renderer_selections
+        if "app_workflow_registry" in s.artifact_families
+    )
+    good = [
+        o
+        for o in bundle.outputs
+        if o.path
+        in (
+            "workflows/analyze_document/module_interface.yaml",
+            "workflows/workflow_registry.json",
+        )
+    ]
+    with pytest.raises(WorkflowInterfaceMaterializationError, match="exactly one"):
+        _assert_workflow_interface_output_closure(plan, good[:1], selection)
+    with pytest.raises(WorkflowInterfaceMaterializationError, match="exactly one"):
+        _assert_workflow_interface_output_closure(plan, [*good, good[0]], selection)
+    foreign = MaterializedOutput(
+        unit_id=good[0].unit_id,
+        path_scope=good[0].path_scope,
+        path="workflows/other/module_interface.yaml",
+        content=good[0].content,
+        origin="rendered",
+        content_digest=good[0].content_digest,
+    )
+    with pytest.raises(
+        WorkflowInterfaceMaterializationError, match="plan-owned path"
+    ):
+        _assert_workflow_interface_output_closure(plan, [*good, foreign], selection)
+    with pytest.raises(WorkflowInterfaceMaterializationError, match="unauthorized"):
+        _assert_workflow_interface_output_closure(plan, good, None)
+
+
+# ---------------------------------------------------------------------------
+# Correction round 2 — complete canonical layout-row / output / instance
+# identity binding at the direct renderer. Resolution direction is the
+# invariant: family_identity_digest -> exact canonical row -> exact
+# placeholder set, unit id, scope, and path -> exact equality. The renderer
+# never selects a profile from caller-supplied path_scope or path.
+# ---------------------------------------------------------------------------
+
+
+def _forged_output(unit, *, path_scope=None, path=None):
+    from mozaiksai.core.semantics.compilation_plan import PlanOutput
+
+    target = unit.outputs[0]
+    return unit.model_copy(
+        update={
+            "outputs": (
+                PlanOutput.model_construct(
+                    path_scope=path_scope if path_scope is not None else target.path_scope,
+                    path=path if path is not None else target.path,
+                ),
+            )
+        }
+    )
+
+
+def _reject(unit, render_input) -> None:
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        render_workflow_interface_unit,
+    )
+
+    with pytest.raises(WorkflowInterfaceMaterializationError):
+        render_workflow_interface_unit(unit=unit, render_input=render_input)
+
+
+def _relative_interface_unit_and_input():
+    from mozaiksai.core.semantics.materialization import (
+        project_workflow_interface_render_input,
+    )
+
+    payloads = _fixture_payloads()
+    plan = derive_compilation_plan(
+        graph=_build_graph(payloads),
+        payloads=tuple(payloads.values()),
+        registry=build_app_layout_registry(()),
+        scope_selection=CompilationScopeSelection(
+            workflow_manifest_scope=PathScope.WORKFLOW_RELATIVE
+        ),
+    )
+    unit = next(
+        u
+        for u in plan.units
+        if u.family_kind == _INTERFACE_FAMILY and u.sources
+    )
+    render_input = project_workflow_interface_render_input(
+        unit=unit, payload_by_node={p.node_id: p for p in payloads.values()}
+    )
+    return unit, render_input
+
+
+def _registry_unit_and_input():
+    from mozaiksai.core.semantics.materialization import (
+        project_workflow_interface_render_input,
+    )
+
+    payloads = _fixture_payloads()
+    _graph, plan = _derive(payloads)
+    unit = _family_units(plan)[_REGISTRY_FAMILY]
+    render_input = project_workflow_interface_render_input(
+        unit=unit, payload_by_node={p.node_id: p for p in payloads.values()}
+    )
+    return unit, render_input
+
+
+def test_workspace_interface_row_identity_attack_matrix() -> None:
+    """Hostile matrix A-O for the canonical workspace interface unit: every
+    scope, placeholder, row-digest, unit-id, path, and render-input identity
+    contradiction rejects before bytes."""
+
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        _canonical_rows_by_digest,
+        render_workflow_interface_unit,
+    )
+
+    _payloads, _plan, unit, render_input = _projected_interface_unit_and_input()
+    assert render_workflow_interface_unit(unit=unit, render_input=render_input)
+    relative_row_digest = next(
+        digest
+        for digest, row in _canonical_rows_by_digest().items()
+        if row.kind == _INTERFACE_FAMILY and row.path_scope == "workflow_relative"
+    )
+
+    # A-C: scope substitution with the canonical path kept
+    for scope in ("app_bundle_root", "generated_staging", "module_relative"):
+        _reject(_forged_output(unit, path_scope=scope), render_input)
+    # D: coordinated scope+path substitution toward the twin representation
+    # while keeping the workspace row identity — Codex 3's key reproducer.
+    _reject(
+        _forged_output(
+            unit, path_scope="workflow_relative", path="module_interface.yaml"
+        ),
+        render_input,
+    )
+    # E: surplus placeholder axis
+    _reject(
+        unit.model_copy(
+            update={
+                "placeholder_values": (
+                    ("module_id", "documents"),
+                    ("workflow_id", "analyze_document"),
+                )
+            }
+        ),
+        render_input,
+    )
+    # F: substituted placeholder axis
+    _reject(
+        unit.model_copy(update={"placeholder_values": (("module_id", "documents"),)}),
+        render_input,
+    )
+    # G: removed placeholder
+    _reject(unit.model_copy(update={"placeholder_values": ()}), render_input)
+    # H: relative-row digest with the workspace unit id and output kept
+    _reject(
+        unit.model_copy(update={"family_identity_digest": relative_row_digest}),
+        render_input,
+    )
+    # I: relative-shaped unit id with the workspace digest kept
+    _reject(
+        unit.model_copy(
+            update={
+                "unit_id": (
+                    f"{_INTERFACE_FAMILY}/analyze_document/{relative_row_digest[:12]}"
+                )
+            }
+        ),
+        render_input,
+    )
+    # J: unknown row digest entirely
+    _reject(
+        unit.model_copy(update={"family_identity_digest": "0" * 64}), render_input
+    )
+    # K: wrong row-digest prefix inside the unit id
+    _reject(
+        unit.model_copy(
+            update={"unit_id": f"{_INTERFACE_FAMILY}/analyze_document/000000000000"}
+        ),
+        render_input,
+    )
+    # L: correct scope/path but an extra placeholder rejects (same as E but
+    # asserting the output identity was untouched)
+    forged = unit.model_copy(
+        update={
+            "placeholder_values": (
+                ("page_id", "home"),
+                ("workflow_id", "analyze_document"),
+            )
+        }
+    )
+    assert forged.outputs == unit.outputs
+    _reject(forged, render_input)
+    # M: correct placeholders/path but wrong scope
+    _reject(_forged_output(unit, path_scope="deployment_derived"), render_input)
+    # N: correct scope/placeholders but another workflow's path
+    _reject(
+        _forged_output(unit, path="workflows/other_workflow/module_interface.yaml"),
+        render_input,
+    )
+    # O: correct unit identity but a render input naming another workflow
+    _reject(unit, render_input.model_copy(update={"workflow_id": "other_workflow"}))
+
+
+def test_relative_interface_row_identity_attack_matrix() -> None:
+    """Hostile matrix A-H for the canonical workflow-relative twin unit."""
+
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        _canonical_rows_by_digest,
+        render_workflow_interface_unit,
+    )
+
+    unit, render_input = _relative_interface_unit_and_input()
+    assert unit.outputs[0].path == "module_interface.yaml"
+    content = render_workflow_interface_unit(unit=unit, render_input=render_input)
+    assert b"workflow_id: analyze_document" in content
+    workspace_row_digest = next(
+        digest
+        for digest, row in _canonical_rows_by_digest().items()
+        if row.kind == _INTERFACE_FAMILY and row.path_scope == "workspace_root"
+    )
+
+    # A: coordinated scope+path substitution toward the workspace
+    # representation while keeping the relative row identity (the inverse of
+    # Codex 3's reproducer).
+    _reject(
+        _forged_output(
+            unit,
+            path_scope="workspace_root",
+            path="workflows/analyze_document/module_interface.yaml",
+        ),
+        render_input,
+    )
+    # B-D: other scope substitutions
+    for scope in ("app_bundle_root", "module_relative", "generated_staging"):
+        _reject(_forged_output(unit, path_scope=scope), render_input)
+    # E: extra placeholder axis
+    _reject(
+        unit.model_copy(
+            update={
+                "placeholder_values": (
+                    ("module_id", "documents"),
+                    ("workflow_id", "analyze_document"),
+                )
+            }
+        ),
+        render_input,
+    )
+    # F: missing workflow identity
+    _reject(unit.model_copy(update={"placeholder_values": ()}), render_input)
+    # G: wrong unit-id row-digest suffix
+    _reject(
+        unit.model_copy(
+            update={"unit_id": f"{_INTERFACE_FAMILY}/analyze_document/000000000000"}
+        ),
+        render_input,
+    )
+    # H: workspace family_identity_digest with the relative output kept
+    _reject(
+        unit.model_copy(update={"family_identity_digest": workspace_row_digest}),
+        render_input,
+    )
+
+
+def test_app_registry_row_identity_attack_matrix() -> None:
+    """Hostile matrix for the canonical registry unit: any scope
+    substitution, any placeholder at all, wrong unit id, wrong or
+    interface-substituted row digest — all reject."""
+
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        _canonical_rows_by_digest,
+        render_workflow_interface_unit,
+    )
+
+    unit, render_input = _registry_unit_and_input()
+    assert unit.placeholder_values == ()
+    assert render_workflow_interface_unit(unit=unit, render_input=render_input)
+    interface_row_digest = next(
+        digest
+        for digest, row in _canonical_rows_by_digest().items()
+        if row.kind == _INTERFACE_FAMILY and row.path_scope == "workspace_root"
+    )
+
+    for scope in (
+        "app_bundle_root",
+        "generated_staging",
+        "module_relative",
+        "workflow_relative",
+        "deployment_derived",
+    ):
+        _reject(_forged_output(unit, path_scope=scope), render_input)
+    for placeholder in (
+        (("workflow_id", "analyze_document"),),
+        (("module_id", "documents"),),
+        (("page_id", "home"),),
+    ):
+        _reject(
+            unit.model_copy(update={"placeholder_values": placeholder}), render_input
+        )
+    _reject(
+        unit.model_copy(update={"unit_id": f"{_REGISTRY_FAMILY}/000000000000"}),
+        render_input,
+    )
+    _reject(
+        unit.model_copy(update={"family_identity_digest": "0" * 64}), render_input
+    )
+    # An interface row digest substituted into the registry unit contradicts
+    # family kind through canonical row resolution.
+    _reject(
+        unit.model_copy(update={"family_identity_digest": interface_row_digest}),
+        render_input,
+    )
+    # Correct path with incorrect scope.
+    _reject(_forged_output(unit, path_scope="app_bundle_root"), render_input)
+
+
+def test_full_canonical_row_substitution_is_the_plan_authoritys_boundary() -> None:
+    """A COMPLETE canonical unit of the other twin row is recognized as that
+    row's canonical shape — the direct renderer's contract is "exactly one
+    canonical unit shape this renderer owns", while membership of that unit
+    in the current CompilationPlan is #475/#477 plan authority (proven by
+    the plan-authority suites), deliberately not re-implemented here."""
+
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        render_workflow_interface_unit,
+    )
+
+    _payloads, _plan, workspace_unit, workspace_input = (
+        _projected_interface_unit_and_input()
+    )
+    relative_unit, relative_input = _relative_interface_unit_and_input()
+    # Each complete canonical shape renders under its own row identity...
+    assert render_workflow_interface_unit(
+        unit=workspace_unit, render_input=workspace_input
+    )
+    assert render_workflow_interface_unit(
+        unit=relative_unit, render_input=relative_input
+    )
+    # ...and any PARTIAL cross-substitution of the twin identities rejects
+    # (the coordinated matrices above); the two complete canonical units
+    # differ in exactly the row-derived facts.
+    assert workspace_unit.family_identity_digest != relative_unit.family_identity_digest
+    assert workspace_unit.unit_id != relative_unit.unit_id
+    assert workspace_unit.outputs != relative_unit.outputs
+    assert (
+        workspace_unit.placeholder_values == relative_unit.placeholder_values
+    )  # same workflow instance identity, different row identity
+
+
+def test_renderer_row_contract_matches_the_canonical_registry() -> None:
+    """Drift guard: the renderer's canonical row contract is exactly the
+    workflow-interface rows of the one canonical core registry — same
+    digests, kinds, owners, scopes, and templates."""
+
+    from mozaiksai.core.semantics.compilation_plan import snapshot_layout_registry
+    from mozaiksai.core.semantics.workflow_interface_materialization import (
+        _canonical_rows_by_digest,
+    )
+
+    snapshot = snapshot_layout_registry(build_app_layout_registry(()))
+    expected = {
+        row.row_digest: row
+        for row in snapshot.rows
+        if row.kind in WORKFLOW_INTERFACE_FAMILIES
+    }
+    resolved = _canonical_rows_by_digest()
+    assert set(resolved) == set(expected)
+    profiles = {
+        (row.kind, row.owner, row.path_scope, row.path_template)
+        for row in resolved.values()
+    }
+    assert profiles == {
+        (
+            _INTERFACE_FAMILY,
+            "workflow",
+            "workspace_root",
+            "workflows/{workflow_id}/module_interface.yaml",
+        ),
+        (_INTERFACE_FAMILY, "workflow", "workflow_relative", "module_interface.yaml"),
+        (
+            _REGISTRY_FAMILY,
+            "app_workspace",
+            "workspace_root",
+            "workflows/workflow_registry.json",
+        ),
+    }


### PR DESCRIPTION
## Plan workflow module interfaces and app workflow registries

**Classification: MOZAIKS_OSS — semantic compiler families.** The compiler slice over the merged #478 module-workflow capability semantics, from exact main `36b33e02`. Implements the read-only design delivered for this slice: two new deterministic families, one new renderer authority, and the identity mechanics canonical event identity requires. No runtime migration, no legacy cleanup, no AppGenerator/AgentGenerator production cutover, no AI-launch/sequencing semantics.

### The two families

| Family | Output | Scope | What it is |
|---|---|---|---|
| `workflow_module_interface` | `workflows/{workflow_id}/module_interface.yaml` (twin rows, workspace + workflow-relative, gated by the existing `workflow_manifest_scope` selection) | per workflow | **`mozaiks.module_interface.v2`** — exact projection of one workflow's capability closure: capabilities, typed bindings (`consumes_action` / `commits_result_through_action` / `triggered_by_event`), committed result ids, canonical trigger event ids. A validation/diff surface — validator `generated_app_validator`, runtime consumer **NONE**, never independent authority. |
| `app_workflow_registry` | `workflows/workflow_registry.json` | one per app | **`mozaiks.app_workflow_registry.v1`** — workflows, `startup_mode`, capability ownership, event triggers. Deliberately NOT the factory `extension_registry.json`: journeys, transitions, entrypoints, and AI-launch facts have no semantics yet and stay deferred; runtime consumer **NONE** until the platform migration slice. |

Both are RENDER families on a new `workflow_interface_executor` materializer, resolved only through an `ImplementationBinding` renderer selection pinning **`deterministic_workflow_interface_renderer@1`** with exactly the two-family set (same authorization pattern as `deterministic_app_config_renderer@1`), rendering under the existing `mozaiks.yaml_decl_bytes.v1` / `mozaiks.json_decl_bytes.v1` byte contracts, with exact output-closure assertions in `materialize_plan` and `rematerialize_plan`.

### Identity mechanics: `taxonomy_sources`

Canonical event identity lives on the EVENT node's single EVENT-category taxonomy reference (#478 round 2), not on any payload — so payload digests alone cannot pin the one node-level fact these artifacts render. Plan units gain `taxonomy_sources`: pinned `(node_id, category, identifier)` triples that enter `identity_payload` **and** serialization only when non-empty. Every pre-existing payload-only unit keeps its exact digest and serialized form (a `model_serializer` keeps `model_dump` representation-identical to the identity payload). A forged pinned identifier (re-digested) fails canonical plan-authority rederivation typed; a genuine canonical-identity rename moves exactly the dependent units' reuse signatures.

### Source locality (payload-driven, never edge-hop spillover)

Selection follows typed payload references, mirroring the #478 rule that payloads own meaning:

- **Interface footprint**: the workflow payload, its capabilities, their bindings, ALL capability-owned results (committed or advisory — ownership, never delivery, is result membership), and binding-referenced module payloads (`module_id` is the only module fact rendered). **ACTION payload bodies are never pinned** — action identity is the node id inside the binding payload (`ModuleActionRef` doctrine), so unrelated action-body changes never reprint an interface. Proven: action-description and producer-description mutations leave both unit digests untouched; module/result mutations move only the interface.
- **Registry footprint**: workflow + capability payloads + `triggered_by_event` bindings + event taxonomy pins only. Module, action, result, and consume/commit-binding facts are excluded — module churn can never reprint the registry.
- Rendered event ids come only from pinned taxonomy identities; the renderer never reads graph taxonomy, clocks, environment, or filesystem, and render inputs must bind the unit's exact pinned source **and** taxonomy sets (mismatch fails closed).

A workflow with no capabilities renders truthful empty projections (`capabilities: []`), and refinement reuses untouched interface/registry bytes byte-for-byte through the regeneration closure (proven via `rematerialize_plan`).

### Golden re-pins (identity-only, once)

Registry rows 123 → 126 (`render` census 79 → 82) and the corpus plan gains the derived units (the corpus workflow has no capability bindings → empty projections; 65 → 67 units, gap set unchanged). Corpus golden re-pinned once with in-line rationale; **every pre-existing unit digest is unchanged**. The reduced 5B/5C fixture registry is untouched (kept-template filter), so all 5B/5C goldens stand.

### Correction Round 1 (Codex 3 review — 2 material defects fixed)

**Root invariant enforced**: `workflow_module_interface` is an exact deterministic projection of the complete application-semantic surface of ONE workflow — no semantic result disappears merely because delivery is absent, and no renderer can emit workflow A's semantics into workflow B's path.

1. **Complete capability-owned result projection**: result membership is now ownership (`WorkflowResultPayload.workflow_capability_node_id` + the #478 capability→DECLARES→result closure), never delivery. The footprint pins EVERY capability-owned `WORKFLOW_RESULT` (advisory results included), and `mozaiks.module_interface.v2` gains an explicit per-capability `results` block (`result_id` + optional `description` only — no provider/model/structured-output/prompt/runtime/route/handler identity), sorted by `result_id`, rendered before `bindings`. Commit bindings remain the separate delivery relation: removing R1's commit binding keeps R1 in `results` and changes only the binding projection; fan-out renders the result once with each explicit commit binding. The registry footprint is untouched — result-only changes reprint the interface and never the registry. Golden re-pinned once (documented in-line: fixes missing semantic output projection); corpus golden and all pre-existing unit identities unchanged (the corpus workflow owns no capabilities).
2. **Exact workflow/path renderer binding**: `render_workflow_interface_unit` now binds three identities before any byte — the plan unit's placeholder workflow identity, the render input's `workflow_id`, and the exact canonical output path derived from the layout row's own template expansion (`workflows/{exact_workflow_id}/module_interface.yaml` workspace-scoped; the unchanged scope-relative template for the workflow-relative twin; the fixed registry path). Exact string equality — no glob, no filename inference, no normalization, no silent rewrite; traversal, doubled slashes, wrong case, wrong filename, another workflow's valid path, a renamed render input, and foreign-workflow source payloads all fail closed, independent of canonical plan authority (which is separately proven to reject a path-forged plan) and of the output-closure assertions (missing/duplicate/foreign-path/unauthorized outputs, each proven distinctly).

New permanent regressions: the 9-case result locality matrix, advisory-result plan-authority forgery attacks (dropped/added/substituted result sources reject; truthful graph removal re-identifies), advisory-result rematerialization (mutate/delete/add ⇒ interface re-rendered, registry reused; unrelated workflow's result ⇒ interface reused), the direct-renderer path attack matrix, and the three-protection separation test. Bounded sibling audit re-run over every `module_interface.v2` rendered field (workflow_id, capability_id/description, result_id/description, binding role, module_id, action identity, event identity, output path): each byte traces to a pinned payload, pinned taxonomy identity, or the three-way identity binding — no further same-family defect found.

### Correction Round 2 — final bounded closure (complete output/instance identity)

Codex 3's remaining structural defect: the round-1 path check selected its expected path FROM caller-supplied `path_scope`, so coordinated scope+path mutation could relocate a unit's bytes. The renderer now binds the **complete canonical layout-row/output/instance identity**, in the invariant direction:

`family_identity_digest` → the exact content-addressed canonical `RegistryFamilyRow` this renderer owns (resolved from the one canonical core registry via the planner's own `snapshot_layout_registry` machinery — no second hand-written table, no filesystem/environment/dynamic discovery; a drift guard test proves the renderer contract equals the registry's three rows) → that row derives the exact placeholder set (EXACTLY `(("workflow_id", <id>),)` for both interface twins, EXACTLY `()` for the registry — surplus/missing/substituted axes reject), the exact canonical `unit_id` (via unit-id derivation helpers extracted from the planner and now used by both, never a permissive parse), the exact `path_scope`, and the exact template-expanded path → every supplied unit fact must equal that canonical result before bytes; `render_input.workflow_id` must equal the unit's canonical instance identity, whose value is re-validated under the planner's closed grammar. The renderer never chooses a profile from supplied scope or path.

All of Codex 3's reproducers are permanent rejections: the 15-case workspace-interface matrix (A–O: scope substitutions incl. `app_bundle_root`/`generated_staging`/`module_relative`, the coordinated workspace→relative scope+path substitution, surplus/substituted/missing placeholders, twin-digest and twin-unit-id cross-substitutions, unknown digests, wrong digest prefixes, foreign paths, renamed inputs), the 8-case relative-twin matrix (incl. the inverse coordinated substitution), and the registry matrix (five scope substitutions, any placeholder at all, wrong unit id, wrong/interface-substituted row digest). The responsibility boundary is documented and tested: a COMPLETE canonical unit of the other twin row renders as that row's shape — the direct renderer answers "is this exactly one canonical unit shape I own?", while membership in the current CompilationPlan remains #475/#477 plan authority, deliberately not re-implemented in the renderer. Round-1's result projection is untouched, and all 64 pre-existing corpus units were explicitly re-compared against exact base `36b33e02`: digest- and serialization-identical, zero moved.

### Proofs

New `tests/test_workflow_interface_families.py` (17 after correction round 1): exact payload-driven footprints incl. taxonomy pins; golden bytes for both artifacts; unrelated-mutation digest stability; dependent-mutation exactness (interface-only vs both); canonical-identity rename moves both units; truthful empty projections; renderer-selection authorization matrix (missing selection, partial family set); byte-for-byte refinement reuse; forged-taxonomy plan-authority rejection; cross-process byte/digest determinism. Existing suites updated: corpus golden + closed field-universe (+`PlanTaxonomySource`), B2A census/binding fixtures + unwired-scan allowlist, semantics hygiene owner files, 5B/executable-contract call-site threading.

Full suite green (see checks); ruff, scoped mypy (4 modules), strict MkDocs, source hygiene, `git diff --check` clean. ADR 0007 and CHANGELOG updated.

### Boundaries

No runtime changes (workflow manager, platform capability routes, and module event router untouched — the two-resolver/two-parser divergences and the `WORKFLOW_CAPABILITY_UNRESOLVED` idempotency defect stay documented for the runtime-migration slice); no legacy v1 `module_interface.yaml` writer/prompt cleanup (factory-cleanup slice); no AppGenerator/AgentGenerator production cutover; no sequencing/journey/entrypoint/AI-launch semantics; no AG2 primitives, provider/model identity, hosted/mobile/evaluation work.

Do not merge — draft for independent exact-head review (reviewer: **Codex 3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
