### PR TITLE
feat(semantics): close taxonomy-source plan and reuse authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ This project follows a practical pre-1.0 changelog format:
 ## Unreleased
 
 ### Added
+
+- **Node-level taxonomy identity in plan and reuse authority (ADR 0007)**:
+  `CompilationPlan` units gain a generic `taxonomy_sources` contract
+  (`PlanTaxonomySource`: exact `(node, category, identifier)` triples under
+  the closed taxonomy vocabulary and grammars) for canonical identities that
+  live on graph nodes rather than typed payloads. A pinned taxonomy identity
+  now participates in unit identity, serialization, canonical authority
+  rederivation, and — closing the defect found in the #479 review — the
+  regeneration/reuse signature: a unit whose node-level identity changed can
+  never be classified reusable, so stale bytes are never copied forward.
+  Empty taxonomy sources are omitted from identity and serialization alike,
+  keeping every pre-existing plan unit byte- and digest-identical. No family
+  derives taxonomy sources yet; this is the generic prerequisite for the
+  re-architected workflow-interface families.
 - **Typed module↔workflow capability semantics**: the semantic graph now
   models the relationship between deterministic application capabilities
   (modules, actions, events) and agentic capabilities (workflows) as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ This project follows a practical pre-1.0 changelog format:
   `CompilationPlan` units gain a generic `taxonomy_sources` contract
   (`PlanTaxonomySource`: exact `(node, category, identifier)` triples under
   the closed taxonomy vocabulary and grammars) for canonical identities that
-  live on graph nodes rather than typed payloads. A pinned taxonomy identity
+  live on graph nodes rather than typed payloads. Identifiers are stored in
+  canonical spelling at model construction, including trimmed whitespace.
+  A pinned taxonomy identity
   now participates in unit identity, serialization, canonical authority
   rederivation, and — closing the defect found in the #479 review — the
   regeneration/reuse signature: a unit whose node-level identity changed can

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -357,7 +357,9 @@ payload — the canonical event identity, for example, is the EVENT node's
 single EVENT-category taxonomy reference. Plan units therefore carry a
 generic `taxonomy_sources` contract (`PlanTaxonomySource`: exact
 `(node, category, identifier)` triples) for node-level identities their
-bytes consume. A pinned taxonomy identity participates consistently in unit
+bytes consume. The model stores the grammar-normalized identifier during
+construction, so surrounding whitespace cannot change serialization, unit
+identity, digest, or reuse authority. A pinned taxonomy identity participates consistently in unit
 identity, serialization, canonical authority rederivation, and the
 regeneration/reuse signature — a unit whose node-level identity changed is
 never classified reusable — while empty taxonomy sources are omitted from

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -352,6 +352,19 @@ authoritative emitters of these paths until the atomic 5D cutover; hygiene
 guards prove they do not call the B2A renderer and that no production module
 imports it.
 
