### PR TITLE
feat(semantics): add closed contracts for action requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Closed semantic action requests**: `ActionPayload.request_contract` replaces
+  shallow request fields with one immutable, bounded contract algebra for null,
+  scalars, homogeneous arrays, and closed objects. Offline module-schema imports
+  reject unproven closure and unsupported assertions. Executable module dispatch
+  schemas retain their current authority; realization proofs remain deferred.
 - **Canonical workflow module interfaces**: the offline compiler renders
   `mozaiks.module_interface.v2` from exact workflow capability, result,
   binding, module, and event-taxonomy sources. Advisory results are retained;

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -184,6 +184,96 @@ resolver, serializer, taxonomy, or binding authority. Implementation binding
 continues to select a verified implementation only for a requirement already
 present in the pinned graph and cannot add payload facts.
 
+### Closed action request contracts
+
+`ActionPayload.request_contract` owns the application's semantic input
+requirement. It is a required, non-null `ObjectContract`; an action accepting
+no request data explicitly declares an empty closed object. The retired
+`request_fields` input is rejected, including when supplied alongside the new
+contract. Response fields, event payloads, data/entity fields, and workflow
+structured outputs retain their existing contracts.
+
+The canonical algebra lives in `mozaiksai.core.semantics.closed_contracts`:
+
+| Variant | Value meaning and fields |
+|---|---|
+| `NullContract` (`null`) | Exactly null; no nullable flag or other variant fields. |
+| `ScalarContract` (`boolean`, `integer`, `number`, `string`) | Required `nullable`; optional nonempty homogeneous scalar `enum`, excluding null. |
+| `ArrayContract` (`array`) | Required `nullable` and one recursive `items` contract. |
+| `ObjectContract` (`object`) | Required `nullable`, property tuple, and explicit `additional_properties: false`. |
+| `ContractProperty` | Exact nonempty `name`, explicit `required`, and a recursive `contract`. |
+
+Property absence, a present null value, a null-only contract, and a nullable
+non-null type are distinct. Optionality belongs to the property; nullability
+belongs to its value. Every object is closed. Duplicate property names or enum
+values reject. Properties sort by exact name and enums sort by scalar value.
+Boolean and integer values never coerce into each other. INTEGER enum members
+are exact signed 64-bit integers; NUMBER enum members are exact finite floats.
+Negative floating zero stores as positive zero. Integer/float enum forms are
+deliberately distinct canonical representations.
+
+The versioned profile `mozaiks.closed_contract_profile.v1` permits depth **32**
+(root depth one) and **1024** total contract occurrences. Property wrappers do
+not add nodes or depth; reused children count at every occurrence. Iterative
+preflight rejects cycles and excessive depth or width before recursive model
+validation. Exceeding a limit is `UNSUPPORTED`, never a compatibility success.
+Raw properties accept only lists or tuples so a lazy iterable cannot bypass
+the aggregate limits. Validated state contains only frozen models, tuples, and
+strict scalar values. Nested instances revalidate; update-copy paths reject.
+Identity and digest use the existing canonical serialization primitives.
+
+`closed_contract_schema.import_closed_contract_schema` is an explicit offline
+import boundary for existing module action `input_schema` documents. It
+supports only the finite profile's JSON-schema-like `type`, scalar `enum`,
+homogeneous `items`, and closed object `properties`/`required` declarations.
+Object `additionalProperties` must explicitly be false. Omission, open or
+schema-valued additional properties, unsupported assertions, unknown keys,
+refs, schema compositions/unions, conditional schemas, and custom validation
+hooks reject. Format, patterns, numeric/string/array bounds, multiples,
+uniqueness, contains, and tuple arrays are never silently erased. This phase
+has no reference expansion, general union semantics, or schema exporter.
+
+The offline projector imports an explicitly supplied module action schema
+into request authority. An identity-only surface mutation can join that same
+module action declaration; without request authority it reports a typed
+`MISSING` gap. Unsupported module schemas report `UNSUPPORTED`. It never
+invents an empty request for unknown input. Bounds apply before the projector
+copies an input schema recursively. The producer audit found only this offline
+projector and semantic test fixtures; no production prompt, generator, or
+runtime consumes the removed shallow request field.
+
+The executable boundary remains:
+
+```text
+ActionPayload.request_contract       semantic application requirement
+module.yaml actions[].input_schema   executable artifact projection
+```
+
+Production module dispatch continues consuming the executable projection.
+Future publication must prove that the selected executable schema realizes
+the semantic request contract. Its initial compatibility policy must require
+normalized equality before broader compatible realization is considered.
+This phase implements neither that proof nor assignability, result/action-input
+projection, compatibility receipts, implementation-binding extensions, runtime
+delivery, or ArtifactRevision evidence changes.
+
+The existing immutable `CanonicalJsonValue` family is shared from
+`mozaiksai.core.semantics.canonical_json`; plan authority imports the same
+classes. Extraction preserves the entire accepted value domain, declaration
+order, serialized bytes, and digest semantics. It does not sort exact pinned
+document entries or replace the canonical serializer.
+
+The action request migration legitimately changes the semantic corpus action
+payload, containing graph, aggregate plan header, and archive digests. These
+golden changes are `EXPECTED_SEMANTIC_MIGRATION`: a permanent proof restores
+only the retired request field and its containing digest pins to recover the
+exact base identities. All 61 corpus units and the historical 59-unit proof
+remain byte/digest identical. The workflow interface excludes action payload
+bodies from its source footprint: changing a referenced action request
+contract preserves actual interface reuse and identical bytes after
+authority serialization and rematerialization. Any other identity change is
+`UNRELATED_DRIFT` and fails the migration proof.
+
 ### Aggregate CompilationPlan authority
 
 Exactly one aggregate `CompilationPlan` is authoritative for a bounded build.

