### PR TITLE
feat(compiler): materialize canonical workflow module interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Canonical workflow module interfaces**: the offline compiler renders
+  `mozaiks.module_interface.v2` from exact workflow capability, result,
+  binding, module, and event-taxonomy sources. Advisory results are retained;
+  event identity changes invalidate reuse through the real rematerialization
+  path. Both canonical layout representations enforce row-first output
+  identity. The retired factory writer stays absent. App workflow registry,
+  runtime routing, and persistent workflow launch remain separate/deferred.
 - **Node-level taxonomy identity in plan and reuse authority (ADR 0007)**:
   `CompilationPlan` units gain a generic `taxonomy_sources` contract
   (`PlanTaxonomySource`: exact `(node, category, identifier)` triples under
@@ -26,9 +33,8 @@ This project follows a practical pre-1.0 changelog format:
   regeneration/reuse signature: a unit whose node-level identity changed can
   never be classified reusable, so stale bytes are never copied forward.
   Empty taxonomy sources are omitted from identity and serialization alike,
-  keeping every pre-existing plan unit byte- and digest-identical. No family
-  derives taxonomy sources yet; this is the generic prerequisite for the
-  re-architected workflow-interface families.
+  keeping every pre-existing plan unit byte- and digest-identical. The
+  workflow module interface is the first family deriving these sources.
 - **Typed module↔workflow capability semantics**: the semantic graph now
   models the relationship between deterministic application capabilities
   (modules, actions, events) and agentic capabilities (workflows) as

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -365,7 +365,75 @@ regeneration/reuse signature — a unit whose node-level identity changed is
 never classified reusable — while empty taxonomy sources are omitted from
 identity and serialization alike, so every payload-only unit's digest and
 serialized form are unchanged. Families that consume node-level identity
-(the re-architected workflow-interface corpus) build on this primitive.
+(the workflow interface below) build on this primitive.
+
+### Canonical workflow module interface
+
+PR #479 is closed and superseded evidence, not an implementation dependency.
+PR #482 retired the independently authored v1 factory interface and its
+non-materializing AppGenerator task authority. PR #481 supplies canonical
+taxonomy-source identity and reuse authority. This slice restores only
+`module_interface.yaml` as `mozaiks.module_interface.v2`, derived through
+`SemanticGraphV2` → `CompilationPlan` → exact family sources → a closed render
+input → the deterministic interface renderer. There is one compiler byte
+writer and no factory or agent writer for this artifact.
+
+The `workflow_module_interface` family has two canonical layout rows:
+`workspace_root: workflows/{workflow_id}/module_interface.yaml` and
+`workflow_relative: module_interface.yaml`. Both are workflow-owned,
+conditional on `when_workflow_declared`, multiplicity `many`, disposition
+`render`, materializer `workflow_interface_executor`, validator
+`generated_app_validator`, security `internal_contract`, and dependent on
+`workflow_manifest`. Their runtime consumer is **NONE**. The existing workflow
+scope selection chooses one row; both retain exactly the `workflow_id`
+placeholder, including the scope-implied identity of the relative row.
+Bundle composition retains its existing global-root boundary: workspace
+interfaces materialize into bundles, while workflow-relative units remain
+explicitly deferred there and are proven through the direct renderer.
+
+For workflow W, C is every capability it owns, R is every result C owns
+(including advisory results with no commit binding), B is every typed binding
+C owns, M is every module referenced by an action binding, and E is every
+referenced trigger event. Payload sources are exactly `{W} ∪ C ∪ R ∪ B ∪ M`.
+Edge sources are exactly workflow/capability, capability/result and
+capability/binding ownership plus the existing typed binding-edge projection:
+consumes action, commit action with the result-node discriminator, commit
+result reference, and event consumption. Each E contributes only its exact
+EVENT-category `PlanTaxonomySource`. Action and event payload bodies,
+unrelated nodes, ambient registry entries, and unrelated graph edges are
+excluded.
+
+The YAML document contains `schema_version`, semantic `workflow_id`, and
+sorted `capabilities`. Each capability carries its `capability_id`, optional
+payload-owned description, all owned `results` (`result_id`, optional
+description), and sorted typed `bindings`. `consumes_action` carries
+`module_id` and `action_node_id`; `commits_result_through_action` also carries
+`workflow_result_id`; `triggered_by_event` carries `event_type`. No action
+body, request/response schema, result structured-output schema, approval
+policy, runtime workflow identity, provider/model identity, or AG2 identity
+enters the document. Serialization uses the existing canonical YAML byte
+contract, with no clock, filesystem, environment, or runtime registry input.
+
+Direct output validation resolves `family_identity_digest` to an exact live
+canonical row **before** interpreting scope/path. That row and the canonical
+instance derive the shared planner unit ID, exact placeholder set, output
+scope, and expanded path; the input workflow identity must match. A complete
+alternate twin is a valid direct-renderer shape, but substituting it into a
+plan still fails #475/#477 canonical rederivation. Renderer shape validation
+does not replace plan-membership authority.
+
+Selective rematerialization pins actual referenced event taxonomy and all
+owned results. The first end-to-end taxonomy-source family proof exercises
+canonical derivation, serialization/reload, actual historical-byte reuse,
+event-identity mutation, and comparison with clean successor materialization.
+Whole selected payloads remain conservative invalidation boundaries: unused
+fields of a selected WorkflowPayload or ModulePayload may invalidate its
+interface. Field-level PlanSource granularity is not introduced here.
+
+The app workflow registry, runtime capability routing, and production
+AppGenerator/AgentGenerator cutovers remain deferred. Persistent workflow
+launch is a separate contract; workflow touchpoints and page launch semantics
+do not enter this artifact.
 
 ## ApplicationManifest
 

--- a/mozaiksai/core/runtime/app/layout_registry.py
+++ b/mozaiksai/core/runtime/app/layout_registry.py
@@ -99,6 +99,7 @@ class ArtifactKind(StrEnum):
     MODULE_ADMIN_UI = "module_admin_ui"
     MODULE_UI_EXTENSION_BARREL = "module_ui_extension_barrel"
     WORKFLOW_MANIFEST = "workflow_manifest"
+    WORKFLOW_MODULE_INTERFACE = "workflow_module_interface"
     WORKFLOW_CONFIG = "workflow_config"
     WORKFLOW_TOOL = "workflow_tool"
     WORKFLOW_UI = "workflow_ui"
@@ -174,6 +175,7 @@ class MaterializerIdentifier(StrEnum):
     PAGE_SCHEMA_EXECUTOR = "page_schema_executor"
     APP_CONFIG_EXECUTOR = "app_config_executor"
     WORKFLOW_GENERATOR = "workflow_generator"
+    WORKFLOW_INTERFACE_EXECUTOR = "workflow_interface_executor"
     CAPABILITY_PACK_MATERIALIZER = "capability_pack_materializer"
     DOWNLOAD_DEPLOYMENT_RENDERER = "download_deployment_renderer"
     PRESERVED_OPAQUE = "preserved_opaque"
@@ -715,6 +717,28 @@ def _core_families() -> tuple[ArtifactFamily, ...]:
         _family(ArtifactKind.APP_MANIFEST, LayoutOwner.PLATFORM, Requirement.REQUIRED, workspace, "app/app.json", ValidatorIdentifier.APP_LOADER, RuntimeConsumerIdentifier.APP_LOADER, inputs=application_inputs),
         _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workspace, "workflows/{workflow_id}/orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, multiplicity=Multiplicity.MANY, inputs=workflow_inputs),
         _family(ArtifactKind.WORKFLOW_MANIFEST, LayoutOwner.WORKFLOW, Requirement.CONDITIONAL, workflow, "orchestrator.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, inputs=workflow_inputs),
+        *(
+            _family(
+                ArtifactKind.WORKFLOW_MODULE_INTERFACE,
+                LayoutOwner.WORKFLOW,
+                Requirement.CONDITIONAL,
+                scope,
+                template,
+                ValidatorIdentifier.GENERATED_APP_VALIDATOR,
+                RuntimeConsumerIdentifier.NONE,
+                condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED,
+                multiplicity=Multiplicity.MANY,
+                materializer=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                disposition=ArtifactDisposition.RENDER,
+                security=SecurityClass.INTERNAL_CONTRACT,
+                deps=(ArtifactKind.WORKFLOW_MANIFEST,),
+                inputs=("workflow", "workflow_capability", "workflow_result", "workflow_capability_binding", "module"),
+            )
+            for scope, template in (
+                (workspace, "workflows/{workflow_id}/module_interface.yaml"),
+                (workflow, "module_interface.yaml"),
+            )
+        ),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "agents.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, assignment=(AssignmentKind.WORKFLOW_PARTICIPANT_IMPLEMENTATION,), deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=workflow_inputs),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "context_variables.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, disposition=ArtifactDisposition.RENDER, deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=workflow_inputs),
         _family(ArtifactKind.WORKFLOW_CONFIG, LayoutOwner.WORKFLOW, Requirement.OPTIONAL, workflow, "structured_outputs.yaml", ValidatorIdentifier.WORKFLOW_MANAGER, RuntimeConsumerIdentifier.WORKFLOW_MANAGER, condition=ConditionIdentifier.WHEN_WORKFLOW_DECLARED, assignment=(AssignmentKind.WORKFLOW_STRUCTURED_MODELS_IMPLEMENTATION,), deps=(ArtifactKind.WORKFLOW_MANIFEST,), inputs=workflow_inputs),

--- a/mozaiksai/core/semantics/compilation_plan.py
+++ b/mozaiksai/core/semantics/compilation_plan.py
@@ -58,6 +58,7 @@ from mozaiksai.core.runtime.app.layout_registry import (
 )
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
     SemanticEdgeKind,
     SemanticGraphV2,
     SemanticNodeKind,
@@ -75,7 +76,12 @@ from mozaiksai.core.semantics.payloads import (
     OptionalFamilySelectionStatus,
     PagePayload,
     SemanticPayloadBase,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityPayload,
     WorkflowPayload,
+    WorkflowResultPayload,
+    derive_workflow_capability_binding_edges,
+    derive_workflow_result_edges,
     parse_semantic_payload,
     validate_semantic_graph_v2_payload_closure,
 )
@@ -129,6 +135,21 @@ _INSTANCE_PATH_SCOPES = frozenset({"module_relative", "workflow_relative"})
 
 class CompilationPlanError(ValueError):
     """The plan inputs or document violate the Slice 4B contract."""
+
+
+def canonical_instance_identity_value(value: str) -> str:
+    """Validate the existing planner instance domain without inferring identity."""
+    if _VALUE_RE.fullmatch(value) is None:
+        raise ValueError(f"instance identity {value!r} is outside the closed domain")
+    return value
+
+
+def canonical_instance_unit_id(kind: str, instance: str, row_digest: str) -> str:
+    """Shared planner/renderer identity for one content-addressed family row."""
+    family = _identifier(kind, field_name="family_kind")
+    identity = canonical_instance_identity_value(instance)
+    digest = _validate_digest(row_digest, field_name="family_identity_digest")
+    return f"{family}/{identity}/{digest[:12]}"
 
 
 def _identifier(value: Any, *, field_name: str) -> str:
@@ -1333,6 +1354,78 @@ def derive_compilation_plan(
             return tuple(sorted(instances))
         return None
 
+    def _workflow_interface_footprint(
+        workflow_node_id: str,
+    ) -> tuple[tuple[PlanSource, ...], tuple[PlanEdgeSource, ...], tuple[PlanTaxonomySource, ...]]:
+        """Pin only the workflow's typed interface meaning, including advisory results.
+
+        Action references supply identity, not action implementation. Trigger
+        event identity comes from node taxonomy, not the event payload body.
+        Whole selected payloads remain conservative invalidation boundaries.
+        """
+        capabilities = [
+            payload for payload in payload_by_node.values()
+            if isinstance(payload, WorkflowCapabilityPayload)
+            and payload.workflow_node_id == workflow_node_id
+        ]
+        capability_ids = {payload.node_id for payload in capabilities}
+        results = [
+            payload for payload in payload_by_node.values()
+            if isinstance(payload, WorkflowResultPayload)
+            and payload.workflow_capability_node_id in capability_ids
+        ]
+        bindings = [
+            payload for payload in payload_by_node.values()
+            if isinstance(payload, WorkflowCapabilityBindingPayload)
+            and payload.workflow_capability_node_id in capability_ids
+        ]
+        selected = {
+            workflow_node_id,
+            *capability_ids,
+            *(payload.node_id for payload in results),
+            *(payload.node_id for payload in bindings),
+            *(payload.module_action.module_node_id for payload in bindings if payload.module_action),
+        }
+        edges = [
+            SemanticEdge(
+                kind=SemanticEdgeKind.DECLARES,
+                source_node_id=workflow_node_id,
+                target_node_id=capability.node_id,
+            )
+            for capability in capabilities
+        ]
+        for result in results:
+            edges.extend(derive_workflow_result_edges(result))
+        for binding in bindings:
+            edges.extend(derive_workflow_capability_binding_edges(binding))
+        sources = tuple(
+            PlanSource(node_id=node_id, payload_digest=payload_by_node[node_id].payload_digest)
+            for node_id in sorted(selected)
+        )
+        edge_sources = tuple(
+            PlanEdgeSource(
+                kind=edge.kind,
+                source_node_id=edge.source_node_id,
+                target_node_id=edge.target_node_id,
+                discriminator=edge.discriminator,
+                edge_identity=edge.edge_identity,
+            )
+            for edge in edges
+        )
+        taxonomy_sources = []
+        for event_id in sorted({binding.event_node_id for binding in bindings if binding.event_node_id}):
+            references = [
+                reference for reference in node_by_id[event_id].taxonomy_references
+                if reference.category.value == "event"
+            ]
+            # Graph payload closure already proves a single, truthfully emitted identity.
+            if len(references) != 1:
+                raise CompilationPlanError("interface trigger requires one canonical event identity")
+            taxonomy_sources.append(PlanTaxonomySource(
+                node_id=event_id, category="event", identifier=references[0].identifier,
+            ))
+        return sources, edge_sources, tuple(taxonomy_sources)
+
     def _renderer_footprint(
         row: RegistryFamilyRow, *, root_node_id: str | None = None
     ) -> tuple[tuple[PlanSource, ...], tuple[PlanEdgeSource, ...]]:
@@ -1407,11 +1500,12 @@ def derive_compilation_plan(
         }
         field = identity_fields[placeholder]
         value = str(getattr(payload_by_node[node_id], field, "") or "").strip()
-        if _VALUE_RE.fullmatch(value) is None:
+        try:
+            return canonical_instance_identity_value(value)
+        except ValueError as exc:
             raise CompilationPlanError(
                 f"payload {node_id!r} lacks canonical renderer identity {field!r}"
-            )
-        return value
+            ) from exc
 
     def _app_config_inputs_complete(row: RegistryFamilyRow) -> bool:
         """Slice 5D-0B2A: application-config families with closed inputs.
@@ -1505,6 +1599,8 @@ def derive_compilation_plan(
         gaps until a later prerequisite explicitly closes their normative
         source models.
         """
+        if row.kind == "workflow_module_interface":
+            return isinstance(payload_by_node.get(root_node_id or ""), WorkflowPayload)
         if row.kind in _APP_CONFIG_RENDER_KINDS and root_node_id is None:
             return _app_config_inputs_complete(row)
         if row.kind != "app_ui_page_schema" or root_node_id is None:
@@ -1571,7 +1667,7 @@ def derive_compilation_plan(
             PathScope.MODULE_RELATIVE.value,
         }:
             selected_scope = verified_scope_selection.module_scope
-        elif row.kind == "workflow_manifest":
+        elif row.kind in {"workflow_manifest", "workflow_module_interface"}:
             selected_scope = verified_scope_selection.workflow_manifest_scope
         if selected_scope is not None and row.path_scope != selected_scope.value:
             _add_unit(
@@ -1747,7 +1843,7 @@ def derive_compilation_plan(
                 )
                 identity = "-".join(value for _name, value in values)
                 unit = FamilyInstancePlan(
-                    unit_id=f"{row.kind}/{identity}/{row_digest[:12]}",
+                    unit_id=canonical_instance_unit_id(row.kind, identity, row_digest),
                     family_kind=row.kind,
                     family_identity_digest=row_digest,
                     disposition=disposition,
@@ -1792,9 +1888,15 @@ def derive_compilation_plan(
                 # their instance identity lives in placeholder_values and the
                 # collision domain, not the relative path.
 
-                unit_sources, unit_edge_sources = _renderer_footprint(
-                    row, root_node_id=node.node_id
-                )
+                unit_taxonomy_sources: tuple[PlanTaxonomySource, ...] = ()
+                if row.kind == "workflow_module_interface":
+                    unit_sources, unit_edge_sources, unit_taxonomy_sources = (
+                        _workflow_interface_footprint(node.node_id)
+                    )
+                else:
+                    unit_sources, unit_edge_sources = _renderer_footprint(
+                        row, root_node_id=node.node_id
+                    )
                 resolved_sources = unit_sources or (
                     PlanSource(
                         node_id=node.node_id,
@@ -1810,7 +1912,7 @@ def derive_compilation_plan(
                     )
                     continue
                 unit = FamilyInstancePlan(
-                    unit_id=f"{row.kind}/{local}/{row_digest[:12]}",
+                    unit_id=canonical_instance_unit_id(row.kind, local, row_digest),
                     family_kind=row.kind,
                     family_identity_digest=row_digest,
                     disposition=disposition,
@@ -1819,6 +1921,7 @@ def derive_compilation_plan(
                     outputs=(PlanOutput(path_scope=row.path_scope, path=path),),
                     sources=resolved_sources,
                     edge_sources=unit_edge_sources,
+                    taxonomy_sources=unit_taxonomy_sources,
                     materializer=row.materializer,
                     validator=row.validator,
                     assignment_kind=assignment_kind,

--- a/mozaiksai/core/semantics/materialization.py
+++ b/mozaiksai/core/semantics/materialization.py
@@ -1,14 +1,15 @@
 """ADR 0007 Slice 4C deterministic offline materialization (offline-only).
 
-This module implements the first honest deterministic materialization path:
+This module owns the deterministic materialization path:
 
     SemanticGraphV2 -> CompilationPlan -> accepted ImplementationBinding
-    -> canonical ``app_ui_page_schema`` bytes -> composed candidate bundle
+    -> canonical family bytes -> composed candidate bundle
 
-Exactly one renderer family is renderer-ready in this slice:
-``app_ui_page_schema``. Its renderer is a pure function of the plan unit's
-complete semantic source footprint (the page payload plus its linked section
-payloads) and nothing else. It consumes no AppBuildPlan, agent context,
+Page schemas, the closed application-configuration families, and workspace
+workflow module interfaces render from each unit's exact semantic footprint.
+The interface projection includes owned advisory results and pinned event
+taxonomy; its pure renderer lives in the separate interface materialization
+module. This owner consumes no AppBuildPlan, agent context,
 generated files, conversation history, runtime state, environment variables,
 clocks, randomness, or filesystem enumeration — this module deliberately
 imports none of those capabilities.
@@ -17,7 +18,7 @@ Authorities are unchanged: ``layout_registry`` remains the sole
 family/materializer authority; the ``CompilationPlan`` owns dispositions,
 source footprints, and physical output paths; the graph-v2
 ``ImplementationBinding`` pins the one accepted deterministic implementation
-identity/version for the page-schema materializer. This module adds no
+identity/version for each selected materializer. This module adds no
 registry, no alternate family map, no alternate output ownership, and no
 alternate artifact identity.
 
@@ -47,7 +48,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from types import UnionType
-from typing import Any, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 import yaml
 from pydantic import BaseModel
@@ -98,11 +99,17 @@ from mozaiksai.core.semantics.payloads import (
     AuthPayload,
     IntegrationConfigValueKind,
     IntegrationPayload,
+    ModulePayload,
     OptionalFamilyKind,
     OptionalFamilySelectionStatus,
     PagePayload,
     SectionPayload,
     SemanticPayloadBase,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityBindingRole,
+    WorkflowCapabilityPayload,
+    WorkflowPayload,
+    WorkflowResultPayload,
     parse_semantic_payload,
 )
 from mozaiksai.core.semantics.plan_authority import (
@@ -111,6 +118,20 @@ from mozaiksai.core.semantics.plan_authority import (
     validate_compilation_plan_against_authority,
 )
 from mozaiksai.core.semantics.portable_path import detect_collisions
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+    WORKFLOW_MODULE_INTERFACE,
+    RenderInputCommitsResultBinding,
+    RenderInputConsumesActionBinding,
+    RenderInputTriggeredByEventBinding,
+    RenderInputWorkflowBinding,
+    RenderInputWorkflowCapability,
+    RenderInputWorkflowResult,
+    WorkflowInterfaceMaterializationError,
+    WorkflowInterfaceRenderInput,
+    render_workflow_module_interface_unit,
+)
 
 PAGE_SCHEMA_FAMILY: Literal["app_ui_page_schema"] = "app_ui_page_schema"
 PAGE_BYTES_SCHEMA_VERSION: Literal["mozaiks.page_bytes.v1"] = "mozaiks.page_bytes.v1"
@@ -157,6 +178,8 @@ def _is_closed_annotation(annotation: Any) -> bool:
             return True  # walked separately
         return annotation in _CLOSED_SCALARS
     origin = get_origin(annotation)
+    if origin is Annotated:
+        return _is_closed_annotation(get_args(annotation)[0])
     if origin is Literal:
         return True
     if origin in (Union, UnionType):
@@ -353,8 +376,118 @@ def resolve_app_config_renderer_selection(
 
 
 # ---------------------------------------------------------------------------
-# Application-family render input (the one payload->renderer boundary)
+# Family render input (the one payload->renderer boundary)
 # ---------------------------------------------------------------------------
+
+
+def resolve_workflow_interface_renderer_selection(
+    binding: ImplementationBinding,
+    *,
+    graph: SemanticGraphV2,
+    layout_registry: Any,
+) -> RendererSelection:
+    """Bind the one interface family to its accepted deterministic implementation."""
+    validate_implementation_binding_against_graph(binding, graph, layout_registry=layout_registry)
+    matches = [
+        selection for selection in binding.renderer_selections
+        if WORKFLOW_MODULE_INTERFACE in selection.artifact_families
+    ]
+    if len(matches) != 1:
+        raise WorkflowInterfaceMaterializationError("binding requires one interface renderer selection")
+    selection = matches[0]
+    if (
+        set(selection.artifact_families) != {WORKFLOW_MODULE_INTERFACE}
+        or selection.materializer_id is not MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR
+        or selection.implementation_id != WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID
+        or selection.implementation_version != WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION
+    ):
+        raise WorkflowInterfaceMaterializationError("binding pins an unaccepted interface renderer contract")
+    return selection
+
+
+def project_workflow_interface_render_input(
+    *, unit: FamilyInstancePlan, payload_by_node: Mapping[str, SemanticPayloadBase],
+) -> WorkflowInterfaceRenderInput:
+    """Project only plan-pinned payloads and event identities; never consult ambient graph facts."""
+    selected: dict[str, SemanticPayloadBase] = {}
+    for source in unit.sources:
+        payload = payload_by_node.get(source.node_id)
+        if payload is None or payload.payload_digest != source.payload_digest:
+            raise WorkflowInterfaceMaterializationError("interface payload source is absent or stale")
+        selected[source.node_id] = payload
+    workflows = [p for p in selected.values() if isinstance(p, WorkflowPayload)]
+    if len(workflows) != 1:
+        raise WorkflowInterfaceMaterializationError("interface requires exactly one workflow payload")
+    workflow = workflows[0]
+    capabilities = [p for p in selected.values() if isinstance(p, WorkflowCapabilityPayload)]
+    capability_nodes = {p.node_id for p in capabilities}
+    results = [p for p in selected.values() if isinstance(p, WorkflowResultPayload)]
+    bindings = [p for p in selected.values() if isinstance(p, WorkflowCapabilityBindingPayload)]
+    if (
+        any(p.workflow_node_id != workflow.node_id for p in capabilities)
+        or any(p.workflow_capability_node_id not in capability_nodes for p in results)
+        or any(p.workflow_capability_node_id not in capability_nodes for p in bindings)
+    ):
+        raise WorkflowInterfaceMaterializationError("interface source ownership escapes its workflow")
+    expected = {
+        workflow.node_id, *capability_nodes,
+        *(p.node_id for p in results), *(p.node_id for p in bindings),
+        *(p.module_action.module_node_id for p in bindings if p.module_action),
+    }
+    if set(selected) != expected:
+        raise WorkflowInterfaceMaterializationError("interface payload footprint is not exact")
+    referenced_events = {p.event_node_id for p in bindings if p.event_node_id}
+    if (
+        {pin.node_id for pin in unit.taxonomy_sources} != referenced_events
+        or any(pin.category != "event" for pin in unit.taxonomy_sources)
+    ):
+        raise WorkflowInterfaceMaterializationError("interface event taxonomy footprint is not exact")
+    event_identity = {pin.node_id: pin.identifier for pin in unit.taxonomy_sources}
+    projected = []
+    for capability in capabilities:
+        projected_bindings: list[RenderInputWorkflowBinding] = []
+        for binding in bindings:
+            if binding.workflow_capability_node_id != capability.node_id:
+                continue
+            if binding.binding_role is WorkflowCapabilityBindingRole.TRIGGERED_BY_EVENT:
+                if binding.event_node_id is None:
+                    raise WorkflowInterfaceMaterializationError("trigger binding lacks event identity")
+                projected_bindings.append(RenderInputTriggeredByEventBinding(
+                    event_type=event_identity[binding.event_node_id],
+                ))
+                continue
+            ref = binding.module_action
+            module = selected.get(ref.module_node_id) if ref else None
+            if ref is None or not isinstance(module, ModulePayload):
+                raise WorkflowInterfaceMaterializationError("interface action binding lacks its module payload")
+            if binding.binding_role is WorkflowCapabilityBindingRole.CONSUMES_ACTION:
+                projected_bindings.append(RenderInputConsumesActionBinding(
+                    module_id=module.module_id, action_node_id=ref.action_node_id,
+                ))
+            else:
+                result = selected.get(binding.workflow_result_node_id or "")
+                if not isinstance(result, WorkflowResultPayload) or result.workflow_capability_node_id != capability.node_id:
+                    raise WorkflowInterfaceMaterializationError("commit binding lacks its owned result")
+                projected_bindings.append(RenderInputCommitsResultBinding(
+                    module_id=module.module_id, action_node_id=ref.action_node_id,
+                    workflow_result_id=result.result_id,
+                ))
+        projected.append(RenderInputWorkflowCapability(
+            capability_id=capability.capability_id,
+            description=capability.description,
+            results=tuple(
+                RenderInputWorkflowResult(result_id=p.result_id, description=p.description)
+                for p in results if p.workflow_capability_node_id == capability.node_id
+            ),
+            bindings=tuple(projected_bindings),
+        ))
+    return WorkflowInterfaceRenderInput(
+        workflow_id=workflow.workflow_id,
+        sources=unit.sources,
+        edge_sources=unit.edge_sources,
+        taxonomy_sources=unit.taxonomy_sources,
+        capabilities=tuple(projected),
+    )
 
 
 _CONFIG_VALUE_TYPES: dict[IntegrationConfigValueKind, Literal["text", "url", "secret"]] = {
@@ -562,7 +695,7 @@ def project_app_family_render_input(
 
 
 def _canonical_yaml_bytes(document: Mapping[str, Any]) -> bytes:
-    text = yaml.safe_dump(
+    text: str = yaml.safe_dump(
         dict(document),
         sort_keys=False,
         allow_unicode=True,
@@ -840,6 +973,7 @@ def _materialize_unit(
     *,
     payload_by_node: Mapping[str, SemanticPayloadBase],
     app_config_selection: RendererSelection | None,
+    workflow_interface_selection: RendererSelection | None,
     preserved_by_unit: Mapping[str, PreservedOpaqueArtifact],
     bundle_outputs: list[MaterializedOutput],
     external: list[str],
@@ -859,7 +993,16 @@ def _materialize_unit(
             raise MaterializationError(
                 f"render unit {unit.unit_id!r} must own exactly one composable output"
             )
-        if unit.family_kind in APP_CONFIG_FAMILIES:
+        if unit.family_kind == WORKFLOW_MODULE_INTERFACE:
+            if workflow_interface_selection is None:
+                raise WorkflowInterfaceMaterializationError("interface renderer selection was not resolved")
+            content = render_workflow_module_interface_unit(
+                unit=unit,
+                render_input=project_workflow_interface_render_input(
+                    unit=unit, payload_by_node=payload_by_node,
+                ),
+            )
+        elif unit.family_kind in APP_CONFIG_FAMILIES:
             if app_config_selection is None:
                 raise MaterializationError(
                     f"render unit {unit.unit_id!r} requires the resolved "
@@ -943,7 +1086,7 @@ def materialize_plan(
 ) -> MaterializedBundle:
     """Materialize every plan-authorized output for one CompilationPlan.
 
-    Renders exactly the renderer-ready page units through the bound accepted
+    Renders exactly the renderer-ready units through their bound accepted
     implementation, places exact preserved bytes for supplied
     ``preserve_unowned`` units, and reports every other unit's disposition
     explicitly. Canonical authority inputs are required and the submitted plan
@@ -972,6 +1115,16 @@ def materialize_plan(
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
+    workflow_interface_selection: RendererSelection | None = None
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind == WORKFLOW_MODULE_INTERFACE
+        and any(output.path_scope in _COMPOSABLE_PATH_SCOPES for output in unit.outputs)
+        for unit in verified_plan.units
+    ):
+        workflow_interface_selection = resolve_workflow_interface_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry,
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
 
     outputs: list[MaterializedOutput] = []
@@ -985,6 +1138,7 @@ def materialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=app_config_selection,
+            workflow_interface_selection=workflow_interface_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,
@@ -1081,6 +1235,16 @@ def rematerialize_plan(
         app_config_selection = resolve_app_config_renderer_selection(
             binding, graph=verified_graph, layout_registry=layout_registry
         )
+    workflow_interface_selection: RendererSelection | None = None
+    if any(
+        unit.disposition is PlanDisposition.RENDER
+        and unit.family_kind == WORKFLOW_MODULE_INTERFACE
+        and any(output.path_scope in _COMPOSABLE_PATH_SCOPES for output in unit.outputs)
+        for unit in verified_plan.units
+    ):
+        workflow_interface_selection = resolve_workflow_interface_renderer_selection(
+            binding, graph=verified_graph, layout_registry=layout_registry,
+        )
     preserved_by_unit = _match_preserved(verified_plan, preserved_artifacts)
     base_by_unit: dict[str, list[MaterializedOutput]] = {}
     for output in base_bundle.outputs:
@@ -1138,6 +1302,7 @@ def rematerialize_plan(
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=app_config_selection,
+            workflow_interface_selection=workflow_interface_selection,
             preserved_by_unit=preserved_by_unit,
             bundle_outputs=outputs,
             external=external,

--- a/mozaiksai/core/semantics/workflow_interface_materialization.py
+++ b/mozaiksai/core/semantics/workflow_interface_materialization.py
@@ -1,0 +1,319 @@
+"""Pure deterministic rendering of compiler-owned workflow module interfaces.
+
+Closed inputs are projected from a canonical plan unit by the materialization
+owner. This renderer adds only the ``mozaiks.module_interface.v2`` serialization
+shape. It reads no semantic graph, payload objects, filesystem, or runtime
+state. Row identity establishes the exact output shape; aggregate plan
+membership remains the canonical plan authority's responsibility.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+from mozaiksai.core.semantics.compilation_plan import (
+    FamilyInstancePlan,
+    PlanDisposition,
+    PlanEdgeSource,
+    PlanSource,
+    PlanSourceScope,
+    PlanTaxonomySource,
+    canonical_instance_identity_value,
+    canonical_instance_unit_id,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.decl_bytes import yaml_decl_bytes
+from mozaiksai.core.semantics.refs import SemanticsModel, validate_node_id_grammar
+from mozaiksai.core.taxonomy import SemanticCategory, validate_identifier_grammar
+
+WORKFLOW_MODULE_INTERFACE = "workflow_module_interface"
+WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID = "deterministic_workflow_interface_renderer"
+WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION = "1"
+MODULE_INTERFACE_SCHEMA_VERSION: Literal["mozaiks.module_interface.v2"] = (
+    "mozaiks.module_interface.v2"
+)
+
+
+class WorkflowInterfaceMaterializationError(ValueError):
+    """The unit or input violates the canonical interface renderer contract."""
+
+
+class _ActionBinding(SemanticsModel):
+    module_id: str
+    action_node_id: str
+
+    @field_validator("module_id")
+    @classmethod
+    def _module_id(cls, value: str) -> str:
+        return canonical_instance_identity_value(value)
+
+    @field_validator("action_node_id")
+    @classmethod
+    def _action_node_id(cls, value: str) -> str:
+        return validate_node_id_grammar(value)
+
+
+class RenderInputConsumesActionBinding(_ActionBinding):
+    role: Literal["consumes_action"] = "consumes_action"
+
+
+class RenderInputCommitsResultBinding(_ActionBinding):
+    role: Literal["commits_result_through_action"] = "commits_result_through_action"
+    workflow_result_id: str = Field(pattern=r"^[a-z][a-z0-9_]*$")
+
+
+class RenderInputTriggeredByEventBinding(SemanticsModel):
+    role: Literal["triggered_by_event"] = "triggered_by_event"
+    event_type: str
+
+    @field_validator("event_type")
+    @classmethod
+    def _event_type(cls, value: str) -> str:
+        return validate_identifier_grammar(SemanticCategory.EVENT, value)
+
+
+RenderInputWorkflowBinding = Annotated[
+    RenderInputConsumesActionBinding
+    | RenderInputCommitsResultBinding
+    | RenderInputTriggeredByEventBinding,
+    Field(discriminator="role"),
+]
+
+
+class RenderInputWorkflowResult(SemanticsModel):
+    result_id: str = Field(pattern=r"^[a-z][a-z0-9_]*$")
+    description: str | None = None
+
+
+class RenderInputWorkflowCapability(SemanticsModel):
+    capability_id: str
+    description: str | None = None
+    results: tuple[RenderInputWorkflowResult, ...] = ()
+    bindings: tuple[RenderInputWorkflowBinding, ...] = ()
+
+    @field_validator("capability_id")
+    @classmethod
+    def _capability_id(cls, value: str) -> str:
+        return validate_identifier_grammar(SemanticCategory.CAPABILITY, value)
+
+    @field_validator("results")
+    @classmethod
+    def _results(
+        cls, value: tuple[RenderInputWorkflowResult, ...]
+    ) -> tuple[RenderInputWorkflowResult, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.result_id))
+        if len({item.result_id for item in ordered}) != len(ordered):
+            raise ValueError("duplicate result identity in one capability")
+        return ordered
+
+    @field_validator("bindings")
+    @classmethod
+    def _bindings(
+        cls, value: tuple[RenderInputWorkflowBinding, ...]
+    ) -> tuple[RenderInputWorkflowBinding, ...]:
+        ordered = tuple(sorted(value, key=_binding_identity))
+        if len({_binding_identity(item) for item in ordered}) != len(ordered):
+            raise ValueError("duplicate capability binding identity")
+        return ordered
+
+    @model_validator(mode="after")
+    def _committed_results_owned(self) -> RenderInputWorkflowCapability:
+        result_ids = {item.result_id for item in self.results}
+        for binding in self.bindings:
+            if (
+                isinstance(binding, RenderInputCommitsResultBinding)
+                and binding.workflow_result_id not in result_ids
+            ):
+                raise ValueError("commit binding names a result outside its capability")
+        return self
+
+
+def _binding_identity(binding: RenderInputWorkflowBinding) -> tuple[str, ...]:
+    if isinstance(binding, RenderInputTriggeredByEventBinding):
+        return (binding.role, binding.event_type)
+    return (
+        binding.role,
+        binding.module_id,
+        binding.action_node_id,
+        binding.workflow_result_id
+        if isinstance(binding, RenderInputCommitsResultBinding)
+        else "",
+    )
+
+
+class WorkflowInterfaceRenderInput(SemanticsModel):
+    """Only interface facts and their exact three plan-pinned source sets."""
+
+    workflow_id: str
+    sources: tuple[PlanSource, ...] = Field(min_length=1)
+    edge_sources: tuple[PlanEdgeSource, ...] = ()
+    taxonomy_sources: tuple[PlanTaxonomySource, ...] = ()
+    capabilities: tuple[RenderInputWorkflowCapability, ...] = ()
+
+    @field_validator("workflow_id")
+    @classmethod
+    def _workflow_id(cls, value: str) -> str:
+        return canonical_instance_identity_value(value)
+
+    @field_validator("sources")
+    @classmethod
+    def _sources(cls, value: tuple[PlanSource, ...]) -> tuple[PlanSource, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.node_id))
+        if len({item.node_id for item in ordered}) != len(ordered):
+            raise ValueError("duplicate payload source identity")
+        return ordered
+
+    @field_validator("edge_sources")
+    @classmethod
+    def _edges(cls, value: tuple[PlanEdgeSource, ...]) -> tuple[PlanEdgeSource, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.edge_identity))
+        if len({item.edge_identity for item in ordered}) != len(ordered):
+            raise ValueError("duplicate edge source identity")
+        return ordered
+
+    @field_validator("taxonomy_sources")
+    @classmethod
+    def _taxonomy(
+        cls, value: tuple[PlanTaxonomySource, ...]
+    ) -> tuple[PlanTaxonomySource, ...]:
+        ordered = tuple(sorted(value, key=lambda item: (item.node_id, item.identifier)))
+        if any(item.category != SemanticCategory.EVENT.value for item in ordered):
+            raise ValueError("interface taxonomy sources must identify events only")
+        if len({item.node_id for item in ordered}) != len(ordered):
+            raise ValueError("duplicate event taxonomy source identity")
+        return ordered
+
+    @field_validator("capabilities")
+    @classmethod
+    def _capabilities(
+        cls, value: tuple[RenderInputWorkflowCapability, ...]
+    ) -> tuple[RenderInputWorkflowCapability, ...]:
+        ordered = tuple(sorted(value, key=lambda item: item.capability_id))
+        if len({item.capability_id for item in ordered}) != len(ordered):
+            raise ValueError("duplicate workflow capability identity")
+        return ordered
+
+    @model_validator(mode="after")
+    def _exact_trigger_identities(self) -> WorkflowInterfaceRenderInput:
+        triggers = {
+            binding.event_type
+            for capability in self.capabilities
+            for binding in capability.bindings
+            if isinstance(binding, RenderInputTriggeredByEventBinding)
+        }
+        if triggers != {item.identifier for item in self.taxonomy_sources}:
+            raise ValueError("trigger identities must equal the pinned event taxonomy set")
+        return self
+
+
+def _binding_document(binding: RenderInputWorkflowBinding) -> dict[str, object]:
+    if isinstance(binding, RenderInputTriggeredByEventBinding):
+        return {"role": binding.role, "event_type": binding.event_type}
+    result: dict[str, object] = {
+        "role": binding.role,
+        "module_id": binding.module_id,
+        "action_node_id": binding.action_node_id,
+    }
+    if isinstance(binding, RenderInputCommitsResultBinding):
+        result["workflow_result_id"] = binding.workflow_result_id
+    return result
+
+
+def render_workflow_module_interface_unit(
+    *, unit: FamilyInstancePlan, render_input: WorkflowInterfaceRenderInput
+) -> bytes:
+    """Render exactly one canonical interface unit shape, in either live row.
+
+    Resolve the row from the pinned digest first. Caller scope and path never
+    select an output profile. A complete alternate canonical twin is a valid
+    shape here; authorization to include it in a plan is checked upstream.
+    """
+    try:
+        unit = FamilyInstancePlan.model_validate(unit.model_dump(mode="json"))
+        render_input = WorkflowInterfaceRenderInput.model_validate(
+            render_input.model_dump(mode="json")
+        )
+    except ValueError as exc:
+        raise WorkflowInterfaceMaterializationError(
+            "interface unit or render input failed cold validation"
+        ) from exc
+
+    if (
+        unit.family_kind != WORKFLOW_MODULE_INTERFACE
+        or unit.disposition is not PlanDisposition.RENDER
+        or unit.source_scope is not PlanSourceScope.DECLARED
+        or unit.materializer != "workflow_interface_executor"
+    ):
+        raise WorkflowInterfaceMaterializationError("unit is not an active interface render unit")
+    rows = {
+        row.row_digest: row
+        for row in snapshot_layout_registry(build_app_layout_registry(())).rows
+        if row.kind == WORKFLOW_MODULE_INTERFACE
+    }
+    row = rows.get(unit.family_identity_digest)
+    if row is None:
+        raise WorkflowInterfaceMaterializationError("family digest names no canonical interface row")
+    if (
+        unit.materializer != row.materializer
+        or unit.disposition.value != row.disposition.value
+        or unit.validator != row.validator
+    ):
+        raise WorkflowInterfaceMaterializationError("unit does not match its row's renderer contract")
+    if len(unit.placeholder_values) != 1 or unit.placeholder_values[0][0] != "workflow_id":
+        raise WorkflowInterfaceMaterializationError("unit requires exactly the workflow_id placeholder")
+    workflow_id = canonical_instance_identity_value(unit.placeholder_values[0][1])
+    if unit.unit_id != canonical_instance_unit_id(row.kind, workflow_id, row.row_digest):
+        raise WorkflowInterfaceMaterializationError("unit id does not match its canonical row and instance")
+    if render_input.workflow_id != workflow_id:
+        raise WorkflowInterfaceMaterializationError("render input workflow_id differs from unit identity")
+    expected_path = row.path_template.replace("{workflow_id}", workflow_id)
+    if (
+        len(unit.outputs) != 1
+        or unit.outputs[0].path_scope != row.path_scope
+        or unit.outputs[0].path != expected_path
+    ):
+        raise WorkflowInterfaceMaterializationError("output differs from the exact canonical row expansion")
+    if (
+        render_input.sources != unit.sources
+        or render_input.edge_sources != unit.edge_sources
+        or render_input.taxonomy_sources != unit.taxonomy_sources
+    ):
+        raise WorkflowInterfaceMaterializationError("render input does not match the exact pinned source sets")
+
+    capabilities: list[dict[str, object]] = []
+    for capability in render_input.capabilities:
+        document: dict[str, object] = {"capability_id": capability.capability_id}
+        if capability.description is not None:
+            document["description"] = capability.description
+        document["results"] = [
+            result.model_dump(mode="json", exclude_none=True) for result in capability.results
+        ]
+        document["bindings"] = [_binding_document(binding) for binding in capability.bindings]
+        capabilities.append(document)
+    return yaml_decl_bytes(
+        {
+            "schema_version": MODULE_INTERFACE_SCHEMA_VERSION,
+            "workflow_id": workflow_id,
+            "capabilities": capabilities,
+        }
+    )
+
+
+__all__ = [
+    "MODULE_INTERFACE_SCHEMA_VERSION",
+    "WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID",
+    "WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION",
+    "WORKFLOW_MODULE_INTERFACE",
+    "RenderInputCommitsResultBinding",
+    "RenderInputConsumesActionBinding",
+    "RenderInputTriggeredByEventBinding",
+    "RenderInputWorkflowBinding",
+    "RenderInputWorkflowCapability",
+    "RenderInputWorkflowResult",
+    "WorkflowInterfaceMaterializationError",
+    "WorkflowInterfaceRenderInput",
+    "render_workflow_module_interface_unit",
+]

--- a/tests/fixtures/workflow_interface_pre_family_corpus.json
+++ b/tests/fixtures/workflow_interface_pre_family_corpus.json
@@ -1,0 +1,8651 @@
+{
+  "base_commit": "71c355a728a1470286d02f23eba666bfe93a5ff9",
+  "unit_count": 59,
+  "plan_digest": "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2",
+  "unit_proof_digest": "c27885233d404cf253c80ad6e4fb4f44309b444a4efe41eb80461e11c601d5ea",
+  "plan": {
+    "schema_version": "mozaiks.compilation_plan.v1",
+    "graph_id": "corpus-app",
+    "graph_version": 1,
+    "scope": {
+      "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+      "tenant_id": "tenant1",
+      "workspace_id": "ws1",
+      "pre_app_scope_id": null
+    },
+    "graph_digest": "19d4fa7f8db76e05a3710b58f5909ddb807ccb7ce37facb51e8278de2a19f86b",
+    "scope_selection": {
+      "app_manifest_scope": "app_bundle_root",
+      "module_scope": "app_bundle_root",
+      "workflow_manifest_scope": "workflow_relative"
+    },
+    "registry_schema_version": "mozaiks.app_layout.v2",
+    "registry_digest": "06ac7c5816119b7e79527f470cb7fbcec603d897a58245f15dda2629d197b479",
+    "assignment_contracts_digest": "632d2c5a70178c373d6f43ad3f92223c5908306caed048760faeb381af0a76a6",
+    "units": [
+      {
+        "unit_id": "app_auth_config/inactive/b36f0958330e",
+        "family_kind": "app_auth_config",
+        "family_identity_digest": "b36f0958330eb0192df936b8ea6fc6fb5ab4038fc0cf0f2e71b4fff28a89d74f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_brand_theme/inactive/d865e352a4bc",
+        "family_kind": "app_brand_theme",
+        "family_identity_digest": "d865e352a4bc5c73a82d9e28727fb4d335250f013c674ae911ff5e4e63d4a3ee",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_config/inactive/68893cd15ecb",
+        "family_kind": "app_config",
+        "family_identity_digest": "68893cd15ecbf22ded718c2fd10b6a418d4b21ea242092f5999c187ed658f291",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_data_contract/inactive/8fd54c2225fa",
+        "family_kind": "app_data_contract",
+        "family_identity_digest": "8fd54c2225fa1ba97dc8ff1cbb4c0484507826f8261d0ca6ce8be7a3a9abf038",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "data_contract_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/154d2d33f454",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "154d2d33f454e265941a511e0c83fbf8bb5e026dd3142df7d30448f441fa3e82",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "docker-compose.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/57a2326a5ec1",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "57a2326a5ec16e286a1ab007dbcd73f05dc9d3d367b6b05e1905855a301ba240",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/5a585f926ac7",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "5a585f926ac7a5520056aca2b8cbd46b41db97d44c63bad362f46533387ecc84",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/deploy.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/6cfdf3027bbd",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "6cfdf3027bbd80327d0e8d94ad1ea015068ac3ab6006f77f4116a544cc003ae9",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.staging.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/a1b49ffd1ad2",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "a1b49ffd1ad25d9c1ff074d233c7c9f440135916f0e32c4da4745c5577deacb5",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/readiness.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/aef13c0b3f9f",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "aef13c0b3f9f39f01de0b336036c77e7c75b4773c8ee69cc29abe85c212b9c60",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.production.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/e23909e6ac70",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "e23909e6ac70dd6ff00e76121df336d5014738fe6f1e7f038dc902f52ba1e0e0",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "deployment.manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_deployment_artifact/fbea3fe3ef11",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "fbea3fe3ef115f8ad2ce264a3d41b6bbf0e7d4cbc7c9eec64e04fbcd6314cc3f",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "Dockerfile"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_integrations_config/inactive/220f7104547e",
+        "family_kind": "app_integrations_config",
+        "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_manifest/scope_inactive/ccaefd92a7d0",
+        "family_kind": "app_manifest",
+        "family_identity_digest": "ccaefd92a7d0d437aa4ef0fe4f1c8efdbf217d0583ac0e446ae053243c93af69",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_service_adapter/inactive/5255a858ebb1",
+        "family_kind": "app_service_adapter",
+        "family_identity_digest": "5255a858ebb112044b558a9e375b9878c65a2bd58cf65324f1acb43b5a6cd9d8",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_service_integration_client/inactive/20b0da544328",
+        "family_kind": "app_service_integration_client",
+        "family_identity_digest": "20b0da544328c991721e5073c59d5f0535300835b35d20d90d88cd3509e73215",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_shell_config/inactive/b478c2fb6bf2",
+        "family_kind": "app_shell_config",
+        "family_identity_digest": "b478c2fb6bf20480f1c228f9638c4ffb6e2dd3bd931e2126ee50566a7cb6325b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_auth_adapter/inactive/1f333550e5b7",
+        "family_kind": "app_ui_auth_adapter",
+        "family_identity_digest": "1f333550e5b77c3c6c05c14e42f0d346ec5614e093bb2f83997a40f684006922",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_custom_route/inactive/fe6837585ad2",
+        "family_kind": "app_ui_custom_route",
+        "family_identity_digest": "fe6837585ad2d2c082a7773c7ee32af1aabca647e4da540b238afb892e114cbd",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_extension_barrel/inactive/3b8717b40db0",
+        "family_kind": "app_ui_extension_barrel",
+        "family_identity_digest": "3b8717b40db02f7c0640a7a9868d35effedd1841b876e89f882107ba452ca809",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_module_api/inactive/8c36e8fa7ab1",
+        "family_kind": "app_ui_module_api",
+        "family_identity_digest": "8c36e8fa7ab1555d8e1294a3d1bd0b41cf4a4e197d9c57d93549f61f4f78321e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_page_schema/home/484a8be83170",
+        "family_kind": "app_ui_page_schema",
+        "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "page_id",
+            "home"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/pages/home.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          },
+          {
+            "node_id": "mozaiks.section.hero",
+            "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+          },
+          {
+            "node_id": "mozaiks.section.pricing",
+            "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+          }
+        ],
+        "edge_sources": [
+          {
+            "kind": "renders",
+            "source_node_id": "mozaiks.page.home",
+            "target_node_id": "mozaiks.section.hero",
+            "discriminator": null,
+            "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+          }
+        ],
+        "depends_on_units": [],
+        "materializer": "page_schema_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "app_ui_route_manifest/eacaaede41e7",
+        "family_kind": "app_ui_route_manifest",
+        "family_identity_digest": "eacaaede41e7e2cea936d8a13169abddf7f13a38cfac8beae25f0d4f17875470",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/route_manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.application.corpus",
+            "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+          },
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2",
+          "app_ui_page_schema/home/484a8be83170"
+        ],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_manifest/scope_inactive/279ac515333f",
+        "family_kind": "module_manifest",
+        "family_identity_digest": "279ac515333fc9f73a4740fc21f1f0b1ac7239f2b73bb8b05b23749f270c0b93",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_admin_ui/scope_inactive/8d674ce88e7b",
+        "family_kind": "module_admin_ui",
+        "family_identity_digest": "8d674ce88e7bfd8177d2975a9b94a4cac8ea834a6aaafdd43c453d12c28c7f89",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_api/scope_inactive/48775ee49e02",
+        "family_kind": "module_backend_api",
+        "family_identity_digest": "48775ee49e02919e5e5330c6addb6a4791dbb12289db7ac68a0b0c11cc446972",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_handler/scope_inactive/278888e52105",
+        "family_kind": "module_backend_handler",
+        "family_identity_digest": "278888e52105c415852a68ea2e54ad8e8084a07fea0501635ae8f4b49b71f547",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_helper/scope_inactive/e48e56151cc9",
+        "family_kind": "module_backend_helper",
+        "family_identity_digest": "e48e56151cc9013cb15e435486b5ddee5a398f8104e73bf93d7d2550934bc7bb",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_policy/scope_inactive/ea644d66e48f",
+        "family_kind": "module_backend_policy",
+        "family_identity_digest": "ea644d66e48fbc8dccb8fa5c7777fedaaae2502659a41bfe95cfe47620d7ae74",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_repo/scope_inactive/7abbd7c446d8",
+        "family_kind": "module_backend_repo",
+        "family_identity_digest": "7abbd7c446d8d86a2f15d62063261a744486db52785d9de76ae0d6d6dff1b973",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_schemas/scope_inactive/ee4c9ca15382",
+        "family_kind": "module_backend_schemas",
+        "family_identity_digest": "ee4c9ca15382f4d3b4a56b293f060b60c1104bf7213e8ab274b2a7eb1f2495a6",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_backend_service/scope_inactive/4b723cc8e42f",
+        "family_kind": "module_backend_service",
+        "family_identity_digest": "4b723cc8e42f31c970091154e4e525fdac0de4f1fc51c636dbd089cd7a5b1ac5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/4942d8b24b09",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4942d8b24b093b2d05f3abf7792d440717f1e9977aefc25764239e7e20f41586",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/4d2a2094772a",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4d2a2094772a4df11241f3711f247956adf9f4cc277c6148a27e0ea27e1ef770",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/85b47855fd4e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "85b47855fd4e823515d23b6ba9d75dbd1020587f782a6715b51a67ccd330a524",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/a1687bc81fe1",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a1687bc81fe195f03f9a9a41cfb12b2882fc1fecc2e6371a8606fd8488f1f7b5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/a21d5505ff45",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a21d5505ff45b3a55a5fbdb2a151559154a496fb5c3e85b88b9271de9ae91308",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/a48fecc11d86",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a48fecc11d866572729fc56cdb0a9b28057458f07d683b1bb562b066e1f43a1d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/aeecad8bb43e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "aeecad8bb43e9cb01f9246469dbd405ad733d4e7e377b12ee92f05ada8063a50",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/b55afdbaff33",
+        "family_kind": "module_contract",
+        "family_identity_digest": "b55afdbaff339932334e060af7ec25979550e85dd36f098fb49dd1d97aa1f266",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/c9473422a77f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "c9473422a77f036ff82e74a55dcf90c1bce6d28318186c3cccf77653695bc532",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_contract/scope_inactive/d9e60834b12f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "d9e60834b12f46dcc5b3ceed00dbc1402cf182c4f516d28ae480954cfa9ca7d2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_runtime_extensions/scope_inactive/bfc0133e6423",
+        "family_kind": "module_runtime_extensions",
+        "family_identity_digest": "bfc0133e64233af3f2efc868e017b426040d048ddfccdb0916fc963618857415",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "module_ui_extension_barrel/scope_inactive/482787d9c463",
+        "family_kind": "module_ui_extension_barrel",
+        "family_identity_digest": "482787d9c4638dbaebad59a0801e9ef20c9fc6330b7c56a6cc7e32c54bb28881",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/163752fc4dfe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "163752fc4dfe6d2b8167aad2f5d2475d412f888c4a93a7f23004a3e860d2a588",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/1f569d14a264",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "1f569d14a2642f6b7c1ff90486878fdf2458280b7b2eefba193c2a92a27f1f75",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/4fc9cf284272",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "4fc9cf284272c5bb8a1f80e42c341c3bab47ba6dec7b20a082112e69c5a860c7",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/682230fcc806",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "682230fcc806b9f05d1902394da0175ac5e469b255f13a91b67b1f690480549e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/6eeceb7bafea",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "6eeceb7bafeaa71d5d3e01177d501f25c57678cf457763ca9a86e31ade48a01b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/955a937781bc",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "955a937781bc8410097f60ddd9dae2b68df7718c7284da1d4c0df9cb358cb8ac",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/95a3ed11bcf2",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "95a3ed11bcf25674f8674f8d0c300893e8965685c73075cdb4f64ca08d4b341d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/ae4a42449842",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "ae4a424498426fdb8efa548956066c043b740d2a3d915281f1117f04660cb464",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/b6b6963d7d3c",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "b6b6963d7d3c5b59d409b2f9e65cd56678c4d3ea86b24ce205b7fbf82d9cb7f2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/d7189ed94db1",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "d7189ed94db10efc3b0f8b6331b09987c6f123acc2c3fe3724770d13148ef0c1",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/f3ee3a94b981",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f3ee3a94b981e733e0f0f5e5c5afe4066af1f14b3ae5b734141032b1ee9b45ba",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/f75e58857dbe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f75e58857dbee2bb579b298571d15c9c4a4fceea9f293d556bd5370826134808",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "prohibited_legacy/prohibited/fdedcfc8ed5b",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "fdedcfc8ed5beb28c62daa023c201d8a8df5f772f2a7d67aa1cda572760dc719",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "workflow_manifest/scope_inactive/b54cc58cd6af",
+        "family_kind": "workflow_manifest",
+        "family_identity_digest": "b54cc58cd6af598f48d11429afd072689e2755b4dd747283985db346ebefd94f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "workflow_generator",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      {
+        "unit_id": "workflow_task_batch/digest/685d2783ce17",
+        "family_kind": "workflow_task_batch",
+        "family_identity_digest": "685d2783ce17e6cebe3096f8127ea428fe1e9c14b0512e0fd880fbf1c1fe9f1e",
+        "disposition": "input_only",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "workflow_id",
+            "digest"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "workflow_relative",
+            "path": "extended_orchestration/task_batches.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.workflow.digest",
+            "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "workflow_manifest/scope_inactive/b54cc58cd6af"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      }
+    ],
+    "gaps": [
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "app_admin_registry",
+        "path_template": "admin/admin_registry.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_backend_support",
+        "path_template": "backend/admin_config.py",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_config",
+        "path_template": "config/ai.json",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "app_dashboard",
+        "path_template": "dashboard/dashboard.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_data_migration",
+        "path_template": "data/migrations/{migration_id}.json",
+        "subject": "when_migration_declared",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "app_framework_metadata",
+        "path_template": ".mozaiks/pack_provenance.json",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_manifest",
+        "path_template": "app.json",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "app_provenance",
+        "path_template": "provenance.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_refinement_harness",
+        "path_template": "refinement_harness/config/harness.yaml",
+        "subject": "when_refinement_harness_required",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_refinement_harness",
+        "path_template": "refinement_harness/config/policies.yaml",
+        "subject": "when_refinement_harness_required",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_refinement_harness",
+        "path_template": "refinement_harness/config/tools.yaml",
+        "subject": "when_refinement_harness_required",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_refinement_harness",
+        "path_template": "refinement_harness/prompts/{pack_id}.yaml",
+        "subject": "when_refinement_harness_required",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_refinement_policy",
+        "path_template": "config/refinement_policy.yaml",
+        "subject": "when_refinement_harness_required",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "__init__.py",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "index.html",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "package-lock.json",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "package.json",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "pnpm-lock.yaml",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "pyproject.toml",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "requirements.txt",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "tsconfig.json",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "vite.config.js",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "vite.config.ts",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_root_support",
+        "path_template": "yarn.lock",
+        "subject": "when_runtime_support_selected",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_secret_references",
+        "path_template": "security/secrets.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "app_service_route",
+        "path_template": "services/routes/{pack_id}.py",
+        "subject": "when_app_route_extension_declared",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_service_support",
+        "path_template": "services/config.py",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "app_subscription_config",
+        "path_template": "config/subscriptions.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "app_targets_config",
+        "path_template": "config/targets.json",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "placeholder_underivable",
+        "family_kind": "generated_app_staging",
+        "path_template": "generated/apps/{app_id}/{build_id}/app/app.json",
+        "subject": "app_id__build_id",
+        "adr_slice": 4
+      },
+      {
+        "code": "placeholder_underivable",
+        "family_kind": "generated_app_staging",
+        "path_template": "generated/apps/{app_id}/{build_id}/app/modules/{module_id}/module.yaml",
+        "subject": "app_id__build_id",
+        "adr_slice": 4
+      },
+      {
+        "code": "placeholder_underivable",
+        "family_kind": "generated_workflow_staging",
+        "path_template": "generated/workflows/{app_id}/{build_id}/{workflow_id}/orchestrator.yaml",
+        "subject": "app_id__build_id",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "module_admin_ui",
+        "path_template": "modules/{module_id}/ui/admin/{page_id}.jsx",
+        "subject": "when_module_admin_page_declared",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_backend_api",
+        "path_template": "modules/{module_id}/backend/api.py",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_backend_base_handler",
+        "path_template": "modules/{module_id}/backend/base_handler.py",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_backend_handler",
+        "path_template": "modules/{module_id}/backend/handler.py",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "module_backend_helper",
+        "path_template": "modules/{module_id}/backend/{helper_id}.py",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "module_backend_policy",
+        "path_template": "modules/{module_id}/backend/policy.py",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "module_backend_repo",
+        "path_template": "modules/{module_id}/backend/repo.py",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "module_backend_schemas",
+        "path_template": "modules/{module_id}/backend/schemas.py",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "module_backend_service",
+        "path_template": "modules/{module_id}/backend/service.py",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/admin.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/commercial.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/events.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/notifications.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/policy_hooks.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/profile.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/reactions.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/relationships.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/service.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_contract",
+        "path_template": "modules/{module_id}/contracts/settings.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_manifest",
+        "path_template": "modules/{module_id}/module.yaml",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_undeclared",
+        "family_kind": "module_runtime_extensions",
+        "path_template": "modules/{module_id}/runtime_extensions.yaml",
+        "subject": null,
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "module_ui_extension_barrel",
+        "path_template": "modules/{module_id}/ui/index.js",
+        "subject": "reports",
+        "adr_slice": 4
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "workflow_config",
+        "path_template": "agents.yaml",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_config",
+        "path_template": "context_variables.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_config",
+        "path_template": "middleware.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "output_contract_unresolved",
+        "family_kind": "workflow_config",
+        "path_template": "structured_outputs.yaml",
+        "subject": null,
+        "adr_slice": 5
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_config",
+        "path_template": "tools.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_config",
+        "path_template": "transition_graph.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_config",
+        "path_template": "ui_config.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "renderer_input_incomplete",
+        "family_kind": "workflow_manifest",
+        "path_template": "orchestrator.yaml",
+        "subject": "digest",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "workflow_tool",
+        "path_template": "tools/{tool_id}.py",
+        "subject": "when_workflow_tool_declared",
+        "adr_slice": 4
+      },
+      {
+        "code": "binding_condition_deferred",
+        "family_kind": "workflow_ui",
+        "path_template": "ui/{workflow_id}/{component_id}.jsx",
+        "subject": "when_workflow_component_declared",
+        "adr_slice": 4
+      }
+    ],
+    "plan_digest": "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2"
+  },
+  "registry_snapshot": {
+    "registry_schema_version": "mozaiks.app_layout.v2",
+    "rows": [
+      {
+        "kind": "app_admin_registry",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "admin/admin_registry.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_auth_config",
+        "owner": "platform",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_auth_enabled",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/auth.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_backend_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "backend/admin_config.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_brand_theme",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_theme_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "brand/theme_config.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_config",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/ai.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "app_config",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_assets_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/asset_manifest.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "app_dashboard",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "dashboard/dashboard.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_data_contract",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_data_contract_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "data/contract.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "persistence_contract"
+        ],
+        "validator": "data_contract_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "data_alias",
+          "data_collection",
+          "module"
+        ]
+      },
+      {
+        "kind": "app_data_migration",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_migration_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "data/migrations/{migration_id}.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "data_contract_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.production.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.staging.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".github/workflows/deploy.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".github/workflows/readiness.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "Dockerfile",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "deployment.manifest.json",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "docker-compose.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      {
+        "kind": "app_framework_metadata",
+        "owner": "factory",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": ".mozaiks/pack_provenance.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "provenance_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_integrations_config",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_integrations_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/integrations.yaml",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      {
+        "kind": "app_manifest",
+        "owner": "platform",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "always",
+        "path_scope": "app_bundle_root",
+        "path_template": "app.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_manifest",
+        "owner": "platform",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "always",
+        "path_scope": "workspace_root",
+        "path_template": "app/app.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_provenance",
+        "owner": "factory",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "provenance.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "provenance_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_refinement_harness",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_refinement_harness_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "refinement_harness/config/harness.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "refinement_harness"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_refinement_harness",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_refinement_harness_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "refinement_harness/config/policies.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "refinement_harness"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_refinement_harness",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_refinement_harness_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "refinement_harness/config/tools.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "refinement_harness"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_refinement_harness",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_refinement_harness_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "refinement_harness/prompts/{pack_id}.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "refinement_harness"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_refinement_policy",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_refinement_harness_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/refinement_policy.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "refinement_harness"
+        ],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "__init__.py",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "index.html",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "package-lock.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "package.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "pnpm-lock.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "pyproject.toml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "requirements.txt",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "tsconfig.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "vite.config.js",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "vite.config.ts",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_root_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_runtime_support_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "yarn.lock",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_secret_references",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "security/secrets.yaml",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      {
+        "kind": "app_service_adapter",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_owned_integration_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/adapters/{adapter_area}/{pack_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "integration_adapter_implementation",
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      {
+        "kind": "app_service_integration_client",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_managed_capability_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/integrations/{pack_id}_client.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface",
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      {
+        "kind": "app_service_route",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_route_extension_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/routes/{pack_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "api_surface",
+          "app_route_extension_implementation",
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "artifact_declaration"
+        ]
+      },
+      {
+        "kind": "app_service_support",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/config.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      {
+        "kind": "app_shell_config",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_shell_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/shell.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_subscription_config",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_subscriptions_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/subscriptions.yaml",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "subscription_config"
+        ],
+        "validator": "subscriptions_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "capability",
+          "limit",
+          "meter",
+          "plan",
+          "product"
+        ]
+      },
+      {
+        "kind": "app_targets_config",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/targets.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "app_ui_auth_adapter",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_auth_enabled",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/auth/authAdapter.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "auth"
+        ]
+      },
+      {
+        "kind": "app_ui_custom_route",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/pages/custom/{page_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "custom_page_implementation",
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "page"
+        ]
+      },
+      {
+        "kind": "app_ui_extension_barrel",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/index.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "app_ui_custom_route"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "page"
+        ]
+      },
+      {
+        "kind": "app_ui_module_api",
+        "owner": "platform",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/lib/moduleApi.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      {
+        "kind": "app_ui_page_schema",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_page_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/pages/{page_id}.yaml",
+        "materializer": "page_schema_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "page",
+          "section",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "app_ui_route_manifest",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/route_manifest.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "app_ui_custom_route",
+          "app_ui_page_schema"
+        ],
+        "semantic_input_kinds": [
+          "application",
+          "page"
+        ]
+      },
+      {
+        "kind": "generated_app_staging",
+        "owner": "factory",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_generated_staging_selected",
+        "path_scope": "generated_staging",
+        "path_template": "generated/apps/{app_id}/{build_id}/app/app.json",
+        "materializer": "app_generator",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "generated_app_staging",
+        "owner": "factory",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_generated_staging_selected",
+        "path_scope": "generated_staging",
+        "path_template": "generated/apps/{app_id}/{build_id}/app/modules/{module_id}/module.yaml",
+        "materializer": "app_generator",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "generated_workflow_staging",
+        "owner": "factory",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_generated_staging_selected",
+        "path_scope": "generated_staging",
+        "path_template": "generated/workflows/{app_id}/{build_id}/{workflow_id}/orchestrator.yaml",
+        "materializer": "app_generator",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "module_manifest",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/module.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_manifest",
+        "owner": "module",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "module.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "permission"
+        ]
+      },
+      {
+        "kind": "module_admin_ui",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_admin_page_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/ui/admin/{page_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_admin_page_implementation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      {
+        "kind": "module_admin_ui",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_admin_page_declared",
+        "path_scope": "module_relative",
+        "path_template": "ui/admin/{page_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_admin_page_implementation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      {
+        "kind": "module_backend_api",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/api.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_api",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/api.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_base_handler",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/base_handler.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_handler",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/handler.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "business_services"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_handler",
+        "owner": "module",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/handler.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "business_services"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_helper",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_helper_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/{helper_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_helper_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module"
+        ]
+      },
+      {
+        "kind": "module_backend_helper",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_helper_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/{helper_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_helper_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module"
+        ]
+      },
+      {
+        "kind": "module_backend_policy",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/policy.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_policy",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/policy.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_repo",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/repo.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_repo",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/repo.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_schemas",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/schemas.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "data_models",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_schemas",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/schemas.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "data_models",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_service",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/service.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_backend_service",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/service.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/admin.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/commercial.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/events.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/notifications.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/policy_hooks.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/profile.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/reactions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/relationships.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/service.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/settings.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/admin.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/commercial.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/events.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/notifications.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/policy_hooks.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/profile.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/reactions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/relationships.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/service.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/settings.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      {
+        "kind": "module_runtime_extensions",
+        "owner": "module",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_module_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/runtime_extensions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "module_runtime_extensions",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "runtime_extensions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "module_ui_extension_barrel",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/ui/index.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      {
+        "kind": "module_ui_extension_barrel",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_admin_page_declared",
+        "path_scope": "module_relative",
+        "path_template": "ui/index.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/data.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/data_migrations/{migration_id}.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/llm.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/secrets.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "control_plane/{extension_id}.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/database/schema.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/database/seed.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/models.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/models/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/subscriptions.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/data/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/security/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "module_relative",
+        "path_template": "contracts/subscriptions.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "workflow_manifest",
+        "owner": "workflow",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "orchestrator.yaml",
+        "materializer": "workflow_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_manifest",
+        "owner": "workflow",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_workflow_declared",
+        "path_scope": "workspace_root",
+        "path_template": "workflows/{workflow_id}/orchestrator.yaml",
+        "materializer": "workflow_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "agents.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "workflow_participant_implementation"
+        ],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "context_variables.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "middleware.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "structured_outputs.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "workflow_structured_models_implementation"
+        ],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "tools.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "transition_graph.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_config",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_workflow_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "ui_config.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_task_batch",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "extended_orchestration/task_batches.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "input_only",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": []
+      },
+      {
+        "kind": "workflow_tool",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_workflow_tool_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "tools/{tool_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "workflow_tool_implementation"
+        ],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "workflow"
+        ]
+      },
+      {
+        "kind": "workflow_ui",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_workflow_component_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "ui/{workflow_id}/{component_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "workflow_ui_implementation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "workflow"
+        ]
+      }
+    ],
+    "snapshot_digest": "06ac7c5816119b7e79527f470cb7fbcec603d897a58245f15dda2629d197b479"
+  },
+  "units": [
+    {
+      "unit_id": "app_auth_config/inactive/b36f0958330e",
+      "canonical_layout_row": {
+        "kind": "app_auth_config",
+        "owner": "platform",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_auth_enabled",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/auth.yaml",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "auth"
+        ]
+      },
+      "family_identity_digest": "b36f0958330eb0192df936b8ea6fc6fb5ab4038fc0cf0f2e71b4fff28a89d74f",
+      "identity_payload": {
+        "unit_id": "app_auth_config/inactive/b36f0958330e",
+        "family_kind": "app_auth_config",
+        "family_identity_digest": "b36f0958330eb0192df936b8ea6fc6fb5ab4038fc0cf0f2e71b4fff28a89d74f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_auth_config/inactive/b36f0958330e",
+        "family_kind": "app_auth_config",
+        "family_identity_digest": "b36f0958330eb0192df936b8ea6fc6fb5ab4038fc0cf0f2e71b4fff28a89d74f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_auth_config/inactive/b36f0958330e\",\"family_kind\":\"app_auth_config\",\"family_identity_digest\":\"b36f0958330eb0192df936b8ea6fc6fb5ab4038fc0cf0f2e71b4fff28a89d74f\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_generator\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "7c3f6e78cbec286e3fc2327de63a2b66a77ce96ff1cbc0bbc30a4daf35e6564d",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_brand_theme/inactive/d865e352a4bc",
+      "canonical_layout_row": {
+        "kind": "app_brand_theme",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_theme_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "brand/theme_config.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "d865e352a4bc5c73a82d9e28727fb4d335250f013c674ae911ff5e4e63d4a3ee",
+      "identity_payload": {
+        "unit_id": "app_brand_theme/inactive/d865e352a4bc",
+        "family_kind": "app_brand_theme",
+        "family_identity_digest": "d865e352a4bc5c73a82d9e28727fb4d335250f013c674ae911ff5e4e63d4a3ee",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_brand_theme/inactive/d865e352a4bc",
+        "family_kind": "app_brand_theme",
+        "family_identity_digest": "d865e352a4bc5c73a82d9e28727fb4d335250f013c674ae911ff5e4e63d4a3ee",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_brand_theme/inactive/d865e352a4bc\",\"family_kind\":\"app_brand_theme\",\"family_identity_digest\":\"d865e352a4bc5c73a82d9e28727fb4d335250f013c674ae911ff5e4e63d4a3ee\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_generator\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "1e48985605e3778770a19bcca532ecc70611d75e3fca069f222c784af5307c07",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_config/inactive/68893cd15ecb",
+      "canonical_layout_row": {
+        "kind": "app_config",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_assets_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/asset_manifest.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "workflow"
+        ]
+      },
+      "family_identity_digest": "68893cd15ecbf22ded718c2fd10b6a418d4b21ea242092f5999c187ed658f291",
+      "identity_payload": {
+        "unit_id": "app_config/inactive/68893cd15ecb",
+        "family_kind": "app_config",
+        "family_identity_digest": "68893cd15ecbf22ded718c2fd10b6a418d4b21ea242092f5999c187ed658f291",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_config/inactive/68893cd15ecb",
+        "family_kind": "app_config",
+        "family_identity_digest": "68893cd15ecbf22ded718c2fd10b6a418d4b21ea242092f5999c187ed658f291",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_config/inactive/68893cd15ecb\",\"family_kind\":\"app_config\",\"family_identity_digest\":\"68893cd15ecbf22ded718c2fd10b6a418d4b21ea242092f5999c187ed658f291\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "b2ce07df9edf3496bdb8b3b6fb6bd6ba1b93c1ea150153c70337655f95841590",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_data_contract/inactive/8fd54c2225fa",
+      "canonical_layout_row": {
+        "kind": "app_data_contract",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_data_contract_required",
+        "path_scope": "app_bundle_root",
+        "path_template": "data/contract.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "persistence_contract"
+        ],
+        "validator": "data_contract_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "data_alias",
+          "data_collection",
+          "module"
+        ]
+      },
+      "family_identity_digest": "8fd54c2225fa1ba97dc8ff1cbb4c0484507826f8261d0ca6ce8be7a3a9abf038",
+      "identity_payload": {
+        "unit_id": "app_data_contract/inactive/8fd54c2225fa",
+        "family_kind": "app_data_contract",
+        "family_identity_digest": "8fd54c2225fa1ba97dc8ff1cbb4c0484507826f8261d0ca6ce8be7a3a9abf038",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "data_contract_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_data_contract/inactive/8fd54c2225fa",
+        "family_kind": "app_data_contract",
+        "family_identity_digest": "8fd54c2225fa1ba97dc8ff1cbb4c0484507826f8261d0ca6ce8be7a3a9abf038",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "data_contract_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_data_contract/inactive/8fd54c2225fa\",\"family_kind\":\"app_data_contract\",\"family_identity_digest\":\"8fd54c2225fa1ba97dc8ff1cbb4c0484507826f8261d0ca6ce8be7a3a9abf038\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"data_contract_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "72ce4d408bf013efc07d3647b4e46769ea9a1e289e7953cd749d3e18079a2b66",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/154d2d33f454",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "docker-compose.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "154d2d33f454e265941a511e0c83fbf8bb5e026dd3142df7d30448f441fa3e82",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/154d2d33f454",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "154d2d33f454e265941a511e0c83fbf8bb5e026dd3142df7d30448f441fa3e82",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "docker-compose.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/154d2d33f454",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "154d2d33f454e265941a511e0c83fbf8bb5e026dd3142df7d30448f441fa3e82",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "docker-compose.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/154d2d33f454\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"154d2d33f454e265941a511e0c83fbf8bb5e026dd3142df7d30448f441fa3e82\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\"docker-compose.yml\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "5b6701ad8bdacd69f94d350eacb1df18bee805d95503344d43bfe7def6e2d316",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": "docker-compose.yml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/57a2326a5ec1",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "57a2326a5ec16e286a1ab007dbcd73f05dc9d3d367b6b05e1905855a301ba240",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/57a2326a5ec1",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "57a2326a5ec16e286a1ab007dbcd73f05dc9d3d367b6b05e1905855a301ba240",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/57a2326a5ec1",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "57a2326a5ec16e286a1ab007dbcd73f05dc9d3d367b6b05e1905855a301ba240",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/57a2326a5ec1\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"57a2326a5ec16e286a1ab007dbcd73f05dc9d3d367b6b05e1905855a301ba240\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\".env.example\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "d510239e1ca3b56f0aed786d99d1f74de02b47112cd38eaf752d950080608ccb",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": ".env.example"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/5a585f926ac7",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".github/workflows/deploy.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "5a585f926ac7a5520056aca2b8cbd46b41db97d44c63bad362f46533387ecc84",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/5a585f926ac7",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "5a585f926ac7a5520056aca2b8cbd46b41db97d44c63bad362f46533387ecc84",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/deploy.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/5a585f926ac7",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "5a585f926ac7a5520056aca2b8cbd46b41db97d44c63bad362f46533387ecc84",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/deploy.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/5a585f926ac7\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"5a585f926ac7a5520056aca2b8cbd46b41db97d44c63bad362f46533387ecc84\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\".github/workflows/deploy.yml\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "331b759f33efec3e839c2866d6b17567915d64083c98c709500d96e44df262cb",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": ".github/workflows/deploy.yml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/6cfdf3027bbd",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.staging.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "6cfdf3027bbd80327d0e8d94ad1ea015068ac3ab6006f77f4116a544cc003ae9",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/6cfdf3027bbd",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "6cfdf3027bbd80327d0e8d94ad1ea015068ac3ab6006f77f4116a544cc003ae9",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.staging.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/6cfdf3027bbd",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "6cfdf3027bbd80327d0e8d94ad1ea015068ac3ab6006f77f4116a544cc003ae9",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.staging.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/6cfdf3027bbd\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"6cfdf3027bbd80327d0e8d94ad1ea015068ac3ab6006f77f4116a544cc003ae9\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\".env.staging.example\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "4bc83e6a1de84771c503869b0792543ecfefd39eb003fa9b80b96e5de86f27f4",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": ".env.staging.example"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/a1b49ffd1ad2",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".github/workflows/readiness.yml",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "a1b49ffd1ad25d9c1ff074d233c7c9f440135916f0e32c4da4745c5577deacb5",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/a1b49ffd1ad2",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "a1b49ffd1ad25d9c1ff074d233c7c9f440135916f0e32c4da4745c5577deacb5",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/readiness.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/a1b49ffd1ad2",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "a1b49ffd1ad25d9c1ff074d233c7c9f440135916f0e32c4da4745c5577deacb5",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".github/workflows/readiness.yml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/a1b49ffd1ad2\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"a1b49ffd1ad25d9c1ff074d233c7c9f440135916f0e32c4da4745c5577deacb5\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\".github/workflows/readiness.yml\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "5b518cd6f8a141b5872d192fe7fa53c57bba62a4831e74caf3824582f4faf949",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": ".github/workflows/readiness.yml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/aef13c0b3f9f",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": ".env.production.example",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "aef13c0b3f9f39f01de0b336036c77e7c75b4773c8ee69cc29abe85c212b9c60",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/aef13c0b3f9f",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "aef13c0b3f9f39f01de0b336036c77e7c75b4773c8ee69cc29abe85c212b9c60",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.production.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/aef13c0b3f9f",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "aef13c0b3f9f39f01de0b336036c77e7c75b4773c8ee69cc29abe85c212b9c60",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": ".env.production.example"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/aef13c0b3f9f\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"aef13c0b3f9f39f01de0b336036c77e7c75b4773c8ee69cc29abe85c212b9c60\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\".env.production.example\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "c19f3550b17bb9974c3389b98b2b4c36030146fdf7062144add35c7072f12765",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": ".env.production.example"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/e23909e6ac70",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "deployment.manifest.json",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "e23909e6ac70dd6ff00e76121df336d5014738fe6f1e7f038dc902f52ba1e0e0",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/e23909e6ac70",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "e23909e6ac70dd6ff00e76121df336d5014738fe6f1e7f038dc902f52ba1e0e0",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "deployment.manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/e23909e6ac70",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "e23909e6ac70dd6ff00e76121df336d5014738fe6f1e7f038dc902f52ba1e0e0",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "deployment.manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/e23909e6ac70\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"e23909e6ac70dd6ff00e76121df336d5014738fe6f1e7f038dc902f52ba1e0e0\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\"deployment.manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "533d72f8e1cf894bbcd70521c904966c3d459be7e98eff48275835f1391bc49f",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": "deployment.manifest.json"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_deployment_artifact/fbea3fe3ef11",
+      "canonical_layout_row": {
+        "kind": "app_deployment_artifact",
+        "owner": "download_renderer",
+        "requirement": "generated",
+        "multiplicity": "single",
+        "condition": "when_deployment_export_requested",
+        "path_scope": "deployment_derived",
+        "path_template": "Dockerfile",
+        "materializer": "download_deployment_renderer",
+        "disposition": "external_handoff",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "deployment_target"
+        ]
+      },
+      "family_identity_digest": "fbea3fe3ef115f8ad2ce264a3d41b6bbf0e7d4cbc7c9eec64e04fbcd6314cc3f",
+      "identity_payload": {
+        "unit_id": "app_deployment_artifact/fbea3fe3ef11",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "fbea3fe3ef115f8ad2ce264a3d41b6bbf0e7d4cbc7c9eec64e04fbcd6314cc3f",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "Dockerfile"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_deployment_artifact/fbea3fe3ef11",
+        "family_kind": "app_deployment_artifact",
+        "family_identity_digest": "fbea3fe3ef115f8ad2ce264a3d41b6bbf0e7d4cbc7c9eec64e04fbcd6314cc3f",
+        "disposition": "external_handoff",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "deployment_derived",
+            "path": "Dockerfile"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.deploy.container",
+            "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "download_deployment_renderer",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_deployment_artifact/fbea3fe3ef11\",\"family_kind\":\"app_deployment_artifact\",\"family_identity_digest\":\"fbea3fe3ef115f8ad2ce264a3d41b6bbf0e7d4cbc7c9eec64e04fbcd6314cc3f\",\"disposition\":\"external_handoff\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"deployment_derived\",\"path\":\"Dockerfile\"}],\"sources\":[{\"node_id\":\"mozaiks.deploy.container\",\"payload_digest\":\"b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"download_deployment_renderer\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "57e2937f7e87f9054a9e9b226f3648e9af3ac959164565b6df0fb563b60691b4",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "deployment_derived",
+          "path": "Dockerfile"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.deploy.container",
+          "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_integrations_config/inactive/220f7104547e",
+      "canonical_layout_row": {
+        "kind": "app_integrations_config",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_integrations_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/integrations.yaml",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+      "identity_payload": {
+        "unit_id": "app_integrations_config/inactive/220f7104547e",
+        "family_kind": "app_integrations_config",
+        "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_integrations_config/inactive/220f7104547e",
+        "family_kind": "app_integrations_config",
+        "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_integrations_config/inactive/220f7104547e\",\"family_kind\":\"app_integrations_config\",\"family_identity_digest\":\"220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "570de4198713842efa5771275b977c0adbedae9d1ec9a771eaa665dc190be948",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_manifest/scope_inactive/ccaefd92a7d0",
+      "canonical_layout_row": {
+        "kind": "app_manifest",
+        "owner": "platform",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "always",
+        "path_scope": "workspace_root",
+        "path_template": "app/app.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "app_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "auth"
+        ]
+      },
+      "family_identity_digest": "ccaefd92a7d0d437aa4ef0fe4f1c8efdbf217d0583ac0e446ae053243c93af69",
+      "identity_payload": {
+        "unit_id": "app_manifest/scope_inactive/ccaefd92a7d0",
+        "family_kind": "app_manifest",
+        "family_identity_digest": "ccaefd92a7d0d437aa4ef0fe4f1c8efdbf217d0583ac0e446ae053243c93af69",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_manifest/scope_inactive/ccaefd92a7d0",
+        "family_kind": "app_manifest",
+        "family_identity_digest": "ccaefd92a7d0d437aa4ef0fe4f1c8efdbf217d0583ac0e446ae053243c93af69",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "app_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_manifest/scope_inactive/ccaefd92a7d0\",\"family_kind\":\"app_manifest\",\"family_identity_digest\":\"ccaefd92a7d0d437aa4ef0fe4f1c8efdbf217d0583ac0e446ae053243c93af69\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "115cb3f728854b028d4f756ddfe82c97053d32bdc338a59a0545e896d9c69c2a",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_service_adapter/inactive/5255a858ebb1",
+      "canonical_layout_row": {
+        "kind": "app_service_adapter",
+        "owner": "app_workspace",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_app_owned_integration_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/adapters/{adapter_area}/{pack_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "integration_adapter_implementation",
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      "family_identity_digest": "5255a858ebb112044b558a9e375b9878c65a2bd58cf65324f1acb43b5a6cd9d8",
+      "identity_payload": {
+        "unit_id": "app_service_adapter/inactive/5255a858ebb1",
+        "family_kind": "app_service_adapter",
+        "family_identity_digest": "5255a858ebb112044b558a9e375b9878c65a2bd58cf65324f1acb43b5a6cd9d8",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_service_adapter/inactive/5255a858ebb1",
+        "family_kind": "app_service_adapter",
+        "family_identity_digest": "5255a858ebb112044b558a9e375b9878c65a2bd58cf65324f1acb43b5a6cd9d8",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_service_adapter/inactive/5255a858ebb1\",\"family_kind\":\"app_service_adapter\",\"family_identity_digest\":\"5255a858ebb112044b558a9e375b9878c65a2bd58cf65324f1acb43b5a6cd9d8\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "9260728f4dfc4a54de32115297f4da73e58e8faf4efe357b1707d5adbc66785f",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_service_integration_client/inactive/20b0da544328",
+      "canonical_layout_row": {
+        "kind": "app_service_integration_client",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_managed_capability_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/integrations/{pack_id}_client.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface",
+          "service_foundation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "application",
+          "integration"
+        ]
+      },
+      "family_identity_digest": "20b0da544328c991721e5073c59d5f0535300835b35d20d90d88cd3509e73215",
+      "identity_payload": {
+        "unit_id": "app_service_integration_client/inactive/20b0da544328",
+        "family_kind": "app_service_integration_client",
+        "family_identity_digest": "20b0da544328c991721e5073c59d5f0535300835b35d20d90d88cd3509e73215",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_service_integration_client/inactive/20b0da544328",
+        "family_kind": "app_service_integration_client",
+        "family_identity_digest": "20b0da544328c991721e5073c59d5f0535300835b35d20d90d88cd3509e73215",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_service_integration_client/inactive/20b0da544328\",\"family_kind\":\"app_service_integration_client\",\"family_identity_digest\":\"20b0da544328c991721e5073c59d5f0535300835b35d20d90d88cd3509e73215\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "91f14c97d82c675a984964c0099692568b04136ec55304b3a661447da1479364",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_shell_config/inactive/b478c2fb6bf2",
+      "canonical_layout_row": {
+        "kind": "app_shell_config",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_shell_selected",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/shell.json",
+        "materializer": "app_generator",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "b478c2fb6bf20480f1c228f9638c4ffb6e2dd3bd931e2126ee50566a7cb6325b",
+      "identity_payload": {
+        "unit_id": "app_shell_config/inactive/b478c2fb6bf2",
+        "family_kind": "app_shell_config",
+        "family_identity_digest": "b478c2fb6bf20480f1c228f9638c4ffb6e2dd3bd931e2126ee50566a7cb6325b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_shell_config/inactive/b478c2fb6bf2",
+        "family_kind": "app_shell_config",
+        "family_identity_digest": "b478c2fb6bf20480f1c228f9638c4ffb6e2dd3bd931e2126ee50566a7cb6325b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "app_generator",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_shell_config/inactive/b478c2fb6bf2\",\"family_kind\":\"app_shell_config\",\"family_identity_digest\":\"b478c2fb6bf20480f1c228f9638c4ffb6e2dd3bd931e2126ee50566a7cb6325b\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_generator\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "7054bcf419f8077aeaeced537c873eb496a3f8d06a2faf0835fea817d074dc9c",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_auth_adapter/inactive/1f333550e5b7",
+      "canonical_layout_row": {
+        "kind": "app_ui_auth_adapter",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_auth_enabled",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/auth/authAdapter.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "auth"
+        ]
+      },
+      "family_identity_digest": "1f333550e5b77c3c6c05c14e42f0d346ec5614e093bb2f83997a40f684006922",
+      "identity_payload": {
+        "unit_id": "app_ui_auth_adapter/inactive/1f333550e5b7",
+        "family_kind": "app_ui_auth_adapter",
+        "family_identity_digest": "1f333550e5b77c3c6c05c14e42f0d346ec5614e093bb2f83997a40f684006922",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_auth_adapter/inactive/1f333550e5b7",
+        "family_kind": "app_ui_auth_adapter",
+        "family_identity_digest": "1f333550e5b77c3c6c05c14e42f0d346ec5614e093bb2f83997a40f684006922",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_auth_adapter/inactive/1f333550e5b7\",\"family_kind\":\"app_ui_auth_adapter\",\"family_identity_digest\":\"1f333550e5b77c3c6c05c14e42f0d346ec5614e093bb2f83997a40f684006922\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "f5238d76c13abc4f8b4016f7777fcb785d81f1ee0af3a9a7e12fc27add1460c8",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_custom_route/inactive/fe6837585ad2",
+      "canonical_layout_row": {
+        "kind": "app_ui_custom_route",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/pages/custom/{page_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "custom_page_implementation",
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "page"
+        ]
+      },
+      "family_identity_digest": "fe6837585ad2d2c082a7773c7ee32af1aabca647e4da540b238afb892e114cbd",
+      "identity_payload": {
+        "unit_id": "app_ui_custom_route/inactive/fe6837585ad2",
+        "family_kind": "app_ui_custom_route",
+        "family_identity_digest": "fe6837585ad2d2c082a7773c7ee32af1aabca647e4da540b238afb892e114cbd",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_custom_route/inactive/fe6837585ad2",
+        "family_kind": "app_ui_custom_route",
+        "family_identity_digest": "fe6837585ad2d2c082a7773c7ee32af1aabca647e4da540b238afb892e114cbd",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_custom_route/inactive/fe6837585ad2\",\"family_kind\":\"app_ui_custom_route\",\"family_identity_digest\":\"fe6837585ad2d2c082a7773c7ee32af1aabca647e4da540b238afb892e114cbd\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "d36a4881345cc6f339616a649b5edb9a38c8ce0b46429286bc24006e46732645",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_extension_barrel/inactive/3b8717b40db0",
+      "canonical_layout_row": {
+        "kind": "app_ui_extension_barrel",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/index.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "app_ui_custom_route"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "page"
+        ]
+      },
+      "family_identity_digest": "3b8717b40db02f7c0640a7a9868d35effedd1841b876e89f882107ba452ca809",
+      "identity_payload": {
+        "unit_id": "app_ui_extension_barrel/inactive/3b8717b40db0",
+        "family_kind": "app_ui_extension_barrel",
+        "family_identity_digest": "3b8717b40db02f7c0640a7a9868d35effedd1841b876e89f882107ba452ca809",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_extension_barrel/inactive/3b8717b40db0",
+        "family_kind": "app_ui_extension_barrel",
+        "family_identity_digest": "3b8717b40db02f7c0640a7a9868d35effedd1841b876e89f882107ba452ca809",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_extension_barrel/inactive/3b8717b40db0\",\"family_kind\":\"app_ui_extension_barrel\",\"family_identity_digest\":\"3b8717b40db02f7c0640a7a9868d35effedd1841b876e89f882107ba452ca809\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_custom_route/inactive/fe6837585ad2\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "c3ed9d918b8a718f9de86dd8fdb801739fcc3a64bde173aa33e52129e9e3fccc",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "app_ui_custom_route/inactive/fe6837585ad2"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_module_api/inactive/8c36e8fa7ab1",
+      "canonical_layout_row": {
+        "kind": "app_ui_module_api",
+        "owner": "platform",
+        "requirement": "conditional",
+        "multiplicity": "single",
+        "condition": "when_custom_route_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/lib/moduleApi.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      "family_identity_digest": "8c36e8fa7ab1555d8e1294a3d1bd0b41cf4a4e197d9c57d93549f61f4f78321e",
+      "identity_payload": {
+        "unit_id": "app_ui_module_api/inactive/8c36e8fa7ab1",
+        "family_kind": "app_ui_module_api",
+        "family_identity_digest": "8c36e8fa7ab1555d8e1294a3d1bd0b41cf4a4e197d9c57d93549f61f4f78321e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_module_api/inactive/8c36e8fa7ab1",
+        "family_kind": "app_ui_module_api",
+        "family_identity_digest": "8c36e8fa7ab1555d8e1294a3d1bd0b41cf4a4e197d9c57d93549f61f4f78321e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_module_api/inactive/8c36e8fa7ab1\",\"family_kind\":\"app_ui_module_api\",\"family_identity_digest\":\"8c36e8fa7ab1555d8e1294a3d1bd0b41cf4a4e197d9c57d93549f61f4f78321e\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "cf5a8d8aefd0233db3c9a5dafc95f90a30b392dc86147c0447845842b1d08c1d",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_page_schema/home/484a8be83170",
+      "canonical_layout_row": {
+        "kind": "app_ui_page_schema",
+        "owner": "app_workspace",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_page_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/pages/{page_id}.yaml",
+        "materializer": "page_schema_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "page",
+          "section",
+          "workflow"
+        ]
+      },
+      "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+      "identity_payload": {
+        "unit_id": "app_ui_page_schema/home/484a8be83170",
+        "family_kind": "app_ui_page_schema",
+        "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "page_id",
+            "home"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/pages/home.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          },
+          {
+            "node_id": "mozaiks.section.hero",
+            "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+          },
+          {
+            "node_id": "mozaiks.section.pricing",
+            "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+          }
+        ],
+        "edge_sources": [
+          {
+            "kind": "renders",
+            "source_node_id": "mozaiks.page.home",
+            "target_node_id": "mozaiks.section.hero",
+            "discriminator": null,
+            "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+          }
+        ],
+        "depends_on_units": [],
+        "materializer": "page_schema_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_page_schema/home/484a8be83170",
+        "family_kind": "app_ui_page_schema",
+        "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "page_id",
+            "home"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/pages/home.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          },
+          {
+            "node_id": "mozaiks.section.hero",
+            "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+          },
+          {
+            "node_id": "mozaiks.section.pricing",
+            "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+          }
+        ],
+        "edge_sources": [
+          {
+            "kind": "renders",
+            "source_node_id": "mozaiks.page.home",
+            "target_node_id": "mozaiks.section.hero",
+            "discriminator": null,
+            "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+          }
+        ],
+        "depends_on_units": [],
+        "materializer": "page_schema_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_page_schema/home/484a8be83170\",\"family_kind\":\"app_ui_page_schema\",\"family_identity_digest\":\"484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"page_id\",\"home\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/pages/home.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"},{\"node_id\":\"mozaiks.section.hero\",\"payload_digest\":\"f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167\"},{\"node_id\":\"mozaiks.section.pricing\",\"payload_digest\":\"391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94\"}],\"edge_sources\":[{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.hero\",\"discriminator\":null,\"edge_identity\":\"5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45\"}],\"depends_on_units\":[],\"materializer\":\"page_schema_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "b3384ec549b4ecb003b11da030f7b3cd4c84b9be0fb115875994f297fc1740c6",
+      "placeholder_values": [
+        [
+          "page_id",
+          "home"
+        ]
+      ],
+      "depends_on_units": [],
+      "outputs": [
+        {
+          "path_scope": "app_bundle_root",
+          "path": "ui/pages/home.yaml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.page.home",
+          "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+        },
+        {
+          "node_id": "mozaiks.section.hero",
+          "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+        },
+        {
+          "node_id": "mozaiks.section.pricing",
+          "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+        }
+      ],
+      "edge_sources": [
+        {
+          "kind": "renders",
+          "source_node_id": "mozaiks.page.home",
+          "target_node_id": "mozaiks.section.hero",
+          "discriminator": null,
+          "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+        }
+      ],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "app_ui_route_manifest/eacaaede41e7",
+      "canonical_layout_row": {
+        "kind": "app_ui_route_manifest",
+        "owner": "platform",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "app_bundle_root",
+        "path_template": "ui/route_manifest.json",
+        "materializer": "app_config_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "page_bundle"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "app_ui_custom_route",
+          "app_ui_page_schema"
+        ],
+        "semantic_input_kinds": [
+          "application",
+          "page"
+        ]
+      },
+      "family_identity_digest": "eacaaede41e7e2cea936d8a13169abddf7f13a38cfac8beae25f0d4f17875470",
+      "identity_payload": {
+        "unit_id": "app_ui_route_manifest/eacaaede41e7",
+        "family_kind": "app_ui_route_manifest",
+        "family_identity_digest": "eacaaede41e7e2cea936d8a13169abddf7f13a38cfac8beae25f0d4f17875470",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/route_manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.application.corpus",
+            "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+          },
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2",
+          "app_ui_page_schema/home/484a8be83170"
+        ],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "app_ui_route_manifest/eacaaede41e7",
+        "family_kind": "app_ui_route_manifest",
+        "family_identity_digest": "eacaaede41e7e2cea936d8a13169abddf7f13a38cfac8beae25f0d4f17875470",
+        "disposition": "render",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [
+          {
+            "path_scope": "app_bundle_root",
+            "path": "ui/route_manifest.json"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.application.corpus",
+            "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+          },
+          {
+            "node_id": "mozaiks.page.home",
+            "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "app_ui_custom_route/inactive/fe6837585ad2",
+          "app_ui_page_schema/home/484a8be83170"
+        ],
+        "materializer": "app_config_executor",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"app_ui_route_manifest/eacaaede41e7\",\"family_kind\":\"app_ui_route_manifest\",\"family_identity_digest\":\"eacaaede41e7e2cea936d8a13169abddf7f13a38cfac8beae25f0d4f17875470\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/route_manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d\"},{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"}],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_custom_route/inactive/fe6837585ad2\",\"app_ui_page_schema/home/484a8be83170\"],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "a6cea7c8463d1aa50400aaf3e21a5b802a528ee8eb2ac5f7de28f220a6de3717",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "app_ui_custom_route/inactive/fe6837585ad2",
+        "app_ui_page_schema/home/484a8be83170"
+      ],
+      "outputs": [
+        {
+          "path_scope": "app_bundle_root",
+          "path": "ui/route_manifest.json"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.application.corpus",
+          "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+        },
+        {
+          "node_id": "mozaiks.page.home",
+          "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_manifest/scope_inactive/279ac515333f",
+      "canonical_layout_row": {
+        "kind": "module_manifest",
+        "owner": "module",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "module.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "permission"
+        ]
+      },
+      "family_identity_digest": "279ac515333fc9f73a4740fc21f1f0b1ac7239f2b73bb8b05b23749f270c0b93",
+      "identity_payload": {
+        "unit_id": "module_manifest/scope_inactive/279ac515333f",
+        "family_kind": "module_manifest",
+        "family_identity_digest": "279ac515333fc9f73a4740fc21f1f0b1ac7239f2b73bb8b05b23749f270c0b93",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_manifest/scope_inactive/279ac515333f",
+        "family_kind": "module_manifest",
+        "family_identity_digest": "279ac515333fc9f73a4740fc21f1f0b1ac7239f2b73bb8b05b23749f270c0b93",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_manifest/scope_inactive/279ac515333f\",\"family_kind\":\"module_manifest\",\"family_identity_digest\":\"279ac515333fc9f73a4740fc21f1f0b1ac7239f2b73bb8b05b23749f270c0b93\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "25b47a082ce0bc719804a031a44e3284f589279e21578a2c2e5ca3371d8d9810",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_admin_ui/scope_inactive/8d674ce88e7b",
+      "canonical_layout_row": {
+        "kind": "module_admin_ui",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_admin_page_declared",
+        "path_scope": "module_relative",
+        "path_template": "ui/admin/{page_id}.jsx",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_admin_page_implementation"
+        ],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      "family_identity_digest": "8d674ce88e7bfd8177d2975a9b94a4cac8ea834a6aaafdd43c453d12c28c7f89",
+      "identity_payload": {
+        "unit_id": "module_admin_ui/scope_inactive/8d674ce88e7b",
+        "family_kind": "module_admin_ui",
+        "family_identity_digest": "8d674ce88e7bfd8177d2975a9b94a4cac8ea834a6aaafdd43c453d12c28c7f89",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_admin_ui/scope_inactive/8d674ce88e7b",
+        "family_kind": "module_admin_ui",
+        "family_identity_digest": "8d674ce88e7bfd8177d2975a9b94a4cac8ea834a6aaafdd43c453d12c28c7f89",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_admin_ui/scope_inactive/8d674ce88e7b\",\"family_kind\":\"module_admin_ui\",\"family_identity_digest\":\"8d674ce88e7bfd8177d2975a9b94a4cac8ea834a6aaafdd43c453d12c28c7f89\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "170278608ca8bf78e7f7970c7f56c7c57c5e0150ca2c1297024c54b63594bfc2",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_api/scope_inactive/48775ee49e02",
+      "canonical_layout_row": {
+        "kind": "module_backend_api",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/api.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "api_surface"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "48775ee49e02919e5e5330c6addb6a4791dbb12289db7ac68a0b0c11cc446972",
+      "identity_payload": {
+        "unit_id": "module_backend_api/scope_inactive/48775ee49e02",
+        "family_kind": "module_backend_api",
+        "family_identity_digest": "48775ee49e02919e5e5330c6addb6a4791dbb12289db7ac68a0b0c11cc446972",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_api/scope_inactive/48775ee49e02",
+        "family_kind": "module_backend_api",
+        "family_identity_digest": "48775ee49e02919e5e5330c6addb6a4791dbb12289db7ac68a0b0c11cc446972",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_api/scope_inactive/48775ee49e02\",\"family_kind\":\"module_backend_api\",\"family_identity_digest\":\"48775ee49e02919e5e5330c6addb6a4791dbb12289db7ac68a0b0c11cc446972\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "ef9e91896ddc1c99e8bcda959270d6dcc5b89713ee380f5e148c2e2c0c433196",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_handler/scope_inactive/278888e52105",
+      "canonical_layout_row": {
+        "kind": "module_backend_handler",
+        "owner": "module",
+        "requirement": "required",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/handler.py",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [
+          "business_services"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "278888e52105c415852a68ea2e54ad8e8084a07fea0501635ae8f4b49b71f547",
+      "identity_payload": {
+        "unit_id": "module_backend_handler/scope_inactive/278888e52105",
+        "family_kind": "module_backend_handler",
+        "family_identity_digest": "278888e52105c415852a68ea2e54ad8e8084a07fea0501635ae8f4b49b71f547",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_handler/scope_inactive/278888e52105",
+        "family_kind": "module_backend_handler",
+        "family_identity_digest": "278888e52105c415852a68ea2e54ad8e8084a07fea0501635ae8f4b49b71f547",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_handler/scope_inactive/278888e52105\",\"family_kind\":\"module_backend_handler\",\"family_identity_digest\":\"278888e52105c415852a68ea2e54ad8e8084a07fea0501635ae8f4b49b71f547\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "cc665e8baff124aaffd3fc6032d63f656ac51199516342286256c39ca08d9fbe",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_helper/scope_inactive/e48e56151cc9",
+      "canonical_layout_row": {
+        "kind": "module_backend_helper",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_helper_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/{helper_id}.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "module_helper_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module"
+        ]
+      },
+      "family_identity_digest": "e48e56151cc9013cb15e435486b5ddee5a398f8104e73bf93d7d2550934bc7bb",
+      "identity_payload": {
+        "unit_id": "module_backend_helper/scope_inactive/e48e56151cc9",
+        "family_kind": "module_backend_helper",
+        "family_identity_digest": "e48e56151cc9013cb15e435486b5ddee5a398f8104e73bf93d7d2550934bc7bb",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_helper/scope_inactive/e48e56151cc9",
+        "family_kind": "module_backend_helper",
+        "family_identity_digest": "e48e56151cc9013cb15e435486b5ddee5a398f8104e73bf93d7d2550934bc7bb",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_helper/scope_inactive/e48e56151cc9\",\"family_kind\":\"module_backend_helper\",\"family_identity_digest\":\"e48e56151cc9013cb15e435486b5ddee5a398f8104e73bf93d7d2550934bc7bb\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "506fe6625ccddaf797704f686d93be5855fbfb76482f95de7377a7bf36f31588",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_policy/scope_inactive/ea644d66e48f",
+      "canonical_layout_row": {
+        "kind": "module_backend_policy",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/policy.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "ea644d66e48fbc8dccb8fa5c7777fedaaae2502659a41bfe95cfe47620d7ae74",
+      "identity_payload": {
+        "unit_id": "module_backend_policy/scope_inactive/ea644d66e48f",
+        "family_kind": "module_backend_policy",
+        "family_identity_digest": "ea644d66e48fbc8dccb8fa5c7777fedaaae2502659a41bfe95cfe47620d7ae74",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_policy/scope_inactive/ea644d66e48f",
+        "family_kind": "module_backend_policy",
+        "family_identity_digest": "ea644d66e48fbc8dccb8fa5c7777fedaaae2502659a41bfe95cfe47620d7ae74",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_policy/scope_inactive/ea644d66e48f\",\"family_kind\":\"module_backend_policy\",\"family_identity_digest\":\"ea644d66e48fbc8dccb8fa5c7777fedaaae2502659a41bfe95cfe47620d7ae74\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "1e3c5db9f39a7fb88aedbd382a22df37a842abe591685a6b70e8d10d3ff3028f",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_repo/scope_inactive/7abbd7c446d8",
+      "canonical_layout_row": {
+        "kind": "module_backend_repo",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/repo.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "7abbd7c446d8d86a2f15d62063261a744486db52785d9de76ae0d6d6dff1b973",
+      "identity_payload": {
+        "unit_id": "module_backend_repo/scope_inactive/7abbd7c446d8",
+        "family_kind": "module_backend_repo",
+        "family_identity_digest": "7abbd7c446d8d86a2f15d62063261a744486db52785d9de76ae0d6d6dff1b973",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_repo/scope_inactive/7abbd7c446d8",
+        "family_kind": "module_backend_repo",
+        "family_identity_digest": "7abbd7c446d8d86a2f15d62063261a744486db52785d9de76ae0d6d6dff1b973",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_repo/scope_inactive/7abbd7c446d8\",\"family_kind\":\"module_backend_repo\",\"family_identity_digest\":\"7abbd7c446d8d86a2f15d62063261a744486db52785d9de76ae0d6d6dff1b973\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "ea962f6435eb6400478788214b90c48d5b14ac48350e6888edbb03192cb08eac",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_schemas/scope_inactive/ee4c9ca15382",
+      "canonical_layout_row": {
+        "kind": "module_backend_schemas",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/schemas.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "data_models",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "ee4c9ca15382f4d3b4a56b293f060b60c1104bf7213e8ab274b2a7eb1f2495a6",
+      "identity_payload": {
+        "unit_id": "module_backend_schemas/scope_inactive/ee4c9ca15382",
+        "family_kind": "module_backend_schemas",
+        "family_identity_digest": "ee4c9ca15382f4d3b4a56b293f060b60c1104bf7213e8ab274b2a7eb1f2495a6",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_schemas/scope_inactive/ee4c9ca15382",
+        "family_kind": "module_backend_schemas",
+        "family_identity_digest": "ee4c9ca15382f4d3b4a56b293f060b60c1104bf7213e8ab274b2a7eb1f2495a6",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_schemas/scope_inactive/ee4c9ca15382\",\"family_kind\":\"module_backend_schemas\",\"family_identity_digest\":\"ee4c9ca15382f4d3b4a56b293f060b60c1104bf7213e8ab274b2a7eb1f2495a6\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "32080101dd5fb67b9766aa7336d54a5a930b2e82ed38d555d07d1d3391cb9009",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_backend_service/scope_inactive/4b723cc8e42f",
+      "canonical_layout_row": {
+        "kind": "module_backend_service",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_module_declared",
+        "path_scope": "module_relative",
+        "path_template": "backend/service.py",
+        "materializer": "preserved_opaque",
+        "disposition": "agent_author",
+        "assignment_kinds": [
+          "business_services",
+          "module_backend_implementation"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "action",
+          "capability",
+          "event",
+          "module",
+          "notification",
+          "permission",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "4b723cc8e42f31c970091154e4e525fdac0de4f1fc51c636dbd089cd7a5b1ac5",
+      "identity_payload": {
+        "unit_id": "module_backend_service/scope_inactive/4b723cc8e42f",
+        "family_kind": "module_backend_service",
+        "family_identity_digest": "4b723cc8e42f31c970091154e4e525fdac0de4f1fc51c636dbd089cd7a5b1ac5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_backend_service/scope_inactive/4b723cc8e42f",
+        "family_kind": "module_backend_service",
+        "family_identity_digest": "4b723cc8e42f31c970091154e4e525fdac0de4f1fc51c636dbd089cd7a5b1ac5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_backend_service/scope_inactive/4b723cc8e42f\",\"family_kind\":\"module_backend_service\",\"family_identity_digest\":\"4b723cc8e42f31c970091154e4e525fdac0de4f1fc51c636dbd089cd7a5b1ac5\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "1ca0731b63b2b92ecd3888d714d2e1e464f63aa366c05daa6fcc28b35c2cd04d",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/4942d8b24b09",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/profile.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "4942d8b24b093b2d05f3abf7792d440717f1e9977aefc25764239e7e20f41586",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/4942d8b24b09",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4942d8b24b093b2d05f3abf7792d440717f1e9977aefc25764239e7e20f41586",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/4942d8b24b09",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4942d8b24b093b2d05f3abf7792d440717f1e9977aefc25764239e7e20f41586",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/4942d8b24b09\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"4942d8b24b093b2d05f3abf7792d440717f1e9977aefc25764239e7e20f41586\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "0421999fd5bfaf9ae22858c864731f6fbfdca08bd973aa8314e295995fa57448",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/4d2a2094772a",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/reactions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "4d2a2094772a4df11241f3711f247956adf9f4cc277c6148a27e0ea27e1ef770",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/4d2a2094772a",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4d2a2094772a4df11241f3711f247956adf9f4cc277c6148a27e0ea27e1ef770",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/4d2a2094772a",
+        "family_kind": "module_contract",
+        "family_identity_digest": "4d2a2094772a4df11241f3711f247956adf9f4cc277c6148a27e0ea27e1ef770",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/4d2a2094772a\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"4d2a2094772a4df11241f3711f247956adf9f4cc277c6148a27e0ea27e1ef770\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "3442d081b35f3fdf9b36911e698b611a64481a72079c139bef5fb0215c81e41f",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/85b47855fd4e",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/settings.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "85b47855fd4e823515d23b6ba9d75dbd1020587f782a6715b51a67ccd330a524",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/85b47855fd4e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "85b47855fd4e823515d23b6ba9d75dbd1020587f782a6715b51a67ccd330a524",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/85b47855fd4e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "85b47855fd4e823515d23b6ba9d75dbd1020587f782a6715b51a67ccd330a524",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/85b47855fd4e\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"85b47855fd4e823515d23b6ba9d75dbd1020587f782a6715b51a67ccd330a524\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "147de1e94bbcfc6b4d953ae4dcef20708de1fd577baa36b36ef1f9c23bbb8014",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/a1687bc81fe1",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/service.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "a1687bc81fe195f03f9a9a41cfb12b2882fc1fecc2e6371a8606fd8488f1f7b5",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/a1687bc81fe1",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a1687bc81fe195f03f9a9a41cfb12b2882fc1fecc2e6371a8606fd8488f1f7b5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/a1687bc81fe1",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a1687bc81fe195f03f9a9a41cfb12b2882fc1fecc2e6371a8606fd8488f1f7b5",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/a1687bc81fe1\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"a1687bc81fe195f03f9a9a41cfb12b2882fc1fecc2e6371a8606fd8488f1f7b5\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "f0ef1d9b60a8dfd59d1b76864e6af89a03f7821f6cf5f15b16627b1563fd05ce",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/a21d5505ff45",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/policy_hooks.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "a21d5505ff45b3a55a5fbdb2a151559154a496fb5c3e85b88b9271de9ae91308",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/a21d5505ff45",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a21d5505ff45b3a55a5fbdb2a151559154a496fb5c3e85b88b9271de9ae91308",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/a21d5505ff45",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a21d5505ff45b3a55a5fbdb2a151559154a496fb5c3e85b88b9271de9ae91308",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/a21d5505ff45\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"a21d5505ff45b3a55a5fbdb2a151559154a496fb5c3e85b88b9271de9ae91308\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "7590dd6a6b3d2711e90430ebe999ee3f5a24c023b04fc1806b91e489c220c0c2",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/a48fecc11d86",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/admin.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "a48fecc11d866572729fc56cdb0a9b28057458f07d683b1bb562b066e1f43a1d",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/a48fecc11d86",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a48fecc11d866572729fc56cdb0a9b28057458f07d683b1bb562b066e1f43a1d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/a48fecc11d86",
+        "family_kind": "module_contract",
+        "family_identity_digest": "a48fecc11d866572729fc56cdb0a9b28057458f07d683b1bb562b066e1f43a1d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/a48fecc11d86\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"a48fecc11d866572729fc56cdb0a9b28057458f07d683b1bb562b066e1f43a1d\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "68c32252455f5ca2de621abf05e4c02b2a8de3128ce6f5b3910826231ee9a0f0",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/aeecad8bb43e",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/notifications.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "aeecad8bb43e9cb01f9246469dbd405ad733d4e7e377b12ee92f05ada8063a50",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/aeecad8bb43e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "aeecad8bb43e9cb01f9246469dbd405ad733d4e7e377b12ee92f05ada8063a50",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/aeecad8bb43e",
+        "family_kind": "module_contract",
+        "family_identity_digest": "aeecad8bb43e9cb01f9246469dbd405ad733d4e7e377b12ee92f05ada8063a50",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/aeecad8bb43e\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"aeecad8bb43e9cb01f9246469dbd405ad733d4e7e377b12ee92f05ada8063a50\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "fcc604ee8567b87be70675203a3c23d2d6d139b47c6e9bc8a0bf1373ef6cd1fd",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/b55afdbaff33",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/commercial.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "b55afdbaff339932334e060af7ec25979550e85dd36f098fb49dd1d97aa1f266",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/b55afdbaff33",
+        "family_kind": "module_contract",
+        "family_identity_digest": "b55afdbaff339932334e060af7ec25979550e85dd36f098fb49dd1d97aa1f266",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/b55afdbaff33",
+        "family_kind": "module_contract",
+        "family_identity_digest": "b55afdbaff339932334e060af7ec25979550e85dd36f098fb49dd1d97aa1f266",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/b55afdbaff33\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"b55afdbaff339932334e060af7ec25979550e85dd36f098fb49dd1d97aa1f266\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "ef5c3621b88f7dd1005a7b221819bcf59a824150d018d6bea3e884d468b959fa",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/c9473422a77f",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/relationships.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "c9473422a77f036ff82e74a55dcf90c1bce6d28318186c3cccf77653695bc532",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/c9473422a77f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "c9473422a77f036ff82e74a55dcf90c1bce6d28318186c3cccf77653695bc532",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/c9473422a77f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "c9473422a77f036ff82e74a55dcf90c1bce6d28318186c3cccf77653695bc532",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/c9473422a77f\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"c9473422a77f036ff82e74a55dcf90c1bce6d28318186c3cccf77653695bc532\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "7cd219c76bb3f7f77d3486e5bb20f49045581ed07e24240b983a6a8a36363e9b",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_contract/scope_inactive/d9e60834b12f",
+      "canonical_layout_row": {
+        "kind": "module_contract",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "contracts/events.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "event",
+          "module",
+          "notification",
+          "reaction"
+        ]
+      },
+      "family_identity_digest": "d9e60834b12f46dcc5b3ceed00dbc1402cf182c4f516d28ae480954cfa9ca7d2",
+      "identity_payload": {
+        "unit_id": "module_contract/scope_inactive/d9e60834b12f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "d9e60834b12f46dcc5b3ceed00dbc1402cf182c4f516d28ae480954cfa9ca7d2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_contract/scope_inactive/d9e60834b12f",
+        "family_kind": "module_contract",
+        "family_identity_digest": "d9e60834b12f46dcc5b3ceed00dbc1402cf182c4f516d28ae480954cfa9ca7d2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_contract/scope_inactive/d9e60834b12f\",\"family_kind\":\"module_contract\",\"family_identity_digest\":\"d9e60834b12f46dcc5b3ceed00dbc1402cf182c4f516d28ae480954cfa9ca7d2\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "73a3c1819f5b0a4cefd249b8c8b936c1256e8978e0877f6b47e2b51bc8c05852",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_runtime_extensions/scope_inactive/bfc0133e6423",
+      "canonical_layout_row": {
+        "kind": "module_runtime_extensions",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "module_relative",
+        "path_template": "runtime_extensions.yaml",
+        "materializer": "module_contract_executor",
+        "disposition": "render",
+        "assignment_kinds": [
+          "module_contract"
+        ],
+        "validator": "module_loader",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "bfc0133e64233af3f2efc868e017b426040d048ddfccdb0916fc963618857415",
+      "identity_payload": {
+        "unit_id": "module_runtime_extensions/scope_inactive/bfc0133e6423",
+        "family_kind": "module_runtime_extensions",
+        "family_identity_digest": "bfc0133e64233af3f2efc868e017b426040d048ddfccdb0916fc963618857415",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_runtime_extensions/scope_inactive/bfc0133e6423",
+        "family_kind": "module_runtime_extensions",
+        "family_identity_digest": "bfc0133e64233af3f2efc868e017b426040d048ddfccdb0916fc963618857415",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "module_contract_executor",
+        "assignment_kind": null,
+        "validator": "module_loader",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_runtime_extensions/scope_inactive/bfc0133e6423\",\"family_kind\":\"module_runtime_extensions\",\"family_identity_digest\":\"bfc0133e64233af3f2efc868e017b426040d048ddfccdb0916fc963618857415\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"module_contract_executor\",\"assignment_kind\":null,\"validator\":\"module_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "328e0b2310c070f6ae2f9ebd096ff25df895d1bc4f2b5fd0dd0f714b4f4d6187",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "module_ui_extension_barrel/scope_inactive/482787d9c463",
+      "canonical_layout_row": {
+        "kind": "module_ui_extension_barrel",
+        "owner": "module",
+        "requirement": "optional",
+        "multiplicity": "many",
+        "condition": "when_module_admin_page_declared",
+        "path_scope": "module_relative",
+        "path_template": "ui/index.js",
+        "materializer": "preserved_opaque",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "generated_app_validator",
+        "dependency_families": [
+          "module_manifest"
+        ],
+        "semantic_input_kinds": [
+          "artifact_declaration",
+          "module",
+          "page"
+        ]
+      },
+      "family_identity_digest": "482787d9c4638dbaebad59a0801e9ef20c9fc6330b7c56a6cc7e32c54bb28881",
+      "identity_payload": {
+        "unit_id": "module_ui_extension_barrel/scope_inactive/482787d9c463",
+        "family_kind": "module_ui_extension_barrel",
+        "family_identity_digest": "482787d9c4638dbaebad59a0801e9ef20c9fc6330b7c56a6cc7e32c54bb28881",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "module_ui_extension_barrel/scope_inactive/482787d9c463",
+        "family_kind": "module_ui_extension_barrel",
+        "family_identity_digest": "482787d9c4638dbaebad59a0801e9ef20c9fc6330b7c56a6cc7e32c54bb28881",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [
+          "module_manifest/scope_inactive/279ac515333f"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "generated_app_validator",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"module_ui_extension_barrel/scope_inactive/482787d9c463\",\"family_kind\":\"module_ui_extension_barrel\",\"family_identity_digest\":\"482787d9c4638dbaebad59a0801e9ef20c9fc6330b7c56a6cc7e32c54bb28881\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[\"module_manifest/scope_inactive/279ac515333f\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "238ddb69ec9086bd17611a7f8fd6e8c4169ccb15784e819197a6559313a28525",
+      "placeholder_values": [],
+      "depends_on_units": [
+        "module_manifest/scope_inactive/279ac515333f"
+      ],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/163752fc4dfe",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/database/seed.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "163752fc4dfe6d2b8167aad2f5d2475d412f888c4a93a7f23004a3e860d2a588",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/163752fc4dfe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "163752fc4dfe6d2b8167aad2f5d2475d412f888c4a93a7f23004a3e860d2a588",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/163752fc4dfe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "163752fc4dfe6d2b8167aad2f5d2475d412f888c4a93a7f23004a3e860d2a588",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/163752fc4dfe\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"163752fc4dfe6d2b8167aad2f5d2475d412f888c4a93a7f23004a3e860d2a588\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "fa211ab466ebe4841fda1d434319325da34c98abafd3b6d03c5024384afa8fc3",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/1f569d14a264",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/security/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "1f569d14a2642f6b7c1ff90486878fdf2458280b7b2eefba193c2a92a27f1f75",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/1f569d14a264",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "1f569d14a2642f6b7c1ff90486878fdf2458280b7b2eefba193c2a92a27f1f75",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/1f569d14a264",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "1f569d14a2642f6b7c1ff90486878fdf2458280b7b2eefba193c2a92a27f1f75",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/1f569d14a264\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"1f569d14a2642f6b7c1ff90486878fdf2458280b7b2eefba193c2a92a27f1f75\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "7dc94f2d349b64d5ee5aa98daf20e39271c24fcfb2a9be82393056eb3fca2d2c",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/4fc9cf284272",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/models/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "4fc9cf284272c5bb8a1f80e42c341c3bab47ba6dec7b20a082112e69c5a860c7",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/4fc9cf284272",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "4fc9cf284272c5bb8a1f80e42c341c3bab47ba6dec7b20a082112e69c5a860c7",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/4fc9cf284272",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "4fc9cf284272c5bb8a1f80e42c341c3bab47ba6dec7b20a082112e69c5a860c7",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/4fc9cf284272\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"4fc9cf284272c5bb8a1f80e42c341c3bab47ba6dec7b20a082112e69c5a860c7\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "de58eb62989f320e85919874b23ca37a25196a56440c715e15c1a5ad17351b25",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/682230fcc806",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "control_plane/{extension_id}.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "682230fcc806b9f05d1902394da0175ac5e469b255f13a91b67b1f690480549e",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/682230fcc806",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "682230fcc806b9f05d1902394da0175ac5e469b255f13a91b67b1f690480549e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/682230fcc806",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "682230fcc806b9f05d1902394da0175ac5e469b255f13a91b67b1f690480549e",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/682230fcc806\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"682230fcc806b9f05d1902394da0175ac5e469b255f13a91b67b1f690480549e\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "2744acf9c4144c4bfe95a67b7e4620243e0af5708443acddc87d2c4aa9482f59",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/6eeceb7bafea",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/models.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "6eeceb7bafeaa71d5d3e01177d501f25c57678cf457763ca9a86e31ade48a01b",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/6eeceb7bafea",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "6eeceb7bafeaa71d5d3e01177d501f25c57678cf457763ca9a86e31ade48a01b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/6eeceb7bafea",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "6eeceb7bafeaa71d5d3e01177d501f25c57678cf457763ca9a86e31ade48a01b",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/6eeceb7bafea\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"6eeceb7bafeaa71d5d3e01177d501f25c57678cf457763ca9a86e31ade48a01b\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "fb3f1b3119acd591eb7b4d96627916cceb88dadd4ebd844a06c0e7f1de42ee83",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/955a937781bc",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/llm.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "955a937781bc8410097f60ddd9dae2b68df7718c7284da1d4c0df9cb358cb8ac",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/955a937781bc",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "955a937781bc8410097f60ddd9dae2b68df7718c7284da1d4c0df9cb358cb8ac",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/955a937781bc",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "955a937781bc8410097f60ddd9dae2b68df7718c7284da1d4c0df9cb358cb8ac",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/955a937781bc\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"955a937781bc8410097f60ddd9dae2b68df7718c7284da1d4c0df9cb358cb8ac\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "05d221d173e9c23277984fc9dd2518bce54750d0a1d4ced23141ac99dc5d832c",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/95a3ed11bcf2",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/data_migrations/{migration_id}.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "95a3ed11bcf25674f8674f8d0c300893e8965685c73075cdb4f64ca08d4b341d",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/95a3ed11bcf2",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "95a3ed11bcf25674f8674f8d0c300893e8965685c73075cdb4f64ca08d4b341d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/95a3ed11bcf2",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "95a3ed11bcf25674f8674f8d0c300893e8965685c73075cdb4f64ca08d4b341d",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/95a3ed11bcf2\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"95a3ed11bcf25674f8674f8d0c300893e8965685c73075cdb4f64ca08d4b341d\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "48963e417ce9781bdb43b563b23af7e9b1fb15140c127005de60829aa097bdf5",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/ae4a42449842",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/secrets.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "ae4a424498426fdb8efa548956066c043b740d2a3d915281f1117f04660cb464",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/ae4a42449842",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "ae4a424498426fdb8efa548956066c043b740d2a3d915281f1117f04660cb464",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/ae4a42449842",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "ae4a424498426fdb8efa548956066c043b740d2a3d915281f1117f04660cb464",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/ae4a42449842\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"ae4a424498426fdb8efa548956066c043b740d2a3d915281f1117f04660cb464\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "71bf8fbe7df837ff0e560d20e40ec20ae327cd1117efad7fd865ebfb4033c6ea",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/b6b6963d7d3c",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "config/data.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "b6b6963d7d3c5b59d409b2f9e65cd56678c4d3ea86b24ce205b7fbf82d9cb7f2",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/b6b6963d7d3c",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "b6b6963d7d3c5b59d409b2f9e65cd56678c4d3ea86b24ce205b7fbf82d9cb7f2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/b6b6963d7d3c",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "b6b6963d7d3c5b59d409b2f9e65cd56678c4d3ea86b24ce205b7fbf82d9cb7f2",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/b6b6963d7d3c\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"b6b6963d7d3c5b59d409b2f9e65cd56678c4d3ea86b24ce205b7fbf82d9cb7f2\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "f3602b6cf5b0a7c1eaf64561fafa23a9f8ebbcc0c0e696c46c06757dbaaebe87",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/d7189ed94db1",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "services/data/{extension_id}.py",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "d7189ed94db10efc3b0f8b6331b09987c6f123acc2c3fe3724770d13148ef0c1",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/d7189ed94db1",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "d7189ed94db10efc3b0f8b6331b09987c6f123acc2c3fe3724770d13148ef0c1",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/d7189ed94db1",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "d7189ed94db10efc3b0f8b6331b09987c6f123acc2c3fe3724770d13148ef0c1",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/d7189ed94db1\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"d7189ed94db10efc3b0f8b6331b09987c6f123acc2c3fe3724770d13148ef0c1\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "f3c3a0ad6c1b6113e1adbc02f0ebd04c2afc2e8aa1779d53fe3b5f3664d5576e",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/f3ee3a94b981",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/backend/database/schema.json",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "f3ee3a94b981e733e0f0f5e5c5afe4066af1f14b3ae5b734141032b1ee9b45ba",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/f3ee3a94b981",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f3ee3a94b981e733e0f0f5e5c5afe4066af1f14b3ae5b734141032b1ee9b45ba",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/f3ee3a94b981",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f3ee3a94b981e733e0f0f5e5c5afe4066af1f14b3ae5b734141032b1ee9b45ba",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/f3ee3a94b981\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"f3ee3a94b981e733e0f0f5e5c5afe4066af1f14b3ae5b734141032b1ee9b45ba\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "bdd2e57e80a5d73f5e7a1d635981a1d0fe354d65c2dee084d7fd9b394fdf6bee",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/f75e58857dbe",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "many",
+        "condition": "never",
+        "path_scope": "app_bundle_root",
+        "path_template": "modules/{module_id}/contracts/subscriptions.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "f75e58857dbee2bb579b298571d15c9c4a4fceea9f293d556bd5370826134808",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/f75e58857dbe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f75e58857dbee2bb579b298571d15c9c4a4fceea9f293d556bd5370826134808",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/f75e58857dbe",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "f75e58857dbee2bb579b298571d15c9c4a4fceea9f293d556bd5370826134808",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/f75e58857dbe\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"f75e58857dbee2bb579b298571d15c9c4a4fceea9f293d556bd5370826134808\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "952944bf434fb50ae20e717e9f2350993a24a3a05e0e5aca182ff272101c0f7e",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "prohibited_legacy/prohibited/fdedcfc8ed5b",
+      "canonical_layout_row": {
+        "kind": "prohibited_legacy",
+        "owner": "prohibited",
+        "requirement": "prohibited",
+        "multiplicity": "single",
+        "condition": "never",
+        "path_scope": "module_relative",
+        "path_template": "contracts/subscriptions.yaml",
+        "materializer": "none",
+        "disposition": "inapplicable",
+        "assignment_kinds": [],
+        "validator": "app_paths",
+        "dependency_families": [],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "fdedcfc8ed5beb28c62daa023c201d8a8df5f772f2a7d67aa1cda572760dc719",
+      "identity_payload": {
+        "unit_id": "prohibited_legacy/prohibited/fdedcfc8ed5b",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "fdedcfc8ed5beb28c62daa023c201d8a8df5f772f2a7d67aa1cda572760dc719",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "prohibited_legacy/prohibited/fdedcfc8ed5b",
+        "family_kind": "prohibited_legacy",
+        "family_identity_digest": "fdedcfc8ed5beb28c62daa023c201d8a8df5f772f2a7d67aa1cda572760dc719",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "none",
+        "assignment_kind": null,
+        "validator": "app_paths",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"prohibited_legacy/prohibited/fdedcfc8ed5b\",\"family_kind\":\"prohibited_legacy\",\"family_identity_digest\":\"fdedcfc8ed5beb28c62daa023c201d8a8df5f772f2a7d67aa1cda572760dc719\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"none\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "237a33f130ed9d701639d070e915e7c65969605c6fa037cb43946c0e049700a8",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "workflow_manifest/scope_inactive/b54cc58cd6af",
+      "canonical_layout_row": {
+        "kind": "workflow_manifest",
+        "owner": "workflow",
+        "requirement": "conditional",
+        "multiplicity": "many",
+        "condition": "when_workflow_declared",
+        "path_scope": "workspace_root",
+        "path_template": "workflows/{workflow_id}/orchestrator.yaml",
+        "materializer": "workflow_generator",
+        "disposition": "render",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [],
+        "semantic_input_kinds": [
+          "capability",
+          "event",
+          "trigger",
+          "workflow"
+        ]
+      },
+      "family_identity_digest": "b54cc58cd6af598f48d11429afd072689e2755b4dd747283985db346ebefd94f",
+      "identity_payload": {
+        "unit_id": "workflow_manifest/scope_inactive/b54cc58cd6af",
+        "family_kind": "workflow_manifest",
+        "family_identity_digest": "b54cc58cd6af598f48d11429afd072689e2755b4dd747283985db346ebefd94f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "workflow_generator",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "workflow_manifest/scope_inactive/b54cc58cd6af",
+        "family_kind": "workflow_manifest",
+        "family_identity_digest": "b54cc58cd6af598f48d11429afd072689e2755b4dd747283985db346ebefd94f",
+        "disposition": "inapplicable",
+        "source_scope": "declared",
+        "placeholder_values": [],
+        "outputs": [],
+        "sources": [],
+        "edge_sources": [],
+        "depends_on_units": [],
+        "materializer": "workflow_generator",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"workflow_manifest/scope_inactive/b54cc58cd6af\",\"family_kind\":\"workflow_manifest\",\"family_identity_digest\":\"b54cc58cd6af598f48d11429afd072689e2755b4dd747283985db346ebefd94f\",\"disposition\":\"inapplicable\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[],\"sources\":[],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"workflow_generator\",\"assignment_kind\":null,\"validator\":\"workflow_manager\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "a23051e578418e9d3303170d949dc619d7fd540e8391a4777dd691828bf4bedb",
+      "placeholder_values": [],
+      "depends_on_units": [],
+      "outputs": [],
+      "sources": [],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    },
+    {
+      "unit_id": "workflow_task_batch/digest/685d2783ce17",
+      "canonical_layout_row": {
+        "kind": "workflow_task_batch",
+        "owner": "workflow",
+        "requirement": "optional",
+        "multiplicity": "single",
+        "condition": "when_app_declared",
+        "path_scope": "workflow_relative",
+        "path_template": "extended_orchestration/task_batches.yaml",
+        "materializer": "preserved_opaque",
+        "disposition": "input_only",
+        "assignment_kinds": [],
+        "validator": "workflow_manager",
+        "dependency_families": [
+          "workflow_manifest"
+        ],
+        "semantic_input_kinds": []
+      },
+      "family_identity_digest": "685d2783ce17e6cebe3096f8127ea428fe1e9c14b0512e0fd880fbf1c1fe9f1e",
+      "identity_payload": {
+        "unit_id": "workflow_task_batch/digest/685d2783ce17",
+        "family_kind": "workflow_task_batch",
+        "family_identity_digest": "685d2783ce17e6cebe3096f8127ea428fe1e9c14b0512e0fd880fbf1c1fe9f1e",
+        "disposition": "input_only",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "workflow_id",
+            "digest"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "workflow_relative",
+            "path": "extended_orchestration/task_batches.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.workflow.digest",
+            "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "workflow_manifest/scope_inactive/b54cc58cd6af"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "model_dump_json_mode": {
+        "unit_id": "workflow_task_batch/digest/685d2783ce17",
+        "family_kind": "workflow_task_batch",
+        "family_identity_digest": "685d2783ce17e6cebe3096f8127ea428fe1e9c14b0512e0fd880fbf1c1fe9f1e",
+        "disposition": "input_only",
+        "source_scope": "declared",
+        "placeholder_values": [
+          [
+            "workflow_id",
+            "digest"
+          ]
+        ],
+        "outputs": [
+          {
+            "path_scope": "workflow_relative",
+            "path": "extended_orchestration/task_batches.yaml"
+          }
+        ],
+        "sources": [
+          {
+            "node_id": "mozaiks.workflow.digest",
+            "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+          }
+        ],
+        "edge_sources": [],
+        "depends_on_units": [
+          "workflow_manifest/scope_inactive/b54cc58cd6af"
+        ],
+        "materializer": "preserved_opaque",
+        "assignment_kind": null,
+        "validator": "workflow_manager",
+        "required_structured_output_ref": null,
+        "base_plan_digest": null
+      },
+      "serialized_json": "{\"unit_id\":\"workflow_task_batch/digest/685d2783ce17\",\"family_kind\":\"workflow_task_batch\",\"family_identity_digest\":\"685d2783ce17e6cebe3096f8127ea428fe1e9c14b0512e0fd880fbf1c1fe9f1e\",\"disposition\":\"input_only\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"workflow_id\",\"digest\"]],\"outputs\":[{\"path_scope\":\"workflow_relative\",\"path\":\"extended_orchestration/task_batches.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.workflow.digest\",\"payload_digest\":\"d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2\"}],\"edge_sources\":[],\"depends_on_units\":[\"workflow_manifest/scope_inactive/b54cc58cd6af\"],\"materializer\":\"preserved_opaque\",\"assignment_kind\":null,\"validator\":\"workflow_manager\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+      "unit_digest": "29661b8ff61401d5c2db2455b8e9561175c9a33d2513dcbeda2f079618eb9747",
+      "placeholder_values": [
+        [
+          "workflow_id",
+          "digest"
+        ]
+      ],
+      "depends_on_units": [
+        "workflow_manifest/scope_inactive/b54cc58cd6af"
+      ],
+      "outputs": [
+        {
+          "path_scope": "workflow_relative",
+          "path": "extended_orchestration/task_batches.yaml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.workflow.digest",
+          "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+        }
+      ],
+      "edge_sources": [],
+      "taxonomy_sources": []
+    }
+  ]
+}

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -186,6 +186,7 @@ def _bundle_for(plan, graph, payloads, _authority_inputs) -> MaterializedBundle:
             unit,
             payload_by_node=payload_by_node,
             app_config_selection=selection,
+            workflow_interface_selection=None,
             preserved_by_unit={},
             bundle_outputs=outputs,
             external=[],

--- a/tests/test_app_family_materialization_b2a.py
+++ b/tests/test_app_family_materialization_b2a.py
@@ -385,7 +385,11 @@ def _materialize(graph, payloads, plan):
 
 def test_accepted_b1_registry_census_is_unchanged() -> None:
     registry = build_app_layout_registry(())
-    census = Counter(f.disposition.value for f in registry.families)
+    # The new interface twins have their own layout proof; every B1 row stays.
+    census = Counter(
+        f.disposition.value for f in registry.families
+        if f.kind.value != "workflow_module_interface"
+    )
     assert dict(census) == {
         "render": 79,
         "agent_author": 19,
@@ -827,6 +831,7 @@ def test_b2a_renderer_is_unwired_from_production_code() -> None:
     allowed = {
         Path("mozaiksai/core/semantics/app_config_materialization.py"),
         Path("mozaiksai/core/semantics/decl_bytes.py"),
+        Path("mozaiksai/core/semantics/workflow_interface_materialization.py"),
         Path("mozaiksai/core/semantics/materialization.py"),
     }
     offenders: list[str] = []

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -73,7 +73,10 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # resolution is ImplementationBinding authority enforced at materialization),
 # so the gap set shrinks by exactly that one structural entry. Identity-only:
 # no unit, byte, footprint, or assignment fact changed.
-_GOLDEN_PLAN_DIGEST = "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2"
+# The interface family adds exactly two layout rows and two units (one scope
+# inactive). Its complete pre-family fixture proves all 59 prior units unchanged;
+# only aggregate identity incorporates this newly declared family.
+_GOLDEN_PLAN_DIGEST = "f37b6ef7cd20344a0908eff052cfd83eeaccd8e113f345ea1f37a9c5a73d127d"
 
 
 def _registry():
@@ -557,7 +560,8 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
     excluded = {
         Path("mozaiksai/core/semantics/compilation_plan.py"),
         Path("mozaiksai/core/semantics/decl_bytes.py"),
-        Path("mozaiksai/core/semantics/app_config_materialization.py"),
+            Path("mozaiksai/core/semantics/app_config_materialization.py"),
+            Path("mozaiksai/core/semantics/workflow_interface_materialization.py"),
         Path("mozaiksai/core/semantics/resolver.py"),
         Path("mozaiksai/core/semantics/refs.py"),
         # Slice 4C offline materializer: consumes the plan inside the

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -430,6 +430,7 @@ def test_agent_author_has_no_slice_4c_materialization_path() -> None:
             unit,
             payload_by_node={},
                 app_config_selection=None,
+            workflow_interface_selection=None,
             preserved_by_unit={},
             bundle_outputs=[],
             external=[],

--- a/tests/test_module_interface_retirement.py
+++ b/tests/test_module_interface_retirement.py
@@ -1,38 +1,76 @@
-"""Retirement guard: a future compiler owner must deliberately change this test."""
+"""Retired factory ownership stays closed around one explicit compiler lane."""
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-COMPILER_OWNER_ALLOWLIST: frozenset[str] = frozenset()
+COMPILER_METADATA_REFERENCES = frozenset({
+    "mozaiksai/core/runtime/app/layout_registry.py",
+    "mozaiksai/core/semantics/compilation_plan.py",
+    "mozaiksai/core/semantics/materialization.py",
+})
+COMPILER_BYTE_WRITER = "mozaiksai/core/semantics/workflow_interface_materialization.py"
 ACTIVE_TREES = ("factory_app", "mozaiksai", "mozaiks_cli", "scripts", "examples")
 SOURCE_SUFFIXES = {".py", ".yaml", ".yml", ".json", ".md", ".txt", ".js", ".ts", ".jsx", ".tsx", ".ps1", ".sh", ".j2"}
-RETIRED_REFERENCE = re.compile(r"module_interface|module[ ._-]+interface[ ._-]+v1", re.IGNORECASE)
+INTERFACE_REFERENCE = re.compile(r"module_interface|module[ ._-]+interface[ ._-]+v1", re.IGNORECASE)
+RETIRED_REFERENCE = re.compile(
+    r"mozaiks\.module_interface\.v1|module[ ._-]+interface[ ._-]+v1"
+    r"|generate_module_interface_files|_MODULE_INTERFACE_TEMPLATE",
+    re.IGNORECASE,
+)
 
 
-def test_active_sources_have_zero_module_interface_authors() -> None:
-    # Deliberately stricter than detecting writes: prompts, templates, filenames,
-    # schema markers and serializers all count. Historical docs live outside
-    # these active trees. No future producer is grandfathered in.
-    assert COMPILER_OWNER_ALLOWLIST == frozenset()
+def test_active_sources_have_only_the_canonical_compiler_interface_lane() -> None:
+    # Metadata/projection references are named individually; only the separate
+    # compiler renderer owns bytes. Factory prompts, templates, filenames and
+    # writers remain forbidden, with no directory exemptions. Retired v1 forms
+    # remain forbidden even inside the explicitly allowed compiler files.
+    allowed_references = COMPILER_METADATA_REFERENCES | {COMPILER_BYTE_WRITER}
+    referenced_paths = set()
+    schema_owners = set()
     violations = []
     for tree in ACTIVE_TREES:
         for path in (ROOT / tree).rglob("*"):
             if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
                 continue
             relative = path.relative_to(ROOT).as_posix()
-            if relative in COMPILER_OWNER_ALLOWLIST:
-                continue
+            if INTERFACE_REFERENCE.search(path.name):
+                referenced_paths.add(relative)
             if RETIRED_REFERENCE.search(path.name):
                 violations.append(relative)
             for line_number, line in enumerate(path.read_text(encoding="utf-8-sig").splitlines(), 1):
+                if INTERFACE_REFERENCE.search(line):
+                    referenced_paths.add(relative)
+                if "mozaiks.module_interface.v2" in line:
+                    schema_owners.add(relative)
                 if RETIRED_REFERENCE.search(line):
                     violations.append(f"{relative}:{line_number}")
-    assert not violations, "Active module-interface authoring references: " + ", ".join(violations)
+    assert not violations, "Retired module-interface authoring references: " + ", ".join(violations)
+    assert referenced_paths == allowed_references
+    assert schema_owners == {COMPILER_BYTE_WRITER}
+
+
+def test_compiler_interface_has_exactly_one_renderer_implementation() -> None:
+    from mozaiksai.core.semantics import materialization, workflow_interface_materialization
+
+    renderer = workflow_interface_materialization.render_workflow_module_interface_unit
+    assert materialization.render_workflow_module_interface_unit is renderer
+    definitions = []
+    for relative in COMPILER_METADATA_REFERENCES | {COMPILER_BYTE_WRITER}:
+        tree = ast.parse((ROOT / relative).read_text(encoding="utf-8-sig"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name.startswith("render_")
+                and "module_interface" in node.name
+            ):
+                definitions.append((relative, node.name))
+    assert definitions == [(COMPILER_BYTE_WRITER, "render_workflow_module_interface_unit")]
 
 
 @pytest.mark.parametrize("reference", [
@@ -42,4 +80,15 @@ def test_active_sources_have_zero_module_interface_authors() -> None:
     "_MODULE_INTERFACE_TEMPLATE",
 ])
 def test_hygiene_detects_each_retired_authoring_form(reference: str) -> None:
+    assert INTERFACE_REFERENCE.search(reference)
+
+
+@pytest.mark.parametrize("reference", [
+    "mozaiks.module_interface.v1",
+    "module interface v1",
+    "generate_module_interface_files",
+    "_MODULE_INTERFACE_TEMPLATE",
+])
+def test_retired_authority_is_forbidden_even_in_compiler_files(reference: str) -> None:
     assert RETIRED_REFERENCE.search(reference)
+    assert not RETIRED_REFERENCE.search("mozaiks.module_interface.v2")

--- a/tests/test_plan_taxonomy_sources.py
+++ b/tests/test_plan_taxonomy_sources.py
@@ -247,6 +247,7 @@ def test_every_preexisting_corpus_unit_keeps_exact_bytes_and_identity() -> None:
             "unit_digest": unit.unit_digest,
         }
         for unit in _corpus_plan().units
+        if unit.family_kind != "workflow_module_interface"
     ]
     assert len(rows) == 59
     assert canonical_digest(rows) == "23a30860c1bad68123df0c3e208fc150e9f0d8aadef8f64d15a993e7333c8e8a"

--- a/tests/test_workflow_interface_closure.py
+++ b/tests/test_workflow_interface_closure.py
@@ -1,0 +1,130 @@
+"""Closed renderer domains and the single offline interface projection boundary."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import BaseModel
+
+from mozaiksai.core.semantics.materialization import (
+    _is_closed_annotation,
+    _walk_model_closure,
+    project_workflow_interface_render_input,
+)
+from mozaiksai.core.semantics.payloads import SemanticPayloadBase
+from mozaiksai.core.semantics.refs import SemanticsModel
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WorkflowInterfaceRenderInput,
+    render_workflow_module_interface_unit,
+)
+from tests.test_workflow_interface_rematerialization import _state, _unit
+
+ROOT = Path(__file__).resolve().parents[1]
+RENDERER = "mozaiksai.core.semantics.workflow_interface_materialization"
+
+
+def test_interface_input_recursive_closure_includes_discriminated_binding_models():
+    violations = []
+    visited = set()
+    _walk_model_closure(WorkflowInterfaceRenderInput, "interface", violations, visited)
+    assert violations == []
+    assert {
+        "RenderInputConsumesActionBinding",
+        "RenderInputCommitsResultBinding",
+        "RenderInputTriggeredByEventBinding",
+        "PlanSource",
+        "PlanEdgeSource",
+        "PlanTaxonomySource",
+    } <= {model.__name__ for model in visited}
+    assert all(model.model_config.get("frozen") for model in visited)
+
+
+def test_annotated_metadata_cannot_hide_any_or_an_open_nested_model():
+    assert not _is_closed_annotation(Annotated[Any, "metadata"])
+    assert not _is_closed_annotation(tuple[Annotated[dict[str, Any], "metadata"], ...])
+
+    class OpenChild(BaseModel):
+        value: dict[str, Any]
+
+    class ClosedParent(SemanticsModel):
+        children: tuple[Annotated[OpenChild, "metadata"], ...]
+
+    ClosedParent.model_rebuild()
+    violations = []
+    visited = set()
+    _walk_model_closure(ClosedParent, "parent", violations, visited)
+    assert OpenChild in visited
+    assert any("does not forbid unknown fields" in item for item in violations)
+    assert any("open annotation" in item for item in violations)
+
+
+def test_pure_interface_renderer_imports_no_ambient_state_or_semantic_authoring_models():
+    source = ROOT / "mozaiksai/core/semantics/workflow_interface_materialization.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    for forbidden in (
+        "os", "time", "datetime", "random", "uuid", "pathlib", "subprocess",
+        "socket", "requests", "httpx", "factory_app",
+        "mozaiksai.core.semantics.graph", "mozaiksai.core.semantics.payloads",
+    ):
+        assert not any(
+            name == forbidden or name.startswith(forbidden + ".") for name in imported
+        ), forbidden
+
+
+def test_only_the_offline_materialization_owner_imports_the_interface_renderer():
+    importers = set()
+    for package in ("mozaiksai", "factory_app", "mozaiks_cli"):
+        for path in (ROOT / package).rglob("*.py"):
+            source = path.read_text(encoding="utf-8")
+            if "workflow_interface_materialization" not in source:
+                continue
+            for node in ast.walk(ast.parse(source)):
+                if isinstance(node, ast.Import):
+                    imports_renderer = any(alias.name == RENDERER for alias in node.names)
+                elif isinstance(node, ast.ImportFrom):
+                    imports_renderer = node.module in {RENDERER, "workflow_interface_materialization"} or (
+                        node.module in {"mozaiksai.core.semantics", None}
+                        and any(alias.name == "workflow_interface_materialization" for alias in node.names)
+                    )
+                else:
+                    continue
+                if imports_renderer:
+                    importers.add(path.relative_to(ROOT).as_posix())
+    assert importers == {"mozaiksai/core/semantics/materialization.py"}
+
+
+def test_projection_reads_only_exact_pinned_payload_keys_without_ambient_iteration():
+    state = _state()
+    unit = _unit(state)
+    payloads = {payload.node_id: payload for payload in state["payloads"]}
+    pinned = {source.node_id for source in unit.sources}
+    reads = []
+
+    class PinnedLookupOnly(Mapping[str, SemanticPayloadBase]):
+        def __getitem__(self, key: str) -> SemanticPayloadBase:
+            assert key in pinned, f"projection attempted an unpinned read: {key}"
+            reads.append(key)
+            return payloads[key]
+
+        def __iter__(self) -> Iterator[str]:
+            raise AssertionError("projection must not enumerate ambient payloads")
+
+        def __len__(self) -> int:
+            raise AssertionError("projection must not inspect ambient payload count")
+
+    projected = project_workflow_interface_render_input(unit=unit, payload_by_node=PinnedLookupOnly())
+    assert reads == [source.node_id for source in unit.sources]
+    expected = project_workflow_interface_render_input(unit=unit, payload_by_node=payloads)
+    assert projected == expected
+    assert render_workflow_module_interface_unit(
+        unit=unit, render_input=projected
+    ) == render_workflow_module_interface_unit(unit=unit, render_input=expected)

--- a/tests/test_workflow_interface_corpus_identity.py
+++ b/tests/test_workflow_interface_corpus_identity.py
@@ -1,0 +1,143 @@
+"""Exact pre-family corpus proof captured from authoritative main #481/#482."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    FamilyInstancePlan,
+    LayoutRegistrySnapshot,
+    PlanDisposition,
+    RegistryFamilyRow,
+    derive_compilation_plan,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.payloads import WorkflowPayload
+from tests.test_semantic_payload_graph_v2 import _corpus_graph
+
+_FIXTURE = Path(__file__).parent / "fixtures/workflow_interface_pre_family_corpus.json"
+_BASE_COMMIT = "71c355a728a1470286d02f23eba666bfe93a5ff9"
+_BASE_UNIT_COUNT = 59
+_BASE_PLAN_DIGEST = "4e3a809b0982e18fa24f85da753a1df9734ae38132199c0be5931263fbd202f2"
+_BASE_UNIT_PROOF_DIGEST = "c27885233d404cf253c80ad6e4fb4f44309b444a4efe41eb80461e11c601d5ea"
+_INTERFACE_FAMILY = "workflow_module_interface"
+
+
+def _baseline() -> dict[str, Any]:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _unit_proof(unit: FamilyInstancePlan, row: RegistryFamilyRow) -> dict[str, Any]:
+    """Capture every requested representation independently, including omissions."""
+    return {
+        "unit_id": unit.unit_id,
+        "canonical_layout_row": row.model_dump(mode="json"),
+        "family_identity_digest": unit.family_identity_digest,
+        "identity_payload": unit.identity_payload,
+        "model_dump_json_mode": unit.model_dump(mode="json"),
+        "serialized_json": unit.model_dump_json(),
+        "unit_digest": unit.unit_digest,
+        "placeholder_values": [list(pair) for pair in unit.placeholder_values],
+        "depends_on_units": list(unit.depends_on_units),
+        "outputs": [item.model_dump(mode="json") for item in unit.outputs],
+        "sources": [item.model_dump(mode="json") for item in unit.sources],
+        "edge_sources": [item.model_dump(mode="json") for item in unit.edge_sources],
+        "taxonomy_sources": [item.model_dump(mode="json") for item in unit.taxonomy_sources],
+    }
+
+
+def test_pre_family_capture_is_complete_and_self_consistent() -> None:
+    baseline = _baseline()
+    assert baseline["base_commit"] == _BASE_COMMIT
+    assert baseline["unit_count"] == _BASE_UNIT_COUNT
+    assert baseline["plan_digest"] == _BASE_PLAN_DIGEST
+    assert baseline["unit_proof_digest"] == _BASE_UNIT_PROOF_DIGEST
+    assert canonical_digest(baseline["units"]) == _BASE_UNIT_PROOF_DIGEST
+    plan = CompilationPlan.model_validate(baseline["plan"])
+    snapshot = LayoutRegistrySnapshot.model_validate(baseline["registry_snapshot"])
+    assert plan.plan_digest == baseline["plan_digest"]
+    assert plan.registry_digest == snapshot.snapshot_digest
+    assert len(plan.units) == _BASE_UNIT_COUNT
+    assert all(row.kind != _INTERFACE_FAMILY for row in snapshot.rows)
+    row_by_digest = {row.row_digest: row for row in snapshot.rows}
+    assert [
+        _unit_proof(unit, row_by_digest[unit.family_identity_digest])
+        for unit in plan.units
+    ] == baseline["units"]
+
+
+def test_every_pre_existing_corpus_unit_retains_exact_identity_and_bytes() -> None:
+    baseline = _baseline()
+    graph, payloads = _corpus_graph()
+    registry = build_app_layout_registry(())
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=registry)
+    snapshot = snapshot_layout_registry(registry)
+    row_by_digest = {row.row_digest: row for row in snapshot.rows}
+    old_ids = {unit["unit_id"] for unit in baseline["units"]}
+    current_by_id = {unit.unit_id: unit for unit in plan.units}
+    assert old_ids <= current_by_id.keys(), "A pre-existing unit was deleted or moved"
+    existing = [unit for unit in plan.units if unit.unit_id in old_ids]
+    proof = [_unit_proof(unit, row_by_digest[unit.family_identity_digest]) for unit in existing]
+    assert len(proof) == _BASE_UNIT_COUNT
+    # Complete record equality, not merely a digest comparison: this checks the
+    # canonical row, both identity representations, exact serialized JSON, all
+    # placeholders, dependencies, outputs, and all three source footprints.
+    assert proof == baseline["units"]
+    assert canonical_digest(proof) == _BASE_UNIT_PROOF_DIGEST
+    for before in baseline["units"]:
+        after = current_by_id[before["unit_id"]]
+        assert after.model_dump_json().encode("utf-8") == before["serialized_json"].encode("utf-8")
+        assert after.taxonomy_sources == ()
+        assert "taxonomy_sources" not in after.model_dump(mode="json")
+
+
+def test_only_canonical_interface_rows_and_their_units_extend_the_corpus() -> None:
+    baseline = _baseline()
+    graph, payloads = _corpus_graph()
+    registry = build_app_layout_registry(())
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=registry)
+    snapshot = snapshot_layout_registry(registry)
+    old_snapshot = LayoutRegistrySnapshot.model_validate(baseline["registry_snapshot"])
+    old_row_digests = {row.row_digest for row in old_snapshot.rows}
+    assert [row for row in snapshot.rows if row.row_digest in old_row_digests] == list(old_snapshot.rows)
+    new_rows = [row for row in snapshot.rows if row.row_digest not in old_row_digests]
+    assert len(new_rows) == 2
+    assert {row.kind for row in new_rows} == {_INTERFACE_FAMILY}
+    assert {(row.path_scope, row.path_template) for row in new_rows} == {
+        ("workspace_root", "workflows/{workflow_id}/module_interface.yaml"),
+        ("workflow_relative", "module_interface.yaml"),
+    }
+    workflow_ids = {payload.workflow_id for payload in payloads if isinstance(payload, WorkflowPayload)}
+    assert workflow_ids == {"digest"}
+    old_unit_ids = {unit["unit_id"] for unit in baseline["units"]}
+    new_units = {unit.unit_id: unit for unit in plan.units if unit.unit_id not in old_unit_ids}
+    expected_ids = set()
+    for row in new_rows:
+        active = row.path_scope == plan.scope_selection.workflow_manifest_scope.value
+        if not active:
+            unit_id = f"{_INTERFACE_FAMILY}/scope_inactive/{row.row_digest[:12]}"
+            expected_ids.add(unit_id)
+            unit = new_units[unit_id]
+            assert unit.family_kind == _INTERFACE_FAMILY
+            assert unit.family_identity_digest == row.row_digest
+            assert unit.disposition is PlanDisposition.INAPPLICABLE
+            assert unit.outputs == ()
+            assert unit.placeholder_values == ()
+            continue
+        for workflow_id in workflow_ids:
+            unit_id = f"{_INTERFACE_FAMILY}/{workflow_id}/{row.row_digest[:12]}"
+            expected_ids.add(unit_id)
+            unit = new_units[unit_id]
+            assert unit.family_kind == _INTERFACE_FAMILY
+            assert unit.family_identity_digest == row.row_digest
+            assert unit.placeholder_values == (("workflow_id", workflow_id),)
+            assert len(unit.outputs) == 1
+            assert unit.outputs[0].path_scope == row.path_scope
+            assert unit.outputs[0].path == row.path_template.format(workflow_id=workflow_id)
+    assert new_units.keys() == expected_ids
+    assert len(plan.units) == _BASE_UNIT_COUNT + len(expected_ids)

--- a/tests/test_workflow_interface_layout.py
+++ b/tests/test_workflow_interface_layout.py
@@ -1,0 +1,38 @@
+"""The interface has exactly two offline compiler-owned layout representations."""
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+
+
+def test_exact_interface_layout_rows_have_no_runtime_or_agent_authority() -> None:
+    registry = build_app_layout_registry(())
+    rows = [row for row in registry.families if row.kind.value == "workflow_module_interface"]
+    assert len(rows) == 2
+    expected_templates = {
+        "workspace_root": "workflows/{workflow_id}/module_interface.yaml",
+        "workflow_relative": "module_interface.yaml",
+    }
+    assert {row.path_scope.value for row in rows} == set(expected_templates)
+    for row in rows:
+        assert row.identity_payload == {
+            "kind": "workflow_module_interface",
+            "owner": "workflow",
+            "requirement": "conditional",
+            "multiplicity": "many",
+            "condition": "when_workflow_declared",
+            "path_scope": row.path_scope.value,
+            "path_template": expected_templates[row.path_scope.value],
+            "materializer": "workflow_interface_executor",
+            "disposition": "render",
+            "validator": "generated_app_validator",
+            "runtime_consumer": "none",
+            "security_class": "internal_contract",
+            "assignment_kinds": [],
+            "allowed_stub_kinds": [],
+            "dependency_families": ["workflow_manifest"],
+            "semantic_input_kinds": [
+                "module", "workflow", "workflow_capability",
+                "workflow_capability_binding", "workflow_result",
+            ],
+        }
+    assert all(row.kind.value != "app_workflow_registry" for row in registry.families)
+    assert all(row.path_template != "workflows/workflow_registry.json" for row in registry.families)

--- a/tests/test_workflow_interface_rematerialization.py
+++ b/tests/test_workflow_interface_rematerialization.py
@@ -1,0 +1,664 @@
+"""Canonical interface ownership, selective reuse, and taxonomy rematerialization."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    MaterializerIdentifier,
+    PathScope,
+    build_app_layout_registry,
+)
+from mozaiksai.core.semantics import materialization
+from mozaiksai.core.semantics.binding import RendererSelection, build_implementation_binding
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    CompilationPlan,
+    CompilationScopeSelection,
+    PlanDisposition,
+    PlanEdgeSource,
+    PlanSource,
+    PlanTaxonomySource,
+    derive_compilation_plan,
+    plan_regeneration_closure,
+)
+from mozaiksai.core.semantics.graph import (
+    SemanticEdge,
+    SemanticEdgeKind,
+    SemanticNodeV2,
+    TaxonomyReference,
+    build_semantic_graph_v2,
+)
+from mozaiksai.core.semantics.payloads import (
+    ActionPayload,
+    ModuleActionRef,
+    SemanticPayloadBase,
+    WorkflowCapabilityBindingPayload,
+    WorkflowCapabilityPayload,
+    WorkflowResultPayload,
+    build_semantic_payload,
+    derive_workflow_capability_binding_edges,
+    derive_workflow_result_edges,
+    semantic_payload_ref,
+)
+from mozaiksai.core.semantics.plan_authority import (
+    CompilationPlanAuthorityInputs,
+    PlanAuthorityError,
+    build_compilation_plan_authority_inputs,
+    validate_compilation_plan_against_authority,
+)
+from mozaiksai.core.semantics.refs import SemanticGraphRef
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+    WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+    WorkflowInterfaceRenderInput,
+    render_workflow_module_interface_unit,
+)
+from tests import test_workflow_capability_semantics as capability_fixture
+
+ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW_ID = "analyze_document"
+_OTHER_WORKFLOW_ID = "archive_document"
+_ADVISORY = "mozaiks.workflow_result.advisory_summary"
+_SECOND_CAPABILITY = "mozaiks.workflow_capability.document_notes"
+_SECOND_RESULT = "mozaiks.workflow_result.document_notes"
+_NEW_EVENT_ID = "domain.documents.imported"
+
+
+@dataclass
+class _Fixture:
+    payloads: dict[str, SemanticPayloadBase]
+    action_owners: dict[str, str]
+    event_identities: dict[str, str]
+
+
+def _other(node_id: str) -> str:
+    namespace, local = node_id.rsplit(".", 1)
+    return f"{namespace}.other_{local}"
+
+
+def _rebuilt(payload: SemanticPayloadBase, **changes: Any) -> SemanticPayloadBase:
+    return build_semantic_payload(type(payload), **{**payload.model_dump(mode="json"), **changes})
+
+
+def _replace(fixture: _Fixture, node_id: str, **changes: Any) -> None:
+    fixture.payloads[node_id] = _rebuilt(fixture.payloads[node_id], **changes)
+
+
+def _result(node_id: str, result_id: str, capability: str) -> SemanticPayloadBase:
+    return build_semantic_payload(
+        WorkflowResultPayload,
+        node_id=node_id,
+        payload_version=1,
+        scope=capability_fixture._SCOPE,
+        result_id=result_id,
+        description="An advisory result with no commit binding",
+        workflow_capability_node_id=capability,
+    )
+
+
+def _fixture() -> _Fixture:
+    payloads = capability_fixture._fixture_payloads()
+    payloads[_ADVISORY] = _result(_ADVISORY, "advisory_summary", capability_fixture._CAPABILITY)
+    payloads[_SECOND_CAPABILITY] = _rebuilt(
+        payloads[capability_fixture._CAPABILITY],
+        node_id=_SECOND_CAPABILITY,
+        capability_id="documents.notes",
+        description="Independent notes capability",
+    )
+    payloads[_SECOND_RESULT] = _result(_SECOND_RESULT, "notes", _SECOND_CAPABILITY)
+    replacements = {
+        **{node_id: _other(node_id) for node_id in payloads},
+        "documents": "archives",
+        _WORKFLOW_ID: _OTHER_WORKFLOW_ID,
+        capability_fixture._EVENT_ID: "domain.archives.created",
+        "documents.analysis": "archives.analysis",
+        "documents.notes": "archives.notes",
+    }
+
+    def clone(value: Any) -> Any:
+        if isinstance(value, str):
+            return replacements.get(value, value)
+        if isinstance(value, list):
+            return [clone(item) for item in value]
+        if isinstance(value, dict):
+            return {key: clone(item) for key, item in value.items()}
+        return value
+
+    for payload in list(payloads.values()):
+        copied = build_semantic_payload(type(payload), **clone(payload.model_dump(mode="json")))
+        payloads[copied.node_id] = copied
+    action_owners = {
+        action: capability_fixture._MODULE
+        for action in (
+            capability_fixture._ACTION_CREATE,
+            capability_fixture._ACTION_GET,
+            capability_fixture._ACTION_STORE,
+        )
+    }
+    action_owners.update({_other(action): _other(owner) for action, owner in list(action_owners.items())})
+    return _Fixture(
+        payloads,
+        action_owners,
+        {
+            capability_fixture._EVENT: capability_fixture._EVENT_ID,
+            _other(capability_fixture._EVENT): "domain.archives.created",
+        },
+    )
+
+
+def _edges(fixture: _Fixture) -> list[SemanticEdge]:
+    edges = [
+        SemanticEdge(kind=SemanticEdgeKind.DECLARES, source_node_id=owner, target_node_id=action)
+        for action, owner in fixture.action_owners.items()
+    ]
+    for payload in fixture.payloads.values():
+        if isinstance(payload, ActionPayload):
+            for node_id, event_id in fixture.event_identities.items():
+                if event_id in payload.emits:
+                    edges.append(SemanticEdge(
+                        kind=SemanticEdgeKind.EMITS,
+                        source_node_id=payload.node_id,
+                        target_node_id=node_id,
+                    ))
+        elif isinstance(payload, WorkflowCapabilityPayload):
+            edges.append(SemanticEdge(
+                kind=SemanticEdgeKind.DECLARES,
+                source_node_id=payload.workflow_node_id,
+                target_node_id=payload.node_id,
+            ))
+        elif isinstance(payload, WorkflowResultPayload):
+            edges.extend(derive_workflow_result_edges(payload))
+        elif isinstance(payload, WorkflowCapabilityBindingPayload):
+            edges.extend(derive_workflow_capability_binding_edges(payload))
+    return edges
+
+
+def _state(
+    fixture: _Fixture | None = None,
+    *,
+    scope: PathScope = PathScope.WORKSPACE_ROOT,
+    version: int = 1,
+    reverse: bool = False,
+    reload: bool = False,
+) -> dict[str, Any]:
+    fixture = fixture or _fixture()
+    payloads = list(fixture.payloads.values())
+    nodes = [
+        SemanticNodeV2(
+            node_id=payload.node_id,
+            kind=payload.payload_kind,
+            payload_ref=semantic_payload_ref(payload),
+            taxonomy_references=(
+                (TaxonomyReference(category="event", identifier=fixture.event_identities[payload.node_id]),)
+                if payload.node_id in fixture.event_identities else ()
+            ),
+        )
+        for payload in payloads
+    ]
+    edges = _edges(fixture)
+    graph = build_semantic_graph_v2(
+        graph_id="workflow-interface-proof",
+        version=version,
+        scope=capability_fixture._SCOPE,
+        nodes=list(reversed(nodes)) if reverse else nodes,
+        edges=list(reversed(edges)) if reverse else edges,
+    )
+    if reverse:
+        payloads.reverse()
+    registry = build_app_layout_registry(())
+    selection = CompilationScopeSelection(workflow_manifest_scope=scope)
+    plan = derive_compilation_plan(graph=graph, payloads=payloads, registry=registry, scope_selection=selection)
+    authority = build_compilation_plan_authority_inputs(
+        graph=graph, payloads=payloads, registry=registry, scope_selection=selection,
+    )
+    if reload:
+        plan = CompilationPlan.model_validate_json(plan.model_dump_json())
+        authority = CompilationPlanAuthorityInputs.model_validate_json(authority.model_dump_json())
+        graph = authority.graph
+        payloads = list(authority.payloads)
+    binding = build_implementation_binding(
+        binding_id="workflow_interface_proof",
+        version=1,
+        scope=graph.scope,
+        semantic_graph_ref=SemanticGraphRef(
+            subject_id=graph.graph_id,
+            subject_version=graph.version,
+            content_digest=graph.graph_digest,
+            scope=graph.scope,
+        ),
+        renderer_selections=(
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.PAGE_SCHEMA_EXECUTOR,
+                artifact_families=("app_ui_page_schema",),
+                implementation_id=materialization.PAGE_SCHEMA_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=materialization.PAGE_SCHEMA_RENDERER_IMPLEMENTATION_VERSION,
+            ),
+            RendererSelection(
+                materializer_id=MaterializerIdentifier.WORKFLOW_INTERFACE_EXECUTOR,
+                artifact_families=("workflow_module_interface",),
+                implementation_id=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_ID,
+                implementation_version=WORKFLOW_INTERFACE_RENDERER_IMPLEMENTATION_VERSION,
+            ),
+        ),
+    )
+    return {
+        "plan": plan, "authority_inputs": authority, "graph": graph,
+        "payloads": payloads, "binding": binding, "layout_registry": registry,
+    }
+
+
+def _unit(state: dict[str, Any], workflow_id: str = _WORKFLOW_ID):
+    return next(
+        unit for unit in state["plan"].units
+        if unit.family_kind == "workflow_module_interface"
+        and unit.disposition is PlanDisposition.RENDER
+        and unit.placeholder_values == (("workflow_id", workflow_id),)
+    )
+
+
+def _direct_bytes(state: dict[str, Any], workflow_id: str = _WORKFLOW_ID) -> bytes:
+    unit = _unit(state, workflow_id)
+    render_input = materialization.project_workflow_interface_render_input(
+        unit=unit, payload_by_node={payload.node_id: payload for payload in state["payloads"]},
+    )
+    return render_workflow_module_interface_unit(unit=unit, render_input=render_input)
+
+
+def _rematerialize(base: dict[str, Any], successor: dict[str, Any], bundle=None):
+    return materialization.rematerialize_plan(
+        base_bundle=bundle or materialization.materialize_plan(**base),
+        base_plan=base["plan"],
+        base_authority_inputs=base["authority_inputs"],
+        successor_plan=successor["plan"],
+        successor_authority_inputs=successor["authority_inputs"],
+        **{key: value for key, value in successor.items() if key not in {"plan", "authority_inputs"}},
+    )
+
+
+def _event_identity_change(fixture: _Fixture, *, other: bool = False) -> None:
+    event = _other(capability_fixture._EVENT) if other else capability_fixture._EVENT
+    producer = _other(capability_fixture._ACTION_CREATE) if other else capability_fixture._ACTION_CREATE
+    identity = "domain.archives.imported" if other else _NEW_EVENT_ID
+    fixture.event_identities[event] = identity
+    _replace(fixture, producer, emits=(identity,))
+
+
+def test_exact_payload_edge_and_taxonomy_footprints_and_all_owned_results() -> None:
+    fixture = _fixture()
+    state = _state(fixture)
+    unit = _unit(state)
+    owned = {
+        capability_fixture._WORKFLOW,
+        capability_fixture._CAPABILITY,
+        _SECOND_CAPABILITY,
+        capability_fixture._RESULT,
+        _ADVISORY,
+        _SECOND_RESULT,
+        capability_fixture._BINDING_TRIGGER,
+        capability_fixture._BINDING_READ,
+        capability_fixture._BINDING_RESULT,
+        capability_fixture._MODULE,
+    }
+    assert unit.sources == tuple(sorted(
+        (PlanSource(node_id=node, payload_digest=fixture.payloads[node].payload_digest) for node in owned),
+        key=lambda item: item.node_id,
+    ))
+    meaning_edges = []
+    for node in owned:
+        payload = fixture.payloads[node]
+        if isinstance(payload, WorkflowCapabilityPayload):
+            meaning_edges.append(SemanticEdge(
+                kind="declares", source_node_id=capability_fixture._WORKFLOW, target_node_id=node,
+            ))
+        elif isinstance(payload, WorkflowResultPayload):
+            meaning_edges.extend(derive_workflow_result_edges(payload))
+        elif isinstance(payload, WorkflowCapabilityBindingPayload):
+            meaning_edges.extend(derive_workflow_capability_binding_edges(payload))
+    assert unit.edge_sources == tuple(sorted(
+        (PlanEdgeSource(edge_identity=edge.edge_identity, **edge.model_dump(mode="json")) for edge in meaning_edges),
+        key=lambda item: item.edge_identity,
+    ))
+    assert unit.taxonomy_sources == (PlanTaxonomySource(
+        node_id=capability_fixture._EVENT, category="event", identifier=capability_fixture._EVENT_ID,
+    ),)
+    document = yaml.safe_load(_direct_bytes(state))
+    assert set(document) == {"schema_version", "workflow_id", "capabilities"}
+    assert document["schema_version"] == "mozaiks.module_interface.v2"
+    capabilities = {item["capability_id"]: item for item in document["capabilities"]}
+    assert set(capabilities) == {"documents.analysis", "documents.notes"}
+    assert {result["result_id"] for result in capabilities["documents.analysis"]["results"]} == {
+        "analysis_result", "advisory_summary",
+    }
+    assert [result["result_id"] for result in capabilities["documents.notes"]["results"]] == ["notes"]
+    assert capabilities["documents.notes"]["bindings"] == []
+
+
+@pytest.mark.parametrize("reload", [False, True], ids=["live-authorities", "serialized-authorities"])
+def test_real_taxonomy_identity_change_rerenders_and_never_copies_old_bytes(reload: bool) -> None:
+    base = _state(reload=reload)
+    original_bundle = materialization.materialize_plan(**base)
+    changed = _fixture()
+    _event_identity_change(changed)
+    successor = _state(changed, version=2, reload=reload)
+    affected = _unit(successor)
+    unrelated = _unit(successor, _OTHER_WORKFLOW_ID)
+    assert affected.taxonomy_sources
+    closure = plan_regeneration_closure(base["plan"], successor["plan"])
+    assert affected.unit_id in closure.affected
+    assert affected.unit_id not in closure.reusable
+    assert unrelated.unit_id in closure.reusable
+    refreshed = _rematerialize(base, successor, original_bundle)
+    outputs = {output.unit_id: output for output in refreshed.outputs}
+    original_outputs = {output.unit_id: output for output in original_bundle.outputs}
+    assert outputs[affected.unit_id].origin == "rendered"
+    assert outputs[affected.unit_id].content != original_outputs[affected.unit_id].content
+    assert _NEW_EVENT_ID.encode() in outputs[affected.unit_id].content
+    assert capability_fixture._EVENT_ID.encode() not in outputs[affected.unit_id].content
+    assert outputs[unrelated.unit_id].origin == "reused"
+    assert outputs[unrelated.unit_id].content == original_outputs[unrelated.unit_id].content
+    assert refreshed.files() == materialization.materialize_plan(**successor).files()
+
+
+def _mutate(fixture: _Fixture, change: str) -> None:
+    if change == "capability_added":
+        node = "mozaiks.workflow_capability.extra_analysis"
+        fixture.payloads[node] = _rebuilt(
+            fixture.payloads[capability_fixture._CAPABILITY],
+            node_id=node, capability_id="documents.extra_analysis",
+        )
+    elif change == "capability_removed":
+        fixture.payloads.pop(_SECOND_CAPABILITY)
+        fixture.payloads.pop(_SECOND_RESULT)
+    elif change in {"capability_id", "capability_description"}:
+        field = "capability_id" if change == "capability_id" else "description"
+        _replace(fixture, capability_fixture._CAPABILITY, **{field: "documents.changed"})
+    elif change in {"owned_result_added", "advisory_result_added"}:
+        node = "mozaiks.workflow_result.extra_advisory"
+        fixture.payloads[node] = _result(node, "extra_advisory", capability_fixture._CAPABILITY)
+    elif change == "owned_result_removed":
+        fixture.payloads.pop(capability_fixture._RESULT)
+        fixture.payloads.pop(capability_fixture._BINDING_RESULT)
+    elif change == "advisory_result_removed":
+        fixture.payloads.pop(_ADVISORY)
+    elif change in {"result_id", "result_description", "advisory_id", "advisory_description"}:
+        node = _ADVISORY if change.startswith("advisory") else capability_fixture._RESULT
+        field = "result_id" if change.endswith("_id") else "description"
+        _replace(fixture, node, **{field: "updated_result"})
+    elif change == "commit_added":
+        node = "mozaiks.workflow_capability_binding.extra_commit"
+        fixture.payloads[node] = _rebuilt(
+            fixture.payloads[capability_fixture._BINDING_RESULT],
+            node_id=node,
+            module_action=ModuleActionRef(
+                module_node_id=capability_fixture._MODULE,
+                action_node_id=capability_fixture._ACTION_GET,
+            ),
+        )
+    elif change == "commit_removed":
+        fixture.payloads.pop(capability_fixture._BINDING_RESULT)
+    elif change in {"commit_changed", "consumes_action_changed"}:
+        node = (
+            capability_fixture._BINDING_RESULT
+            if change == "commit_changed" else capability_fixture._BINDING_READ
+        )
+        _replace(fixture, node, module_action=ModuleActionRef(
+            module_node_id=capability_fixture._MODULE,
+            action_node_id=capability_fixture._ACTION_CREATE,
+        ))
+    elif change == "trigger_changed":
+        _replace(
+            fixture, capability_fixture._BINDING_TRIGGER,
+            event_node_id=_other(capability_fixture._EVENT),
+        )
+    elif change == "module_id":
+        _replace(fixture, capability_fixture._MODULE, module_id="files")
+    elif change == "action_node_identity":
+        old = capability_fixture._ACTION_GET
+        new = "mozaiks.action.documents_fetch_content"
+        fixture.payloads[new] = _rebuilt(fixture.payloads.pop(old), node_id=new)
+        fixture.action_owners[new] = fixture.action_owners.pop(old)
+        _replace(fixture, capability_fixture._BINDING_READ, module_action=ModuleActionRef(
+            module_node_id=capability_fixture._MODULE, action_node_id=new,
+        ))
+    elif change == "event_identity":
+        _event_identity_change(fixture)
+    elif change in {"action_body", "action_request_schema", "action_response_schema"}:
+        field = {
+            "action_body": "description",
+            "action_request_schema": "request_fields",
+            "action_response_schema": "response_fields",
+        }[change]
+        value = "Different implementation description" if field == "description" else [
+            {"name": "changed_field", "field_type": "string", "required": False},
+        ]
+        _replace(fixture, capability_fixture._ACTION_GET, **{field: value})
+    elif change in {"event_body", "event_schema"}:
+        values = (
+            {"description": "Changed event payload body"}
+            if change == "event_body" else {
+                "payload_fields": [{"name": "extra", "field_type": "string", "required": False}],
+            }
+        )
+        _replace(fixture, capability_fixture._EVENT, **values)
+    elif change == "producer_action_body":
+        _replace(fixture, capability_fixture._ACTION_CREATE, description="Changed producer implementation")
+    elif change.startswith("unrelated_"):
+        kind = change.removeprefix("unrelated_")
+        if kind == "event_identity":
+            _event_identity_change(fixture, other=True)
+            return
+        node = {
+            "workflow": capability_fixture._WORKFLOW,
+            "capability": capability_fixture._CAPABILITY,
+            "result": capability_fixture._RESULT,
+            "module": capability_fixture._MODULE,
+            "action": capability_fixture._ACTION_GET,
+            "event": capability_fixture._EVENT,
+        }[kind]
+        _replace(fixture, _other(node), description="Only another workflow's facts changed")
+    elif change == "order_only":
+        fixture.payloads = dict(reversed(list(fixture.payloads.items())))
+        fixture.event_identities = dict(reversed(list(fixture.event_identities.items())))
+        fixture.action_owners = dict(reversed(list(fixture.action_owners.items())))
+    else:
+        raise AssertionError(f"Unknown test mutation {change}")
+
+
+_AFFECTED_CHANGES = (
+    "capability_added", "capability_removed", "capability_id", "capability_description",
+    "owned_result_added", "owned_result_removed", "result_id", "result_description",
+    "advisory_result_added", "advisory_result_removed", "advisory_id", "advisory_description",
+    "commit_added", "commit_removed", "commit_changed", "consumes_action_changed",
+    "trigger_changed", "module_id", "action_node_identity", "event_identity",
+)
+_REUSABLE_CHANGES = (
+    "action_body", "action_request_schema", "action_response_schema", "producer_action_body",
+    "event_body", "event_schema", "unrelated_workflow", "unrelated_capability",
+    "unrelated_result", "unrelated_module", "unrelated_action", "unrelated_event",
+    "unrelated_event_identity", "order_only",
+)
+
+
+@pytest.mark.parametrize("change", (*_AFFECTED_CHANGES, *_REUSABLE_CHANGES))
+def test_selective_interface_rematerialization_matrix(change: str) -> None:
+    base = _state()
+    base_bundle = materialization.materialize_plan(**base)
+    fixture = _fixture()
+    _mutate(fixture, change)
+    successor = _state(fixture, version=2, reverse=change == "order_only")
+    target = _unit(successor)
+    unaffected = _unit(successor, _OTHER_WORKFLOW_ID)
+    expected_affected = change in _AFFECTED_CHANGES
+    closure = plan_regeneration_closure(base["plan"], successor["plan"])
+    assert (target.unit_id in closure.affected) is expected_affected
+    assert (target.unit_id in closure.reusable) is not expected_affected
+    refreshed = _rematerialize(base, successor, base_bundle)
+    output_by_id = {output.unit_id: output for output in refreshed.outputs}
+    before_by_id = {output.unit_id: output for output in base_bundle.outputs}
+    target_output = output_by_id[target.unit_id]
+    assert target_output.origin == ("rendered" if expected_affected else "reused")
+    if expected_affected:
+        assert target_output.content != before_by_id[target.unit_id].content
+        assert unaffected.unit_id in closure.reusable
+        assert output_by_id[unaffected.unit_id].origin == "reused"
+    else:
+        assert target_output.content == before_by_id[target.unit_id].content
+    assert refreshed.files() == materialization.materialize_plan(**successor).files()
+
+
+@pytest.mark.parametrize("node_id", [capability_fixture._WORKFLOW, capability_fixture._MODULE])
+def test_whole_included_payload_pins_conservatively_invalidate_unused_descriptions(node_id: str) -> None:
+    base = _state()
+    fixture = _fixture()
+    _replace(fixture, node_id, description="An included payload field absent from interface bytes")
+    successor = _state(fixture, version=2)
+    unit_id = _unit(successor).unit_id
+    assert unit_id in plan_regeneration_closure(base["plan"], successor["plan"]).affected
+    refreshed = _rematerialize(base, successor)
+    assert next(output for output in refreshed.outputs if output.unit_id == unit_id).origin == "rendered"
+    assert _direct_bytes(base) == _direct_bytes(successor)
+
+
+def test_commit_fan_out_keeps_one_result_ownership_row_and_advisory_result() -> None:
+    fixture = _fixture()
+    _mutate(fixture, "commit_added")
+    document = yaml.safe_load(_direct_bytes(_state(fixture)))
+    capability = next(item for item in document["capabilities"] if item["capability_id"] == "documents.analysis")
+    assert [result["result_id"] for result in capability["results"]] == ["advisory_summary", "analysis_result"]
+    commits = [binding for binding in capability["bindings"] if binding["role"] == "commits_result_through_action"]
+    assert len(commits) == 2
+    assert {binding["workflow_result_id"] for binding in commits} == {"analysis_result"}
+    assert {binding["action_node_id"] for binding in commits} == {
+        capability_fixture._ACTION_GET, capability_fixture._ACTION_STORE,
+    }
+
+
+def _forged_taxonomy_plan(state: dict[str, Any], change: str) -> CompilationPlan:
+    plan = state["plan"]
+    target_id = _unit(state).unit_id
+    document = plan.model_dump(mode="json")
+    unit = next(unit for unit in document["units"] if unit["unit_id"] == target_id)
+    original = unit["taxonomy_sources"][0]
+    alternate = {
+        "node_id": _other(capability_fixture._EVENT),
+        "category": "event",
+        "identifier": "domain.archives.created",
+    }
+    if change == "missing":
+        unit.pop("taxonomy_sources")
+    elif change == "surplus":
+        unit["taxonomy_sources"] = sorted([original, alternate], key=lambda item: item["node_id"])
+    elif change == "stale":
+        unit["taxonomy_sources"] = [{**original, "identifier": _NEW_EVENT_ID}]
+    else:
+        assert change == "substituted"
+        unit["taxonomy_sources"] = [alternate]
+    document["plan_digest"] = canonical_digest({key: value for key, value in document.items() if key != "plan_digest"})
+    return CompilationPlan.model_validate_json(json.dumps(document))
+
+
+@pytest.mark.parametrize("change", ["missing", "surplus", "stale", "substituted"])
+def test_redigested_taxonomy_forgeries_reject_before_render_or_historical_reuse(change: str, monkeypatch) -> None:
+    state = _state(reload=True)
+    bundle = materialization.materialize_plan(**state)
+    forged = _forged_taxonomy_plan(state, change)
+    assert forged.plan_digest != state["plan"].plan_digest
+    with pytest.raises(PlanAuthorityError):
+        validate_compilation_plan_against_authority(forged, state["authority_inputs"])
+
+    def forbidden_renderer(**_kwargs):
+        raise AssertionError("Canonical authority must reject before any renderer runs")
+
+    monkeypatch.setattr(materialization, "render_workflow_module_interface_unit", forbidden_renderer)
+    forged_state = {**state, "plan": forged}
+    with pytest.raises(materialization.MaterializationError, match="canonical authority"):
+        materialization.materialize_plan(**forged_state)
+    with pytest.raises(materialization.MaterializationError, match="canonical authority"):
+        _rematerialize(state, forged_state, bundle)
+    with pytest.raises(materialization.MaterializationError, match="canonical authority"):
+        _rematerialize(forged_state, state, bundle)
+
+
+@pytest.mark.parametrize("scope", [PathScope.WORKSPACE_ROOT, PathScope.WORKFLOW_RELATIVE])
+def test_interface_bytes_deterministic_across_process_order_and_all_round_trips(scope: PathScope) -> None:
+    state = _state(scope=scope)
+    expected = _direct_bytes(state)
+    again = _state(scope=scope)
+    reordered = _state(scope=scope, reverse=True)
+    reloaded = _state(scope=scope, reload=True)
+    assert _direct_bytes(again) == _direct_bytes(reordered) == _direct_bytes(reloaded) == expected
+    assert again["plan"] == reordered["plan"] == reloaded["plan"] == state["plan"]
+    unit = _unit(state)
+    projected = materialization.project_workflow_interface_render_input(
+        unit=unit, payload_by_node={payload.node_id: payload for payload in state["payloads"]},
+    )
+    raw_input = projected.model_dump(mode="json")
+    raw_input["sources"].reverse()
+    raw_input["edge_sources"].reverse()
+    raw_input["taxonomy_sources"].reverse()
+    raw_input["capabilities"].reverse()
+    for capability in raw_input["capabilities"]:
+        capability["results"].reverse()
+        capability["bindings"].reverse()
+    reloaded_input = WorkflowInterfaceRenderInput.model_validate_json(json.dumps(raw_input))
+    assert reloaded_input == projected
+    assert render_workflow_module_interface_unit(unit=unit, render_input=reloaded_input) == expected
+    probe = (
+        "from tests.test_workflow_interface_rematerialization import _state, _direct_bytes\n"
+        "from mozaiksai.core.runtime.app.layout_registry import PathScope\n"
+        f"print(_direct_bytes(_state(scope=PathScope({scope.value!r}))).hex())\n"
+    )
+    completed = subprocess.run([sys.executable, "-c", probe], cwd=ROOT, capture_output=True, text=True, timeout=60)
+    assert completed.returncode == 0, completed.stderr
+    assert bytes.fromhex(completed.stdout.strip()) == expected
+
+
+def test_equivalent_canonical_taxonomy_spelling_and_order_reuse_historical_bytes() -> None:
+    fixture = _fixture()
+    second_trigger = "mozaiks.workflow_capability_binding.analysis_on_archive"
+    fixture.payloads[second_trigger] = _rebuilt(
+        fixture.payloads[capability_fixture._BINDING_TRIGGER],
+        node_id=second_trigger, event_node_id=_other(capability_fixture._EVENT),
+    )
+    base = _state(fixture)
+    assert len(_unit(base).taxonomy_sources) == 2
+    successor = _state(fixture, version=2, reverse=True, reload=True)
+    document = successor["plan"].model_dump(mode="json")
+    for unit in document["units"]:
+        if "taxonomy_sources" in unit:
+            unit["taxonomy_sources"].reverse()
+        for taxonomy in unit.get("taxonomy_sources", []):
+            taxonomy["identifier"] = f"  {taxonomy['identifier']}  "
+    successor["plan"] = CompilationPlan.model_validate_json(json.dumps(document))
+    validate_compilation_plan_against_authority(successor["plan"], successor["authority_inputs"])
+    refreshed = _rematerialize(base, successor)
+    assert all(output.origin == "reused" for output in refreshed.outputs)
+    assert refreshed.files() == materialization.materialize_plan(**base).files()
+
+
+def test_runtime_registry_changes_cannot_affect_interface_reuse(monkeypatch, tmp_path) -> None:
+    from mozaiksai.core.workflow import workflow_manager
+
+    base = _state()
+    bundle = materialization.materialize_plan(**base)
+    runtime_registry = tmp_path / "extension_registry.json"
+    runtime_registry.write_text('{"entrypoints": [{"id": "different_runtime_workflow"}]}', encoding="utf-8")
+    monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(tmp_path))
+
+    def forbidden_registry():
+        raise AssertionError("Compiler interface must not consult the runtime workflow registry")
+
+    monkeypatch.setattr(workflow_manager, "get_workflow_manager", forbidden_registry)
+    successor = _state(version=2)
+    refreshed = _rematerialize(base, successor, bundle)
+    assert all(output.origin == "reused" for output in refreshed.outputs)
+    assert refreshed.files() == bundle.files()

--- a/tests/test_workflow_interface_renderer.py
+++ b/tests/test_workflow_interface_renderer.py
@@ -1,0 +1,379 @@
+"""Direct renderer shape authority, closed inputs, and canonical interface bytes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from mozaiksai.core.runtime.app.layout_registry import (
+    ValidatorIdentifier,
+    build_app_layout_registry,
+)
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.compilation_plan import (
+    FamilyInstancePlan,
+    PlanDisposition,
+    PlanEdgeSource,
+    PlanOutput,
+    PlanSource,
+    PlanSourceScope,
+    PlanTaxonomySource,
+    canonical_instance_unit_id,
+    snapshot_layout_registry,
+)
+from mozaiksai.core.semantics.workflow_interface_materialization import (
+    WORKFLOW_MODULE_INTERFACE,
+    RenderInputCommitsResultBinding,
+    RenderInputConsumesActionBinding,
+    RenderInputTriggeredByEventBinding,
+    RenderInputWorkflowCapability,
+    RenderInputWorkflowResult,
+    WorkflowInterfaceMaterializationError,
+    WorkflowInterfaceRenderInput,
+    render_workflow_module_interface_unit,
+)
+
+
+def _rows():
+    return {
+        row.path_scope: row
+        for row in snapshot_layout_registry(build_app_layout_registry(())).rows
+        if row.kind == WORKFLOW_MODULE_INTERFACE
+    }
+
+
+def _renderer_case(path_scope="workspace_root"):
+    row = _rows()[path_scope]
+    sources = (
+        PlanSource(node_id="workflow.orders", payload_digest="1" * 64),
+        PlanSource(node_id="capability.orders", payload_digest="2" * 64),
+    )
+    edge_facts = {
+        "kind": "declares",
+        "source_node_id": "workflow.orders",
+        "target_node_id": "capability.orders",
+        "discriminator": None,
+    }
+    edges = (PlanEdgeSource(**edge_facts, edge_identity=canonical_digest(edge_facts)),)
+    taxonomy = (
+        PlanTaxonomySource(
+            node_id="event.order_created", category="event", identifier="domain.order.created"
+        ),
+    )
+    unit = FamilyInstancePlan(
+        unit_id=canonical_instance_unit_id(row.kind, "orders", row.row_digest),
+        family_kind=row.kind,
+        family_identity_digest=row.row_digest,
+        disposition=PlanDisposition.RENDER,
+        source_scope=PlanSourceScope.DECLARED,
+        placeholder_values=(("workflow_id", "orders"),),
+        outputs=(
+            PlanOutput(
+                path_scope=row.path_scope,
+                path=row.path_template.replace("{workflow_id}", "orders"),
+            ),
+        ),
+        sources=sources,
+        edge_sources=edges,
+        taxonomy_sources=taxonomy,
+        materializer=row.materializer,
+        validator=row.validator,
+    )
+    render_input = WorkflowInterfaceRenderInput(
+        workflow_id="orders",
+        sources=sources,
+        edge_sources=edges,
+        taxonomy_sources=taxonomy,
+        capabilities=(
+            RenderInputWorkflowCapability(
+                capability_id="orders.analysis",
+                description="Analyze orders",
+                results=(
+                    RenderInputWorkflowResult(result_id="summary", description="Order summary"),
+                    RenderInputWorkflowResult(result_id="advice"),
+                ),
+                bindings=(
+                    RenderInputTriggeredByEventBinding(event_type="domain.order.created"),
+                    RenderInputConsumesActionBinding(module_id="orders", action_node_id="action.list"),
+                    RenderInputCommitsResultBinding(
+                        module_id="orders",
+                        action_node_id="action.save",
+                        workflow_result_id="summary",
+                    ),
+                    RenderInputCommitsResultBinding(
+                        module_id="orders",
+                        action_node_id="action.archive",
+                        workflow_result_id="summary",
+                    ),
+                ),
+            ),
+        ),
+    )
+    return unit, render_input
+
+
+@pytest.mark.parametrize("scope", ["workspace_root", "workflow_relative"])
+def test_exact_document_keeps_advisory_results_and_action_node_identity(scope):
+    unit, render_input = _renderer_case(scope)
+    rendered = render_workflow_module_interface_unit(unit=unit, render_input=render_input)
+    document = yaml.safe_load(rendered)
+    assert document == {
+        "schema_version": "mozaiks.module_interface.v2",
+        "workflow_id": "orders",
+        "capabilities": [
+            {
+                "capability_id": "orders.analysis",
+                "description": "Analyze orders",
+                "results": [
+                    {"result_id": "advice"},
+                    {"result_id": "summary", "description": "Order summary"},
+                ],
+                "bindings": [
+                    {
+                        "role": "commits_result_through_action",
+                        "module_id": "orders",
+                        "action_node_id": "action.archive",
+                        "workflow_result_id": "summary",
+                    },
+                    {
+                        "role": "commits_result_through_action",
+                        "module_id": "orders",
+                        "action_node_id": "action.save",
+                        "workflow_result_id": "summary",
+                    },
+                    {
+                        "role": "consumes_action",
+                        "module_id": "orders",
+                        "action_node_id": "action.list",
+                    },
+                    {"role": "triggered_by_event", "event_type": "domain.order.created"},
+                ],
+            },
+        ],
+    }
+    assert rendered.endswith(b"\n")
+    assert b"\r" not in rendered
+
+
+@pytest.mark.parametrize("scope", ["workspace_root", "workflow_relative"])
+@pytest.mark.parametrize(
+    "attack",
+    [
+        "app_bundle_root",
+        "generated_staging",
+        "module_relative",
+        "other_twin_output",
+        "extra_placeholder",
+        "missing_placeholder",
+        "substituted_placeholder",
+        "wrong_digest_suffix",
+        "other_row_digest",
+        "other_unit_id",
+        "correct_path_wrong_scope",
+        "correct_scope_foreign_path",
+        "input_workflow_mismatch",
+        "surplus_output",
+        "missing_output",
+        "wrong_family",
+        "wrong_materializer",
+        "wrong_disposition",
+        "wrong_validator",
+        "unknown_row_digest",
+        "invalid_workflow_grammar",
+    ],
+)
+def test_hostile_output_identity_matrix_rejects(scope, attack):
+    unit, render_input = _renderer_case(scope)
+    other_scope = "workflow_relative" if scope == "workspace_root" else "workspace_root"
+    other_unit, _ = _renderer_case(other_scope)
+    output = unit.outputs[0]
+    updates = {}
+    if attack in {"app_bundle_root", "generated_staging", "module_relative"}:
+        updates["outputs"] = (PlanOutput(path_scope=attack, path=output.path),)
+    elif attack == "other_twin_output":
+        # Coordinated scope AND path substitution retains the original row identity.
+        updates["outputs"] = other_unit.outputs
+    elif attack == "extra_placeholder":
+        updates["placeholder_values"] = (*unit.placeholder_values, ("module_id", "orders"))
+    elif attack == "missing_placeholder":
+        updates["placeholder_values"] = ()
+    elif attack == "substituted_placeholder":
+        updates["placeholder_values"] = (("workflow_id", "foreign"),)
+    elif attack == "wrong_digest_suffix":
+        updates["unit_id"] = f"workflow_module_interface/orders/{'0' * 12}"
+    elif attack == "other_row_digest":
+        updates["family_identity_digest"] = other_unit.family_identity_digest
+    elif attack == "other_unit_id":
+        updates["unit_id"] = other_unit.unit_id
+    elif attack == "correct_path_wrong_scope":
+        updates["outputs"] = (PlanOutput(path_scope=other_scope, path=output.path),)
+    elif attack == "correct_scope_foreign_path":
+        updates["outputs"] = (
+            PlanOutput(path_scope=scope, path="workflows/foreign/module_interface.yaml"),
+        )
+    elif attack == "input_workflow_mismatch":
+        render_input = render_input.model_copy(update={"workflow_id": "foreign"})
+    elif attack == "surplus_output":
+        updates["outputs"] = (*unit.outputs, PlanOutput(path_scope=scope, path="extra.yaml"))
+    elif attack == "missing_output":
+        updates["outputs"] = ()
+    elif attack == "wrong_family":
+        updates["family_kind"] = "workflow_manifest"
+    elif attack == "wrong_materializer":
+        updates["materializer"] = "workflow_generator"
+    elif attack == "wrong_disposition":
+        updates["disposition"] = PlanDisposition.INPUT_ONLY
+    elif attack == "wrong_validator":
+        updates["validator"] = ValidatorIdentifier.WORKFLOW_MANAGER
+    elif attack == "unknown_row_digest":
+        updates["family_identity_digest"] = "0" * 64
+    elif attack == "invalid_workflow_grammar":
+        updates["placeholder_values"] = (("workflow_id", "../Orders"),)
+    else:
+        raise AssertionError(attack)
+    forged = unit.model_copy(update=updates)
+    with pytest.raises(WorkflowInterfaceMaterializationError):
+        render_workflow_module_interface_unit(unit=forged, render_input=render_input)
+
+
+def test_complete_alternate_canonical_unit_is_recognized_as_that_shape():
+    workspace_unit, workspace_input = _renderer_case("workspace_root")
+    relative_unit, relative_input = _renderer_case("workflow_relative")
+    assert workspace_unit.unit_id != relative_unit.unit_id
+    assert render_workflow_module_interface_unit(
+        unit=workspace_unit, render_input=workspace_input
+    ) == render_workflow_module_interface_unit(unit=relative_unit, render_input=relative_input)
+
+
+@pytest.mark.parametrize("field", ["sources", "edge_sources", "taxonomy_sources"])
+@pytest.mark.parametrize("attack", ["missing", "surplus", "stale", "substituted"])
+def test_exact_pinned_footprint_mismatch_rejects(field, attack):
+    unit, render_input = _renderer_case()
+    values = getattr(unit, field)
+    first = values[0]
+    if field == "sources":
+        changed = first.model_copy(
+            update={"payload_digest": "f" * 64}
+            if attack == "stale"
+            else {"node_id": "workflow.foreign"}
+        )
+    elif field == "taxonomy_sources":
+        changed = first.model_copy(
+            update={"identifier": "domain.order.updated"}
+            if attack == "stale"
+            else {"node_id": "event.foreign"}
+        )
+    else:
+        facts = first.model_dump(mode="json", exclude={"edge_identity"})
+        facts["target_node_id"] = "capability.foreign"
+        if attack == "stale":
+            facts["discriminator"] = "result.foreign"
+        changed = PlanEdgeSource(**facts, edge_identity=canonical_digest(facts))
+    forged_values = (
+        values[1:]
+        if attack == "missing"
+        else (*values, changed)
+        if attack == "surplus"
+        else (changed, *values[1:])
+    )
+    forged = unit.model_copy(update={field: forged_values})
+    with pytest.raises(WorkflowInterfaceMaterializationError):
+        render_workflow_module_interface_unit(unit=forged, render_input=render_input)
+
+
+@pytest.mark.parametrize("path", [(), ("capabilities", 0), ("capabilities", 0, "results", 0), ("capabilities", 0, "bindings", 0)])
+def test_closed_input_rejects_unowned_fields_at_every_document_level(path):
+    _, render_input = _renderer_case()
+    raw = render_input.model_dump(mode="json")
+    target = raw
+    for part in path:
+        target = target[part]
+    target["runtime_identity"] = "unowned"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkflowInterfaceRenderInput.model_validate(raw)
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        {"role": "unknown_role", "event_type": "domain.order.created"},
+        {"role": "consumes_action", "module_id": "orders"},
+        {"role": "consumes_action", "module_id": "orders", "action_node_id": "action.list", "event_type": "domain.order.created"},
+        {"role": "triggered_by_event", "event_type": "bad event"},
+        {"role": "commits_result_through_action", "module_id": "orders", "action_node_id": "action.save", "workflow_result_id": "foreign"},
+    ],
+)
+def test_binding_roles_are_closed_and_commits_cannot_reference_foreign_results(binding):
+    _, render_input = _renderer_case()
+    raw = render_input.model_dump(mode="json")
+    raw["capabilities"][0]["bindings"] = [binding]
+    with pytest.raises(ValidationError):
+        WorkflowInterfaceRenderInput.model_validate(raw)
+
+
+@pytest.mark.parametrize("field", ["capabilities", "sources", "edge_sources", "taxonomy_sources", "results", "bindings"])
+def test_duplicate_identities_reject(field):
+    _, render_input = _renderer_case()
+    raw = render_input.model_dump(mode="json")
+    target = raw["capabilities"][0] if field in {"results", "bindings"} else raw
+    target[field].append(target[field][0])
+    with pytest.raises(ValidationError, match="duplicate"):
+        WorkflowInterfaceRenderInput.model_validate(raw)
+
+
+def test_direct_entry_cold_validates_frozen_objects_and_nested_inputs():
+    unit, render_input = _renderer_case()
+    with pytest.raises(ValidationError, match="frozen"):
+        render_input.workflow_id = "foreign"
+    with pytest.raises(ValidationError, match="frozen"):
+        render_input.capabilities[0].description = "Changed"
+    forged_binding = render_input.capabilities[0].bindings[0].model_copy(
+        update={"action_node_id": "not a node"}
+    )
+    forged_capability = render_input.capabilities[0].model_copy(update={"bindings": (forged_binding,)})
+    forged_input = render_input.model_copy(update={"capabilities": (forged_capability,)})
+    with pytest.raises(WorkflowInterfaceMaterializationError, match="cold validation"):
+        render_workflow_module_interface_unit(unit=unit, render_input=forged_input)
+
+
+@pytest.mark.parametrize("scope", ["workspace_root", "workflow_relative"])
+def test_ordering_repeated_render_and_serialized_round_trip_are_byte_identical(scope):
+    unit, render_input = _renderer_case(scope)
+    baseline = render_workflow_module_interface_unit(unit=unit, render_input=render_input)
+    raw = render_input.model_dump(mode="json")
+    for field in ("sources", "edge_sources", "taxonomy_sources", "capabilities"):
+        raw[field].reverse()
+    for capability in raw["capabilities"]:
+        capability["results"].reverse()
+        capability["bindings"].reverse()
+    shuffled_input = WorkflowInterfaceRenderInput.model_validate(raw)
+    assert shuffled_input == render_input
+    for _ in range(3):
+        assert render_workflow_module_interface_unit(unit=unit, render_input=shuffled_input) == baseline
+    assert render_workflow_module_interface_unit(
+        unit=FamilyInstancePlan.model_validate_json(unit.model_dump_json()),
+        render_input=WorkflowInterfaceRenderInput.model_validate_json(shuffled_input.model_dump_json()),
+    ) == baseline
+
+
+def test_repeated_fresh_processes_produce_identical_interface_bytes():
+    script = """
+import json
+from tests.test_workflow_interface_renderer import _renderer_case
+from mozaiksai.core.semantics.workflow_interface_materialization import render_workflow_module_interface_unit
+values = []
+for scope in ('workspace_root', 'workflow_relative'):
+    unit, render_input = _renderer_case(scope)
+    values.append(render_workflow_module_interface_unit(unit=unit, render_input=render_input).decode())
+print(json.dumps(values))
+"""
+    first = subprocess.check_output([sys.executable, "-c", script], text=True)
+    second = subprocess.check_output([sys.executable, "-c", script], text=True)
+    assert first == second
+    workspace, relative = json.loads(first)
+    assert workspace == relative


### PR DESCRIPTION
## Canonical workflow module interfaces

This adds one compiler family, `workflow_module_interface`, which deterministically projects existing SemanticGraph meaning into `mozaiks.module_interface.v2`. A referenced event identity change now causes the real rematerialization path to replace its owner's interface bytes, while unrelated workflow interfaces remain reusable.

Exact base: `71c355a728a1470286d02f23eba666bfe93a5ff9`.
Exact head: `50a70473a7add04c85644e723f53855936b7e061`.
Branch: `astra/workflow-module-interface-v2`.

Preflight fetched this exact main and confirmed #481 post-main CI [33992889281](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/33992889281) terminal green before branch creation. Closed #479 remains superseded evidence only; nothing was cherry-picked. #482 retired factory/agent ownership; #481 supplies the taxonomy-source and reuse-authority primitive.

### Layout and document

Only two rows are added:

| Scope | Template |
| --- | --- |
| `workspace_root` | `workflows/{workflow_id}/module_interface.yaml` |
| `workflow_relative` | `module_interface.yaml` |

Both rows: owner `workflow`, conditional `when_workflow_declared`, multiplicity `many`, materializer `workflow_interface_executor`, disposition `render`, validator `generated_app_validator`, runtime consumer **NONE**, security `internal_contract`, dependency `workflow_manifest`. Both carry exactly `(("workflow_id", workflow_id),)` for active instances. Existing workflow scope selection picks the active row; the other is explicitly inactive. Workflow-relative bundle composition remains deferred; both rows are proven through direct rendering.

The YAML contains only `schema_version`, semantic `workflow_id`, and ordered `capabilities`. Each capability has its ID, optional payload-owned description, every owned result (ID and optional description), and typed bindings:

- `consumes_action`: `module_id`, `action_node_id`.
- `commits_result_through_action`: `module_id`, `action_node_id`, `workflow_result_id`.
- `triggered_by_event`: canonical `event_type`.

All advisory/uncommitted results remain first-class. Commit fan-out does not duplicate result ownership. No action body or request/response schema, result output schema, runtime/AG2/provider/model identity, approval policy, or launch information is rendered.

### Exact authority footprint

For workflow W, C contains every owned capability, R every C-owned result, B every C-owned typed binding, M the modules referenced by action bindings, and E the events referenced by trigger bindings.

- Payload pins: exactly `{W} ∪ C ∪ R ∪ B ∪ M`, as canonical node/digest pairs. Action and event payloads are excluded.
- Edge pins: `W DECLARES C`, `C DECLARES R`, `C DECLARES B`, plus the existing typed binding-edge projection: `B CONSUMES A`; commit `B BINDS A` with result-node discriminator and `B CONSUMES R`; trigger `B CONSUMES E`.
- Taxonomy pins: exactly each referenced E's canonical EVENT identity. No ambient or unrelated taxonomy enters.

Projection accesses payloads only by plan-pinned keys. Closed frozen role unions and source models prohibit undeclared input. The pure renderer consumes no graph, payload models, filesystem, runtime registry, environment, clocks, or randomness. The existing recursive closure checker now recognizes `Annotated` closed unions while still rejecting open annotated types.

### Output identity and plan authority

The renderer resolves `family_identity_digest` to a live canonical row first, then derives the exact unit ID through the shared planner helper, exact placeholder set, scope and expanded path. Caller scope never chooses the expected profile. Both-row hostile matrices reject scope/path swaps, coordinated twin forgeries, surplus/missing/substituted placeholders, wrong row/unit digest prefixes, foreign workflow paths, and input workflow mismatches.

A complete alternate canonical twin is valid as a direct-renderer shape. #475/#477 canonical rederivation remains the separate plan-membership authority before rendering or historical-byte reuse.

### Rematerialization and identity proofs

The 34-case actual-rematerialization matrix covers owned capability/result/advisory/binding additions, removals and edits; module/action-node/event identity changes; and reuse for unrelated facts, referenced action body/schemas, event body/schema, and input ordering. Additional checks prove runtime-registry independence and the documented conservative invalidation from whole selected WorkflowPayload/ModulePayload pins.

The first real #481 taxonomy-source family acceptance derives nonempty taxonomy pins, materializes, changes a referenced canonical event plus producer declarations, derives the successor, proves the owner is affected and unrelated interface reusable, calls real rematerialization, checks fresh bytes contain the new identity and exclude the old one, and compares against clean successor materialization. This repeats through serialized plans and authority inputs. Two-pin canonical whitespace/order variants reuse historical bytes. Missing, surplus, stale and substituted re-digested taxonomy pins reject before any renderer runs or old bytes are reused.

Exact-base capture observed **59 pre-family units**. The permanent fixture compares every old unit's canonical row, IDs, identity payload, JSON-mode dump, serialized bytes, digest, placeholders, dependencies, outputs and all three source sets. All 59 are identical; no IDs moved or disappeared. The corpus now has 61 units, adding only the active interface and inactive alternate row. Unit-proof fingerprint: `c27885233d404cf253c80ad6e4fb4f44309b444a4efe41eb80461e11c601d5ea`. Only the directly affected aggregate CompilationPlan golden changes for the two new rows/units; prior unit fingerprints and unrelated goldens are retained.

#482 writer hygiene permits three exact metadata/projection files and one byte renderer, with no directory exemption. Retired v1 authority remains forbidden even within allowed files; factory and agent writers remain zero. Repeated derivation, shuffled graph/input, separate processes and serialization/reload yield identical bytes for both direct-render layout rows.

### Validation and review

- Final focused suite: **699 passed, 1 skipped**, including interface/layout/direct hostile identity matrices/result/taxonomy E2E; #478 capability semantics; #481 taxonomy; #482 hygiene/materializing task authority; CompilationPlan/regeneration; #475/#477 authority; materialization/rematerialization; composition/enforcement; 5A/5B/5C; ArtifactRevision contracts/store; source hygiene.
- Independent interface review suite: **143 passed**.
- Full `python -m pytest -q --no-cov`: **14740 passed, 94 skipped, 4 warnings** in 912.33s on the reviewed head.
- Repository-wide source hygiene scan: passed.
- `ruff check .`: passed.
- Scoped mypy over all four production files: passed.
- Strict MkDocs and `git diff --check`: passed.
- Commit is DCO signed; GitHub DCO **passed** on the published head. GitHub CI is **running**, not yet terminal.

Codex 3 independent exact-head review: **PASS, no blocking findings** at `50a70473a7add04c85644e723f53855936b7e061`; independently ran 143 interface/corpus/closure/E2E/hygiene tests. This records a local independent review, not a GitHub approval.

### OSS Change Impact

- Layer: offline semantic compiler, canonical layout, deterministic projection/rendering.
- Build workflows: no workflow sequence, transition, entrypoint, factory task or prompt changes.
- Runtime/platform and app workspaces: no routing or runtime consumer changes; consumer is NONE.
- Docs: ADR 0007 and changelog describe this bounded slice and conservative whole-payload invalidation.
- Compatibility: all 59 existing units remain identical; only the new family extends aggregate plan identity.
- Explicitly absent: app workflow registry, runtime routing, workflow touchpoints, persistent workflow launch changes, AppGenerator/AgentGenerator production cutovers, and ArtifactRevision 5D.

DCO signed. **Draft; auto-merge disabled. Do not merge.** Exact-head reviewer: **Codex 3**.
