### PR TITLE
feat(workflow): version orchestrator and structured-output contracts

### DIFF
--- a/.agents/skills/create-workflow/SKILL.md
+++ b/.agents/skills/create-workflow/SKILL.md
@@ -79,9 +79,10 @@ Always define YAML contracts before implementation.
 
 ### 1. `orchestrator.yaml`
 
-Use the current startup field name:
+Declare the required document version and use the current startup field name:
 
 ```yaml
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ExampleWorkflow
 max_turns: 20
 human_in_the_loop: true
@@ -101,9 +102,10 @@ Rules:
 
 ### 2. `structured_outputs.yaml`
 
-Use the current top-level shape:
+Declare the required document version in the current top-level shape:
 
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 registry:
   InterviewAgent: null
   GeneratorAgent: MyOutputModel
@@ -246,7 +248,7 @@ with the emitted payload shape.
 Before finishing, verify:
 
 1. `workflow_startup_mode` is used in `orchestrator.yaml`.
-2. `structured_outputs.yaml` uses top-level `registry` and `models`.
+2. `structured_outputs.yaml` declares `schema_version: mozaiks.structured_outputs.v1` with top-level `registry` and `models`.
 3. `transition_graph.yaml` handles only workflow-local routing.
 4. Any cross-workflow sequencing or routed entry behavior is authored in
    `extended_orchestration/extension_registry.json`, not in workflow files.

--- a/.claude/skills/create-workflow/SKILL.md
+++ b/.claude/skills/create-workflow/SKILL.md
@@ -77,9 +77,10 @@ Always define YAML contracts before implementation.
 
 ### 1. `orchestrator.yaml`
 
-Use the current startup field name:
+Declare the required document version and use the current startup field name:
 
 ```yaml
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ExampleWorkflow
 max_turns: 20
 human_in_the_loop: true
@@ -99,9 +100,10 @@ Rules:
 
 ### 2. `structured_outputs.yaml`
 
-Use the current top-level shape:
+Declare the required document version in the current top-level shape:
 
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 registry:
   InterviewAgent: null
   GeneratorAgent: MyOutputModel
@@ -244,7 +246,7 @@ with the emitted payload shape.
 Before finishing, verify:
 
 1. `workflow_startup_mode` is used in `orchestrator.yaml`.
-2. `structured_outputs.yaml` uses top-level `registry` and `models`.
+2. `structured_outputs.yaml` declares `schema_version: mozaiks.structured_outputs.v1` with top-level `registry` and `models`.
 3. `transition_graph.yaml` handles only workflow-local routing.
 4. Any cross-workflow sequencing or routed entry behavior is authored in
    `extended_orchestration/extension_registry.json`, not in workflow files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,14 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Changed
 
+- **Self-versioned workflow documents**: `orchestrator.yaml` now requires
+  `schema_version: mozaiks.orchestrator.v1`; `structured_outputs.yaml` requires
+  `schema_version: mozaiks.structured_outputs.v1`. Public parsers retain the
+  exact version and reject missing, null, unsupported, or altered spellings.
+  OSS workflows, producers, examples, and authoring guidance migrate together.
+  App workspaces must migrate their documents when upgrading; there is no
+  unversioned fallback. Whole-document identity changes, while compiled output
+  models, workflow interfaces, and unrelated compiler units retain identity.
 - Upgraded the AG2 runtime to 1.0.3, including ACP 0.12.1 compatibility and corrected usage-event accounting coverage.
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,7 @@ When an agent needs to produce a UI artifact:
 
 **1. structured_outputs.yaml** - Define model and register to agent:
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 registry:
   MyAgent: MyOutputModel  # Agent outputs this schema
 

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1021,6 +1021,43 @@ their existing warning policy, while an invalid or unevaluable output schema
 returns `INVALID_OUTPUT_SCHEMA`. This does not change module dispatch topology,
 ArtifactRevision evidence, workflow results, or runtime result delivery.
 
+### Explicit workflow document versions
+
+The public `OrchestratorConfig` and `StructuredOutputsConfig` contracts require
+exact in-document literals: `mozaiks.orchestrator.v1` and
+`mozaiks.structured_outputs.v1`, respectively. Both public parsers retain
+`schema_version`. Missing, null, unknown, misspelled, or whitespace-altered
+versions reject; no parser injects a default. The spelling follows the existing
+`mozaiks.<contract>.vN` vocabulary, including underscore-separated contract names.
+
+The version identifies the enclosing YAML document. It is never inserted into
+`registry`, `models`, compiled output fields, or provider response schemas.
+Whole source-document and immutable authority-input identities consequently
+change (`EXPECTED_DOCUMENT_VERSION_MIGRATION`). The captured 61-unit compiler
+corpus, historical 59-unit proof, executable six-unit plans, structured-output
+acceptance references, assignment/artifact results, action contracts, and
+workflow interface bytes remain unchanged. Restoring only version metadata for
+comparison recovers the prior source/authority fingerprints; other changes are
+`UNRELATED_DRIFT`. Historical captures themselves remain immutable.
+
+Authority references and ArtifactRevision identities that pin the whole changed
+document also migrate. In the existing genesis/child revision fixtures, this
+propagates through parent references and enclosing ledger/evidence digests while
+artifact addresses, content digests, exact bodies, and bundle identity remain
+equal. These are expected document-authority changes, not an evidence redesign.
+
+Existing offline orchestrator projection validates this metadata through the
+public contract's literal annotation and does not project it into topology.
+Workflow names, startup, turns, patterns, messages, agents, and triggers retain
+their previous meaning. Parsed versions can later be compared with
+`ChildContractRef.contract_schema_version`; this prerequisite adds no content
+resolver, implementation selection, binding, or ArtifactRevision redesign.
+
+The [workflow document migration census](../architecture/workflows/workflow-document-version-migration.md)
+records governed OSS documents, producers, exclusions, and the required App Zero
+migration when its pinned OSS version advances. Unversioned downstream documents
+receive no compatibility exception.
+
 ## BuildContextBindingRef
 
 Build contexts are immutable, declared compiler inputs — not hidden prompt

--- a/docs/architecture/builder/agentgenerator-output-assembly-contract.md
+++ b/docs/architecture/builder/agentgenerator-output-assembly-contract.md
@@ -76,6 +76,11 @@ The runtime injects it as `context_variables["structured_output"]` for the worke
 
 ## WorkflowBundleBuilderOutput
 
+The serialized YAML inside each `orchestrator.yaml` file must declare top-level
+`schema_version: mozaiks.orchestrator.v1`; each `structured_outputs.yaml` file
+must declare `schema_version: mozaiks.structured_outputs.v1`. The assembler
+validates these document versions; the outer bundle is not their authority.
+
 The worker emits a single `WorkflowBundleBuilderOutput` structured output:
 
 ```yaml

--- a/docs/architecture/mozaiksai/auto-tool-execution.md
+++ b/docs/architecture/mozaiksai/auto-tool-execution.md
@@ -29,7 +29,9 @@ When an auto-tool agent outputs structured JSON:
 If the auto-invoked tool is backend-only, use `tool_type: Agent_Tool` and omit
 the `ui` block entirely.
 
-**structured_outputs.yaml** - Register agent to output model:
+**structured_outputs.yaml** - Register agent to output model (registry fragment;
+the full document also requires `schema_version: mozaiks.structured_outputs.v1`
+and the corresponding `models` definitions):
 ```yaml
 registry:
   OutputAgent: MyOutputModel

--- a/docs/architecture/workflows/declarative-ag2-mapping.md
+++ b/docs/architecture/workflows/declarative-ag2-mapping.md
@@ -165,6 +165,7 @@ Used for:
 Canonical shape:
 
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 registry:
   AgentName: ModelName
 models:

--- a/docs/architecture/workflows/proposal-only-workflow-pattern.md
+++ b/docs/architecture/workflows/proposal-only-workflow-pattern.md
@@ -49,6 +49,7 @@ section provides guidance to select `proposal_only`. The archetype specifies:
 ## Orchestrator Shape
 
 ```yaml
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ContentReviewWorkflow
 max_turns: 30
 human_in_the_loop: true          # Always true for proposal_only
@@ -146,6 +147,9 @@ lifecycle_tools: []
 ## Structured Output
 
 ### Minimum required fields
+
+The following is a `models` fragment; a complete `structured_outputs.yaml`
+also declares `schema_version: mozaiks.structured_outputs.v1` and `registry`.
 
 ```yaml
 models:
@@ -444,4 +448,3 @@ issued, dependency released):
 - [ ] `next_step` field guides operator to the downstream execution workflow
 - [ ] `README.md` states "PLAN ONLY" and "no action is executed by this workflow"
 - [ ] No provider secrets or credentials in any workflow YAML file
-

--- a/docs/architecture/workflows/structured-output-extraction-contract.md
+++ b/docs/architecture/workflows/structured-output-extraction-contract.md
@@ -53,6 +53,7 @@ UI (receives tool_call/tool_response events)
 Defines Pydantic models and maps agents to their output models.
 
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 # Registry: agent name → model name
 registry:
   ExampleDecomposerAgent: ExampleDecomposition

--- a/docs/architecture/workflows/workflow-authoring-contracts.md
+++ b/docs/architecture/workflows/workflow-authoring-contracts.md
@@ -129,9 +129,16 @@ Rules:
 
 ## Canonical File Shapes
 
+Every `orchestrator.yaml` must declare `schema_version: mozaiks.orchestrator.v1`;
+every `structured_outputs.yaml` must declare
+`schema_version: mozaiks.structured_outputs.v1`. These are required top-level
+fields. Missing, blank, or unsupported versions are rejected; the filename does
+not supply a default.
+
 ### `orchestrator.yaml`
 
 ```yaml
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ExampleWorkflow
 max_turns: 20
 human_in_the_loop: true
@@ -274,6 +281,7 @@ Rules:
 ### `structured_outputs.yaml`
 
 ```yaml
+schema_version: mozaiks.structured_outputs.v1
 registry:
   JokeWriterAgent: JokeCollection
 