--- a/mozaiksai/core/semantics/canonical_json.py
+++ b/mozaiksai/core/semantics/canonical_json.py
@@ -1,0 +1,164 @@
+"""Shared immutable canonical JSON values for semantic authority documents.
+
+This is the existing plan-authority value algebra, extracted without changing
+its accepted values, declaration order, frozen state, or serialized shape.
+Canonical byte encoding and digests remain owned by ``semantics.canonical``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
+
+
+class _AuthorityModel(BaseModel):
+    """Frozen base for authority documents: no unchecked update path exists.
+
+    ``model_copy(update=...)`` bypasses pydantic validation, which would let
+    a raw mutable or non-JSON value masquerade as validated authority state.
+    Authority models therefore refuse update-copies entirely — reconstruct
+    through ``model_validate`` instead. Plain no-update copies stay safe
+    because every field is itself frozen/immutable.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    def model_copy(self, *, update=None, deep: bool = False):
+        if update:
+            raise TypeError(
+                f"{type(self).__name__} does not support model_copy(update=...); "
+                "reconstruct through model_validate so authority content is "
+                "always validated"
+            )
+        return super().model_copy(deep=deep)
+
+
+def _reject_nonfinite(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("canonical JSON forbids NaN and infinite floats")
+    return value
+
+
+class CanonicalJsonEntry(_AuthorityModel):
+    """One key/value pair of a canonical JSON object."""
+
+    key: StrictStr
+    value: CanonicalJsonValue
+
+    @field_validator("value")
+    @classmethod
+    def _finite(cls, value: Any) -> Any:
+        return _reject_nonfinite(value)
+
+
+class CanonicalJsonObject(_AuthorityModel):
+    """Recursively closed, immutable, deterministic JSON object.
+
+    Entries carry unique string keys in their exact declaration order —
+    declaration order is meaning in structured-output contracts, so the
+    authority pins the document precisely as derivation consumed it; the
+    stored order is itself deterministic and survives serialization. Values
+    are drawn only from the closed JSON algebra: no mutable dict/list
+    survives construction and no non-JSON value can enter.
+    """
+
+    entries: tuple[CanonicalJsonEntry, ...] = ()
+
+    @model_validator(mode="after")
+    def _unique_keys(self) -> CanonicalJsonObject:
+        keys = [entry.key for entry in self.entries]
+        if len(set(keys)) != len(keys):
+            raise ValueError("canonical JSON object declares duplicate keys")
+        return self
+
+    @classmethod
+    def from_python(cls, value: Mapping[str, Any]) -> CanonicalJsonObject:
+        if not isinstance(value, Mapping):
+            raise ValueError("canonical JSON object requires a mapping")
+        entries = []
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ValueError(
+                    f"canonical JSON object keys must be str, got {type(key).__name__}"
+                )
+            entries.append(CanonicalJsonEntry(key=key, value=_json_value(item)))
+        return cls(entries=tuple(entries))
+
+    def to_python(self) -> dict[str, Any]:
+        return {entry.key: _python_value(entry.value) for entry in self.entries}
+
+
+class CanonicalJsonArray(_AuthorityModel):
+    """Recursively closed, immutable JSON array preserving element order."""
+
+    items: tuple[CanonicalJsonValue, ...] = ()
+
+    @field_validator("items")
+    @classmethod
+    def _finite_items(cls, value: tuple[Any, ...]) -> tuple[Any, ...]:
+        for item in value:
+            _reject_nonfinite(item)
+        return value
+
+
+CanonicalJsonValue = (
+    None
+    | StrictBool
+    | StrictInt
+    | StrictFloat
+    | StrictStr
+    | CanonicalJsonArray
+    | CanonicalJsonObject
+)
+
+CanonicalJsonEntry.model_rebuild()
+CanonicalJsonArray.model_rebuild()
+CanonicalJsonObject.model_rebuild()
+
+
+def _json_value(value: Any) -> Any:
+    """Normalize one Python value into the closed algebra, failing closed
+    immediately on anything that is not exact JSON."""
+    if value is None or type(value) is bool or type(value) is str:
+        return value
+    if type(value) is int:
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("canonical JSON forbids NaN and infinite floats")
+        return value
+    if isinstance(value, Mapping):
+        return CanonicalJsonObject.from_python(value)
+    if type(value) in (list, tuple):
+        return CanonicalJsonArray(items=tuple(_json_value(item) for item in value))
+    raise ValueError(
+        "canonical JSON forbids values of type " f"{type(value).__name__}"
+    )
+
+
+def _python_value(value: Any) -> Any:
+    if isinstance(value, CanonicalJsonObject):
+        return value.to_python()
+    if isinstance(value, CanonicalJsonArray):
+        return [_python_value(item) for item in value.items]
+    return value
+
+
+__all__ = [
+    "CanonicalJsonArray",
+    "CanonicalJsonEntry",
+    "CanonicalJsonObject",
+    "CanonicalJsonValue",
+]

--- a/mozaiksai/core/semantics/closed_contract_schema.py
+++ b/mozaiksai/core/semantics/closed_contract_schema.py
@@ -1,0 +1,121 @@
+"""Explicit import of the finite JSON-schema-shaped action request profile.
+
+The canonical closed contract is the resulting semantic authority. This
+importer accepts only exact null/scalar types, homogeneous arrays, and
+explicitly closed objects. Unsupported assertions are rejected, never erased.
+No references, unions, provider dialects, or executable validators are read.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mozaiksai.core.semantics.closed_contracts import (
+    CLOSED_CONTRACT_PROFILE_VERSION,
+    MAX_CONTRACT_DEPTH,
+    MAX_CONTRACT_NODES,
+    ArrayContract,
+    ClosedContract,
+    ClosedContractUnsupported,
+    ContractProperty,
+    NullContract,
+    ObjectContract,
+    ScalarContract,
+)
+
+_SCALAR_TYPES = frozenset({"boolean", "integer", "number", "string"})
+_SCHEMA_KEYS = {
+    "null": frozenset({"type"}),
+    **{kind: frozenset({"type", "enum"}) for kind in _SCALAR_TYPES},
+    "array": frozenset({"type", "items"}),
+    "object": frozenset({"type", "properties", "required", "additionalProperties"}),
+}
+
+
+def _unsupported(reason: str) -> ClosedContractUnsupported:
+    return ClosedContractUnsupported(f"UNSUPPORTED: {reason} under {CLOSED_CONTRACT_PROFILE_VERSION}")
+
+
+def _check_schema_profile(value: Any) -> None:
+    """Validate the raw document iteratively before any recursive conversion."""
+    stack: list[tuple[Any, int, bool]] = [(value, 1, False)]
+    active: set[int] = set()
+    count = 0
+    while stack:
+        current, depth, leaving = stack.pop()
+        if leaving:
+            active.remove(id(current))
+            continue
+        if type(current) is not dict:
+            raise _unsupported("each schema must be an exact object document")
+        if id(current) in active:
+            raise _unsupported("cyclic schema document")
+        count += 1
+        if depth > MAX_CONTRACT_DEPTH:
+            raise _unsupported(f"contract depth exceeds {MAX_CONTRACT_DEPTH}")
+        if count > MAX_CONTRACT_NODES:
+            raise _unsupported(f"contract nodes exceed {MAX_CONTRACT_NODES}")
+        kind = current.get("type")
+        if type(kind) is not str or kind not in _SCHEMA_KEYS:
+            raise _unsupported("schema requires one supported exact type")
+        if any(type(key) is not str for key in current):
+            raise _unsupported("schema keys must be exact strings")
+        unexpected = set(current) - _SCHEMA_KEYS[kind]
+        if unexpected:
+            raise _unsupported(f"schema keywords {sorted(unexpected)!r}")
+        active.add(id(current))
+        stack.append((current, depth, True))
+        if kind in _SCALAR_TYPES and "enum" in current:
+            if type(current["enum"]) is not list or not current["enum"]:
+                raise _unsupported("scalar enum must be a nonempty exact array")
+        elif kind == "array":
+            if "items" not in current:
+                raise _unsupported("homogeneous array requires an items contract")
+            stack.append((current["items"], depth + 1, False))
+        elif kind == "object":
+            if current.get("additionalProperties") is not False:
+                raise _unsupported("object additionalProperties must be explicitly false")
+            properties = current.get("properties", {})
+            if type(properties) is not dict:
+                raise _unsupported("object properties must be an exact mapping")
+            if len(properties) > MAX_CONTRACT_NODES - count:
+                raise _unsupported(f"contract nodes exceed {MAX_CONTRACT_NODES}")
+            if any(type(name) is not str or not name for name in properties):
+                raise _unsupported("property names must be nonempty exact strings")
+            required = current.get("required", [])
+            if type(required) is not list or any(type(name) is not str for name in required):
+                raise _unsupported("required must be an exact array of property names")
+            if len(required) != len(set(required)) or not set(required) <= set(properties):
+                raise _unsupported("required names must be unique declared properties")
+            stack.extend((child, depth + 1, False) for child in properties.values())
+
+
+def _convert_schema(value: dict[str, Any]) -> ClosedContract:
+    kind = value["type"]
+    if kind == "null":
+        return NullContract()
+    if kind in _SCALAR_TYPES:
+        return ScalarContract.model_validate({"kind": kind, "nullable": False, "enum": value.get("enum")})
+    if kind == "array":
+        return ArrayContract(nullable=False, items=_convert_schema(value["items"]))
+    required = set(value.get("required", []))
+    return ObjectContract(
+        nullable=False,
+        properties=tuple(
+            ContractProperty(name=name, required=name in required, contract=_convert_schema(child))
+            for name, child in value.get("properties", {}).items()
+        ),
+        additional_properties=False,
+    )
+
+
+def import_closed_contract_schema(value: Any) -> ClosedContract:
+    """Import exactly the bounded proof profile, retaining every supported fact."""
+    _check_schema_profile(value)
+    try:
+        return _convert_schema(value)
+    except (TypeError, ValueError) as exc:
+        raise _unsupported(f"schema has no exact closed-contract representation: {exc}") from exc
+
+
+__all__ = ["import_closed_contract_schema"]

--- a/mozaiksai/core/semantics/closed_contracts.py
+++ b/mozaiksai/core/semantics/closed_contracts.py
@@ -1,0 +1,249 @@
+"""Finite immutable contracts for application-semantic compatibility proofs.
+
+``mozaiks.closed_contract_profile.v1`` supports only null, scalar, homogeneous
+array, and closed object contracts. Nullable values and optional properties
+are separate facts. No provider dialect, references, schema importer, or
+assignability implementation belongs to this algebra.
+
+The profile permits at most 32 contract levels (the root is level one) and
+1,024 contract occurrences, including repeated children. Property wrappers do
+not add a contract level or node. An iterative preflight enforces those limits
+and rejects cycles before recursive validation. Exceeding either limit is
+unsupported. INTEGER enums contain exact signed-64-bit ints; NUMBER enums
+contain exact finite floats. The two enum representations never coerce each
+other or booleans. Every identity uses the existing canonical JSON primitives.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import (
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+from mozaiksai.core.semantics.canonical import canonical_digest, canonical_json
+from mozaiksai.core.semantics.refs import SemanticsModel
+
+CLOSED_CONTRACT_PROFILE_VERSION: Literal["mozaiks.closed_contract_profile.v1"] = (
+    "mozaiks.closed_contract_profile.v1"
+)
+MAX_CONTRACT_DEPTH = 32
+MAX_CONTRACT_NODES = 1024
+
+
+class ClosedContractKind(StrEnum):
+    NULL = "null"
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    NUMBER = "number"
+    STRING = "string"
+    ARRAY = "array"
+    OBJECT = "object"
+
+
+class ClosedContractUnsupported(ValueError):
+    """The input exceeds the finite proof profile; it cannot receive a proof."""
+
+
+def _check_contract_limits(value: Any) -> None:
+    """Bound traversal without recursion or serializing unvalidated models."""
+    stack: list[tuple[Any, int, bool]] = [(value, 1, False)]
+    active: set[int] = set()
+    count = 0
+    while stack:
+        current, depth, leaving = stack.pop()
+        if leaving:
+            active.remove(id(current))
+            continue
+        raw = current.__dict__ if isinstance(current, ContractModel) else current
+        if not isinstance(raw, Mapping):
+            continue  # The closed field validator rejects malformed shapes.
+        if id(current) in active:
+            raise ClosedContractUnsupported("UNSUPPORTED: cyclic closed contract")
+        active.add(id(current))
+        stack.append((current, depth, True))
+        if "contract" in raw and "kind" not in raw:
+            stack.append((raw["contract"], depth, False))
+            continue
+        count += 1
+        if depth > MAX_CONTRACT_DEPTH:
+            raise ClosedContractUnsupported(
+                f"UNSUPPORTED: contract depth exceeds {MAX_CONTRACT_DEPTH} "
+                f"under {CLOSED_CONTRACT_PROFILE_VERSION}"
+            )
+        if count > MAX_CONTRACT_NODES:
+            raise ClosedContractUnsupported(
+                f"UNSUPPORTED: contract nodes exceed {MAX_CONTRACT_NODES} "
+                f"under {CLOSED_CONTRACT_PROFILE_VERSION}"
+            )
+        if "items" in raw:
+            stack.append((raw["items"], depth + 1, False))
+        properties = raw.get("properties", ())
+        if isinstance(properties, (list, tuple)):
+            if len(properties) + count > MAX_CONTRACT_NODES:
+                raise ClosedContractUnsupported(
+                    f"UNSUPPORTED: contract nodes exceed {MAX_CONTRACT_NODES} "
+                    f"under {CLOSED_CONTRACT_PROFILE_VERSION}"
+                )
+            stack.extend((prop, depth + 1, False) for prop in properties)
+
+
+class ContractModel(SemanticsModel):
+    """Deeply immutable authority with no unchecked update-copy path."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, revalidate_instances="always")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _proof_limits(cls, value: Any) -> Any:
+        _check_contract_limits(value)
+        return value
+
+    def model_copy(self, *, update: Mapping[str, Any] | None = None, deep: bool = False) -> Self:
+        if update:
+            raise TypeError("contract updates require model_validate; model_copy(update=...) is forbidden")
+        return type(self).model_validate(self)
+
+    def copy(self, *, include=None, exclude=None, update=None, deep: bool = False):
+        if include is not None or exclude is not None or update:
+            raise TypeError("contract changes require model_validate; copy changes are forbidden")
+        return self.model_copy(deep=deep)
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+    @property
+    def contract_digest(self) -> str:
+        return canonical_digest(self.identity_payload)
+
+
+class NullContract(ContractModel):
+    kind: Literal[ClosedContractKind.NULL] = ClosedContractKind.NULL
+
+
+class ScalarContract(ContractModel):
+    kind: Literal[
+        ClosedContractKind.BOOLEAN,
+        ClosedContractKind.INTEGER,
+        ClosedContractKind.NUMBER,
+        ClosedContractKind.STRING,
+    ]
+    nullable: StrictBool
+    enum: tuple[StrictBool | StrictInt | StrictFloat | StrictStr, ...] | None = None
+
+    @field_validator("enum", mode="before")
+    @classmethod
+    def _canonical_enum(cls, value: Any, info: ValidationInfo) -> Any:
+        if value is None:
+            return None
+        if type(value) not in (tuple, list) or not value:
+            raise ValueError("scalar enum requires a non-empty scalar sequence")
+        kind = info.data.get("kind")
+        if not isinstance(kind, ClosedContractKind):
+            raise ValueError("enum requires a valid scalar kind")
+        expected = {
+            ClosedContractKind.BOOLEAN: bool,
+            ClosedContractKind.INTEGER: int,
+            ClosedContractKind.NUMBER: float,
+            ClosedContractKind.STRING: str,
+        }.get(kind)
+        if expected is None or any(type(item) is not expected for item in value):
+            raise ValueError("enum values must have the exact scalar kind; null and coercion are forbidden")
+        if expected is float and any(not math.isfinite(item) for item in value):
+            raise ValueError("non-finite enum numbers are unsupported")
+        normalized = tuple(0.0 if type(item) is float and item == 0.0 else item for item in value)
+        # Reuse the existing signed-64-bit/finite scalar authority, not a second
+        # serialization domain with values that cannot acquire canonical identity.
+        canonical_json(normalized)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("duplicate scalar enum values")
+        return tuple(sorted(normalized))
+
+
+class ArrayContract(ContractModel):
+    kind: Literal[ClosedContractKind.ARRAY] = ClosedContractKind.ARRAY
+    nullable: StrictBool
+    items: ClosedContract
+
+
+class ContractProperty(ContractModel):
+    name: StrictStr = Field(min_length=1)
+    required: StrictBool
+    contract: ClosedContract
+
+
+class ObjectContract(ContractModel):
+    kind: Literal[ClosedContractKind.OBJECT] = ClosedContractKind.OBJECT
+    nullable: StrictBool
+    properties: tuple[ContractProperty, ...]
+    additional_properties: Literal[False]
+
+    @field_validator("properties", mode="before")
+    @classmethod
+    def _property_sequence(cls, value: Any) -> Any:
+        if type(value) not in (list, tuple):
+            raise ValueError("properties require an explicit list or tuple")
+        return value
+
+    @field_validator("additional_properties", mode="before")
+    @classmethod
+    def _closed_object(cls, value: Any) -> bool:
+        if value is not False:
+            raise ValueError("additional_properties must be explicitly false")
+        return False
+
+    @field_validator("properties")
+    @classmethod
+    def _properties(cls, value: tuple[ContractProperty, ...]) -> tuple[ContractProperty, ...]:
+        ordered = tuple(sorted(value, key=lambda prop: prop.name))
+        if len({prop.name for prop in ordered}) != len(ordered):
+            raise ValueError("duplicate contract property names")
+        return ordered
+
+
+ClosedContract = Annotated[
+    NullContract | ScalarContract | ArrayContract | ObjectContract,
+    Field(discriminator="kind"),
+]
+
+ArrayContract.model_rebuild()
+ContractProperty.model_rebuild()
+ObjectContract.model_rebuild()
+_CONTRACT_ADAPTER: TypeAdapter[ClosedContract] = TypeAdapter(ClosedContract)
+
+
+def parse_closed_contract(value: Any) -> ClosedContract:
+    """Validate only the canonical algebra; provider/schema documents reject."""
+    _check_contract_limits(value)
+    return _CONTRACT_ADAPTER.validate_python(value)
+
+
+__all__ = [
+    "CLOSED_CONTRACT_PROFILE_VERSION",
+    "MAX_CONTRACT_DEPTH",
+    "MAX_CONTRACT_NODES",
+    "ArrayContract",
+    "ClosedContract",
+    "ClosedContractKind",
+    "ClosedContractUnsupported",
+    "ContractModel",
+    "ContractProperty",
+    "NullContract",
+    "ObjectContract",
+    "ScalarContract",
+    "parse_closed_contract",
+]

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -17,10 +17,12 @@ from types import NoneType
 from typing import Any, Literal, get_args
 
 import yaml
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from mozaiksai.core.runtime.app.page_schema import AppPageSection
 from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.closed_contract_schema import import_closed_contract_schema
+from mozaiksai.core.semantics.closed_contracts import ClosedContractUnsupported, ObjectContract
 from mozaiksai.core.semantics.graph import (
     SemanticEdge,
     SemanticEdgeKind,
@@ -487,6 +489,45 @@ _PAGE_API_PATH = re.compile(r"^/api/[A-Za-z0-9_./-]+$")
 _PATH_TOKEN = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
 
 
+def _action_request_contract(value: Any, path: str) -> ObjectContract:
+    try:
+        contract = import_closed_contract_schema(value)
+        if not isinstance(contract, ObjectContract) or contract.nullable:
+            raise ClosedContractUnsupported("UNSUPPORTED: action request root must be a non-null closed object")
+    except ClosedContractUnsupported as exc:
+        raise ProjectionError([
+            ProjectionGap(kind=ProjectionGapKind.UNSUPPORTED, source_path=path, reason=str(exc)),
+        ]) from exc
+    return contract
+
+
+def _preflight_action_request_schemas(source: Any) -> None:
+    """Bound raw action schemas before the existing recursive source copy."""
+    def field(value: Any, name: str) -> Any:
+        if isinstance(value, Mapping):
+            return value.get(name)
+        if isinstance(value, BaseModel):
+            return getattr(value, name, None)
+        return None
+
+    modules = field(source, "modules")
+    if isinstance(modules, Mapping):
+        entries = [(f"modules.{key}", value) for key, value in modules.items()]
+    elif isinstance(modules, Sequence) and not isinstance(modules, (str, bytes, bytearray)):
+        entries = [(f"modules[{index}]", value) for index, value in enumerate(modules)]
+    else:
+        return
+    for path, bundle in entries:
+        manifest = field(bundle, "manifest") or field(bundle, "module_manifest") or bundle
+        actions = field(manifest, "actions")
+        if not isinstance(actions, Sequence) or isinstance(actions, (str, bytes, bytearray)):
+            continue
+        for index, action in enumerate(actions):
+            schema = field(action, "input_schema")
+            if schema is not None:
+                _action_request_contract(schema, f"{path}.manifest.actions[{index}].input_schema")
+
+
 def _plain(value: Any) -> Any:
     if hasattr(value, "model_dump"):
         return _plain(value.model_dump(mode="json"))
@@ -676,6 +717,15 @@ class _Builder:
                 if field.is_required() and NoneType in get_args(field.annotation)
             }
             fields.update(self.content.get(node_id, {}))
+            if node.kind is SemanticNodeKind.ACTION and "request_contract" not in fields:
+                source_path = sorted(group for group, subject in self.node_groups if subject == node_id)[0]
+                raise ProjectionError([
+                    ProjectionGap(
+                        kind=ProjectionGapKind.MISSING,
+                        source_path=source_path,
+                        reason=f"action {node_id!r} requires an explicit module input_schema request contract",
+                    ),
+                ])
             try:
                 payloads[node_id] = build_semantic_payload(
                     model,
@@ -1469,6 +1519,19 @@ class _Builder:
             for j, raw_action in enumerate(_as_list(manifest.get("actions"))):
                 item = _mapping(raw_action)
                 action = _node_id(SemanticNodeKind.ACTION, f"{module_id}_{item.get('id')}")
+                request_path = f"{base}.manifest.actions[{j}].input_schema"
+                if item.get("input_schema") is None:
+                    raise ProjectionError([
+                        ProjectionGap(
+                            kind=ProjectionGapKind.MISSING,
+                            source_path=request_path,
+                            reason="action requires an explicit input_schema; an empty request must declare a closed empty object",
+                        ),
+                    ])
+                request_contract = _action_request_contract(item["input_schema"], request_path)
+                self.content_field(action, "request_contract", request_contract, request_path)
+                for leaf_path, _ in _iter_leaves(item["input_schema"], request_path):
+                    self.mark(leaf_path, node=SemanticNodeKind.ACTION, identity="exact request schema normalized into the closed semantic contract")
                 emitted_event_ids = tuple(
                     sorted({str(event_type) for event_type in _as_list(item.get("emits"))})
                 )
@@ -2592,6 +2655,7 @@ def project_semantic_graph(
     effect, and Slice 1 remains the only taxonomy authority, so the caller
     supplies the registry it has pinned.
     """
+    _preflight_action_request_schemas(source)
     plain = _plain(source)
     if not isinstance(plain, dict) or not plain:
         raise ProjectionError(

--- a/mozaiksai/core/semantics/payloads.py
+++ b/mozaiksai/core/semantics/payloads.py
@@ -24,11 +24,18 @@ re-verifies it, so a tampered field or digest fails closed at validation.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, TypeAdapter, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from mozaiksai.core.runtime.app.page_schema import (
     AppPageMeta,
@@ -36,6 +43,7 @@ from mozaiksai.core.runtime.app.page_schema import (
     AppPageSection,
 )
 from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.closed_contracts import ObjectContract
 from mozaiksai.core.semantics.graph import (
     SemanticEdge,
     SemanticEdgeKind,
@@ -122,7 +130,7 @@ def _canonical_id(value: str, *, field_name: str) -> str:
 
 
 class FieldType(StrEnum):
-    """Closed field-type set for typed request/response/data shapes."""
+    """Closed field-type set for response/data shapes."""
 
     STRING = "string"
     TEXT = "text"
@@ -1084,12 +1092,24 @@ class ModulePayload(SemanticPayloadBase):
 
 
 class ActionPayload(SemanticPayloadBase):
+    model_config = ConfigDict(revalidate_instances="always")
+
     payload_kind: Literal[SemanticNodeKind.ACTION] = SemanticNodeKind.ACTION
     description: str | None
-    request_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
+    request_contract: ObjectContract
     response_fields: tuple[TypedFieldSpec, ...] = Field(default_factory=tuple)
     emits: tuple[str, ...] = Field(default_factory=tuple)
     entitlement_gate: str | None = None
+
+    def model_copy(self, *, update: Mapping[str, Any] | None = None, deep: bool = False) -> Self:
+        if update is not None:
+            raise TypeError("action updates require build_semantic_payload; unchecked copies are forbidden")
+        return type(self).model_validate(self)
+
+    def copy(self, *, include=None, exclude=None, update=None, deep: bool = False):
+        if include is not None or exclude is not None or update is not None:
+            raise TypeError("action changes require build_semantic_payload; unchecked copies are forbidden")
+        return self.model_copy(deep=deep)
 
     @field_validator("description")
     @classmethod
@@ -1098,7 +1118,14 @@ class ActionPayload(SemanticPayloadBase):
             return None
         return _text(value, field_name="description")
 
-    @field_validator("request_fields", "response_fields")
+    @field_validator("request_contract")
+    @classmethod
+    def _request_contract(cls, value: ObjectContract) -> ObjectContract:
+        if value.nullable:
+            raise ValueError("action request_contract must be a non-null OBJECT")
+        return value
+
+    @field_validator("response_fields")
     @classmethod
     def _fields(
         cls, value: tuple[TypedFieldSpec, ...], info: ValidationInfo

--- a/mozaiksai/core/semantics/plan_authority.py
+++ b/mozaiksai/core/semantics/plan_authority.py
@@ -52,22 +52,19 @@ content, no filesystem paths, and no hosted state.
 
 from __future__ import annotations
 
-import math
 from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    StrictBool,
-    StrictFloat,
-    StrictInt,
-    StrictStr,
-    field_validator,
-    model_validator,
-)
+from pydantic import field_validator
 
+from mozaiksai.core.semantics.canonical_json import (
+    CanonicalJsonArray,
+    CanonicalJsonEntry,
+    CanonicalJsonObject,
+    CanonicalJsonValue,
+    _AuthorityModel,
+)
 from mozaiksai.core.semantics.compilation_plan import (
     CompilationPlan,
     CompilationScopeSelection,
@@ -123,139 +120,6 @@ class PlanAuthorityError(ValueError):
         self.category = category
         self.plan_digest = plan_digest
         self.unit_id = unit_id
-
-
-class _AuthorityModel(BaseModel):
-    """Frozen base for authority documents: no unchecked update path exists.
-
-    ``model_copy(update=...)`` bypasses pydantic validation, which would let
-    a raw mutable or non-JSON value masquerade as validated authority state.
-    Authority models therefore refuse update-copies entirely — reconstruct
-    through ``model_validate`` instead. Plain no-update copies stay safe
-    because every field is itself frozen/immutable.
-    """
-
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-    def model_copy(self, *, update=None, deep: bool = False):
-        if update:
-            raise TypeError(
-                f"{type(self).__name__} does not support model_copy(update=...); "
-                "reconstruct through model_validate so authority content is "
-                "always validated"
-            )
-        return super().model_copy(deep=deep)
-
-
-def _reject_nonfinite(value: Any) -> Any:
-    if isinstance(value, float) and not math.isfinite(value):
-        raise ValueError("canonical JSON forbids NaN and infinite floats")
-    return value
-
-
-class CanonicalJsonEntry(_AuthorityModel):
-    """One key/value pair of a canonical JSON object."""
-
-    key: StrictStr
-    value: CanonicalJsonValue
-
-    @field_validator("value")
-    @classmethod
-    def _finite(cls, value: Any) -> Any:
-        return _reject_nonfinite(value)
-
-
-class CanonicalJsonObject(_AuthorityModel):
-    """Recursively closed, immutable, deterministic JSON object.
-
-    Entries carry unique string keys in their exact declaration order —
-    declaration order is meaning in structured-output contracts, so the
-    authority pins the document precisely as derivation consumed it; the
-    stored order is itself deterministic and survives serialization. Values
-    are drawn only from the closed JSON algebra: no mutable dict/list
-    survives construction and no non-JSON value can enter.
-    """
-
-    entries: tuple[CanonicalJsonEntry, ...] = ()
-
-    @model_validator(mode="after")
-    def _unique_keys(self) -> CanonicalJsonObject:
-        keys = [entry.key for entry in self.entries]
-        if len(set(keys)) != len(keys):
-            raise ValueError("canonical JSON object declares duplicate keys")
-        return self
-
-    @classmethod
-    def from_python(cls, value: Mapping[str, Any]) -> CanonicalJsonObject:
-        if not isinstance(value, Mapping):
-            raise ValueError("canonical JSON object requires a mapping")
-        entries = []
-        for key, item in value.items():
-            if type(key) is not str:
-                raise ValueError(
-                    f"canonical JSON object keys must be str, got {type(key).__name__}"
-                )
-            entries.append(CanonicalJsonEntry(key=key, value=_json_value(item)))
-        return cls(entries=tuple(entries))
-
-    def to_python(self) -> dict[str, Any]:
-        return {entry.key: _python_value(entry.value) for entry in self.entries}
-
-
-class CanonicalJsonArray(_AuthorityModel):
-    """Recursively closed, immutable JSON array preserving element order."""
-
-    items: tuple[CanonicalJsonValue, ...] = ()
-
-    @field_validator("items")
-    @classmethod
-    def _finite_items(cls, value: tuple[Any, ...]) -> tuple[Any, ...]:
-        for item in value:
-            _reject_nonfinite(item)
-        return value
-
-
-CanonicalJsonValue = (
-    None
-    | StrictBool
-    | StrictInt
-    | StrictFloat
-    | StrictStr
-    | CanonicalJsonArray
-    | CanonicalJsonObject
-)
-
-CanonicalJsonEntry.model_rebuild()
-CanonicalJsonArray.model_rebuild()
-CanonicalJsonObject.model_rebuild()
-
-
-def _json_value(value: Any) -> Any:
-    """Normalize one Python value into the closed algebra, failing closed
-    immediately on anything that is not exact JSON."""
-    if value is None or type(value) is bool or type(value) is str:
-        return value
-    if type(value) is int:
-        return value
-    if type(value) is float:
-        if not math.isfinite(value):
-            raise ValueError("canonical JSON forbids NaN and infinite floats")
-        return value
-    if isinstance(value, Mapping):
-        return CanonicalJsonObject.from_python(value)
-    if type(value) in (list, tuple):
-        return CanonicalJsonArray(items=tuple(_json_value(item) for item in value))
-    raise ValueError(
-        "canonical JSON forbids values of type " f"{type(value).__name__}"
-    )
-
-
-def _python_value(value: Any) -> Any:
-    if isinstance(value, CanonicalJsonObject):
-        return value.to_python()
-    if isinstance(value, CanonicalJsonArray):
-        return [_python_value(item) for item in value.items]
-    return value
 
 
 class CompilationPlanAuthorityInputs(_AuthorityModel):
@@ -504,6 +368,7 @@ __all__ = [
     "CanonicalJsonArray",
     "CanonicalJsonEntry",
     "CanonicalJsonObject",
+    "CanonicalJsonValue",
     "CompilationPlanAuthorityInputs",
     "PlanAuthorityError",
     "PlanAuthorityMismatch",

--- a/tests/fixtures/action-request-migration.json
+++ b/tests/fixtures/action-request-migration.json
@@ -1,0 +1,136 @@
+{
+  "base_commit": "e2713d64205079bad8c7b3dbc44186f26998e652",
+  "graph_digest": "19d4fa7f8db76e05a3710b58f5909ddb807ccb7ce37facb51e8278de2a19f86b",
+  "plan_digest": "f37b6ef7cd20344a0908eff052cfd83eeaccd8e113f345ea1f37a9c5a73d127d",
+  "archive_digest": "sha256:785d575f4e4ab73d16b2e28d54896ede3ea2e0d40a7013e05f2bf361fd6fc2f7",
+  "payload_digests": [
+    {
+      "node_id": "mozaiks.application.corpus",
+      "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+    },
+    {
+      "node_id": "mozaiks.auth.corpus",
+      "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+    },
+    {
+      "node_id": "mozaiks.integration.email",
+      "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+    },
+    {
+      "node_id": "mozaiks.surface.web",
+      "payload_digest": "8597949cc2890a65e3872e5855ada8bc7cd7e29a7de053083ff48cf9e6638473"
+    },
+    {
+      "node_id": "mozaiks.page.home",
+      "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+    },
+    {
+      "node_id": "mozaiks.section.hero",
+      "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+    },
+    {
+      "node_id": "mozaiks.module.reports",
+      "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+    },
+    {
+      "node_id": "mozaiks.action.create_report",
+      "payload_digest": "cea6a938e1e480935dc59dd08c9a53f6d937671b82001e5095b8d2ef2a69e5a9"
+    },
+    {
+      "node_id": "mozaiks.capability.reporting",
+      "payload_digest": "2d00bb5fe4bf5ab70e9b682b7c0c0845e5e27c2f6f860c26114537fca3a5f9f9"
+    },
+    {
+      "node_id": "mozaiks.permission.report_admin",
+      "payload_digest": "b311da1fc157485c35a7ec5526dc433dfd728f9a8fecfd6b1c91b66ef716a7c8"
+    },
+    {
+      "node_id": "mozaiks.event.report_created",
+      "payload_digest": "ec1e184183fb430371876e16a2078719b67762a7236840942d63f1dd4298d1c2"
+    },
+    {
+      "node_id": "mozaiks.reaction.notify_owner",
+      "payload_digest": "0f70e1174fc1920e8132f8e07585ca2a7fc3cbe09fb8266c5844342eadc2caf1"
+    },
+    {
+      "node_id": "mozaiks.notification.report_ready",
+      "payload_digest": "487c871e0e9203afcf6b6f48de9e4cad90f21f78b3666feaae00453e482f4a29"
+    },
+    {
+      "node_id": "mozaiks.data.reports",
+      "payload_digest": "39faac4197b0135cea8543e43c6c94ba2731b043229d21e99354cdaefedf737e"
+    },
+    {
+      "node_id": "mozaiks.alias.reports",
+      "payload_digest": "4725020bea5632df606dbb0a069f80873dba2ee47baca5a4c633d2204ccf15e1"
+    },
+    {
+      "node_id": "mozaiks.workflow.digest",
+      "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+    },
+    {
+      "node_id": "mozaiks.trigger.on_report",
+      "payload_digest": "55cfae61f2a73262eeffcbc97d84d6c21662c8608ccefb5b641feb8561ffa197"
+    },
+    {
+      "node_id": "mozaiks.plan.pro",
+      "payload_digest": "2368a16fbdc29a6578a6f187b599097d0ce655bcf78362f766a92c657ab3725a"
+    },
+    {
+      "node_id": "mozaiks.product.addon",
+      "payload_digest": "48a2faaaab9c2bfc8cd050d1fa36df12f4acd1da391d26a43baef66ebf819cdd"
+    },
+    {
+      "node_id": "mozaiks.meter.report_runs",
+      "payload_digest": "c47cbe03db966df098e9750932af5a3ebf8707f7477f7f715153777002b1cfc0"
+    },
+    {
+      "node_id": "mozaiks.limit.report_runs",
+      "payload_digest": "b9d5f4fd593203ae6508eca92c7a491d42ecfd5ea6600a599b8b75121ab22b4c"
+    },
+    {
+      "node_id": "mozaiks.deploy.container",
+      "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+    },
+    {
+      "node_id": "mozaiks.artifact.report_hook",
+      "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+    },
+    {
+      "node_id": "mozaiks.section.pricing",
+      "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+    }
+  ],
+  "action_payload": {
+    "payload_schema_version": "mozaiks.semantic_payload.v1",
+    "node_id": "mozaiks.action.create_report",
+    "payload_version": 1,
+    "scope": {
+      "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+      "tenant_id": "tenant1",
+      "workspace_id": "ws1",
+      "pre_app_scope_id": null
+    },
+    "payload_digest": "cea6a938e1e480935dc59dd08c9a53f6d937671b82001e5095b8d2ef2a69e5a9",
+    "payload_kind": "action",
+    "description": "Create one report",
+    "request_fields": [
+      {
+        "name": "name",
+        "field_type": "string",
+        "required": true
+      }
+    ],
+    "response_fields": [
+      {
+        "name": "report_id",
+        "field_type": "reference",
+        "required": true
+      }
+    ],
+    "emits": [
+      "reports.report_created"
+    ],
+    "entitlement_gate": "reports.premium"
+  }
+}

--- a/tests/test_action_request_contracts.py
+++ b/tests/test_action_request_contracts.py
@@ -1,0 +1,271 @@
+"""Action request authority replacement and classified semantic identity proof."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.archive import (
+    ArchiveEntry,
+    archive_digest,
+    build_deterministic_archive,
+)
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.closed_contracts import ObjectContract
+from mozaiksai.core.semantics.payloads import ActionPayload, build_semantic_payload
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+
+
+def _empty_request() -> dict:
+    return {"kind": "object", "nullable": False, "properties": [], "additional_properties": False}
+
+
+def _action(**fields) -> ActionPayload:
+    return build_semantic_payload(
+        ActionPayload, node_id="mozaiks.action.request", payload_version=1,
+        scope=ExecutionAccessScopeRef(tenant_id="tenant1"), description=None, **fields,
+    )
+
+
+def test_action_requires_explicit_non_null_closed_empty_request() -> None:
+    with pytest.raises(ValidationError, match="request_contract"):
+        _action()
+    action = _action(request_contract=_empty_request())
+    assert action.request_contract == ObjectContract(
+        nullable=False, properties=(), additional_properties=False,
+    )
+    assert "request_fields" not in ActionPayload.model_fields
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        _action(request_contract=_empty_request(), request_fields=())
+    with pytest.raises(ValidationError):
+        _action(request_fields=())
+
+
+@pytest.mark.parametrize("contract", [
+    None,
+    {"kind": "null"},
+    {"kind": "string", "nullable": False},
+    {"kind": "array", "nullable": False, "items": {"kind": "null"}},
+    {**_empty_request(), "nullable": True},
+    {"kind": "object", "nullable": False, "properties": []},
+    {**_empty_request(), "additional_properties": True},
+])
+def test_invalid_action_request_roots_reject(contract) -> None:
+    with pytest.raises(ValidationError):
+        _action(request_contract=contract)
+
+
+def test_action_owns_detached_deeply_immutable_request_authority() -> None:
+    request = _empty_request()
+    request["properties"] = [{
+        "name": "labels", "required": False,
+        "contract": {"kind": "array", "nullable": True, "items": {
+            "kind": "string", "nullable": False, "enum": ["z", "a"],
+        }},
+    }]
+    action = _action(request_contract=request)
+    before = action.model_dump_json()
+    request["properties"][0]["contract"]["items"]["enum"].append("changed")
+    request["properties"].clear()
+    assert action.model_dump_json() == before
+    prop = action.request_contract.properties[0]
+    with pytest.raises(ValidationError):
+        prop.required = True
+    with pytest.raises(ValidationError):
+        prop.contract.items.enum += ("changed",)
+    with pytest.raises(ValidationError):
+        action.request_contract = ObjectContract(nullable=False, properties=(), additional_properties=False)
+    for model in (action, action.request_contract, prop, prop.contract, prop.contract.items):
+        with pytest.raises(TypeError):
+            model.model_copy(update={"request_contract": {}})
+        with pytest.raises(TypeError):
+            model.copy(update={"request_contract": {}})
+        assert model.model_copy() == model
+        assert model.model_copy(deep=True) == model
+    assert ActionPayload.model_validate_json(before).model_dump_json() == before
+
+
+def test_action_revalidates_existing_nested_contracts_and_self_digest() -> None:
+    action = _action(request_contract=_empty_request())
+    raw = action.model_dump(mode="python")
+    # Unchecked construction remains untrusted at every normal parse/copy boundary.
+    raw["request_contract"] = ObjectContract.model_construct(
+        kind="object", nullable=False, properties=[], additional_properties=True,
+    )
+    forged = ActionPayload.model_construct(**raw)
+    for validate in (ActionPayload.model_validate, lambda value: value.model_copy()):
+        with pytest.raises(ValidationError):
+            validate(forged)
+    changed = action.model_dump(mode="json")
+    changed["request_contract"]["properties"] = [{
+        "name": "value", "required": True, "contract": {"kind": "null"},
+    }]
+    with pytest.raises(ValidationError, match="payload_digest does not match"):
+        ActionPayload.model_validate(changed)
+
+
+def test_semantic_migration_changes_only_action_request_and_containing_identity() -> None:
+    from tests.test_compilation_plan import _plan
+    from tests.test_semantic_payload_graph_v2 import _corpus_graph
+
+    baseline = json.loads((Path(__file__).parent / "fixtures/action-request-migration.json").read_text())
+    assert baseline["base_commit"] == "e2713d64205079bad8c7b3dbc44186f26998e652"
+    graph, payloads = _corpus_graph()
+    action = next(payload for payload in payloads if isinstance(payload, ActionPayload))
+    original_action = baseline["action_payload"]
+    assert action.payload_digest != original_action["payload_digest"]
+    assert action.request_contract.model_dump(mode="json") == {
+        "kind": "object", "nullable": False, "additional_properties": False,
+        "properties": [{"name": "name", "required": True,
+                        "contract": {"kind": "string", "nullable": False, "enum": None}}],
+    }
+    restored_action = action.canonical_payload(include_digest=False)
+    restored_action.pop("request_contract")
+    restored_action["request_fields"] = original_action["request_fields"]
+    assert canonical_digest(restored_action) == original_action["payload_digest"]
+    restored_action["payload_digest"] = original_action["payload_digest"]
+    assert restored_action == original_action
+    original_digests = {
+        entry["node_id"]: entry["payload_digest"] for entry in baseline["payload_digests"]
+    }
+    for payload in payloads:
+        if payload.node_id != action.node_id:
+            assert payload.payload_digest == original_digests[payload.node_id]
+
+    restored_graph = graph.canonical_payload(include_digest=False)
+    node = next(node for node in restored_graph["nodes"] if node["node_id"] == action.node_id)
+    node["payload_ref"]["content_digest"] = original_action["payload_digest"]
+    assert canonical_digest(restored_graph) == baseline["graph_digest"]
+    restored_graph["graph_digest"] = baseline["graph_digest"]
+    assert graph.graph_digest != baseline["graph_digest"]
+
+    plan = _plan()
+    restored_plan = plan.canonical_payload(include_digest=False)
+    restored_plan["graph_digest"] = baseline["graph_digest"]
+    assert canonical_digest(restored_plan) == baseline["plan_digest"]
+    assert len(plan.units) == 61
+    # This exact equality permits no unit/source/row changes hidden by a golden repin.
+    assert plan.plan_digest != baseline["plan_digest"]
+
+    entries = [ArchiveEntry(
+        path=f"payloads/{payload.node_id}.json",
+        content=json.dumps(
+            restored_action if payload.node_id == action.node_id else payload.canonical_payload(),
+            sort_keys=True, ensure_ascii=True,
+        ).encode("ascii"),
+    ) for payload in payloads]
+    entries.append(ArchiveEntry(path="graph.json", content=json.dumps(
+        restored_graph, sort_keys=True, ensure_ascii=True,
+    ).encode("ascii")))
+    assert archive_digest(build_deterministic_archive(entries)) == baseline["archive_digest"]
+
+
+def test_referenced_action_request_change_preserves_real_interface_reuse_and_bytes() -> None:
+    from mozaiksai.core.semantics import materialization
+    from mozaiksai.core.semantics.compilation_plan import plan_regeneration_closure
+    from tests import test_workflow_capability_semantics as capability
+    from tests.test_workflow_interface_rematerialization import (
+        _fixture,
+        _mutate,
+        _rematerialize,
+        _state,
+        _unit,
+    )
+
+    fixture = _fixture()
+    base = _state(fixture, reload=True)
+    original = copy.deepcopy(fixture.payloads)
+    _mutate(fixture, "action_request_schema")
+    changed = fixture.payloads[capability._ACTION_GET]
+    before = original[capability._ACTION_GET]
+    assert changed.request_contract != before.request_contract
+    assert changed.node_id == before.node_id
+    assert changed.payload_digest != before.payload_digest
+    for node_id, payload in fixture.payloads.items():
+        if node_id != changed.node_id:
+            assert payload == original[node_id]  # Includes module ownership and capability bindings.
+    successor = _state(fixture, version=2, reload=True)
+    unit_id = _unit(base).unit_id
+    assert _unit(base).identity_payload == _unit(successor).identity_payload
+    assert unit_id in plan_regeneration_closure(base["plan"], successor["plan"]).reusable
+    bundle = materialization.materialize_plan(**base)
+    refreshed = _rematerialize(base, successor, bundle)
+    before_output = next(output for output in bundle.outputs if output.unit_id == unit_id)
+    after_output = next(output for output in refreshed.outputs if output.unit_id == unit_id)
+    assert after_output.origin == "reused"
+    assert before_output.content == after_output.content
+    assert refreshed.files() == materialization.materialize_plan(**successor).files()
+
+
+def test_action_request_algebra_is_recursively_closed_strict_and_immutable() -> None:
+    from types import UnionType
+    from typing import Annotated, Any, Literal, Union, get_args, get_origin
+
+    from pydantic import BaseModel, Strict
+
+    from mozaiksai.core.semantics.closed_contracts import (
+        ArrayContract,
+        ClosedContract,
+        ContractProperty,
+        NullContract,
+        ScalarContract,
+    )
+
+    visited: set[type[BaseModel]] = set()
+
+    def walk(annotation, metadata=()):
+        assert annotation is not Any, "request authority cannot contain Any"
+        origin = get_origin(annotation)
+        if origin is Annotated:
+            nested, *details = get_args(annotation)
+            walk(nested, (*metadata, *details))
+        elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            if annotation in visited:
+                return
+            visited.add(annotation)
+            assert annotation.model_config.get("extra") == "forbid"
+            assert annotation.model_config.get("frozen") is True
+            assert annotation.model_config.get("revalidate_instances") == "always"
+            for field in annotation.model_fields.values():
+                walk(field.annotation, field.metadata)
+        elif origin in (Union, UnionType):
+            for member in get_args(annotation):
+                walk(member)
+        elif origin is tuple:
+            args = get_args(annotation)
+            assert len(args) == 2 and args[1] is Ellipsis, "only immutable homogeneous collections"
+            walk(args[0])
+        elif origin is Literal:
+            assert all(type(value) is bool or isinstance(value, str) for value in get_args(annotation))
+        elif annotation is type(None):
+            return
+        elif annotation in (bool, int, float, str):
+            assert any(isinstance(item, Strict) and item.strict for item in metadata)
+        else:
+            raise AssertionError(f"open or mutable request-contract annotation: {annotation!r}")
+
+    walk(ActionPayload.model_fields["request_contract"].annotation)
+    walk(ClosedContract)
+    assert visited == {NullContract, ScalarContract, ArrayContract, ObjectContract, ContractProperty}
+
+
+@pytest.mark.parametrize("nested", [
+    {"kind": "integer", "nullable": False, "enum": [True]},
+    {"kind": "number", "nullable": False, "enum": [1]},
+    {"kind": "number", "nullable": False, "enum": [float("nan")]},
+    {"kind": "number", "nullable": False, "enum": [float("inf")]},
+    {"kind": "number", "nullable": False, "enum": [float("-inf")]},
+    {"kind": "string", "nullable": 0},
+])
+def test_action_payload_boundary_preserves_nested_strict_and_finite_scalar_domains(nested) -> None:
+    request = _empty_request()
+    request["properties"] = [{
+        "name": "nested", "required": True,
+        "contract": {"kind": "array", "nullable": False, "items": nested},
+    }]
+    with pytest.raises(ValidationError):
+        _action(request_contract=request)

--- a/tests/test_canonical_json_extraction.py
+++ b/tests/test_canonical_json_extraction.py
@@ -1,0 +1,211 @@
+"""Shared JSON extraction preserves the exact pre-extraction authority contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import UserDict
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.runtime.app.layout_registry import build_app_layout_registry
+from mozaiksai.core.semantics import canonical_json, plan_authority
+from mozaiksai.core.semantics.canonical import CanonicalSerializationError, canonical_digest
+from mozaiksai.core.semantics.canonical_json import (
+    CanonicalJsonArray,
+    CanonicalJsonEntry,
+    CanonicalJsonObject,
+)
+from mozaiksai.core.semantics.graph import SemanticNodeV2, build_semantic_graph_v2
+from mozaiksai.core.semantics.payloads import (
+    WorkflowPayload,
+    build_semantic_payload,
+    semantic_payload_ref,
+)
+from mozaiksai.core.semantics.refs import ExecutionAccessScopeRef
+
+# Captured before extraction at exact main e2713d64205079bad8c7b3dbc44186f26998e652.
+# The workflow-only authority intentionally excludes ActionPayload so the
+# separate request-contract migration cannot account for any drift here.
+_REFERENCE_JSON = (
+    '{"entries":[{"key":"ordered","value":{"entries":[{"key":"z","value":null},'
+    '{"key":"a","value":{"items":[true,false,0,1,-7,1.25,"\u00e9",'
+    '{"entries":[{"key":"empty","value":{"entries":[]}},'
+    '{"key":"array","value":{"items":[]}}]}]}}]}},'
+    '{"key":"integer_boundary","value":{"items":[-9223372036854775808,9223372036854775807]}},'
+    '{"key":"nested","value":{"entries":[{"key":"quote","value":"a\\\"b"},'
+    '{"key":"backslash","value":"a\\\\b"},{"key":"zero","value":-0.0}]}}]}'
+)
+_REFERENCE_VALUE_DIGEST = "539a466bcae96dc6afc1dcc911e13fe135122984d7a361916042f20b6d397d93"
+_REFERENCE_DOCUMENT_DIGEST = "f40bbcad06a16663633f63b97c18f3649211295f42397bcf1d34e3703413ec7f"
+_REFERENCE_DOCUMENT_BYTES_SHA256 = "0adbcd2aae3eca7a7fa32cbbbb676d38d902bbbd4ad0f3566b0fcdb7f32c2dd7"
+_REFERENCE_AUTHORITY_BYTE_COUNT = 59230
+
+
+def _source() -> dict[str, Any]:
+    return {
+        "ordered": {"z": None, "a": [True, False, 0, 1, -7, 1.25, "\u00e9", {"empty": {}, "array": []}]},
+        "integer_boundary": [-(2**63), 2**63 - 1],
+        "nested": {"quote": 'a"b', "backslash": "a\\b", "zero": -0.0},
+    }
+
+
+def _authority():
+    scope = ExecutionAccessScopeRef(tenant_id="tenant-json", workspace_id="workspace-json")
+    payload = build_semantic_payload(
+        WorkflowPayload,
+        node_id="mozaiks.workflow.probe",
+        payload_version=1,
+        scope=scope,
+        workflow_id="probe",
+        description="No-action authority preserves extraction evidence",
+        startup_mode=None,
+        topology=None,
+    )
+    graph = build_semantic_graph_v2(
+        graph_id="canonical-json-extraction",
+        version=1,
+        scope=scope,
+        nodes=[SemanticNodeV2(
+            node_id=payload.node_id, kind=payload.payload_kind, payload_ref=semantic_payload_ref(payload),
+        )],
+        edges=[],
+    )
+    return plan_authority.build_compilation_plan_authority_inputs(
+        graph=graph, payloads=[payload], registry=build_app_layout_registry(()),
+        structured_output_configs=_source(),
+    )
+
+
+def test_plan_authority_uses_the_same_shared_types_without_parallel_models() -> None:
+    for name in ("CanonicalJsonArray", "CanonicalJsonEntry", "CanonicalJsonObject", "CanonicalJsonValue"):
+        assert getattr(plan_authority, name) is getattr(canonical_json, name)
+    assert plan_authority._AuthorityModel is canonical_json._AuthorityModel
+    assert issubclass(plan_authority.CompilationPlanAuthorityInputs, canonical_json._AuthorityModel)
+
+
+def test_value_serialization_and_digest_are_byte_identical_to_exact_base() -> None:
+    value = CanonicalJsonObject.from_python(_source())
+    assert value.model_dump_json().encode("utf-8") == _REFERENCE_JSON.encode("utf-8")
+    assert value.model_dump(mode="json") == json.loads(_REFERENCE_JSON)
+    assert canonical_digest(value.model_dump(mode="json")) == _REFERENCE_VALUE_DIGEST
+    assert value.to_python() == _source()
+    assert CanonicalJsonObject.model_validate_json(_REFERENCE_JSON) == value
+
+
+def test_complete_plan_authority_serialization_and_digest_are_unchanged() -> None:
+    authority = _authority()
+    encoded = authority.model_dump_json().encode("utf-8")
+    assert len(encoded) == _REFERENCE_AUTHORITY_BYTE_COUNT
+    assert hashlib.sha256(encoded).hexdigest() == _REFERENCE_DOCUMENT_BYTES_SHA256
+    assert plan_authority.compilation_plan_authority_digest(authority) == _REFERENCE_DOCUMENT_DIGEST
+    reloaded = plan_authority.CompilationPlanAuthorityInputs.model_validate_json(encoded)
+    assert reloaded == authority
+    assert reloaded.model_dump_json().encode("utf-8") == encoded
+
+
+def test_declaration_and_array_order_remain_part_of_authority_identity() -> None:
+    first = CanonicalJsonObject.from_python({"z": [1, 2], "a": False})
+    reordered_properties = CanonicalJsonObject.from_python({"a": False, "z": [1, 2]})
+    reordered_array = CanonicalJsonObject.from_python({"z": [2, 1], "a": False})
+    assert [entry.key for entry in first.entries] == ["z", "a"]
+    assert list(first.to_python()) == ["z", "a"]
+    assert len({canonical_digest(value.model_dump(mode="json")) for value in (
+        first, reordered_properties, reordered_array,
+    )}) == 3
+
+
+@pytest.mark.parametrize("value,expected", [
+    (None, None), (True, True), (False, False), (0, 0), (1, 1), (-4, -4),
+    (1.5, 1.5), ("text", "text"), ([], []), ((), []),
+    ([1, (True, {"nested": None})], [1, [True, {"nested": None}]]),
+    (UserDict({"b": 1, "a": False}), {"b": 1, "a": False}),
+])
+def test_existing_python_value_domain_and_scalar_types_remain_accepted(value: Any, expected: Any) -> None:
+    wrapped = CanonicalJsonObject.from_python({"value": value})
+    result = wrapped.to_python()["value"]
+    assert result == expected
+    assert type(result) is type(expected)
+    assert CanonicalJsonObject.model_validate_json(wrapped.model_dump_json()) == wrapped
+
+
+def test_boolean_integer_and_float_values_remain_distinct_in_serialization() -> None:
+    value = CanonicalJsonObject.from_python({"values": [True, False, 1, 0, 1.0, 0.0]})
+    assert [type(item) for item in value.to_python()["values"]] == [bool, bool, int, int, float, float]
+    assert value.model_dump_json() == '{"entries":[{"key":"values","value":{"items":[true,false,1,0,1.0,0.0]}}]}'
+
+
+def test_value_acceptance_does_not_expand_or_narrow_canonical_digest_integer_limits() -> None:
+    # The pre-existing value algebra accepts Python integers; the separately
+    # versioned canonical byte encoder owns its signed-64-bit digest limit.
+    value = CanonicalJsonObject.from_python({"integer": 2**100})
+    assert value.to_python()["integer"] == 2**100
+    with pytest.raises(CanonicalSerializationError, match="signed 64-bit"):
+        canonical_digest(value.model_dump(mode="json"))
+
+
+@pytest.mark.parametrize("value", [
+    float("nan"), float("inf"), -float("inf"), {"nested": float("nan")},
+    [float("inf")], {1, 2}, frozenset({1}), b"bytes", bytearray(b"bytes"),
+    Decimal("1.5"), complex(1, 2), date(2026, 1, 1), object(), {1: "not a string key"},
+])
+def test_non_json_values_still_reject_at_construction(value: Any) -> None:
+    with pytest.raises(ValueError):
+        CanonicalJsonObject.from_python({"value": value})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_direct_typed_construction_still_rejects_nonfinite_scalars(value: float) -> None:
+    with pytest.raises(ValidationError, match="NaN and infinite"):
+        CanonicalJsonEntry(key="number", value=value)
+    with pytest.raises(ValidationError, match="NaN and infinite"):
+        CanonicalJsonArray(items=(value,))
+
+
+def test_duplicate_keys_and_unknown_model_fields_still_reject() -> None:
+    with pytest.raises(ValidationError, match="duplicate keys"):
+        CanonicalJsonObject(entries=(CanonicalJsonEntry(key="same", value=1), CanonicalJsonEntry(key="same", value=2)))
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        CanonicalJsonObject.model_validate({"entries": [], "extra": True})
+
+
+def test_nested_authority_is_detached_from_mutable_inputs_and_outputs() -> None:
+    source = {"object": {"list": [1, {"value": "original"}]}}
+    value = CanonicalJsonObject.from_python(source)
+    before = value.model_dump_json()
+    source["object"]["list"][1]["value"] = "mutated input"
+    source["object"]["list"].append(False)
+    exported = value.to_python()
+    exported["object"]["list"][1]["value"] = "mutated output"
+    assert value.model_dump_json() == before
+    outer = value.entries[0]
+    nested = outer.value
+    assert isinstance(nested, CanonicalJsonObject)
+    array = nested.entries[0].value
+    assert isinstance(array, CanonicalJsonArray)
+    assert isinstance(array.items, tuple)
+    assert isinstance(array.items[1], CanonicalJsonObject)
+    with pytest.raises(ValidationError, match="frozen"):
+        value.entries = ()
+    with pytest.raises(ValidationError, match="frozen"):
+        outer.value = None
+    with pytest.raises(ValidationError, match="frozen"):
+        array.items = ()
+    with pytest.raises(TypeError):
+        array.items[0] = 2
+
+
+def test_copy_semantics_preserve_deep_immutability_without_update_bypass() -> None:
+    value = CanonicalJsonObject.from_python({"nested": [{"item": 1}]})
+    array = value.entries[0].value
+    assert isinstance(array, CanonicalJsonArray)
+    for model in (value, value.entries[0], array, array.items[0], _authority()):
+        assert model.model_copy() == model
+        assert model.model_copy(deep=True) == model
+        assert model.model_copy(update={}) == model
+        with pytest.raises(TypeError, match="does not support model_copy"):
+            model.model_copy(update={"unvalidated": []})

--- a/tests/test_closed_contract_schema.py
+++ b/tests/test_closed_contract_schema.py
@@ -1,0 +1,218 @@
+"""Exact schema import and offline request-authority projection fail closed."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.runtime.app.module_loader import ModuleDefinition
+from mozaiksai.core.semantics.closed_contract_schema import import_closed_contract_schema
+from mozaiksai.core.semantics.closed_contracts import (
+    MAX_CONTRACT_DEPTH,
+    MAX_CONTRACT_NODES,
+    ArrayContract,
+    ClosedContractUnsupported,
+    NullContract,
+    ObjectContract,
+    ScalarContract,
+)
+from mozaiksai.core.semantics.offline_projection import (
+    ProjectionDisposition,
+    ProjectionError,
+    ProjectionGapKind,
+    project_semantic_graph,
+)
+from mozaiksai.core.semantics.payloads import ActionPayload
+from tests.test_semantic_offline_projection import SCOPE, _pinned_registry
+
+
+def _object(properties: dict[str, Any] | None = None, required: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "type": "object", "properties": properties or {}, "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+def _source(schema: Any) -> dict[str, Any]:
+    return {"modules": [{"manifest": {
+        "module": {"id": "probe"},
+        "actions": [{"id": "write", "input_schema": schema}],
+    }}]}
+
+
+def _project(source: dict[str, Any]):
+    return project_semantic_graph(
+        source, graph_id="request-contract-import", version=1, scope=SCOPE,
+        taxonomy_registry=_pinned_registry(),
+    )
+
+
+def _nested_schema(depth: int) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "integer"}
+    for _ in range(depth - 1):
+        schema = {"type": "array", "items": schema}
+    return schema
+
+
+def test_nested_schema_import_preserves_exact_properties_requiredness_and_scalar_enums() -> None:
+    schema = _object({
+        "optional": {"type": "null"},
+        "exact name": {"type": "string", "enum": ["z", "a"]},
+        "records": {"type": "array", "items": _object({"enabled": {"type": "boolean"}}, ["enabled"])},
+    }, ["records", "exact name"])
+    before = copy.deepcopy(schema)
+    contract = import_closed_contract_schema(schema)
+    assert isinstance(contract, ObjectContract)
+    assert contract.nullable is False
+    assert contract.additional_properties is False
+    assert [prop.name for prop in contract.properties] == ["exact name", "optional", "records"]
+    assert [prop.required for prop in contract.properties] == [True, False, True]
+    assert isinstance(contract.properties[0].contract, ScalarContract)
+    assert contract.properties[0].contract.enum == ("a", "z")
+    assert isinstance(contract.properties[1].contract, NullContract)
+    assert isinstance(contract.properties[2].contract, ArrayContract)
+    assert schema == before
+    schema["properties"].clear()
+    assert len(contract.properties) == 3
+
+
+@pytest.mark.parametrize("schema", [
+    {"type": "null"}, {"type": "boolean", "enum": [True, False]},
+    {"type": "integer", "enum": [2, 1]}, {"type": "number", "enum": [2.0, 1.5]},
+    {"type": "string"}, {"type": "array", "items": {"type": "null"}},
+    _object(), {"type": "object", "additionalProperties": False},
+])
+def test_supported_exact_schema_shapes_import(schema: dict[str, Any]) -> None:
+    contract = import_closed_contract_schema(schema)
+    assert contract.contract_digest
+
+
+def test_property_and_enum_order_do_not_change_imported_identity() -> None:
+    first = _object({"z": {"type": "integer", "enum": [2, 1]}, "a": {"type": "string"}}, ["z", "a"])
+    second = _object({"a": {"type": "string"}, "z": {"type": "integer", "enum": [1, 2]}}, ["a", "z"])
+    assert import_closed_contract_schema(first) == import_closed_contract_schema(second)
+    assert import_closed_contract_schema(first).model_dump_json() == import_closed_contract_schema(second).model_dump_json()
+
+
+@pytest.mark.parametrize("schema", [
+    {}, True, False, {"type": "unknown"}, {"type": ["string", "null"]},
+    {"type": "object"}, {"type": "object", "additionalProperties": True},
+    {"type": "object", "additionalProperties": {}},
+    {"type": "object", "additionalProperties": None},
+    {"type": "object", "additionalProperties": 0},
+    {"type": "array"}, {"type": "array", "items": [{"type": "string"}]},
+    {"type": "array", "items": {}}, {"type": "null", "enum": [None]},
+    {"type": "null", "nullable": True}, {"type": "string", "items": {"type": "string"}},
+    {"type": "integer", "enum": [True]}, {"type": "integer", "enum": [1.0]},
+    {"type": "number", "enum": [1]}, {"type": "number", "enum": [1.0, 2]},
+    {"type": "string", "enum": ["x", None]}, {"type": "string", "enum": ["x", "x"]},
+    {"type": "string", "enum": []}, {"type": "string", "enum": None},
+    {"type": "number", "enum": [float("nan")]},
+    {"type": "number", "enum": [float("inf")]},
+    {"type": "number", "enum": [-float("inf")]},
+    _object({"": {"type": "string"}}), _object({1: {"type": "string"}}),
+    _object({"x": {"type": "string"}}, ["missing"]),
+    _object({"x": {"type": "string"}}, ["x", "x"]),
+    {"type": "object", "properties": [], "additionalProperties": False},
+])
+def test_malformed_or_unrepresentable_schema_is_unsupported(schema: Any) -> None:
+    with pytest.raises(ClosedContractUnsupported, match="UNSUPPORTED"):
+        import_closed_contract_schema(schema)
+
+
+@pytest.mark.parametrize("keyword,value", [
+    ("format", "email"), ("pattern", "[a-z]+"), ("minimum", 0), ("maximum", 3),
+    ("exclusiveMinimum", 0), ("exclusiveMaximum", 3), ("multipleOf", 2),
+    ("minLength", 1), ("maxLength", 5), ("minItems", 1), ("maxItems", 5),
+    ("uniqueItems", True), ("contains", {"type": "string"}),
+    ("prefixItems", [{"type": "string"}]),
+    ("$ref", "https://example.invalid/schema"), ("$ref", "#/$defs/recursive"),
+    ("$dynamicRef", "#dynamic"), ("$defs", {"recursive": {"$ref": "#/$defs/recursive"}}),
+    ("anyOf", [{"type": "string"}, {"type": "null"}]),
+    ("oneOf", [{"type": "string"}, {"type": "integer"}]),
+    ("allOf", [{"type": "string"}]), ("not", {"type": "null"}),
+    ("if", {"type": "string"}), ("then", {"type": "string"}), ("else", {"type": "string"}),
+    ("dependentSchemas", {"x": {"type": "string"}}), ("validator", "custom.validate"),
+])
+def test_unsupported_schema_assertions_are_never_silently_discarded(keyword: str, value: Any) -> None:
+    with pytest.raises(ClosedContractUnsupported, match=keyword.replace("$", r"\$")):
+        import_closed_contract_schema({"type": "string", keyword: value})
+
+
+def test_schema_depth_and_node_limits_are_shared_with_the_canonical_profile() -> None:
+    assert import_closed_contract_schema(_nested_schema(MAX_CONTRACT_DEPTH))
+    assert import_closed_contract_schema(_object({f"p{i}": {"type": "null"} for i in range(MAX_CONTRACT_NODES - 1)}))
+    with pytest.raises(ClosedContractUnsupported, match="depth exceeds"):
+        import_closed_contract_schema(_nested_schema(MAX_CONTRACT_DEPTH + 1))
+    with pytest.raises(ClosedContractUnsupported, match="nodes exceed"):
+        import_closed_contract_schema(_object({f"p{i}": {"type": "null"} for i in range(MAX_CONTRACT_NODES)}))
+
+
+def test_shared_acyclic_schema_occurrences_are_allowed_but_cycles_reject() -> None:
+    shared = {"type": "string"}
+    contract = import_closed_contract_schema(_object({"a": shared, "b": shared}))
+    assert isinstance(contract, ObjectContract)
+    assert len(contract.properties) == 2
+    cyclic: dict[str, Any] = {"type": "array"}
+    cyclic["items"] = cyclic
+    with pytest.raises(ClosedContractUnsupported, match="cyclic"):
+        import_closed_contract_schema(cyclic)
+
+
+def test_projector_uses_explicit_request_contract_and_marks_every_schema_fact_projected() -> None:
+    schema = _object({"message": {"type": "string"}, "count": {"type": "integer", "enum": [2, 1]}}, ["message"])
+    result = _project(_source(schema))
+    action = next(payload for payload in result.payloads if isinstance(payload, ActionPayload))
+    assert action.request_contract == import_closed_contract_schema(schema)
+    rows = [row for row in result.coverage if ".input_schema" in row.source_path]
+    assert rows
+    assert all(row.disposition is ProjectionDisposition.PROJECTED for row in rows)
+    assert result.source_facts == result.represented_facts
+
+
+def test_missing_schema_and_surface_only_action_reject_as_missing_authority() -> None:
+    missing = _source(_object())
+    missing["modules"][0]["manifest"]["actions"][0].pop("input_schema")
+    with pytest.raises(ProjectionError) as failure:
+        _project(missing)
+    assert failure.value.gaps[0].kind is ProjectionGapKind.MISSING
+    surface = {"app_build_plan": {"surface_map": {"surfaces": [{
+        "surface_id": "probe", "surface_kind": "module", "owner": "app",
+        "owned_mutations": ["write"],
+    }]}}}
+    with pytest.raises(ProjectionError) as failure:
+        _project(surface)
+    assert failure.value.gaps[0].kind is ProjectionGapKind.MISSING
+    assert "input_schema" in failure.value.gaps[0].reason
+    combined = {**surface, **_source(_object())}
+    assert any(isinstance(payload, ActionPayload) for payload in _project(combined).payloads)
+
+
+@pytest.mark.parametrize("schema", [None, {}, {"type": "object"}, {"type": "string"}, {"type": "array", "items": {"type": "null"}}])
+def test_unknown_or_non_object_projection_request_rejects(schema: Any) -> None:
+    with pytest.raises(ProjectionError) as failure:
+        _project(_source(schema))
+    expected = ProjectionGapKind.MISSING if schema is None else ProjectionGapKind.UNSUPPORTED
+    assert failure.value.gaps[0].kind is expected
+
+
+def test_typed_runtime_manifest_default_schema_is_not_closed_request_authority() -> None:
+    module = ModuleDefinition.model_validate({
+        "schema_version": "mozaiks.module.v1",
+        "module": {"id": "probe", "handler": "backend.handler:Handler"},
+        "actions": [{"id": "write", "description": "Write a record", "handler_method": "write"}],
+    })
+    with pytest.raises(ProjectionError) as failure:
+        _project({"modules": [{"manifest": module}]})
+    assert failure.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED
+
+
+def test_schema_bombs_reject_before_projectors_recursive_source_copy() -> None:
+    cyclic: dict[str, Any] = _object()
+    cyclic["properties"]["self"] = cyclic
+    for schema in (cyclic, _object({"deep": _nested_schema(2000)})):
+        with pytest.raises(ProjectionError) as failure:
+            _project(_source(schema))
+        assert failure.value.gaps[0].kind is ProjectionGapKind.UNSUPPORTED

--- a/tests/test_closed_contracts.py
+++ b/tests/test_closed_contracts.py
@@ -1,0 +1,364 @@
+"""Finite contract profile: exact domains, bounded validation, and immutable identity."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.canonical import canonical_digest, canonical_json
+from mozaiksai.core.semantics.closed_contracts import (
+    CLOSED_CONTRACT_PROFILE_VERSION,
+    MAX_CONTRACT_DEPTH,
+    MAX_CONTRACT_NODES,
+    ArrayContract,
+    ClosedContractUnsupported,
+    ContractProperty,
+    NullContract,
+    ObjectContract,
+    ScalarContract,
+    parse_closed_contract,
+)
+
+
+def _object(*properties: dict[str, Any], nullable: bool = False) -> dict[str, Any]:
+    return {
+        "kind": "object",
+        "nullable": nullable,
+        "properties": list(properties),
+        "additional_properties": False,
+    }
+
+
+def _property(name="value", *, required=True, contract=None):
+    return {
+        "name": name,
+        "required": required,
+        "contract": contract if contract is not None else {"kind": "null"},
+    }
+
+
+def _scalar(kind="string", *, nullable=False, enum=None):
+    return {"kind": kind, "nullable": nullable, "enum": enum}
+
+
+@pytest.mark.parametrize(
+    ("kind", "values", "expected"),
+    [
+        ("boolean", [True, False], (False, True)),
+        ("integer", [3, -1, 0], (-1, 0, 3)),
+        ("integer", [2**63 - 1, -(2**63)], (-(2**63), 2**63 - 1)),
+        ("number", [3.5, -0.0, -1.0], (-1.0, 0.0, 3.5)),
+        ("string", ["é", "a", "A"], ("A", "a", "é")),
+    ],
+)
+def test_scalar_enums_keep_exact_types_and_canonical_order(kind, values, expected):
+    contract = parse_closed_contract(_scalar(kind, nullable=True, enum=values))
+    assert isinstance(contract, ScalarContract)
+    assert contract.enum == expected
+    assert tuple(type(item) for item in contract.enum) == tuple(type(item) for item in expected)
+    assert contract.nullable is True
+    assert contract.contract_digest == canonical_digest(contract.model_dump(mode="json"))
+
+
+@pytest.mark.parametrize("kind", ["boolean", "integer", "number", "string"])
+def test_unrestricted_scalar_omitted_and_explicit_no_enum_share_one_identity(kind):
+    omitted = parse_closed_contract({"kind": kind, "nullable": False})
+    explicit = parse_closed_contract(_scalar(kind))
+    assert omitted == explicit
+    assert omitted.model_dump_json() == explicit.model_dump_json()
+    assert omitted.contract_digest == explicit.contract_digest
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"kind": "unknown"},
+        {"kind": "null", "unknown": 1},
+        {"kind": "null", "nullable": False},
+        {"kind": "null", "enum": [None]},
+        {"kind": "null", "items": {"kind": "null"}},
+        {"kind": "null", "properties": []},
+        {"kind": "null", "additional_properties": False},
+        {**_scalar(), "items": {"kind": "null"}},
+        {**_scalar(), "properties": []},
+        {"kind": "array", "nullable": False},
+        {"kind": "array", "nullable": False, "items": [{"kind": "null"}]},
+        {**_object(), "additional_properties": True},
+        {**_object(), "additional_properties": {}},
+        {**_object(), "additional_properties": 0},
+        {**_object(), "additional_properties": "false"},
+        {key: value for key, value in _object().items() if key != "additional_properties"},
+        {key: value for key, value in _object().items() if key != "properties"},
+        {key: value for key, value in _object().items() if key != "nullable"},
+        _object(_property("same"), _property("same")),
+        _object(_property("")),
+        _object(_property(123)),
+        _object(_property(required=1)),
+        _object({"name": "value", "contract": {"kind": "null"}}),
+        _scalar("string", enum=[]),
+        _scalar("string", enum="value"),
+        _scalar("string", enum=[1]),
+        _scalar("string", enum=["a", 1]),
+        _scalar("string", enum=[None]),
+        _scalar("string", enum=["a", "a"]),
+        _scalar("string", enum=[["a"]]),
+        _scalar("string", enum=[{"value": "a"}]),
+        _scalar("integer", enum=[True]),
+        _scalar("integer", enum=[1.0]),
+        _scalar("integer", enum=[1, 2.0]),
+        _scalar("integer", enum=[-(2**63) - 1]),
+        _scalar("integer", enum=[2**63]),
+        _scalar("number", enum=[1]),
+        _scalar("number", enum=[True]),
+        _scalar("number", enum=[1.0, 2]),
+        _scalar("number", enum=[float("nan")]),
+        _scalar("number", enum=[float("inf")]),
+        _scalar("number", enum=[float("-inf")]),
+        _scalar("number", enum=[-0.0, 0.0]),
+        _scalar("boolean", enum=[0]),
+        _scalar("boolean", enum=[False, 1]),
+        _scalar(nullable=0),
+        _scalar(nullable="false"),
+    ],
+)
+def test_hostile_shapes_fail_closed(document):
+    with pytest.raises(ValueError):
+        parse_closed_contract(document)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("format", "email"),
+        ("pattern", "^a"),
+        ("minimum", 0),
+        ("maximum", 10),
+        ("exclusiveMinimum", 0),
+        ("multipleOf", 2),
+        ("minLength", 1),
+        ("maxLength", 10),
+        ("minItems", 1),
+        ("maxItems", 10),
+        ("uniqueItems", True),
+        ("contains", {"kind": "null"}),
+        ("prefixItems", [{"kind": "null"}]),
+        ("$ref", "https://example.invalid/schema.json"),
+        ("$ref", "#"),
+        ("$dynamicRef", "#recursive"),
+        ("anyOf", [{"kind": "string"}, {"kind": "integer"}]),
+        ("anyOf", [_scalar(), {"kind": "null"}]),
+        ("oneOf", [_scalar(), {"kind": "null"}]),
+        ("allOf", [_scalar()]),
+        ("not", {"kind": "null"}),
+        ("if", {"kind": "null"}),
+        ("then", {"kind": "null"}),
+        ("else", {"kind": "null"}),
+        ("dependentSchemas", {}),
+        ("validator", "custom.hook"),
+        ("additionalProperties", False),
+    ],
+)
+def test_deferred_assertions_refs_and_general_unions_are_never_erased(field, value):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        parse_closed_contract({**_scalar(), field: value})
+
+
+def test_absent_null_present_null_only_and_nullable_scalar_are_distinct_authorities():
+    absent_allowed = parse_closed_contract(_object(_property(required=False)))
+    present_null_only = parse_closed_contract(_object(_property(required=True)))
+    null_only_value = NullContract()
+    nullable_string = parse_closed_contract(_object(_property(contract=_scalar(nullable=True))))
+    authorities = (absent_allowed, present_null_only, null_only_value, nullable_string)
+    assert len({contract.contract_digest for contract in authorities}) == 4
+    assert absent_allowed.properties[0].required is False
+    assert present_null_only.properties[0].required is True
+    assert isinstance(present_null_only.properties[0].contract, NullContract)
+    assert nullable_string.properties[0].contract.nullable is True
+    assert "nullable" not in null_only_value.model_dump()
+
+
+def test_empty_closed_object_and_exact_property_names_remain_explicit():
+    empty = ObjectContract(nullable=False, properties=(), additional_properties=False)
+    assert empty.model_dump(mode="json") == _object()
+    named = parse_closed_contract(_object(_property(" name "), _property("name"), _property("Name")))
+    assert tuple(prop.name for prop in named.properties) == (" name ", "Name", "name")
+
+
+def _array_chain(depth):
+    value = {"kind": "null"}
+    for _ in range(depth - 1):
+        value = {"kind": "array", "nullable": False, "items": value}
+    return value
+
+
+def test_profile_depth_boundary_is_exact_and_checked_before_recursive_validation():
+    assert CLOSED_CONTRACT_PROFILE_VERSION == "mozaiks.closed_contract_profile.v1"
+    assert MAX_CONTRACT_DEPTH == 32
+    accepted = parse_closed_contract(_array_chain(MAX_CONTRACT_DEPTH))
+    assert isinstance(accepted, ArrayContract)
+    for depth in (MAX_CONTRACT_DEPTH + 1, 2000):
+        with pytest.raises(ClosedContractUnsupported, match="UNSUPPORTED: contract depth"):
+            parse_closed_contract(_array_chain(depth))
+        with pytest.raises(ValueError, match="UNSUPPORTED: contract depth"):
+            ArrayContract.model_validate(_array_chain(depth))
+
+
+def test_profile_node_boundary_counts_every_contract_occurrence():
+    assert MAX_CONTRACT_NODES == 1024
+    leaf = {"kind": "null"}
+    allowed = _object(*(_property(f"p{index}", contract=leaf) for index in range(MAX_CONTRACT_NODES - 1)))
+    assert len(parse_closed_contract(allowed).properties) == MAX_CONTRACT_NODES - 1
+    allowed["properties"].append(_property("too_many", contract=leaf))
+    with pytest.raises(ClosedContractUnsupported, match="UNSUPPORTED: contract nodes"):
+        parse_closed_contract(allowed)
+    with pytest.raises(ValueError, match="UNSUPPORTED: contract nodes"):
+        ObjectContract.model_validate(allowed)
+
+
+@pytest.mark.parametrize("shape", ["array", "object", "forged_model"])
+def test_recursive_cycles_fail_unsupported_without_serializing_or_recursing(shape):
+    if shape == "array":
+        value = {"kind": "array", "nullable": False}
+        value["items"] = value
+    elif shape == "object":
+        value = _object()
+        value["properties"].append(_property(contract=value))
+    else:
+        value = ArrayContract(nullable=False, items=NullContract())
+        object.__setattr__(value, "items", value)
+    with pytest.raises(ClosedContractUnsupported, match="UNSUPPORTED: cyclic"):
+        parse_closed_contract(value)
+
+
+def test_input_lists_and_dicts_cannot_mutate_nested_contract_authority():
+    raw = _object(_property(contract={"kind": "array", "nullable": False, "items": _scalar(enum=["b", "a"])}))
+    contract = parse_closed_contract(raw)
+    before = contract.model_dump_json()
+    raw["properties"][0]["name"] = "changed"
+    raw["properties"][0]["contract"]["items"]["enum"].append("later")
+    raw["properties"].append(_property("later"))
+    assert contract.model_dump_json() == before
+    assert isinstance(contract.properties, tuple)
+    assert isinstance(contract.properties[0].contract.items.enum, tuple)
+    with pytest.raises(ValidationError, match="frozen"):
+        contract.properties[0].required = False
+    with pytest.raises(ValidationError, match="frozen"):
+        contract.properties[0].contract.items.enum += ("later",)
+    with pytest.raises(TypeError):
+        contract.properties[0] = ContractProperty(name="new", required=True, contract=NullContract())
+    with pytest.raises(ValidationError, match="frozen"):
+        contract.nullable = True
+
+
+@pytest.mark.parametrize("model", [NullContract(), ScalarContract(kind="string", nullable=False), ArrayContract(nullable=False, items=NullContract()), ObjectContract(nullable=False, properties=(), additional_properties=False), ContractProperty(name="value", required=False, contract=NullContract())])
+def test_update_copy_paths_reject_and_safe_copies_revalidate(model):
+    with pytest.raises(TypeError, match="model_validate"):
+        model.model_copy(update={"nullable": True})
+    with pytest.raises(TypeError, match="model_validate"):
+        model.copy(update={"nullable": True})
+    with pytest.raises(TypeError, match="model_validate"):
+        model.copy(exclude={"kind"})
+    with pytest.raises(TypeError, match="model_validate"):
+        model.copy(include=set())
+    assert model.model_copy() == model
+    assert model.model_copy(deep=True) == model
+    assert model.copy() == model
+
+
+def test_forged_existing_and_nested_models_are_revalidated_not_trusted():
+    scalar = ScalarContract.model_construct(kind="integer", nullable=False, enum=(True,))
+    with pytest.raises(ValueError, match="exact scalar kind"):
+        parse_closed_contract(scalar)
+    with pytest.raises(ValueError, match="exact scalar kind"):
+        ArrayContract(nullable=False, items=scalar)
+    with pytest.raises(ValueError, match="exact scalar kind"):
+        scalar.model_copy()
+    opened = ObjectContract.model_construct(kind="object", nullable=False, properties=(), additional_properties=0)
+    with pytest.raises(ValueError, match="explicitly false"):
+        ContractProperty(name="value", required=True, contract=opened)
+    nullable_null = NullContract.model_construct(kind="null")
+    object.__setattr__(nullable_null, "nullable", True)
+    with pytest.raises(ValueError, match="Extra inputs"):
+        parse_closed_contract(nullable_null)
+
+
+@pytest.mark.parametrize("collection", ["generator", "set", "iterator", "mapping"])
+def test_property_collection_cannot_bypass_whole_contract_bounds(collection):
+    prop = ContractProperty(name="value", required=True, contract=NullContract())
+    values = {
+        "generator": (item for item in (prop,)),
+        "set": {prop},
+        "iterator": iter((prop,)),
+        "mapping": {"value": prop},
+    }[collection]
+    with pytest.raises(ValueError, match="explicit list or tuple"):
+        ObjectContract(nullable=False, properties=values, additional_properties=False)
+
+
+def test_nested_forged_instances_cannot_reintroduce_mutable_or_unvalidated_authority():
+    bad_scalar = ScalarContract.model_construct(kind="integer", nullable=False, enum=[True])
+    bad_property = ContractProperty.model_construct(name="value", required=True, contract=bad_scalar)
+    bad_object = ObjectContract.model_construct(
+        kind="object", nullable=False, properties=[bad_property], additional_properties=False,
+    )
+    for validate in (
+        lambda: ObjectContract.model_validate(bad_object),
+        lambda: bad_object.model_copy(deep=True),
+        lambda: ArrayContract(nullable=False, items=bad_object),
+        lambda: ObjectContract(nullable=False, properties=[bad_property], additional_properties=False),
+    ):
+        with pytest.raises(ValueError, match="exact scalar kind"):
+            validate()
+    invalid_required = ContractProperty.model_construct(name="value", required=1, contract=NullContract())
+    with pytest.raises(ValueError, match="valid boolean"):
+        ObjectContract(nullable=False, properties=[invalid_required], additional_properties=False)
+
+
+def _deterministic_example(reverse=False):
+    properties = [
+        _property("zeta", required=False, contract=_scalar("number", enum=[1.5, -0.0, -2.0])),
+        _property("alpha", contract={"kind": "array", "nullable": True, "items": _object(_property("child", contract=_scalar(enum=["z", "a"])))}),
+    ]
+    if reverse:
+        properties.reverse()
+        properties = [dict(reversed(tuple(prop.items()))) for prop in properties]
+        number = next(prop["contract"] for prop in properties if prop["name"] == "zeta")
+        number["enum"].reverse()
+    raw = _object(*properties)
+    if reverse:
+        raw = dict(reversed(tuple(raw.items())))
+    return parse_closed_contract(raw)
+
+
+def test_property_enum_mapping_order_and_round_trip_preserve_exact_canonical_identity():
+    first = _deterministic_example()
+    second = _deterministic_example(reverse=True)
+    assert first == second
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+    assert first.model_dump_json() == second.model_dump_json()
+    assert first.contract_digest == second.contract_digest
+    assert canonical_json(first.identity_payload) == canonical_json(second.identity_payload)
+    assert parse_closed_contract(json.loads(first.model_dump_json())) == first
+    assert ObjectContract.model_validate_json(first.model_dump_json()) == first
+    negative = ScalarContract(kind="number", nullable=False, enum=(-0.0,))
+    positive = ScalarContract(kind="number", nullable=False, enum=(0.0,))
+    assert negative.model_dump_json() == positive.model_dump_json()
+    assert negative.contract_digest == positive.contract_digest
+
+
+def test_contract_identity_is_identical_in_repeated_processes():
+    script = """
+import json
+from tests.test_closed_contracts import _deterministic_example
+contract = _deterministic_example(reverse=True)
+print(json.dumps([contract.model_dump_json(), contract.contract_digest]))
+"""
+    first = subprocess.check_output([sys.executable, "-c", script], text=True)
+    second = subprocess.check_output([sys.executable, "-c", script], text=True)
+    assert first == second
+    assert json.loads(first) == [_deterministic_example().model_dump_json(), _deterministic_example().contract_digest]

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -76,7 +76,10 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 # The interface family adds exactly two layout rows and two units (one scope
 # inactive). Its complete pre-family fixture proves all 59 prior units unchanged;
 # only aggregate identity incorporates this newly declared family.
-_GOLDEN_PLAN_DIGEST = "f37b6ef7cd20344a0908eff052cfd83eeaccd8e113f345ea1f37a9c5a73d127d"
+# EXPECTED_SEMANTIC_MIGRATION: the graph digest changes with action request
+# authority. All 61 unit bodies remain identical; the migration proof restores
+# only the original graph digest to recover the exact pre-migration plan hash.
+_GOLDEN_PLAN_DIGEST = "9fe1d96e4c38fb8c6b061333deae1a9095626e4305b3ac8377b10ef0ae2b3737"
 
 
 def _registry():

--- a/tests/test_deterministic_page_materialization.py
+++ b/tests/test_deterministic_page_materialization.py
@@ -163,8 +163,20 @@ def _source(*, column_label: str = "Order") -> dict:
                 "manifest": {
                     "module": {"id": "orders", "description": "Order management"},
                     "actions": [
-                        {"id": "list_orders", "description": "List orders."},
-                        {"id": "create_order", "description": "Create an order."},
+                        {
+                            "id": "list_orders", "description": "List orders.",
+                            "input_schema": {
+                                "type": "object", "properties": {}, "additionalProperties": False,
+                            },
+                        },
+                        {
+                            "id": "create_order", "description": "Create an order.",
+                            "input_schema": {
+                                "type": "object", "required": ["customer_name"],
+                                "properties": {"customer_name": {"type": "string"}},
+                                "additionalProperties": False,
+                            },
+                        },
                     ],
                 }
             }

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -239,10 +239,15 @@ def _corpus_source() -> dict:
                     "actions": [
                         {
                             "id": "export_report",
+                            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
                             "emits": ["domain.reports.generated"],
                             "entitlement_gate": "reports.export",
                         },
-                        {"id": "view_report", "entitlement_gate": "reports.view"},
+                        {
+                            "id": "view_report",
+                            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+                            "entitlement_gate": "reports.view",
+                        },
                     ],
                     "permissions": [{"id": "reports.read", "description": "Read reports"}],
                     "capabilities": [
@@ -658,6 +663,7 @@ def test_current_runtime_models_and_agentgenerator_bundle_shape_project() -> Non
                     "id": "export_report",
                     "description": "Export a report.",
                     "handler_method": "export_report",
+                    "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
                     "emits": ["domain.reports.generated"],
                     "entitlement_gate": "reports.export",
                 }
@@ -891,15 +897,18 @@ def test_committed_design_docs_subscription_build_context_and_route_sources() ->
     from tests.test_design_docs_bundle_persistence import _bundle
     from tests.test_subscription_contract_designer import _sample_contract
 
-    design_result = project_semantic_graph(
-        {"DesignDocsBundle": _bundle()},
-        graph_id="recorded-design-docs",
-        version=1,
-        scope=SCOPE,
-        taxonomy_registry=_pinned_registry(),
-    )
-    assert design_result.graph.nodes
-    assert design_result.source_facts == design_result.represented_facts
+    # Recorded surface mutations identify actions but contain no request
+    # authority. Missing module contracts must not become guessed empty inputs.
+    with pytest.raises(ProjectionError) as design_error:
+        project_semantic_graph(
+            {"DesignDocsBundle": _bundle()},
+            graph_id="recorded-design-docs",
+            version=1,
+            scope=SCOPE,
+            taxonomy_registry=_pinned_registry(),
+        )
+    assert design_error.value.gaps[0].kind is ProjectionGapKind.MISSING
+    assert "input_schema" in design_error.value.gaps[0].reason
 
     with pytest.raises(ProjectionError) as exc_info:
         project_semantic_graph(
@@ -1135,7 +1144,10 @@ source = {
         {
             "manifest": {
                 "module": {"id": "reports"},
-                "actions": [{"id": "export_report", "entitlement_gate": "reports.export"}],
+                "actions": [{
+                    "id": "export_report", "entitlement_gate": "reports.export",
+                    "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+                }],
                 "capabilities": [{"capability_id": "reports.export"}],
             }
         }
@@ -1357,7 +1369,10 @@ def test_entitlement_gate_requires_declared_capability_input_closure() -> None:
     module = {
         "manifest": {
             "module": {"id": "reports"},
-            "actions": [{"id": "export_report", "entitlement_gate": "reports.export"}],
+            "actions": [{
+                "id": "export_report", "entitlement_gate": "reports.export",
+                "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+            }],
         }
     }
     with pytest.raises(ProjectionError) as exc_info:

--- a/tests/test_semantic_payload_graph_v2.py
+++ b/tests/test_semantic_payload_graph_v2.py
@@ -25,6 +25,11 @@ from mozaiksai.core.semantics.archive import (
 from mozaiksai.core.semantics.binding import ImplementationBinding
 from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.capabilities import advertised_semantic_compiler_capabilities
+from mozaiksai.core.semantics.closed_contracts import (
+    ContractProperty,
+    ObjectContract,
+    ScalarContract,
+)
 from mozaiksai.core.semantics.graph import (
     SEMANTIC_GRAPH_V2_SCHEMA_VERSION,
     SemanticEdge,
@@ -252,8 +257,11 @@ _OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant2")
 
 # Golden Merkle-root vector: pinned digests for the full-corpus v2 graph and
 # its archived fixture.  Independent of host, process, and input order.
-_GOLDEN_GRAPH_DIGEST = "19d4fa7f8db76e05a3710b58f5909ddb807ccb7ce37facb51e8278de2a19f86b"
-_GOLDEN_ARCHIVE_DIGEST = "sha256:785d575f4e4ab73d16b2e28d54896ede3ea2e0d40a7013e05f2bf361fd6fc2f7"
+# EXPECTED_SEMANTIC_MIGRATION: only the action request contract and containing
+# graph/archive identities change; test_action_request_contracts restores and
+# verifies the exact original identities from the pinned base evidence.
+_GOLDEN_GRAPH_DIGEST = "421b7359cbd42d0f94a1ac9fbb38387240dda7bbea322add2a72027d14cc4810"
+_GOLDEN_ARCHIVE_DIGEST = "sha256:f1d2e8e104e1778b607b7771c1ff0ff6522628d78df52f548ecca91894ab43e4"
 
 
 def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str = "Home"):
@@ -374,7 +382,14 @@ def _corpus_payloads(*, scope: ExecutionAccessScopeRef = _SCOPE, home_title: str
             payload_version=1,
             scope=scope,
             description="Create one report",
-            request_fields=(field,),
+            request_contract=ObjectContract(
+                nullable=False,
+                additional_properties=False,
+                properties=(ContractProperty(
+                    name="name", required=True,
+                    contract=ScalarContract(kind="string", nullable=False),
+                ),),
+            ),
             response_fields=(
                 TypedFieldSpec(name="report_id", field_type=FieldType.REFERENCE, required=True),
             ),
@@ -1651,13 +1666,21 @@ def test_unordered_identity_collections_remain_permutation_stable() -> None:
         TypedFieldSpec(name="alpha", field_type=FieldType.INTEGER, required=True),
     )
     emits = ("reports.report_updated", "reports.report_created")
+    properties = (
+        ContractProperty(name="zeta", required=False,
+                         contract=ScalarContract(kind="string", nullable=False)),
+        ContractProperty(name="alpha", required=True,
+                         contract=ScalarContract(kind="integer", nullable=False)),
+    )
     first = build_semantic_payload(
         ActionPayload,
         node_id=action.node_id,
         payload_version=action.payload_version,
         scope=action.scope,
         description=action.description,
-        request_fields=fields,
+        request_contract=ObjectContract(
+            nullable=False, properties=properties, additional_properties=False,
+        ),
         response_fields=fields,
         emits=emits,
         entitlement_gate=action.entitlement_gate,
@@ -1668,13 +1691,15 @@ def test_unordered_identity_collections_remain_permutation_stable() -> None:
         payload_version=action.payload_version,
         scope=action.scope,
         description=action.description,
-        request_fields=tuple(reversed(fields)),
+        request_contract=ObjectContract(
+            nullable=False, properties=tuple(reversed(properties)), additional_properties=False,
+        ),
         response_fields=tuple(reversed(fields)),
         emits=tuple(reversed(emits)),
         entitlement_gate=action.entitlement_gate,
     )
     assert permuted.payload_digest == first.payload_digest
-    assert permuted.request_fields == first.request_fields
+    assert permuted.request_contract == first.request_contract
     assert permuted.response_fields == first.response_fields
     assert permuted.emits == first.emits
 

--- a/tests/test_workflow_capability_semantics.py
+++ b/tests/test_workflow_capability_semantics.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from mozaiksai.core.semantics.closed_contracts import ObjectContract
 from mozaiksai.core.semantics.graph import (
     SemanticEdge,
     SemanticEdgeKind,
@@ -90,6 +91,9 @@ def _action(node_id: str, *, description: str, emits: tuple[str, ...] = ()) -> A
         payload_version=1,
         scope=_SCOPE,
         description=description,
+        request_contract=ObjectContract(
+            nullable=False, properties=(), additional_properties=False,
+        ),
         emits=emits,
     )
 
@@ -345,6 +349,7 @@ def _rebuilt_action(payloads: dict[str, SemanticPayloadBase], node_id: str, **ov
         "payload_version": base.payload_version,
         "scope": base.scope,
         "description": base.description,
+        "request_contract": base.request_contract,
         "emits": base.emits,
     }
     fields.update(overrides)

--- a/tests/test_workflow_interface_rematerialization.py
+++ b/tests/test_workflow_interface_rematerialization.py
@@ -434,12 +434,22 @@ def _mutate(fixture: _Fixture, change: str) -> None:
     elif change in {"action_body", "action_request_schema", "action_response_schema"}:
         field = {
             "action_body": "description",
-            "action_request_schema": "request_fields",
+            "action_request_schema": "request_contract",
             "action_response_schema": "response_fields",
         }[change]
-        value = "Different implementation description" if field == "description" else [
-            {"name": "changed_field", "field_type": "string", "required": False},
-        ]
+        if field == "description":
+            value = "Different implementation description"
+        elif field == "request_contract":
+            value = {
+                "kind": "object", "nullable": False, "additional_properties": False,
+                "properties": [{
+                    "name": "changed_field", "required": True,
+                    "contract": {"kind": "array", "nullable": False,
+                                 "items": {"kind": "string", "nullable": True}},
+                }],
+            }
+        else:
+            value = [{"name": "changed_field", "field_type": "string", "required": False}]
         _replace(fixture, capability_fixture._ACTION_GET, **{field: value})
     elif change in {"event_body", "event_schema"}:
         values = (


### PR DESCRIPTION
ActionPayload now requires one canonical recursive request contract, replacing the shallow request_fields authority. An inputless action explicitly declares a non-null closed empty object; omission and the retired field reject.

Base: `e2713d64205079bad8c7b3dbc44186f26998e652` (exact #483 main; post-main CI 34003537267 terminal green before branch creation).
Exact reviewed head: `2d840a932c20222861276407629f6ac5162d826b`.

## Contract and migration

- One closed immutable algebra: null, strict scalar, homogeneous array, closed object, and required/optional property. Value nullability is independent of property absence. Scalar enums reject duplicates, null, mixed types, bool/integer coercion, and non-finite numbers; names and enum values canonicalize deterministically.
- Profile `mozaiks.closed_contract_profile.v1`: depth 32, 1024 contract occurrences. Iterative checks bound depth/width and reject cycles before recursive validation. There are no refs or general unions. INTEGER enum values use signed 64-bit integers; NUMBER enum values use exact finite floats.
- Nested models revalidate, all collections store tuples, and unchecked copy/update paths reject. Identity uses the existing canonical serialization primitives.
- The existing CanonicalJsonValue implementation moves unchanged to canonical_json.py. Plan authority imports the same classes; all seven extracted definitions remain AST-identical. Exact JSON bytes and the complete 59,230-byte plan-authority serialization remain unchanged.
- The only semantic producer outside fixtures is the offline projector. Its explicit bounded schema importer consumes module action input_schema only when closure and every assertion are supported. Open/omitted closure, unsupported assertions, refs, unions, cycles, and excessive limits fail UNSUPPORTED. Surface-only action names without request authority fail MISSING. Synthetic fixtures declare their requests; the recorded DesignDocs fixture remains untouched and now proves the precise missing-authority gap.
- No production prompt, generator, or runtime consumes request_fields. Production dispatch continues consuming module.yaml actions[].input_schema. Future realization must initially require normalized equality with the semantic request contract; no compatibility proof is implemented here.

## Identity evidence

Only three existing goldens change, all classified EXPECTED_SEMANTIC_MIGRATION:

| Identity | Before | After |
|---|---|---|
| Corpus graph | 19d4fa7f8db76e05a3710b58f5909ddb807ccb7ce37facb51e8278de2a19f86b | 421b7359cbd42d0f94a1ac9fbb38387240dda7bbea322add2a72027d14cc4810 |
| Corpus plan | f37b6ef7cd20344a0908eff052cfd83eeaccd8e113f345ea1f37a9c5a73d127d | 9fe1d96e4c38fb8c6b061333deae1a9095626e4305b3ac8377b10ef0ae2b3737 |
| Corpus archive | sha256:785d575f4e4ab73d16b2e28d54896ede3ea2e0d40a7013e05f2bf361fd6fc2f7 | sha256:f1d2e8e104e1778b607b7771c1ff0ff6522628d78df52f548ecca91894ab43e4 |

The permanent migration test restores only the old request field and its containing digest pins to recover the exact original identities. All 61 existing corpus unit bodies remain unchanged, including the historical 59-unit byte/digest proof; no historical corpus fixture or unit fingerprint was repinned. Composition/ArtifactRevision identities derive from their migrated graph inputs; their contracts/evidence and fixed output bytes are unchanged. No UNRELATED_DRIFT was accepted.

Fixture impact map: the shared semantic corpus (`_corpus_payloads`/`_corpus_graph`), the #478 capability fixture (`_action`/`_rebuilt_action`, also consumed by #483), the offline projection corpus (`_corpus_source`), and the 4C orders source (`_source`) explicitly migrate action requests. B2A `_extended_fixture`, 5B/5C composition helpers, plan-authority fixtures, and ArtifactRevision tests inherit graph identity changes through those shared roots. Their derived identity assertions remain dynamic; no additional fixed golden or ArtifactRevision evidence shape was changed. The separate workflow-only canonical-JSON authority fixture deliberately excludes action payloads and retains its exact original digest and bytes.

A referenced action request-only change passes through serialized authorities and real rematerialization: the workflow_module_interface unit remains REUSABLE, origin is reused, bytes are identical, and the successor matches clean materialization.

## Validation

- Required focused run: **920 passed, 1 skipped**; separate schema importer suite: **80 passed**.
- New contract suites cover the complete hostile shape matrix, recursive closure, null/absence distinctions, enum types, deep immutability/copies, depth/node limits, schema assertion rejection, process/order determinism, and exact migration identities.
- Regression run includes semantic payload closure, #478/#481/#482/#483, CompilationPlan and #475/#477 authority, materialization/rematerialization, 4C, 5A/5B/5C composition, ArtifactRevision contracts/store, and source hygiene.
- Full `python -m pytest -q --no-cov` on exact published head `2d840a932c20222861276407629f6ac5162d826b`: **14981 passed, 94 skipped, 3 warnings** in 940.48 seconds.
- `ruff check .`, scoped mypy on all six changed production modules, strict MkDocs, actual source hygiene scan, and `git diff --check`: PASS.
- DCO, GitGuardian, and [CI](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34006502990): terminal PASS on the exact published head. The CI-equivalent Gitleaks history scan also passed locally.

Codex 3 independently reviewed the exact head above: PASS, no blocking findings; 244 tests passed across the four new suites and interface corpus proofs before the final constant-only rename; 38 extraction tests passed afterward.

## OSS change impact

- Layer: offline semantic/compiler contracts.
- Build workflow, runtime/platform, and app workspace behavior: unchanged. No generator or dispatch cutover.
- Docs: ADR 0007 specifies the profile, migration, semantic/executable boundary, and future normalized-equality requirement; changelog updated.
- Compatibility: intentional pre-1.0 semantic request-field replacement. Response/data/event/entity/workflow-output sibling types remain unchanged.
- Deferred: result bindings/projection, action-input projection, assignability, receipts, approval policy, binding-aware plans, ArtifactRevision evidence changes, runtime delivery/registry, workflow touchpoints, and AG2/provider changes.

Draft review only. DCO signed. Auto-merge disabled. Do not merge.