+Some canonical identities live on the graph node rather than on any typed
+payload — the canonical event identity, for example, is the EVENT node's
+single EVENT-category taxonomy reference. Plan units therefore carry a
+generic `taxonomy_sources` contract (`PlanTaxonomySource`: exact
+`(node, category, identifier)` triples) for node-level identities their
+bytes consume. A pinned taxonomy identity participates consistently in unit
+identity, serialization, canonical authority rederivation, and the
+regeneration/reuse signature — a unit whose node-level identity changed is
+never classified reusable — while empty taxonomy sources are omitted from
+identity and serialization alike, so every payload-only unit's digest and
+serialized form are unchanged. Families that consume node-level identity
+(the re-architected workflow-interface corpus) build on this primitive.
+
 ## ApplicationManifest
 
 `ApplicationManifest` is the minimal root identity and reference document,

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -48,7 +48,7 @@ from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_serializer, model_validator
 
 from mozaiksai.core.runtime.app.layout_registry import (
     ArtifactDisposition,
@@ -496,6 +496,47 @@ class PlanSource(SemanticsModel):
         return _validate_digest(value, field_name="payload_digest")
 
 
+class PlanTaxonomySource(SemanticsModel):
+    """One node-level canonical taxonomy identity a unit's bytes depend on.
+
+    Some canonical identities live on the graph node, not on any typed
+    payload — the canonical event identity, for example, is the EVENT node's
+    single EVENT-category taxonomy reference. Payload digests cannot pin such
+    a fact, so a unit whose bytes consume it pins the exact ``(node,
+    category, identifier)`` triple here. Changing the node's canonical
+    identity then changes the unit's identity AND its reuse signature exactly
+    like a payload change would — a node-level identity can never change
+    underneath bytes that were classified reusable.
+
+    This is a generic plan primitive: it knows the closed taxonomy category
+    vocabulary and identifier grammars, and nothing about any family that
+    might consume it. No timestamps, no runtime, provider, or model identity.
+    """
+
+    node_id: str
+    category: str
+    identifier: str
+
+    @field_validator("node_id")
+    @classmethod
+    def _node(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+    @field_validator("category")
+    @classmethod
+    def _category(cls, value: str) -> str:
+        from mozaiksai.core.taxonomy import SemanticCategory
+
+        return SemanticCategory(str(value or "").strip()).value
+
+    @model_validator(mode="after")
+    def _grammar(self) -> PlanTaxonomySource:
+        from mozaiksai.core.taxonomy import validate_identifier_grammar
+
+        validate_identifier_grammar(self.category, self.identifier)
+        return self
+
+
 class PlanEdgeSource(SemanticsModel):
     """One complete graph relationship whose facts can affect rendered bytes."""
 
@@ -577,6 +618,11 @@ class FamilyInstancePlan(SemanticsModel):
     outputs: tuple[PlanOutput, ...] = Field(default_factory=tuple)
     sources: tuple[PlanSource, ...] = Field(default_factory=tuple)
     edge_sources: tuple[PlanEdgeSource, ...] = Field(default_factory=tuple)
+    #: Node-level canonical taxonomy identities this unit's bytes consume.
+    #: Empty for every family whose facts are fully payload-pinned; entering
+    #: identity, serialization, and the reuse signature only when non-empty
+    #: keeps every pre-existing payload-only unit byte- and digest-stable.
+    taxonomy_sources: tuple[PlanTaxonomySource, ...] = Field(default_factory=tuple)
     depends_on_units: tuple[str, ...] = Field(default_factory=tuple)
     materializer: str
     assignment_kind: AssignmentKind | None = None
@@ -652,6 +698,19 @@ class FamilyInstancePlan(SemanticsModel):
             raise ValueError("duplicate edge source identities in one unit")
         return ordered
 
+    @field_validator("taxonomy_sources")
+    @classmethod
+    def _taxonomy_sources(
+        cls, value: tuple[PlanTaxonomySource, ...]
+    ) -> tuple[PlanTaxonomySource, ...]:
+        ordered = tuple(
+            sorted(value, key=lambda item: (item.node_id, item.category, item.identifier))
+        )
+        keys = [(item.node_id, item.category) for item in ordered]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate taxonomy source identities in one unit")
+        return ordered
+
     @field_validator("depends_on_units")
     @classmethod
     def _deps(cls, value: tuple[str, ...]) -> tuple[str, ...]:
@@ -659,6 +718,21 @@ class FamilyInstancePlan(SemanticsModel):
         if len(ordered) != len(set(ordered)):
             raise ValueError("duplicate unit dependencies")
         return ordered
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: Any) -> Any:
+        """Serialize with the exact identity representation.
+
+        ``taxonomy_sources`` is omitted when empty so the serialized unit,
+        the identity payload, and the unit digest all state the same claim
+        ("no node-level identity feeds these bytes") in the same shape —
+        every pre-existing payload-only unit keeps its exact serialized form
+        and digest, byte for byte.
+        """
+        data = handler(self)
+        if isinstance(data, dict) and not data.get("taxonomy_sources"):
+            data.pop("taxonomy_sources", None)
+        return data
 
     @model_validator(mode="after")
     def _shape(self) -> FamilyInstancePlan:
@@ -699,7 +773,7 @@ class FamilyInstancePlan(SemanticsModel):
 
     @property
     def identity_payload(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "unit_id": self.unit_id,
             "family_kind": self.family_kind,
             "family_identity_digest": self.family_identity_digest,
@@ -726,6 +800,20 @@ class FamilyInstancePlan(SemanticsModel):
             ),
             "base_plan_digest": self.base_plan_digest,
         }
