### PR TITLE
fix(compiler): make structured output identity provider-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **Provider-neutral structured-output identity**: canonical contracts now pin
+  a versioned acceptance profile and truthful optionality independently of
+  provider wire formatting. Build and cold resolution consume the same explicit
+  model authority. Module schema checking and evaluation failures now reject
+  validation instead of reporting success; explicit empty schemas remain valid.
 - **Canonical plan authority is now enforced across execution and durable
   revision closure (ADR 0007 lane)**: assignment compilation
   (`compile_approved_plan`), composition (`compose_plan_artifacts`, including

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -918,12 +918,10 @@ regions the graph declares.
 
 ## Structured-Output Strictness
 
-The audit found that `structured_outputs.yaml` declarations appear strict
-while the dynamically compiled runtime Pydantic models are permissive: the
-compiler in `mozaiksai/core/workflow/outputs/structured.py` builds models via
-`create_model` with no `model_config`, so unknown fields are ignored at
-runtime. `_patch_model_schema` makes the provider JSON-schema projection look
-strict, but provider/runtime validation therefore disagree. Open-ended dict
+The original audit found that `structured_outputs.yaml` declarations appeared
+strict while dynamically compiled runtime Pydantic models ignored unknown
+fields. `_patch_model_schema` made the provider JSON-schema projection look
+strict, so provider formatting obscured the acceptance contract. Open-ended dict
 fields have two current behaviors that stack on the same live agent-creation
 path: the `get_llm_for_workflow` helper (still called by the agent factory
 for every agent) logs a warning and falls back to a plain LLM configuration,
@@ -945,8 +943,9 @@ This ADR requires, for the compiler's structured-output surface:
   projection;
 - provider projection is deterministic — the same declaration always produces
   the same provider schema, and silent strictness downgrades are removed;
-- runtime validation is equivalent to provider-schema validation, so a payload
-  the provider would reject cannot pass the runtime;
+- runtime validation matches the canonical acceptance contract. A provider
+  protocol may strengthen its wire projection, such as requiring nullable
+  optional fields to be present, without changing application acceptance;
 - validation failure is observable — a typed, recorded failure, never
   warning-and-continue (the current silent no-op on structured-output
   validation failure in `mozaiksai/core/workflow/outputs/runtime_events.py`
@@ -957,6 +956,70 @@ This ADR requires, for the compiler's structured-output surface:
 
 This ADR does not implement the flip; it is rollout work (slice 5) gated on
 the compatibility report.
+
+### Provider-neutral acceptance identity prerequisite
+
+`build_models_from_config` now returns unpatched canonical Pydantic models.
+Explicit `exact_model_ids` applies `extra="forbid"` when models are created,
+before a parent can capture a child schema. Generic runtime loading keeps its
+existing default acceptance policy; this is not the global strictness flip.
+`get_provider_response_model` remains the sole provider adapter. It creates
+separate response models with the current OpenAI strict required fields,
+reference inlining, and object closure. Production agent construction continues
+to use that adapter.
+
+`canonical_structured_output_schema` invokes the unmodified Pydantic validation
+schema compiler directly. Acceptance profile
+`mozaiks.structured_output_acceptance_profile.v1` retains refs, defaults,
+annotations, nullable unions, and canonical exact-object closure. It sorts
+object keys and schema `required` names, while preserving data-array order in
+defaults, examples, and enum members. The model compiler sorts distinct finite
+JSON scalar literal declarations before naming their enum; equality-alias
+declarations retain order because Python Enum gives the first value acceptance
+meaning. Union branch order remains compiler authority.
+
+`StructuredOutputContractRef` is now
+`mozaiks.structured_output_contract_ref.v2`, pinning `workflow_name`, `model_id`,
+`acceptance_profile`, and `schema_digest`. The digest covers the profile and
+canonical schema. The old ref version is rejected. This acceptance profile is
+separate from `mozaiks.closed_contract_profile.v1`: no compatibility algebra or
+assignability proof is inferred from a Pydantic schema.
+
+Both reference APIs require explicit configuration and exact model IDs:
+
+| Caller | Authority classification | Inputs |
+|---|---|---|
+| `derive_compilation_plan` | `CANONICAL_COMPILER` | Supplied configs and the selected assignment-descriptor authority |
+| `compile_approved_plan` | `COLD_AUTHORITY_BOUNDARY` | Configs, exact model IDs, and identity bindings from the same immutable `CompilationPlanAuthorityInputs` |
+| `resolve_assignment_admission` | `COLD_AUTHORITY_BOUNDARY` | Supplied configs and explicit exact model IDs; the pinned ref must match |
+| `build_assignment_artifact_result` | `COLD_AUTHORITY_BOUNDARY` | Supplied configs and explicit exact model IDs; the pinned ref must match |
+| Workflow model loading and provider adaptation | `PRODUCTION_RUNTIME_DEFAULT` | Runtime configuration and caches; never reference identity authority |
+
+Synthetic reference tests also supply explicit exact model sets. Canonical
+rederivation supplies the frozen descriptor snapshot, so later ambient registry
+changes cannot alter either schema exactness or semantic identity bindings.
+A separate persisted schema snapshot is unnecessary for these consumers:
+existing immutable authority inputs already contain the exact source documents.
+
+The exact-base migration fixture records provider-influenced schemas, references,
+plans, assignments, artifact results, and generated bytes from main
+`430d3ffaeab0b27843d7fbeba275c5be316ff586`. Ref-dependent identities are classified
+`EXPECTED_STRUCTURED_OUTPUT_IDENTITY_MIGRATION`; restoring only those references
+and their enclosing digests recovers the captured documents exactly. Authority
+inputs, unrelated units, artifact bytes, the existing 61-unit corpus, historical
+59-unit proof, action request contracts, and workflow interface bytes retain
+their identities. Other changes would be `UNRELATED_DRIFT` and fail the proof.
+
+Runtime module JSON Schema validation remains Draft 7. The shared validator
+normalizes nullable syntax, checks the schema, and evaluates the value. Any
+normalization, checking, construction, or evaluation exception returns a
+deterministic `schema_invalid` diagnostic; value violations return
+`value_invalid`. Explicit `{}` is a universal schema and is checked; `None`
+means absence only at callers that allow no schema. Module inputs, event
+emission, and event routing reject diagnostics. Output value violations retain
+their existing warning policy, while an invalid or unevaluable output schema
+returns `INVALID_OUTPUT_SCHEMA`. This does not change module dispatch topology,
+ArtifactRevision evidence, workflow results, or runtime result delivery.
 
 ## BuildContextBindingRef
 

--- a/mozaiksai/core/runtime/composition/module_event_router.py
+++ b/mozaiksai/core/runtime/composition/module_event_router.py
@@ -373,9 +373,10 @@ class ModuleEventRouter:
                 for event in events:
                     event_type = str(getattr(event, "type", "") or "").strip()
                     payload_schema = getattr(event, "payload_schema", None)
-                    if event_type and isinstance(payload_schema, dict) and payload_schema:
-                        self._event_schemas_by_producer[(module_id, event_type)] = dict(payload_schema)
-                        self._event_schemas_by_type[event_type].append((module_id, dict(payload_schema)))
+                    if event_type and payload_schema is not None:
+                        schema = dict(payload_schema) if isinstance(payload_schema, dict) else payload_schema
+                        self._event_schemas_by_producer[(module_id, event_type)] = schema
+                        self._event_schemas_by_type[event_type].append((module_id, schema))
             reactions_manifest = getattr(manifests, "reactions", None)
             if reactions_manifest is not None:
                 for reaction_model in reactions_manifest.reactions:
@@ -468,7 +469,7 @@ class ModuleEventRouter:
         event_provenance: ModuleEventProvenance,
     ) -> ModuleEventPayloadValidationError | None:
         schema = self._payload_schema_for_event(event_type, event_provenance)
-        if not schema:
+        if schema is None:
             return None
         payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
         diagnostic = validate_json_schema(payload, schema)
@@ -489,7 +490,7 @@ class ModuleEventRouter:
         producer_module = str(event_provenance.producer_module_id or "").strip()
         if producer_module:
             schema = self._event_schemas_by_producer.get((producer_module, event_type))
-            if schema:
+            if schema is not None:
                 return schema
         schemas = self._event_schemas_by_type.get(event_type) or []
         if len(schemas) == 1:

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -158,13 +158,14 @@ def _normalize_nullable_schema(schema: Any) -> Any:
     return normalize_nullable_schema(schema)
 
 
-def _validate_schema(value: Any, schema: dict[str, Any]) -> str | None:
+def _validate_schema(value: Any, schema: dict[str, Any] | bool | None) -> str | None:
     """Validate *value* against a JSON Schema dict.
 
     Returns None on success or a short error string on failure.
-    Empty or non-dict schemas are skipped (returns None).
+    ``None`` means no schema was supplied. Every explicit schema is checked,
+    including the universal empty object and boolean Draft 7 schemas.
     """
-    if not schema or not isinstance(schema, dict):
+    if schema is None:
         return None
     diagnostic = validate_json_schema(value, schema)
     return diagnostic.message if diagnostic is not None else None
@@ -442,7 +443,7 @@ class ModuleExecutor:
         schemas = self._action_schemas.get(request.module, {}).get(request.action, {})
         input_schema = schemas.get("input") if schemas else None
         output_schema = schemas.get("output") if schemas else None
-        if input_schema:
+        if input_schema is not None:
             input_error = _validate_schema(request.params, input_schema)
             if input_error:
                 logger.warning(
@@ -603,14 +604,26 @@ class ModuleExecutor:
                 error_code="MODULE_RESULT_NOT_JSON_SAFE",
             )
 
-        # Output schema validation — warn only; don't fail the caller on a
-        # module contract bug. Validates the exact transport shape.
-        if output_schema and result is not None:
-            out_error = _validate_schema(result, output_schema)
-            if out_error:
+        # Output value violations retain the existing warning policy. A schema
+        # that cannot be checked or evaluated cannot establish success.
+        if output_schema is not None:
+            output_diagnostic = validate_json_schema(result, output_schema)
+            if output_diagnostic is not None:
                 logger.warning(
                     "MODULE_OUTPUT_INVALID: module=%s action=%s error=%s",
-                    request.module, request.action, out_error)
+                    request.module, request.action, output_diagnostic.message)
+                if output_diagnostic.category == "schema_invalid":
+                    asyncio.create_task(
+                        self._emit_dispatch_audit(
+                            replace(dispatch_audit, outcome="failed", reason="INVALID_OUTPUT_SCHEMA"),
+                            error="INVALID_OUTPUT_SCHEMA",
+                        )
+                    )
+                    return ModuleResult(
+                        success=False,
+                        error=f"Output schema validation failed for {request.module}.{request.action}: {output_diagnostic.message}",
+                        error_code="INVALID_OUTPUT_SCHEMA",
+                    )
 
         # Response size gate — the exact wire render. These dump options are
         # byte-for-byte what starlette.responses.JSONResponse.render() emits
@@ -759,7 +772,7 @@ class ModuleExecutor:
                     diagnostic=diagnostic,
                 )
             payload_schema = self._event_payload_schemas.get(request.module, {}).get(event_type_text)
-            if payload_schema:
+            if payload_schema is not None:
                 validation_diagnostic = validate_json_schema(payload, payload_schema)
                 if validation_diagnostic is not None:
                     raise ModuleEventPayloadValidationError(

--- a/mozaiksai/core/runtime/composition/schema_validation.py
+++ b/mozaiksai/core/runtime/composition/schema_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Shared JSON Schema helpers for runtime contract validation."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import jsonschema
 
@@ -20,6 +20,7 @@ class SchemaValidationDiagnostic:
     path: str
     schema_path: str
     validator: str | None = None
+    category: Literal["value_invalid", "schema_invalid"] = "value_invalid"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -27,6 +28,7 @@ class SchemaValidationDiagnostic:
             "path": self.path,
             "schema_path": self.schema_path,
             "validator": self.validator,
+            "category": self.category,
         }
 
 
@@ -53,38 +55,81 @@ def normalize_nullable_schema(schema: Any) -> Any:
     return normalized
 
 
-def validate_json_schema(value: Any, schema: dict[str, Any]) -> SchemaValidationDiagnostic | None:
-    """Validate *value* against a JSON Schema dict and return structured errors."""
+def _schema_failure(
+    message: str, *, validator: str, schema_path: str = "$",
+) -> SchemaValidationDiagnostic:
+    logger.warning("MODULE_SCHEMA_ERROR: %s schema_path=%s validator=%s", message, schema_path, validator)
+    return SchemaValidationDiagnostic(
+        message=message,
+        path="$",
+        schema_path=schema_path,
+        validator=validator,
+        category="schema_invalid",
+    )
 
-    if not schema or not isinstance(schema, dict):
-        return None
+
+def validate_json_schema(
+    value: Any, schema: dict[str, Any] | bool,
+) -> SchemaValidationDiagnostic | None:
+    """Check a normalized Draft 7 schema and then validate its value.
+
+    ``None`` is returned only after both checks succeed. The empty object is
+    a valid universal schema; absence is handled explicitly by callers, not
+    represented as an unchecked schema here. Exception diagnostics use stable
+    stage descriptions rather than exception reprs or runtime addresses.
+    """
     try:
-        validator = jsonschema.Draft7Validator(normalize_nullable_schema(schema))
+        normalized = normalize_nullable_schema(schema)
+    except Exception:
+        return _schema_failure("Schema normalization failed.", validator="normalization")
+    try:
+        jsonschema.Draft7Validator.check_schema(normalized)
+    except jsonschema.exceptions.SchemaError as exc:
+        return _schema_failure(
+            "Schema is invalid under Draft 7.",
+            validator=exc.validator if type(exc.validator) is str else "schema",
+            schema_path=_json_path(exc.path),
+        )
+    except Exception:
+        return _schema_failure("Schema checking failed.", validator="schema")
+    try:
+        validator = jsonschema.Draft7Validator(normalized)
+    except Exception:
+        return _schema_failure("Schema validator construction failed.", validator="construction")
+    try:
         errors = sorted(
             validator.iter_errors(value),
-            key=lambda err: (list(err.path), list(err.schema_path), err.message),
+            key=lambda err: (_json_path(err.path), _json_path(err.schema_path), str(err.validator)),
         )
         if not errors:
             return None
-        exc = errors[0]
+        value_error = errors[0]
+        constraint = str(value_error.validator) if value_error.validator else None
+        message = (f"Value does not satisfy the {constraint!r} constraint." if constraint
+                   else "Value does not satisfy the declared schema.")
+        if constraint == "required" and isinstance(value_error.instance, dict):
+            missing = sorted(name for name in value_error.validator_value if name not in value_error.instance)
+            message = "Missing required properties: " + ", ".join(repr(name) for name in missing) + "."
         return SchemaValidationDiagnostic(
-            message=exc.message,
-            path=_json_path(exc.path),
-            schema_path=_json_path(exc.schema_path),
-            validator=str(exc.validator) if exc.validator else None,
+            message=message,
+            path=_json_path(value_error.path),
+            schema_path=_json_path(value_error.schema_path),
+            validator=constraint,
         )
-    except Exception as exc:  # malformed schema - preserve existing non-crashing behavior
-        logger.warning("MODULE_SCHEMA_ERROR: could not validate schema: %s", exc)
-        return None
+    except Exception:
+        return _schema_failure("Schema evaluation failed.", validator="evaluation")
 
 
 def _json_path(parts: Any) -> str:
     path = "$"
-    for part in parts:
-        if isinstance(part, int):
-            path += f"[{part}]"
-        elif isinstance(part, str) and part.isidentifier():
-            path += f".{part}"
-        else:
-            path += f"[{part!r}]"
+    try:
+        for part in parts:
+            if type(part) is int:
+                path += f"[{part}]"
+            elif type(part) is str:
+                path += f".{part}" if part.isidentifier() else f"[{part!r}]"
+            else:
+                path += '["<non-json-key>"]'
+    except Exception:
+        return '$["<invalid-path>"]'
     return path

--- a/mozaiksai/core/workflow/assignment_admission.py
+++ b/mozaiksai/core/workflow/assignment_admission.py
@@ -28,6 +28,7 @@ def resolve_assignment_admission(
     assignment: CompiledAssignment,
     *,
     structured_output_configs: Mapping[str, Any],
+    exact_model_ids: frozenset[str],
     workflow_agent_configs: Mapping[str, Any],
 ) -> ResolvedAssignmentAdmission:
     """Resolve exactly one Factory participant without creating runtime identity."""
@@ -37,7 +38,7 @@ def resolve_assignment_admission(
     )
     contract_ref = verified_assignment.required_structured_output_ref
     resolve_structured_output_contract_ref(
-        contract_ref, configs=structured_output_configs
+        contract_ref, configs=structured_output_configs, exact_model_ids=exact_model_ids
     )
 
     raw_structured = structured_output_configs.get(contract_ref.workflow_name)

