### PR TITLE
fix(runtime): preserve declared tool routing through AG2 Network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- **AG2 Network tool routing**: declared tools retain authorized context writes
+  and hand off from actual tool-call events, including turns with no text.
+  Source-agent scoping and context-write policy remain enforced through graph
+  reload and packet publication.
 - **Provider-neutral structured-output identity**: canonical contracts now pin
   a versioned acceptance profile and truthful optionality independently of
   provider wire formatting. Build and cold resolution consume the same explicit

--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -87,8 +87,8 @@ intent below remain authoritative for maintainers.
 | --- | --- | --- | --- | --- | --- | --- |
 | `AG2-WP-001` | `Hub`/`AgentClient` workflow execution | `AG2NetworkRunner` adapts workflow YAML, app/session identity, artifact validation, and `RunResult` semantics. | When AG2 ships a stable high-level workflow runner, shrink this to request/result conversion. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py` |
 | `AG2-WP-002` | Workflow turn-failure policy | The runner maps `HubListener.on_turn_failed` to a failed `RunResult` because the channel otherwise remains alive. | Delete the listener mapping when AG2 exposes a failed channel result or native close policy. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py` |
-| `AG2-WP-003` | Round-end packet context updates | `_install_context_update_handler` wraps AG2's default handler so tool updates reach `EV_PACKET` before `WorkflowAdapter.fold(...)`. | Delete the wrapper when AG2 exposes a public packet transform or context-update hook. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py`, `test_workflow_network_graph.py` |
-| `AG2-WP-004` | Source-scoped transition composition | Local conditions preserve YAML `source_agent` semantics not expressible by AG2 1.0.3 conditions alone. | Replace them when `FromSpeaker` composes natively with context, tool, or expression conditions. | `ACTIVE` | 1.0.3 | `test_workflow_network_graph.py` |
+| `AG2-WP-003` | Round-end packet context updates | `_install_context_update_handler` wraps AG2's default handler so tool updates reach `EV_PACKET` before `WorkflowAdapter.fold(...)`. | Delete the wrapper when AG2 exposes a public packet transform or context-update hook. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py`, `test_workflow_network_graph.py`, `test_ag2_network_tool_routing.py` |
+| `AG2-WP-004` | Source-scoped transition composition | Local conditions preserve YAML `source_agent` semantics; `SourceScopedToolCalled` remains a native `ToolCalled` subtype for packet recognition. | Replace them when `FromSpeaker` composes natively with context, tool, or expression conditions and native packet construction recognizes that composition. | `ACTIVE` | 1.0.3 | `test_workflow_network_graph.py`, `test_ag2_network_tool_routing.py` |
 | `AG2-WP-005` | Long-lived code environments | `SandboxPort` owns generated-app boot, preview URLs, session lifecycle, and budgets; AG2 tools currently execute snippets/processes. | Re-evaluate as a thin AG2 binding if `CodeEnvironment` gains long-lived servers and exposed ports. | `WATCH` | 1.0.3 | `test_sandbox_boundary_and_persistence.py`, `test_sandbox_shell_contract.py` |
 | `AG2-WP-006` | Workflow startup target | `BootstrapInitialDispatch` performs one initial human-to-agent dispatch without creating a reusable author transition. | Delete it when AG2 channels accept a native initial target. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py`, `test_workflow_network_graph.py` |
 | `AG2-WP-007` | Workflow-agent response schema | Mozaiks validates canonical artifact contracts after packets; AG2 does not provide per-agent channel response pressure. | Adopt native `response_schema` for model pressure while retaining Mozaiks hard validation. | `WATCH` | 1.0.3 | `test_structured_output_runtime_contracts.py`, `test_structured_output_fail_closed.py` |
@@ -98,6 +98,20 @@ intent below remain authoritative for maintainers.
 | `AG2-WP-011` | Typed one-shot Consulting | `AG2StructuredAgentRunner` performs refinement LLM checkpoints while Mozaiks retains artifact policy. | Adopt Consulting when it supports a typed one-question/one-response contract. | `WATCH` | 1.0.3 | `test_ag2_agent_runner.py` |
 | `AG2-WP-012` | App-scoped channel events | Mozaiks projects AG2 WAL events into app-scoped websocket and chat persistence contracts. | Shrink WAL polling when native subscriptions preserve those product boundaries. | `WATCH` | 1.0.3 | `test_ag2_network_execution_alignment.py` |
 | `AG2-WP-013` | Durable human attachment | `_attach_human_client` reconnects hydrated human identity because AG2 lacks public `HubClient.attach_human(...)`. | Delete the private fallback when AG2 exposes public human reattachment. | `ACTIVE` | 1.0.3 | `test_ag2_network_execution_alignment.py` |
+
+For `AG2-WP-003`, preserve the trusted callable invocation and retained mutation
+attribution described in [Declarative Config to AG2 Mapping](declarative-ag2-mapping.md#context_variablesyaml)
+when replacing the packet hook. Ordinary packet updates must not acquire
+deterministic-tool authority merely because a variable permits that writer.
+
+For `AG2-WP-004`, AG2 1.0.3 recognizes static routing tools through a top-level
+`isinstance(condition, ToolCalled)` check in its packet builder. A standalone
+condition that delegates only `evaluate()` is insufficient. The registered
+subclass preserves source checking at native graph selection and survives
+`TransitionGraph.to_dict()` / `loads()`. On upgrades, verify actual callable
+execution through native tool events, empty-text turns, wrong-source same-name
+calls, graph rehydration, deterministic precedence, and HITL pause/resume.
+Mozaiks does not replace AG2's tool-event interpretation or packet builder.
 
 ## Private and Internal API Register
 

--- a/docs/architecture/workflows/declarative-ag2-mapping.md
+++ b/docs/architecture/workflows/declarative-ag2-mapping.md
@@ -70,10 +70,19 @@ Runtime compilation rules:
 - `condition_type: context_expression` rules compile to a source-scoped custom
   AG2 1.0 `TransitionCondition` that evaluates Mozaiks
   `${context_variable}` syntax against workflow context state
-- `condition_type: tool_called` rules compile to a source-scoped adapter over
-  AG2 `ToolCalled`
+- `condition_type: tool_called` rules compile to `SourceScopedToolCalled`, a
+  native AG2 `ToolCalled` subclass that also checks the declared source agent
 - `target_agent: user` pauses the run for user input
 - `target_agent: terminate` compiles to `TerminateTarget`
+
+AG2 derives tool routing from its native `ToolCallEvent` stream, including turns
+with an empty message body. The registered `mozaiks_source_tool_called` condition
+retains both `source_agent_id` and `tool_name` through graph serialization and
+rehydration. Static tool routing still evaluates the source predicate when AG2
+selects the target: another agent calling the same tool cannot satisfy that
+rule. Text mentioning the tool and a `ToolResultEvent` without its matching
+call do not establish a tool transition. AG2 owns event interpretation, packet
+construction, transition evaluation, and workflow state progression.
 
 LLM classification belongs before routing: a Refinement Engine route, agent tool, or
 structured output sets context state; the graph then routes deterministically.
@@ -113,6 +122,25 @@ agents:
     variables:
       - var_name
 ```
+
+`ContextAuthorityPolicy` owns write permission. The factory-injected
+`ContextVariablesBridge` checks each set or delete before accepting it. A
+declared `deterministic_tool` writer is selected only inside the trusted callable
+invocation installed by the agent factory, bound to that exact bridge, policy
+instance, and `(workflow_name, app_id, chat_id)` run. Tool arguments cannot
+replace the injected bridge or choose its writer identity. Ordinary bridge
+access remains `context_bridge`; a variable declaration alone does not establish
+tool provenance.
+
+The invocation's deterministic attribution expires when the callable exits,
+including on failure. Revocation also applies to invocation context inherited
+by unfinished child tasks. Each pending set or delete retains the writer that
+authorized that operation; later operations are checked independently. Before
+publication, the packet adapter verifies the same policy/run binding and checks
+every pending operation again under its retained writer. Updates already present
+in an outgoing packet receive only `context_bridge` attribution. Authorized
+updates then reach AG2's native fold before `ContextEquals` selects the next
+speaker.
 
 ### `tools.yaml`
 

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -43,10 +43,12 @@ from mozaiksai.core.ports.orchestration import RunStatus
 from mozaiksai.core.workflow.context.authority import (
     AGENT_TEXT_WRITER,
     CONTEXT_BRIDGE_WRITER,
-    DETERMINISTIC_TOOL_WRITER,
     LIVE_USER_CONTEXT_WRITER,
     SENTINEL_TEXT_TRIGGER_WRITER,
+    ContextAuthorityError,
     ContextAuthorityPolicy,
+    ContextWriterId,
+    resolve_declared_context_writer,
 )
 from mozaiksai.core.workflow.execution.network_graph import compile_transition_rules_to_graph
 from mozaiksai.core.workflow.outputs.runtime_validation import validate_agent_structured_output