+        # Node-level taxonomy identity enters unit identity only when this
+        # unit actually pins one: absence and emptiness are the same claim
+        # ("no node-level identity feeds these bytes"), and conditional
+        # inclusion keeps every pre-existing payload-only unit digest stable.
+        if self.taxonomy_sources:
+            payload["taxonomy_sources"] = [
+                {
+                    "node_id": item.node_id,
+                    "category": item.category,
+                    "identifier": item.identifier,
+                }
+                for item in self.taxonomy_sources
+            ]
+        return payload
 
     @property
     def unit_digest(self) -> str:
@@ -1920,6 +2008,19 @@ def _authoring_contract_identity(unit: FamilyInstancePlan) -> Any:
 
 
 def _reuse_signature(unit: FamilyInstancePlan, plan: CompilationPlan) -> Any:
+    """Every fact capable of changing this unit's authorized bytes.
+
+    The regeneration closure deliberately decomposes unit facts rather than
+    comparing ``unit_digest``, so this tuple is the explicit reuse-authority
+    contract: a fact that can reach bytes but is absent here would let stale
+    bytes be classified reusable. ``unit_id`` keys the join and
+    ``family_kind`` is carried inside the content-addressed
+    ``family_identity_digest``; everything else meaning-bearing appears
+    directly — including node-level ``taxonomy_sources``, which are already
+    canonically sorted, so an order-only permutation of the same identities
+    never regenerates while any identifier, category, node, addition, or
+    removal always does.
+    """
     return (
         unit.family_identity_digest,
         unit.disposition.value,
@@ -1928,6 +2029,10 @@ def _reuse_signature(unit: FamilyInstancePlan, plan: CompilationPlan) -> Any:
         tuple((output.path_scope, output.path) for output in unit.outputs),
         tuple((source.node_id, source.payload_digest) for source in unit.sources),
         tuple(source.edge_identity for source in unit.edge_sources),
+        tuple(
+            (item.node_id, item.category, item.identifier)
+            for item in unit.taxonomy_sources
+        ),
         unit.depends_on_units,
         unit.materializer,
         _authoring_contract_identity(unit),
@@ -2016,6 +2121,7 @@ __all__ = [
     "PlanEdgeSource",
     "PlanOutput",
     "PlanSource",
+    "PlanTaxonomySource",
     "PlanSourceScope",
     "RegenerationClosure",
     "RegistryFamilyRow",

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -48,7 +48,7 @@ from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_serializer, model_validator
+from pydantic import Field, ValidationInfo, field_validator, model_serializer, model_validator
 
 from mozaiksai.core.runtime.app.layout_registry import (
     ArtifactDisposition,
@@ -529,12 +529,15 @@ class PlanTaxonomySource(SemanticsModel):
 
         return SemanticCategory(str(value or "").strip()).value
 
-    @model_validator(mode="after")
-    def _grammar(self) -> PlanTaxonomySource:
+    @field_validator("identifier")
+    @classmethod
+    def _identifier(cls, value: str, info: ValidationInfo) -> str:
         from mozaiksai.core.taxonomy import validate_identifier_grammar
 
-        validate_identifier_grammar(self.category, self.identifier)
-        return self
+        category = info.data.get("category")
+        if category is None:
+            raise ValueError("identifier requires a valid taxonomy category")
+        return validate_identifier_grammar(category, value)
 
 
 class PlanEdgeSource(SemanticsModel):

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -644,6 +644,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         PlanGap,
         PlanOutput,
         PlanSource,
+        PlanTaxonomySource,
         RegenerationClosure,
     )
 
@@ -672,6 +673,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
             "outputs",
             "sources",
             "edge_sources",
+            "taxonomy_sources",
             "depends_on_units",
             "materializer",
             "assignment_kind",
@@ -681,6 +683,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         },
         PlanOutput: {"path_scope", "path"},
         PlanSource: {"node_id", "payload_digest"},
+        PlanTaxonomySource: {"node_id", "category", "identifier"},
         PlanEdgeSource: {
             "kind",
             "source_node_id",
@@ -753,6 +756,7 @@ def test_plan_models_carry_no_live_runtime_identifiers() -> None:
         | allowed_fields[FamilyInstancePlan]
         | allowed_fields[PlanOutput]
         | allowed_fields[PlanSource]
+        | allowed_fields[PlanTaxonomySource]
         | allowed_fields[PlanEdgeSource]
         | allowed_fields[PlanGap]
             | {"ref_schema_version", "tenant_id", "workspace_id", "pre_app_scope_id"}

--- a/tests/test_plan_taxonomy_sources.py
+++ b/tests/test_plan_taxonomy_sources.py
@@ -15,6 +15,7 @@ bytes may be copied.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from mozaiksai.core.semantics.compilation_plan import (
     CompilationPlan,
     FamilyInstancePlan,
     PlanTaxonomySource,
+    _reuse_signature,
     derive_compilation_plan,
     plan_regeneration_closure,
 )
@@ -101,6 +103,86 @@ def test_taxonomy_source_contract_is_closed_and_grammar_validated() -> None:
         PlanTaxonomySource.model_validate({**_TAXONOMY, "created_at": "now"})
 
 
+@pytest.mark.parametrize("category,identifier", [
+    ("event", "domain.order.created"),
+    ("capability", "orders.analysis"),
+    ("artifact_family", "app_manifest"),
+])
+@pytest.mark.parametrize("padding", [(" ", ""), ("", " "), ("\t ", " \n")])
+def test_taxonomy_source_stores_canonical_identity(
+    category: str, identifier: str, padding: tuple[str, str],
+) -> None:
+    canonical = PlanTaxonomySource(**{**_TAXONOMY, "category": category, "identifier": identifier})
+    prefix, suffix = padding
+    supplied = {
+        "node_id": f"{prefix}{canonical.node_id}{suffix}",
+        "category": f"{prefix}{category}{suffix}",
+        "identifier": f"{prefix}{identifier}{suffix}",
+    }
+    source = PlanTaxonomySource.model_validate(supplied)
+    assert source.identifier == identifier
+    assert (source.node_id, source.category, source.identifier) == (
+        canonical.node_id, canonical.category, canonical.identifier,
+    )
+    assert source == canonical
+    assert source.model_dump() == canonical.model_dump()
+    assert source.model_dump(mode="json") == canonical.model_dump(mode="json")
+    assert source.model_dump_json() == canonical.model_dump_json()
+    assert PlanTaxonomySource.model_validate_json(json.dumps(supplied)) == canonical
+    assert PlanTaxonomySource.model_validate_json(source.model_dump_json()) == canonical
+    assert supplied["identifier"] == f"{prefix}{identifier}{suffix}"
+    with pytest.raises(ValidationError, match="frozen"):
+        source.identifier = "domain.order.updated"
+
+
+@pytest.mark.parametrize("category,identifier", [
+    ("event", " domain order.created "),
+    ("event", " Domain.order.created "),
+    ("capability", " orders/analysis "),
+    ("artifact_family", " app.manifest "),
+    ("event", " \t\n "),
+])
+def test_taxonomy_source_normalization_still_rejects_invalid_grammar(
+    category: str, identifier: str,
+) -> None:
+    with pytest.raises(ValidationError, match="identifier must match"):
+        PlanTaxonomySource(**{**_TAXONOMY, "category": category, "identifier": identifier})
+
+
+def test_whitespace_and_order_are_identical_unit_and_reuse_authority() -> None:
+    plan = _corpus_plan()
+    unit_id = _pinned_unit_id(plan)
+    base_unit = plan.unit(unit_id)
+    second = {
+        "node_id": "mozaiks.event.order_paid",
+        "category": "event",
+        "identifier": "domain.order.paid",
+    }
+    canonical = FamilyInstancePlan.model_validate({
+        **base_unit.model_dump(mode="json"), "taxonomy_sources": [_TAXONOMY, second],
+    })
+    padded = FamilyInstancePlan.model_validate({
+        **base_unit.model_dump(mode="json"),
+        "taxonomy_sources": [
+            {key: f" \t{value}\n " for key, value in source.items()}
+            for source in [second, _TAXONOMY]
+        ],
+    })
+    assert padded.taxonomy_sources == canonical.taxonomy_sources
+    assert padded == canonical
+    assert padded.model_dump() == canonical.model_dump()
+    assert padded.model_dump(mode="json") == canonical.model_dump(mode="json")
+    assert padded.identity_payload == canonical.identity_payload
+    assert padded.model_dump_json() == canonical.model_dump_json()
+    assert padded.unit_digest == canonical.unit_digest
+    assert _reuse_signature(padded, plan) == _reuse_signature(canonical, plan)
+    assert FamilyInstancePlan.model_validate_json(padded.model_dump_json()) == canonical
+    base = _with_taxonomy(plan, unit_id, canonical.model_dump(mode="json")["taxonomy_sources"])
+    successor = _with_taxonomy(plan, unit_id, padded.model_dump(mode="json")["taxonomy_sources"])
+    assert base.model_dump_json() == successor.model_dump_json()
+    assert unit_id in plan_regeneration_closure(base, successor).reusable
+
+
 def test_unit_normalizes_orders_and_rejects_duplicate_taxonomy_axes() -> None:
     plan = _corpus_plan()
     base_unit = plan.unit(_pinned_unit_id(plan))
@@ -150,6 +232,24 @@ def test_empty_taxonomy_is_absent_from_serialization_identity_and_digest() -> No
     from tests.test_compilation_plan import _GOLDEN_PLAN_DIGEST
 
     assert plan.plan_digest == _GOLDEN_PLAN_DIGEST
+
+
+def test_every_preexisting_corpus_unit_keeps_exact_bytes_and_identity() -> None:
+    # Independently captured from exact base 36b33e021fb04b68c82a8b144ff4fef608ce9b15.
+    # Pin every unit's serialized JSON, dump, identity payload and unit digest,
+    # rather than relying solely on the aggregate plan's serialization digest.
+    rows = [
+        {
+            "unit_id": unit.unit_id,
+            "model_dump": unit.model_dump(mode="json"),
+            "identity_payload": unit.identity_payload,
+            "serialized_json": unit.model_dump_json(),
+            "unit_digest": unit.unit_digest,
+        }
+        for unit in _corpus_plan().units
+    ]
+    assert len(rows) == 59
+    assert canonical_digest(rows) == "23a30860c1bad68123df0c3e208fc150e9f0d8aadef8f64d15a993e7333c8e8a"
 
 
 def test_nonempty_taxonomy_enters_serialization_identity_and_digest() -> None:

--- a/tests/test_plan_taxonomy_sources.py
+++ b/tests/test_plan_taxonomy_sources.py
@@ -1,0 +1,283 @@
+"""PlanTaxonomySource: node-level taxonomy identity in plan and reuse authority.
+
+The generic prerequisite extracted from the #479 architecture reset: a
+node-level taxonomy identity that can affect rendered bytes must participate
+consistently in (1) unit identity, (2) serialization, (3) canonical authority
+rederivation, and (4) the regeneration/reuse signature — while every
+pre-existing payload-only unit stays byte- and digest-identical. No family
+derives taxonomy sources yet; these proofs are deliberately generic and use
+the pinned corpus plus synthetic (self-consistent, re-digested) plan
+documents to exercise the exact reuse-classification path that failed:
+``_reuse_signature`` inside :func:`plan_regeneration_closure`, the same
+classification :func:`rematerialize_plan` consumes to decide which prior
+bytes may be copied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    FamilyInstancePlan,
+    PlanTaxonomySource,
+    derive_compilation_plan,
+    plan_regeneration_closure,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    PlanAuthorityError,
+    build_compilation_plan_authority_inputs,
+    validate_compilation_plan_against_authority,
+)
+from tests.test_compilation_plan import _corpus_graph, _registry
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_TAXONOMY = {
+    "node_id": "mozaiks.event.order_created",
+    "category": "event",
+    "identifier": "domain.order.created",
+}
+
+
+def _corpus_plan() -> CompilationPlan:
+    graph, payloads = _corpus_graph()
+    return derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+
+
+def _redigested(document: dict) -> CompilationPlan:
+    """Recompute the plan self-digest over a mutated document — the
+    attacker's move: internally consistent, but not canonically derived."""
+    body = {key: value for key, value in document.items() if key != "plan_digest"}
+    document["plan_digest"] = canonical_digest(body)
+    return CompilationPlan.model_validate(document)
+
+
+def _with_taxonomy(
+    plan: CompilationPlan, unit_id: str, taxonomy: list[dict]
+) -> CompilationPlan:
+    document = plan.model_dump(mode="json")
+    canonical = sorted(
+        taxonomy, key=lambda item: (item["node_id"], item["category"], item["identifier"])
+    )
+    for unit in document["units"]:
+        if unit["unit_id"] == unit_id:
+            if canonical:
+                unit["taxonomy_sources"] = canonical
+            else:
+                unit.pop("taxonomy_sources", None)
+    return _redigested(document)
+
+
+def _pinned_unit_id(plan: CompilationPlan) -> str:
+    return next(
+        unit.unit_id
+        for unit in plan.units
+        if unit.sources and not unit.depends_on_units
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model contract
+# ---------------------------------------------------------------------------
+
+
+def test_taxonomy_source_contract_is_closed_and_grammar_validated() -> None:
+    source = PlanTaxonomySource(**_TAXONOMY)
+    assert set(PlanTaxonomySource.model_fields) == {"node_id", "category", "identifier"}
+    assert PlanTaxonomySource.model_validate(source.model_dump(mode="json")) == source
+
+    with pytest.raises(ValidationError):
+        PlanTaxonomySource(**{**_TAXONOMY, "category": "provider"})
+    with pytest.raises(ValidationError):
+        PlanTaxonomySource(**{**_TAXONOMY, "identifier": "NotAnEventId"})
+    with pytest.raises(ValidationError):
+        PlanTaxonomySource(**{**_TAXONOMY, "node_id": ""})
+    with pytest.raises(ValidationError):
+        PlanTaxonomySource.model_validate({**_TAXONOMY, "created_at": "now"})
+
+
+def test_unit_normalizes_orders_and_rejects_duplicate_taxonomy_axes() -> None:
+    plan = _corpus_plan()
+    base_unit = plan.unit(_pinned_unit_id(plan))
+    shuffled = (
+        PlanTaxonomySource(
+            node_id="mozaiks.event.zeta", category="event", identifier="domain.z.two"
+        ),
+        PlanTaxonomySource(**_TAXONOMY),
+    )
+    unit = FamilyInstancePlan.model_validate(
+        {**base_unit.model_dump(mode="json"), "taxonomy_sources": [
+            item.model_dump(mode="json") for item in shuffled
+        ]}
+    )
+    assert [item.node_id for item in unit.taxonomy_sources] == [
+        "mozaiks.event.order_created",
+        "mozaiks.event.zeta",
+    ]
+    with pytest.raises(ValidationError, match="duplicate taxonomy source"):
+        FamilyInstancePlan.model_validate(
+            {
+                **base_unit.model_dump(mode="json"),
+                "taxonomy_sources": [
+                    _TAXONOMY,
+                    {**_TAXONOMY, "identifier": "domain.order.updated"},
+                ],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Serialization / identity: pre-existing-unit stability and non-empty participation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_taxonomy_is_absent_from_serialization_identity_and_digest() -> None:
+    """Old-unit stability: no pre-existing unit serializes, digests, or
+    identifies any differently because the field exists."""
+
+    plan = _corpus_plan()
+    for unit in plan.units:
+        assert unit.taxonomy_sources == ()
+        assert "taxonomy_sources" not in unit.model_dump(mode="json")
+        assert "taxonomy_sources" not in unit.identity_payload
+    # The canonical corpus plan digest is byte-identical to the pinned base
+    # golden — the field's existence re-pins nothing.
+    from tests.test_compilation_plan import _GOLDEN_PLAN_DIGEST
+
+    assert plan.plan_digest == _GOLDEN_PLAN_DIGEST
+
+
+def test_nonempty_taxonomy_enters_serialization_identity_and_digest() -> None:
+    plan = _corpus_plan()
+    unit_id = _pinned_unit_id(plan)
+    base_unit = plan.unit(unit_id)
+    carrying = FamilyInstancePlan.model_validate(
+        {**base_unit.model_dump(mode="json"), "taxonomy_sources": [_TAXONOMY]}
+    )
+    assert carrying.model_dump(mode="json")["taxonomy_sources"] == [_TAXONOMY]
+    assert carrying.identity_payload["taxonomy_sources"] == [_TAXONOMY]
+    assert carrying.unit_digest != base_unit.unit_digest
+    # Round trip preserves the exact identity.
+    assert (
+        FamilyInstancePlan.model_validate(carrying.model_dump(mode="json"))
+        == carrying
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reuse signature: the defect that caused the architecture reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "identifier",
+        "category",
+        "added",
+        "removed",
+        "node_substituted",
+    ],
+)
+def test_taxonomy_mutations_are_never_classified_reusable(mutation: str) -> None:
+    """The exact reuse-classification path that failed in #479: two plans
+    whose only difference is one unit's node-level taxonomy identity must
+    classify that unit AFFECTED — reuse of its prior bytes is forbidden."""
+
+    plan = _corpus_plan()
+    unit_id = _pinned_unit_id(plan)
+    base_taxonomy = [_TAXONOMY]
+    successor_taxonomy: list[dict]
+    if mutation == "identifier":
+        successor_taxonomy = [{**_TAXONOMY, "identifier": "domain.order.updated"}]
+    elif mutation == "category":
+        successor_taxonomy = [
+            {**_TAXONOMY, "category": "capability", "identifier": "orders.analysis"}
+        ]
+    elif mutation == "added":
+        successor_taxonomy = [
+            _TAXONOMY,
+            {
+                "node_id": "mozaiks.event.order_paid",
+                "category": "event",
+                "identifier": "domain.order.paid",
+            },
+        ]
+    elif mutation == "removed":
+        successor_taxonomy = []
+    else:
+        successor_taxonomy = [
+            {**_TAXONOMY, "node_id": "mozaiks.event.order_created_v2"}
+        ]
+
+    base = _with_taxonomy(plan, unit_id, base_taxonomy)
+    successor = _with_taxonomy(plan, unit_id, successor_taxonomy)
+    closure = plan_regeneration_closure(base, successor)
+    assert unit_id in closure.affected, mutation
+    assert unit_id not in closure.reusable, mutation
+
+
+def test_identical_and_order_permuted_taxonomy_stays_reusable() -> None:
+    plan = _corpus_plan()
+    unit_id = _pinned_unit_id(plan)
+    second = {
+        "node_id": "mozaiks.event.order_paid",
+        "category": "event",
+        "identifier": "domain.order.paid",
+    }
+    base = _with_taxonomy(plan, unit_id, [_TAXONOMY, second])
+    # The same canonical identities supplied in the opposite order normalize
+    # to one canonical tuple: an order-only permutation never regenerates.
+    successor = _with_taxonomy(plan, unit_id, [second, _TAXONOMY])
+    closure = plan_regeneration_closure(base, successor)
+    assert unit_id in closure.reusable
+    assert unit_id not in closure.affected
+    assert (
+        base.unit(unit_id).taxonomy_sources == successor.unit(unit_id).taxonomy_sources
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical authority: possession of a self-consistent plan proves nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "forged_taxonomy",
+    [
+        [_TAXONOMY],
+        [{**_TAXONOMY, "identifier": "domain.order.updated"}],
+        [
+            _TAXONOMY,
+            {
+                "node_id": "mozaiks.event.order_paid",
+                "category": "event",
+                "identifier": "domain.order.paid",
+            },
+        ],
+    ],
+)
+def test_forged_taxonomy_sources_fail_canonical_rederivation(
+    forged_taxonomy: list[dict],
+) -> None:
+    """Canonical derivation of current families produces EMPTY taxonomy
+    sources, so any caller-forged taxonomy pin — even fully re-digested —
+    is not the canonical derivation of its authorities. When a family that
+    derives non-empty taxonomy sources exists, removing or changing its
+    pinned identity fails the same exact-equality rule in that family's own
+    fixtures."""
+
+    graph, payloads = _corpus_graph()
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=_registry())
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph, payloads=payloads, registry=_registry()
+    )
+    validate_compilation_plan_against_authority(plan, authority)
+    forged = _with_taxonomy(plan, _pinned_unit_id(plan), forged_taxonomy)
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(forged, authority)


### PR DESCRIPTION
## Canonical taxonomy-source plan and reuse authority

Some canonical identities live on graph nodes rather than typed payloads. This PR makes an explicitly pinned node taxonomy identity participate in compilation-unit identity and reuse authority, so changing that identity classifies the unit as affected and prevents reuse of stale bytes.

### Contract

- `PlanTaxonomySource` is a frozen, closed `(node_id, category, identifier)` model. Node ID and category normalize at construction; the identifier field validator stores the canonical value returned by the taxonomy grammar contract.
- `FamilyInstancePlan.taxonomy_sources` sorts deterministically and rejects duplicate node/category axes.
- Empty sources remain omitted from serialization and identity. Nonempty sources participate in serialization, identity payload, unit digest, and the decomposed reuse signature.
- Identifier/category mutation, source addition/removal, and node substitution classify the unit as AFFECTED. Identical identities, surrounding-whitespace variants, and order-only permutations classify it as REUSABLE.
- #475/#477 canonical rederivation remains unchanged. Current derivation emits no nonempty taxonomy sources, so fully re-digested forged taxonomy pins still fail canonical authority validation. Future deriving families owe their own end-to-end pinned-source fixtures.

### Identity and normalization proof

Permanent tests prove canonical stored state, Python/JSON dumps, serialized JSON, identity payload, unit digest, reuse signature, round trips, ordering, invalid grammar rejection, and forged re-digested authority rejection.

All **59 of 59 pre-existing corpus units** retain exact serialized JSON, model dumps, identity payloads, and digests against original base `36b33e021fb04b68c82a8b144ff4fef608ce9b15`. The permanent combined fingerprint remains `23a30860c1bad68123df0c3e208fc150e9f0d8aadef8f64d15a993e7333c8e8a`; the existing plan golden is unchanged. The earlier 64-unit description was incorrect.

The bounded sibling audit identified existing whitespace retention in `TaxonomyReference`. That gap remains deferred; this PR neither reopens it nor changes graph identity contracts.

### Mechanical base movement after #482

| Revision | Exact commit |
| --- | --- |
| Previously reviewed head | `9aaeb09976df50f55ca82571370d1d4762155796` |
| Rebased head | `52a7dedd0744f3ec0f378e1afd320fc7bfc48098` |
| Original base | `36b33e021fb04b68c82a8b144ff4fef608ce9b15` |
| New base, merged #482 | `24e15fa4291434347ee13ab2c7d993d5c201ea82` |

Rebased exactly once, with **zero conflicts and zero manual edits**. Both commits are unchanged in `git range-diff`; the stable full-diff patch ID before/after is `aa228fdbf44e434187617e5f383b5f3e5e6307ef`. All four non-changelog #481 file blobs are byte-identical to the reviewed head. All 16 non-changelog #482 paths match new main exactly, including deletions. Changelog edits preserve both PRs' additions. No factory behavior, AppGenerator task vocabulary, or workflow touchpoint behavior changes were introduced by the rebase.

### Final exact-head review

Codex 3 independently reviewed `52a7dedd0744f3ec0f378e1afd320fc7bfc48098`: **PASS, no blocking findings**. The reviewer independently verified diff equivalence, #482 file preservation, DCO sign-offs, and all 29 taxonomy-source tests. This is a local independent exact-head review, not a GitHub approval.

### Validation

- `tests/test_plan_taxonomy_sources.py`: **29 passed**, independently rerun by Codex 3.
- Focused suite: **709 passed, 1 skipped**. Includes `test_module_interface_retirement.py`, `test_appgenerator_materializing_task_authority.py`, AppGenerator canonical generation and archetype hook tests, CompilationPlan/regeneration closure, #475/#477 authority, materialization/rematerialization, 4C, 5A/5B/5C, ArtifactRevision contracts/store, taxonomy graph contracts, and source hygiene.
- `ruff check .`: passed.
- `mypy --follow-imports=silent mozaiksai/core/semantics/compilation_plan.py`: passed.
- `python -m mkdocs build --strict`: passed.
- `git diff --check` for working tree and PR diff: passed.
- Full `python -m pytest -q --no-cov`: **14602 passed, 94 skipped, 3 warnings** in 580.74s at the rebased exact head.
- Both rebased commits retain DCO sign-offs. GitHub DCO **passed** at the published exact head; GitHub CI is **running** (not yet terminal).

### OSS Change Impact

- Layer: generic offline semantic CompilationPlan contract.
- Build workflows, runtime/platform, app workspaces: no new changes; #482 behavior is preserved exactly.
- Docs: ADR 0007 and changelog describe the taxonomy-source authority contract and canonical stored identifiers.
- Compatibility: empty-source serialization and all 59 existing corpus identities remain unchanged; surrounding whitespace stores canonical identity.
- No workflow-interface families, workflow registry, renderers, workflow touchpoints, AppGenerator/AgentGenerator changes, routing, AG2 changes, or ArtifactRevision implementation changes.

Both commits are DCO signed. Keep this PR **draft**, with **auto-merge disabled**. **Do not merge.** Final exact-head reviewer: **Codex 3**.