--- a/docs/architecture/workflows/workflow-document-version-migration.md
+++ b/docs/architecture/workflows/workflow-document-version-migration.md
@@ -1,0 +1,206 @@
+# Workflow document version migration
+
+This migration starts from exact main
+`5ff00cb1c040d694632e2ec530678c4e9571dc0d` (tree
+`dd750e01833fb127061d085fc2f718a081d8266c`), after the structured-output authority
+change in PR #485. It versions two existing public document contracts:
+
+| Document | Required exact `schema_version` | Public model |
+|---|---|---|
+| `orchestrator.yaml` | `mozaiks.orchestrator.v1` | `OrchestratorConfig` |
+| `structured_outputs.yaml` | `mozaiks.structured_outputs.v1` | `StructuredOutputsConfig` |
+
+These names follow the repository's `mozaiks.<contract>.vN` vocabulary, including
+underscore-separated names such as `mozaiks.runtime_extensions.v1` and
+`mozaiks.structured_output_contract_ref.v2`. No competing document-version name
+was present. Each field is a required `Literal`, with no default or alias.
+Both public parsers serialize and retain it. Missing, null, unknown, misspelled,
+numeric, and whitespace-altered versions reject. A valid version does not permit
+unknown extra keys. Removing the field after parsing fails cold validation.
+
+## Governed document census
+
+`STATIC_REPOSITORY_DOCUMENT`: **15 orchestrators and 15 structured-output
+documents**, 30 files total. Every directory below contains both
+`orchestrator.yaml` and `structured_outputs.yaml`; both files migrate. Each
+receives one root version field, with all prior YAML values preserved.
+
+| Directory | Files migrated |
+|---|---:|
+| `factory_app/workflows/AgentGenerator/` | 2 |
+| `factory_app/workflows/AppGenerator/` | 2 |
+| `factory_app/workflows/AppReview/` | 2 |
+| `factory_app/workflows/BrandAssetGeneratorWorkflow/` | 2 |
+| `factory_app/workflows/DesignDocs/` | 2 |
+| `factory_app/workflows/ExistingAppDiscovery/` | 2 |
+| `factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/` | 2 |
+| `factory_app/workflows/RuntimeSmoke/` | 2 |
+| `factory_app/workflows/RuntimeTaskBatchSmoke/` | 2 |
+| `factory_app/workflows/RuntimeToolCallSmoke/` | 2 |
+| `factory_app/workflows/RuntimeUIPrimitiveSmoke/` | 2 |
+| `factory_app/workflows/SubscriptionContractDesigner/` | 2 |
+| `factory_app/workflows/ThemeCapture/` | 2 |
+| `factory_app/workflows/ValueEngine/` | 2 |
+| `examples/canonical-apps/research-ops/workflows/ResearchWorkflow/` | 2 |
+
+There are no additional tracked same-name YAML documents intentionally excluded
+from this static census. No standalone governed YAML file exists under `tests/`.
+The exact paths and pre-migration source/parser fingerprints are captured in
+`tests/fixtures/workflow-document-version-migration.json`.
+
+## Producer census
+
+`GENERATOR` surfaces updated:
+
+| Producer | Migration |
+|---|---|
+| `mozaiks_cli/commands/init.py::_create_starter_workflow` | Emits both exact versions in starter YAML |
+| `factory_app/workflows/AgentGenerator/agents.yaml` | Bundle authoring instructions, required-file list, checklist, and inline orchestrator example require versions |
+| `factory_app/build_context/AppGenerator/workflow_archetypes.yaml` | All five `orchestrator_defaults` prompt inputs include the version |
+| `scripts/smoke_agentgenerator_live_pack.py::_workflow_generation_prompt` | Live generation prompt requires both versions |
+| `factory_app/workflows/AgentGenerator/tools/workflow_quality_gate.py::validate_workflow_bundle_structure` | Validates both inner YAML documents through existing public parsers before assembly; injects nothing |
+
+Pass-through consumers preserve the supplied version and need no rewriting:
+AgentGenerator `generate_and_download::_write_bundle_to_disk`,
+`workflow_converter::promote_generated_workflow`, and CLI generation
+`_stage_workflow`, `_adapt_orchestrator`, and `_adapt_structured_outputs`.
+WorkflowManager already validates both contracts. Structured-output compilation
+and admission already validate `StructuredOutputsConfig`; model construction
+consumes only `models` and `registry`. The offline projection's existing
+orchestrator consumer now validates the version using `OrchestratorConfig`'s
+literal annotation without adding metadata to semantic topology.
+
+`TEST_FIXTURE`: 21 existing fixture producers/helpers migrate 27 orchestrator
+and 13 structured-output authoring sites:
+
+```text
+tests/slice_5b_helpers.py
+tests/test_agentgenerator_generate_and_download_collection.py
+tests/test_agentgenerator_generated_workflow_e2e.py
+tests/test_ai_research_workspace_golden_path.py
+tests/test_brownfield_agentgenerator_acceptance.py
+tests/test_declarative_contracts_helpers.py
+tests/test_generated_app_archetype_matrix.py
+tests/test_generated_app_functional_acceptance.py
+tests/test_lifecycle_manager_contract.py
+tests/test_pack_config_paths.py
+tests/test_semantic_offline_projection.py
+tests/test_smoke_agentgenerator_live_pack.py
+tests/test_structured_output_cache_invalidation.py
+tests/test_structured_output_canonical_identity.py
+tests/test_structured_output_provider_boundary.py
+tests/test_studio_artifact_restore.py
+tests/test_studio_host_smoke.py
+tests/test_workflow_declarative_contracts.py
+tests/test_workflow_integration_metadata.py
+tests/test_workflow_manager_a2a_config.py
+tests/test_workflow_manager_reinitialize_identity.py
+```
+
+`test_cli_init_prompt.py` additionally verifies both produced headers. New version
+and identity tests exercise strict rejection, retained parser output, cold
+validation, child-reference comparison, deterministic identity, and exact-base
+preservation. The previous #485 identity proof restores only version metadata
+for comparison against its unchanged historical capture; it does not parse an
+unversioned workflow document.
+
+`DOC_EXAMPLE`: full examples and authoring requirements migrate in:
+
+```text
+docs/architecture/workflows/workflow-authoring-contracts.md
+docs/architecture/workflows/proposal-only-workflow-pattern.md
+docs/architecture/workflows/declarative-ag2-mapping.md
+docs/architecture/workflows/structured-output-extraction-contract.md
+docs/guides/adding-workflows/01-overview.md
+docs/architecture/mozaiksai/auto-tool-execution.md
+docs/architecture/builder/agentgenerator-output-assembly-contract.md
+.agents/skills/create-workflow/SKILL.md
+.claude/skills/create-workflow/SKILL.md
+mozaiks_cli/agent_guidance/rules/workflows.md
+CLAUDE.md
+```
+
+The registry-only auto-tool snippet is explicitly a fragment. Event-contract
+trigger snippets and event metadata are also partial or different contracts;
+they do not acquire workflow document versions. Outer bundle models and generated
+output-model declarations retain their existing fields and schemas.
+
+`DEAD_LEGACY`: `scripts/validate_pattern_examples.py` targets absent
+`docs/pattern_examples` and a retired `OrchestratorAgent` shape. It is not an
+active producer of these documents and is excluded. AgentGenerator
+`WorkflowStrategy` planning examples, integration metadata, provider pricing
+registries, and runtime smoke result records are different contracts.
+`smoke_factory_artifact_lineage.py` and `smoke_appgenerator_live_acceptance.py`
+do not author either governed workflow document. Filename-only markers in
+discovery, copy, and CLI staging tests remain deliberately incomplete because
+they never reach public document parsing. Historical JSON identity captures and
+the arbitrary-JSON extraction fixture are evidence, not active workflow
+document producers; they remain unchanged.
+
+## Identity classification and permanent evidence
+
+`EXPECTED_DOCUMENT_VERSION_MIGRATION` covers all 30 source YAML documents and
+their parsed document identities, the executable fixture's structured-output
+configuration fingerprint, and its enclosing immutable plan-authority input
+document and serialized bytes. Removing only the new metadata for comparison
+recovers every captured prior source/parser/configuration/authority fingerprint.
+Raw byte authority still distinguishes formatting; semantic parse identity is
+stable across key ordering, repeated parsing, and process restart.
+
+The existing `tests.slice_5c_revision_helpers.revision_fixture` also pins the
+whole authority document. Comparing it on the exact base and migrated tree
+changes only `compilation_plan_authority_ref.authority_digest` and the enclosing
+genesis `revision_digest` (including its reference). This is also
+`EXPECTED_DOCUMENT_VERSION_MIGRATION`; the plan, binding, graph, ledger, evidence,
+assignments/results, and all six artifact entries and exact bodies remain equal.
+For `tests.test_artifact_revision_store._child_fixture`, the same expected
+migration propagates through the parent revision reference, ledger base revision
+and digest, evidence ledger reference and digest, and child revision references
+and digest. These are the exhaustive child ledger/evidence/revision identity
+changes. Its six artifact addresses, content digests, exact bytes, and bundle
+digest remain unchanged. No ArtifactRevision contract or evidence design changes.
+
+There is **no changed compiler unit** in the captured current corpus (61/61),
+no change to its aggregate plan or graph, and no change to any payload digest.
+The six-unit executable fixture's base/successor plans, selected #485 reference,
+assignments, and artifact result also retain their identities. The #483 workflow
+interface's full identity and rendered bytes remain exact. Output-model fields,
+canonical acceptance schemas, and provider response schemas receive no document
+version field. Historical 59-unit, #481 taxonomy, #482 retirement, #484 action,
+and #485 migration evidence remains unchanged. Any difference beyond the listed
+document metadata is `UNRELATED_DRIFT` and fails the comparison tests.
+
+The new evidence lives in `test_workflow_document_versions.py` and
+`test_workflow_document_identity_migration.py`. Existing workflow-manager,
+generator, offline-projection, canonical identity, plan authority,
+materialization, rematerialization, and ArtifactRevision suites remain required.
+
+## App Zero downstream census
+
+`EXTERNAL_DOWNSTREAM`: read-only inspection of `BlocUnited-LLC/mozaiks-app`
+found **11 orchestrators and 10 structured-output documents**, all unversioned.
+Its inspected OSS pin is `14a8615e52c81f451bc31dd0fb0059f50675753c`.
+Every directory below contains both filenames except the indicated single file:
+
+```text
+workflows/AppMarketing/
+workflows/AssuranceReviewWorkflow/
+workflows/CampaignAssetGeneratorWorkflow/       # orchestrator.yaml only
+workflows/DomainMigrationWorkflow/
+workflows/HostedDeploymentOrchestrator/
+workflows/InfrastructureRemediationWorkflow/
+workflows/InvestorMarketplace/
+workflows/RevenueDistributionReviewWorkflow/
+workflows/RevenueParticipationDesignerWorkflow/
+workflows/RuntimeSmoke/
+workflows/SubscriptionPlanDesigner/
+```
+
+When App Zero advances its pinned Mozaiks version to include this change, all
+governed documents must add the same public schema versions. This is an
+intentional contract migration with no parser compatibility escape hatch.
+This OSS change edits no App Zero files.
+
+Content-resolved implementation-artifact selection remains a separate follow-up.
+This migration adds no selection resolver, handler source proof, binding
+version, approval policy, ArtifactRevision redesign, or runtime result delivery.

--- a/docs/guides/adding-workflows/01-overview.md
+++ b/docs/guides/adding-workflows/01-overview.md
@@ -67,6 +67,7 @@ them as contract references, not as full workflow examples.
 === "orchestrator.yaml"
 
     ```yaml
+    schema_version: mozaiks.orchestrator.v1
     workflow_name: IntakeWorkflow
     max_turns: 20
     human_in_the_loop: true
@@ -109,6 +110,7 @@ them as contract references, not as full workflow examples.
 === "structured_outputs.yaml"
 
     ```yaml
+    schema_version: mozaiks.structured_outputs.v1
     registry:
       IntakeAgent: null
       GeneratorAgent: BuildPlan

--- a/examples/canonical-apps/research-ops/workflows/ResearchWorkflow/orchestrator.yaml
+++ b/examples/canonical-apps/research-ops/workflows/ResearchWorkflow/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ResearchWorkflow
 max_turns: 3
 human_in_the_loop: false

--- a/examples/canonical-apps/research-ops/workflows/ResearchWorkflow/structured_outputs.yaml
+++ b/examples/canonical-apps/research-ops/workflows/ResearchWorkflow/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   ResearchAgent: ResearchSummary
 models:

--- a/factory_app/build_context/AppGenerator/workflow_archetypes.yaml
+++ b/factory_app/build_context/AppGenerator/workflow_archetypes.yaml
@@ -29,6 +29,7 @@ archetypes:
     orchestration_pattern: Feedback Loop
     capability_id_suffix: "-review-workflow"
     orchestrator_defaults:
+      schema_version: mozaiks.orchestrator.v1
       human_in_the_loop: false
       workflow_startup_mode: BackendOnly
       max_turns: 20
@@ -72,6 +73,7 @@ archetypes:
     orchestration_pattern: Pipeline
     capability_id_suffix: "-analysis-workflow"
     orchestrator_defaults:
+      schema_version: mozaiks.orchestrator.v1
       human_in_the_loop: false
       workflow_startup_mode: BackendOnly
       max_turns: 15
@@ -114,6 +116,7 @@ archetypes:
     capability_id_suffix: "-extraction-workflow"
     task_batches_required: true
     orchestrator_defaults:
+      schema_version: mozaiks.orchestrator.v1
       human_in_the_loop: false
       workflow_startup_mode: BackendOnly
       max_turns: 30
@@ -157,6 +160,7 @@ archetypes:
       - "High-risk or irreversible actions must be deferred to a downstream execution workflow."
       - "Applicable to: compliance review, migration planning, deployment remediation plan, data cleanup plan, content moderation proposal, change proposal review, deployment impact assessment."
     orchestrator_defaults:
+      schema_version: mozaiks.orchestrator.v1
       human_in_the_loop: true
       max_turns: 30
       workflow_startup_mode: AgentDriven
@@ -331,6 +335,7 @@ archetypes:
       - "The workflow is not exclusively a planning or review surface."
       - "Applicable to: chat assistant, onboarding wizard, content generation, form submission."
     orchestrator_defaults:
+      schema_version: mozaiks.orchestrator.v1
       human_in_the_loop: true
       workflow_startup_mode: AgentDriven
     tool_constraints:

--- a/factory_app/workflows/AgentGenerator/agents.yaml
+++ b/factory_app/workflows/AgentGenerator/agents.yaml
@@ -476,12 +476,12 @@ agents:
       Generate a production-ready workflow bundle for the assigned workflow. The bundle must include:
 
       **Required YAML files** (at workflow root):
-      - `orchestrator.yaml` — workflow_name, max_turns, human_in_the_loop, workflow_startup_mode, orchestration_pattern, initial_agent, initial_message, triggers[]
+      - `orchestrator.yaml` — schema_version: mozaiks.orchestrator.v1, workflow_name, max_turns, human_in_the_loop, workflow_startup_mode, orchestration_pattern, initial_agent, initial_message, triggers[]
       - `agents.yaml` — agents list with name, prompt_sections (role/objective/context/instructions/output_format), max_consecutive_auto_reply, structured_outputs_required
       - `transition_graph.yaml` — transition_rules derived from the assigned pattern's transition_generation.strategy
       - `tools.yaml` — tools[] and lifecycle_tools[] matching the agent tools planned below
       - `context_variables.yaml` — definitions + agents exposure sections
-      - `structured_outputs.yaml` — models + registry (agents → output model)
+      - `structured_outputs.yaml` — schema_version: mozaiks.structured_outputs.v1, models + registry (agents → output model)
       - `middleware.yaml` — prompt middleware declarations. Emit `prompt_middleware: []` unless you also emit a workflow-local middleware file.
       - `ui_config.yaml` — visual_agents list. This file is required for every
         workflow, including BackendOnly/headless workflows. BackendOnly
@@ -839,6 +839,8 @@ agents:
       - `installRequirements`: external pip packages needed ([] for none)
 
       ## RULES
+      - Every orchestrator.yaml must declare the exact top-level `schema_version: mozaiks.orchestrator.v1`.
+      - Every structured_outputs.yaml must declare the exact top-level `schema_version: mozaiks.structured_outputs.v1`, alongside models and registry. Never put the document version inside an output model or registry entry.
       - `orchestrator.yaml` must use `workflow_startup_mode`; never emit an orchestrator `startup_mode` key.
       - Do NOT generate `backend/models.py`, `ctx.db`, or app-module files — those belong to AppGenerator.
       - Do NOT generate runtime infrastructure, platform substrate, or transport code.
@@ -928,6 +930,8 @@ agents:
       against the runtime contract:
       - every required root YAML file is present
       - every YAML file is complete and parseable
+      - orchestrator.yaml declares exactly `schema_version: mozaiks.orchestrator.v1`
+      - structured_outputs.yaml declares exactly `schema_version: mozaiks.structured_outputs.v1` at the document root, outside models and registry
       - orchestrator.yaml uses workflow_startup_mode and never startup_mode
       - orchestrator.yaml does not contain visual_agents
       - orchestrator.yaml triggers use only type, event, capability_id, endpoint,