@@ -90,36 +92,19 @@ def _json_safe_dict(value: Mapping[str, Any] | None) -> dict[str, Any]:
     return serialized if isinstance(serialized, dict) else {}
 
 
-def _resolve_declared_writer(
-    key: str,
-    *,
-    base_writer: str,
-    elevated_writer: str,
-    context_authority_policy: ContextAuthorityPolicy | None,
-) -> str:
-    """Label a write with the highest-fidelity writer the declaration
-    authorizes for this mechanism. The policy stays the single authority —
-    this only picks between the mechanism's base writer and its declared
-    deterministic form (e.g. a bridge write to a variable whose declaration
-    authorizes deterministic tools, or an agent-text derive for a variable
-    declared with an exact-match sentinel trigger)."""
-    if context_authority_policy is None:
-        return base_writer
-    authority = context_authority_policy.variables.get(key)
-    if authority is not None and elevated_writer in authority.writer_ids:
-        return elevated_writer
-    return base_writer
-
-
 def _authorized_context_updates(
     updates: Mapping[str, Any] | None,
     *,
-    writer_id: str,
+    writer_id: ContextWriterId,
     context_authority_policy: ContextAuthorityPolicy | None,
-    elevated_writer_id: str | None = None,
+    elevated_writer_id: ContextWriterId | None = None,
 ) -> dict[str, Any]:
     if not updates:
         return {}
+    if elevated_writer_id is not None and (
+        writer_id != AGENT_TEXT_WRITER or elevated_writer_id != SENTINEL_TEXT_TRIGGER_WRITER
+    ):
+        raise ContextAuthorityError("context_authority.untrusted_writer_attribution")
     safe: dict[str, Any] = {}
     for key, value in updates.items():
         clean_key = str(key or "").strip()