--- a/mozaiksai/core/workflow/assignment_artifacts.py
+++ b/mozaiksai/core/workflow/assignment_artifacts.py
@@ -189,6 +189,7 @@ def build_assignment_artifact_result(
     structured_output: Mapping[str, Any] | BaseModel,
     artifacts: Mapping[str, str],
     structured_output_configs: Mapping[str, Any],
+    exact_model_ids: frozenset[str],
     validator_runner: ValidatorRunner,
 ) -> AssignmentArtifactResult:
     """Validate untrusted output and generate Mozaiks-owned validation receipts."""
@@ -197,6 +198,7 @@ def build_assignment_artifact_result(
     model = resolve_structured_output_contract_ref(
         verified_assignment.required_structured_output_ref,
         configs=structured_output_configs,
+        exact_model_ids=exact_model_ids,
     )
     raw_output = (
         structured_output.model_dump(mode="json")

--- a/mozaiksai/core/workflow/outputs/structured.py
+++ b/mozaiksai/core/workflow/outputs/structured.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, Optional, Union, get_args, get_origin
 
 _UNION_ORIGINS = (Union, _types.UnionType) if hasattr(_types, "UnionType") else (Union,)
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from ..llm_config import get_llm_config
 from ..workflow_manager import workflow_manager
@@ -44,9 +44,26 @@ def _build_literal_enum(name: str, values: list[Any]) -> type[Enum]:
     # The enum class name enters the compiled model's JSON schema and
     # therefore canonical structured-output identity. Python hash() is
     # process-salted, so the name must be content-derived: a bounded prefix
-    # of the sha256 over the exact ordered value content.
+    # of the sha256 over deterministic value content. Distinct finite JSON
+    # scalar sets have no declaration-order meaning. Equality aliases retain
+    # their order: Python Enum uses the first equal member's exact value/type.
+    # Other runtime literal domains retain their existing compiler behavior.
     import hashlib as _hashlib
     import json as _json
+    import math as _math
+
+    scalar_set = all(
+        type(value) in (type(None), bool, int, float, str)
+        and (type(value) is not float or _math.isfinite(value))
+        for value in values
+    )
+    if scalar_set and len(set(values)) == len(values):
+        values = sorted(
+            values,
+            key=lambda value: _json.dumps(
+                value, ensure_ascii=True, separators=(",", ":"), allow_nan=False,
+            ),
+        )
 
     content = _json.dumps(
         values, ensure_ascii=False, separators=(",", ":"), default=repr
@@ -241,6 +258,12 @@ def _strictify_response_annotation(annotation: Any) -> Any:
 
 
 def get_provider_response_model(model_cls: type[BaseModel]) -> type[BaseModel]:
+    """Build/cache the OpenAI wire model without changing its acceptance model.
+
+    Required-field strengthening and schema ref/object formatting belong only
+    to this separately compiled provider projection. Workflow model caches
+    retain the unpatched acceptance classes regardless of invocation order.
+    """
     cached = _provider_response_model_cache.get(model_cls)
     if cached is not None:
         return cached
@@ -432,7 +455,17 @@ def resolve_field_type(
         return list[inner_type], _build_field(field_kwargs)  # type: ignore
     raise ValueError(f"Unknown field type: {field_type_str}")
 
-def build_models_from_config(models_config: dict[str, Any]) -> dict[str, type]:
+def build_models_from_config(
+    models_config: dict[str, Any], *, exact_model_ids: frozenset[str] = frozenset(),
+) -> dict[str, type]:
+    """Compile provider-neutral acceptance models from workflow declarations.
+
+    Declared defaults and optional fields remain truthful in the model and
+    its ordinary Pydantic schema. Provider response-format preparation is
+    performed separately by ``get_provider_response_model``. Explicit exact
+    model identities configure acceptance closure at construction, before any
+    dependent model captures the child's validation/schema definition.
+    """
     if not models_config:
         return {}
     models: dict[str, type] = {}
@@ -459,8 +492,11 @@ def build_models_from_config(models_config: dict[str, Any]) -> dict[str, type]:
         if unresolved:
             pending.append((name, mdef))
         else:
-            model_cls = create_model(name, **fields)  # type: ignore[arg-type]
-            _patch_model_schema(model_cls)
+            model_cls = create_model(
+                name,
+                __config__=ConfigDict(extra="forbid") if name in exact_model_ids else None,
+                **fields,
+            )  # type: ignore[call-overload]
             models[name] = model_cls
     # iterative resolution
     for _ in range(len(pending)):
@@ -478,8 +514,11 @@ def build_models_from_config(models_config: dict[str, Any]) -> dict[str, type]:
             if unresolved:
                 remaining.append((name, mdef))
             else:
-                model_cls = create_model(name, **fields)  # type: ignore[arg-type]
-                _patch_model_schema(model_cls)
+                model_cls = create_model(
+                    name,
+                    __config__=ConfigDict(extra="forbid") if name in exact_model_ids else None,
+                    **fields,
+                )  # type: ignore[call-overload]
                 models[name] = model_cls
         pending = remaining
         if not pending:

--- a/mozaiksai/core/workflow/plan_assignment_compiler.py
+++ b/mozaiksai/core/workflow/plan_assignment_compiler.py
@@ -7,7 +7,6 @@ touch persistence, or participate in production AppBuildPlan flows.
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -21,7 +20,7 @@ from mozaiksai.core.semantics.plan_authority import (
 from mozaiksai.core.semantics.refs import PlanUnitRef, SemanticPayloadRef
 from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
 
-from .assignment_kinds import AssignmentKind, assignment_contract_descriptor
+from .assignment_kinds import AssignmentKind, descriptors_from_snapshot
 from .structured_output_contracts import (
     StructuredOutputContractRef,
     resolve_structured_output_contract_ref,
@@ -141,7 +140,6 @@ def compile_approved_plan(
     *,
     resolver: SemanticReferenceResolver,
     authority_inputs: CompilationPlanAuthorityInputs,
-    structured_output_configs: Mapping[str, Any],
 ) -> CompiledAssignmentSet:
     """Cold-resolve and compile approved units without execution side effects.
 
@@ -161,8 +159,11 @@ def compile_approved_plan(
     resolved_plan = resolver.resolve(plan_ref, requesting_scope=scope)
     if not isinstance(resolved_plan, CompilationPlan):
         raise ValueError("compilation plan ref did not resolve to a canonical plan")
+    verified_inputs = CompilationPlanAuthorityInputs.model_validate(
+        authority_inputs.model_dump(mode="json")
+    )
     canonical_plan = validate_compilation_plan_against_authority(
-        resolved_plan, authority_inputs
+        resolved_plan, verified_inputs
     )
     if canonical_plan.plan_digest != plan_ref.content_digest:
         raise ValueError(
@@ -170,6 +171,15 @@ def compile_approved_plan(
         )
     plan_order = {unit.unit_id: index for index, unit in enumerate(canonical_plan.units)}
     canonical_units = {unit.unit_id: unit for unit in canonical_plan.units}
+    structured_output_configs = (
+        verified_inputs.structured_output_configs.to_python()
+        if verified_inputs.structured_output_configs is not None
+        else {}
+    )
+    descriptors = descriptors_from_snapshot(verified_inputs.assignment_contract_registry)
+    exact_model_ids = frozenset(
+        descriptor.structured_output_model_id for descriptor in descriptors.values()
+    )
     for spec in plan.assignments:
         unit = canonical_units.get(spec.plan_unit_ref.unit_id)
         if unit is None:
@@ -217,9 +227,11 @@ def compile_approved_plan(
                 )
 
         resolve_structured_output_contract_ref(
-            spec.required_structured_output_ref, configs=structured_output_configs
+            spec.required_structured_output_ref,
+            configs=structured_output_configs,
+            exact_model_ids=exact_model_ids,
         )
-        descriptor = assignment_contract_descriptor(spec.assignment_kind)
+        descriptor = descriptors.get(spec.assignment_kind)
         if descriptor is None:
             raise ValueError("assignment kind has no executable output contract")
         unit_bindings = dict(unit.placeholder_values)

--- a/mozaiksai/core/workflow/structured_output_contracts.py
+++ b/mozaiksai/core/workflow/structured_output_contracts.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import re
 from collections.abc import Mapping
-from typing import Any, Literal, cast
+from typing import Any, Final, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -39,16 +39,22 @@ def stable_digest(data: Any) -> str:
 
 _STRUCTURED_OUTPUT_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
+STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE: Final = (
+    "mozaiks.structured_output_acceptance_profile.v1"
+)
 
 
 class StructuredOutputContractRef(_FrozenModel):
     """Content-pinned locator for a workflow-owned structured-output model."""
 
-    ref_schema_version: Literal["mozaiks.structured_output_contract_ref.v1"] = (
-        "mozaiks.structured_output_contract_ref.v1"
+    ref_schema_version: Literal["mozaiks.structured_output_contract_ref.v2"] = (
+        "mozaiks.structured_output_contract_ref.v2"
     )
     workflow_name: str
     model_id: str
+    acceptance_profile: Literal["mozaiks.structured_output_acceptance_profile.v1"] = (
+        STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE
+    )
     schema_digest: str
 
     @field_validator("workflow_name", "model_id")
@@ -70,49 +76,64 @@ class StructuredOutputContractRef(_FrozenModel):
         return text
 
 
-def structured_output_schema_digest(model: type[BaseModel]) -> str:
-    """Digest the normalized schema emitted by the canonical model compiler."""
+def canonical_structured_output_schema(model: type[BaseModel]) -> dict[str, Any]:
+    """Extract the v1 acceptance schema from a canonical compiler model.
 
-    return stable_digest(model.model_json_schema())
-
-
-def _default_exact_model_ids() -> frozenset[str]:
-    """The canonical registry's exact-model ids — an explicit default only.
-
-    Canonical plan derivation never uses this default: it passes the exact
-    model ids resolved from its supplied assignment-descriptor authority, so
-    ambient registry state cannot influence a schema digest on the canonical
-    path. Production assignment execution keeps the canonical registry as its
-    natural default.
+    Invoke Pydantic's validation-schema compiler directly: a provider or caller
+    override of ``model_json_schema`` cannot become identity authority. Retain
+    refs, annotations, defaults, nullable unions and exact-object closure.
+    Object-key ordering and required-name ordering have no acceptance meaning;
+    all other arrays retain their compiler order. Provider response wrappers
+    are projections and must never be supplied as canonical compiler models.
     """
-    from .assignment_kinds import ASSIGNMENT_CONTRACT_DESCRIPTORS
+    schema = cast(Any, BaseModel.model_json_schema).__func__(
+        model, mode="validation", by_alias=True
+    )
 
-    return frozenset(
-        descriptor.structured_output_model_id
-        for descriptor in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()
+    def normalize(node: dict[str, Any]) -> dict[str, Any]:
+        result = dict(node)
+        if "required" in result:
+            result["required"] = sorted(result["required"])
+        # Traverse schema positions only. A default/enum/example may itself
+        # contain a property called "required" whose array order is data.
+        for keyword in ("$defs", "properties", "patternProperties"):
+            if keyword in result:
+                result[keyword] = {
+                    name: normalize(child) for name, child in result[keyword].items()
+                }
+        for keyword in ("items", "additionalProperties"):
+            if isinstance(result.get(keyword), dict):
+                result[keyword] = normalize(result[keyword])
+        for keyword in ("anyOf", "allOf", "oneOf", "prefixItems"):
+            if keyword in result:
+                result[keyword] = [normalize(child) for child in result[keyword]]
+        return result
+
+    return cast(dict[str, Any], _jsonable(normalize(schema)))
+
+
+def structured_output_schema_digest(model: type[BaseModel]) -> str:
+    """Pin the acceptance profile and its provider-neutral compiled schema."""
+    return stable_digest(
+        {
+            "acceptance_profile": STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE,
+            "schema": canonical_structured_output_schema(model),
+        }
     )
 
 
 def _compiled_models(
-    config: Any, *, exact_model_ids: frozenset[str] | None = None
+    config: Any, *, exact_model_ids: frozenset[str]
 ) -> dict[str, type[BaseModel]]:
     from mozaiksai.core.workflow.declarative.contracts import StructuredOutputsConfig
     from mozaiksai.core.workflow.outputs.structured import build_models_from_config
 
     verified = StructuredOutputsConfig.model_validate(config)
     dumped = verified.model_dump(by_alias=True, exclude_unset=True)
-    models = cast(
+    return cast(
         dict[str, type[BaseModel]],
-        build_models_from_config(dumped.get("models", {})),
+        build_models_from_config(dumped.get("models", {}), exact_model_ids=exact_model_ids),
     )
-    resolved_exact_ids = (
-        exact_model_ids if exact_model_ids is not None else _default_exact_model_ids()
-    )
-    for model_id in resolved_exact_ids & models.keys():
-        model = models[model_id]
-        model.model_config = ConfigDict(**model.model_config, extra="forbid")
-        model.model_rebuild(force=True)
-    return models
 
 
 def build_structured_output_contract_ref(
@@ -120,7 +141,7 @@ def build_structured_output_contract_ref(
     workflow_name: str,
     model_id: str,
     configs: Mapping[str, Any],
-    exact_model_ids: frozenset[str] | None = None,
+    exact_model_ids: frozenset[str],
 ) -> StructuredOutputContractRef:
     """Resolve a model through the existing canonical workflow compiler."""
 
@@ -140,7 +161,10 @@ def build_structured_output_contract_ref(
 
 
 def resolve_structured_output_contract_ref(
-    ref: StructuredOutputContractRef, *, configs: Mapping[str, Any]
+    ref: StructuredOutputContractRef,
+    *,
+    configs: Mapping[str, Any],
+    exact_model_ids: frozenset[str],
 ) -> type[BaseModel]:
     """Cold-resolve a ref and reject unknown or schema-stale contracts."""
 
@@ -152,7 +176,7 @@ def resolve_structured_output_contract_ref(
         raise ValueError(
             f"unknown structured-output workflow {verified_ref.workflow_name!r}"
         )
-    model = _compiled_models(config).get(verified_ref.model_id)
+    model = _compiled_models(config, exact_model_ids=exact_model_ids).get(verified_ref.model_id)
     if model is None:
         raise ValueError(
             f"unknown structured-output model {verified_ref.workflow_name!r}/"
@@ -164,8 +188,10 @@ def resolve_structured_output_contract_ref(
 
 
 __all__ = [
+    "STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE",
     "StructuredOutputContractRef",
     "build_structured_output_contract_ref",
+    "canonical_structured_output_schema",
     "resolve_structured_output_contract_ref",
     "stable_digest",
     "structured_output_schema_digest",

--- a/tests/fixtures/structured-output-identity-migration.json
+++ b/tests/fixtures/structured-output-identity-migration.json
@@ -1,0 +1,1978 @@
+{
+  "base_commit": "430d3ffaeab0b27843d7fbeba275c5be316ff586",
+  "derivation": "tests.slice_5b_composition_helpers.composition_fixture",
+  "config_fingerprint": "9aa3360290e37b5f5f930208d161eda511d08969efa1acd6faee5e949fe7ed21",
+  "selected_model_config": {
+    "type": "model",
+    "description": "Exact source for one predeclared module-local helper.",
+    "fields": {
+      "assignment_kind": {
+        "type": "literal",
+        "values": [
+          "module_helper_implementation"
+        ]
+      },
+      "module_id": {
+        "type": "str",
+        "description": "Canonical owning module identity supplied by the assignment."
+      },
+      "helper_id": {
+        "type": "str",
+        "description": "Canonical helper identity supplied by the declaration."
+      },
+      "helper_source": {
+        "type": "str",
+        "description": "UTF-8 source for the single compiler-owned helper path."
+      }
+    }
+  },
+  "input_document_fingerprint": "dfaa950cf84bd4df7be9086e88b71e9a82b9f3a52e9459303986bd2376b98af7",
+  "input_document_bytes_fingerprint": "c46ef25b950e50d4571e7a771e0a9cfc09211e5c46239185b5652a70c874737f",
+  "descriptor_snapshot": {
+    "registry_schema_version": "mozaiks.assignment_contract_registry.v1",
+    "descriptors": [
+      {
+        "assignment_kind": "app_route_extension_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "AppRouteExtensionImplementationOutput",
+        "owned_artifact_families": [
+          "app_service_route"
+        ],
+        "validator_ids": [
+          "generated_app_validator"
+        ],
+        "identity_bindings": [
+          [
+            "route_id",
+            "pack_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "custom_page_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "CustomPageImplementationOutput",
+        "owned_artifact_families": [
+          "app_ui_custom_route"
+        ],
+        "validator_ids": [
+          "generated_app_validator"
+        ],
+        "identity_bindings": [
+          [
+            "page_id",
+            "page_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "integration_adapter_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "IntegrationAdapterImplementationOutput",
+        "owned_artifact_families": [
+          "app_service_adapter"
+        ],
+        "validator_ids": [
+          "generated_app_validator"
+        ],
+        "identity_bindings": [
+          [
+            "integration_id",
+            "pack_id"
+          ],
+          [
+            "adapter_area",
+            "adapter_area"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "module_admin_page_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "ModuleAdminPageImplementationOutput",
+        "owned_artifact_families": [
+          "module_admin_ui"
+        ],
+        "validator_ids": [
+          "generated_app_validator"
+        ],
+        "identity_bindings": [
+          [
+            "module_id",
+            "module_id"
+          ],
+          [
+            "page_id",
+            "page_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "module_backend_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "ModuleBackendImplementationOutput",
+        "owned_artifact_families": [
+          "module_backend_policy",
+          "module_backend_repo",
+          "module_backend_schemas",
+          "module_backend_service"
+        ],
+        "validator_ids": [
+          "module_loader"
+        ],
+        "identity_bindings": [
+          [
+            "module_id",
+            "module_id"
+          ],
+          [
+            "backend_role",
+            "backend_role"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "module_helper_implementation",
+        "workflow_name": "AppGenerator",
+        "structured_output_model_id": "ModuleHelperImplementationOutput",
+        "owned_artifact_families": [
+          "module_backend_helper"
+        ],
+        "validator_ids": [
+          "module_loader"
+        ],
+        "identity_bindings": [
+          [
+            "module_id",
+            "module_id"
+          ],
+          [
+            "helper_id",
+            "helper_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "workflow_participant_implementation",
+        "workflow_name": "AgentGenerator",
+        "structured_output_model_id": "WorkflowParticipantImplementationOutput",
+        "owned_artifact_families": [
+          "workflow_config"
+        ],
+        "validator_ids": [
+          "workflow_manager"
+        ],
+        "identity_bindings": [
+          [
+            "workflow_id",
+            "workflow_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "workflow_structured_models_implementation",
+        "workflow_name": "AgentGenerator",
+        "structured_output_model_id": "WorkflowStructuredModelsOutput",
+        "owned_artifact_families": [
+          "workflow_config"
+        ],
+        "validator_ids": [
+          "workflow_manager"
+        ],
+        "identity_bindings": [
+          [
+            "workflow_id",
+            "workflow_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "workflow_tool_implementation",
+        "workflow_name": "AgentGenerator",
+        "structured_output_model_id": "WorkflowToolImplementationOutput",
+        "owned_artifact_families": [
+          "workflow_tool"
+        ],
+        "validator_ids": [
+          "workflow_manager"
+        ],
+        "identity_bindings": [
+          [
+            "workflow_id",
+            "workflow_id"
+          ],
+          [
+            "tool_id",
+            "tool_id"
+          ]
+        ]
+      },
+      {
+        "assignment_kind": "workflow_ui_implementation",
+        "workflow_name": "AgentGenerator",
+        "structured_output_model_id": "WorkflowUiImplementationOutput",
+        "owned_artifact_families": [
+          "workflow_ui"
+        ],
+        "validator_ids": [
+          "generated_app_validator"
+        ],
+        "identity_bindings": [
+          [
+            "workflow_id",
+            "workflow_id"
+          ],
+          [
+            "component_id",
+            "component_id"
+          ]
+        ]
+      }
+    ]
+  },
+  "reference": {
+    "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+    "workflow_name": "AppGenerator",
+    "model_id": "ModuleHelperImplementationOutput",
+    "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+  },
+  "provider_influenced_schema": {
+    "additionalProperties": false,
+    "properties": {
+      "assignment_kind": {
+        "enum": [
+          "module_helper_implementation"
+        ],
+        "title": "LiteralEnum_0ce647e185bd",
+        "type": "string"
+      },
+      "module_id": {
+        "description": "Canonical owning module identity supplied by the assignment.",
+        "title": "Module Id",
+        "type": "string"
+      },
+      "helper_id": {
+        "description": "Canonical helper identity supplied by the declaration.",
+        "title": "Helper Id",
+        "type": "string"
+      },
+      "helper_source": {
+        "description": "UTF-8 source for the single compiler-owned helper path.",
+        "title": "Helper Source",
+        "type": "string"
+      }
+    },
+    "required": [
+      "assignment_kind",
+      "module_id",
+      "helper_id",
+      "helper_source"
+    ],
+    "title": "ModuleHelperImplementationOutput",
+    "type": "object"
+  },
+  "unmodified_basemodel_schema": {
+    "$defs": {
+      "LiteralEnum_0ce647e185bd": {
+        "enum": [
+          "module_helper_implementation"
+        ],
+        "title": "LiteralEnum_0ce647e185bd",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "assignment_kind": {
+        "$ref": "#/$defs/LiteralEnum_0ce647e185bd"
+      },
+      "module_id": {
+        "description": "Canonical owning module identity supplied by the assignment.",
+        "title": "Module Id",
+        "type": "string"
+      },
+      "helper_id": {
+        "description": "Canonical helper identity supplied by the declaration.",
+        "title": "Helper Id",
+        "type": "string"
+      },
+      "helper_source": {
+        "description": "UTF-8 source for the single compiler-owned helper path.",
+        "title": "Helper Source",
+        "type": "string"
+      }
+    },
+    "required": [
+      "assignment_kind",
+      "module_id",
+      "helper_id",
+      "helper_source"
+    ],
+    "title": "ModuleHelperImplementationOutput",
+    "type": "object"
+  },
+  "base_plan": {
+    "document": {
+      "schema_version": "mozaiks.compilation_plan.v1",
+      "graph_id": "corpus-app",
+      "graph_version": 1,
+      "scope": {
+        "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+        "tenant_id": "tenant1",
+        "workspace_id": "ws1",
+        "pre_app_scope_id": null
+      },
+      "graph_digest": "53684ec763a2ee80ddabab585340f82f0e1a77fb74960f08fc4426985860b274",
+      "scope_selection": {
+        "app_manifest_scope": "app_bundle_root",
+        "module_scope": "app_bundle_root",
+        "workflow_manifest_scope": "workflow_relative"
+      },
+      "registry_schema_version": "mozaiks.app_layout.v2",
+      "registry_digest": "7957e4fbcfde2f3431c7511e8b1bff5c5ba164643f31c1f9a1dccd0bb2d8aaae",
+      "assignment_contracts_digest": "e37d35bab40ada0b1a9ef772f20beb9c73a3dbe7c565a66967f66ba04279fb99",
+      "units": [
+        {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        }
+      ],
+      "gaps": [],
+      "plan_digest": "567df30ed2df0ebb0557915a22f048f09758b45cb3c793da4f89d51a2495c6ec"
+    },
+    "serialized_json": "{\"schema_version\":\"mozaiks.compilation_plan.v1\",\"graph_id\":\"corpus-app\",\"graph_version\":1,\"scope\":{\"ref_schema_version\":\"mozaiks.execution_access_scope_ref.v1\",\"tenant_id\":\"tenant1\",\"workspace_id\":\"ws1\",\"pre_app_scope_id\":null},\"graph_digest\":\"53684ec763a2ee80ddabab585340f82f0e1a77fb74960f08fc4426985860b274\",\"scope_selection\":{\"app_manifest_scope\":\"app_bundle_root\",\"module_scope\":\"app_bundle_root\",\"workflow_manifest_scope\":\"workflow_relative\"},\"registry_schema_version\":\"mozaiks.app_layout.v2\",\"registry_digest\":\"7957e4fbcfde2f3431c7511e8b1bff5c5ba164643f31c1f9a1dccd0bb2d8aaae\",\"assignment_contracts_digest\":\"e37d35bab40ada0b1a9ef772f20beb9c73a3dbe7c565a66967f66ba04279fb99\",\"units\":[{\"unit_id\":\"app_integrations_config/220f7104547e\",\"family_kind\":\"app_integrations_config\",\"family_identity_digest\":\"220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"config/integrations.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_manifest/4a3db375c920\",\"family_kind\":\"app_manifest\",\"family_identity_digest\":\"4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"app.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.auth.corpus\",\"payload_digest\":\"576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_secret_references/d3d82ba33c06\",\"family_kind\":\"app_secret_references\",\"family_identity_digest\":\"d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"security/secrets.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_ui_page_schema/home/484a8be83170\",\"family_kind\":\"app_ui_page_schema\",\"family_identity_digest\":\"484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"page_id\",\"home\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/pages/home.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"},{\"node_id\":\"mozaiks.section.hero\",\"payload_digest\":\"f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167\"},{\"node_id\":\"mozaiks.section.pricing\",\"payload_digest\":\"de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d\"}],\"edge_sources\":[{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.hero\",\"discriminator\":null,\"edge_identity\":\"5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45\"},{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.pricing\",\"discriminator\":null,\"edge_identity\":\"8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb\"}],\"depends_on_units\":[],\"materializer\":\"page_schema_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_ui_route_manifest/c8c7777a62de\",\"family_kind\":\"app_ui_route_manifest\",\"family_identity_digest\":\"c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/route_manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"}],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_page_schema/home/484a8be83170\"],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"module_backend_helper/report_hook-reports/a641fcf1cb52\",\"family_kind\":\"module_backend_helper\",\"family_identity_digest\":\"a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc\",\"disposition\":\"agent_author\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"helper_id\",\"report_hook\"],[\"module_id\",\"reports\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"modules/reports/backend/report_hook.py\"}],\"sources\":[{\"node_id\":\"mozaiks.artifact.report_hook\",\"payload_digest\":\"fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30\"},{\"node_id\":\"mozaiks.module.reports\",\"payload_digest\":\"46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93\"}],\"edge_sources\":[{\"kind\":\"owns\",\"source_node_id\":\"mozaiks.module.reports\",\"target_node_id\":\"mozaiks.artifact.report_hook\",\"discriminator\":null,\"edge_identity\":\"dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8\"}],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":\"module_helper_implementation\",\"validator\":\"module_loader\",\"required_structured_output_ref\":{\"ref_schema_version\":\"mozaiks.structured_output_contract_ref.v1\",\"workflow_name\":\"AppGenerator\",\"model_id\":\"ModuleHelperImplementationOutput\",\"schema_digest\":\"aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7\"},\"base_plan_digest\":null}],\"gaps\":[],\"plan_digest\":\"567df30ed2df0ebb0557915a22f048f09758b45cb3c793da4f89d51a2495c6ec\"}",
+    "units": [
+      {
+        "unit_id": "app_integrations_config/220f7104547e",
+        "document": {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_integrations_config/220f7104547e\",\"family_kind\":\"app_integrations_config\",\"family_identity_digest\":\"220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"config/integrations.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "cc16ed69adc34ad323245c4ec84c3a60369c553b3e68a4afff0fa046bd162902"
+      },
+      {
+        "unit_id": "app_manifest/4a3db375c920",
+        "document": {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_manifest/4a3db375c920\",\"family_kind\":\"app_manifest\",\"family_identity_digest\":\"4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"app.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.auth.corpus\",\"payload_digest\":\"576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "4036c49be656dca46bf72f37ec1399f53d63119d2bbfa81f09ee45d7f118410e"
+      },
+      {
+        "unit_id": "app_secret_references/d3d82ba33c06",
+        "document": {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_secret_references/d3d82ba33c06\",\"family_kind\":\"app_secret_references\",\"family_identity_digest\":\"d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"security/secrets.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "0c7cfa0b204eda26d793c6d33378f0b241cfe68f5a993e703432453b296a3245"
+      },
+      {
+        "unit_id": "app_ui_page_schema/home/484a8be83170",
+        "document": {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_ui_page_schema/home/484a8be83170\",\"family_kind\":\"app_ui_page_schema\",\"family_identity_digest\":\"484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"page_id\",\"home\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/pages/home.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"},{\"node_id\":\"mozaiks.section.hero\",\"payload_digest\":\"f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167\"},{\"node_id\":\"mozaiks.section.pricing\",\"payload_digest\":\"de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d\"}],\"edge_sources\":[{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.hero\",\"discriminator\":null,\"edge_identity\":\"5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45\"},{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.pricing\",\"discriminator\":null,\"edge_identity\":\"8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb\"}],\"depends_on_units\":[],\"materializer\":\"page_schema_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "805714f93333d96ff4abfc56087ae3a4103a630c3929c67e0f8174fc32980f9b"
+      },
+      {
+        "unit_id": "app_ui_route_manifest/c8c7777a62de",
+        "document": {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_ui_route_manifest/c8c7777a62de\",\"family_kind\":\"app_ui_route_manifest\",\"family_identity_digest\":\"c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/route_manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7\"}],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_page_schema/home/484a8be83170\"],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "df7e7f43484092266cb609fe94d206f3290bcdb2423b17e685d59058f79cb7f1"
+      },
+      {
+        "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+        "document": {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"module_backend_helper/report_hook-reports/a641fcf1cb52\",\"family_kind\":\"module_backend_helper\",\"family_identity_digest\":\"a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc\",\"disposition\":\"agent_author\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"helper_id\",\"report_hook\"],[\"module_id\",\"reports\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"modules/reports/backend/report_hook.py\"}],\"sources\":[{\"node_id\":\"mozaiks.artifact.report_hook\",\"payload_digest\":\"fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30\"},{\"node_id\":\"mozaiks.module.reports\",\"payload_digest\":\"46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93\"}],\"edge_sources\":[{\"kind\":\"owns\",\"source_node_id\":\"mozaiks.module.reports\",\"target_node_id\":\"mozaiks.artifact.report_hook\",\"discriminator\":null,\"edge_identity\":\"dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8\"}],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":\"module_helper_implementation\",\"validator\":\"module_loader\",\"required_structured_output_ref\":{\"ref_schema_version\":\"mozaiks.structured_output_contract_ref.v1\",\"workflow_name\":\"AppGenerator\",\"model_id\":\"ModuleHelperImplementationOutput\",\"schema_digest\":\"aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7\"},\"base_plan_digest\":null}",
+        "unit_digest": "13bc7f4f2dfa1d337904c7f3c86fef45ca83ac3169e6d7d4c7ec5e7a1b496543"
+      }
+    ]
+  },
+  "successor_plan": {
+    "document": {
+      "schema_version": "mozaiks.compilation_plan.v1",
+      "graph_id": "corpus-app",
+      "graph_version": 2,
+      "scope": {
+        "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+        "tenant_id": "tenant1",
+        "workspace_id": "ws1",
+        "pre_app_scope_id": null
+      },
+      "graph_digest": "825e44afe9b5d03924c90839c37cd1d6029eaebac60d0d41499f1e4b0b7ddaa0",
+      "scope_selection": {
+        "app_manifest_scope": "app_bundle_root",
+        "module_scope": "app_bundle_root",
+        "workflow_manifest_scope": "workflow_relative"
+      },
+      "registry_schema_version": "mozaiks.app_layout.v2",
+      "registry_digest": "7957e4fbcfde2f3431c7511e8b1bff5c5ba164643f31c1f9a1dccd0bb2d8aaae",
+      "assignment_contracts_digest": "e37d35bab40ada0b1a9ef772f20beb9c73a3dbe7c565a66967f66ba04279fb99",
+      "units": [
+        {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        }
+      ],
+      "gaps": [],
+      "plan_digest": "82cbb7eb6d45bc91887cdc426c073c120a7d0613fe9b0d4b974413d301cd3445"
+    },
+    "serialized_json": "{\"schema_version\":\"mozaiks.compilation_plan.v1\",\"graph_id\":\"corpus-app\",\"graph_version\":2,\"scope\":{\"ref_schema_version\":\"mozaiks.execution_access_scope_ref.v1\",\"tenant_id\":\"tenant1\",\"workspace_id\":\"ws1\",\"pre_app_scope_id\":null},\"graph_digest\":\"825e44afe9b5d03924c90839c37cd1d6029eaebac60d0d41499f1e4b0b7ddaa0\",\"scope_selection\":{\"app_manifest_scope\":\"app_bundle_root\",\"module_scope\":\"app_bundle_root\",\"workflow_manifest_scope\":\"workflow_relative\"},\"registry_schema_version\":\"mozaiks.app_layout.v2\",\"registry_digest\":\"7957e4fbcfde2f3431c7511e8b1bff5c5ba164643f31c1f9a1dccd0bb2d8aaae\",\"assignment_contracts_digest\":\"e37d35bab40ada0b1a9ef772f20beb9c73a3dbe7c565a66967f66ba04279fb99\",\"units\":[{\"unit_id\":\"app_integrations_config/220f7104547e\",\"family_kind\":\"app_integrations_config\",\"family_identity_digest\":\"220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"config/integrations.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_manifest/4a3db375c920\",\"family_kind\":\"app_manifest\",\"family_identity_digest\":\"4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"app.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.auth.corpus\",\"payload_digest\":\"576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_secret_references/d3d82ba33c06\",\"family_kind\":\"app_secret_references\",\"family_identity_digest\":\"d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"security/secrets.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_ui_page_schema/home/484a8be83170\",\"family_kind\":\"app_ui_page_schema\",\"family_identity_digest\":\"484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"page_id\",\"home\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/pages/home.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899\"},{\"node_id\":\"mozaiks.section.hero\",\"payload_digest\":\"f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167\"},{\"node_id\":\"mozaiks.section.pricing\",\"payload_digest\":\"de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d\"}],\"edge_sources\":[{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.hero\",\"discriminator\":null,\"edge_identity\":\"5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45\"},{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.pricing\",\"discriminator\":null,\"edge_identity\":\"8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb\"}],\"depends_on_units\":[],\"materializer\":\"page_schema_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"app_ui_route_manifest/c8c7777a62de\",\"family_kind\":\"app_ui_route_manifest\",\"family_identity_digest\":\"c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/route_manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899\"}],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_page_schema/home/484a8be83170\"],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null},{\"unit_id\":\"module_backend_helper/report_hook-reports/a641fcf1cb52\",\"family_kind\":\"module_backend_helper\",\"family_identity_digest\":\"a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc\",\"disposition\":\"agent_author\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"helper_id\",\"report_hook\"],[\"module_id\",\"reports\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"modules/reports/backend/report_hook.py\"}],\"sources\":[{\"node_id\":\"mozaiks.artifact.report_hook\",\"payload_digest\":\"fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30\"},{\"node_id\":\"mozaiks.module.reports\",\"payload_digest\":\"46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93\"}],\"edge_sources\":[{\"kind\":\"owns\",\"source_node_id\":\"mozaiks.module.reports\",\"target_node_id\":\"mozaiks.artifact.report_hook\",\"discriminator\":null,\"edge_identity\":\"dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8\"}],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":\"module_helper_implementation\",\"validator\":\"module_loader\",\"required_structured_output_ref\":{\"ref_schema_version\":\"mozaiks.structured_output_contract_ref.v1\",\"workflow_name\":\"AppGenerator\",\"model_id\":\"ModuleHelperImplementationOutput\",\"schema_digest\":\"aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7\"},\"base_plan_digest\":null}],\"gaps\":[],\"plan_digest\":\"82cbb7eb6d45bc91887cdc426c073c120a7d0613fe9b0d4b974413d301cd3445\"}",
+    "units": [
+      {
+        "unit_id": "app_integrations_config/220f7104547e",
+        "document": {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_integrations_config/220f7104547e",
+          "family_kind": "app_integrations_config",
+          "family_identity_digest": "220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "config/integrations.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_paths",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_integrations_config/220f7104547e\",\"family_kind\":\"app_integrations_config\",\"family_identity_digest\":\"220f7104547ee458dddc60b5322872839f36865772cd14a761384ae34332126e\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"config/integrations.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_paths\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "cc16ed69adc34ad323245c4ec84c3a60369c553b3e68a4afff0fa046bd162902"
+      },
+      {
+        "unit_id": "app_manifest/4a3db375c920",
+        "document": {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_manifest/4a3db375c920",
+          "family_kind": "app_manifest",
+          "family_identity_digest": "4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "app.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.auth.corpus",
+              "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "app_loader",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_manifest/4a3db375c920\",\"family_kind\":\"app_manifest\",\"family_identity_digest\":\"4a3db375c9206e22fb77fd8671ba126bd66c6c8536541352d907f64080c72c46\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"app.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.auth.corpus\",\"payload_digest\":\"576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"app_loader\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "4036c49be656dca46bf72f37ec1399f53d63119d2bbfa81f09ee45d7f118410e"
+      },
+      {
+        "unit_id": "app_secret_references/d3d82ba33c06",
+        "document": {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_secret_references/d3d82ba33c06",
+          "family_kind": "app_secret_references",
+          "family_identity_digest": "d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "security/secrets.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.integration.email",
+              "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_secret_references/d3d82ba33c06\",\"family_kind\":\"app_secret_references\",\"family_identity_digest\":\"d3d82ba33c063f13e4641414c59b17898c97203a7585bb18748d6f016a96da02\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"security/secrets.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.integration.email\",\"payload_digest\":\"0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de\"}],\"edge_sources\":[],\"depends_on_units\":[],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "0c7cfa0b204eda26d793c6d33378f0b241cfe68f5a993e703432453b296a3245"
+      },
+      {
+        "unit_id": "app_ui_page_schema/home/484a8be83170",
+        "document": {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_ui_page_schema/home/484a8be83170",
+          "family_kind": "app_ui_page_schema",
+          "family_identity_digest": "484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "page_id",
+              "home"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/pages/home.yaml"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            },
+            {
+              "node_id": "mozaiks.section.hero",
+              "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+            },
+            {
+              "node_id": "mozaiks.section.pricing",
+              "payload_digest": "de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.hero",
+              "discriminator": null,
+              "edge_identity": "5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45"
+            },
+            {
+              "kind": "renders",
+              "source_node_id": "mozaiks.page.home",
+              "target_node_id": "mozaiks.section.pricing",
+              "discriminator": null,
+              "edge_identity": "8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "page_schema_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_ui_page_schema/home/484a8be83170\",\"family_kind\":\"app_ui_page_schema\",\"family_identity_digest\":\"484a8be83170e2c6a2d809afb8eaa4cb24914be383243e44bacecd287d8b69e1\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"page_id\",\"home\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/pages/home.yaml\"}],\"sources\":[{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899\"},{\"node_id\":\"mozaiks.section.hero\",\"payload_digest\":\"f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167\"},{\"node_id\":\"mozaiks.section.pricing\",\"payload_digest\":\"de927ad9a4432ba690783b63ab0ebca5a23a58f038aa04f9d3a486b93c348d7d\"}],\"edge_sources\":[{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.hero\",\"discriminator\":null,\"edge_identity\":\"5efe8a075b89578a8a427863bc1d0ea6d7bed3d83f3546c6ac3e3a320f3a3c45\"},{\"kind\":\"renders\",\"source_node_id\":\"mozaiks.page.home\",\"target_node_id\":\"mozaiks.section.pricing\",\"discriminator\":null,\"edge_identity\":\"8717c73368f097d8c38c3b6e9928c1779801b9403d7b7453ccd6a4f96f102beb\"}],\"depends_on_units\":[],\"materializer\":\"page_schema_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "2fa371b2b6075637220bdea5c477e6c6d4fea0f516aaa1208e2d61d0ba6d8c0a"
+      },
+      {
+        "unit_id": "app_ui_route_manifest/c8c7777a62de",
+        "document": {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "app_ui_route_manifest/c8c7777a62de",
+          "family_kind": "app_ui_route_manifest",
+          "family_identity_digest": "c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5",
+          "disposition": "render",
+          "source_scope": "declared",
+          "placeholder_values": [],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "ui/route_manifest.json"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.application.corpus",
+              "payload_digest": "c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584"
+            },
+            {
+              "node_id": "mozaiks.page.home",
+              "payload_digest": "a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899"
+            }
+          ],
+          "edge_sources": [],
+          "depends_on_units": [
+            "app_ui_page_schema/home/484a8be83170"
+          ],
+          "materializer": "app_config_executor",
+          "assignment_kind": null,
+          "validator": "generated_app_validator",
+          "required_structured_output_ref": null,
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"app_ui_route_manifest/c8c7777a62de\",\"family_kind\":\"app_ui_route_manifest\",\"family_identity_digest\":\"c8c7777a62de4001d403fd4b5d1133b6ab23ed1fd1c45fc9cddda3ac74dbbdc5\",\"disposition\":\"render\",\"source_scope\":\"declared\",\"placeholder_values\":[],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"ui/route_manifest.json\"}],\"sources\":[{\"node_id\":\"mozaiks.application.corpus\",\"payload_digest\":\"c99285be4fe6544021d5047440da63a6dde48c7373c399bd77de53152c602584\"},{\"node_id\":\"mozaiks.page.home\",\"payload_digest\":\"a90964c060b30a59091141467c40c956ad160848bda9173ddd153343a3dd8899\"}],\"edge_sources\":[],\"depends_on_units\":[\"app_ui_page_schema/home/484a8be83170\"],\"materializer\":\"app_config_executor\",\"assignment_kind\":null,\"validator\":\"generated_app_validator\",\"required_structured_output_ref\":null,\"base_plan_digest\":null}",
+        "unit_digest": "349fd7e3dd7a96f42c8892dc1ea3930acc51ba3a382f4b2e1a9f8344c2cb2f72"
+      },
+      {
+        "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+        "document": {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        },
+        "identity_payload": {
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "family_kind": "module_backend_helper",
+          "family_identity_digest": "a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc",
+          "disposition": "agent_author",
+          "source_scope": "declared",
+          "placeholder_values": [
+            [
+              "helper_id",
+              "report_hook"
+            ],
+            [
+              "module_id",
+              "reports"
+            ]
+          ],
+          "outputs": [
+            {
+              "path_scope": "app_bundle_root",
+              "path": "modules/reports/backend/report_hook.py"
+            }
+          ],
+          "sources": [
+            {
+              "node_id": "mozaiks.artifact.report_hook",
+              "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+            },
+            {
+              "node_id": "mozaiks.module.reports",
+              "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+            }
+          ],
+          "edge_sources": [
+            {
+              "kind": "owns",
+              "source_node_id": "mozaiks.module.reports",
+              "target_node_id": "mozaiks.artifact.report_hook",
+              "discriminator": null,
+              "edge_identity": "dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8"
+            }
+          ],
+          "depends_on_units": [],
+          "materializer": "preserved_opaque",
+          "assignment_kind": "module_helper_implementation",
+          "validator": "module_loader",
+          "required_structured_output_ref": {
+            "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+            "workflow_name": "AppGenerator",
+            "model_id": "ModuleHelperImplementationOutput",
+            "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+          },
+          "base_plan_digest": null
+        },
+        "serialized_json": "{\"unit_id\":\"module_backend_helper/report_hook-reports/a641fcf1cb52\",\"family_kind\":\"module_backend_helper\",\"family_identity_digest\":\"a641fcf1cb526ee2fb9180404dd0f9fc00710fa147c72c6f82655b7ee13409bc\",\"disposition\":\"agent_author\",\"source_scope\":\"declared\",\"placeholder_values\":[[\"helper_id\",\"report_hook\"],[\"module_id\",\"reports\"]],\"outputs\":[{\"path_scope\":\"app_bundle_root\",\"path\":\"modules/reports/backend/report_hook.py\"}],\"sources\":[{\"node_id\":\"mozaiks.artifact.report_hook\",\"payload_digest\":\"fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30\"},{\"node_id\":\"mozaiks.module.reports\",\"payload_digest\":\"46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93\"}],\"edge_sources\":[{\"kind\":\"owns\",\"source_node_id\":\"mozaiks.module.reports\",\"target_node_id\":\"mozaiks.artifact.report_hook\",\"discriminator\":null,\"edge_identity\":\"dfbf1d8a836262f8b8dd70028a6bebbd16103491995b59ea67cd9e9ca9b8cbb8\"}],\"depends_on_units\":[],\"materializer\":\"preserved_opaque\",\"assignment_kind\":\"module_helper_implementation\",\"validator\":\"module_loader\",\"required_structured_output_ref\":{\"ref_schema_version\":\"mozaiks.structured_output_contract_ref.v1\",\"workflow_name\":\"AppGenerator\",\"model_id\":\"ModuleHelperImplementationOutput\",\"schema_digest\":\"aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7\"},\"base_plan_digest\":null}",
+        "unit_digest": "13bc7f4f2dfa1d337904c7f3c86fef45ca83ac3169e6d7d4c7ec5e7a1b496543"
+      }
+    ]
+  },
+  "compiled_assignments": {
+    "ordered_assignments": [
+      {
+        "assignment_id": "wa_e210a049dfd45785796d4ffa",
+        "plan_unit_ref": {
+          "ref_schema_version": "mozaiks.plan_unit_ref.v1",
+          "compilation_plan_ref": {
+            "subject_id": "corpus-app",
+            "subject_version": 2,
+            "content_digest": "82cbb7eb6d45bc91887cdc426c073c120a7d0613fe9b0d4b974413d301cd3445",
+            "scope": {
+              "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+              "tenant_id": "tenant1",
+              "workspace_id": "ws1",
+              "pre_app_scope_id": null
+            },
+            "ref_schema_version": "mozaiks.compilation_plan_ref.v1"
+          },
+          "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+          "unit_digest": "13bc7f4f2dfa1d337904c7f3c86fef45ca83ac3169e6d7d4c7ec5e7a1b496543"
+        },
+        "assignment_kind": "module_helper_implementation",
+        "owned_paths": [
+          "modules/reports/backend/report_hook.py"
+        ],
+        "depends_on_unit_refs": [],
+        "dependency_context_refs": [
+          {
+            "ref_schema_version": "mozaiks.semantic_payload_ref.v1",
+            "node_id": "mozaiks.module.reports",
+            "payload_kind": "module",
+            "payload_version": 1,
+            "content_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93",
+            "scope": {
+              "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+              "tenant_id": "tenant1",
+              "workspace_id": "ws1",
+              "pre_app_scope_id": null
+            }
+          },
+          {
+            "ref_schema_version": "mozaiks.semantic_payload_ref.v1",
+            "node_id": "mozaiks.artifact.report_hook",
+            "payload_kind": "artifact_declaration",
+            "payload_version": 1,
+            "content_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30",
+            "scope": {
+              "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+              "tenant_id": "tenant1",
+              "workspace_id": "ws1",
+              "pre_app_scope_id": null
+            }
+          }
+        ],
+        "required_structured_output_ref": {
+          "ref_schema_version": "mozaiks.structured_output_contract_ref.v1",
+          "workflow_name": "AppGenerator",
+          "model_id": "ModuleHelperImplementationOutput",
+          "schema_digest": "aff63ab65fd9000582e74617bf39f4d9ad15b73d33a91e6b8d9769709609e5c7"
+        },
+        "required_validators": [
+          "module_loader"
+        ],
+        "semantic_identity_bindings": [
+          [
+            "module_id",
+            "reports"
+          ],
+          [
+            "helper_id",
+            "report_hook"
+          ]
+        ],
+        "assignment_retry_limit": 2,
+        "base_revision_digest": null,
+        "assignment_digest": "e210a049dfd45785796d4ffa2478986df59220265f707c30c3c174975a37a52d"
+      }
+    ],
+    "assignment_set_digest": "e3217a8acffde892cc98a0740103418473e4c4cb302dd16cf1c54d7b9edaadb3"
+  },
+  "artifact_result": {
+    "result_schema_version": "mozaiks.assignment_artifact_result.v1",
+    "assignment_id": "wa_e210a049dfd45785796d4ffa",
+    "assignment_digest": "e210a049dfd45785796d4ffa2478986df59220265f707c30c3c174975a37a52d",
+    "plan_unit_ref": {
+      "ref_schema_version": "mozaiks.plan_unit_ref.v1",
+      "compilation_plan_ref": {
+        "subject_id": "corpus-app",
+        "subject_version": 2,
+        "content_digest": "82cbb7eb6d45bc91887cdc426c073c120a7d0613fe9b0d4b974413d301cd3445",
+        "scope": {
+          "ref_schema_version": "mozaiks.execution_access_scope_ref.v1",
+          "tenant_id": "tenant1",
+          "workspace_id": "ws1",
+          "pre_app_scope_id": null
+        },
+        "ref_schema_version": "mozaiks.compilation_plan_ref.v1"
+      },
+      "unit_id": "module_backend_helper/report_hook-reports/a641fcf1cb52",
+      "unit_digest": "13bc7f4f2dfa1d337904c7f3c86fef45ca83ac3169e6d7d4c7ec5e7a1b496543"
+    },
+    "base_revision_digest": null,
+    "structured_output_digest": "95f6890f4e3a69d7802de7838e217b617198e3d959a14cf3c40c369a9ff0a40d",
+    "artifacts": [
+      {
+        "path": "modules/reports/backend/report_hook.py",
+        "content": "def report_hook():\n    return None\n",
+        "content_digest": "a62e9f31816d8ef24409c70d7beae70d85577b528120b18cf2b5a0be27dc51e2"
+      }
+    ],
+    "validation_receipts": [
+      {
+        "validator": "module_loader",
+        "subject_digest": "335937493098cc5b923023b2debb8a6ba53f3ac01477ab92a3afa93244d6da16",
+        "passed": true,
+        "evidence_digest": "5e9184572a2119973937151f1bf706093b58aaf241d8e18c69f4ee5f23aa8659"
+      }
+    ],
+    "result_digest": "defe3512e26e8027ea7a5570094aaf900ea2d2d95a408f4ac9c108fd2e64ab33"
+  },
+  "materialized_files": [
+    {
+      "path": "app.json",
+      "content_hex": "7b0a2020226170704964223a2022636f727075732d617070222c0a2020226170704e616d65223a2022436f7270757320417070222c0a20202276657273696f6e223a2022312e302e30222c0a2020226465736372697074696f6e223a20224120636c6f736564206170706c69636174696f6e207061796c6f6164222c0a202022617574685265717569726564223a20747275652c0a20202273746172747570223a207b0a20202020226c616e64696e675f73706f74223a20222f686f6d65220a20207d0a7d0a"
+    },
+    {
+      "path": "config/integrations.yaml",
+      "content_hex": "696e746567726174696f6e733a0a2d20736572766963653a20656d61696c0a20206b696e643a206170695f6b65790a2020707572706f73653a2053656e64206e6f74696669636174696f6e730a202072657175697265645f61743a2072756e74696d650a20206f7074696f6e616c3a2066616c73650a202072657175697265645f6669656c64733a0a20202d206e616d653a20454d41494c5f4150495f4b45590a20202020747970653a207365637265740a2020202072657175697265643a20747275650a"
+    },
+    {
+      "path": "security/secrets.yaml",
+      "content_hex": "76657273696f6e3a20310a736563726574733a0a2d20454d41494c5f4150495f4b45590a"
+    },
+    {
+      "path": "ui/pages/home.yaml",
+      "content_hex": "736368656d615f76657273696f6e3a206d6f7a61696b732e6170705f706167652e76310a6e616d653a20686f6d650a726f7574653a202f686f6d650a7469746c653a20436f6e736f6c650a706167655f747970653a206c616e64696e670a6c61796f75743a2066756c6c2d77696474680a73656374696f6e733a0a2d2069643a206865726f0a20207072696d69746976653a20506167654865616465720a2020636f6e6669673a0a202020207469746c653a2057656c636f6d650a2d2069643a2070726963696e670a20207072696d69746976653a2050616e656c0a2020636f6e6669673a0a202020207469746c653a20506c616e730a"
+    },
+    {
+      "path": "ui/route_manifest.json",
+      "content_hex": "7b0a2020227061676573223a205b0a202020207b0a2020202020202270617468223a20222f686f6d65222c0a20202020202022636f6d706f6e656e74223a2022536368656d6150616765222c0a202020202020226c6162656c223a2022436f6e736f6c65222c0a20202020202022736368656d61223a2022686f6d65220a202020207d0a20205d0a7d0a"
+    }
+  ]
+}

--- a/tests/slice_5b_composition_helpers.py
+++ b/tests/slice_5b_composition_helpers.py
@@ -2,7 +2,7 @@
 
 Every plan here is produced by the one canonical ``derive_compilation_plan``
 implementation and validates against its exact immutable
-``CompilationPlanAuthorityInputs`` — no synthetic ``model_construct`` plans,
+``CompilationPlanAuthorityInputs`` â€” no synthetic ``model_construct`` plans,
 no re-dispositioned units, no fabricated ``preserve_unowned`` content. The
 layout registry is a reduced but internally consistent authority (page schema,
 the four renderer-ready application families, and the module backend-helper
@@ -165,7 +165,7 @@ def _bundle_for(plan, graph, payloads, _authority_inputs) -> MaterializedBundle:
     ``materialize_plan`` has no execution path for AGENT_AUTHOR units (their
     bytes arrive as validated assignment results at composition), so the
     bundle for an agent-bearing plan is assembled from the fully gated render
-    of the same canonical plan restricted to its composable render outputs —
+    of the same canonical plan restricted to its composable render outputs â€”
     which is exactly what materialization itself produces for those units.
     """
     from mozaiksai.core.semantics.materialization import (
@@ -337,7 +337,6 @@ def _build_derived_products() -> dict[str, object]:
         ),
         resolver=resolver,
         authority_inputs=successor_authority,
-        structured_output_configs=configs,
     )
     helper_source = "def report_hook():\n    return None\n"
     helper_path = agent.outputs[0].path.replace("{module_id}", "reports").replace(
@@ -352,7 +351,7 @@ def _build_derived_products() -> dict[str, object]:
             "helper_source": helper_source,
         },
         artifacts={helper_path: helper_source},
-        structured_output_configs=configs,
+        exact_model_ids=frozenset(row.structured_output_model_id for row in successor_authority.assignment_contract_registry.descriptors), structured_output_configs=configs,
         validator_runner=lambda _validator, files: bool(files),
     )
 
@@ -404,7 +403,7 @@ def _build_derived_products() -> dict[str, object]:
 
 def refinement_execution(fixture, base_revision_digest: str):
     """Recompile the agent assignment and its result pinned to a base
-    revision digest — the canonical way to enter refinement composition."""
+    revision digest â€” the canonical way to enter refinement composition."""
     plan = fixture["successor"]
     resolver = fixture["resolver"]
     configs = fixture["configs"]
@@ -453,7 +452,6 @@ def refinement_execution(fixture, base_revision_digest: str):
         ),
         resolver=resolver,
         authority_inputs=fixture["authority_inputs"],
-        structured_output_configs=configs,
     )
     helper_source = "def report_hook():" + chr(10) + "    return None" + chr(10)
     helper_path = agent.outputs[0].path.replace(
@@ -468,7 +466,7 @@ def refinement_execution(fixture, base_revision_digest: str):
             "helper_source": helper_source,
         },
         artifacts={helper_path: helper_source},
-        structured_output_configs=configs,
+        exact_model_ids=frozenset(row.structured_output_model_id for row in fixture["authority_inputs"].assignment_contract_registry.descriptors), structured_output_configs=configs,
         validator_runner=lambda _validator, files: bool(files),
     )
     return assignments, result

--- a/tests/slice_5b_helpers.py
+++ b/tests/slice_5b_helpers.py
@@ -52,7 +52,7 @@ def compiled_assignment(
     ref = build_structured_output_contract_ref(
         workflow_name="AppGenerator",
         model_id="ArtifactOutput",
-        configs={"AppGenerator": config},
+        exact_model_ids=frozenset(), configs={"AppGenerator": config},
     )
     scope = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="workspace")
     plan_ref = CompilationPlanRef(

--- a/tests/test_assignment_admission.py
+++ b/tests/test_assignment_admission.py
@@ -17,7 +17,7 @@ def test_unique_factory_participant_resolves_ephemerally() -> None:
     assignment, config = compiled_assignment()
     admission = resolve_assignment_admission(
         assignment,
-        structured_output_configs={"AppGenerator": config},
+        exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
         workflow_agent_configs={"AppGenerator": agent_config()},
     )
     assert isinstance(admission, ResolvedAssignmentAdmission)
@@ -34,7 +34,7 @@ def test_zero_and_multiple_participant_matches_fail() -> None:
     with pytest.raises(ValueError, match="no Factory participant"):
         resolve_assignment_admission(
             assignment,
-            structured_output_configs={"AppGenerator": zero},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": zero},
             workflow_agent_configs={"AppGenerator": agent_config()},
         )
 
@@ -44,7 +44,7 @@ def test_zero_and_multiple_participant_matches_fail() -> None:
     with pytest.raises(ValueError, match="ambiguous Factory participants"):
         resolve_assignment_admission(
             assignment,
-            structured_output_configs={"AppGenerator": multiple},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": multiple},
             workflow_agent_configs={
                 "AppGenerator": {
                     "agents": agent_config()["agents"]
@@ -59,13 +59,13 @@ def test_undeclared_participant_and_workflow_mismatch_fail() -> None:
     with pytest.raises(ValueError, match="not declared"):
         resolve_assignment_admission(
             assignment,
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             workflow_agent_configs={"AppGenerator": agent_config(participant="Other")},
         )
     with pytest.raises(ValueError, match="workflow mismatch"):
         resolve_assignment_admission(
             assignment,
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             workflow_agent_configs={},
         )
 
@@ -102,6 +102,6 @@ def test_stale_schema_and_runtime_identity_injection_fail() -> None:
     with pytest.raises(ValueError, match="schema digest mismatch"):
         resolve_assignment_admission(
             forged,
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             workflow_agent_configs={"AppGenerator": agent_config()},
         )

--- a/tests/test_assignment_artifacts.py
+++ b/tests/test_assignment_artifacts.py
@@ -24,7 +24,7 @@ def _build(*, paths: tuple[str, ...] = ("data/contract.json",)):
         assignment=assignment,
         structured_output={"message": "complete"},
         artifacts=artifacts,
-        structured_output_configs={"AppGenerator": config},
+        exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
         validator_runner=lambda _validator, _files: True,
     )
     return assignment, config, result
@@ -37,14 +37,14 @@ def test_artifact_result_is_closed_content_bound_and_order_independent() -> None
         assignment=assignment,
         structured_output={"message": "complete"},
         artifacts={paths[0]: "service\n", paths[1]: "handler\n"},
-        structured_output_configs={"AppGenerator": config},
+        exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
         validator_runner=lambda _validator, _files: True,
     )
     second = build_assignment_artifact_result(
         assignment=assignment,
         structured_output={"message": "complete"},
         artifacts={paths[1]: "handler\n", paths[0]: "service\n"},
-        structured_output_configs={"AppGenerator": config},
+        exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
         validator_runner=lambda _validator, _files: True,
     )
     assert first == second
@@ -82,7 +82,7 @@ def test_missing_extra_case_and_parent_child_artifacts_fail(
             assignment=assignment,
             structured_output={"message": "complete"},
             artifacts=artifacts,
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             validator_runner=lambda _validator, _files: True,
         )
 
@@ -94,7 +94,7 @@ def test_malformed_output_and_failed_validator_never_create_result() -> None:
             assignment=assignment,
             structured_output={"message": {"channel": "runtime"}},
             artifacts={"data/contract.json": "{}\n"},
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             validator_runner=lambda _validator, _files: True,
         )
     with pytest.raises(ValueError, match="failed"):
@@ -102,7 +102,7 @@ def test_malformed_output_and_failed_validator_never_create_result() -> None:
             assignment=assignment,
             structured_output={"message": "complete"},
             artifacts={"data/contract.json": "{}\n"},
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(), structured_output_configs={"AppGenerator": config},
             validator_runner=lambda _validator, _files: False,
         )
 

--- a/tests/test_compilation_plan_authority.py
+++ b/tests/test_compilation_plan_authority.py
@@ -1047,8 +1047,10 @@ def test_enum_names_are_content_derived_not_process_salted() -> None:
     assert first.__name__.startswith("StatusEnum_")
     suffix = first.__name__.rsplit("_", 1)[1]
     assert len(suffix) == 12 and int(suffix, 16) >= 0
-    different = _build_literal_enum("Status", ["published", "draft"])
-    assert different.__name__ != first.__name__  # order is content
+    reordered = _build_literal_enum("Status", ["published", "draft"])
+    assert reordered.__name__ == first.__name__
+    different = _build_literal_enum("Status", ["draft", "archived"])
+    assert different.__name__ != first.__name__
 
 
 @pytest.mark.parametrize("hash_seed", ["1", "2", "12345"])

--- a/tests/test_executable_family_contracts_b1.py
+++ b/tests/test_executable_family_contracts_b1.py
@@ -131,9 +131,9 @@ def test_compiler_assignment_vocabulary_and_locator_are_exhaustive() -> None:
         ref = build_structured_output_contract_ref(
             workflow_name=descriptor.workflow_name,
             model_id=descriptor.structured_output_model_id,
-            configs=CONFIGS,
+            exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs=CONFIGS,
         )
-        assert resolve_structured_output_contract_ref(ref, configs=CONFIGS)
+        assert resolve_structured_output_contract_ref(ref, exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs=CONFIGS)
 
 
 def test_exact_output_models_reject_unknown_fields_and_arbitrary_paths() -> None:
@@ -143,9 +143,9 @@ def test_exact_output_models_reject_unknown_fields_and_arbitrary_paths() -> None
     ref = build_structured_output_contract_ref(
         workflow_name=descriptor.workflow_name,
         model_id=descriptor.structured_output_model_id,
-        configs=CONFIGS,
+        exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs=CONFIGS,
     )
-    model = resolve_structured_output_contract_ref(ref, configs=CONFIGS)
+    model = resolve_structured_output_contract_ref(ref, exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs=CONFIGS)
     valid = {
         "assignment_kind": "module_helper_implementation",
         "module_id": "reports",
@@ -170,7 +170,6 @@ def test_artifact_result_rejects_semantic_identity_substitution() -> None:
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
         authority_inputs=_AUTHORITY["inputs"],
-        structured_output_configs={"AppGenerator": config},
     ).ordered_assignments[0]
     assert dict(assignment.semantic_identity_bindings) == {
         "module_id": "reports",
@@ -188,7 +187,7 @@ def test_artifact_result_rejects_semantic_identity_substitution() -> None:
             artifacts={
                 assignment.owned_paths[0]: "def report_hook():\n    return None\n"
             },
-            structured_output_configs={"AppGenerator": config},
+            exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), structured_output_configs={"AppGenerator": config},
             validator_runner=lambda _validator, _files: True,
         )
 

--- a/tests/test_executable_plan_contracts.py
+++ b/tests/test_executable_plan_contracts.py
@@ -353,10 +353,10 @@ def test_structured_output_ref_is_cold_and_schema_pinned() -> None:
     ref = build_structured_output_contract_ref(
         workflow_name="AppGenerator",
         model_id="ModuleHelperImplementationOutput",
-        configs={"AppGenerator": APP_GENERATOR_CONFIG},
+        exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": APP_GENERATOR_CONFIG},
     )
     assert resolve_structured_output_contract_ref(
-        ref, configs={"AppGenerator": APP_GENERATOR_CONFIG}
+        ref, exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": APP_GENERATOR_CONFIG}
     )
 
     changed = copy.deepcopy(APP_GENERATOR_CONFIG)
@@ -364,11 +364,11 @@ def test_structured_output_ref_is_cold_and_schema_pinned() -> None:
         " Canonical mutation."
     )
     with pytest.raises(ValueError, match="schema digest mismatch"):
-        resolve_structured_output_contract_ref(ref, configs={"AppGenerator": changed})
+        resolve_structured_output_contract_ref(ref, exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": changed})
     changed_ref = build_structured_output_contract_ref(
         workflow_name="AppGenerator",
         model_id="ModuleHelperImplementationOutput",
-        configs={"AppGenerator": changed},
+        exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": changed},
     )
     assert changed_ref.schema_digest != ref.schema_digest
 
@@ -376,13 +376,13 @@ def test_structured_output_ref_is_cold_and_schema_pinned() -> None:
         build_structured_output_contract_ref(
             workflow_name="AppGenerator",
             model_id="UnknownModel",
-            configs={"AppGenerator": APP_GENERATOR_CONFIG},
+            exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": APP_GENERATOR_CONFIG},
         )
     with pytest.raises(ValueError, match="unknown structured-output workflow"):
         build_structured_output_contract_ref(
             workflow_name="UnknownWorkflow",
             model_id="ModuleHelperImplementationOutput",
-            configs={"AppGenerator": APP_GENERATOR_CONFIG},
+            exact_model_ids=frozenset(item.structured_output_model_id for item in ASSIGNMENT_CONTRACT_DESCRIPTORS.values()), configs={"AppGenerator": APP_GENERATOR_CONFIG},
         )
     with pytest.raises(ValidationError, match="canonical workflow/model identifier"):
         StructuredOutputContractRef(

--- a/tests/test_plan_assignment_compiler.py
+++ b/tests/test_plan_assignment_compiler.py
@@ -103,7 +103,6 @@ def test_closed_spec_compiles_paths_and_identity_from_plan_unit() -> None:
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
         authority_inputs=_AUTHORITY["inputs"],
-        structured_output_configs={"AppGenerator": config},
     )
     assignment = result.ordered_assignments[0]
     assert assignment.owned_paths == tuple(output.path for output in unit.outputs)
@@ -152,7 +151,6 @@ def test_missing_or_extra_source_ref_fails_exact_closure() -> None:
             ApprovedPlan(assignments=(missing,)),
             resolver=resolver,
             authority_inputs=_AUTHORITY["inputs"],
-            structured_output_configs={"AppGenerator": config},
         )
 
 
@@ -206,7 +204,6 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
         authority_inputs=_AUTHORITY["inputs"],
-        structured_output_configs={"AppGenerator": config},
     ).ordered_assignments[0]
     assert {ref.unit_id for ref in compiled.depends_on_unit_refs} == set(
         unit.depends_on_units
@@ -220,7 +217,6 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
             ApprovedPlan(assignments=(missing,)),
             resolver=resolver,
             authority_inputs=_AUTHORITY["inputs"],
-            structured_output_configs={"AppGenerator": config},
         )
 
     foreign_plan_ref = plan_ref.model_copy(update={"subject_id": "foreign_graph"})
@@ -239,7 +235,6 @@ def test_source_and_unit_dependency_refs_are_exact_and_same_plan() -> None:
             ApprovedPlan(assignments=(foreign,)),
             resolver=resolver,
             authority_inputs=_AUTHORITY["inputs"],
-            structured_output_configs={"AppGenerator": config},
         )
 
 
@@ -263,7 +258,6 @@ def test_extra_semantic_source_ref_fails_exact_closure() -> None:
             ApprovedPlan(assignments=(extra,)),
             resolver=resolver,
             authority_inputs=_AUTHORITY["inputs"],
-            structured_output_configs={"AppGenerator": config},
         )
 
 
@@ -289,7 +283,6 @@ def test_stale_structured_output_schema_digest_fails() -> None:
             ApprovedPlan(assignments=(tampered,)),
             resolver=resolver,
             authority_inputs=_AUTHORITY["inputs"],
-            structured_output_configs={"AppGenerator": config},
         )
 
 
@@ -315,7 +308,6 @@ def _compile(config, resolver, spec):
         ApprovedPlan(assignments=(spec,)),
         resolver=resolver,
         authority_inputs=_AUTHORITY["inputs"],
-        structured_output_configs={"AppGenerator": config},
     )
 
 

--- a/tests/test_runtime_schema_validation.py
+++ b/tests/test_runtime_schema_validation.py
@@ -1,0 +1,364 @@
+"""Schema errors reject module input, output, emission, and event delivery."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.runtime.composition import schema_validation
+from mozaiksai.core.runtime.composition.module_event_router import ModuleEventPayloadValidationError
+from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, _validate_schema
+from tests.test_module_event_router import (
+    _handler_target_reaction,
+    _loaded_module,
+    _router,
+    _with_event_schema,
+)
+from tests.test_module_executor_dispatch import _request
+
+_BROKEN_SCHEMAS = (
+    {"minLength": "three"},
+    {"required": "field"},
+    {"properties": []},
+    {"type": "unknown"},
+    {"properties": {"value": {"type": 3}}},
+    {"$ref": "#/definitions/missing"},
+    {"$ref": "urn:mozaiks:missing-schema"},
+)
+
+
+@pytest.mark.parametrize("schema", _BROKEN_SCHEMAS)
+def test_malformed_or_unevaluable_schema_never_returns_success(schema: dict[str, Any]) -> None:
+    first = schema_validation.validate_json_schema({"value": 1}, schema)
+    second = schema_validation.validate_json_schema({"value": 1}, schema)
+    assert first is not None
+    assert first.category == "schema_invalid"
+    assert first == second
+    assert first.path == "$"
+    assert first.schema_path.startswith("$")
+    assert first.validator
+    assert "0x" not in first.message
+    assert "Traceback" not in first.message
+    assert first.to_dict()["category"] == "schema_invalid"
+
+
+@pytest.mark.parametrize("schema", [None, [], "", 0, 1])
+def test_explicit_non_schema_inputs_are_invalid_in_the_strict_validator(schema: Any) -> None:
+    diagnostic = schema_validation.validate_json_schema({}, schema)
+    assert diagnostic is not None
+    assert diagnostic.category == "schema_invalid"
+
+
+@pytest.mark.parametrize("phase", ["normalization", "schema", "construction", "evaluation"])
+def test_all_validator_exceptions_become_deterministic_schema_diagnostics(phase: str, monkeypatch) -> None:
+    original_validator = schema_validation.jsonschema.Draft7Validator
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("backend object at 0xDEADBEEF\nTraceback: unstable implementation detail")
+
+    if phase == "normalization":
+        monkeypatch.setattr(schema_validation, "normalize_nullable_schema", fail)
+    elif phase == "schema":
+        monkeypatch.setattr(original_validator, "check_schema", fail)
+    else:
+        class BrokenValidator:
+            check_schema = staticmethod(original_validator.check_schema)
+
+            def __init__(self, _schema):
+                if phase == "construction":
+                    fail()
+
+            def iter_errors(self, _value):
+                fail()
+
+        monkeypatch.setattr(schema_validation.jsonschema, "Draft7Validator", BrokenValidator)
+    first = schema_validation.validate_json_schema({}, {})
+    second = schema_validation.validate_json_schema({}, {})
+    assert first is not None
+    assert first == second
+    assert first.category == "schema_invalid"
+    assert first.validator == phase
+    assert first.path == first.schema_path == "$"
+    assert "0x" not in first.message
+    assert "Traceback" not in first.message
+
+
+def test_normalization_recursion_failure_does_not_become_validation_success() -> None:
+    cyclic = {"type": "object"}
+    cyclic["properties"] = {"self": cyclic}
+    diagnostic = schema_validation.validate_json_schema({}, cyclic)
+    assert diagnostic is not None
+    assert diagnostic.category == "schema_invalid"
+    assert diagnostic.validator == "normalization"
+
+
+def test_normalized_schema_is_checked_before_construction_and_value_evaluation(monkeypatch) -> None:
+    original = schema_validation.jsonschema.Draft7Validator
+    calls = []
+
+    class RecordingValidator:
+        @staticmethod
+        def check_schema(schema):
+            calls.append(("check", schema))
+            original.check_schema(schema)
+
+        def __init__(self, schema):
+            calls.append(("construct", schema))
+            self.validator = original(schema)
+
+        def iter_errors(self, value):
+            calls.append(("evaluate", value))
+            return self.validator.iter_errors(value)
+
+    monkeypatch.setattr(schema_validation.jsonschema, "Draft7Validator", RecordingValidator)
+    source = {"type": "string", "nullable": True, "enum": ["ready"]}
+    assert schema_validation.validate_json_schema(None, source) is None
+    assert [phase for phase, _ in calls] == ["check", "construct", "evaluate"]
+    assert calls[0][1]["type"] == ["string", "null"]
+    assert calls[0][1]["enum"] == ["ready", None]
+    assert source == {"type": "string", "nullable": True, "enum": ["ready"]}
+
+
+def test_valid_schema_invalid_value_has_bounded_value_diagnostic() -> None:
+    schema = {"type": "object", "properties": {"count": {"type": "integer"}}}
+    diagnostic = schema_validation.validate_json_schema({"count": "not an integer"}, schema)
+    assert diagnostic is not None
+    assert diagnostic.category == "value_invalid"
+    assert diagnostic.path == "$.count"
+    assert diagnostic.schema_path == "$.properties.count.type"
+    assert diagnostic.validator == "type"
+    assert schema_validation.validate_json_schema({"count": 1}, schema) is None
+
+
+def test_value_diagnostics_never_include_runtime_object_addresses() -> None:
+    first = schema_validation.validate_json_schema(object(), {"type": "string"})
+    second = schema_validation.validate_json_schema(object(), {"type": "string"})
+    assert first is not None
+    assert first == second
+    assert first.category == "value_invalid"
+    assert "0x" not in first.message
+
+
+@pytest.mark.parametrize("boundary", ["value", "schema"])
+def test_non_json_dictionary_keys_have_stable_diagnostic_paths(boundary: str) -> None:
+    def diagnostic_for_fresh_key():
+        if boundary == "value":
+            return schema_validation.validate_json_schema(
+                {object(): 1}, {"additionalProperties": {"type": "string"}},
+            )
+        return schema_validation.validate_json_schema(
+            {}, {"properties": {object(): {"type": "unknown"}}},
+        )
+
+    first = diagnostic_for_fresh_key()
+    second = diagnostic_for_fresh_key()
+    assert first is not None
+    assert first == second
+    assert first.category == ("value_invalid" if boundary == "value" else "schema_invalid")
+    expected_path = '$["<non-json-key>"]' if boundary == "value" else '$.properties["<non-json-key>"].type'
+    assert (first.path if boundary == "value" else first.schema_path) == expected_path
+    assert "0x" not in str(first.to_dict())
+
+
+def test_malformed_schema_error_metadata_still_returns_stable_failure(monkeypatch) -> None:
+    class BrokenPath:
+        def __iter__(self):
+            raise RuntimeError("path at 0xDEADBEEF")
+
+    def malformed_schema_error(_schema):
+        error = schema_validation.jsonschema.exceptions.SchemaError("unstable diagnostic")
+        error.path = BrokenPath()
+        error.validator = object()
+        raise error
+
+    monkeypatch.setattr(schema_validation.jsonschema.Draft7Validator, "check_schema", malformed_schema_error)
+    first = schema_validation.validate_json_schema({}, {})
+    assert first is not None
+    assert first == schema_validation.validate_json_schema({}, {})
+    assert first.category == "schema_invalid"
+    assert first.schema_path == '$["<invalid-path>"]'
+    assert first.validator == "schema"
+    assert "0x" not in str(first.to_dict())
+
+
+@pytest.mark.parametrize("value", [None, {}, [], False, 0, "anything"])
+def test_explicit_empty_schema_is_valid_universal_draft7_contract(value: Any) -> None:
+    assert schema_validation.validate_json_schema(value, {}) is None
+    assert schema_validation.validate_json_schema(value, True) is None
+    diagnostic = schema_validation.validate_json_schema(value, False)
+    assert diagnostic is not None
+    assert diagnostic.category == "value_invalid"
+
+
+def test_absence_is_skipped_only_at_the_explicit_caller_boundary(monkeypatch) -> None:
+    import mozaiksai.core.runtime.composition.module_executor as executor_module
+
+    calls = []
+    original = executor_module.validate_json_schema
+
+    def record(value, schema):
+        calls.append(schema)
+        return original(value, schema)
+
+    monkeypatch.setattr(executor_module, "validate_json_schema", record)
+    assert _validate_schema({"anything": True}, None) is None
+    assert calls == []
+    assert _validate_schema({"anything": True}, {}) is None
+    assert calls == [{}]
+    assert _validate_schema({}, []) is not None
+
+
+class _Handler:
+    def __init__(self, result: Any = None):
+        self.result = result
+        self.calls = 0
+
+    def run(self, _ctx, **_params):
+        self.calls += 1
+        return self.result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema", (*_BROKEN_SCHEMAS, [], "", 0))
+async def test_executor_rejects_bad_input_schema_before_handler(schema: Any) -> None:
+    handler = _Handler({"value": 1})
+    executor = ModuleExecutor()
+    executor.register("probe", handler, action_schemas={"run": {"input": schema}})
+    result = await executor.execute(_request(module="probe", action="run"))
+    assert result.success is False
+    assert result.error_code == "INVALID_PARAMS"
+    assert handler.calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema", _BROKEN_SCHEMAS)
+@pytest.mark.parametrize("value", [None, {"value": 1}])
+async def test_executor_rejects_bad_output_schema_including_null_results(schema: Any, value: Any) -> None:
+    handler = _Handler(value)
+    executor = ModuleExecutor()
+    executor.register("probe", handler, action_schemas={"run": {"output": schema}})
+    result = await executor.execute(_request(module="probe", action="run"))
+    assert handler.calls == 1
+    assert result.success is False
+    assert result.error_code == "INVALID_OUTPUT_SCHEMA"
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_output_value_invalid_policy_remains_warning_only() -> None:
+    executor = ModuleExecutor()
+    executor.register("probe", _Handler(None), action_schemas={"run": {"output": {"type": "object"}}})
+    result = await executor.execute(_request(module="probe", action="run"))
+    assert result.success is True
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema", (*_BROKEN_SCHEMAS, [], "", 0))
+async def test_executor_rejects_bad_event_schema_before_emission(schema: Any) -> None:
+    emitted = []
+
+    async def emit(event_type, envelope):
+        emitted.append((event_type, envelope))
+
+    class Handler:
+        async def run(self, ctx):
+            await ctx.emit("domain.probe.changed", {"value": 1})
+            return {}
+
+    executor = ModuleExecutor(event_emitter=emit)
+    executor.register("probe", Handler(), event_payload_schemas={"domain.probe.changed": schema})
+    result = await executor.execute(_request(module="probe", action="run"))
+    assert result.success is False
+    assert result.error_code == "INVALID_EVENT_PAYLOAD"
+    assert emitted == []
+
+
+def _event_envelope(producer: str = "producer") -> dict[str, Any]:
+    return {
+        "id": "schema-proof-event",
+        "type": "domain.probe.changed",
+        "source": {"layer": "module", "module_id": producer, "action_id": "run"},
+        "tenant": {"app_id": "app-1", "tenant_id": "tenant-1"},
+        "payload": {"value": 1},
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema", (*_BROKEN_SCHEMAS, [], "", 0))
+async def test_router_rejects_bad_schema_before_any_reaction(schema: Any) -> None:
+    called = []
+
+    class Handler:
+        async def on_event(self, _ctx, **payload):
+            called.append(payload)
+
+    producer = _with_event_schema(_loaded_module("producer"), event_type="domain.probe.changed", payload_schema=schema)
+    consumer = _loaded_module(
+        "consumer", reactions=[_handler_target_reaction("domain.probe.changed")], handler=Handler(),
+    )
+    router = _router([producer, consumer])
+    with pytest.raises(ModuleEventPayloadValidationError) as failure:
+        await router.handle_event("domain.probe.changed", _event_envelope())
+    assert failure.value.diagnostic.category == "schema_invalid"
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_router_retains_explicit_universal_schema_for_the_exact_producer() -> None:
+    called = []
+
+    class Handler:
+        async def on_event(self, _ctx, **payload):
+            called.append(payload)
+
+    universal = _with_event_schema(_loaded_module("producer"), event_type="domain.probe.changed", payload_schema={})
+    restrictive = _with_event_schema(
+        _loaded_module("other"), event_type="domain.probe.changed",
+        payload_schema={"type": "object", "required": ["absent"]},
+    )
+    consumer = _loaded_module(
+        "consumer", reactions=[_handler_target_reaction("domain.probe.changed")], handler=Handler(),
+    )
+    router = _router([universal, restrictive, consumer])
+    await router.handle_event("domain.probe.changed", _event_envelope())
+    assert called == [{"value": 1}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["input", "output", "emission", "router"])
+async def test_explicit_empty_schema_never_bypasses_validation_in_any_caller(boundary: str, monkeypatch) -> None:
+    def cannot_normalize(_schema):
+        raise RuntimeError("injected schema normalization failure")
+
+    monkeypatch.setattr(schema_validation, "normalize_nullable_schema", cannot_normalize)
+    if boundary == "router":
+        producer = _with_event_schema(
+            _loaded_module("producer"), event_type="domain.probe.changed", payload_schema={},
+        )
+        with pytest.raises(ModuleEventPayloadValidationError) as failure:
+            await _router([producer]).handle_event("domain.probe.changed", _event_envelope())
+        assert failure.value.diagnostic.category == "schema_invalid"
+        return
+    if boundary == "emission":
+        emitted = []
+
+        async def emit(event_type, envelope):
+            emitted.append((event_type, envelope))
+
+        class Handler:
+            async def run(self, ctx):
+                await ctx.emit("domain.probe.changed", {})
+
+        executor = ModuleExecutor(event_emitter=emit)
+        executor.register("probe", Handler(), event_payload_schemas={"domain.probe.changed": {}})
+        result = await executor.execute(_request(module="probe", action="run"))
+        assert result.error_code == "INVALID_EVENT_PAYLOAD"
+        assert emitted == []
+    else:
+        executor = ModuleExecutor()
+        executor.register("probe", _Handler(), action_schemas={"run": {boundary: {}}})
+        result = await executor.execute(_request(module="probe", action="run"))
+        assert result.error_code == ("INVALID_PARAMS" if boundary == "input" else "INVALID_OUTPUT_SCHEMA")
+    assert result.success is False

--- a/tests/test_structured_output_canonical_identity.py
+++ b/tests/test_structured_output_canonical_identity.py
@@ -1,0 +1,216 @@
+"""Canonical acceptance identity is independent of provider and ambient state."""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.workflow import assignment_kinds
+from mozaiksai.core.workflow.outputs import structured
+from mozaiksai.core.workflow.structured_output_contracts import (
+    STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE,
+    StructuredOutputContractRef,
+    build_structured_output_contract_ref,
+    canonical_structured_output_schema,
+    resolve_structured_output_contract_ref,
+    stable_digest,
+    structured_output_schema_digest,
+)
+
+
+def _config():
+    return {"models": {
+        "Child": {"type": "model", "fields": {"label": {"type": "str"}}},
+        "Output": {"type": "model", "fields": {
+            "child": {"type": "Child"},
+            "message": {"type": "str"},
+            "note": {"type": "str", "default": None},
+            "items": {"type": "list[str]"},
+            "status": {"type": "literal", "values": ["ready", "waiting"]},
+        }},
+    }, "registry": {"Author": "Output"}}
+
+
+def _ref(config=None, *, exact=frozenset()):
+    return build_structured_output_contract_ref(
+        workflow_name="Probe", model_id="Output",
+        configs={"Probe": _config() if config is None else config}, exact_model_ids=exact,
+    )
+
+
+def _model(config=None, *, exact=frozenset()):
+    config = _config() if config is None else config
+    return resolve_structured_output_contract_ref(
+        _ref(config, exact=exact), configs={"Probe": config}, exact_model_ids=exact,
+    )
+
+
+def test_ref_versions_profile_and_canonical_optionality():
+    ref = _ref()
+    assert ref.ref_schema_version == "mozaiks.structured_output_contract_ref.v2"
+    assert ref.acceptance_profile == STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE
+    assert StructuredOutputContractRef.model_validate_json(ref.model_dump_json()) == ref
+    model = _model()
+    schema = canonical_structured_output_schema(model)
+    assert "note" not in schema["required"]
+    assert "$defs" in schema
+    assert "additionalProperties" not in schema
+    assert ref.schema_digest == stable_digest({
+        "acceptance_profile": STRUCTURED_OUTPUT_ACCEPTANCE_PROFILE, "schema": schema,
+    })
+    for field, value in (("ref_schema_version", "mozaiks.structured_output_contract_ref.v1"),
+                         ("acceptance_profile", "mozaiks.closed_contract_profile.v1"),
+                         ("provider", "openai")):
+        with pytest.raises(ValidationError):
+            StructuredOutputContractRef.model_validate({**ref.model_dump(), field: value})
+    with pytest.raises(ValidationError, match="frozen"):
+        ref.acceptance_profile = "changed"
+
+
+@pytest.mark.parametrize("policy", ["inlining", "closure", "required", "wrapper"])
+def test_provider_preparation_cannot_change_canonical_identity(monkeypatch, policy):
+    model = _model()
+    before = canonical_structured_output_schema(model)
+    digest = structured_output_schema_digest(model)
+    reference = _ref()
+    if policy == "inlining":
+        monkeypatch.setattr(structured, "_inline_schema_refs", lambda node, defs, stack=None: node)
+    elif policy == "closure":
+        monkeypatch.setattr(structured, "_patch_model_schema", lambda cls: None)
+    elif policy == "required":
+        def patch(cls):
+            cls.model_json_schema = classmethod(lambda cls, **kwargs: {"type": "object", "required": []})
+        monkeypatch.setattr(structured, "_patch_model_schema", patch)
+    else:
+        monkeypatch.setattr(structured, "get_provider_response_model", lambda cls: structured.build_models_from_config({
+            "Wire": {"type": "model", "fields": {"provider_field": {"type": "int"}}},
+        })["Wire"])
+    wire = structured.get_provider_response_model(model)
+    assert wire.model_json_schema() != before
+    # Even a direct class-method override is presentation, not core-model authority.
+    monkeypatch.setattr(model, "model_json_schema", classmethod(lambda cls, **kwargs: wire.model_json_schema()))
+    assert canonical_structured_output_schema(model) == before
+    assert structured_output_schema_digest(model) == digest
+    assert _ref() == reference
+
+
+@pytest.mark.parametrize("mutation", ["add", "remove", "optional", "required", "scalar", "nested", "enum", "items", "closure"])
+def test_actual_acceptance_changes_move_identity(mutation):
+    config = _config()
+    fields = config["models"]["Output"]["fields"]
+    if mutation == "add":
+        fields["extra"] = {"type": "str"}
+    elif mutation == "remove":
+        del fields["message"]
+    elif mutation == "optional":
+        fields["message"]["default"] = None
+    elif mutation == "required":
+        del fields["note"]["default"]
+    elif mutation == "scalar":
+        fields["message"]["type"] = "int"
+    elif mutation == "nested":
+        config["models"]["Child"]["fields"]["count"] = {"type": "int"}
+    elif mutation == "enum":
+        fields["status"]["values"].append("finished")
+    elif mutation == "items":
+        fields["items"]["type"] = "list[int]"
+    exact = frozenset({"Output"}) if mutation == "closure" else frozenset()
+    assert _ref(config, exact=exact).schema_digest != _ref().schema_digest
+
+
+def test_equivalent_declaration_order_and_repeated_compilation_are_identical():
+    original = _config()
+    reverse = copy.deepcopy(original)
+    reverse["models"] = dict(reversed(list(reverse["models"].items())))
+    for definition in reverse["models"].values():
+        definition["fields"] = dict(reversed(list(definition["fields"].items())))
+    reverse["models"]["Output"]["fields"]["status"]["values"].reverse()
+    assert _ref(reverse) == _ref(original) == _ref(original)
+    assert canonical_structured_output_schema(_model(reverse)) == canonical_structured_output_schema(_model(original))
+
+
+def test_default_data_order_is_not_schema_required_order():
+    config = _config()
+    config["models"]["Output"]["fields"]["data"] = {"type": "dict", "default": {"required": ["z", "a"]}}
+    model = _model(config)
+    assert canonical_structured_output_schema(model)["properties"]["data"]["default"] == {"required": ["z", "a"]}
+
+
+def test_both_ref_boundaries_require_explicit_exactness_and_cold_mismatch_rejects():
+    with pytest.raises(TypeError, match="exact_model_ids"):
+        build_structured_output_contract_ref(workflow_name="Probe", model_id="Output", configs={"Probe": _config()})
+    ref = _ref(exact=frozenset({"Output"}))
+    with pytest.raises(TypeError, match="exact_model_ids"):
+        resolve_structured_output_contract_ref(ref, configs={"Probe": _config()})
+    with pytest.raises(ValueError, match="schema digest mismatch"):
+        resolve_structured_output_contract_ref(ref, configs={"Probe": _config()}, exact_model_ids=frozenset())
+
+
+def test_cold_process_and_hash_seed_preserve_identity():
+    script = """import json
+from tests.test_structured_output_canonical_identity import _config, _ref, _model
+from mozaiksai.core.workflow.outputs.structured import get_provider_response_model
+model = _model(exact=frozenset({'Output', 'Child'}))
+get_provider_response_model(model)
+print(json.dumps(_ref(exact=frozenset({'Output', 'Child'})).model_dump(mode='json'), sort_keys=True))
+"""
+    expected = _ref(exact=frozenset({"Output", "Child"})).model_dump(mode="json")
+    for seed in ("1", "17"):
+        completed = subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True, env={**os.environ, "PYTHONHASHSEED": seed})
+        assert json.loads(completed.stdout.splitlines()[-1]) == expected
+
+
+def test_fixed_plan_authority_is_independent_of_ambient_descriptors(monkeypatch):
+    from dataclasses import replace
+
+    from mozaiksai.core.semantics import compilation_plan
+    from mozaiksai.core.semantics.plan_authority import validate_compilation_plan_against_authority
+    from mozaiksai.core.workflow.plan_assignment_compiler import ApprovedPlan, compile_approved_plan
+    from tests.test_plan_assignment_compiler import _AUTHORITY, _fixture
+
+    _, plan, _, resolver, spec = _fixture()
+    inputs = _AUTHORITY["inputs"]
+    expected = compile_approved_plan(ApprovedPlan(assignments=(spec,)), resolver=resolver, authority_inputs=inputs)
+    originals = assignment_kinds.ASSIGNMENT_CONTRACT_DESCRIPTORS
+    altered = {kind: replace(row, structured_output_model_id="OtherModel", identity_bindings=()) for kind, row in originals.items()}
+    for ambient in ({}, altered):
+        monkeypatch.setattr(assignment_kinds, "ASSIGNMENT_CONTRACT_DESCRIPTORS", ambient)
+        monkeypatch.setattr(compilation_plan, "ASSIGNMENT_CONTRACT_DESCRIPTORS", ambient)
+        assert validate_compilation_plan_against_authority(plan, inputs) == plan
+        assert compile_approved_plan(ApprovedPlan(assignments=(spec,)), resolver=resolver, authority_inputs=inputs) == expected
+
+
+def test_admission_and_artifact_boundaries_pin_explicit_exactness(monkeypatch):
+    from mozaiksai.core.workflow.assignment_admission import resolve_assignment_admission
+    from mozaiksai.core.workflow.assignment_artifacts import build_assignment_artifact_result
+    from tests.slice_5b_helpers import agent_config, compiled_assignment
+
+    assignment, config = compiled_assignment()
+    configs = {"AppGenerator": config}
+    monkeypatch.setattr(assignment_kinds, "ASSIGNMENT_CONTRACT_DESCRIPTORS", {})
+    for exact in (frozenset(), frozenset({"ArtifactOutput"})):
+        def admit(exact=exact):
+            return resolve_assignment_admission(
+                assignment, structured_output_configs=configs, exact_model_ids=exact,
+                workflow_agent_configs={"AppGenerator": agent_config()},
+            )
+
+        def artifact(exact=exact):
+            return build_assignment_artifact_result(
+                assignment=assignment, structured_output={"message": "ready"},
+                artifacts={assignment.owned_paths[0]: "{}"},
+                structured_output_configs=configs, exact_model_ids=exact,
+                validator_runner=lambda _validator, _files: True,
+            )
+
+        for boundary in (admit, artifact):
+            if exact:
+                with pytest.raises(ValueError, match="schema digest mismatch"):
+                    boundary()
+            else:
+                assert boundary()

--- a/tests/test_structured_output_identity_migration.py
+++ b/tests/test_structured_output_identity_migration.py
@@ -1,0 +1,115 @@
+"""Exact-base evidence isolates the provider-neutral reference migration."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.plan_authority import compilation_plan_authority_digest
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+from tests.slice_5b_composition_helpers import composition_fixture
+
+_FIXTURE = Path(__file__).parent / "fixtures/structured-output-identity-migration.json"
+_BASE = "430d3ffaeab0b27843d7fbeba275c5be316ff586"
+_FIXTURE_FINGERPRINT = "55e1b12cabae2fff5c2ec6f612f4306821c4b66b40c70ff8490c7af89176bc4a"
+
+
+def _baseline():
+    value = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    assert value["base_commit"] == _BASE
+    assert canonical_digest(value) == _FIXTURE_FINGERPRINT
+    return value
+
+
+def _restore_unit_locator(document, original):
+    restored = copy.deepcopy(document)
+    restored["compilation_plan_ref"]["content_digest"] = original["compilation_plan_ref"]["content_digest"]
+    restored["unit_digest"] = original["unit_digest"]
+    assert restored == original
+    return restored
+
+
+def test_exact_base_capture_preserves_provider_influenced_identity_evidence():
+    baseline = _baseline()
+    assert baseline["reference"]["ref_schema_version"] == "mozaiks.structured_output_contract_ref.v1"
+    assert stable_digest(baseline["provider_influenced_schema"]) == baseline["reference"]["schema_digest"]
+    assert baseline["provider_influenced_schema"] != baseline["unmodified_basemodel_schema"]
+    for name in ("base_plan", "successor_plan"):
+        captured = baseline[name]
+        assert json.loads(captured["serialized_json"]) == captured["document"]
+        assert len(captured["units"]) == 6
+        for unit in captured["units"]:
+            assert json.loads(unit["serialized_json"]) == unit["document"]
+            assert canonical_digest(unit["identity_payload"]) == unit["unit_digest"]
+
+
+def test_reference_migration_changes_only_exact_ref_dependent_unit_and_plan_identity():
+    baseline = _baseline()
+    current = composition_fixture()
+    assert stable_digest(current["configs"]) == baseline["config_fingerprint"]
+    authority = current["authority_inputs"]
+    assert authority.assignment_contract_registry.model_dump(mode="json") == baseline["descriptor_snapshot"]
+    assert compilation_plan_authority_digest(authority) == baseline["input_document_fingerprint"]
+    assert hashlib.sha256(authority.model_dump_json().encode()).hexdigest() == baseline["input_document_bytes_fingerprint"]
+    old_ref = baseline["reference"]
+    assert current["configs"][old_ref["workflow_name"]]["models"][old_ref["model_id"]] == baseline["selected_model_config"]
+    for key, fixture_key in (("base", "base_plan"), ("successor", "successor_plan")):
+        plan = current[key]
+        captured = baseline[fixture_key]
+        before_by_id = {unit["unit_id"]: unit for unit in captured["units"]}
+        assert [unit.unit_id for unit in plan.units] == list(before_by_id)
+        changed = []
+        for unit in plan.units:
+            before = before_by_id[unit.unit_id]
+            document = unit.model_dump(mode="json")
+            if unit.required_structured_output_ref is None:
+                assert document == before["document"]
+                assert unit.identity_payload == before["identity_payload"]
+                assert unit.model_dump_json() == before["serialized_json"]
+                assert unit.unit_digest == before["unit_digest"]
+            else:
+                changed.append(unit.unit_id)
+                assert document["required_structured_output_ref"] != old_ref
+                assert unit.unit_digest != before["unit_digest"]
+                document["required_structured_output_ref"] = old_ref
+                assert document == before["document"]
+                identity = unit.identity_payload
+                identity["required_structured_output_ref"] = old_ref
+                assert identity == before["identity_payload"]
+        assert changed == ["module_backend_helper/report_hook-reports/a641fcf1cb52"]
+        restored = plan.canonical_payload(include_digest=False)
+        restored["units"] = captured["document"]["units"]
+        assert canonical_digest(restored) == captured["document"]["plan_digest"]
+        restored["plan_digest"] = captured["document"]["plan_digest"]
+        assert restored == captured["document"]
+
+
+def test_assignment_and_artifact_migration_preserves_all_non_identity_content():
+    baseline = _baseline()
+    current = composition_fixture()
+    assignments = current["assignments"].model_dump(mode="json")
+    original_set = baseline["compiled_assignments"]
+    assert len(assignments["ordered_assignments"]) == len(original_set["ordered_assignments"]) == 1
+    assignment = assignments["ordered_assignments"][0]
+    original = original_set["ordered_assignments"][0]
+    assert assignment["assignment_digest"] != original["assignment_digest"]
+    assignment["plan_unit_ref"] = _restore_unit_locator(assignment["plan_unit_ref"], original["plan_unit_ref"])
+    assignment["required_structured_output_ref"] = original["required_structured_output_ref"]
+    assignment["assignment_digest"] = stable_digest({key: value for key, value in assignment.items() if key not in {"assignment_id", "assignment_digest"}})
+    assignment["assignment_id"] = f"wa_{assignment['assignment_digest'][:24]}"
+    assert assignment == original
+    assignments["assignment_set_digest"] = stable_digest([assignment["assignment_digest"]])
+    assert assignments == original_set
+
+    result = current["result"].model_dump(mode="json")
+    original_result = baseline["artifact_result"]
+    assert result["result_digest"] != original_result["result_digest"]
+    result["assignment_id"] = original_result["assignment_id"]
+    result["assignment_digest"] = original_result["assignment_digest"]
+    result["plan_unit_ref"] = _restore_unit_locator(result["plan_unit_ref"], original_result["plan_unit_ref"])
+    result["result_digest"] = stable_digest({key: value for key, value in result.items() if key != "result_digest"})
+    assert result == original_result
+    assert [{"path": path, "content_hex": content.hex()} for path, content in sorted(current["materialized"].files().items())] == baseline["materialized_files"]

--- a/tests/test_structured_output_provider_boundary.py
+++ b/tests/test_structured_output_provider_boundary.py
@@ -1,0 +1,322 @@
+"""Canonical model compilation stays separate from provider response formatting."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from pydantic import BaseModel, ValidationError, create_model
+
+from mozaiksai.core.workflow.outputs import structured
+
+MODELS = {
+    # Declare the dependent first to exercise the compiler's deferred pass.
+    "Envelope": {
+        "type": "model",
+        "fields": {
+            "child": {"type": "Child"},
+            "trace": {"type": "optional_str"},
+            "attempts": {"type": "int", "default": 1},
+            "rows": {"type": "optional_list", "items": "Child"},
+        },
+    },
+    "Child": {
+        "type": "model",
+        "fields": {
+            "label": {"type": "str"},
+            "note": {"type": "optional_str"},
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def isolated_caches():
+    caches = (
+        structured._workflow_models,
+        structured._workflow_registries,
+        structured._workflow_structured_agents,
+        structured._provider_response_model_cache,
+    )
+    saved = [dict(cache) for cache in caches]
+    for cache in caches:
+        cache.clear()
+    try:
+        yield
+    finally:
+        for cache, prior in zip(caches, saved, strict=True):
+            cache.clear()
+            cache.update(prior)
+
+
+def test_canonical_compilation_never_invokes_provider_schema_patch(monkeypatch):
+    def forbidden_patch(_model):
+        raise AssertionError("canonical model compilation reached provider preparation")
+
+    monkeypatch.setattr(structured, "_patch_model_schema", forbidden_patch)
+    models = structured.build_models_from_config(copy.deepcopy(MODELS))
+    assert set(models) == {"Child", "Envelope"}
+    for model in models.values():
+        assert "model_json_schema" not in model.__dict__
+        assert "__mozaiks_schema_patched" not in model.__dict__
+        assert model.model_json_schema() == BaseModel.model_json_schema.__func__(model)
+
+
+def test_optional_canonical_fields_remain_optional_while_provider_wire_stays_strict():
+    models = structured.build_models_from_config(copy.deepcopy(MODELS))
+    canonical = models["Envelope"]
+    original = canonical.model_json_schema()
+    assert original["required"] == ["child"]
+    assert original["$defs"]["Child"]["required"] == ["label"]
+    assert original["properties"]["trace"]["default"] is None
+    assert original["properties"]["attempts"]["default"] == 1
+    assert "additionalProperties" not in original
+    assert canonical.model_validate({"child": {"label": "value"}}).trace is None
+
+    provider = structured.get_provider_response_model(canonical)
+    wire = provider.model_json_schema()
+    assert provider is not canonical
+    assert set(wire["required"]) == set(original["properties"])
+    assert wire["additionalProperties"] is False
+    assert wire["properties"]["child"]["required"] == ["label", "note"]
+    assert wire["properties"]["child"]["additionalProperties"] is False
+    assert "$defs" not in wire and "$ref" not in json.dumps(wire)
+    assert all(field.is_required() for field in provider.model_fields.values())
+    with pytest.raises(ValidationError):
+        provider.model_validate({"child": {"label": "value"}})
+    provider.model_validate({
+        "child": {"label": "value", "note": None},
+        "trace": None, "attempts": 1, "rows": None,
+    })
+    assert canonical.model_json_schema() == original
+    assert models["Child"].model_fields["note"].is_required() is False
+    assert structured.get_provider_response_model(canonical) is provider
+
+
+@pytest.mark.parametrize("provider_first", [False, True])
+def test_workflow_and_provider_cache_order_preserves_canonical_schema(monkeypatch, provider_first):
+    from mozaiksai.core.workflow.structured_output_contracts import (
+        build_structured_output_contract_ref,
+        canonical_structured_output_schema,
+        resolve_structured_output_contract_ref,
+        structured_output_schema_digest,
+    )
+
+    config = {"structured_outputs": {"models": copy.deepcopy(MODELS), "registry": {"ProbeAgent": "Envelope"}}}
+    monkeypatch.setattr(structured.workflow_manager, "get_config", lambda _name: config)
+    expected_model = structured.build_models_from_config(
+        copy.deepcopy(MODELS), exact_model_ids=frozenset(),
+    )["Envelope"]
+    expected = expected_model.model_json_schema()
+    expected_acceptance = canonical_structured_output_schema(expected_model)
+    expected_digest = structured_output_schema_digest(expected_model)
+    authority = {
+        "configs": {"ProviderBoundaryProbe": config["structured_outputs"]},
+        "exact_model_ids": frozenset(),
+    }
+    expected_ref = build_structured_output_contract_ref(
+        workflow_name="ProviderBoundaryProbe", model_id="Envelope", **authority,
+    )
+    assert expected_ref.schema_digest == expected_digest
+
+    def assert_canonical_authority(model):
+        assert model.model_json_schema() == expected
+        assert canonical_structured_output_schema(model) == expected_acceptance
+        assert structured_output_schema_digest(model) == expected_digest
+        reference = build_structured_output_contract_ref(
+            workflow_name="ProviderBoundaryProbe", model_id="Envelope", **authority,
+        )
+        assert reference == expected_ref
+        assert reference.model_dump_json() == expected_ref.model_dump_json()
+        cold_ref = type(reference).model_validate_json(reference.model_dump_json())
+        resolved = resolve_structured_output_contract_ref(cold_ref, **authority)
+        assert canonical_structured_output_schema(resolved) == expected_acceptance
+        assert structured_output_schema_digest(resolved) == expected_digest
+
+    models, registry = structured.load_workflow_structured_outputs("ProviderBoundaryProbe")
+    canonical = registry["ProbeAgent"]
+    if not provider_first:
+        assert_canonical_authority(canonical)
+    provider = structured.get_provider_response_model(canonical)
+    assert_canonical_authority(canonical)
+    assert provider.model_json_schema() != expected
+    assert structured._workflow_models["ProviderBoundaryProbe"]["Envelope"] is canonical
+    assert structured._workflow_registries["ProviderBoundaryProbe"]["ProbeAgent"] is canonical
+    assert structured._provider_response_model_cache[canonical] is provider
+    again, _ = structured.load_workflow_structured_outputs("ProviderBoundaryProbe")
+    assert again["Envelope"] is models["Envelope"]
+
+    structured.invalidate_workflow_structured_outputs("ProviderBoundaryProbe")
+    assert canonical not in structured._provider_response_model_cache
+    assert models["Child"] not in structured._provider_response_model_cache
+    refreshed, _ = structured.load_workflow_structured_outputs("ProviderBoundaryProbe")
+    assert refreshed["Envelope"] is not canonical
+    assert_canonical_authority(refreshed["Envelope"])
+    structured.get_provider_response_model(refreshed["Envelope"])
+    assert_canonical_authority(refreshed["Envelope"])
+    structured.invalidate_all_workflow_structured_outputs()
+    assert structured._provider_response_model_cache == {}
+    cold, _ = structured.load_workflow_structured_outputs("ProviderBoundaryProbe")
+    assert_canonical_authority(cold["Envelope"])
+
+
+@pytest.mark.parametrize("policy", ["inline_refs", "additional_properties", "required", "wrapper"])
+def test_provider_policy_changes_cannot_mutate_canonical_models(monkeypatch, policy):
+    model = structured.build_models_from_config(copy.deepcopy(MODELS))["Envelope"]
+    baseline = model.model_json_schema()
+    original_wire = structured.get_provider_response_model(model).model_json_schema()
+    structured._provider_response_model_cache.clear()
+    if policy == "inline_refs":
+        monkeypatch.setattr(
+            structured, "_inline_schema_refs", lambda node, definitions: {**node, "$defs": definitions},
+        )
+    elif policy == "additional_properties":
+        original_prepare = structured._add_additional_properties
+
+        def alternate_objects(schema):
+            result = original_prepare(schema)
+            if isinstance(result, dict) and result.get("type") == "object":
+                result["additionalProperties"] = True
+            return result
+
+        monkeypatch.setattr(structured, "_add_additional_properties", alternate_objects)
+    elif policy == "required":
+        original_prepare = structured._add_additional_properties
+
+        def alternate_required(schema):
+            result = original_prepare(schema)
+            if isinstance(result, dict) and result.get("type") == "object":
+                result["required"] = []
+            return result
+
+        monkeypatch.setattr(structured, "_add_additional_properties", alternate_required)
+    else:
+        monkeypatch.setattr(
+            structured, "get_provider_response_model",
+            lambda _model: create_model("AlternateWire", provider_only=(str, ...)),
+        )
+    changed_wire = structured.get_provider_response_model(model).model_json_schema()
+    assert changed_wire != original_wire
+    assert model.model_json_schema() == baseline
+    assert "model_json_schema" not in model.__dict__
+
+
+def test_canonical_model_schema_is_stable_across_process_and_provider_order():
+    script = """
+import json
+import sys
+from mozaiksai.core.workflow.outputs.structured import build_models_from_config, get_provider_response_model
+from tests.test_structured_output_provider_boundary import MODELS
+model = build_models_from_config(MODELS)['Envelope']
+if sys.argv[1] == 'provider-first':
+    get_provider_response_model(model).model_json_schema()
+first = model.model_json_schema()
+get_provider_response_model(model).model_json_schema()
+print(json.dumps([first, model.model_json_schema()], sort_keys=True))
+"""
+    canonical_first = subprocess.check_output([sys.executable, "-c", script, "canonical-first"], text=True)
+    provider_first = subprocess.check_output([sys.executable, "-c", script, "provider-first"], text=True)
+    assert canonical_first == provider_first
+    first, second = json.loads(canonical_first)
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_agent_factory_still_supplies_the_strict_provider_wrapper(monkeypatch):
+    from mozaiksai.core.workflow.agents import factory
+    from tests.test_structured_output_fail_closed import _FakeAgent, _patch_agent_factory
+
+    canonical = structured.build_models_from_config(copy.deepcopy(MODELS))["Envelope"]
+    original = canonical.model_json_schema()
+    _patch_agent_factory(
+        monkeypatch,
+        agent_config={"name": "StrictAgent", "structured_outputs_required": True},
+        registry={"StrictAgent": canonical},
+    )
+    await factory.create_agents("StrictWorkflow", context_variables={})
+    supplied = _FakeAgent.created[0].kwargs["response_schema"]
+    assert supplied is structured.get_provider_response_model(canonical)
+    assert supplied is not canonical
+    assert supplied.model_json_schema()["additionalProperties"] is False
+    assert all(field.is_required() for field in supplied.model_fields.values())
+    assert canonical.model_json_schema() == original
+
+
+def test_distinct_scalar_literal_order_does_not_change_compiled_schema_identity():
+    from mozaiksai.core.workflow.structured_output_contracts import structured_output_schema_digest
+
+    config = {
+        "Status": {"type": "literal", "values": ["z", "a"]},
+        "Result": {"type": "model", "fields": {
+            "status": {"type": "Status"},
+            "amount": {"type": "literal", "values": [3, 1]},
+        }},
+    }
+    reordered = copy.deepcopy(config)
+    reordered["Status"]["values"].reverse()
+    reordered["Result"]["fields"]["amount"]["values"].reverse()
+    first = structured.build_models_from_config(config)["Result"]
+    second = structured.build_models_from_config(reordered)["Result"]
+    assert first.model_json_schema() == second.model_json_schema()
+    assert structured_output_schema_digest(first) == structured_output_schema_digest(second)
+    assert config["Status"]["values"] == ["z", "a"]
+    assert config["Result"]["fields"]["amount"]["values"] == [3, 1]
+
+
+@pytest.mark.parametrize("values", [[True, 1], [1, True], [1.0, 1], [1, 1.0], [False, 0]])
+def test_equality_alias_literal_order_preserves_existing_enum_value_type(values):
+    model = structured.build_models_from_config({
+        "Result": {"type": "model", "fields": {"value": {"type": "literal", "values": values}}},
+    })["Result"]
+    accepted = model.model_validate({"value": values[-1]}).value
+    assert type(accepted.value) is type(values[0])
+    assert accepted.value == values[0]
+
+
+@pytest.mark.parametrize("exact_ids", [frozenset({"Envelope"}), frozenset({"Child"}), frozenset({"Envelope", "Child"})])
+def test_nested_exact_closure_is_constructed_before_dependents_in_either_declaration_order(exact_ids):
+    expected = None
+    for definitions in (MODELS, dict(reversed(tuple(MODELS.items())))):
+        model = structured.build_models_from_config(
+            copy.deepcopy(definitions), exact_model_ids=exact_ids,
+        )["Envelope"]
+        schema = model.model_json_schema()
+        assert (schema.get("additionalProperties") is False) == ("Envelope" in exact_ids)
+        assert (schema["$defs"]["Child"].get("additionalProperties") is False) == ("Child" in exact_ids)
+        for location in ("Envelope", "Child"):
+            value = {"child": {"label": "value"}}
+            target = value if location == "Envelope" else value["child"]
+            target["unowned"] = 1
+            if location in exact_ids:
+                with pytest.raises(ValidationError, match="extra_forbidden"):
+                    model.model_validate(value)
+            else:
+                model.model_validate(value)
+        if expected is None:
+            expected = schema
+        assert schema == expected
+
+
+def test_nested_exact_closure_is_independent_of_process_hash_order():
+    script = """
+import json
+from mozaiksai.core.workflow.outputs.structured import build_models_from_config
+from tests.test_structured_output_provider_boundary import MODELS
+result = []
+for names in ({'Envelope'}, {'Child'}, {'Envelope', 'Child'}):
+    models = build_models_from_config(MODELS, exact_model_ids=frozenset(names))
+    result.append(models['Envelope'].model_json_schema())
+print(json.dumps(result, sort_keys=True))
+"""
+    outputs = [
+        subprocess.check_output(
+            [sys.executable, "-c", script],
+            text=True, env={**os.environ, "PYTHONHASHSEED": str(seed)},
+        )
+        for seed in (1, 17)
+    ]
+    assert outputs[0] == outputs[1]

--- a/tests/test_structured_output_runtime_contracts.py
+++ b/tests/test_structured_output_runtime_contracts.py
@@ -105,7 +105,7 @@ def test_appgenerator_structured_outputs_load_task_batch_build_task_contract() -
     assert task.context_variables[1].key == "current_build_task_id"
 
 
-def test_appgenerator_app_schema_output_schema_uses_strict_section_config_union() -> None:
+def test_appgenerator_provider_schema_uses_strict_section_config_union() -> None:
     workflows_root = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
 
     _workflow_manager_mod.UnifiedWorkflowManager._instance = None
@@ -115,7 +115,7 @@ def test_appgenerator_app_schema_output_schema_uses_strict_section_config_union(
     _structured_mod._workflow_structured_agents.clear()
 
     _, registry = _structured_mod.load_workflow_structured_outputs("AppGenerator")
-    schema = registry["AppSchemaAgent"].model_json_schema()
+    schema = _structured_mod.get_provider_response_model(registry["AppSchemaAgent"]).model_json_schema()
     section_schema = schema["properties"]["pages"]["items"]["properties"]["sections"]["items"]
     config_schema = section_schema["properties"]["config"]
 


### PR DESCRIPTION
Canonical structured-output references currently hash provider-patched schemas, so OpenAI wire formatting can change compiler identity while hiding optionality. Schema validation also reports success after schema construction or evaluation errors.

This change separates unpatched acceptance models from the existing strict provider wrapper. `StructuredOutputContractRef` v2 pins `mozaiks.structured_output_acceptance_profile.v1` and its canonical schema digest. Exact object closure is applied at model construction, including nested models. Build and cold resolution require explicit model authority; assignment compilation reads configurations and identity bindings from the same immutable plan authority inputs.

Runtime Draft 7 validation now normalizes, checks, and evaluates schemas in order. Each failed stage returns a deterministic diagnostic. Module input/event boundaries reject failures; malformed output schemas return `INVALID_OUTPUT_SCHEMA`. Explicit `{}` remains universal, and permitted absence is handled separately. Existing output value-invalid warning behavior is preserved.

Provider and authority proof:

- Provider inlining, object closure, required-field preparation, and wrapper generation cannot alter canonical identity. Actual property, optionality, type, nested structure, enum, item, and exactness changes do.
- Canonical/provider cache order, cache clearing, declaration ordering and fresh-process hash seeds preserve references and digests. Equality-alias enum declarations retain their existing order-sensitive meaning.
- Both ref APIs require explicit configuration and exact model IDs. The canonical compiler supplies descriptor authority; assignment compilation, admission and artifact construction are cold authority boundaries. Runtime defaults never validate canonical references.
- Existing immutable authority inputs already pin source documents; no additional schema snapshot is needed.

Identity migration:

- Exact-base evidence records the old provider-influenced schemas, executable plans, assignment and artifact result. Only the structured-output-dependent unit and enclosing identity references migrate (`EXPECTED_STRUCTURED_OUTPUT_IDENTITY_MIGRATION`). Restoring those references/digests recovers the captured records exactly.
- Configuration/descriptor authority, generated bytes, all 61 existing corpus units, historical 59-unit proof, #483 workflow interface bytes/reuse, and #484 action request/canonical JSON identities remain unchanged. Existing fixed goldens are not repinned. ArtifactRevision evidence shapes are unchanged.

OSS change impact: universal structured-output compiler and framework module validation boundaries. No factory YAML/prompts, app workspace files, routing topology, workflow registry/touchpoints, or AG2 mechanics changed. Module manifest representation and dispatch topology remain unchanged. ADR 0007 and CHANGELOG document the acceptance profile, caller classifications, migration and diagnostic contract. Compatibility impact is intentional rejection of v1 references and malformed schemas; callers must rebuild affected references from pinned authority.

Validation:

- Full `pytest -q --no-cov`: **15,104 passed, 94 skipped, 3 warnings** (783.18s).
- Focused compiler/runtime regression: **1,215 passed, 1 skipped** across 44 files, covering structured outputs/cache/fail-closed, executable families, canonical authority, assignment admission/artifacts, taxonomy, factory retirement, interfaces, closed action requests, materialization, 5B/5C, ArtifactRevision and module execution/events.
- Additional renderer closure and composition ledger: **21 passed**.
- Codex 3 independent review: **120 tests passed**, then **4 tests passed** on the committed exact head; no blocking findings.
- Whole-repo Ruff, scoped mypy (8 production files), strict MkDocs, actual source-hygiene scan, git diff checks, staged and complete-HEAD Gitleaks scans passed.

Exact base: `430d3ffaeab0b27843d7fbeba275c5be316ff586`.
Exact head: `fa6920d6d1fb42f87ef80502f95547f7db8cf003` (DCO signed).

Draft only; auto-merge disabled; do not merge.

Terminal checks: [CI passed](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34041287357), [DCO passed](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34041287269); GitGuardian passed. All checks target the exact head above. Codex 3 exact-head review: PASS, no blocking findings.