@@ -981,7 +985,7 @@ agents:
         "files": [
           {
             "filename": "orchestrator.yaml",
-            "content": "workflow_name: ...\n...",
+            "content": "schema_version: mozaiks.orchestrator.v1\nworkflow_name: ...\n...",
             "installRequirements": []
           },
           {

--- a/factory_app/workflows/AgentGenerator/orchestrator.yaml
+++ b/factory_app/workflows/AgentGenerator/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: AgentGenerator
 max_turns: 25
 human_in_the_loop: true

--- a/factory_app/workflows/AgentGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AgentGenerator/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 models:
   AgentTool:
     type: model

--- a/factory_app/workflows/AgentGenerator/tools/workflow_quality_gate.py
+++ b/factory_app/workflows/AgentGenerator/tools/workflow_quality_gate.py
@@ -280,6 +280,10 @@ def validate_workflow_bundle_structure(
     bundle_entries: list[dict[str, Any]],
     expected_workflows: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    from mozaiksai.core.workflow.declarative.contracts import (
+        parse_orchestrator_config,
+        parse_structured_outputs_config,
+    )
     from mozaiksai.core.workflow.execution.network_graph import compile_transition_rules_to_graph
     from mozaiksai.core.workflow.task_batches import parse_task_batches_config
 
@@ -309,6 +313,15 @@ def validate_workflow_bundle_structure(
 
         payloads, yaml_errors = _yaml_payloads_from_files(files)
         report["errors"].extend(yaml_errors)
+
+        for filename, parser in (
+            ("orchestrator.yaml", parse_orchestrator_config),
+            ("structured_outputs.yaml", parse_structured_outputs_config),
+        ):
+            try:
+                parser(payloads.get(filename, {}))
+            except ValueError as exc:
+                report["errors"].append(str(exc))
 
         orchestrator = payloads.get("orchestrator.yaml")
         if isinstance(orchestrator, dict):

--- a/factory_app/workflows/AppGenerator/orchestrator.yaml
+++ b/factory_app/workflows/AppGenerator/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: AppGenerator
 max_turns: 25
 human_in_the_loop: true

--- a/factory_app/workflows/AppGenerator/structured_outputs.yaml
+++ b/factory_app/workflows/AppGenerator/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 models:
   PrimitiveSectionHint:
     type: model

--- a/factory_app/workflows/AppReview/orchestrator.yaml
+++ b/factory_app/workflows/AppReview/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: AppReview
 max_turns: 50
 human_in_the_loop: true

--- a/factory_app/workflows/AppReview/structured_outputs.yaml
+++ b/factory_app/workflows/AppReview/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   ReviewAgent: null
 

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: BrandAssetGeneratorWorkflow
 max_turns: 30
 human_in_the_loop: true

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/structured_outputs.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/structured_outputs.yaml
@@ -1,2 +1,3 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   BrandDesignerAgent: null

--- a/factory_app/workflows/DesignDocs/orchestrator.yaml
+++ b/factory_app/workflows/DesignDocs/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: DesignDocs
 max_turns: 8
 human_in_the_loop: false

--- a/factory_app/workflows/DesignDocs/structured_outputs.yaml
+++ b/factory_app/workflows/DesignDocs/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   DesignDocsAgent: DesignDocsBundle
 

--- a/factory_app/workflows/ExistingAppDiscovery/orchestrator.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 # ExistingAppDiscovery Workflow Orchestrator
 # Entry point for brownfield-app adopters who already have an application
 # and want to integrate it with Mozaiks.

--- a/factory_app/workflows/ExistingAppDiscovery/structured_outputs.yaml
+++ b/factory_app/workflows/ExistingAppDiscovery/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 # ExistingAppDiscovery Structured Outputs
 #
 # Only DiscoveryArtifactAssemblerAgent produces structured output.

--- a/factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/orchestrator.yaml
+++ b/factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: RuntimeContextExpressionTaskBatchSmoke
 max_turns: 8
 human_in_the_loop: false

--- a/factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/structured_outputs.yaml
+++ b/factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   TaskPlannerAgent: RuntimeTaskBatchPlanOutput
   ModuleTaskWorkerAgent: RuntimeTaskBatchWorkerOutput

--- a/factory_app/workflows/RuntimeSmoke/orchestrator.yaml
+++ b/factory_app/workflows/RuntimeSmoke/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: RuntimeSmoke
 max_turns: 6
 human_in_the_loop: false

--- a/factory_app/workflows/RuntimeSmoke/structured_outputs.yaml
+++ b/factory_app/workflows/RuntimeSmoke/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   RuntimeSmokeAgent: RuntimeSmokeResult
 

--- a/factory_app/workflows/RuntimeTaskBatchSmoke/orchestrator.yaml
+++ b/factory_app/workflows/RuntimeTaskBatchSmoke/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: RuntimeTaskBatchSmoke
 max_turns: 8
 human_in_the_loop: false

--- a/factory_app/workflows/RuntimeTaskBatchSmoke/structured_outputs.yaml
+++ b/factory_app/workflows/RuntimeTaskBatchSmoke/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   TaskPlannerAgent: RuntimeTaskBatchPlanOutput
   ModuleTaskWorkerAgent: RuntimeTaskBatchWorkerOutput

--- a/factory_app/workflows/RuntimeToolCallSmoke/orchestrator.yaml
+++ b/factory_app/workflows/RuntimeToolCallSmoke/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: RuntimeToolCallSmoke
 max_turns: 8
 human_in_the_loop: false

--- a/factory_app/workflows/RuntimeToolCallSmoke/structured_outputs.yaml
+++ b/factory_app/workflows/RuntimeToolCallSmoke/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   RuntimeToolCallSmokeAgent: RuntimeToolCallSmokeResult
   RuntimeConnectorSmokeAgent: RuntimeConnectorSmokeResult

--- a/factory_app/workflows/RuntimeUIPrimitiveSmoke/orchestrator.yaml
+++ b/factory_app/workflows/RuntimeUIPrimitiveSmoke/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: RuntimeUIPrimitiveSmoke
 max_turns: 10
 human_in_the_loop: true

--- a/factory_app/workflows/RuntimeUIPrimitiveSmoke/structured_outputs.yaml
+++ b/factory_app/workflows/RuntimeUIPrimitiveSmoke/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   ReviewAgent: RuntimeUIPrimitiveSmokeResult
 

--- a/factory_app/workflows/SubscriptionContractDesigner/orchestrator.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: SubscriptionContractDesigner
 max_turns: 6
 human_in_the_loop: true

--- a/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 registry:
   ContractDesignerAgent: SubscriptionContractOutput
 

--- a/factory_app/workflows/ThemeCapture/orchestrator.yaml
+++ b/factory_app/workflows/ThemeCapture/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 # ThemeCapture Workflow Orchestrator
 # Captures the visual identity of an existing application and produces
 # a valid theme_config.json that Mozaiks can use for embedded widgets

--- a/factory_app/workflows/ThemeCapture/structured_outputs.yaml
+++ b/factory_app/workflows/ThemeCapture/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 # ThemeCapture Structured Outputs
 #
 # Only ThemeConfigAssemblerAgent produces structured output.

--- a/factory_app/workflows/ValueEngine/orchestrator.yaml
+++ b/factory_app/workflows/ValueEngine/orchestrator.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ValueEngine
 max_turns: 25
 human_in_the_loop: true

--- a/factory_app/workflows/ValueEngine/structured_outputs.yaml
+++ b/factory_app/workflows/ValueEngine/structured_outputs.yaml
@@ -1,3 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
 # ValueEngine Structured Outputs
 # Planning schemas for app concept, capability mapping, and build decomposition
 

--- a/mozaiks_cli/agent_guidance/rules/workflows.md
+++ b/mozaiks_cli/agent_guidance/rules/workflows.md
@@ -26,6 +26,7 @@ workflows/{WorkflowName}/
 ## Rules
 
 - Keep workflow configuration declarative and structured-output-first.
+- Require top-level `schema_version: mozaiks.orchestrator.v1` in `orchestrator.yaml` and `schema_version: mozaiks.structured_outputs.v1` in `structured_outputs.yaml`. Missing or unsupported versions fail validation; do not infer them from filenames.
 - Put reasoning in agent prompts and structured outputs.
 - Keep tools deterministic: persist, validate, emit events, or call declared APIs.
 - Do not put classification/inference heuristics in tools.

--- a/mozaiks_cli/commands/init.py
+++ b/mozaiks_cli/commands/init.py
@@ -1084,7 +1084,8 @@ def _create_starter_workflow(workflows_dir: Path) -> None:
     (workflow_dir / "tools").mkdir(exist_ok=True)
     (workflow_dir / "ui").mkdir(exist_ok=True)
 
-    orchestrator = """workflow_name: HelloWorkflow
+    orchestrator = """schema_version: mozaiks.orchestrator.v1
+workflow_name: HelloWorkflow
 max_turns: 10
 human_in_the_loop: true
 workflow_startup_mode: UserDriven
@@ -1129,7 +1130,8 @@ agents:
     variables: []
 """
 
-    structured_outputs_yaml = """registry: {}
+    structured_outputs_yaml = """schema_version: mozaiks.structured_outputs.v1
+registry: {}
 models: {}
 """
 

--- a/mozaiksai/core/semantics/offline_projection.py
+++ b/mozaiksai/core/semantics/offline_projection.py
@@ -17,7 +17,7 @@ from types import NoneType
 from typing import Any, Literal, get_args
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 from mozaiksai.core.runtime.app.page_schema import AppPageSection
 from mozaiksai.core.semantics.canonical import canonical_digest
@@ -65,6 +65,7 @@ from mozaiksai.core.taxonomy import (
     TaxonomyRegistry,
     validate_identifier_grammar,
 )
+from mozaiksai.core.workflow.declarative.contracts import OrchestratorConfig
 
 PROJECTION_SCHEMA_VERSION: Literal["mozaiks.semantic_projection.v2"] = (
     "mozaiks.semantic_projection.v2"
@@ -420,8 +421,12 @@ _WORKFLOW_STARTUP_MODES = {
     "UserDriven": WorkflowStartupMode.USER_DRIVEN,
     "BackendOnly": WorkflowStartupMode.BACKEND_ONLY,
 }
+_ORCHESTRATOR_SCHEMA_VERSION: TypeAdapter[str] = TypeAdapter(
+    OrchestratorConfig.model_fields["schema_version"].annotation
+)
 _ORCHESTRATOR_FIELDS = frozenset(
     {
+        "schema_version",
         "workflow_name",
         "description",
         "max_turns",
@@ -2159,6 +2164,22 @@ class _Builder:
                         )
                     ]
                 )
+            try:
+                _ORCHESTRATOR_SCHEMA_VERSION.validate_python(orchestration.get("schema_version"))
+            except ValidationError as exc:
+                raise ProjectionError(
+                    [
+                        ProjectionGap(
+                            kind=(
+                                ProjectionGapKind.MISSING
+                                if "schema_version" not in orchestration
+                                else ProjectionGapKind.UNSUPPORTED
+                            ),
+                            source_path=path,
+                            reason="orchestrator.yaml schema_version must match the OrchestratorConfig contract",
+                        )
+                    ]
+                ) from exc
             self.mark(
                 path,
                 node=SemanticNodeKind.WORKFLOW,

--- a/mozaiksai/core/workflow/declarative/contracts.py
+++ b/mozaiksai/core/workflow/declarative/contracts.py
@@ -70,6 +70,7 @@ class OrchestratorTriggerSpec(DeclarativeModel):
 
 
 class OrchestratorConfig(DeclarativeModel):
+    schema_version: Literal["mozaiks.orchestrator.v1"]
     workflow_name: str
     max_turns: int = 50
     human_in_the_loop: bool = False
@@ -880,6 +881,7 @@ class StructuredOutputUnionSpec(DeclarativeModel):
 
 
 class StructuredOutputsConfig(DeclarativeModel):
+    schema_version: Literal["mozaiks.structured_outputs.v1"]
     registry: dict[str, str | None] = Field(default_factory=dict)
     models: dict[str, StructuredOutputModelSpec | StructuredOutputLiteralSpec | StructuredOutputUnionSpec] = (
         Field(default_factory=dict)

--- a/scripts/smoke_agentgenerator_live_pack.py
+++ b/scripts/smoke_agentgenerator_live_pack.py
@@ -159,6 +159,8 @@ def _workflow_generation_prompt(
         f"Generate a minimal but runnable Mozaiks workflow bundle for {workflow_name}.\n"
         f"Role: {role}. Description: {description}\n"
         f"Use AG2 Network pattern {pattern_id}: {pattern_name}.\n"
+        "Emit top-level schema_version: mozaiks.orchestrator.v1 in orchestrator.yaml and "
+        "schema_version: mozaiks.structured_outputs.v1 in structured_outputs.yaml.\n"
         f"Set orchestrator.yaml workflow_startup_mode to {startup_mode}; never emit startup_mode.\n"
         f"Set human_in_the_loop to {str(human_in_the_loop).lower()}.\n"
         f"Required root YAML files: {root_files}.\n"

--- a/tests/fixtures/workflow-document-version-migration.json
+++ b/tests/fixtures/workflow-document-version-migration.json
@@ -1,0 +1,483 @@
+{
+  "base_commit": "5ff00cb1c040d694632e2ec530678c4e9571dc0d",
+  "base_tree": "dd750e01833fb127061d085fc2f718a081d8266c",
+  "documents": [
+    {
+      "path": "examples/canonical-apps/research-ops/workflows/ResearchWorkflow/orchestrator.yaml",
+      "source_bytes_fingerprint": "e680d072da3a364a73036fa61ea0a4f84a76ab3cd55bb5d91e8232802c8ba73c",
+      "source_document_fingerprint": "d14bf545c06a19e1b67d0ee1714257fd33931771c0af5aef2ff697961d15ecd7",
+      "parser_document_fingerprint": "523fde87cd4d47f19291290b45e42e624afa826e6f5b93d623ae6d32c2465686"
+    },
+    {
+      "path": "examples/canonical-apps/research-ops/workflows/ResearchWorkflow/structured_outputs.yaml",
+      "source_bytes_fingerprint": "ad3be434f888c91d7fdfcbe9a8fce8ad11c9d0ee3534605fed0e05f890b929fc",
+      "source_document_fingerprint": "d2f182710ab730e0ee350232ec02e21eb418f50358a2271f0df93cccd7205a6d",
+      "parser_document_fingerprint": "d2f182710ab730e0ee350232ec02e21eb418f50358a2271f0df93cccd7205a6d"
+    },
+    {
+      "path": "factory_app/workflows/AgentGenerator/orchestrator.yaml",
+      "source_bytes_fingerprint": "e0e8b199db082f67abd915bb65f4b4b1759cc702f1cb843adccda24a74a5a903",
+      "source_document_fingerprint": "77f809921d5555302baab72be4d50f5c81ef8c0f8b3f8040d595ac0748dd1d47",
+      "parser_document_fingerprint": "2818d9b94f8ff02f375e2378baf8948c6d2a7371b391a200a992a55af0fed145"
+    },
+    {
+      "path": "factory_app/workflows/AgentGenerator/structured_outputs.yaml",
+      "source_bytes_fingerprint": "1812a3415ca2632d9dfc83c792111488b2ec22e60268a18e7a137051e91e9c3d",
+      "source_document_fingerprint": "2e067eae84b6a93abbb1aa6ca341d2623eaabb0cc564eba4e097671f8a1e5a0d",
+      "parser_document_fingerprint": "4eb8665ffe57d75ca02378735f64239298073659ddc91dce74eacf956b328865"
+    },
+    {
+      "path": "factory_app/workflows/AppGenerator/orchestrator.yaml",
+      "source_bytes_fingerprint": "dd0f2e6000c3bcbbc2bd5ba09d3414c924ace95c974f7f4d48c37ac334b8289c",
+      "source_document_fingerprint": "8ba3da45acacf6535b25bdddb8503530ba4756ec92351faee069754cc5bf266d",
+      "parser_document_fingerprint": "672f2827e531aa4aeeedce8bca750a03f313734b78db6ed018efee20789e8145"
+    },
+    {
+      "path": "factory_app/workflows/AppGenerator/structured_outputs.yaml",
+      "source_bytes_fingerprint": "9efc3b6c3afc2b84611ec9e0215fe74b940d006f840ebfefebf285112c550729",
+      "source_document_fingerprint": "15bb220ae89cff18010ad913aa83163b43c008b0e11c1cf743f126a6b1837cd0",
+      "parser_document_fingerprint": "32d3e5cfebba7ae811128e63a272ac146e8798c5396651b443b06e153ad54383"
+    },
+    {
+      "path": "factory_app/workflows/AppReview/orchestrator.yaml",
+      "source_bytes_fingerprint": "18dbf36f12de21f71c83e8e6d934edb3624f689ffda7297b23f4c4347e1677ad",
+      "source_document_fingerprint": "23f3e3ff4d21d0c2ce62d7e25b076e542e4b6a9b555ab21a5ef648b441c56418",
+      "parser_document_fingerprint": "24242f295468556fe7bc99601299e3bf24b2ab7d05e9f5213a48547bafc87a15"
+    },
+    {
+      "path": "factory_app/workflows/AppReview/structured_outputs.yaml",
+      "source_bytes_fingerprint": "8e458edd5fb20c099052bfcbbd2ea25ede6b84edeea4c4b79164287cb63303b5",
+      "source_document_fingerprint": "6480e0083e8246c82034a124167de79de3c0f5a65a894795484707b0c9a0cb17",
+      "parser_document_fingerprint": "6480e0083e8246c82034a124167de79de3c0f5a65a894795484707b0c9a0cb17"
+    },
+    {
+      "path": "factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml",
+      "source_bytes_fingerprint": "a932cf2a62d43e9a83764dc374ab4eaa4929f6dbc02b13b682fef6a33c74850a",
+      "source_document_fingerprint": "22472122cb970db7e6b4767f0b755db4a4ee60912ff2387df05262d0e9c9f317",
+      "parser_document_fingerprint": "c19666878d1222b14d41058ba8feb047a93c986f3ca084f3a1a0fe2588fda3df"
+    },
+    {
+      "path": "factory_app/workflows/BrandAssetGeneratorWorkflow/structured_outputs.yaml",
+      "source_bytes_fingerprint": "651f7ec29822adbd9c3cd02f250d84e8b6df3fc0f7d88081ce8aea682b9bd528",
+      "source_document_fingerprint": "953acda1b1433672ac42c6b18353cfe75f688a143f08e004ad835e7796c6707e",
+      "parser_document_fingerprint": "953acda1b1433672ac42c6b18353cfe75f688a143f08e004ad835e7796c6707e"
+    },
+    {
+      "path": "factory_app/workflows/DesignDocs/orchestrator.yaml",
+      "source_bytes_fingerprint": "a7f58022e1d50e9fd7e9b8aecad096de8e81b35f00a045c356f9c96a7ec08f27",
+      "source_document_fingerprint": "5409c8f3548e95fd5120b11ae3ecb88c5b84f0445ebf1e847e87d8a85851e56a",
+      "parser_document_fingerprint": "0175313d8e3818475c8271717df242ee2702af5179070ba9a56ac16922989e99"
+    },
+    {
+      "path": "factory_app/workflows/DesignDocs/structured_outputs.yaml",
+      "source_bytes_fingerprint": "9a5114888b068fbcdef0d28409b2fcc28cedd9f1689869858edb0828195ae506",
+      "source_document_fingerprint": "f026bfd106b0d6ba946669743f2d9851a3b0e3fc7e38be50324be75beb1b1f94",
+      "parser_document_fingerprint": "b0f6798f6aaf7cae91c97a5334bee0118ec9863037aa06561a36f4b8c478e227"
+    },
+    {
+      "path": "factory_app/workflows/ExistingAppDiscovery/orchestrator.yaml",
+      "source_bytes_fingerprint": "45fbff99742555823df71a91b0f9c25ae7c3aa1ef45801833c423ff902e4aabc",
+      "source_document_fingerprint": "d67a9bf8c1635f2df3f36697281f6f6c7e0928eeeb117dcfb9f4b2ad96591386",
+      "parser_document_fingerprint": "1f297613bfb3f12fed1bdad4a82be8d9faa4c939f6f3bfcedcbf655aab895b47"
+    },
+    {
+      "path": "factory_app/workflows/ExistingAppDiscovery/structured_outputs.yaml",
+      "source_bytes_fingerprint": "ee1663aaac67ac961dbf9555581a6e38792625ab98f59be31afeeecd7dbbc05f",
+      "source_document_fingerprint": "bec70b3c12d2c140b08220966892a1e87de40a1e97eb706c1ae6e4bbd592b987",
+      "parser_document_fingerprint": "683c40bb8b8bb7b4a11dbcbcbe75f4de270290bac799dd7a9879f81b1b3a6c06"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/orchestrator.yaml",
+      "source_bytes_fingerprint": "362ebf50bb7db50dda46b3bc22a8238f90e5fddb50c0d2e17f813a7091bef9c6",
+      "source_document_fingerprint": "5358b572c3480350fb7a802a6e6af649c143e7f548cee68d6b462476a771cf0e",
+      "parser_document_fingerprint": "eacbb04814b71a7d0eec9d922d5f4d7d83d83995b8330309243f36a4ff67054f"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeContextExpressionTaskBatchSmoke/structured_outputs.yaml",
+      "source_bytes_fingerprint": "0a6bcbb0b8443e8fbcb4afa9f4ae75ce7028d82796698a2691afb96ccbb4834f",
+      "source_document_fingerprint": "0e679040565aa060824654481ab99f241637226586d389c0dca51b221cf7540e",
+      "parser_document_fingerprint": "0e679040565aa060824654481ab99f241637226586d389c0dca51b221cf7540e"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeSmoke/orchestrator.yaml",
+      "source_bytes_fingerprint": "2342ea72f054d3739ec8ced145fd2822ee222b750f43f7113e42376bb9358408",
+      "source_document_fingerprint": "8782302ad28cb48b7d067e0627d1262f2676f33287d41795dc670ae5350bd408",
+      "parser_document_fingerprint": "c8a891c7f45f843f9a387c478c9221e94d2759c9cf4d0e00f7ffa759a05a403a"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeSmoke/structured_outputs.yaml",
+      "source_bytes_fingerprint": "ae2819dc6738a3b87494d2fdcb270a9a1b446fc2966a63433527ef06d3fb2e97",
+      "source_document_fingerprint": "1359db60ba0b06d073cc2f919af153a50305a35e4878586be5bd3ab65c69dee8",
+      "parser_document_fingerprint": "1359db60ba0b06d073cc2f919af153a50305a35e4878586be5bd3ab65c69dee8"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeTaskBatchSmoke/orchestrator.yaml",
+      "source_bytes_fingerprint": "559998f31a1b6fca35538b02105b0b83c0c5dc355a27e3dae34131234065511a",
+      "source_document_fingerprint": "84bfe5ce26c7a22fd5bbfde98f2d964601363a842d2389f60975fdec4219f435",
+      "parser_document_fingerprint": "a2dc4f0a4897199dcd871678f7f9d6ae7e57d124d99e952df20bf6856005ed1b"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeTaskBatchSmoke/structured_outputs.yaml",
+      "source_bytes_fingerprint": "4da57414dc17f46066cdb2f302654b8da7b0f46ca5f79c5f7720d17fd6a99d85",
+      "source_document_fingerprint": "943e2f02e6b07229ae7b014b5480962d5485e7be3ff0d0f9e21154b2fdb1ac65",
+      "parser_document_fingerprint": "943e2f02e6b07229ae7b014b5480962d5485e7be3ff0d0f9e21154b2fdb1ac65"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeToolCallSmoke/orchestrator.yaml",
+      "source_bytes_fingerprint": "9dceee38668ff2302ea9e5cd3ba16f5b80d9e361f38dbb0c8750405d7f68d036",
+      "source_document_fingerprint": "ff92f0990cff07b9503f7c977bc1c6ecba548865b640eec9df5177082718d1c5",
+      "parser_document_fingerprint": "778af8063d2372258598f2d6072a56afd045f522593b7b9b547eeebe48475fe1"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeToolCallSmoke/structured_outputs.yaml",
+      "source_bytes_fingerprint": "7b994c4379476f22fabcdb91fa36f9ff8c99c501982edf4a9063eba5b3705461",
+      "source_document_fingerprint": "66a56852fdfab30476b92d035c0487e53834c5aee1996f56170a17fcf9dcc963",
+      "parser_document_fingerprint": "66a56852fdfab30476b92d035c0487e53834c5aee1996f56170a17fcf9dcc963"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeUIPrimitiveSmoke/orchestrator.yaml",
+      "source_bytes_fingerprint": "8136c5a514ab1a515e27465de75bb0bd8ee88c73d4d730621fb8a085300fd18d",
+      "source_document_fingerprint": "8aa505430f2904dc41b845a173cce8fe50a5ebbc7d391c8db1dcdd61845fbd63",
+      "parser_document_fingerprint": "4f3102c1d4a1006c3cbb8e5c1e0d819dba503e9346415d9360e44ae9a497510e"
+    },
+    {
+      "path": "factory_app/workflows/RuntimeUIPrimitiveSmoke/structured_outputs.yaml",
+      "source_bytes_fingerprint": "a28cb5b547400a61992a7ac5fb665dec556f7899648ae11acdb82c98f5638de4",
+      "source_document_fingerprint": "0d3382c785c380fc3d490040511eb6b99711746008a5ec085aa91d2331037687",
+      "parser_document_fingerprint": "0d3382c785c380fc3d490040511eb6b99711746008a5ec085aa91d2331037687"
+    },
+    {
+      "path": "factory_app/workflows/SubscriptionContractDesigner/orchestrator.yaml",
+      "source_bytes_fingerprint": "071aab0449739eb55d49fcc71ca7b6ccc4ba8d1a36f091e43841f7fb6f2d4e56",
+      "source_document_fingerprint": "a9bbc609cc94c9119cb88f449f78975f080ff1ef294afa25a8931324d3eaf8b1",
+      "parser_document_fingerprint": "7e52b2b617333be946518b6da30d32771613b61061af3d0437d056c14f71a9f9"
+    },
+    {
+      "path": "factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml",
+      "source_bytes_fingerprint": "3c29cd15f2f52829310827075c7bd57b1307b67b0ea79a3635308142dbaa3414",
+      "source_document_fingerprint": "293f27dafd447cf791de0635f3143c86232d12d88d107e2cdca5c341fce97725",
+      "parser_document_fingerprint": "293f27dafd447cf791de0635f3143c86232d12d88d107e2cdca5c341fce97725"
+    },
+    {
+      "path": "factory_app/workflows/ThemeCapture/orchestrator.yaml",
+      "source_bytes_fingerprint": "362025fa1d9bdf29c192e6967ac95c689e4d1ab69eb463514160e1ef5704893b",
+      "source_document_fingerprint": "bba65fe1f9480cd5e8601536a31e30fae668e81283b6a205506942c12e73022c",
+      "parser_document_fingerprint": "ff098d3193dfd7fb8b12d6853d1d1c9c698d01b51fb43696eba65145973c7070"
+    },
+    {
+      "path": "factory_app/workflows/ThemeCapture/structured_outputs.yaml",
+      "source_bytes_fingerprint": "ba31c048b379b9511d6dd5ab34e1463bfa27edc1010a51618bf0a0b2ef38ec53",
+      "source_document_fingerprint": "784d89d900a456c9d9310bc0f55b6cbf283d9d77796c6a6ae64d886f34974099",
+      "parser_document_fingerprint": "784d89d900a456c9d9310bc0f55b6cbf283d9d77796c6a6ae64d886f34974099"
+    },
+    {
+      "path": "factory_app/workflows/ValueEngine/orchestrator.yaml",
+      "source_bytes_fingerprint": "6054dcb9155b065e8540bebb79d52996a7832808f44413fbff9f2842f0ff1aee",
+      "source_document_fingerprint": "db6cb293e1476a2e4742bf67ee1d65170f1517c1f4b582abdab96477b72f8003",
+      "parser_document_fingerprint": "4d2add4ac07cad17009547b65dd558a9d458118c65cf8ac124b5ee346cf49e29"
+    },
+    {
+      "path": "factory_app/workflows/ValueEngine/structured_outputs.yaml",
+      "source_bytes_fingerprint": "2a3a53236ea1c6645cf79634031e8808d4fd98cdad23f137e031d2947b05d2b7",
+      "source_document_fingerprint": "fe59deb41c8b6bf7e1d86b68df4febedce148801477c8385e8480f16faa5158f",
+      "parser_document_fingerprint": "a4d0eba8ff5fc4e6a7bce9d256edbb4c6c5f6a4b1c89cf8bed56e51429644ee7"
+    }
+  ],
+  "corpus": {
+    "unit_count": 61,
+    "plan_digest": "9fe1d96e4c38fb8c6b061333deae1a9095626e4305b3ac8377b10ef0ae2b3737",
+    "serialized_plan_fingerprint": "39d2ec041e7ebbea124762100556cbe8ec374019624ff9feb9e8ce4f5b2c3185",
+    "unit_records_fingerprint": "2bfd99dee6f2a0e276ba5681ef2044fbd5440a4590327975b0d03cf5362a82db",
+    "graph_digest": "421b7359cbd42d0f94a1ac9fbb38387240dda7bbea322add2a72027d14cc4810",
+    "payload_fingerprints": [
+      {
+        "node_id": "mozaiks.application.corpus",
+        "payload_digest": "efd1b393d586e3e1178eb8f91c32667f239af7c4683d25b09cfea7ddc0325a8d"
+      },
+      {
+        "node_id": "mozaiks.auth.corpus",
+        "payload_digest": "576fa815f0bb22231bc13c9346a51dc203c4e0cfc8bac59b35e751366f504f0b"
+      },
+      {
+        "node_id": "mozaiks.integration.email",
+        "payload_digest": "0fbb4e83c453062debeea752b6469183224dda7a81332e8437d9fb3736f6f6de"
+      },
+      {
+        "node_id": "mozaiks.surface.web",
+        "payload_digest": "8597949cc2890a65e3872e5855ada8bc7cd7e29a7de053083ff48cf9e6638473"
+      },
+      {
+        "node_id": "mozaiks.page.home",
+        "payload_digest": "ffdee8988260326637b7b116f8b947a8b9fb736d9dcadb93f41f7029a1a0f9a7"
+      },
+      {
+        "node_id": "mozaiks.section.hero",
+        "payload_digest": "f7efd17324dca80bca2bed522cd1d9fd792a134f0a63cc0efec0eb0fd9c86167"
+      },
+      {
+        "node_id": "mozaiks.module.reports",
+        "payload_digest": "46c6cbff815ff6e7c5c69f844a988cbfe7420f58a4adb310a1ef7d14b6439a93"
+      },
+      {
+        "node_id": "mozaiks.action.create_report",
+        "payload_digest": "a49bed2a896c17c1c221bf735c9924f6bf2b4122953cc17ded4cfaa6135717fa"
+      },
+      {
+        "node_id": "mozaiks.capability.reporting",
+        "payload_digest": "2d00bb5fe4bf5ab70e9b682b7c0c0845e5e27c2f6f860c26114537fca3a5f9f9"
+      },
+      {
+        "node_id": "mozaiks.permission.report_admin",
+        "payload_digest": "b311da1fc157485c35a7ec5526dc433dfd728f9a8fecfd6b1c91b66ef716a7c8"
+      },
+      {
+        "node_id": "mozaiks.event.report_created",
+        "payload_digest": "ec1e184183fb430371876e16a2078719b67762a7236840942d63f1dd4298d1c2"
+      },
+      {
+        "node_id": "mozaiks.reaction.notify_owner",
+        "payload_digest": "0f70e1174fc1920e8132f8e07585ca2a7fc3cbe09fb8266c5844342eadc2caf1"
+      },
+      {
+        "node_id": "mozaiks.notification.report_ready",
+        "payload_digest": "487c871e0e9203afcf6b6f48de9e4cad90f21f78b3666feaae00453e482f4a29"
+      },
+      {
+        "node_id": "mozaiks.data.reports",
+        "payload_digest": "39faac4197b0135cea8543e43c6c94ba2731b043229d21e99354cdaefedf737e"
+      },
+      {
+        "node_id": "mozaiks.alias.reports",
+        "payload_digest": "4725020bea5632df606dbb0a069f80873dba2ee47baca5a4c633d2204ccf15e1"
+      },
+      {
+        "node_id": "mozaiks.workflow.digest",
+        "payload_digest": "d0ee72589a8a586e808c5272ad36378e8d40b7c38ec383f37981c3262c72b5f2"
+      },
+      {
+        "node_id": "mozaiks.trigger.on_report",
+        "payload_digest": "55cfae61f2a73262eeffcbc97d84d6c21662c8608ccefb5b641feb8561ffa197"
+      },
+      {
+        "node_id": "mozaiks.plan.pro",
+        "payload_digest": "2368a16fbdc29a6578a6f187b599097d0ce655bcf78362f766a92c657ab3725a"
+      },
+      {
+        "node_id": "mozaiks.product.addon",
+        "payload_digest": "48a2faaaab9c2bfc8cd050d1fa36df12f4acd1da391d26a43baef66ebf819cdd"
+      },
+      {
+        "node_id": "mozaiks.meter.report_runs",
+        "payload_digest": "c47cbe03db966df098e9750932af5a3ebf8707f7477f7f715153777002b1cfc0"
+      },
+      {
+        "node_id": "mozaiks.limit.report_runs",
+        "payload_digest": "b9d5f4fd593203ae6508eca92c7a491d42ecfd5ea6600a599b8b75121ab22b4c"
+      },
+      {
+        "node_id": "mozaiks.deploy.container",
+        "payload_digest": "b37a72024b1714742b3ec5fdb7410a6083649e70dbd9e5d636a0ea59d0cd1b28"
+      },
+      {
+        "node_id": "mozaiks.artifact.report_hook",
+        "payload_digest": "fbbaf1bca8d401b0c69f9256522bd74f28a219af4e4e079c1c99fb5799ac6e30"
+      },
+      {
+        "node_id": "mozaiks.section.pricing",
+        "payload_digest": "391e13936b7f6f2ccae1450eab7f97303310e8cd12a00ab38042e8f35c438e94"
+      }
+    ]
+  },
+  "executable": {
+    "configs_fingerprint": "9aa3360290e37b5f5f930208d161eda511d08969efa1acd6faee5e949fe7ed21",
+    "input_document_fingerprint": "dfaa950cf84bd4df7be9086e88b71e9a82b9f3a52e9459303986bd2376b98af7",
+    "input_document_bytes_fingerprint": "c46ef25b950e50d4571e7a771e0a9cfc09211e5c46239185b5652a70c874737f",
+    "base_plan_digest": "0dfb2f09415e12d7bd9e2b51f03dc1529128802ea595c38c9d42c833a12bc1ae",
+    "successor_plan_digest": "675a80ebae13ecc23f467fde7857b2e57e7dd662f4c1bc0378190157afdc37ce",
+    "unit_records_fingerprint": "da930308ca5625451aa0bb5a5c0b177821972e0495599091e7542c1a38e5bcb3",
+    "assignment_set_fingerprint": "2d672369067b320566f84e7daf9c2498a10e78aefb3466bdd586e3d3c7f612e6",
+    "artifact_result_fingerprint": "3405531cb662aa029f351d777c10a0b93904e32709d188c1def00f38a0956556",
+    "selected_reference": {
+      "ref_schema_version": "mozaiks.structured_output_contract_ref.v2",
+      "workflow_name": "AppGenerator",
+      "model_id": "ModuleHelperImplementationOutput",
+      "acceptance_profile": "mozaiks.structured_output_acceptance_profile.v1",
+      "schema_digest": "940f284fa7d88e9c49ebd0f3425baba71608e0be0d7f53d2fabba725bd3ed595"
+    }
+  },
+  "canonical_probe_reference": {
+    "ref_schema_version": "mozaiks.structured_output_contract_ref.v2",
+    "workflow_name": "Probe",
+    "model_id": "Output",
+    "acceptance_profile": "mozaiks.structured_output_acceptance_profile.v1",
+    "schema_digest": "ced2b2151105103cf2cb3c7b979cfa425f781b75b8d6dde5febc6eb911bfabcd"
+  },
+  "canonical_probe_model_schema_fingerprint": "e7cec45300941167d43da747fb414cf963fdae1f973c063d3473a9282ed02d40",
+  "workflow_interface": {
+    "unit_id": "workflow_module_interface/analyze_document/6fb165e08211",
+    "unit_digest": "7d5d5eb0f204101b6c70ea424882cc9679f7b9b2d5c1afe73a80b98a6ee524bc",
+    "identity": {
+      "unit_id": "workflow_module_interface/analyze_document/6fb165e08211",
+      "family_kind": "workflow_module_interface",
+      "family_identity_digest": "6fb165e08211b112834ca5a6831066ce6a8b1d4a38b8bea471b88ec8b86fbc1d",
+      "disposition": "render",
+      "source_scope": "declared",
+      "placeholder_values": [
+        [
+          "workflow_id",
+          "analyze_document"
+        ]
+      ],
+      "outputs": [
+        {
+          "path_scope": "workspace_root",
+          "path": "workflows/analyze_document/module_interface.yaml"
+        }
+      ],
+      "sources": [
+        {
+          "node_id": "mozaiks.module.documents",
+          "payload_digest": "7f324b0244e57aec62ea41cdce7d8c13000cf079a7caef01b6c80a506594eb67"
+        },
+        {
+          "node_id": "mozaiks.workflow.analyze_document",
+          "payload_digest": "5b3f8c4da093e29400ab091dc2a4f6c8cbfb10569833898b1c2877ff00d4bf9a"
+        },
+        {
+          "node_id": "mozaiks.workflow_capability.document_notes",
+          "payload_digest": "b40f2963fa6488a340fc2ace531d47002ca82d91394fac447c35f9d6a84ad8b0"
+        },
+        {
+          "node_id": "mozaiks.workflow_capability.documents_analysis",
+          "payload_digest": "aa3bf95b97930f814736adbb041739b6b8364a4cc30520f84296cadec27665f9"
+        },
+        {
+          "node_id": "mozaiks.workflow_capability_binding.analysis_on_created",
+          "payload_digest": "fd8312194e74ac75275dd14e2932ad956e7d519b0aa023ab3f40028cf63bc0db"
+        },
+        {
+          "node_id": "mozaiks.workflow_capability_binding.analysis_reads_content",
+          "payload_digest": "06d87952d63b7558c12601bea6eec03aafef98afea42719dec1733c039f280ed"
+        },
+        {
+          "node_id": "mozaiks.workflow_capability_binding.analysis_stores_result",
+          "payload_digest": "4a08fab97dee94cf352fd97516fee043aa4e1796415fa55089e2e498e142aea0"
+        },
+        {
+          "node_id": "mozaiks.workflow_result.advisory_summary",
+          "payload_digest": "819bbcd548d5e258753e6328fd30524e699bdd4d3506ff1aa5b80fc8abafd3e2"
+        },
+        {
+          "node_id": "mozaiks.workflow_result.analysis_result",
+          "payload_digest": "6116a04e253ea1fa914a69d0d2b89bf29d9279ef2318a5ff02733f610bda5765"
+        },
+        {
+          "node_id": "mozaiks.workflow_result.document_notes",
+          "payload_digest": "904fd4fad1877dcdf81aa2823fd72bf97ffc4ef81a4beb357ffb43802c11f36f"
+        }
+      ],
+      "edge_sources": [
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.document_notes",
+          "target_node_id": "mozaiks.workflow_result.document_notes",
+          "discriminator": null,
+          "edge_identity": "0114cd22c4ad092402368992dd5b25792cb8c49a22130c2fb721bb809c6af0fa"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "target_node_id": "mozaiks.workflow_result.analysis_result",
+          "discriminator": null,
+          "edge_identity": "2637e8b626ea6bfaace2bd1d6315bbd38adfaadcd5f5077ed99b9cc25c5aeb8f"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow.analyze_document",
+          "target_node_id": "mozaiks.workflow_capability.document_notes",
+          "discriminator": null,
+          "edge_identity": "30beea598cab25bfcf11266b4de478a86e5cf154f755ab2ad158c8bd469cb937"
+        },
+        {
+          "kind": "consumes",
+          "source_node_id": "mozaiks.workflow_capability_binding.analysis_reads_content",
+          "target_node_id": "mozaiks.action.documents_get_content",
+          "discriminator": null,
+          "edge_identity": "4c1f97bb95650e97ae418661b49befeaf3e6b9146ef290f7b2b37c8ff61d676e"
+        },
+        {
+          "kind": "consumes",
+          "source_node_id": "mozaiks.workflow_capability_binding.analysis_stores_result",
+          "target_node_id": "mozaiks.workflow_result.analysis_result",
+          "discriminator": null,
+          "edge_identity": "5e3e402944cbf25b30b1e35bc5429a83ce7b9e5f198ac86bb5be0a6afc631713"
+        },
+        {
+          "kind": "binds",
+          "source_node_id": "mozaiks.workflow_capability_binding.analysis_stores_result",
+          "target_node_id": "mozaiks.action.documents_store_analysis",
+          "discriminator": "mozaiks.workflow_result.analysis_result",
+          "edge_identity": "851de3ca6a66ca13083aea2236cd7912cf27ada0e14262a91690770538ccc954"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "target_node_id": "mozaiks.workflow_capability_binding.analysis_on_created",
+          "discriminator": null,
+          "edge_identity": "9004aa22eba9344592bdafcfc664ecb2c6c1257e87fd2735181b68a7f4369824"
+        },
+        {
+          "kind": "consumes",
+          "source_node_id": "mozaiks.workflow_capability_binding.analysis_on_created",
+          "target_node_id": "mozaiks.event.documents_created",
+          "discriminator": null,
+          "edge_identity": "94271745314084fbde29a2f1c45f3c71019d548ae9237d5df777311a976e792b"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "target_node_id": "mozaiks.workflow_capability_binding.analysis_stores_result",
+          "discriminator": null,
+          "edge_identity": "c61a546f18d44e5036b38e5e21347c51eed3a82d7913ac7911e7c09e70c8bba5"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow.analyze_document",
+          "target_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "discriminator": null,
+          "edge_identity": "cf95349184b2293ab08c8d201235d31c145224c79a38d2c1eae97b5e35d322ba"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "target_node_id": "mozaiks.workflow_result.advisory_summary",
+          "discriminator": null,
+          "edge_identity": "d5fc6c7b42965f973c8d1ed40df2025f9dd562230ec29bdf1e1585f3d62f7ce7"
+        },
+        {
+          "kind": "declares",
+          "source_node_id": "mozaiks.workflow_capability.documents_analysis",
+          "target_node_id": "mozaiks.workflow_capability_binding.analysis_reads_content",
+          "discriminator": null,
+          "edge_identity": "e31300c02a9659e26617e70357aa38a49d75890c03256e0921b4c017964cf807"
+        }
+      ],
+      "depends_on_units": [
+        "workflow_manifest/scope_inactive/5824543b2240"
+      ],
+      "materializer": "workflow_interface_executor",
+      "assignment_kind": null,
+      "validator": "generated_app_validator",
+      "required_structured_output_ref": null,
+      "base_plan_digest": null,
+      "taxonomy_sources": [
+        {
+          "node_id": "mozaiks.event.documents_created",
+          "category": "event",
+          "identifier": "domain.documents.created"
+        }
+      ]
+    },
+    "content_hex": "736368656d615f76657273696f6e3a206d6f7a61696b732e6d6f64756c655f696e746572666163652e76320a776f726b666c6f775f69643a20616e616c797a655f646f63756d656e740a6361706162696c69746965733a0a2d206361706162696c6974795f69643a20646f63756d656e74732e616e616c797369730a20206465736372697074696f6e3a20416e616c797a652061206372656174656420646f63756d656e740a2020726573756c74733a0a20202d20726573756c745f69643a2061647669736f72795f73756d6d6172790a202020206465736372697074696f6e3a20416e2061647669736f727920726573756c742077697468206e6f20636f6d6d69742062696e64696e670a20202d20726573756c745f69643a20616e616c797369735f726573756c740a202020206465736372697074696f6e3a204f6e6520616e616c79736973206f66206f6e6520646f63756d656e740a202062696e64696e67733a0a20202d20726f6c653a20636f6d6d6974735f726573756c745f7468726f7567685f616374696f6e0a202020206d6f64756c655f69643a20646f63756d656e74730a20202020616374696f6e5f6e6f64655f69643a206d6f7a61696b732e616374696f6e2e646f63756d656e74735f73746f72655f616e616c797369730a20202020776f726b666c6f775f726573756c745f69643a20616e616c797369735f726573756c740a20202d20726f6c653a20636f6e73756d65735f616374696f6e0a202020206d6f64756c655f69643a20646f63756d656e74730a20202020616374696f6e5f6e6f64655f69643a206d6f7a61696b732e616374696f6e2e646f63756d656e74735f6765745f636f6e74656e740a20202d20726f6c653a207472696767657265645f62795f6576656e740a202020206576656e745f747970653a20646f6d61696e2e646f63756d656e74732e637265617465640a2d206361706162696c6974795f69643a20646f63756d656e74732e6e6f7465730a20206465736372697074696f6e3a20496e646570656e64656e74206e6f746573206361706162696c6974790a2020726573756c74733a0a20202d20726573756c745f69643a206e6f7465730a202020206465736372697074696f6e3a20416e2061647669736f727920726573756c742077697468206e6f20636f6d6d69742062696e64696e670a202062696e64696e67733a205b5d0a"
+  }
+}

--- a/tests/slice_5b_helpers.py
+++ b/tests/slice_5b_helpers.py
@@ -20,6 +20,7 @@ def structured_config(
     *, registry: dict[str, str | None] | None = None
 ) -> dict[str, Any]:
     return {
+        "schema_version": "mozaiks.structured_outputs.v1",
         "models": {
             "ArtifactOutput": {
                 "type": "model",

--- a/tests/test_agentgenerator_generate_and_download_collection.py
+++ b/tests/test_agentgenerator_generate_and_download_collection.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import zipfile
 from importlib import import_module
 from pathlib import Path
 from unittest.mock import AsyncMock
+
+import pytest
+import yaml
 
 
 def _load_generate_and_download_module():
@@ -72,6 +76,7 @@ def _minimal_workflow_files(
         }
     files = {
         "orchestrator.yaml": f"""
+schema_version: mozaiks.orchestrator.v1
 workflow_name: {workflow_name}
 max_turns: 4
 human_in_the_loop: false
@@ -109,6 +114,7 @@ transition_rules:
         ),
         "structured_outputs.yaml": """
 models: {}
+schema_version: mozaiks.structured_outputs.v1
 registry:
   PlannerAgent: null
   WorkerAgent: null
@@ -201,6 +207,69 @@ def test_generate_and_download_writes_bundle_files_and_creates_zip(
         names = zf.namelist()
     assert any("orchestrator.yaml" in n for n in names)
     assert any("agents.yaml" in n for n in names)
+
+
+@pytest.mark.parametrize("filename", ["orchestrator.yaml", "structured_outputs.yaml"])
+@pytest.mark.parametrize("mutation", ["missing", "null", "unknown", "whitespace"])
+def test_workflow_quality_gate_rejects_invalid_document_versions_without_mutating_input(
+    filename: str, mutation: str,
+) -> None:
+    entries = [{"workflow_name": "ReviewWorkflow", "files": _minimal_workflow_files("ReviewWorkflow")}]
+    assert workflow_quality_gate_module.validate_workflow_bundle_structure(bundle_entries=entries)["valid"]
+    selected = next(item for item in entries[0]["files"] if item["filename"] == filename)
+    document = yaml.safe_load(selected["content"])
+    if mutation == "missing":
+        del document["schema_version"]
+    elif mutation == "null":
+        document["schema_version"] = None
+    elif mutation == "unknown":
+        document["schema_version"] = "mozaiks.unsupported.v99"
+    else:
+        document["schema_version"] = f" {document['schema_version']} "
+    selected["content"] = yaml.safe_dump(document, sort_keys=False)
+    before = copy.deepcopy(entries)
+
+    report = workflow_quality_gate_module.validate_workflow_bundle_structure(bundle_entries=entries)
+
+    assert report["valid"] is False
+    assert len(report["errors"]) == 1
+    assert filename in report["errors"][0]
+    assert "schema_version" in report["errors"][0]
+    assert entries == before
+
+
+def test_generate_and_download_blocks_unversioned_document_before_packaging(monkeypatch, tmp_path: Path) -> None:
+    files = _minimal_workflow_files("ReviewWorkflow")
+    selected = next(item for item in files if item["filename"] == "structured_outputs.yaml")
+    document = yaml.safe_load(selected["content"])
+    del document["schema_version"]
+    selected["content"] = yaml.safe_dump(document, sort_keys=False)
+    bundle_results = _make_bundle_results([{"workflow_name": "ReviewWorkflow", "files": files}])
+    before = copy.deepcopy(bundle_results)
+    context = _Context({
+        "chat_id": "chat-version-blocked", "app_id": "app-version-blocked",
+        "user_id": "user-version-blocked", "pack_name": "ReviewWorkflow",
+        "workflow_bundle_results": bundle_results,
+    })
+    generated_root = tmp_path / "generated"
+    ui_mock = AsyncMock()
+    registration_mock = AsyncMock()
+    monkeypatch.setenv("MOZAIKS_GENERATED_ARTIFACTS_PATH", str(generated_root))
+    monkeypatch.setattr(generate_and_download_module, "use_ui_tool", ui_mock)
+    monkeypatch.setattr(generate_and_download_module, "_register_workflow_bundle_artifact_version", registration_mock)
+
+    result = asyncio.run(generate_and_download_module.generate_and_download(
+        DownloadRequest={"confirmation_only": False, "storage_backend": "none"},
+        agent_message="Workflow bundle ready.", context_variables=context,
+    ))
+
+    assert result["status"] == "blocked"
+    assert context.data["workflow_bundle_validation_status"] == "failed"
+    assert any("structured_outputs.yaml" in error and "schema_version" in error for error in result["validation_errors"])
+    assert bundle_results == before
+    assert not generated_root.exists()
+    ui_mock.assert_not_awaited()
+    registration_mock.assert_not_awaited()
 
 
 def test_generate_and_download_multi_workflow_pack_zips_all_bundles(
@@ -612,4 +681,3 @@ def test_merge_workflow_bundle_repair_results_preserves_successful_outputs() -> 
         if not key.startswith("_") and value["workflow_name"] == "BrokenWorkflow"
     )
     assert len(repaired_entry["files"]) == len(_minimal_workflow_files("BrokenWorkflow"))
-

--- a/tests/test_agentgenerator_generated_workflow_e2e.py
+++ b/tests/test_agentgenerator_generated_workflow_e2e.py
@@ -77,6 +77,7 @@ def _write_agentgenerator_bundle(source_dir: Path, workflow_name: str) -> list[d
     _write_yaml(
         source_dir / "orchestrator.yaml",
         {
+            "schema_version": "mozaiks.orchestrator.v1",
             "workflow_name": workflow_name,
             "max_turns": 6,
             "human_in_the_loop": False,
@@ -134,6 +135,7 @@ def _write_agentgenerator_bundle(source_dir: Path, workflow_name: str) -> list[d
     _write_yaml(
         source_dir / "structured_outputs.yaml",
         {
+            "schema_version": "mozaiks.structured_outputs.v1",
             "registry": {
                 "PlannerAgent": "DecompositionPlan",
                 "WorkerAgent": "WorkerOutput",

--- a/tests/test_ai_research_workspace_golden_path.py
+++ b/tests/test_ai_research_workspace_golden_path.py
@@ -490,6 +490,7 @@ def _research_workflow_files() -> dict[str, str]:
     return {
         "orchestrator.yaml": textwrap.dedent(
             """
+            schema_version: mozaiks.orchestrator.v1
             workflow_name: ResearchWorkflow
             workflow_startup_mode: UserDriven
             orchestration_pattern: ag2_network

--- a/tests/test_brownfield_agentgenerator_acceptance.py
+++ b/tests/test_brownfield_agentgenerator_acceptance.py
@@ -205,6 +205,7 @@ def _captured_agentgenerator_bundle() -> dict[str, Any]:
                 "filename": "orchestrator.yaml",
                 "content": textwrap.dedent(
                     """
+                    schema_version: mozaiks.orchestrator.v1
                     workflow_name: ResearchReviewWorkflow
                     max_turns: 4
                     human_in_the_loop: false
@@ -259,6 +260,7 @@ def _captured_agentgenerator_bundle() -> dict[str, Any]:
                 "filename": "structured_outputs.yaml",
                 "content": textwrap.dedent(
                     """
+                    schema_version: mozaiks.structured_outputs.v1
                     registry:
                       ResearchPlannerAgent: ResearchPlan
                       ResearchSummaryAgent: ResearchSummary

--- a/tests/test_cli_init_prompt.py
+++ b/tests/test_cli_init_prompt.py
@@ -111,7 +111,11 @@ def test_init_command_starter_scaffold_seeds_entry_workflow(tmp_path) -> None:
     assert ai_json["chat"]["chat_startup_mode"] == "workflow"
     assert ai_json["workflows"]["entry_point"] == "HelloWorkflow"
     assert "control_plane" not in ai_json
-    assert (target_dir / "workflows" / "HelloWorkflow" / "orchestrator.yaml").exists()
+    workflow_dir = target_dir / "workflows" / "HelloWorkflow"
+    orchestrator = yaml.safe_load((workflow_dir / "orchestrator.yaml").read_text(encoding="utf-8"))
+    structured_outputs = yaml.safe_load((workflow_dir / "structured_outputs.yaml").read_text(encoding="utf-8"))
+    assert orchestrator["schema_version"] == "mozaiks.orchestrator.v1"
+    assert structured_outputs["schema_version"] == "mozaiks.structured_outputs.v1"
 
 
 def test_init_command_creates_package_consumer_scaffold(tmp_path) -> None:

--- a/tests/test_declarative_contracts_helpers.py
+++ b/tests/test_declarative_contracts_helpers.py
@@ -211,6 +211,7 @@ class TestOrchestratorTriggerSpecValidate:
 class TestOrchestratorConfigMaxTurns:
     def _valid_config(self, **kwargs):
         defaults = {
+            "schema_version": "mozaiks.orchestrator.v1",
             "workflow_name": "TestWorkflow",
             "workflow_startup_mode": "UserDriven",
         }
@@ -245,15 +246,20 @@ class TestOrchestratorConfigMaxTurns:
 class TestOrchestratorConfigRequiredText:
     def test_empty_workflow_name_raises(self):
         with pytest.raises(ValidationError):
-            OrchestratorConfig(workflow_name="", workflow_startup_mode="UserDriven")
+            OrchestratorConfig(
+                schema_version="mozaiks.orchestrator.v1", workflow_name="", workflow_startup_mode="UserDriven",
+            )
 
     def test_whitespace_workflow_name_raises(self):
         with pytest.raises(ValidationError):
-            OrchestratorConfig(workflow_name="   ", workflow_startup_mode="UserDriven")
+            OrchestratorConfig(
+                schema_version="mozaiks.orchestrator.v1", workflow_name="   ", workflow_startup_mode="UserDriven",
+            )
 
     def test_empty_orchestration_pattern_raises(self):
         with pytest.raises(ValidationError):
             OrchestratorConfig(
+                schema_version="mozaiks.orchestrator.v1",
                 workflow_name="TestWorkflow",
                 workflow_startup_mode="UserDriven",
                 orchestration_pattern="",

--- a/tests/test_generated_app_archetype_matrix.py
+++ b/tests/test_generated_app_archetype_matrix.py
@@ -890,6 +890,7 @@ def _workflow_files() -> dict[str, str]:
     return {
         "workflows/ResearchWorkflow/orchestrator.yaml": textwrap.dedent(
             """
+            schema_version: mozaiks.orchestrator.v1
             workflow_name: ResearchWorkflow
             max_turns: 3
             human_in_the_loop: false
@@ -928,6 +929,7 @@ def _workflow_files() -> dict[str, str]:
         ).lstrip(),
         "workflows/ResearchWorkflow/structured_outputs.yaml": textwrap.dedent(
             """
+            schema_version: mozaiks.structured_outputs.v1
             registry:
               ResearchAgent: ResearchSummary
             models:

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -354,6 +354,7 @@ def _generated_workflow_agent_files() -> dict[str, str]:
         ),
         "workflows/ResearchWorkflow/orchestrator.yaml": textwrap.dedent(
             """
+            schema_version: mozaiks.orchestrator.v1
             workflow_name: ResearchWorkflow
             max_turns: 3
             human_in_the_loop: false
@@ -392,6 +393,7 @@ def _generated_workflow_agent_files() -> dict[str, str]:
         ),
         "workflows/ResearchWorkflow/structured_outputs.yaml": textwrap.dedent(
             """
+            schema_version: mozaiks.structured_outputs.v1
             registry:
               ResearchAgent: ResearchSummary
             models:

--- a/tests/test_lifecycle_manager_contract.py
+++ b/tests/test_lifecycle_manager_contract.py
@@ -18,7 +18,7 @@ class _Context:
 def _write_orchestrator(workflow_dir: Path) -> None:
     workflow_dir.mkdir(parents=True, exist_ok=True)
     (workflow_dir / "orchestrator.yaml").write_text(
-        f"workflow_name: {workflow_dir.name}\nworkflow_startup_mode: BackendOnly\n",
+        f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {workflow_dir.name}\nworkflow_startup_mode: BackendOnly\n",
         encoding="utf-8",
     )
 

--- a/tests/test_pack_config_paths.py
+++ b/tests/test_pack_config_paths.py
@@ -111,7 +111,7 @@ def test_registry_extends_packaged_default_with_app_overlay(monkeypatch, tmp_pat
     hosted_workflow_dir = workflows_root / "HostedOnly"
     hosted_workflow_dir.mkdir()
     (hosted_workflow_dir / "orchestrator.yaml").write_text(
-        "workflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
+        "schema_version: mozaiks.orchestrator.v1\nworkflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
         encoding="utf-8",
     )
     target_registry = registry_dir / "extension_registry.json"
@@ -189,7 +189,7 @@ def test_explicit_app_registry_without_extends_does_not_discover_factory_workflo
     hosted_workflow_dir = workflows_root / "HostedOnly"
     hosted_workflow_dir.mkdir()
     (hosted_workflow_dir / "orchestrator.yaml").write_text(
-        "workflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
+        "schema_version: mozaiks.orchestrator.v1\nworkflow_name: HostedOnly\nworkflow_startup_mode: BackendOnly\n",
         encoding="utf-8",
     )
     (registry_dir / "extension_registry.json").write_text(

--- a/tests/test_semantic_offline_projection.py
+++ b/tests/test_semantic_offline_projection.py
@@ -339,7 +339,8 @@ def _corpus_source() -> dict:
                 "files": [
                     {
                         "filename": "orchestrator.yaml",
-                        "content": """workflow_name: report_builder
+                        "content": """schema_version: mozaiks.orchestrator.v1
+workflow_name: report_builder
 max_turns: 4
 human_in_the_loop: false
 workflow_startup_mode: BackendOnly
@@ -437,6 +438,45 @@ def test_archetype_corpus_projects_complete_relationship_spine() -> None:
     } <= edge_kinds
     assert result.source_facts == result.represented_facts
     assert extract_semantic_facts(result.graph) == result.represented_facts
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_kind"),
+    [
+        ("missing", ProjectionGapKind.MISSING),
+        (None, ProjectionGapKind.UNSUPPORTED),
+        ("mozaiks.orchestrator.v2", ProjectionGapKind.UNSUPPORTED),
+        (" mozaiks.orchestrator.v1 ", ProjectionGapKind.UNSUPPORTED),
+    ],
+)
+def test_workflow_projection_requires_the_exact_document_version(mutation, expected_kind) -> None:
+    source = _corpus_source()
+    file = source["agent_workflows"][0]["files"][0]
+    document = yaml.safe_load(file["content"])
+    if mutation == "missing":
+        del document["schema_version"]
+    else:
+        document["schema_version"] = mutation
+    file["content"] = yaml.safe_dump(document, sort_keys=False)
+    before = copy.deepcopy(source)
+    with pytest.raises(ProjectionError, match="schema_version") as failure:
+        _project(source)
+    assert failure.value.gaps[0].kind is expected_kind
+    assert failure.value.gaps[0].source_path == "agent_workflows[0].files[0].content"
+    assert source == before
+
+
+def test_workflow_document_version_is_metadata_without_semantic_payload_fields() -> None:
+    source = _corpus_source()
+    first = _project(source)
+    file = source["agent_workflows"][0]["files"][0]
+    document = yaml.safe_load(file["content"])
+    file["content"] = yaml.safe_dump(dict(reversed(tuple(document.items()))), sort_keys=False)
+    second = _project(source)
+    assert first.graph == second.graph
+    assert first.payloads == second.payloads
+    workflow = _payload_for(first, SemanticNodeKind.WORKFLOW, "report_builder")
+    assert "mozaiks.orchestrator.v1" not in workflow.model_dump_json()
 
 
 def test_independent_source_expectations_equal_every_graph_fact() -> None:
@@ -764,7 +804,8 @@ def test_current_runtime_models_and_agentgenerator_bundle_shape_project() -> Non
         "files": [
             {
                 "filename": "orchestrator.yaml",
-                "content": """workflow_name: report_builder
+                "content": """schema_version: mozaiks.orchestrator.v1
+workflow_name: report_builder
 max_turns: 4
 human_in_the_loop: false
 workflow_startup_mode: BackendOnly

--- a/tests/test_smoke_agentgenerator_live_pack.py
+++ b/tests/test_smoke_agentgenerator_live_pack.py
@@ -52,6 +52,7 @@ def _write_valid_workflow(
     _write_yaml(
         workflow_dir / "orchestrator.yaml",
         {
+            "schema_version": "mozaiks.orchestrator.v1",
             "workflow_name": workflow_name,
             "max_turns": 4,
             "human_in_the_loop": startup_mode != "BackendOnly",
@@ -106,6 +107,7 @@ def _write_valid_workflow(
     _write_yaml(
         workflow_dir / "structured_outputs.yaml",
         {
+            "schema_version": "mozaiks.structured_outputs.v1",
             "models": {},
             "registry": {"PlannerAgent": None, "WorkerAgent": None, "AnalysisAgent": None},
         },

--- a/tests/test_structured_output_cache_invalidation.py
+++ b/tests/test_structured_output_cache_invalidation.py
@@ -37,7 +37,7 @@ def _write_workflow(
     workflow_dir = root / workflow_name
     workflow_dir.mkdir(parents=True, exist_ok=True)
     (workflow_dir / "orchestrator.yaml").write_text(
-        f"workflow_name: {workflow_name}\n"
+        f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {workflow_name}\n"
         "workflow_startup_mode: BackendOnly\n"
         "initial_agent: ProbeAgent\n"
         "max_turns: 1\n",
@@ -55,7 +55,7 @@ def _write_workflow(
         "    type: model\n"
         "    fields:\n"
         f"      {field_name}: {{ type: str }}\n"
-        "registry:\n"
+        "schema_version: mozaiks.structured_outputs.v1\nregistry:\n"
         f"  {registry_agent}: ProbeOutput\n",
         encoding="utf-8",
     )
@@ -340,6 +340,7 @@ def test_loader_failure_writes_no_partial_cache(isolated_manager, monkeypatch):
     # compilation but before any cache write.
     bad_config = {
         "structured_outputs": {
+            "schema_version": "mozaiks.structured_outputs.v1",
             "models": {
                 "ProbeOutput": {"type": "model", "fields": {"field_a": {"type": "str"}}}
             },

--- a/tests/test_structured_output_canonical_identity.py
+++ b/tests/test_structured_output_canonical_identity.py
@@ -24,7 +24,7 @@ from mozaiksai.core.workflow.structured_output_contracts import (
 
 
 def _config():
-    return {"models": {
+    return {"schema_version": "mozaiks.structured_outputs.v1", "models": {
         "Child": {"type": "model", "fields": {"label": {"type": "str"}}},
         "Output": {"type": "model", "fields": {
             "child": {"type": "Child"},

--- a/tests/test_structured_output_identity_migration.py
+++ b/tests/test_structured_output_identity_migration.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 
 from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.canonical_json import CanonicalJsonObject
 from mozaiksai.core.semantics.plan_authority import compilation_plan_authority_digest
 from mozaiksai.core.workflow.structured_output_contracts import stable_digest
 from tests.slice_5b_composition_helpers import composition_fixture
@@ -49,11 +50,21 @@ def test_exact_base_capture_preserves_provider_influenced_identity_evidence():
 def test_reference_migration_changes_only_exact_ref_dependent_unit_and_plan_identity():
     baseline = _baseline()
     current = composition_fixture()
-    assert stable_digest(current["configs"]) == baseline["config_fingerprint"]
+    # Restore only the later document-version metadata for comparison with
+    # this immutable pre-version capture. No unversioned config is parsed.
+    original_configs = copy.deepcopy(current["configs"])
+    for config in original_configs.values():
+        assert config.pop("schema_version") == "mozaiks.structured_outputs.v1"
+    assert stable_digest(original_configs) == baseline["config_fingerprint"]
     authority = current["authority_inputs"]
     assert authority.assignment_contract_registry.model_dump(mode="json") == baseline["descriptor_snapshot"]
-    assert compilation_plan_authority_digest(authority) == baseline["input_document_fingerprint"]
-    assert hashlib.sha256(authority.model_dump_json().encode()).hexdigest() == baseline["input_document_bytes_fingerprint"]
+    original_document = authority.model_dump(mode="json")
+    original_document["structured_output_configs"] = CanonicalJsonObject.from_python(
+        original_configs
+    ).model_dump(mode="json")
+    original_authority = type(authority).model_validate(original_document)
+    assert compilation_plan_authority_digest(original_authority) == baseline["input_document_fingerprint"]
+    assert hashlib.sha256(original_authority.model_dump_json().encode()).hexdigest() == baseline["input_document_bytes_fingerprint"]
     old_ref = baseline["reference"]
     assert current["configs"][old_ref["workflow_name"]]["models"][old_ref["model_id"]] == baseline["selected_model_config"]
     for key, fixture_key in (("base", "base_plan"), ("successor", "successor_plan")):

--- a/tests/test_structured_output_provider_boundary.py
+++ b/tests/test_structured_output_provider_boundary.py
@@ -106,7 +106,10 @@ def test_workflow_and_provider_cache_order_preserves_canonical_schema(monkeypatc
         structured_output_schema_digest,
     )
 
-    config = {"structured_outputs": {"models": copy.deepcopy(MODELS), "registry": {"ProbeAgent": "Envelope"}}}
+    config = {"structured_outputs": {
+        "schema_version": "mozaiks.structured_outputs.v1",
+        "models": copy.deepcopy(MODELS), "registry": {"ProbeAgent": "Envelope"},
+    }}
     monkeypatch.setattr(structured.workflow_manager, "get_config", lambda _name: config)
     expected_model = structured.build_models_from_config(
         copy.deepcopy(MODELS), exact_model_ids=frozenset(),

--- a/tests/test_studio_artifact_restore.py
+++ b/tests/test_studio_artifact_restore.py
@@ -421,7 +421,7 @@ def test_promote_restores_generated_app_bundle_as_loadable_platform_root(monkeyp
         ),
         "GeneratedApp/workflows/SupportWorkflow/orchestrator.yaml": "\n".join(
             [
-                "workflow_name: SupportWorkflow",
+                "schema_version: mozaiks.orchestrator.v1\nworkflow_name: SupportWorkflow",
                 "workflow_startup_mode: AgentDriven",
             ]
         ),

--- a/tests/test_studio_host_smoke.py
+++ b/tests/test_studio_host_smoke.py
@@ -247,6 +247,7 @@ def test_platform_host_indexes_workflow_capability_routes(tmp_path):
     workflow_dir.mkdir(parents=True)
     workflow_dir.joinpath("orchestrator.yaml").write_text(
         """
+schema_version: mozaiks.orchestrator.v1
 workflow_name: ReviewWorkflow
 workflow_startup_mode: BackendOnly
 triggers:

--- a/tests/test_workflow_declarative_contracts.py
+++ b/tests/test_workflow_declarative_contracts.py
@@ -22,7 +22,7 @@ def _write_minimal_orchestrator_and_agents(wf_dir: Path, workflow_name: str) -> 
         wf_dir / "orchestrator.yaml",
         "\n".join(
             [
-                f"workflow_name: {workflow_name}",
+                f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {workflow_name}",
                 "workflow_startup_mode: AgentDriven",
                 "human_in_the_loop: true",
             ]
@@ -101,7 +101,7 @@ def test_workflow_manager_rejects_invalid_structured_outputs_contract(tmp_path: 
         wf_dir / "structured_outputs.yaml",
         "\n".join(
             [
-                "registry:",
+                "schema_version: mozaiks.structured_outputs.v1\nregistry:",
                 "  Planner: MissingModel",
                 "models:",
                 "  ActualModel:",
@@ -393,7 +393,7 @@ def test_workflow_manager_accepts_valid_declarative_bundle(tmp_path: Path) -> No
         wf_dir / "structured_outputs.yaml",
         "\n".join(
             [
-                "registry:",
+                "schema_version: mozaiks.structured_outputs.v1\nregistry:",
                 "  Planner: PlannerResponse",
                 "models:",
                 "  PlannerResponse:",

--- a/tests/test_workflow_document_identity_migration.py
+++ b/tests/test_workflow_document_identity_migration.py
@@ -1,0 +1,123 @@
+"""Exact-base evidence separates document metadata from compiled model identity."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mozaiksai.core.semantics.canonical import canonical_digest
+from mozaiksai.core.semantics.canonical_json import CanonicalJsonObject
+from mozaiksai.core.semantics.plan_authority import compilation_plan_authority_digest
+from mozaiksai.core.workflow.declarative.contracts import (
+    parse_orchestrator_config,
+    parse_structured_outputs_config,
+)
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+from tests.slice_5b_composition_helpers import composition_fixture
+from tests.test_plan_taxonomy_sources import _corpus_plan
+from tests.test_semantic_payload_graph_v2 import _corpus_graph
+from tests.test_structured_output_canonical_identity import _model, _ref
+from tests.test_workflow_interface_rematerialization import _direct_bytes, _state, _unit
+
+ROOT = Path(__file__).resolve().parents[1]
+BASELINE = json.loads((ROOT / "tests/fixtures/workflow-document-version-migration.json").read_text(encoding="utf-8"))
+VERSIONS = {
+    "orchestrator.yaml": ("mozaiks.orchestrator.v1", parse_orchestrator_config),
+    "structured_outputs.yaml": ("mozaiks.structured_outputs.v1", parse_structured_outputs_config),
+}
+
+
+def test_exact_base_capture_and_governed_document_census():
+    assert BASELINE["base_commit"] == "5ff00cb1c040d694632e2ec530678c4e9571dc0d"
+    assert BASELINE["base_tree"] == "dd750e01833fb127061d085fc2f718a081d8266c"
+    assert canonical_digest(BASELINE) == "a3d53b6dc39f4bd110bd1a51b52e74fed98ae260cce9f792eb4f214a31011a94"
+    actual = sorted(
+        path.relative_to(ROOT).as_posix()
+        for directory in (ROOT / "factory_app/workflows", ROOT / "examples")
+        for filename in VERSIONS
+        for path in directory.rglob(filename)
+    )
+    assert actual == [row["path"] for row in BASELINE["documents"]]
+    assert len(actual) == 30
+    assert sum(Path(path).name == "orchestrator.yaml" for path in actual) == 15
+
+
+@pytest.mark.parametrize("before", BASELINE["documents"], ids=lambda row: row["path"])
+def test_only_document_version_changes_static_source_and_parser_identity(before):
+    path = ROOT / before["path"]
+    version, parser = VERSIONS[path.name]
+    raw = path.read_bytes()
+    document = yaml.safe_load(raw)
+    parsed = parser(copy.deepcopy(document))
+    assert document["schema_version"] == parsed["schema_version"] == version
+    assert hashlib.sha256(raw).hexdigest() != before["source_bytes_fingerprint"]
+    assert canonical_digest(document) != before["source_document_fingerprint"]
+    assert canonical_digest(parsed) != before["parser_document_fingerprint"]
+    # Comparison to the immutable pre-migration capture; neither restored
+    # dictionary is accepted as an unversioned runtime document.
+    del document["schema_version"]
+    del parsed["schema_version"]
+    assert canonical_digest(document) == before["source_document_fingerprint"]
+    assert canonical_digest(parsed) == before["parser_document_fingerprint"]
+
+
+def test_current_corpus_has_no_changed_units_plans_graph_or_payloads():
+    before = BASELINE["corpus"]
+    plan = _corpus_plan()
+    graph, payloads = _corpus_graph()
+    records = [{
+        "unit_id": unit.unit_id, "document": unit.model_dump(mode="json"),
+        "identity": unit.identity_payload, "serialized_json": unit.model_dump_json(),
+        "unit_digest": unit.unit_digest,
+    } for unit in plan.units]
+    assert len(records) == before["unit_count"] == 61
+    assert canonical_digest(records) == before["unit_records_fingerprint"]
+    assert plan.plan_digest == before["plan_digest"]
+    assert hashlib.sha256(plan.model_dump_json().encode()).hexdigest() == before["serialized_plan_fingerprint"]
+    assert graph.graph_digest == before["graph_digest"]
+    assert [{"node_id": payload.node_id, "payload_digest": payload.payload_digest} for payload in payloads] == before["payload_fingerprints"]
+
+
+def test_document_version_changes_only_whole_source_authority_identity():
+    before = BASELINE["executable"]
+    current = composition_fixture()
+    assert stable_digest(current["configs"]) != before["configs_fingerprint"]
+    authority = current["authority_inputs"]
+    assert compilation_plan_authority_digest(authority) != before["input_document_fingerprint"]
+    assert hashlib.sha256(authority.model_dump_json().encode()).hexdigest() != before["input_document_bytes_fingerprint"]
+    original_configs = copy.deepcopy(current["configs"])
+    for config in original_configs.values():
+        assert config.pop("schema_version") == "mozaiks.structured_outputs.v1"
+    assert stable_digest(original_configs) == before["configs_fingerprint"]
+    original_document = authority.model_dump(mode="json")
+    original_document["structured_output_configs"] = CanonicalJsonObject.from_python(original_configs).model_dump(mode="json")
+    # Restore only metadata for historical comparison, never runtime parsing.
+    restored = type(authority).model_validate(original_document)
+    assert compilation_plan_authority_digest(restored) == before["input_document_fingerprint"]
+    assert hashlib.sha256(restored.model_dump_json().encode()).hexdigest() == before["input_document_bytes_fingerprint"]
+
+    assert current["base"].plan_digest == before["base_plan_digest"]
+    assert current["successor"].plan_digest == before["successor_plan_digest"]
+    units = current["successor"].units
+    assert len(units) == 6
+    assert canonical_digest([unit.model_dump(mode="json") for unit in units]) == before["unit_records_fingerprint"]
+    assert current["assignments"].assignment_set_digest == before["assignment_set_fingerprint"]
+    assert current["result"].result_digest == before["artifact_result_fingerprint"]
+    selected = [unit.required_structured_output_ref.model_dump(mode="json") for unit in units if unit.required_structured_output_ref is not None]
+    assert selected == [before["selected_reference"]]
+
+
+def test_canonical_model_acceptance_and_workflow_interface_bytes_are_unchanged():
+    assert _ref().model_dump(mode="json") == BASELINE["canonical_probe_reference"]
+    assert canonical_digest(_model().model_json_schema()) == BASELINE["canonical_probe_model_schema_fingerprint"]
+    state = _state()
+    unit = _unit(state)
+    assert {
+        "unit_id": unit.unit_id, "unit_digest": unit.unit_digest,
+        "identity": unit.identity_payload, "content_hex": _direct_bytes(state).hex(),
+    } == BASELINE["workflow_interface"]

--- a/tests/test_workflow_document_versions.py
+++ b/tests/test_workflow_document_versions.py
@@ -1,0 +1,151 @@
+"""Self-versioned workflow documents retain exact version authority."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from mozaiksai.core.semantics.refs import ChildContractRef, ExecutionAccessScopeRef
+from mozaiksai.core.workflow.declarative.contracts import (
+    OrchestratorConfig,
+    StructuredOutputsConfig,
+    parse_orchestrator_config,
+    parse_structured_outputs_config,
+)
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+
+CASES = (
+    (OrchestratorConfig, parse_orchestrator_config, {
+        "schema_version": "mozaiks.orchestrator.v1", "workflow_name": "VersionProbe",
+        "workflow_startup_mode": "AgentDriven", "max_turns": 7,
+        "human_in_the_loop": True, "orchestration_pattern": "Pipeline",
+        "initial_agent": "Author", "initial_message": "Begin.",
+        "triggers": [{"type": "event", "event": "domain.probe.ready"}],
+    }),
+    (StructuredOutputsConfig, parse_structured_outputs_config, {
+        "schema_version": "mozaiks.structured_outputs.v1",
+        "registry": {"Author": "Output"}, "models": {
+            "Output": {"type": "model", "fields": {"message": {"type": "str"}}},
+        },
+    }),
+)
+
+
+@pytest.mark.parametrize("model,parser,document", CASES)
+@pytest.mark.parametrize("mutation", ["missing", "null", "unknown", "misspelled", "extra", "whitespace", "numeric"])
+def test_versions_are_required_exact_literals(model, parser, document, mutation):
+    candidate = copy.deepcopy(document)
+    if mutation == "missing":
+        del candidate["schema_version"]
+    elif mutation == "null":
+        candidate["schema_version"] = None
+    elif mutation == "unknown":
+        candidate["schema_version"] += ".unknown"
+    elif mutation == "misspelled":
+        candidate["schema_verison"] = candidate.pop("schema_version")
+    elif mutation == "extra":
+        candidate["unknown_key"] = True
+    elif mutation == "whitespace":
+        candidate["schema_version"] = " " + candidate["schema_version"] + " "
+    else:
+        candidate["schema_version"] = 1
+    with pytest.raises(ValidationError):
+        model.model_validate(candidate)
+    with pytest.raises(ValueError):
+        parser(candidate)
+
+
+@pytest.mark.parametrize("model,parser,document", CASES)
+def test_parsed_version_is_serialized_and_survives_cold_round_trip(model, parser, document):
+    parsed = parser(copy.deepcopy(document))
+    assert parsed["schema_version"] == document["schema_version"]
+    validated = model.model_validate(parsed)
+    assert validated.model_dump()["schema_version"] == document["schema_version"]
+    assert model.model_validate_json(validated.model_dump_json()) == validated
+    stripped = {key: value for key, value in parsed.items() if key != "schema_version"}
+    with pytest.raises(ValidationError, match="schema_version"):
+        model.model_validate(stripped)
+    with pytest.raises(ValueError, match="schema_version"):
+        parser(stripped)
+    assert model.model_fields["schema_version"].is_required()
+
+
+@pytest.mark.parametrize("model,parser,document", CASES)
+def test_child_reference_version_equality_uses_the_parsed_document(model, parser, document):
+    del model
+    raw = yaml.safe_dump(document, sort_keys=False).encode()
+    parsed = parser(yaml.safe_load(raw))
+    orchestrator = "workflow_name" in document
+    ref = ChildContractRef(
+        subject_id="version-probe", subject_version=1,
+        scope=ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="workspace"),
+        content_digest=hashlib.sha256(raw).hexdigest(),
+        artifact_family="workflow_manifest" if orchestrator else "workflow_config",
+        canonical_relative_path="orchestrator.yaml" if orchestrator else "structured_outputs.yaml",
+        contract_schema_version=parsed["schema_version"],
+    )
+    assert ref.contract_schema_version == parsed["schema_version"]
+    different = ChildContractRef.model_validate({**ref.model_dump(), "contract_schema_version": "different.v1"})
+    assert different.contract_schema_version != parsed["schema_version"]
+    assert different.content_digest == ref.content_digest
+
+
+@pytest.mark.parametrize("model,parser,document", CASES)
+def test_semantic_parse_identity_is_stable_without_claiming_equal_source_bytes(model, parser, document):
+    del model
+    first_yaml = yaml.safe_dump(document, sort_keys=False)
+    reordered_yaml = yaml.safe_dump(dict(reversed(list(document.items()))), sort_keys=False)
+    assert first_yaml != reordered_yaml
+    assert hashlib.sha256(first_yaml.encode()).digest() != hashlib.sha256(reordered_yaml.encode()).digest()
+    first = parser(yaml.safe_load(first_yaml))
+    second = parser(yaml.safe_load(reordered_yaml))
+    assert first == second == parser(yaml.safe_load(first_yaml))
+    assert stable_digest(first) == stable_digest(second)
+    script = f"""import json, sys, yaml
+from mozaiksai.core.workflow.declarative.contracts import {parser.__name__}
+from mozaiksai.core.workflow.structured_output_contracts import stable_digest
+print(stable_digest({parser.__name__}(yaml.safe_load(sys.stdin.read()))))
+"""
+    result = subprocess.run([sys.executable, "-c", script], input=reordered_yaml, text=True, capture_output=True, check=True)
+    assert result.stdout.strip() == stable_digest(first)
+
+
+def test_orchestrator_version_changes_only_document_metadata():
+    _, parser, document = CASES[0]
+    parsed = parser(copy.deepcopy(document))
+    assert parsed == {
+        **document,
+        "triggers": [{
+            **document["triggers"][0], "endpoint": None, "method": None,
+            "description": None, "capability_id": None,
+        }],
+    }
+
+
+def test_document_version_never_becomes_an_output_model_field():
+    from mozaiksai.core.workflow.outputs.structured import (
+        build_models_from_config,
+        get_provider_response_model,
+    )
+    from mozaiksai.core.workflow.structured_output_contracts import (
+        build_structured_output_contract_ref,
+        canonical_structured_output_schema,
+    )
+
+    _, parser, document = CASES[1]
+    parsed = parser(copy.deepcopy(document))
+    assert parsed["models"] == document["models"]
+    assert parsed["registry"] == document["registry"]
+    model = build_models_from_config(parsed["models"])["Output"]
+    wire = get_provider_response_model(model)
+    assert "schema_version" not in model.model_fields
+    assert "schema_version" not in json.dumps(canonical_structured_output_schema(model))
+    assert "schema_version" not in json.dumps(wire.model_json_schema())
+    reference = build_structured_output_contract_ref(workflow_name="VersionProbe", model_id="Output", configs={"VersionProbe": parsed}, exact_model_ids=frozenset())
+    assert reference.acceptance_profile == "mozaiks.structured_output_acceptance_profile.v1"

--- a/tests/test_workflow_integration_metadata.py
+++ b/tests/test_workflow_integration_metadata.py
@@ -56,6 +56,7 @@ def test_extract_workflow_integration_metadata_from_bundle_entries() -> None:
                     {
                         "filename": "orchestrator.yaml",
                         "content": """
+schema_version: mozaiks.orchestrator.v1
 workflow_name: TicketBatchTriageWorkflow
 workflow_startup_mode: BackendOnly
 triggers:

--- a/tests/test_workflow_manager_a2a_config.py
+++ b/tests/test_workflow_manager_a2a_config.py
@@ -21,7 +21,7 @@ def test_workflow_manager_loads_optional_a2a_yaml(tmp_path: Path) -> None:
         wf_dir / "orchestrator.yaml",
         "\n".join(
             [
-                "workflow_name: FlowA",
+                "schema_version: mozaiks.orchestrator.v1\nworkflow_name: FlowA",
                 "max_turns: 10",
                 "human_in_the_loop: true",
                 "workflow_startup_mode: AgentDriven",
@@ -80,7 +80,7 @@ def test_workflow_manager_load_summary_logs_degraded_on_partial_failure(
     ok_dir.mkdir()
     _write_yaml(
         ok_dir / "orchestrator.yaml",
-        "workflow_name: GoodFlow\nmax_turns: 5\nhuman_in_the_loop: false\nworkflow_startup_mode: AgentDriven",
+        "schema_version: mozaiks.orchestrator.v1\nworkflow_name: GoodFlow\nmax_turns: 5\nhuman_in_the_loop: false\nworkflow_startup_mode: AgentDriven",
     )
     _write_yaml(
         ok_dir / "agents.yaml",
@@ -90,7 +90,7 @@ def test_workflow_manager_load_summary_logs_degraded_on_partial_failure(
     # Bad workflow — missing workflow_startup_mode (will fail validation).
     bad_dir = tmp_path / "BadFlow"
     bad_dir.mkdir()
-    _write_yaml(bad_dir / "orchestrator.yaml", "workflow_name: BadFlow\nmax_turns: 5")
+    _write_yaml(bad_dir / "orchestrator.yaml", "schema_version: mozaiks.orchestrator.v1\nworkflow_name: BadFlow\nmax_turns: 5")
 
     _workflow_manager_mod.UnifiedWorkflowManager._instance = None
     with caplog.at_level(logging.WARNING):
@@ -111,7 +111,7 @@ def test_workflow_manager_load_summary_logs_ok_when_all_load(
     ok_dir.mkdir()
     _write_yaml(
         ok_dir / "orchestrator.yaml",
-        "workflow_name: FlowOk\nmax_turns: 5\nhuman_in_the_loop: false\nworkflow_startup_mode: AgentDriven",
+        "schema_version: mozaiks.orchestrator.v1\nworkflow_name: FlowOk\nmax_turns: 5\nhuman_in_the_loop: false\nworkflow_startup_mode: AgentDriven",
     )
     _write_yaml(
         ok_dir / "agents.yaml",
@@ -135,7 +135,7 @@ def test_workflow_manager_rejects_removed_startup_mode_only(tmp_path: Path) -> N
         wf_dir / "orchestrator.yaml",
         "\n".join(
             [
-                "workflow_name: FlowLegacy",
+                "schema_version: mozaiks.orchestrator.v1\nworkflow_name: FlowLegacy",
                 "startup_mode: UserDriven",
                 "human_in_the_loop: true",
             ]

--- a/tests/test_workflow_manager_reinitialize_identity.py
+++ b/tests/test_workflow_manager_reinitialize_identity.py
@@ -29,7 +29,7 @@ def _write_minimal_workflow(root: Path, workflow_name: str) -> None:
         wf_dir / "orchestrator.yaml",
         "\n".join(
             [
-                f"workflow_name: {workflow_name}",
+                f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {workflow_name}",
                 "max_turns: 4",
                 "human_in_the_loop: false",
                 "workflow_startup_mode: AgentDriven",


### PR DESCRIPTION
Both public workflow document contracts now require their own exact in-document version. An unversioned orchestrator or structured-output configuration fails validation and AgentGenerator packaging. Parsers retain the supplied validated version for later reference equality.

- `orchestrator.yaml`: `mozaiks.orchestrator.v1`
- `structured_outputs.yaml`: `mozaiks.structured_outputs.v1`

This is the self-versioning prerequisite requested after the implementation-artifact-authority stop. The reference/resolver and implementation-selection work remains deferred.

## Contract and producer migration

All 30 governed OSS documents migrate atomically (15 of each), plus CLI starter output, AgentGenerator instructions/quality gate, five archetype defaults, live generation guidance, fixture producers, and public/agent authoring examples. Existing offline projection validates the public version literal as metadata without changing topology. Missing, null, unknown, misspelled, whitespace-altered versions and unknown keys reject; no default, alias, injection, or unversioned fallback is added.

[Exact document/producer census and downstream requirement](https://github.com/BlocUnited-LLC/mozaiks/blob/6901910e5bb828aef2e3f3f3bd325dba03d4588d/docs/architecture/workflows/workflow-document-version-migration.md) records all paths and exclusions. Read-only App Zero census found 11 orchestrators and 10 structured-output documents at its existing OSS pin. They must migrate when that pin advances; this PR edits no downstream files.

## Identity evidence

The immutable baseline was captured from exact main `5ff00cb1c040d694632e2ec530678c4e9571dc0d`, after #485 post-main CI succeeded. Restoring only version metadata for comparison recovers all prior source/parser/configuration/authority fingerprints. Existing historical captures are unchanged.

`EXPECTED_DOCUMENT_VERSION_MIGRATION`: the 30 enclosing YAML source/parsed document identities, executable fixture source configuration, and enclosing immutable authority-input document/bytes. Actual genesis/child revision fixtures also migrate authority/parent references and enclosing ledger, evidence, and revision digests; their six artifact entries, exact bodies, and bundle digest remain unchanged. `UNRELATED_DRIFT`: none.

Unchanged: 61/61 current corpus units and aggregate plan, historical 59-unit proof, six-unit executable plans, #485 acceptance references and model schemas, assignments/artifact results, #483 interface identity/bytes, #484 action contracts, and #481/#482 authority/retirement behavior. Required versions never enter output-model fields or provider schemas. Repeated/key-reordered/cold-process parsing is deterministic; exact source-byte hashes continue to distinguish formatting.

## OSS change impact

- Layer: public workflow document contracts, their authored sources/producers, and one existing offline metadata consumer.
- Build/runtime: authoring and loading require explicit versions; workflow sequences, transitions, entrypoints, startup behavior, routing, and AG2 mechanics retain their prior meaning.
- Workspace compatibility: intentional pre-1.0 clean migration; existing unversioned documents must be updated on upgrade.
- Documentation: public examples, coding guidance, ADR 0007, migration census, and CHANGELOG.

## Tests run

- Full `python -m pytest -q --no-cov`: **15,174 passed, 94 skipped, 4 warnings**.
- Focused 62-file run: **1,491 passed, 2 skipped, 1 warning**. Covers both document contracts, workflow loading, Factory/generation, structured-output runtime/cache/fail-closed/#485, #481/#482/#483/#484, CompilationPlan and authority, 4C/5A/5B/5C, materialization/rematerialization, ArtifactRevision/content store, and source/prompt hygiene.
- Independent Codex 3 targeted review run: **140 passed**.
- `ruff check .`, scoped mypy (four changed runtime/CLI/gate files), strict MkDocs, source hygiene scan, `git diff --check`, staged and exact-head history Gitleaks scans: **pass**.
- Read-only exact-base genesis/child revision comparison: only declared authority/reference/enclosing identity changes; all six artifact entries, bodies, and bundle identity unchanged.

Scoped mypy passes for the four changed runtime/CLI/gate modules. An additional probe of the prompt-only smoke script reports 19 existing type errors, reproduced identically on the exact base (line numbers shift by the two added prompt lines); those unrelated issues are unchanged.

Codex 3 independently reviewed the complete diff and passed 140 targeted tests with no blocking findings. Exact-head code review PASS: `6901910e5bb828aef2e3f3f3bd325dba03d4588d`; reviewed tree and DCO sign-off verified.

Draft; DCO signed; auto-merge disabled. Do not merge.


## Related issue

N/A — requested prerequisite after #485 and the accepted implementation-artifact-authority stop.

## Current-main verification

- [x] Fresh branch from exact `5ff00cb1c040d694632e2ec530678c4e9571dc0d`; #485 post-main CI [34047567784](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34047567784) terminal success.
- This is a public contract migration. Both documents lacked an explicit document version on that base; no superseded implementation fix is carried forward.

## Boundary confirmation

- [x] OSS-only changes; App Zero inspection was read-only. No hosted-product logic, credentials, or internal URLs introduced.

## Governance check

- [x] Public contract change is explicitly classified and versioned.
- [x] ADR 0007 records document identity, preserved semantic boundaries, and downstream migration requirements.
- No provider mutation or new permissions, secret, payment, deployment, or production-operation path is introduced.

## AI assistance

Codex 4 implemented the change with bounded census/fixture assistance; Codex 3 independently reviewed the exact head.