@@ -127,14 +112,14 @@ def _authorized_context_updates(
             continue
         effective_writer = writer_id
         if elevated_writer_id is not None:
-            effective_writer = _resolve_declared_writer(
+            effective_writer = resolve_declared_context_writer(
                 clean_key,
                 base_writer=writer_id,
-                elevated_writer=elevated_writer_id,
-                context_authority_policy=context_authority_policy,
+                declared_writer=elevated_writer_id,
+                policy=context_authority_policy,
             )
         if context_authority_policy is not None:
-            context_authority_policy.require_can_write(clean_key, writer_id=effective_writer, operation="set")  # type: ignore[arg-type]
+            context_authority_policy.require_can_write(clean_key, writer_id=effective_writer, operation="set")
         safe[clean_key] = value
     return safe
 
@@ -374,6 +359,7 @@ class AG2NetworkRunner:
                     agent=agent,
                     client=client,
                     agent_name=name,
+                    run_identity=(request.workflow_name, request.app_id, request.chat_id),
                     agent_text_context_deriver=request.agent_text_context_deriver,
                     context_authority_policy=request.context_authority_policy,
                 )
@@ -923,6 +909,7 @@ def _install_context_update_handler(
     agent: Any,
     client: Any,
     agent_name: str,
+    run_identity: tuple[str, str, str],
     agent_text_context_deriver: Callable[[str, str], Mapping[str, Any]] | None = None,
     context_authority_policy: ContextAuthorityPolicy | None = None,
 ) -> None:
@@ -935,13 +922,14 @@ def _install_context_update_handler(
     before AG2 selects the next speaker.
     """
 
+    from mozaiksai.core.workflow.agents.factory import ContextVariablesBridge
+
     bridge = getattr(agent, "_mozaiks_context_bridge", None)
-    has_bridge = (
-        bridge is not None
-        and callable(getattr(bridge, "clear_context_updates", None))
-        and callable(getattr(bridge, "consume_context_updates", None))
-    )
-    if not has_bridge and agent_text_context_deriver is None:
+    if bridge is not None:
+        if not isinstance(bridge, ContextVariablesBridge):
+            raise ContextAuthorityError("context_authority.untrusted_bridge")
+        bridge._bind_run(run_identity, context_authority_policy)
+    if bridge is None and agent_text_context_deriver is None and context_authority_policy is None:
         return
 
     async def _handler(envelope: Any) -> None:
@@ -955,12 +943,26 @@ def _install_context_update_handler(
                 and str(getattr(out_envelope, "channel_id", "") or "")
                 == str(getattr(envelope, "channel_id", "") or "")
             ):
+                event_data = _json_safe_dict(getattr(out_envelope, "event_data", {}) or {})
+                existing = dict(event_data.get("context_updates") or {})
+                existing_set = _authorized_context_updates(
+                    existing.get("set") or {},
+                    writer_id=CONTEXT_BRIDGE_WRITER,
+                    context_authority_policy=context_authority_policy,
+                )
+                existing_delete = [str(key) for key in existing.get("delete") or []]
+                if context_authority_policy is not None:
+                    for key in existing_delete:
+                        context_authority_policy.require_can_write(
+                            key, writer_id=CONTEXT_BRIDGE_WRITER, operation="delete",
+                        )
                 bridge_updates = (
-                    bridge.consume_context_updates()
+                    bridge.consume_authorized_context_updates(
+                        policy=context_authority_policy, run_identity=run_identity,
+                    )
                     if bridge is not None
                     else {"set": {}, "delete": []}
                 )
-                event_data = _json_safe_dict(getattr(out_envelope, "event_data", {}) or {})
                 derived_updates: Mapping[str, Any] = {}
                 if agent_text_context_deriver is not None:
                     text = _packet_body_text(event_data)
@@ -982,30 +984,18 @@ def _install_context_update_handler(
                                 elevated_writer_id=SENTINEL_TEXT_TRIGGER_WRITER,
                             )
                 if (
-                    bridge_updates.get("set")
+                    existing
+                    or bridge_updates.get("set")
                     or bridge_updates.get("delete")
                     or derived_updates
                 ):
-                    existing = dict(event_data.get("context_updates") or {})
-                    bridge_set = _authorized_context_updates(
-                        bridge_updates.get("set") or {},
-                        writer_id=CONTEXT_BRIDGE_WRITER,
-                        context_authority_policy=context_authority_policy,
-                        elevated_writer_id=DETERMINISTIC_TOOL_WRITER,
-                    )
-                    existing_set = _authorized_context_updates(
-                        existing.get("set") or {},
-                        writer_id=CONTEXT_BRIDGE_WRITER,
-                        context_authority_policy=context_authority_policy,
-                        elevated_writer_id=DETERMINISTIC_TOOL_WRITER,
-                    )
                     merged_set = {
                         **_json_safe_dict(existing_set),
                         **_json_safe_dict(derived_updates),
-                        **_json_safe_dict(bridge_set),
+                        **_json_safe_dict(bridge_updates.get("set") or {}),
                     }
                     merged_delete = [
-                        *list(existing.get("delete") or []),
+                        *existing_delete,
                         *list(bridge_updates.get("delete") or []),
                     ]
                     event_data["context_updates"] = {

--- a/mozaiksai/core/adapters/ag2_transition_conditions.py
+++ b/mozaiksai/core/adapters/ag2_transition_conditions.py
@@ -124,17 +124,20 @@ class SourceScopedContextExpression:
 
 
 @dataclass(slots=True)
-class SourceScopedToolCalled:
-    """Source-scoped adapter over AG2's `ToolCalled` condition."""
+class SourceScopedToolCalled(ToolCalled):
+    """Native tool-call condition with Mozaiks' declared source scope.
+
+    AG2 recognizes ToolCalled subclasses when deriving routing from tool events.
+    The source predicate is evaluated when its native graph selects the target.
+    """
 
     source_agent_id: str
-    tool_name: str
     name: ClassVar[str] = "mozaiks_source_tool_called"
 
     def evaluate(self, state: WorkflowState, envelope: Envelope) -> bool:
-        return FromSpeaker(self.source_agent_id).evaluate(state, envelope) and ToolCalled(
-            tool_name=self.tool_name,
-        ).evaluate(state, envelope)
+        return FromSpeaker(self.source_agent_id).evaluate(state, envelope) and ToolCalled.evaluate(
+            self, state, envelope
+        )
 
 
 @dataclass(slots=True)

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import inspect
 import logging
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any
 
@@ -21,7 +24,14 @@ from mozaiksai.core.media.ag2 import (
 )
 from mozaiksai.core.media.middleware import build_ag2_media_harvest_middleware
 
-from ..context.authority import CONTEXT_BRIDGE_WRITER, ContextAuthorityPolicy
+from ..context.authority import (
+    CONTEXT_BRIDGE_WRITER,
+    DETERMINISTIC_TOOL_WRITER,
+    ContextAuthorityError,
+    ContextAuthorityPolicy,
+    ContextWriterId,
+    resolve_declared_context_writer,
+)
 from ..context.context_utils import (
     apply_context_exposures as _apply_context_exposures,
 )
@@ -143,6 +153,31 @@ def _log_existing_app_discovery_projection(
 # CONTEXT BRIDGE
 # ------------------------------------------------------------------
 
+@dataclass(slots=True)
+class _WorkflowToolInvocation:
+    bridge: ContextVariablesBridge
+    policy: ContextAuthorityPolicy | None
+    run_identity: tuple[str, str, str] | None
+    active: bool = True
+
+
+_WORKFLOW_TOOL_INVOCATION: ContextVar[_WorkflowToolInvocation | None] = ContextVar(
+    "mozaiks_workflow_tool_invocation", default=None
+)
+
+
+@contextmanager
+def _workflow_tool_invocation(bridge: ContextVariablesBridge):
+    invocation = _WorkflowToolInvocation(bridge, bridge._authority_policy, bridge._run_identity)
+    token = _WORKFLOW_TOOL_INVOCATION.set(invocation)
+    try:
+        yield
+    finally:
+        # Revocation also invalidates records inherited by unfinished child tasks.
+        invocation.active = False
+        _WORKFLOW_TOOL_INVOCATION.reset(token)
+
+
 class ContextVariablesBridge:
     """Shared workflow context exposed to tools and committed through AG2.
 
@@ -156,8 +191,9 @@ class ContextVariablesBridge:
         "__data",
         "_pending_set",
         "_pending_delete",
+        "_pending_writers",
         "_authority_policy",
-        "_writer_id",
+        "_run_identity",
         "_mozaiks_context_authority_policy",
     )
 
@@ -166,14 +202,41 @@ class ContextVariablesBridge:
         data: dict[str, Any],
         *,
         authority_policy: ContextAuthorityPolicy | None = None,
-        writer_id: str = CONTEXT_BRIDGE_WRITER,
     ) -> None:
         self.__data: dict[str, Any] = detach(data)  # type: ignore[assignment]
         self._pending_set: dict[str, Any] = {}
         self._pending_delete: set[str] = set()
+        self._pending_writers: dict[str, ContextWriterId] = {}
         self._authority_policy = authority_policy
-        self._writer_id = writer_id
+        self._run_identity: tuple[str, str, str] | None = None
         self._mozaiks_context_authority_policy = authority_policy
+
+    def _bind_run(
+        self, run_identity: tuple[str, str, str], policy: ContextAuthorityPolicy | None,
+    ) -> None:
+        if policy is not self._authority_policy:
+            raise ContextAuthorityError("context_authority.bridge_policy_mismatch")
+        if policy is not None and policy.workflow_name != run_identity[0]:
+            raise ContextAuthorityError("context_authority.bridge_workflow_mismatch")
+        if self._run_identity is not None and self._run_identity != run_identity:
+            raise ContextAuthorityError("context_authority.bridge_run_mismatch")
+        self._run_identity = run_identity
+
+    def _effective_writer(self, key: str) -> ContextWriterId:
+        invocation = _WORKFLOW_TOOL_INVOCATION.get()
+        if (
+            invocation is not None
+            and invocation.active
+            and invocation.bridge is self
+            and invocation.policy is self._authority_policy
+            and invocation.run_identity is not None
+            and invocation.run_identity == self._run_identity
+        ):
+            return resolve_declared_context_writer(
+                key, base_writer=CONTEXT_BRIDGE_WRITER,
+                declared_writer=DETERMINISTIC_TOOL_WRITER, policy=self._authority_policy,
+            )
+        return CONTEXT_BRIDGE_WRITER
 
     # AG2-compatible read/write API
     def get(self, key: str, default: Any = None) -> Any:
@@ -189,23 +252,27 @@ class ContextVariablesBridge:
         clean_key = str(key or "").strip()
         if not clean_key:
             raise KeyError("context variable key must be non-empty")
+        writer = self._effective_writer(clean_key)
         if self._authority_policy is not None:
-            self._authority_policy.require_can_write(clean_key, writer_id=self._writer_id, operation="set")  # type: ignore[arg-type]
+            self._authority_policy.require_can_write(clean_key, writer_id=writer, operation="set")
         self.__data[clean_key] = detach(value)
         self._pending_set[clean_key] = detach(value)
         self._pending_delete.discard(clean_key)
+        self._pending_writers[clean_key] = writer
 
     def pop(self, key: str, default: Any = None) -> Any:
         clean_key = str(key or "").strip()
         if not clean_key:
             raise KeyError("context variable key must be non-empty")
+        writer = self._effective_writer(clean_key)
         if self._authority_policy is not None:
-            self._authority_policy.require_can_write(clean_key, writer_id=self._writer_id, operation="delete")  # type: ignore[arg-type]
+            self._authority_policy.require_can_write(clean_key, writer_id=writer, operation="delete")
         existed = clean_key in self.__data
         value = self.__data.pop(clean_key, default)
         if existed:
             self._pending_set.pop(clean_key, None)
             self._pending_delete.add(clean_key)
+            self._pending_writers[clean_key] = writer
         return detach(value)
 
     def delete(self, key: str) -> None:
@@ -254,6 +321,20 @@ class ContextVariablesBridge:
     def clear_context_updates(self) -> None:
         self._pending_set.clear()
         self._pending_delete.clear()
+        self._pending_writers.clear()
+
+    def consume_authorized_context_updates(
+        self, *, policy: ContextAuthorityPolicy | None, run_identity: tuple[str, str, str],
+    ) -> dict[str, Any]:
+        self._bind_run(run_identity, policy)
+        for operation, keys in (("set", self._pending_set), ("delete", self._pending_delete)):
+            for key in keys:
+                writer = self._pending_writers.get(key)
+                if writer is None:
+                    raise ContextAuthorityError("context_authority.missing_mutation_provenance")
+                if policy is not None:
+                    policy.require_can_write(key, writer_id=writer, operation=operation)
+        return self.consume_context_updates()
 
     def consume_context_updates(self) -> dict[str, Any]:
         updates = {
@@ -324,16 +405,26 @@ def _wrap_tool_with_context(fn: Callable, context_bridge: ContextVariablesBridge
     if inspect.iscoroutinefunction(fn):
         @wraps(fn)
         async def async_wrapper(*args, **kwargs):
-            kwargs.setdefault("context_variables", context_bridge)
-            return await fn(*args, **kwargs)
+            if "context_variables" in kwargs:
+                raise ContextAuthorityError("context_authority.tool_context_override")
+            bound = new_sig.bind(*args, **kwargs)
+            bound.arguments["context_variables"] = context_bridge
+            call = inspect.BoundArguments(sig, bound.arguments)
+            with _workflow_tool_invocation(context_bridge):
+                return await fn(*call.args, **call.kwargs)
 
         async_wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
         return async_wrapper
     else:
         @wraps(fn)
         def sync_wrapper(*args, **kwargs):
-            kwargs.setdefault("context_variables", context_bridge)
-            return fn(*args, **kwargs)
+            if "context_variables" in kwargs:
+                raise ContextAuthorityError("context_authority.tool_context_override")
+            bound = new_sig.bind(*args, **kwargs)
+            bound.arguments["context_variables"] = context_bridge
+            call = inspect.BoundArguments(sig, bound.arguments)
+            with _workflow_tool_invocation(context_bridge):
+                return fn(*call.args, **call.kwargs)
 
         sync_wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
         return sync_wrapper

--- a/mozaiksai/core/workflow/context/authority.py
+++ b/mozaiksai/core/workflow/context/authority.py
@@ -372,6 +372,24 @@ class ScopedContextWriter:
             raise ContextAuthorityError("context_authority.unsupported_target")
 
 
+def resolve_declared_context_writer(
+    key: str,
+    *,
+    base_writer: ContextWriterId,
+    declared_writer: ContextWriterId,
+    policy: ContextAuthorityPolicy | None,
+) -> ContextWriterId:
+    """Resolve a trusted mechanism's declared attribution, without granting rights.
+
+    Callers establish the mutation mechanism before supplying its writer pair.
+    The returned writer still requires the ordinary policy authorization check.
+    """
+    authority = policy.variables.get(key) if policy is not None else None
+    if authority is not None and declared_writer in authority.writer_ids:
+        return declared_writer
+    return base_writer
+
+
 def build_context_authority_policy(
     *,
     workflow_name: str,

--- a/tests/test_ag2_network_tool_routing.py
+++ b/tests/test_ag2_network_tool_routing.py
@@ -1,0 +1,403 @@
+"""Real factory/tool/Network acceptance with only provider HTTP replaced."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest
+from ag2 import Agent
+from ag2.events import BaseEvent, ToolCallEvent, ToolErrorEvent, ToolResultEvent
+from ag2.network import EV_PACKET, TransitionGraph
+from ag2.observers import observer
+
+from mozaiksai.core.adapters.ag2_network_runner import (
+    AG2NetworkRunner,
+    AG2NetworkRunnerRequest,
+    AG2NetworkRunnerResult,
+)
+from mozaiksai.core.ports.orchestration import RunStatus
+from mozaiksai.core.workflow.agents import factory
+from mozaiksai.core.workflow.context.adapter import create_context_container
+from mozaiksai.core.workflow.context.authority import (
+    ContextAuthorityError,
+    ContextAuthorityPolicy,
+    build_context_authority_policy,
+)
+from mozaiksai.core.workflow.execution.network_graph import compile_transition_rules_to_graph
+
+_WORKFLOW = "IndependentToolRouting"
+_KEY = "review_scope_confirmed"
+
+
+def _after(source: str, target: str = "terminate") -> dict[str, Any]:
+    return {"source_agent": source, "target_agent": target, "transition_type": "after_turn"}
+
+
+def _rules(condition: str = "tool_called", *, pause: bool = False) -> list[dict[str, Any]]:
+    rule: dict[str, Any] = {
+        "source_agent": "AgentA",
+        "target_agent": "AgentB",
+        "transition_type": "condition",
+        "condition_type": condition,
+    }
+    if condition == "tool_called":
+        rule["tool_name"] = "complete_intake"
+    else:
+        rule.update(condition_key=_KEY, condition_value=True)
+    return [
+        rule,
+        _after("AgentA"),
+        _after("AgentB", "user" if pause else "terminate"),
+        _after("AgentC"),
+        _after("user"),
+    ]
+
+
+def _policy(rules: list[dict[str, Any]], *, allowed: bool = True) -> ContextAuthorityPolicy:
+    return build_context_authority_policy(
+        workflow_name=_WORKFLOW,
+        definitions={
+            _KEY: {
+                "type": "boolean",
+                "source": {"type": "state", "default": False},
+                "authority_class": "closed_writer_routing_state",
+                "writer_ids": ["deterministic_tool" if allowed else "transition_router"],
+                "routing": True,
+            },
+        },
+        transition_rules=rules,
+    )
+
+
+@dataclass
+class _SDKScenario:
+    tool_names: tuple[str, ...] = ("complete_intake",)
+    source: str = "AgentA"
+    final_text: str = "Intake finished."
+    mutate_context: bool = False
+    requests: Counter[str] = field(default_factory=Counter)
+    calls: list[str] = field(default_factory=list)
+    events: dict[str, list[BaseEvent]] = field(default_factory=lambda: defaultdict(list))
+    request_bodies: list[dict[str, Any]] = field(default_factory=list)
+
+    def respond(self, request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "provider.invalid"
+        payload = json.loads(request.content)
+        self.request_bodies.append(payload)
+        agent = payload["model"]
+        self.requests[agent] += 1
+        call_tools = agent == self.source and self.requests[agent] == 1 and self.tool_names
+        message: dict[str, Any] = {"role": "assistant", "content": self.final_text}
+        if call_tools:
+            available = {item["function"]["name"] for item in payload["tools"]}
+            assert set(self.tool_names) <= available
+            message.update(
+                content=None,
+                tool_calls=[
+                    {
+                        "id": f"call-{index}",
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": "{}",
+                        },
+                    }
+                    for index, name in enumerate(self.tool_names)
+                ],
+            )
+        elif agent != self.source:
+            message["content"] = f"{agent} executed."
+        return httpx.Response(
+            200,
+            json={
+                "id": f"completion-{agent}-{self.requests[agent]}",
+                "object": "chat.completion",
+                "created": 1,
+                "model": agent,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": "tool_calls" if call_tools else "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+
+class _WorkflowManager:
+    def get_config(self, workflow_name: str) -> dict[str, Any]:
+        assert workflow_name == _WORKFLOW
+        return {
+            "agents": [
+                {
+                    "name": name,
+                    "system_message": f"Act as {name}.",
+                    "structured_outputs_required": False,
+                }
+                for name in ("AgentA", "AgentB", "AgentC")
+            ]
+        }
+
+    def get_auto_tool_agents(self, workflow_name: str) -> set[str]:
+        return set()
+
+    def resolve_workflow_path(self, workflow_name: str) -> None:
+        return None
+
+
+async def _agents(
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: _SDKScenario,
+    client: httpx.AsyncClient,
+    policy: ContextAuthorityPolicy,
+) -> dict[str, Agent]:
+    from mozaiksai.core import observability
+    from mozaiksai.core.workflow import llm_config
+    from mozaiksai.core.workflow.agents import tools
+    from mozaiksai.core.workflow.outputs import structured
+
+    async def complete_intake(context_variables: Any) -> str:
+        """Record the completed intake through the injected workflow context."""
+        scenario.calls.append("complete_intake")
+        if scenario.mutate_context:
+            context_variables[_KEY] = True
+        return "intake recorded"
+
+    async def other_tool(context_variables: Any) -> str:
+        """Perform a different deterministic operation."""
+        scenario.calls.append("other_tool")
+        return "other operation recorded"
+
+    async def config(
+        *args: Any, agent_name: str = "AgentA", **kwargs: Any
+    ) -> tuple[None, dict[str, Any]]:
+        return None, {
+            "config_list": [
+                {
+                    "model": agent_name,
+                    "api_type": "openai",
+                    "api_key": "test-only",
+                    "base_url": "https://provider.invalid/v1",
+                }
+            ],
+            "streaming": False,
+        }
+
+    original_converter = factory.llm_config_to_ag2_config
+
+    def convert(value: dict[str, Any]) -> Any:
+        return original_converter(value).copy(http_client=client)
+
+    def observers(*, agent_name: str, **kwargs: Any) -> list[Any]:
+        async def record(event: BaseEvent) -> None:
+            scenario.events[agent_name].append(event)
+
+        return [observer(ToolCallEvent | ToolResultEvent, record)]
+
+    monkeypatch.setattr(factory, "workflow_manager", _WorkflowManager())
+    monkeypatch.setattr(factory, "get_structured_outputs_for_workflow", lambda _workflow: {})
+    monkeypatch.setattr(factory, "llm_config_to_ag2_config", convert)
+    monkeypatch.setattr(llm_config, "get_llm_config", config)
+    monkeypatch.setattr(structured, "get_llm_for_workflow", config)
+    monkeypatch.setattr(
+        tools,
+        "load_agent_tool_functions",
+        lambda _workflow: {name: [complete_intake, other_tool] for name in ("AgentA", "AgentC")},
+    )
+    monkeypatch.setattr(observability, "build_ag2_token_watchdog_observers", observers)
+    context = create_context_container(
+        initial={_KEY: False},
+        chat_id="tool-routing-chat",
+        app_id="tool-routing-app",
+        authority_policy=policy,
+    )
+    agents = await factory.create_agents(_WORKFLOW, context_variables=context)
+    assert set(agents) == {"AgentA", "AgentB", "AgentC"}
+    assert all(type(agent) is Agent for agent in agents.values())
+    return agents
+
+
+async def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: _SDKScenario,
+    rules: list[dict[str, Any]],
+    *,
+    allowed: bool = True,
+) -> AG2NetworkRunnerResult:
+    policy = _policy(rules, allowed=allowed)
+    graph = compile_transition_rules_to_graph(
+        rules,
+        initial_agent_name=scenario.source,
+        context_authority_policy=policy,
+        agent_id_by_name={name: name for name in ("AgentA", "AgentB", "AgentC")},
+    )
+    assert TransitionGraph.loads(json.dumps(graph.to_dict())).to_dict() == graph.to_dict()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(scenario.respond)) as client:
+        agents = await _agents(monkeypatch, scenario, client, policy)
+        result = await AG2NetworkRunner().run(
+            AG2NetworkRunnerRequest(
+                workflow_name=_WORKFLOW,
+                chat_id="tool-routing-chat",
+                app_id="tool-routing-app",
+                agents=agents,
+                transition_rules=rules,
+                initial_agent_name=scenario.source,
+                initial_message="Complete the current deterministic operation.",
+                context_variables={_KEY: False},
+                context_authority_policy=policy,
+                close_timeout_seconds=3.0,
+            )
+        )
+    return result
+
+
+def _packets(result: AG2NetworkRunnerResult, agent: str) -> list[dict[str, Any]]:
+    return [
+        entry["event_data"]
+        for entry in result.wal
+        if entry["event_type"] == EV_PACKET
+        and result.agent_name_by_id.get(entry["sender_id"]) == agent
+    ]
+
+
+def _assert_real_tool_events(scenario: _SDKScenario, names: tuple[str, ...]) -> None:
+    events = scenario.events[scenario.source]
+    calls = [event for event in events if isinstance(event, ToolCallEvent)]
+    results = [event for event in events if isinstance(event, ToolResultEvent)]
+    assert Counter(event.name for event in calls) == Counter(names)
+    assert {event.parent_id for event in results} == {event.id for event in calls}
+    assert Counter(scenario.calls) == Counter(names)
+    for payload in scenario.request_bodies:
+        for tool in payload.get("tools", []):
+            assert "context_variables" not in tool["function"]["parameters"].get("properties", {})
+
+
+@pytest.mark.asyncio
+async def test_factory_tool_authority_reaches_network_context_equals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _SDKScenario(mutate_context=True)
+    result = await _run(monkeypatch, scenario, _rules("context_equals"))
+    assert result.status is RunStatus.COMPLETED, result.error
+    _assert_real_tool_events(scenario, ("complete_intake",))
+    assert not [event for event in scenario.events["AgentA"] if isinstance(event, ToolErrorEvent)]
+    assert result.context_variables[_KEY] is True
+    assert scenario.requests == {"AgentA": 2, "AgentB": 1}
+    assert _packets(result, "AgentA")[0]["context_updates"]["set"] == {_KEY: True}
+    assert len(_packets(result, "AgentB")) == 1
+
+
+@pytest.mark.asyncio
+async def test_factory_tool_forbidden_write_never_reaches_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _SDKScenario(mutate_context=True)
+    result = await _run(monkeypatch, scenario, _rules("context_equals"), allowed=False)
+    _assert_real_tool_events(scenario, ("complete_intake",))
+    errors = [event for event in scenario.events["AgentA"] if isinstance(event, ToolErrorEvent)]
+    assert len(errors) == 1
+    assert isinstance(errors[0].error, ContextAuthorityError)
+    assert "context_authority.rejected" in str(errors[0].error)
+    assert result.context_variables[_KEY] is False
+    assert scenario.calls == ["complete_intake"]
+    assert scenario.requests["AgentB"] == 0
+    assert all(
+        _KEY not in packet["context_updates"]["set"] for packet in _packets(result, "AgentA")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("final_text", ["Intake finished.", ""])
+async def test_real_tool_called_handoff_survives_graph_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    final_text: str,
+) -> None:
+    scenario = _SDKScenario(final_text=final_text)
+    result = await _run(monkeypatch, scenario, _rules())
+    assert result.status is RunStatus.COMPLETED, result.error
+    _assert_real_tool_events(scenario, ("complete_intake",))
+    assert scenario.requests == {"AgentA": 2, "AgentB": 1}
+    packet = _packets(result, "AgentA")[0]
+    assert packet["routing"]["kind"] == "handoff"
+    assert packet["routing"]["tool"] == "complete_intake"
+    assert packet["body"] == final_text
+    assert len(_packets(result, "AgentB")) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source,names", [("AgentC", ("complete_intake",)), ("AgentA", ("other_tool",)), ("AgentA", ())]
+)
+async def test_tool_called_does_not_route_wrong_source_tool_or_text(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    names: tuple[str, ...],
+) -> None:
+    scenario = _SDKScenario(
+        source=source, tool_names=names, final_text="complete_intake was called"
+    )
+    result = await _run(monkeypatch, scenario, _rules())
+    assert result.status is RunStatus.COMPLETED, result.error
+    _assert_real_tool_events(scenario, names)
+    assert scenario.requests["AgentB"] == 0
+    assert _packets(result, "AgentB") == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "names,target",
+    [
+        (("complete_intake", "other_tool"), "AgentB"),
+        (("other_tool", "complete_intake"), "AgentC"),
+    ],
+)
+async def test_multiple_real_tool_calls_preserve_native_first_emitted_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    names: tuple[str, ...],
+    target: str,
+) -> None:
+    rules = _rules()
+    rules.insert(
+        0,
+        {
+            "source_agent": "AgentA",
+            "target_agent": "AgentC",
+            "transition_type": "condition",
+            "condition_type": "tool_called",
+            "tool_name": "other_tool",
+        },
+    )
+    scenario = _SDKScenario(tool_names=names)
+    result = await _run(monkeypatch, scenario, rules)
+    assert result.status is RunStatus.COMPLETED, result.error
+    _assert_real_tool_events(scenario, names)
+    assert scenario.requests == {"AgentA": 2, target: 1}
+    assert _packets(result, "AgentA")[0]["routing"]["tool"] == names[0]
+    assert len(_packets(result, target)) == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_handoff_pauses_and_resumes_without_duplicate_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _SDKScenario()
+    paused = await _run(monkeypatch, scenario, _rules(pause=True))
+    assert paused.status is RunStatus.PAUSED, paused.error
+    assert paused.live_run is not None
+    try:
+        assert scenario.requests == {"AgentA": 2, "AgentB": 1}
+        assert len(_packets(paused, "AgentA")) == len(_packets(paused, "AgentB")) == 1
+        continued = await paused.live_run.continue_with_user_message("Continue after review.")
+        assert continued.status is RunStatus.COMPLETED, continued.error
+        assert scenario.requests == {"AgentA": 2, "AgentB": 1}
+        assert scenario.calls == ["complete_intake"]
+        assert not _packets(continued, "AgentA")
+        assert not _packets(continued, "AgentB")
+    finally:
+        await paused.live_run.close()

--- a/tests/test_workflow_network_graph.py
+++ b/tests/test_workflow_network_graph.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
+from ag2.events import BaseEvent, ToolCallEvent, ToolResultEvent
 from ag2.network import (
     EV_PACKET,
     Envelope,
+    ToolCalled,
     TransitionGraph,
     WorkflowAdapter,
     WorkflowState,
 )
 
+from mozaiksai.core.adapters.ag2_transition_conditions import SourceScopedToolCalled
 from mozaiksai.core.workflow.agents.transition_graph import wire_transition_graph_with_debugging
 from mozaiksai.core.workflow.execution.network_graph import (
     WorkflowGraphCompileError,
@@ -267,40 +271,166 @@ def test_context_expression_condition_uses_ag2_context_expression_and_is_source_
     )
 
 
-def test_tool_called_condition_uses_ag2_routing_tool_packet():
-    graph = compile_transition_rules_to_graph(
+@pytest.fixture
+def tool_called_graph() -> TransitionGraph:
+    return compile_transition_rules_to_graph(
         [
+            {
+                "source_agent": "PlannerAgent",
+                "target_agent": "user",
+                "transition_type": "after_turn",
+            },
             {
                 "source_agent": "PlannerAgent",
                 "target_agent": "ReviewAgent",
                 "transition_type": "condition",
                 "condition_type": "tool_called",
                 "tool_name": "route_to_review",
-            }
+            },
+            {
+                "source_agent": "PlannerAgent",
+                "target_agent": "WorkerAgent",
+                "transition_type": "condition",
+                "condition_type": "tool_called",
+                "tool_name": "route_to_review",
+            },
         ],
         initial_agent_name="PlannerAgent",
-        agent_id_by_name={"PlannerAgent": "PlannerAgent", "ReviewAgent": "ReviewAgent"},
+        agent_id_by_name={
+            "PlannerAgent": "agent-planner",
+            "ReviewAgent": "agent-review",
+            "WorkerAgent": "agent-worker",
+        },
     )
+
+
+def _build_tool_round_packet(
+    graph: TransitionGraph,
+    *,
+    sender_id: str,
+    body: str,
+    events: list[BaseEvent],
+) -> tuple[Envelope | None, WorkflowState]:
     state = WorkflowState(
-        participant_order=["PlannerAgent", "ReviewAgent"],
-        expected_next_speaker="PlannerAgent",
-        last_speaker_id="PlannerAgent",
+        participant_order=["agent-planner", "agent-review", "agent-worker", "user"],
+        expected_next_speaker=sender_id,
+        last_speaker_id=sender_id,
         turn_count=1,
         creator_id="user",
         graph_data=graph.to_dict(),
         context_vars={},
     )
-    envelope = Envelope(
-        channel_id="mozaiks-local-routing",
-        sender_id="PlannerAgent",
-        audience=None,
-        event_type=EV_PACKET,
-        event_data={"routing": {"tool": "route_to_review"}},
+    packet = WorkflowAdapter().build_round_envelope(
+        metadata=SimpleNamespace(channel_id="mozaiks-local-routing"),
+        sender_id=sender_id,
+        reply=SimpleNamespace(body=body),
+        events=events,
+        state=state,
+        hub=SimpleNamespace(name_to_id_map=lambda: {}),
+    )
+    return packet, state
+
+
+def test_tool_called_condition_round_trip_retains_native_subtype_and_source(
+    tool_called_graph: TransitionGraph,
+) -> None:
+    serialized = tool_called_graph.to_dict()
+    rehydrated = TransitionGraph.loads(serialized)
+
+    assert rehydrated.to_dict() == serialized
+    conditions = [
+        transition.when
+        for transition in rehydrated.transitions
+        if isinstance(transition.when, SourceScopedToolCalled)
+    ]
+    assert len(conditions) == 2
+    for condition in conditions:
+        assert isinstance(condition, ToolCalled)
+        assert condition.name == "mozaiks_source_tool_called"
+        assert condition.source_agent_id == "agent-planner"
+        assert condition.tool_name == "route_to_review"
+    assert [
+        transition["when"]["args"]
+        for transition in serialized["transitions"]
+        if transition["when"]["name"] == "mozaiks_source_tool_called"
+    ] == [{"source_agent_id": "agent-planner", "tool_name": "route_to_review"}] * 2
+
+
+@pytest.mark.parametrize("body", ["", "The review is ready."])
+def test_tool_called_condition_uses_native_events_before_fallback_and_later_matching_rule(
+    tool_called_graph: TransitionGraph,
+    body: str,
+) -> None:
+    call = ToolCallEvent("route_to_review")
+    packet, state = _build_tool_round_packet(
+        TransitionGraph.loads(tool_called_graph.to_dict()),
+        sender_id="agent-planner",
+        body=body,
+        events=[call, ToolResultEvent.from_call(call, "saved")],
     )
 
-    next_state = WorkflowAdapter().fold(envelope, state)
+    assert packet is not None
+    assert packet.event_type == EV_PACKET
+    assert packet.event_data["body"] == body
+    assert packet.event_data["routing"] == {
+        "kind": "handoff",
+        "tool": "route_to_review",
+        "reason": "",
+    }
+    next_state = WorkflowAdapter().fold(packet, state)
+    assert next_state.expected_next_speaker == "agent-review"
 
-    assert next_state.expected_next_speaker == "ReviewAgent"
+
+@pytest.mark.parametrize("body", ["", "The review is ready."])
+def test_tool_called_native_packet_keeps_source_scope_for_same_named_tool(
+    tool_called_graph: TransitionGraph,
+    body: str,
+) -> None:
+    call = ToolCallEvent("route_to_review")
+    packet, state = _build_tool_round_packet(
+        TransitionGraph.loads(tool_called_graph.to_dict()),
+        sender_id="agent-worker",
+        body=body,
+        events=[call, ToolResultEvent.from_call(call, "saved")],
+    )
+
+    assert packet is not None
+    assert packet.event_data["routing"]["tool"] == "route_to_review"
+    assert "target" not in packet.event_data["routing"]
+    next_state = WorkflowAdapter().fold(packet, state)
+    assert next_state.expected_next_speaker is None
+    assert next_state.pending_close_reason == "no_transition_matched"
+
+
+@pytest.mark.parametrize("body", ["", "route_to_review"])
+@pytest.mark.parametrize("event_case", ["text_only", "result_only", "wrong_tool", "unpaired_result"])
+def test_tool_called_requires_matching_native_call_event(
+    tool_called_graph: TransitionGraph,
+    body: str,
+    event_case: str,
+) -> None:
+    matching_call = ToolCallEvent("route_to_review")
+    matching_result = ToolResultEvent.from_call(matching_call, "saved")
+    other_call = ToolCallEvent("other_tool")
+    event_cases: dict[str, list[BaseEvent]] = {
+        "text_only": [],
+        "result_only": [matching_result],
+        "wrong_tool": [other_call, ToolResultEvent.from_call(other_call, "route_to_review")],
+        "unpaired_result": [other_call, matching_result],
+    }
+    packet, state = _build_tool_round_packet(
+        tool_called_graph,
+        sender_id="agent-planner",
+        body=body,
+        events=event_cases[event_case],
+    )
+
+    if not body:
+        assert packet is None
+    else:
+        assert packet is not None
+        assert packet.event_data["routing"] == {"kind": "text"}
+        assert WorkflowAdapter().fold(packet, state).expected_next_speaker == "user"
 
 
 def test_llm_transition_conditions_are_rejected():

--- a/tests/test_workflow_tool_writer_authority.py
+++ b/tests/test_workflow_tool_writer_authority.py
@@ -1,0 +1,319 @@
+"""Invocation provenance must never be replaceable by caller writer metadata."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from mozaiksai.core.adapters import ag2_network_runner as runner
+from mozaiksai.core.workflow.agents.factory import ContextVariablesBridge, _wrap_tool_with_context
+from mozaiksai.core.workflow.context.authority import (
+    AGENT_TEXT_WRITER,
+    CONTEXT_BRIDGE_WRITER,
+    DETERMINISTIC_TOOL_WRITER,
+    LIVE_USER_CONTEXT_WRITER,
+    UI_RESPONSE_TRIGGER_WRITER,
+    ContextAuthorityError,
+    ScopedContextWriter,
+    build_context_authority_policy,
+)
+from mozaiksai.core.workflow.context.schema import load_context_variables_config
+
+RUN = ("ToolAuthorityFlow", "app-1", "chat-1")
+READY = "review_scope_confirmed"
+
+
+def _policy():
+    plan = load_context_variables_config({"definitions": {
+        READY: {
+            "type": "boolean", "source": {"type": "state", "default": False},
+            "authority_class": "closed_writer_routing_state", "routing": True,
+            "writer_ids": ["deterministic_tool"],
+        },
+        "ui_approved": {
+            "type": "boolean", "source": {"type": "state", "default": False},
+            "authority_class": "closed_writer_routing_state", "routing": True,
+            "writer_ids": ["ui_response_trigger"],
+        },
+        "app_id": {"type": "string", "source": {"type": "state", "default": "app-1"}},
+        "note": {"type": "string", "source": {"type": "state", "default": ""}},
+    }})
+    return build_context_authority_policy(workflow_name=RUN[0], definitions=plan.definitions)
+
+
+def _bridge(*, bind=True):
+    policy = _policy()
+    bridge = ContextVariablesBridge(
+        {READY: False, "ui_approved": False, "app_id": RUN[1], "note": ""},
+        authority_policy=policy,
+    )
+    if bind:
+        bridge._bind_run(RUN, policy)
+    return bridge, policy
+
+
+def _set_ready(context_variables):
+    context_variables.set(READY, True)
+
+
+@pytest.mark.parametrize("scoped", [False, True])
+def test_bound_tool_preserves_writer_until_authorized_projection(scoped):
+    bridge, policy = _bridge()
+
+    def tool(context_variables):
+        if scoped:
+            ScopedContextWriter(policy, DETERMINISTIC_TOOL_WRITER).set(context_variables, READY, True)
+        else:
+            _set_ready(context_variables)
+
+    _wrap_tool_with_context(tool, bridge)()
+    assert bridge.get(READY) is True
+    updates = bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN)
+    assert updates == {"set": {READY: True}, "delete": []}
+    assert bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN) == {
+        "set": {}, "delete": [],
+    }
+
+
+@pytest.mark.parametrize("operation", ["set", "delete"])
+@pytest.mark.parametrize("key", [READY, "ui_approved", "app_id"])
+def test_ordinary_bridge_cannot_claim_tool_or_server_authority(operation, key):
+    bridge, _ = _bridge()
+    before = bridge.snapshot()
+    with pytest.raises(ContextAuthorityError):
+        bridge.set(key, True) if operation == "set" else bridge.delete(key)
+    assert bridge.snapshot() == before
+    assert bridge.consume_context_updates() == {"set": {}, "delete": []}
+
+
+@pytest.mark.parametrize("operation", ["set", "delete"])
+@pytest.mark.parametrize("key", ["ui_approved", "app_id"])
+def test_actual_tool_cannot_write_undeclared_mechanism_or_server_state(operation, key):
+    bridge, _ = _bridge()
+    before = bridge.snapshot()
+
+    def tool(context_variables):
+        context_variables.set(key, True) if operation == "set" else context_variables.delete(key)
+
+    with pytest.raises(ContextAuthorityError):
+        _wrap_tool_with_context(tool, bridge)()
+    assert bridge.snapshot() == before
+    assert bridge.consume_context_updates() == {"set": {}, "delete": []}
+
+
+def test_tool_before_run_binding_cannot_create_adoptable_pending_authority():
+    bridge, policy = _bridge(bind=False)
+    with pytest.raises(ContextAuthorityError):
+        _wrap_tool_with_context(_set_ready, bridge)()
+    bridge._bind_run(RUN, policy)
+    assert bridge.get(READY) is False
+    assert bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN) == {
+        "set": {}, "delete": [],
+    }
+
+
+def test_caller_writer_string_and_scoped_writer_cannot_elevate_ordinary_bridge():
+    bridge, policy = _bridge()
+    with pytest.raises(TypeError):
+        ContextVariablesBridge({}, authority_policy=policy, writer_id="deterministic_tool")
+    with pytest.raises(AttributeError):
+        bridge.writer_id = "deterministic_tool"
+    with pytest.raises(ContextAuthorityError):
+        ScopedContextWriter(policy, DETERMINISTIC_TOOL_WRITER).set(bridge, READY, True)
+    assert bridge.get(READY) is False
+
+
+@pytest.mark.parametrize("writer", [
+    CONTEXT_BRIDGE_WRITER, UI_RESPONSE_TRIGGER_WRITER, LIVE_USER_CONTEXT_WRITER, AGENT_TEXT_WRITER,
+])
+def test_untrusted_update_cannot_request_deterministic_attribution(writer):
+    with pytest.raises(ContextAuthorityError, match="untrusted_writer_attribution"):
+        runner._authorized_context_updates(
+            {READY: True}, writer_id=writer, elevated_writer_id=DETERMINISTIC_TOOL_WRITER,
+            context_authority_policy=_policy(),
+        )
+
+
+@pytest.mark.parametrize("replacement", ["keyword", "positional", "metadata"])
+def test_tool_caller_cannot_replace_hidden_context_or_supply_writer_privilege(replacement):
+    bridge, _ = _bridge()
+    entered = []
+
+    def tool(value, context_variables=None, **metadata):
+        entered.append(value)
+        assert context_variables is bridge
+        return metadata
+
+    wrapped = _wrap_tool_with_context(tool, bridge)
+    assert "context_variables" not in inspect.signature(wrapped).parameters
+    if replacement == "keyword":
+        with pytest.raises(ContextAuthorityError, match="tool_context_override"):
+            wrapped("value", context_variables={})
+    elif replacement == "positional":
+        with pytest.raises(TypeError):
+            wrapped("value", {})
+    else:
+        assert wrapped("value", writer_id="deterministic_tool") == {"writer_id": "deterministic_tool"}
+        with pytest.raises(ContextAuthorityError):
+            bridge.set(READY, True)
+    assert entered == (["value"] if replacement == "metadata" else [])
+    assert bridge.get(READY) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_mode", ["return", "error", "cancel"])
+async def test_child_task_inherits_revocation_after_tool_exit(exit_mode):
+    bridge, _ = _bridge()
+    release = asyncio.Event()
+    started = asyncio.Event()
+    children = []
+
+    async def escaped(context_variables):
+        await release.wait()
+        context_variables.set(READY, True)
+
+    async def tool(context_variables):
+        children.append(asyncio.create_task(escaped(context_variables)))
+        started.set()
+        if exit_mode == "error":
+            raise ValueError("tool failed")
+        if exit_mode == "cancel":
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(_wrap_tool_with_context(tool, bridge)())
+    await started.wait()
+    if exit_mode == "cancel":
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    elif exit_mode == "error":
+        with pytest.raises(ValueError, match="tool failed"):
+            await task
+    else:
+        await task
+    release.set()
+    with pytest.raises(ContextAuthorityError):
+        await children[0]
+    assert bridge.get(READY) is False
+    assert bridge.consume_context_updates() == {"set": {}, "delete": []}
+
+
+@pytest.mark.asyncio
+async def test_nested_tool_scopes_restore_only_their_own_bridge():
+    first, policy = _bridge()
+    second = ContextVariablesBridge({READY: False}, authority_policy=policy)
+    second._bind_run((RUN[0], RUN[1], "chat-2"), policy)
+
+    async def inner(context_variables):
+        context_variables.set(READY, True)
+        with pytest.raises(ContextAuthorityError):
+            first.set(READY, True)
+
+    async def outer(context_variables):
+        with pytest.raises(ContextAuthorityError):
+            second.set(READY, True)
+        await _wrap_tool_with_context(inner, second)()
+        context_variables.set(READY, True)
+
+    await _wrap_tool_with_context(outer, first)()
+    assert first.get(READY) is True
+    assert second.get(READY) is True
+    for bridge in (first, second):
+        with pytest.raises(ContextAuthorityError):
+            bridge.delete(READY)
+
+
+@pytest.mark.parametrize("other_run", [
+    ("OtherFlow", RUN[1], RUN[2]), (RUN[0], "app-2", RUN[2]), (RUN[0], RUN[1], "chat-2"),
+])
+def test_pending_mutation_cannot_be_projected_into_another_run(other_run):
+    bridge, policy = _bridge()
+    _wrap_tool_with_context(_set_ready, bridge)()
+    with pytest.raises(ContextAuthorityError, match="bridge_(workflow|run)_mismatch"):
+        bridge.consume_authorized_context_updates(policy=policy, run_identity=other_run)
+    assert bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN)["set"] == {READY: True}
+
+
+@pytest.mark.parametrize("missing_policy", [False, True])
+def test_equal_declarations_or_missing_policy_cannot_replace_bound_policy(missing_policy):
+    bridge, policy = _bridge()
+    _wrap_tool_with_context(_set_ready, bridge)()
+    with pytest.raises(ContextAuthorityError, match="bridge_policy_mismatch"):
+        bridge.consume_authorized_context_updates(
+            policy=None if missing_policy else _policy(), run_identity=RUN,
+        )
+    assert bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN)["set"] == {READY: True}
+
+
+@pytest.mark.parametrize("last_operation", ["set", "delete"])
+def test_final_operation_preserves_attribution_and_detaches_values(last_operation):
+    bridge, policy = _bridge()
+
+    def tool(context_variables):
+        context_variables.set(READY, True)
+        context_variables.delete(READY)
+        if last_operation == "set":
+            context_variables.set(READY, True)
+
+    _wrap_tool_with_context(tool, bridge)()
+    values = {"nested": ["safe"]}
+    bridge.set("note", values)
+    values["nested"].append("caller mutation")
+    updates = bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN)
+    assert updates["set"]["note"] == {"nested": ["safe"]}
+    assert updates["delete"] == ([READY] if last_operation == "delete" else [])
+    assert (READY in updates["set"]) == (last_operation == "set")
+    updates["set"]["note"]["nested"].append("packet mutation")
+    assert bridge.snapshot()["note"] == {"nested": ["safe"]}
+
+
+def test_projection_revalidates_whole_pending_batch_before_consuming():
+    bridge, policy = _bridge()
+    _wrap_tool_with_context(_set_ready, bridge)()
+    bridge.set("note", "allowed")
+    original = policy.variables[READY]
+    # Revocation after mutation must still be enforced at packet projection.
+    policy.variables[READY] = replace(original, writer_ids=frozenset({UI_RESPONSE_TRIGGER_WRITER}))
+    with pytest.raises(ContextAuthorityError):
+        bridge.consume_authorized_context_updates(policy=policy, run_identity=RUN)
+    assert bridge.consume_context_updates() == {"set": {READY: True, "note": "allowed"}, "delete": []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_bridge", [False, True])
+@pytest.mark.parametrize("operation,key", [("set", READY), ("delete", READY), ("delete", "app_id")])
+async def test_raw_packet_metadata_never_inherits_tool_attribution(monkeypatch, with_bridge, operation, key):
+    bridge, policy = _bridge()
+    sent = []
+    handlers = []
+
+    async def send(envelope):
+        sent.append(envelope)
+        return "sent"
+
+    client = SimpleNamespace(send_envelope=send, on_envelope=handlers.append)
+    agent = SimpleNamespace(_mozaiks_context_bridge=bridge) if with_bridge else SimpleNamespace()
+    updates = {"set": {key: True} if operation == "set" else {},
+               "delete": [key] if operation == "delete" else [],
+               "writer_id": "deterministic_tool"}
+    outgoing = SimpleNamespace(event_type=runner.EV_PACKET, channel_id="channel-1", event_data={
+        "context_updates": updates, "writer_id": "deterministic_tool",
+    })
+
+    async def default_handler(envelope, active_client):
+        if with_bridge:
+            _wrap_tool_with_context(_set_ready, bridge)()
+        await active_client.send_envelope(outgoing)
+
+    monkeypatch.setattr(runner, "default_handler", default_handler)
+    runner._install_context_update_handler(
+        agent=agent, client=client, agent_name="A", run_identity=RUN, context_authority_policy=policy,
+    )
+    with pytest.raises(ContextAuthorityError):
+        await handlers[0](SimpleNamespace(channel_id="channel-1"))
+    assert sent == []
+    assert client.send_envelope is send
+    assert bridge.consume_context_updates() == {"set": {}, "delete": []}


### PR DESCRIPTION
Deterministic workflow tools could not update routing state that explicitly allowed `deterministic_tool`: the factory bridge rejected the write as `context_bridge` before the Network adapter could publish it. Separately, source-scoped `tool_called` conditions were invisible to AG2's native packet builder, so a successfully executed tool did not dispatch the next agent.

## Related issue

N/A — two generic runtime defects reproduced by the compatibility gate.

## Current-main verification

- [x] Started from exact green main `451caaff5ac1d558de517eeb604b8c325d5e4331`, after merged #486 post-main CI succeeded.
- [x] Reproduced both failures against the unchanged main tree: an actual callable produced tool events but its context write was rejected; source-scoped tool routing stayed text-only, and the empty-text turn timed out.

## Summary

The trusted factory callable boundary now establishes invocation provenance bound to the exact bridge, policy instance, and workflow/app/chat run. One authority helper resolves the declared mechanism before the existing early permission check. Each pending set/delete retains its authorized writer for a second policy check before packet publication. Caller writer strings, hidden-context replacement, unbound invocations, other runs/policies, and expired child-task scopes cannot establish deterministic attribution. Raw packet sets/deletes retain ordinary bridge attribution. `ContextAuthorityPolicy` permissions are unchanged.

`SourceScopedToolCalled` is now a native `ToolCalled` subtype, which AG2 1.0.3 recognizes through its packet-builder `isinstance` check. It retains `FromSpeaker` evaluation and its registered serialization tag. AG2 continues to interpret actual tool events and construct/fold workflow packets.

The acceptance harness uses `factory.create_agents`, the real OpenAI SDK/AG2 response-processing path, actual callable tools and `ToolCallEvent`/`ToolResultEvent`, serialized/rehydrated graphs, and the actual Network runner. Only the SDK HTTP transport is fake. Correct-source handoff, context-driven dispatch, empty text, wrong source/tool, text-only and result-only negatives, native precedence, and HITL pause/resume are covered. No paid provider request was needed.

## Tests run

- Focused suite across 35 test selections: **588 passed** (`python -m pytest -q --no-cov --reruns 0 ...`). This includes context authority and immutable bridge; Network compiler/runner and new callable acceptance; HITL; `RuntimeToolCallSmoke` structure; `RuntimeContextExpressionTaskBatchSmoke`; workflow declarative/#486 version contracts; #485 structured-output contracts; module isolation; sessions/reconnect; and AG2 hygiene/watchpoints.
- New invocation-authority matrix plus actual callable acceptance: **49 passed**. Codex 3 independently ran **75 targeted tests**, all passing.
- Full `python -m pytest -q --no-cov`: **15,235 passed, 94 skipped, 4 warnings** in 18m45s; exit 0.
- `python -m ruff check .`: passed.
- Scoped mypy on the four changed production files with `--follow-imports=silent`: passed. Existing repository configuration suppresses errors in `agents.factory`; the other three modules are unsuppressed.
- `python -m mkdocs build --strict`, production-readiness source hygiene, and `git diff --check`: passed.
- Gitleaks staged scan and exact-head scan: passed. Commit is DCO signed.

The live `RuntimeToolCallSmoke` requiring provider/Mongo infrastructure was not invoked. Its checked-in structure passed, and native callable execution is separately proven through the deterministic SDK transport acceptance tests. HITL acceptance proves tool handoff, user pause, and user-triggered termination without duplicate tool or agent dispatch.

<details>
<summary>Exact focused command</summary>

```powershell
python -m pytest -q --no-cov --reruns 0 tests/test_workflow_tool_writer_authority.py tests/test_context_authority_policy.py tests/test_context_authority_hostile.py tests/test_bridge_immutable_context.py tests/test_workflow_context_authority_compile.py tests/test_workflow_network_graph.py tests/test_ag2_network_execution_alignment.py tests/test_ag2_network_tool_routing.py tests/test_ag2_network_patternbook.py tests/test_agent_factory_web_tools.py tests/test_live_runtime_smoke.py::TestRuntimeToolCallSmokeStructure tests/test_runtime_context_expression_task_batch_smoke.py tests/test_runtime_task_batch_smoke.py tests/test_workflow_declarative_contracts.py tests/test_workflow_document_versions.py tests/test_workflow_document_identity_migration.py tests/test_structured_output_canonical_identity.py tests/test_structured_output_provider_boundary.py tests/test_structured_output_runtime_contracts.py tests/test_structured_output_fail_closed.py tests/test_structured_output_cache_invalidation.py tests/test_structured_output_identity_migration.py tests/test_structured_output_helpers.py tests/test_module_dispatch_authority_contract.py tests/test_module_dispatch_authority_policy.py tests/test_module_router_context_overrides.py tests/test_workflow_session_manager.py tests/test_workflow_bridge.py tests/test_session_router.py tests/test_session_launcher.py tests/test_runtime_websocket_contract.py tests/test_tenant_isolation_helpers.py tests/test_ag2_terminology_hygiene.py tests/test_ag2_watchpoint_governance.py tests/test_ag2_dependency_contract.py
```

</details>


## OSS Change Impact

- **Layer / primitives:** universal runtime adapter and factory agent construction; `Run`, `ExecutionEngine`, and `Event`.
- **Build workflow impact:** existing declared tool/context transitions work through their current contracts. Authored workflows and workflow sequences are unchanged.
- **Runtime/platform impact:** preserves trusted tool provenance and native source-scoped routing. Platform module dispatch and context authority remain isolated.
- **App workspace impact:** no workspace or App Zero changes. Independent workflows receive the same generic correction.
- **Docs:** existing declarative/AG2 mapping, upgrade watchpoints, and Unreleased changelog.
- **Compatibility risk:** ordinary callers can no longer label raw bridge/packet writes as deterministic tools. The supported factory invocation path preserves declared authority. No schema/dependency/compiler/artifact changes.

## Boundary confirmation

- [x] Generic OSS runtime correction; no hosted-product logic, credentials, or internal URLs.
- [x] #485 acceptance algebra and #486 required versions remain unchanged: `mozaiks.orchestrator.v1` and `mozaiks.structured_outputs.v1`.
- [x] Exact diff is limited to four runtime source files, three test files, and three documentation files; all other tracked blobs match the base.

## Governance check

- [x] Ordinary correction to existing runtime contracts; no new public schema, workflow family, provider mutation path, authority bypass, or learned intelligence.
- [x] Existing context-authority policy remains the sole permission owner. Trusted-mechanism attribution and isolation were independently reviewed by Codex 3.
- [x] No publication one-way-door area requiring a new ADR.

## AI assistance

Implemented by Codex 4/Astra with bounded test/documentation assistance and independent Codex 3 review of exact head `b488b5d376ab701f9499fbb5804a8b26925f5354`.

Draft; auto-merge disabled; do not merge. [CI](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34066698461) and [DCO](https://github.com/BlocUnited-LLC/mozaiks/actions/runs/34066698477) are terminal success on the exact published head. All PR checks, including GitGuardian and secret scanning, passed. Codex 3's final exact-head disposition is **PASS, no blocking findings or outstanding publication gates**; the [final handoff](https://github.com/BlocUnited-LLC/mozaiks/pull/487#issuecomment-5563047943) records the evidence.
