### PR TITLE
feat(semantics): verify implementation artifacts by exact content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,18 @@ This project follows a practical pre-1.0 changelog format:
   analysis is closed over the full Python binding grammar including
   exception-handler and match-pattern captures. The entire real canonical
   split-pack corpus — 10 modules, 63 actions — certifies end to end with
-  proven pack-contract blob reads. The commerce module manifest's capability
-  entries were repaired to the canonical `ModuleCapability` contract (unique
-  capability ids with `kind`/`title`), which module loading requires.
+  proven pack-contract blob reads. The split-capable certifier is internal:
+  `resolve_module_action_implementation` is the only public
+  authority-producing API (no exported function accepts a preconstructed
+  split authority), direct dynamic-execution primitives are rejected in
+  construction scope even through `builtins` access, aliased builtins
+  imports, or simple rebinding (a bounded own-source proof — not a proof of
+  arbitrary imported dependency behavior), and pack-contract
+  `required_outputs` must be unambiguous: duplicate paths and omitted or
+  non-canonical authority-relevant owners reject. The commerce module
+  manifest's capability entries were repaired to the canonical
+  `ModuleCapability` contract (unique capability ids with `kind`/`title`),
+  which module loading requires.
 
 - **Closed semantic action requests**: `ActionPayload.request_contract` replaces
   shallow request fields with one immutable, bounded contract algebra for null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Added
 
+- **Content-resolved implementation artifact authority**: implementation
+  selection for the future ImplementationBinding v2 now proves exact scope,
+  canonical artifact family/address, exact verified bytes, and exact document
+  schema versions for `orchestrator.yaml`, `structured_outputs.yaml`, and
+  `module.yaml` — resolved only through the immutable blob store, never a
+  filesystem path. Structured-output contract refs resolve only against the
+  selected workflow's exact configuration, and module handler sources carry a
+  bounded static export proof: the declared handler class and action
+  `handler_method` must be explicitly present in the selected verified source.
+
 - **Closed semantic action requests**: `ActionPayload.request_contract` replaces
   shallow request fields with one immutable, bounded contract algebra for null,
   scalars, homogeneous arrays, and closed objects. Offline module-schema imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,17 +71,25 @@ This project follows a practical pre-1.0 changelog format:
   schema versions for `orchestrator.yaml`, `structured_outputs.yaml`, and
   `module.yaml` — resolved only through the immutable blob store, never a
   filesystem path. Structured-output contract refs resolve only against the
-  selected workflow's exact configuration, and module handler sources carry a
-  bounded static export proof with exactly two certification modes and no
-  general source closure: `EXPLICIT_HANDLER` (the selected `handler.py`
-  explicitly defines the action `handler_method`) and
-  `CANONICAL_BASE_HANDLER` (the capability-pack contract proves the canonical
-  workspace_handler_split ownership and the regenerated `base_handler.py`
-  class explicitly defines the method behind the preserved leaf subclass).
-  Certified implementation identity covers both source digests, and the
-  entire real canonical split-pack corpus — 10 modules, 63 actions —
-  certifies end to end. The commerce module manifest's capability entries
-  were repaired to the canonical `ModuleCapability` contract (unique
+  selected workflow's exact configuration. Handler, base-handler, and
+  pack-contract sources are scope-bound selections (execution scope must
+  equal the requesting scope and the module selection's scope), and module
+  handler sources carry a bounded static export proof with exactly two
+  certification modes and no general source closure: `EXPLICIT_HANDLER` (a
+  true standalone class — zero bases — explicitly defining the action
+  `handler_method`) and `CANONICAL_BASE_HANDLER` (the two-source
+  workspace_handler_split closure, whose ownership authority is
+  content-resolved from the exact verified bytes of the module's owning
+  capability-pack `contract.yaml`, never caller-asserted; the canonical base
+  import must be an unconditional top-level statement before the class, and
+  a leaf override of the selected method stays a two-source certification
+  with a recorded `method_source`). Certified implementation identity covers
+  the leaf digest, base digest, and pack-contract digest; rebinding
+  analysis is closed over the full Python binding grammar including
+  exception-handler and match-pattern captures. The entire real canonical
+  split-pack corpus — 10 modules, 63 actions — certifies end to end with
+  proven pack-contract blob reads. The commerce module manifest's capability
+  entries were repaired to the canonical `ModuleCapability` contract (unique
   capability ids with `kind`/`title`), which module loading requires.
 
 - **Closed semantic action requests**: `ActionPayload.request_contract` replaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,17 @@ This project follows a practical pre-1.0 changelog format:
   `module.yaml` — resolved only through the immutable blob store, never a
   filesystem path. Structured-output contract refs resolve only against the
   selected workflow's exact configuration, and module handler sources carry a
-  bounded static export proof: the declared handler class and action
-  `handler_method` must be explicitly present in the selected verified source.
+  bounded static export proof with exactly two certification modes and no
+  general source closure: `EXPLICIT_HANDLER` (the selected `handler.py`
+  explicitly defines the action `handler_method`) and
+  `CANONICAL_BASE_HANDLER` (the capability-pack contract proves the canonical
+  workspace_handler_split ownership and the regenerated `base_handler.py`
+  class explicitly defines the method behind the preserved leaf subclass).
+  Certified implementation identity covers both source digests, and the
+  entire real canonical split-pack corpus — 10 modules, 63 actions —
+  certifies end to end. The commerce module manifest's capability entries
+  were repaired to the canonical `ModuleCapability` contract (unique
+  capability ids with `kind`/`title`), which module loading requires.
 
 - **Closed semantic action requests**: `ActionPayload.request_contract` replaces
   shallow request fields with one immutable, bounded contract algebra for null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,11 @@ This project follows a practical pre-1.0 changelog format:
   split authority), direct dynamic-execution primitives are rejected in
   construction scope even through `builtins` access, aliased builtins
   imports, or simple rebinding, uninspected locally-defined callables cannot
-  be invoked or applied as decorators during module/class construction
-  (deferred runtime helpers remain allowed; a bounded own-source proof — not
-  a proof of arbitrary imported dependency behavior), and pack-contract
+  be invoked or applied as decorators during module/class construction, and
+  construction-time anonymous lambdas are prohibited except a lambda stored
+  directly in a simple named binding (deferred runtime helpers remain
+  allowed; a bounded own-source proof — not a proof of arbitrary imported
+  dependency behavior), and pack-contract
   `required_outputs` must be unambiguous: duplicate paths and omitted or
   non-canonical authority-relevant owners reject. The commerce module
   manifest's capability entries were repaired to the canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,10 @@ This project follows a practical pre-1.0 changelog format:
   authority-producing API (no exported function accepts a preconstructed
   split authority), direct dynamic-execution primitives are rejected in
   construction scope even through `builtins` access, aliased builtins
-  imports, or simple rebinding (a bounded own-source proof — not a proof of
-  arbitrary imported dependency behavior), and pack-contract
+  imports, or simple rebinding, uninspected locally-defined callables cannot
+  be invoked or applied as decorators during module/class construction
+  (deferred runtime helpers remain allowed; a bounded own-source proof — not
+  a proof of arbitrary imported dependency behavior), and pack-contract
   `required_outputs` must be unambiguous: duplicate paths and omitted or
   non-canonical authority-relevant owners reject. The commerce module
   manifest's capability entries were repaired to the canonical

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1231,10 +1231,16 @@ proof boundary of its own
   rebinding, and uninspected locally-defined callables (functions, classes,
   bound lambdas) may exist but may not be referenced during module/class
   construction — no direct or aliased invocation, no local class
-  construction, no decorator application, no lambda invoked or applied as a
-  decorator — so within this bounded own-source construction grammar the
-  certified visible class/method binding IS the effective import-time
-  export. Deferred function/method bodies may freely use local helpers
+  construction, no decorator application. Construction-time anonymous
+  lambdas are prohibited except a lambda stored directly in a simple named
+  binding (`helper = lambda: ...`); a stored lambda becomes an ordinary
+  local callable name covered by the Load-reference rule, and every other
+  lambda position (walrus, call arguments, containers, subscripts,
+  conditionals, decorators, defaults, annotations, class bases) rejects
+  generically — locally supplied executable callbacks cannot cross the
+  construction boundary. Within this bounded own-source construction
+  grammar the certified visible class/method binding IS the effective
+  import-time export. Deferred function/method bodies may freely use local helpers
   (runtime behavior, outside the import-time proof), and arbitrary imported
   dependency behavior remains outside the proof. Pack-contract `required_outputs` must be
   unambiguous at this boundary: duplicate paths reject, and

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1192,27 +1192,43 @@ proof boundary of its own
   declared action, `handler_method`, and the action request contract imported
   through the closed-contract profile; a manifest declaring another module id
   cannot be selected for a module instance.
-- handler sources are selected as `AccountedArtifact`s with a mandatory
-  non-null `content_digest` at a canonical `module_backend_handler` address
-  that matches the manifest's declared handler entrypoint, and carry a
-  **bounded static export proof** (AST-level, never executed). Certification
-  supports exactly two bounded modes and no general Python source closure:
-  `EXPLICIT_HANDLER` — the selected `handler.py` explicitly defines the
-  selected `handler_method`; and `CANONICAL_BASE_HANDLER` — the module's
-  owning capability-pack contract proves the canonical
-  `workspace_handler_split` ownership (preserved workspace-owned `handler.py`,
-  regenerated template-owned `base_handler.py`), the leaf class directly
-  subclasses the single canonical base imported exactly as
-  `from .base_handler import <Base>`, and the base class — itself with no
-  bases — explicitly defines the selected method. Both sources resolve as
-  digest-mandatory verified blobs in the same module scope and instance, and
-  the certified implementation identity covers BOTH source digests, so
-  regenerating only the base — or editing only the preserved leaf — changes
-  identity. A leaf override of the selected method certifies as
-  `EXPLICIT_HANDLER`. Arbitrary imports, mixins, multiple or transitive
-  inheritance, star or dynamic imports, redefinitions, conditional or
-  decorated definitions, monkeypatching, `__getattr__` tricks, and every
-  other dynamic export fail closed.
+- handler, base-handler, and pack-contract sources are selected as
+  scope-bound `SelectedAccountedArtifact`s (execution scope plus
+  digest-mandatory `AccountedArtifact`); the selection scope must equal both
+  the requesting scope and the module selection's scope, so identical bytes
+  under another tenant or workspace scope are never the same selection. The
+  handler address must be canonical `module_backend_handler` and match the
+  manifest's declared entrypoint, and certification carries a **bounded
+  static export proof** (AST-level, never executed) with exactly two modes
+  and no general Python source closure. `EXPLICIT_HANDLER` — a true
+  standalone one-source class: the declared handler class has ZERO bases and
+  explicitly defines the selected `handler_method` (a class declaring any
+  base is not eligible, even with an explicit method).
+  `CANONICAL_BASE_HANDLER` — the two-source `workspace_handler_split`
+  closure: the split authority is content-resolved from the exact verified
+  bytes of the module's owning capability-pack contract (canonical
+  `build_context/{contract_id}/contract.yaml` path derived from the parsed
+  contract id; the contract must own this module's manifest, its
+  workspace-owned `handler.py` leaf, and its template-owned
+  `base_handler.py`) — never caller-asserted and never inferred from
+  filenames. The leaf class directly subclasses the single canonical base,
+  bound by exactly one `from .base_handler import <Base>` that is an
+  unconditional top-level statement appearing before the class definition;
+  the base class — itself with no bases — explicitly defines the selected
+  method, or the leaf explicitly overrides it (the proof records
+  `method_source`, and an override remains a two-source
+  `CANONICAL_BASE_HANDLER` certification). The certified implementation
+  identity covers the leaf digest, the base digest, AND the pack-contract
+  digest, so regenerating only the base, editing only the preserved leaf, or
+  changing only the certification authority changes identity; module/action
+  identity stays outside it for `ImplementationBinding v2` to pin
+  separately. Rebinding analysis is closed over the Python binding grammar —
+  including exception-handler captures, match-pattern captures, walrus
+  targets (also inside comprehensions and default arguments), and type-alias
+  statements. Arbitrary imports, mixins, multiple or transitive inheritance,
+  star or dynamic or nested/conditional/late imports, redefinitions,
+  conditional or decorated definitions, monkeypatching, `__getattr__`
+  tricks, and every other dynamic export fail closed.
 
 ## OSS And Proprietary Intelligence
 

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1225,10 +1225,19 @@ proof boundary of its own
   separately. Rebinding analysis is closed over the Python binding grammar —
   including exception-handler captures, match-pattern captures, walrus
   targets (also inside comprehensions and default arguments), and type-alias
-  statements. Arbitrary imports, mixins, multiple or transitive inheritance,
-  star or dynamic or nested/conditional/late imports, redefinitions,
-  conditional or decorated definitions, monkeypatching, `__getattr__`
-  tricks, and every other dynamic export fail closed.
+  statements. Direct dynamic-execution primitives (`exec`, `eval`,
+  `setattr`, ...) are rejected in construction scope even when reached
+  through `builtins` access, aliased builtins imports, or simple rebinding —
+  a bounded static own-source export/binding proof, not a proof of arbitrary
+  imported dependency behavior. Pack-contract `required_outputs` must be
+  unambiguous at this boundary: duplicate paths reject, and
+  authority-relevant ownership must be explicit (never defaulted).
+  `resolve_module_action_implementation` is the only public
+  authority-producing API — no exported function accepts a preconstructed
+  split authority. Arbitrary imports, mixins, multiple or transitive
+  inheritance, star or dynamic or nested/conditional/late imports,
+  redefinitions, conditional or decorated definitions, monkeypatching,
+  `__getattr__` tricks, and every other dynamic export fail closed.
 
 ## OSS And Proprietary Intelligence
 

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1226,10 +1226,17 @@ proof boundary of its own
   including exception-handler captures, match-pattern captures, walrus
   targets (also inside comprehensions and default arguments), and type-alias
   statements. Direct dynamic-execution primitives (`exec`, `eval`,
-  `setattr`, ...) are rejected in construction scope even when reached
-  through `builtins` access, aliased builtins imports, or simple rebinding —
-  a bounded static own-source export/binding proof, not a proof of arbitrary
-  imported dependency behavior. Pack-contract `required_outputs` must be
+  `setattr`, `locals`, ...) are rejected in construction scope even when
+  reached through `builtins` access, aliased builtins imports, or simple
+  rebinding, and uninspected locally-defined callables (functions, classes,
+  bound lambdas) may exist but may not be referenced during module/class
+  construction — no direct or aliased invocation, no local class
+  construction, no decorator application, no lambda invoked or applied as a
+  decorator — so within this bounded own-source construction grammar the
+  certified visible class/method binding IS the effective import-time
+  export. Deferred function/method bodies may freely use local helpers
+  (runtime behavior, outside the import-time proof), and arbitrary imported
+  dependency behavior remains outside the proof. Pack-contract `required_outputs` must be
   unambiguous at this boundary: duplicate paths reject, and
   authority-relevant ownership must be explicit (never defaulted).
   `resolve_module_action_implementation` is the only public

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1195,13 +1195,24 @@ proof boundary of its own
 - handler sources are selected as `AccountedArtifact`s with a mandatory
   non-null `content_digest` at a canonical `module_backend_handler` address
   that matches the manifest's declared handler entrypoint, and carry a
-  **bounded static export proof**: the declared handler class and action
-  `handler_method` must be explicitly present in the selected verified source
-  (AST-level, never executed). Inherited methods, redefinitions, conditional
-  or decorated definitions, monkeypatching, `__getattr__` tricks, and other
-  dynamic exports fail closed. Certified implementation selection requires
-  the selected source to expose the declared handler explicitly; no
-  source-closure engine exists.
+  **bounded static export proof** (AST-level, never executed). Certification
+  supports exactly two bounded modes and no general Python source closure:
+  `EXPLICIT_HANDLER` — the selected `handler.py` explicitly defines the
+  selected `handler_method`; and `CANONICAL_BASE_HANDLER` — the module's
+  owning capability-pack contract proves the canonical
+  `workspace_handler_split` ownership (preserved workspace-owned `handler.py`,
+  regenerated template-owned `base_handler.py`), the leaf class directly
+  subclasses the single canonical base imported exactly as
+  `from .base_handler import <Base>`, and the base class — itself with no
+  bases — explicitly defines the selected method. Both sources resolve as
+  digest-mandatory verified blobs in the same module scope and instance, and
+  the certified implementation identity covers BOTH source digests, so
+  regenerating only the base — or editing only the preserved leaf — changes
+  identity. A leaf override of the selected method certifies as
+  `EXPLICIT_HANDLER`. Arbitrary imports, mixins, multiple or transitive
+  inheritance, star or dynamic imports, redefinitions, conditional or
+  decorated definitions, monkeypatching, `__getattr__` tricks, and every
+  other dynamic export fail closed.
 
 ## OSS And Proprietary Intelligence
 

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -1162,6 +1162,47 @@ the graph, and a `BuildContextBindingRef` proves which inputs were available
 but cannot itself select output semantics. This keeps private strategy and
 provider resolution injectable without making either a second semantic author.
 
+### Content-resolved implementation artifact authority
+
+A future ImplementationBinding v2 must be able to truthfully claim "this exact
+implementation realizes this semantic workflow/action". A `ChildContractRef`
+or digest alone cannot carry that claim, so implementation selection is a
+proof boundary of its own
+(`mozaiksai/core/semantics/implementation_artifacts.py`):
+
+- a **selected contract artifact** couples one `ChildContractRef` to one
+  canonical `ArtifactAddress`; the reference path and address path must be
+  equal, and the canonical layout registry then independently proves artifact
+  family, path scope, placeholder identity (in the planner's closed instance
+  domain), and owner kind. Path equality alone is never authority.
+- bytes come only from `ArtifactContentStore.get_verified_blob()` — no
+  filesystem fallback, sibling checkout, glob/path discovery, mutable alias,
+  or caller assertion, and never from an opaque resolver registration with
+  `content=None`. The exact verified bytes then parse under the strict
+  document contract, and the parsed document's own `schema_version` must
+  equal the reference's `contract_schema_version`
+  (`mozaiks.orchestrator.v1`, `mozaiks.structured_outputs.v1`,
+  `mozaiks.module.v1`).
+- workflow implementation facts (`orchestrator.yaml`,
+  `structured_outputs.yaml`) expose the runtime workflow name and the exact
+  structured-output configuration; a `StructuredOutputContractRef` resolves
+  only against that selected configuration, so a same-schema contract from
+  another workflow is not interchangeable.
+- module implementation facts (`module.yaml`) expose module identity, the
+  declared action, `handler_method`, and the action request contract imported
+  through the closed-contract profile; a manifest declaring another module id
+  cannot be selected for a module instance.
+- handler sources are selected as `AccountedArtifact`s with a mandatory
+  non-null `content_digest` at a canonical `module_backend_handler` address
+  that matches the manifest's declared handler entrypoint, and carry a
+  **bounded static export proof**: the declared handler class and action
+  `handler_method` must be explicitly present in the selected verified source
+  (AST-level, never executed). Inherited methods, redefinitions, conditional
+  or decorated definitions, monkeypatching, `__getattr__` tricks, and other
+  dynamic exports fail closed. Certified implementation selection requires
+  the selected source to expose the declared handler explicitly; no
+  source-closure engine exists.
+
 ## OSS And Proprietary Intelligence
 
 Per the boundary ADR 0005 reserves (PR #394) and

--- a/factory_app/build_context/commerce/templates/modules/commerce/module.yaml
+++ b/factory_app/build_context/commerce/templates/modules/commerce/module.yaml
@@ -366,32 +366,33 @@ actions:
     permissions: [commerce.orders.manage]
     emits: [domain.commerce.order.updated]
 
+# Capability ids are unique public surface identifiers (ModuleDefinition
+# rejects duplicates). Each grants its capability group through one primary
+# action target; the remaining actions stay reachable through the standard
+# /api/modules/commerce/{action} surface and share the same permissions and
+# entitlement gates.
 capabilities:
   - capability_id: commerce.products.browse
+    kind: action
     target: list_products
+    title: Browse products
   - capability_id: commerce.products.manage
+    kind: action
     target: create_product
-  - capability_id: commerce.products.manage
-    target: update_product
-  - capability_id: commerce.products.manage
-    target: archive_product
+    title: Manage products
   - capability_id: commerce.inventory.manage
+    kind: action
     target: adjust_inventory
+    title: Adjust inventory
   - capability_id: commerce.cart.manage
+    kind: action
     target: get_cart
-  - capability_id: commerce.cart.manage
-    target: add_cart_item
-  - capability_id: commerce.cart.manage
-    target: update_cart_item
-  - capability_id: commerce.cart.manage
-    target: remove_cart_item
-  - capability_id: commerce.cart.manage
-    target: clear_cart
+    title: Manage cart
   - capability_id: commerce.checkout.start
+    kind: action
     target: start_checkout
+    title: Start checkout
   - capability_id: commerce.orders.manage
+    kind: action
     target: list_orders
-  - capability_id: commerce.orders.manage
-    target: get_order
-  - capability_id: commerce.orders.manage
-    target: update_order_status
+    title: Manage orders

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -1,0 +1,816 @@
+"""Content-resolved implementation artifact authority for ADR 0007.
+
+Future ``ImplementationBinding v2`` must be able to truthfully claim that one
+exact implementation realizes one semantic workflow/action.  A
+``ChildContractRef``/digest alone cannot carry that claim.  This module is the
+selection boundary that can: a typed selection couples the existing
+``ChildContractRef`` identity to one canonical ``ArtifactAddress``, the
+canonical layout registry independently proves family, path scope,
+placeholders, owner, and physical representation, the immutable blob store
+returns the exact verified bytes, the strict document parser accepts them, and
+the parsed document's own schema version must equal the reference's declared
+``contract_schema_version``.
+
+Module handler sources additionally carry a bounded static export proof: the
+declared handler class and each certified action ``handler_method`` must be
+explicitly present in the selected verified source.  Certified implementation
+selection requires the selected source to expose the declared handler
+explicitly — inherited methods, monkeypatching, ``__getattr__`` tricks, and
+other dynamic exports are rejected, never executed to find out.
+
+There is no filesystem fallback, sibling checkout, glob/open/path discovery,
+mutable alias, or caller assertion anywhere on this path.  Opaque resolver
+registration with ``content=None`` never satisfies this boundary: bytes come
+only from ``ArtifactContentStore.get_verified_blob``.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from pydantic import model_validator
+
+from mozaiksai.core.artifacts.content_store import (
+    ArtifactContentStore,
+    ContentIntegrityError,
+    ContentNotFoundError,
+)
+from mozaiksai.core.runtime.app.layout_registry import (
+    AppLayoutRegistry,
+    ArtifactFamily,
+    ArtifactKind,
+    LayoutOwner,
+    PathScope,
+    PlaceholderIdentifier,
+    Requirement,
+    default_app_layout_registry,
+)
+from mozaiksai.core.semantics.closed_contract_schema import import_closed_contract_schema
+from mozaiksai.core.semantics.closed_contracts import ClosedContract
+from mozaiksai.core.semantics.compilation_plan import canonical_instance_identity_value
+from mozaiksai.core.semantics.composition_ledger import AccountedArtifact, ArtifactAddress
+from mozaiksai.core.semantics.refs import (
+    ChildContractRef,
+    ExecutionAccessScopeRef,
+    SemanticsModel,
+)
+from mozaiksai.core.workflow.structured_output_contracts import (
+    StructuredOutputContractRef,
+    resolve_structured_output_contract_ref,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from mozaiksai.core.runtime.app.module_loader import ActionDef, ModuleDefinition
+    from mozaiksai.core.workflow.declarative.contracts import (
+        OrchestratorConfig,
+        StructuredOutputsConfig,
+    )
+
+
+class ImplementationArtifactError(ValueError):
+    """The selection fails one of the exact implementation-artifact proofs."""
+
+
+#: The single instance placeholder each instance-relative collision domain uses.
+_INSTANCE_PLACEHOLDER_BY_SCOPE: dict[PathScope, PlaceholderIdentifier] = {
+    PathScope.MODULE_RELATIVE: PlaceholderIdentifier.MODULE_ID,
+    PathScope.WORKFLOW_RELATIVE: PlaceholderIdentifier.WORKFLOW_ID,
+}
+
+#: Builtins whose presence in module/class statement space defeats static
+#: export proof (they can create, replace, or hide exports at import time).
+_DYNAMIC_EXPORT_BUILTINS = frozenset(
+    {"setattr", "delattr", "getattr", "globals", "vars", "eval", "exec", "__import__", "type"}
+)
+
+
+class SelectedContractArtifact(SemanticsModel):
+    """One immutable contract selection: typed reference plus physical address.
+
+    Path equality between the reference and the address is required but is
+    never authority by itself — resolution independently proves the canonical
+    layout facts and the exact bytes.
+    """
+
+    contract_ref: ChildContractRef
+    address: ArtifactAddress
+
+    @model_validator(mode="after")
+    def _paths_agree(self) -> SelectedContractArtifact:
+        if self.contract_ref.canonical_relative_path != self.address.path:
+            raise ValueError(
+                "selected contract reference path does not equal its artifact address path"
+            )
+        return self
+
+
+class ModuleActionExportProof(SemanticsModel):
+    """Static proof that one verified source explicitly exports one handler method."""
+
+    handler_class: str
+    handler_method: str
+    content_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWorkflowOrchestrator:
+    """Exact content-resolved ``orchestrator.yaml`` for one workflow instance."""
+
+    selection: SelectedContractArtifact
+    workflow_instance: str
+    config: OrchestratorConfig
+    document: dict[str, Any]
+
+    @property
+    def workflow_name(self) -> str:
+        """The runtime workflow name declared by the exact parsed document."""
+        return self.config.workflow_name
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWorkflowStructuredOutputs:
+    """Exact content-resolved ``structured_outputs.yaml`` for one workflow instance."""
+
+    selection: SelectedContractArtifact
+    workflow_instance: str
+    config: StructuredOutputsConfig
+    document: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWorkflowImplementation:
+    """One workflow instance's paired exact implementation documents."""
+
+    orchestrator: ResolvedWorkflowOrchestrator
+    structured_outputs: ResolvedWorkflowStructuredOutputs
+
+    @property
+    def workflow_instance(self) -> str:
+        return self.orchestrator.workflow_instance
+
+    @property
+    def workflow_name(self) -> str:
+        return self.orchestrator.workflow_name
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedModuleManifest:
+    """Exact content-resolved ``module.yaml`` for one module instance."""
+
+    selection: SelectedContractArtifact
+    module_instance: str
+    definition: ModuleDefinition
+    handler_relative_path: str
+    handler_class: str
+
+    def action(self, action_id: str) -> ActionDef:
+        """Return the exact declared action; unknown action ids fail closed."""
+        for candidate in self.definition.actions:
+            if candidate.id == action_id:
+                return candidate
+        raise ImplementationArtifactError(
+            f"module {self.module_instance!r} declares no action {action_id!r}"
+        )
+
+    def action_request_contract(self, action_id: str) -> ClosedContract:
+        """Import the declared action input schema as one closed contract."""
+        return import_closed_contract_schema(self.action(action_id).input_schema)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedModuleHandlerSource:
+    """Exact digest-verified handler source selected for one module instance."""
+
+    artifact: AccountedArtifact
+    module_instance: str
+    handler_class: str
+    content_digest: str
+    source_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedModuleActionImplementation:
+    """One certified module action: manifest, handler source, and export proof."""
+
+    module: ResolvedModuleManifest
+    handler: ResolvedModuleHandlerSource
+    action: ActionDef
+    request_contract: ClosedContract
+    export_proof: ModuleActionExportProof
+
+
+def _prove_canonical_layout(
+    address: ArtifactAddress,
+    *,
+    expected_kind: ArtifactKind,
+    expected_owner: LayoutOwner,
+    layout_registry: AppLayoutRegistry,
+) -> tuple[ArtifactFamily, dict[str, str]]:
+    """Prove family, scope, placeholders, and ownership from the layout registry."""
+    try:
+        match = layout_registry.match_path(address.path, address.path_scope)
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"artifact address {address.path!r} has no canonical layout row in "
+            f"scope {address.path_scope.value!r}: {exc}"
+        ) from exc
+    family = match.family
+    if family.requirement is Requirement.PROHIBITED:
+        raise ImplementationArtifactError(
+            f"artifact address {address.path!r} is prohibited by the canonical layout"
+        )
+    if family.kind is not expected_kind:
+        raise ImplementationArtifactError(
+            f"artifact address {address.path!r} resolves to family "
+            f"{family.kind.value!r}, not {expected_kind.value!r}"
+        )
+    if family.owner is not expected_owner:
+        raise ImplementationArtifactError(
+            f"artifact family {family.kind.value!r} is owned by {family.owner.value!r}, "
+            f"not {expected_owner.value!r}"
+        )
+
+    instance: dict[str, str] = {}
+    scope_placeholder = _INSTANCE_PLACEHOLDER_BY_SCOPE.get(address.path_scope)
+    if scope_placeholder is not None:
+        names = tuple(name for name, _value in address.placeholder_values)
+        if names != (scope_placeholder.value,):
+            raise ImplementationArtifactError(
+                f"{address.path_scope.value} artifact addresses require exactly the "
+                f"{scope_placeholder.value!r} placeholder, got {names!r}"
+            )
+        raw_value = address.placeholder_values[0][1]
+        try:
+            instance[scope_placeholder.value] = canonical_instance_identity_value(raw_value)
+        except ValueError as exc:
+            raise ImplementationArtifactError(str(exc)) from exc
+    for name, value in match.values.items():
+        try:
+            instance[name.value] = canonical_instance_identity_value(value)
+        except ValueError as exc:
+            raise ImplementationArtifactError(str(exc)) from exc
+    return family, instance
+
+
+def _require_instance(instance: dict[str, str], placeholder: PlaceholderIdentifier) -> str:
+    value = instance.get(placeholder.value)
+    if value is None:
+        raise ImplementationArtifactError(
+            f"canonical layout proof produced no {placeholder.value!r} instance identity"
+        )
+    return value
+
+
+async def _resolve_selection_bytes(
+    selection: SelectedContractArtifact,
+    *,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    expected_kind: ArtifactKind,
+    expected_owner: LayoutOwner,
+    layout_registry: AppLayoutRegistry,
+) -> tuple[SelectedContractArtifact, bytes, dict[str, str]]:
+    """Cold-verify one selection and return its exact bytes and instance identity."""
+    try:
+        verified = SelectedContractArtifact.model_validate(selection.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"selected contract artifact failed cold validation: {exc}"
+        ) from exc
+    if requesting_scope != verified.contract_ref.scope:
+        raise ImplementationArtifactError(
+            "cross-scope implementation artifact selection fails closed"
+        )
+    family, instance = _prove_canonical_layout(
+        verified.address,
+        expected_kind=expected_kind,
+        expected_owner=expected_owner,
+        layout_registry=layout_registry,
+    )
+    if verified.contract_ref.artifact_family != family.kind.value:
+        raise ImplementationArtifactError(
+            f"reference artifact family {verified.contract_ref.artifact_family!r} does "
+            f"not equal the proven layout family {family.kind.value!r}"
+        )
+    try:
+        data = await content_store.get_verified_blob(verified.contract_ref.content_digest)
+    except (ContentNotFoundError, ContentIntegrityError) as exc:
+        raise ImplementationArtifactError(
+            f"selected contract bytes did not resolve exactly: {exc}"
+        ) from exc
+    return verified, data, instance
+
+
+def _parse_yaml_mapping(data: bytes, *, description: str) -> dict[str, Any]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ImplementationArtifactError(f"{description} bytes are not UTF-8") from exc
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ImplementationArtifactError(f"{description} bytes are not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ImplementationArtifactError(f"{description} document root must be a mapping")
+    return raw
+
+
+def _require_schema_version(declared: str, ref: ChildContractRef, *, description: str) -> None:
+    if declared != ref.contract_schema_version:
+        raise ImplementationArtifactError(
+            f"{description} declares schema version {declared!r} but the reference "
+            f"pins {ref.contract_schema_version!r}"
+        )
+
+
+async def resolve_workflow_orchestrator_artifact(
+    selection: SelectedContractArtifact,
+    *,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedWorkflowOrchestrator:
+    """Resolve one workflow's exact ``orchestrator.yaml`` implementation document."""
+    from mozaiksai.core.workflow.declarative.contracts import (
+        OrchestratorConfig,
+        parse_orchestrator_config,
+    )
+
+    verified, data, instance = await _resolve_selection_bytes(
+        selection,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+        expected_kind=ArtifactKind.WORKFLOW_MANIFEST,
+        expected_owner=LayoutOwner.WORKFLOW,
+        layout_registry=layout_registry or default_app_layout_registry(),
+    )
+    raw = _parse_yaml_mapping(data, description="orchestrator.yaml")
+    try:
+        document = parse_orchestrator_config(raw)
+        config = OrchestratorConfig.model_validate(raw)
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"orchestrator.yaml bytes failed the strict document contract: {exc}"
+        ) from exc
+    _require_schema_version(
+        config.schema_version, verified.contract_ref, description="orchestrator.yaml"
+    )
+    return ResolvedWorkflowOrchestrator(
+        selection=verified,
+        workflow_instance=_require_instance(instance, PlaceholderIdentifier.WORKFLOW_ID),
+        config=config,
+        document=document,
+    )
+
+
+async def resolve_workflow_structured_outputs_artifact(
+    selection: SelectedContractArtifact,
+    *,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedWorkflowStructuredOutputs:
+    """Resolve one workflow's exact ``structured_outputs.yaml`` implementation document."""
+    from mozaiksai.core.workflow.declarative.contracts import (
+        StructuredOutputsConfig,
+        parse_structured_outputs_config,
+    )
+
+    verified, data, instance = await _resolve_selection_bytes(
+        selection,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+        expected_kind=ArtifactKind.WORKFLOW_CONFIG,
+        expected_owner=LayoutOwner.WORKFLOW,
+        layout_registry=layout_registry or default_app_layout_registry(),
+    )
+    if verified.address.path != "structured_outputs.yaml":
+        raise ImplementationArtifactError(
+            f"structured-output selection must address structured_outputs.yaml, "
+            f"got {verified.address.path!r}"
+        )
+    raw = _parse_yaml_mapping(data, description="structured_outputs.yaml")
+    try:
+        document = parse_structured_outputs_config(raw)
+        config = StructuredOutputsConfig.model_validate(raw)
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"structured_outputs.yaml bytes failed the strict document contract: {exc}"
+        ) from exc
+    _require_schema_version(
+        config.schema_version, verified.contract_ref, description="structured_outputs.yaml"
+    )
+    return ResolvedWorkflowStructuredOutputs(
+        selection=verified,
+        workflow_instance=_require_instance(instance, PlaceholderIdentifier.WORKFLOW_ID),
+        config=config,
+        document=document,
+    )
+
+
+def pair_workflow_implementation_artifacts(
+    orchestrator: ResolvedWorkflowOrchestrator,
+    structured_outputs: ResolvedWorkflowStructuredOutputs,
+) -> ResolvedWorkflowImplementation:
+    """Pair the two documents of one workflow instance; cross-workflow pairs reject."""
+    if (
+        orchestrator.selection.contract_ref.scope
+        != structured_outputs.selection.contract_ref.scope
+    ):
+        raise ImplementationArtifactError(
+            "workflow implementation documents belong to different execution scopes"
+        )
+    if orchestrator.workflow_instance != structured_outputs.workflow_instance:
+        raise ImplementationArtifactError(
+            f"structured outputs of workflow {structured_outputs.workflow_instance!r} "
+            f"cannot implement workflow {orchestrator.workflow_instance!r}"
+        )
+    return ResolvedWorkflowImplementation(
+        orchestrator=orchestrator, structured_outputs=structured_outputs
+    )
+
+
+def resolve_selected_structured_output_contract(
+    implementation: ResolvedWorkflowImplementation,
+    ref: StructuredOutputContractRef,
+    *,
+    exact_model_ids: frozenset[str] = frozenset(),
+) -> type[BaseModel]:
+    """Resolve one #485 contract ref against exactly this selected configuration.
+
+    A same-schema contract from another workflow is not interchangeable: the
+    reference must name this implementation's runtime workflow, and the model
+    is compiled only from this selection's exact parsed document.
+    """
+    try:
+        verified_ref = StructuredOutputContractRef.model_validate(ref.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"structured-output contract ref failed cold validation: {exc}"
+        ) from exc
+    if verified_ref.workflow_name != implementation.workflow_name:
+        raise ImplementationArtifactError(
+            f"structured-output contract of workflow {verified_ref.workflow_name!r} is "
+            f"not interchangeable into workflow {implementation.workflow_name!r}"
+        )
+    try:
+        return resolve_structured_output_contract_ref(
+            verified_ref,
+            configs={verified_ref.workflow_name: implementation.structured_outputs.document},
+            exact_model_ids=exact_model_ids,
+        )
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"structured-output contract did not resolve against the selected "
+            f"configuration: {exc}"
+        ) from exc
+
+
+async def resolve_module_manifest_artifact(
+    selection: SelectedContractArtifact,
+    *,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedModuleManifest:
+    """Resolve one module's exact ``module.yaml`` implementation document."""
+    from mozaiksai.core.runtime.app.module_loader import (
+        ModuleDefinition,
+        _validate_entrypoint,
+    )
+
+    verified, data, instance = await _resolve_selection_bytes(
+        selection,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+        expected_kind=ArtifactKind.MODULE_MANIFEST,
+        expected_owner=LayoutOwner.MODULE,
+        layout_registry=layout_registry or default_app_layout_registry(),
+    )
+    raw = _parse_yaml_mapping(data, description="module.yaml")
+    try:
+        definition = ModuleDefinition.model_validate(raw)
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"module.yaml bytes failed the strict document contract: {exc}"
+        ) from exc
+    _require_schema_version(
+        definition.schema_version, verified.contract_ref, description="module.yaml"
+    )
+    module_instance = _require_instance(instance, PlaceholderIdentifier.MODULE_ID)
+    if definition.module.id != module_instance:
+        raise ImplementationArtifactError(
+            f"module manifest declares module {definition.module.id!r} and cannot be "
+            f"selected for module instance {module_instance!r}"
+        )
+    handler_relative_path, handler_class = _validate_entrypoint(definition.module.handler)
+    return ResolvedModuleManifest(
+        selection=verified,
+        module_instance=module_instance,
+        definition=definition,
+        handler_relative_path=handler_relative_path,
+        handler_class=handler_class,
+    )
+
+
+async def resolve_module_handler_source(
+    artifact: AccountedArtifact,
+    *,
+    module: ResolvedModuleManifest,
+    content_store: ArtifactContentStore,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedModuleHandlerSource:
+    """Resolve the exact handler source the module manifest declares.
+
+    The selection is an ``AccountedArtifact`` whose ``content_digest`` is
+    mandatory at this boundary: an address without exact content identity is
+    not a certified selection.
+    """
+    try:
+        verified = AccountedArtifact.model_validate(artifact.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"handler source artifact failed cold validation: {exc}"
+        ) from exc
+    if verified.content_digest is None:
+        raise ImplementationArtifactError(
+            "certified handler selection requires a non-null content digest"
+        )
+    _family, instance = _prove_canonical_layout(
+        verified.address,
+        expected_kind=ArtifactKind.MODULE_BACKEND_HANDLER,
+        expected_owner=LayoutOwner.MODULE,
+        layout_registry=layout_registry or default_app_layout_registry(),
+    )
+    module_instance = _require_instance(instance, PlaceholderIdentifier.MODULE_ID)
+    if module_instance != module.module_instance:
+        raise ImplementationArtifactError(
+            f"handler source of module {module_instance!r} cannot implement module "
+            f"{module.module_instance!r}"
+        )
+    if verified.address.path_scope is PathScope.MODULE_RELATIVE:
+        expected_path = module.handler_relative_path
+    else:
+        expected_path = f"modules/{module.module_instance}/{module.handler_relative_path}"
+    if verified.address.path != expected_path:
+        raise ImplementationArtifactError(
+            f"module {module.module_instance!r} declares its handler at "
+            f"{expected_path!r}, not {verified.address.path!r}"
+        )
+    try:
+        data = await content_store.get_verified_blob(verified.content_digest)
+    except (ContentNotFoundError, ContentIntegrityError) as exc:
+        raise ImplementationArtifactError(
+            f"selected handler bytes did not resolve exactly: {exc}"
+        ) from exc
+    try:
+        source_text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ImplementationArtifactError("handler source bytes are not UTF-8") from exc
+    return ResolvedModuleHandlerSource(
+        artifact=verified,
+        module_instance=module_instance,
+        handler_class=module.handler_class,
+        content_digest=verified.content_digest,
+        source_text=source_text,
+    )
+
+
+def _iter_scope_statements(body: list[ast.stmt]):
+    """Yield every statement of one scope without entering nested def/class bodies."""
+    pending: list[ast.AST] = list(body)
+    while pending:
+        node = pending.pop()
+        if isinstance(node, ast.stmt):
+            yield node
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                continue
+        pending.extend(ast.iter_child_nodes(node))
+
+
+def _target_names(target: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(target):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+    return names
+
+
+def _statement_binds_name(stmt: ast.stmt, name: str) -> bool:
+    """True when one scope statement (re)binds ``name`` in that scope."""
+    if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        return stmt.name == name
+    if isinstance(stmt, ast.Assign):
+        return any(name in _target_names(target) for target in stmt.targets)
+    if isinstance(stmt, ast.AnnAssign | ast.AugAssign):
+        return name in _target_names(stmt.target)
+    if isinstance(stmt, ast.Delete):
+        return any(name in _target_names(target) for target in stmt.targets)
+    if isinstance(stmt, ast.For | ast.AsyncFor):
+        return name in _target_names(stmt.target)
+    if isinstance(stmt, ast.With | ast.AsyncWith):
+        return any(
+            item.optional_vars is not None and name in _target_names(item.optional_vars)
+            for item in stmt.items
+        )
+    if isinstance(stmt, ast.Import | ast.ImportFrom):
+        return any((alias.asname or alias.name.split(".")[0]) == name for alias in stmt.names)
+    if isinstance(stmt, ast.Global | ast.Nonlocal):
+        return name in stmt.names
+    return any(
+        isinstance(node, ast.NamedExpr)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == name
+        for node in ast.walk(stmt)
+    )
+
+
+def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
+    for stmt in statements:
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        for node in ast.walk(stmt):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in _DYNAMIC_EXPORT_BUILTINS
+            ):
+                raise ImplementationArtifactError(
+                    f"{where} calls {node.func.id!r}; the export is not statically provable"
+                )
+
+
+def prove_module_action_export(
+    handler: ResolvedModuleHandlerSource, *, handler_method: str
+) -> ModuleActionExportProof:
+    """Prove the declared class explicitly exports ``handler_method`` in this source.
+
+    The proof is bounded and static: the source is parsed, never executed.  It
+    fails closed on every construct that could make the visible definition not
+    be the effective export — redefinition, conditional or decorated
+    definitions, name rebinding, monkeypatching, ``__getattr__`` tricks, and
+    any further reference to the handler class name.
+    """
+    handler_class = handler.handler_class
+    try:
+        tree = ast.parse(handler.source_text)
+    except SyntaxError as exc:
+        raise ImplementationArtifactError(
+            f"handler source is not statically parseable: {exc}"
+        ) from exc
+
+    module_statements = list(_iter_scope_statements(tree.body))
+    class_defs = [
+        stmt
+        for stmt in module_statements
+        if isinstance(stmt, ast.ClassDef) and stmt.name == handler_class
+    ]
+    if not class_defs:
+        raise ImplementationArtifactError(
+            f"declared handler class {handler_class!r} is absent from the selected source"
+        )
+    if len(class_defs) != 1:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} is bound more than once; the export is "
+            "not statically provable"
+        )
+    class_def = class_defs[0]
+    if class_def not in tree.body:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} is defined conditionally; the export is "
+            "not statically provable"
+        )
+    if class_def.decorator_list or class_def.keywords:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} uses decorators or class keywords; the "
+            "export is not statically provable"
+        )
+    for stmt in module_statements:
+        if stmt is class_def:
+            continue
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "__getattr__":
+            raise ImplementationArtifactError(
+                "module-level __getattr__ defeats static export proof"
+            )
+        if _statement_binds_name(stmt, handler_class):
+            raise ImplementationArtifactError(
+                f"handler class {handler_class!r} is rebound outside its definition"
+            )
+    _reject_dynamic_builtins(module_statements, where="handler module scope")
+
+    class_statements = list(_iter_scope_statements(class_def.body))
+    method_defs = [
+        stmt
+        for stmt in class_statements
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+        and stmt.name == handler_method
+    ]
+    if not method_defs:
+        raise ImplementationArtifactError(
+            f"action handler_method {handler_method!r} is not explicitly defined on "
+            f"class {handler_class!r} in the selected source"
+        )
+    if len(method_defs) != 1:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is bound more than once on class "
+            f"{handler_class!r}; the export is not statically provable"
+        )
+    method_def = method_defs[0]
+    if method_def not in class_def.body:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is defined conditionally; the export "
+            "is not statically provable"
+        )
+    if method_def.decorator_list:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is decorated; the export is not "
+            "statically provable"
+        )
+    for stmt in class_statements:
+        if stmt is method_def:
+            continue
+        if (
+            isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+            and stmt.name in {"__getattr__", "__getattribute__"}
+        ):
+            raise ImplementationArtifactError(
+                f"class-level {stmt.name} defeats static export proof"
+            )
+        if _statement_binds_name(stmt, handler_method):
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is rebound in the class body; the "
+                "export is not statically provable"
+            )
+    _reject_dynamic_builtins(class_statements, where="handler class scope")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == handler_class:
+            raise ImplementationArtifactError(
+                f"handler class {handler_class!r} is referenced dynamically; the "
+                "export is not statically provable"
+            )
+    return ModuleActionExportProof(
+        handler_class=handler_class,
+        handler_method=handler_method,
+        content_digest=handler.content_digest,
+    )
+
+
+async def resolve_module_action_implementation(
+    module_selection: SelectedContractArtifact,
+    handler_artifact: AccountedArtifact,
+    *,
+    action_id: str,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedModuleActionImplementation:
+    """Resolve and prove one certified module action implementation end to end."""
+    registry = layout_registry or default_app_layout_registry()
+    module = await resolve_module_manifest_artifact(
+        module_selection,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+        layout_registry=registry,
+    )
+    handler = await resolve_module_handler_source(
+        handler_artifact,
+        module=module,
+        content_store=content_store,
+        layout_registry=registry,
+    )
+    action = module.action(action_id)
+    export_proof = prove_module_action_export(handler, handler_method=action.handler_method)
+    return ResolvedModuleActionImplementation(
+        module=module,
+        handler=handler,
+        action=action,
+        request_contract=module.action_request_contract(action_id),
+        export_proof=export_proof,
+    )
+
+
+__all__ = [
+    "ImplementationArtifactError",
+    "ModuleActionExportProof",
+    "ResolvedModuleActionImplementation",
+    "ResolvedModuleHandlerSource",
+    "ResolvedModuleManifest",
+    "ResolvedWorkflowImplementation",
+    "ResolvedWorkflowOrchestrator",
+    "ResolvedWorkflowStructuredOutputs",
+    "SelectedContractArtifact",
+    "pair_workflow_implementation_artifacts",
+    "prove_module_action_export",
+    "resolve_module_action_implementation",
+    "resolve_module_handler_source",
+    "resolve_module_manifest_artifact",
+    "resolve_selected_structured_output_contract",
+    "resolve_workflow_orchestrator_artifact",
+    "resolve_workflow_structured_outputs_artifact",
+]

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -27,7 +27,10 @@ only from ``ArtifactContentStore.get_verified_blob``.
 from __future__ import annotations
 
 import ast
+import posixpath
+from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -48,6 +51,7 @@ from mozaiksai.core.runtime.app.layout_registry import (
     Requirement,
     default_app_layout_registry,
 )
+from mozaiksai.core.semantics.canonical import canonical_digest
 from mozaiksai.core.semantics.closed_contract_schema import import_closed_contract_schema
 from mozaiksai.core.semantics.closed_contracts import ClosedContract
 from mozaiksai.core.semantics.compilation_plan import canonical_instance_identity_value
@@ -109,12 +113,68 @@ class SelectedContractArtifact(SemanticsModel):
         return self
 
 
-class ModuleActionExportProof(SemanticsModel):
-    """Static proof that one verified source explicitly exports one handler method."""
+class HandlerCertificationMode(StrEnum):
+    """The two bounded implementation-certification modes.
 
+    ``EXPLICIT_HANDLER``: the selected canonical ``handler.py`` explicitly
+    defines the selected ``handler_method``.
+
+    ``CANONICAL_BASE_HANDLER``: the module uses the canonical
+    ``workspace_handler_split`` contract — a preserved workspace-owned
+    ``handler.py`` leaf that directly subclasses the regenerated
+    template-owned ``base_handler.py`` class, which explicitly defines the
+    selected method.  Exactly these two sources may participate; there is no
+    general Python source closure.
+    """
+
+    EXPLICIT_HANDLER = "explicit_handler"
+    CANONICAL_BASE_HANDLER = "canonical_base_handler"
+
+
+class WorkspaceHandlerSplitAuthority(SemanticsModel):
+    """Proof that one module legitimately uses the canonical handler split.
+
+    The split is never inferred merely because files carry the split names:
+    the owning capability-pack contract must declare the canonical ownership —
+    ``handler.py`` as the preserved workspace-owned leaf and
+    ``base_handler.py`` as the regenerated template-owned implementation.
+    Build it with :func:`workspace_handler_split_authority_from_pack_contract`.
+    """
+
+    contract_id: str
+    module_instance: str
+    handler_path: str
+    base_handler_path: str
+
+
+class ModuleActionExportProof(SemanticsModel):
+    """Static proof that one certified selection explicitly exports one method.
+
+    ``implementation_digest`` is the certified implementation identity: for
+    ``CANONICAL_BASE_HANDLER`` it covers BOTH meaning-bearing source digests,
+    so changing only ``base_handler.py`` — or only the preserved
+    ``handler.py`` — changes the certified identity.
+    """
+
+    mode: HandlerCertificationMode
     handler_class: str
     handler_method: str
     content_digest: str
+    base_handler_class: str | None = None
+    base_content_digest: str | None = None
+
+    @property
+    def implementation_digest(self) -> str:
+        return canonical_digest(
+            {
+                "mode": self.mode.value,
+                "handler_class": self.handler_class,
+                "handler_method": self.handler_method,
+                "content_digest": self.content_digest,
+                "base_handler_class": self.base_handler_class,
+                "base_content_digest": self.base_content_digest,
+            }
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,14 +254,29 @@ class ResolvedModuleHandlerSource:
 
 
 @dataclass(frozen=True, slots=True)
+class ResolvedModuleBaseHandlerSource:
+    """Exact digest-verified canonical base-handler source for one module.
+
+    Participates in certification only under a proven
+    :class:`WorkspaceHandlerSplitAuthority` for the same module instance.
+    """
+
+    artifact: AccountedArtifact
+    module_instance: str
+    content_digest: str
+    source_text: str
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedModuleActionImplementation:
-    """One certified module action: manifest, handler source, and export proof."""
+    """One certified module action: manifest, handler source(s), export proof."""
 
     module: ResolvedModuleManifest
     handler: ResolvedModuleHandlerSource
     action: ActionDef
     request_contract: ClosedContract
     export_proof: ModuleActionExportProof
+    base_handler: ResolvedModuleBaseHandlerSource | None = None
 
 
 def _prove_canonical_layout(
@@ -581,6 +656,155 @@ async def resolve_module_handler_source(
     )
 
 
+def workspace_handler_split_authority_from_pack_contract(
+    contract: Mapping[str, Any], *, module_instance: str
+) -> WorkspaceHandlerSplitAuthority:
+    """Prove the canonical workspace_handler_split ownership from a pack contract.
+
+    The owning capability-pack ``contract.yaml`` must declare, in
+    ``required_outputs``, this module's ``handler.py`` as the preserved
+    workspace-owned leaf (``owner: workspace``) and its ``base_handler.py`` as
+    the regenerated template-owned implementation (``owner: templates``, the
+    canonical materializer default).  Absent or inconsistent declarations
+    reject: the split is contract authority, never a filename coincidence.
+    """
+    if not isinstance(contract, Mapping):
+        raise ImplementationArtifactError("pack contract must be a mapping document")
+    contract_type = str(contract.get("contract_type") or "").strip()
+    if contract_type != "build_pack_instructions":
+        raise ImplementationArtifactError(
+            "workspace_handler_split authority requires a build_pack_instructions "
+            f"contract, got {contract_type!r}"
+        )
+    contract_id = str(contract.get("contract_id") or "").strip()
+    if not contract_id:
+        raise ImplementationArtifactError("pack contract declares no contract_id")
+    instance = canonical_instance_identity_value(str(module_instance or "").strip())
+    handler_path = f"modules/{instance}/backend/handler.py"
+    base_handler_path = f"modules/{instance}/backend/base_handler.py"
+    owners: dict[str, str] = {}
+    for entry in contract.get("required_outputs") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        path = str(entry.get("path") or "").strip()
+        if path in {handler_path, base_handler_path}:
+            owners[path] = str(entry.get("owner") or "templates").strip()
+    if handler_path not in owners:
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} does not declare {handler_path!r}; "
+            "the workspace_handler_split authority is absent"
+        )
+    if base_handler_path not in owners:
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} does not declare {base_handler_path!r}; "
+            "the workspace_handler_split authority is absent"
+        )
+    if owners[handler_path] != "workspace":
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} declares {handler_path!r} with owner "
+            f"{owners[handler_path]!r}; the canonical split requires the preserved "
+            "leaf to be workspace-owned"
+        )
+    if owners[base_handler_path] != "templates":
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} declares {base_handler_path!r} with owner "
+            f"{owners[base_handler_path]!r}; the canonical split requires the "
+            "regenerated implementation to be template-owned"
+        )
+    return WorkspaceHandlerSplitAuthority(
+        contract_id=contract_id,
+        module_instance=instance,
+        handler_path=handler_path,
+        base_handler_path=base_handler_path,
+    )
+
+
+async def resolve_module_base_handler_source(
+    artifact: AccountedArtifact,
+    *,
+    module: ResolvedModuleManifest,
+    handler: ResolvedModuleHandlerSource,
+    split_authority: WorkspaceHandlerSplitAuthority,
+    content_store: ArtifactContentStore,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedModuleBaseHandlerSource:
+    """Resolve the exact canonical base-handler source for one module.
+
+    The base participates only under the module's proven split authority, in
+    the SAME module scope and instance as the selected leaf handler, at the
+    canonical ``base_handler.py`` sibling of the declared handler entrypoint,
+    with a mandatory verified content digest.
+    """
+    try:
+        verified_authority = WorkspaceHandlerSplitAuthority.model_validate(
+            split_authority.model_dump(mode="json")
+        )
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"workspace_handler_split authority failed cold validation: {exc}"
+        ) from exc
+    if verified_authority.module_instance != module.module_instance:
+        raise ImplementationArtifactError(
+            f"workspace_handler_split authority for module "
+            f"{verified_authority.module_instance!r} cannot certify module "
+            f"{module.module_instance!r}"
+        )
+    try:
+        verified = AccountedArtifact.model_validate(artifact.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"base-handler source artifact failed cold validation: {exc}"
+        ) from exc
+    if verified.content_digest is None:
+        raise ImplementationArtifactError(
+            "certified base-handler selection requires a non-null content digest"
+        )
+    _family, instance = _prove_canonical_layout(
+        verified.address,
+        expected_kind=ArtifactKind.MODULE_BACKEND_BASE_HANDLER,
+        expected_owner=LayoutOwner.MODULE,
+        layout_registry=layout_registry or default_app_layout_registry(),
+    )
+    module_instance = _require_instance(instance, PlaceholderIdentifier.MODULE_ID)
+    if module_instance != module.module_instance:
+        raise ImplementationArtifactError(
+            f"base handler of module {module_instance!r} cannot implement module "
+            f"{module.module_instance!r}"
+        )
+    if verified.address.path_scope is not handler.artifact.address.path_scope:
+        raise ImplementationArtifactError(
+            "leaf handler and base handler must be selected in the same module scope"
+        )
+    base_relative = posixpath.join(
+        posixpath.dirname(module.handler_relative_path), "base_handler.py"
+    )
+    if verified.address.path_scope is PathScope.MODULE_RELATIVE:
+        expected_path = base_relative
+    else:
+        expected_path = f"modules/{module.module_instance}/{base_relative}"
+    if verified.address.path != expected_path:
+        raise ImplementationArtifactError(
+            f"module {module.module_instance!r} declares its canonical base handler "
+            f"at {expected_path!r}, not {verified.address.path!r}"
+        )
+    try:
+        data = await content_store.get_verified_blob(verified.content_digest)
+    except (ContentNotFoundError, ContentIntegrityError) as exc:
+        raise ImplementationArtifactError(
+            f"selected base-handler bytes did not resolve exactly: {exc}"
+        ) from exc
+    try:
+        source_text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ImplementationArtifactError("base-handler source bytes are not UTF-8") from exc
+    return ResolvedModuleBaseHandlerSource(
+        artifact=verified,
+        module_instance=module_instance,
+        content_digest=verified.content_digest,
+        source_text=source_text,
+    )
+
+
 def _iter_scope_statements(body: list[ast.stmt]):
     """Yield every statement of one scope without entering nested def/class bodies."""
     pending: list[ast.AST] = list(body)
@@ -755,9 +979,334 @@ def prove_module_action_export(
                 "export is not statically provable"
             )
     return ModuleActionExportProof(
+        mode=HandlerCertificationMode.EXPLICIT_HANDLER,
         handler_class=handler_class,
         handler_method=handler_method,
         content_digest=handler.content_digest,
+    )
+
+
+def _leaf_explicitly_defines_method(source_text: str, *, handler_class: str, handler_method: str) -> bool:
+    """Cheap mode probe: does the leaf directly define the selected method?
+
+    Only decides WHICH bounded certification mode applies; every actual
+    guarantee is enforced by the full mode-specific proof afterwards.
+    """
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return True  # let the explicit proof produce the canonical rejection
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ClassDef) and stmt.name == handler_class:
+            return any(
+                isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef)
+                and child.name == handler_method
+                for child in stmt.body
+            )
+    return True  # absent class: the explicit proof owns that rejection too
+
+
+def _prove_canonical_leaf_subclass(
+    handler: ResolvedModuleHandlerSource, *, handler_method: str
+) -> str:
+    """Prove the leaf is the bounded canonical subclass and return its base name.
+
+    Exactly one top-level handler class with exactly one plain-name base,
+    bound by exactly one ``from .base_handler import <Base>`` — no aliasing,
+    no star imports, no second base, no mixins, no conditional or dynamic
+    construction, no rebinding, no ``__getattr__``/setattr tricks, and no
+    leaf binding of the selected method (a leaf override is certified through
+    EXPLICIT_HANDLER instead).
+    """
+    handler_class = handler.handler_class
+    try:
+        tree = ast.parse(handler.source_text)
+    except SyntaxError as exc:
+        raise ImplementationArtifactError(
+            f"handler source is not statically parseable: {exc}"
+        ) from exc
+
+    module_statements = list(_iter_scope_statements(tree.body))
+    class_defs = [
+        stmt
+        for stmt in module_statements
+        if isinstance(stmt, ast.ClassDef) and stmt.name == handler_class
+    ]
+    if not class_defs:
+        raise ImplementationArtifactError(
+            f"declared handler class {handler_class!r} is absent from the selected source"
+        )
+    if len(class_defs) != 1:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} is bound more than once; the export is "
+            "not statically provable"
+        )
+    class_def = class_defs[0]
+    if class_def not in tree.body:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} is defined conditionally; the export is "
+            "not statically provable"
+        )
+    if class_def.decorator_list or class_def.keywords:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} uses decorators or class keywords; the "
+            "export is not statically provable"
+        )
+    if len(class_def.bases) != 1:
+        raise ImplementationArtifactError(
+            f"canonical split leaf {handler_class!r} must declare exactly one base "
+            f"class, found {len(class_def.bases)}; multiple inheritance and mixins "
+            "are not certifiable"
+        )
+    base_expr = class_def.bases[0]
+    if not isinstance(base_expr, ast.Name):
+        raise ImplementationArtifactError(
+            f"canonical split leaf {handler_class!r} base class must be a plain "
+            "imported name"
+        )
+    base_name = base_expr.id
+
+    canonical_imports: list[ast.ImportFrom] = []
+    for stmt in module_statements:
+        if stmt is class_def:
+            continue
+        if isinstance(stmt, ast.ImportFrom):
+            if any(alias.name == "*" for alias in stmt.names):
+                raise ImplementationArtifactError(
+                    "star imports defeat static export proof"
+                )
+            binds_base = any(
+                (alias.asname or alias.name) == base_name for alias in stmt.names
+            )
+            if binds_base:
+                if (
+                    stmt.level == 1
+                    and stmt.module == "base_handler"
+                    and len(stmt.names) == 1
+                    and stmt.names[0].name == base_name
+                    and stmt.names[0].asname is None
+                ):
+                    canonical_imports.append(stmt)
+                    continue
+                raise ImplementationArtifactError(
+                    f"base class {base_name!r} must be imported exactly as "
+                    f"'from .base_handler import {base_name}'"
+                )
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "__getattr__":
+            raise ImplementationArtifactError(
+                "module-level __getattr__ defeats static export proof"
+            )
+        if _statement_binds_name(stmt, handler_class):
+            raise ImplementationArtifactError(
+                f"handler class {handler_class!r} is rebound outside its definition"
+            )
+        if _statement_binds_name(stmt, base_name):
+            raise ImplementationArtifactError(
+                f"base class {base_name!r} is rebound outside its canonical import"
+            )
+    if len(canonical_imports) != 1:
+        raise ImplementationArtifactError(
+            f"base class {base_name!r} must be bound by exactly one "
+            f"'from .base_handler import {base_name}' import"
+        )
+    _reject_dynamic_builtins(module_statements, where="handler module scope")
+
+    class_statements = list(_iter_scope_statements(class_def.body))
+    for stmt in class_statements:
+        if (
+            isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+            and stmt.name in {"__getattr__", "__getattribute__"}
+        ):
+            raise ImplementationArtifactError(
+                f"class-level {stmt.name} defeats static export proof"
+            )
+        if _statement_binds_name(stmt, handler_method):
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is bound dynamically in the leaf "
+                "class body; the export is not statically provable"
+            )
+    _reject_dynamic_builtins(class_statements, where="handler class scope")
+
+    base_references = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id == base_name
+    ]
+    if len(base_references) != 1 or base_references[0] is not base_expr:
+        raise ImplementationArtifactError(
+            f"base class {base_name!r} may be referenced only as the leaf's single "
+            "base; other references are not statically provable"
+        )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == handler_class:
+            raise ImplementationArtifactError(
+                f"handler class {handler_class!r} is referenced dynamically; the "
+                "export is not statically provable"
+            )
+    return base_name
+
+
+def _prove_base_handler_method(
+    base_handler: ResolvedModuleBaseHandlerSource,
+    *,
+    base_class: str,
+    handler_method: str,
+) -> None:
+    """Prove the canonical base class explicitly defines the selected method.
+
+    The base class must be the single top-level class of the regenerated
+    base-handler source, with no bases of its own (no transitive
+    inheritance), no dynamic construction, and an explicit undecorated
+    definition of the selected method.
+    """
+    try:
+        tree = ast.parse(base_handler.source_text)
+    except SyntaxError as exc:
+        raise ImplementationArtifactError(
+            f"base-handler source is not statically parseable: {exc}"
+        ) from exc
+
+    module_statements = list(_iter_scope_statements(tree.body))
+    class_defs = [
+        stmt
+        for stmt in module_statements
+        if isinstance(stmt, ast.ClassDef) and stmt.name == base_class
+    ]
+    if not class_defs:
+        raise ImplementationArtifactError(
+            f"canonical base class {base_class!r} is absent from the selected "
+            "base-handler source"
+        )
+    if len(class_defs) != 1:
+        raise ImplementationArtifactError(
+            f"base class {base_class!r} is bound more than once; the export is not "
+            "statically provable"
+        )
+    class_def = class_defs[0]
+    if class_def not in tree.body:
+        raise ImplementationArtifactError(
+            f"base class {base_class!r} is defined conditionally; the export is not "
+            "statically provable"
+        )
+    if class_def.decorator_list or class_def.keywords:
+        raise ImplementationArtifactError(
+            f"base class {base_class!r} uses decorators or class keywords; the "
+            "export is not statically provable"
+        )
+    if class_def.bases:
+        raise ImplementationArtifactError(
+            f"canonical base class {base_class!r} must not inherit from anything; "
+            "transitive inheritance is not certifiable"
+        )
+    for stmt in module_statements:
+        if stmt is class_def:
+            continue
+        if isinstance(stmt, ast.ImportFrom) and any(
+            alias.name == "*" for alias in stmt.names
+        ):
+            raise ImplementationArtifactError("star imports defeat static export proof")
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "__getattr__":
+            raise ImplementationArtifactError(
+                "module-level __getattr__ defeats static export proof"
+            )
+        if _statement_binds_name(stmt, base_class):
+            raise ImplementationArtifactError(
+                f"base class {base_class!r} is rebound outside its definition"
+            )
+    _reject_dynamic_builtins(module_statements, where="base-handler module scope")
+
+    class_statements = list(_iter_scope_statements(class_def.body))
+    method_defs = [
+        stmt
+        for stmt in class_statements
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+        and stmt.name == handler_method
+    ]
+    if not method_defs:
+        raise ImplementationArtifactError(
+            f"action handler_method {handler_method!r} is not explicitly defined on "
+            f"canonical base class {base_class!r} in the selected source"
+        )
+    if len(method_defs) != 1:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is bound more than once on base "
+            f"class {base_class!r}; the export is not statically provable"
+        )
+    method_def = method_defs[0]
+    if method_def not in class_def.body:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is defined conditionally; the export "
+            "is not statically provable"
+        )
+    if method_def.decorator_list:
+        raise ImplementationArtifactError(
+            f"handler_method {handler_method!r} is decorated; the export is not "
+            "statically provable"
+        )
+    for stmt in class_statements:
+        if stmt is method_def:
+            continue
+        if (
+            isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+            and stmt.name in {"__getattr__", "__getattribute__"}
+        ):
+            raise ImplementationArtifactError(
+                f"class-level {stmt.name} defeats static export proof"
+            )
+        if _statement_binds_name(stmt, handler_method):
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is rebound in the base class "
+                "body; the export is not statically provable"
+            )
+    _reject_dynamic_builtins(class_statements, where="base-handler class scope")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == base_class:
+            raise ImplementationArtifactError(
+                f"base class {base_class!r} is referenced dynamically; the export is "
+                "not statically provable"
+            )
+
+
+def certify_module_action_export(
+    handler: ResolvedModuleHandlerSource,
+    *,
+    handler_method: str,
+    base_handler: ResolvedModuleBaseHandlerSource | None = None,
+) -> ModuleActionExportProof:
+    """Certify one action export through exactly one of the two bounded modes.
+
+    A leaf that explicitly defines the selected method certifies as
+    ``EXPLICIT_HANDLER`` (the strict single-source proof).  Otherwise, and
+    only when the canonical base-handler source is selected under proven
+    split authority, the ``CANONICAL_BASE_HANDLER`` proof runs over exactly
+    the two canonical sources.  No other source may participate.
+    """
+    if base_handler is not None and base_handler.module_instance != handler.module_instance:
+        raise ImplementationArtifactError(
+            f"base handler of module {base_handler.module_instance!r} cannot certify "
+            f"module {handler.module_instance!r}"
+        )
+    if _leaf_explicitly_defines_method(
+        handler.source_text,
+        handler_class=handler.handler_class,
+        handler_method=handler_method,
+    ):
+        return prove_module_action_export(handler, handler_method=handler_method)
+    if base_handler is None:
+        # Preserve the strict single-source rejection.
+        return prove_module_action_export(handler, handler_method=handler_method)
+    base_class = _prove_canonical_leaf_subclass(handler, handler_method=handler_method)
+    _prove_base_handler_method(
+        base_handler, base_class=base_class, handler_method=handler_method
+    )
+    return ModuleActionExportProof(
+        mode=HandlerCertificationMode.CANONICAL_BASE_HANDLER,
+        handler_class=handler.handler_class,
+        handler_method=handler_method,
+        content_digest=handler.content_digest,
+        base_handler_class=base_class,
+        base_content_digest=base_handler.content_digest,
     )
 
 
@@ -769,8 +1318,16 @@ async def resolve_module_action_implementation(
     content_store: ArtifactContentStore,
     requesting_scope: ExecutionAccessScopeRef,
     layout_registry: AppLayoutRegistry | None = None,
+    base_handler_artifact: AccountedArtifact | None = None,
+    split_authority: WorkspaceHandlerSplitAuthority | None = None,
 ) -> ResolvedModuleActionImplementation:
-    """Resolve and prove one certified module action implementation end to end."""
+    """Resolve and prove one certified module action implementation end to end.
+
+    Without a base selection, certification is the strict single-source
+    ``EXPLICIT_HANDLER`` proof.  A ``base_handler_artifact`` participates only
+    together with the module's proven :class:`WorkspaceHandlerSplitAuthority`;
+    a base selection without split authority rejects.
+    """
     registry = layout_registry or default_app_layout_registry()
     module = await resolve_module_manifest_artifact(
         module_selection,
@@ -784,30 +1341,53 @@ async def resolve_module_action_implementation(
         content_store=content_store,
         layout_registry=registry,
     )
+    base_handler: ResolvedModuleBaseHandlerSource | None = None
+    if base_handler_artifact is not None:
+        if split_authority is None:
+            raise ImplementationArtifactError(
+                "a base-handler selection requires the module's proven "
+                "workspace_handler_split authority"
+            )
+        base_handler = await resolve_module_base_handler_source(
+            base_handler_artifact,
+            module=module,
+            handler=handler,
+            split_authority=split_authority,
+            content_store=content_store,
+            layout_registry=registry,
+        )
     action = module.action(action_id)
-    export_proof = prove_module_action_export(handler, handler_method=action.handler_method)
+    export_proof = certify_module_action_export(
+        handler, handler_method=action.handler_method, base_handler=base_handler
+    )
     return ResolvedModuleActionImplementation(
         module=module,
         handler=handler,
         action=action,
         request_contract=module.action_request_contract(action_id),
         export_proof=export_proof,
+        base_handler=base_handler,
     )
 
 
 __all__ = [
+    "HandlerCertificationMode",
     "ImplementationArtifactError",
     "ModuleActionExportProof",
     "ResolvedModuleActionImplementation",
+    "ResolvedModuleBaseHandlerSource",
     "ResolvedModuleHandlerSource",
     "ResolvedModuleManifest",
     "ResolvedWorkflowImplementation",
     "ResolvedWorkflowOrchestrator",
     "ResolvedWorkflowStructuredOutputs",
     "SelectedContractArtifact",
+    "WorkspaceHandlerSplitAuthority",
+    "certify_module_action_export",
     "pair_workflow_implementation_artifacts",
     "prove_module_action_export",
     "resolve_module_action_implementation",
+    "resolve_module_base_handler_source",
     "resolve_module_handler_source",
     "resolve_module_manifest_artifact",
     "resolve_selected_structured_output_contract",

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -11,12 +11,19 @@ returns the exact verified bytes, the strict document parser accepts them, and
 the parsed document's own schema version must equal the reference's declared
 ``contract_schema_version``.
 
-Module handler sources additionally carry a bounded static export proof: the
-declared handler class and each certified action ``handler_method`` must be
-explicitly present in the selected verified source.  Certified implementation
-selection requires the selected source to expose the declared handler
-explicitly — inherited methods, monkeypatching, ``__getattr__`` tricks, and
-other dynamic exports are rejected, never executed to find out.
+Module handler sources additionally carry a bounded static export proof with
+exactly two certification modes.  ``EXPLICIT_HANDLER`` certifies a true
+standalone one-source class: the declared handler class has zero bases and
+explicitly defines the selected ``handler_method``.  ``CANONICAL_BASE_HANDLER``
+certifies the bounded canonical ``workspace_handler_split`` two-source closure:
+the split is proven from the exact verified bytes of the module's owning
+capability-pack contract (never asserted by the caller, never inferred from
+filenames), and exactly ``handler.py`` plus ``base_handler.py`` participate.
+Monkeypatching, ``__getattr__`` tricks, arbitrary inheritance, and every other
+dynamic export are rejected, never executed to find out.  Every handler, base
+handler, and pack-contract selection is execution-scope-bound: the selection's
+:class:`ExecutionAccessScopeRef` must equal both the requesting scope and the
+module selection's scope.
 
 There is no filesystem fallback, sibling checkout, glob/open/path discovery,
 mutable alias, or caller assertion anywhere on this path.  Opaque resolver
@@ -92,6 +99,9 @@ _DYNAMIC_EXPORT_BUILTINS = frozenset(
     {"setattr", "delattr", "getattr", "globals", "vars", "eval", "exec", "__import__", "type"}
 )
 
+#: ``type X = ...`` statements bind ``X``; the node exists on Python >= 3.12.
+_TYPE_ALIAS_NODE: type[ast.stmt] | None = getattr(ast, "TypeAlias", None)
+
 
 class SelectedContractArtifact(SemanticsModel):
     """One immutable contract selection: typed reference plus physical address.
@@ -113,68 +123,110 @@ class SelectedContractArtifact(SemanticsModel):
         return self
 
 
+class SelectedAccountedArtifact(SemanticsModel):
+    """One scope-bound exact source selection: execution scope plus artifact.
+
+    Handler, base-handler, and pack-contract selections all pass through this
+    wrapper so no source can be selected without carrying the execution scope
+    it was selected under.  Resolution requires the scope to equal both the
+    requesting scope and the parent module selection's scope: identical bytes
+    under a different tenant or workspace scope are not the same selection.
+    """
+
+    scope: ExecutionAccessScopeRef
+    artifact: AccountedArtifact
+
+
 class HandlerCertificationMode(StrEnum):
     """The two bounded implementation-certification modes.
 
-    ``EXPLICIT_HANDLER``: the selected canonical ``handler.py`` explicitly
-    defines the selected ``handler_method``.
+    ``EXPLICIT_HANDLER``: a true standalone one-source class — the declared
+    handler class has ZERO bases and explicitly defines the selected
+    ``handler_method`` in the selected ``handler.py``.  A class that declares
+    any base is not eligible for this mode, even when it explicitly defines
+    the selected method.
 
-    ``CANONICAL_BASE_HANDLER``: the module uses the canonical
-    ``workspace_handler_split`` contract — a preserved workspace-owned
-    ``handler.py`` leaf that directly subclasses the regenerated
-    template-owned ``base_handler.py`` class, which explicitly defines the
-    selected method.  Exactly these two sources may participate; there is no
-    general Python source closure.
+    ``CANONICAL_BASE_HANDLER``: the bounded canonical
+    ``workspace_handler_split`` two-source closure — a preserved
+    workspace-owned ``handler.py`` leaf that directly subclasses the single
+    regenerated template-owned ``base_handler.py`` class.  Both source
+    digests are meaning-bearing for every split-certified action, including a
+    leaf override of the selected method.  Exactly these two sources may
+    participate; there is no general Python source closure.
     """
 
     EXPLICIT_HANDLER = "explicit_handler"
     CANONICAL_BASE_HANDLER = "canonical_base_handler"
 
 
-class WorkspaceHandlerSplitAuthority(SemanticsModel):
-    """Proof that one module legitimately uses the canonical handler split.
+class HandlerMethodSource(StrEnum):
+    """Which certified source explicitly defines the selected method."""
 
-    The split is never inferred merely because files carry the split names:
-    the owning capability-pack contract must declare the canonical ownership —
-    ``handler.py`` as the preserved workspace-owned leaf and
-    ``base_handler.py`` as the regenerated template-owned implementation.
-    Build it with :func:`workspace_handler_split_authority_from_pack_contract`.
-    """
-
-    contract_id: str
-    module_instance: str
-    handler_path: str
-    base_handler_path: str
+    HANDLER = "handler"
+    BASE_HANDLER = "base_handler"
 
 
 class ModuleActionExportProof(SemanticsModel):
     """Static proof that one certified selection explicitly exports one method.
 
-    ``implementation_digest`` is the certified implementation identity: for
-    ``CANONICAL_BASE_HANDLER`` it covers BOTH meaning-bearing source digests,
-    so changing only ``base_handler.py`` — or only the preserved
-    ``handler.py`` — changes the certified identity.
+    ``implementation_digest`` is the certified source-closure identity: for
+    ``CANONICAL_BASE_HANDLER`` it covers BOTH meaning-bearing source digests
+    plus the exact pack-contract digest that authorized the split, so changing
+    only ``base_handler.py``, only the preserved ``handler.py``, or only the
+    certification authority changes the certified identity.  Module and
+    action identity stay deliberately outside this digest — a future
+    ``ImplementationBinding v2`` pins them separately.
     """
 
     mode: HandlerCertificationMode
+    method_source: HandlerMethodSource
     handler_class: str
     handler_method: str
     content_digest: str
     base_handler_class: str | None = None
     base_content_digest: str | None = None
+    split_contract_content_digest: str | None = None
+
+    @model_validator(mode="after")
+    def _mode_shape(self) -> ModuleActionExportProof:
+        if self.mode is HandlerCertificationMode.EXPLICIT_HANDLER:
+            if self.method_source is not HandlerMethodSource.HANDLER:
+                raise ValueError(
+                    "EXPLICIT_HANDLER proofs certify the handler source method"
+                )
+            if (
+                self.base_handler_class is not None
+                or self.base_content_digest is not None
+                or self.split_contract_content_digest is not None
+            ):
+                raise ValueError(
+                    "EXPLICIT_HANDLER proofs carry no base or pack-contract identity"
+                )
+        else:
+            if self.base_handler_class is None or self.base_content_digest is None:
+                raise ValueError(
+                    "CANONICAL_BASE_HANDLER proofs require both source identities"
+                )
+            if self.split_contract_content_digest is None:
+                raise ValueError(
+                    "CANONICAL_BASE_HANDLER proofs require the pack-contract digest"
+                )
+        return self
 
     @property
     def implementation_digest(self) -> str:
-        return canonical_digest(
-            {
-                "mode": self.mode.value,
-                "handler_class": self.handler_class,
-                "handler_method": self.handler_method,
-                "content_digest": self.content_digest,
-                "base_handler_class": self.base_handler_class,
-                "base_content_digest": self.base_content_digest,
-            }
-        )
+        payload: dict[str, str | None] = {
+            "mode": self.mode.value,
+            "method_source": self.method_source.value,
+            "handler_class": self.handler_class,
+            "handler_method": self.handler_method,
+            "content_digest": self.content_digest,
+        }
+        if self.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER:
+            payload["base_handler_class"] = self.base_handler_class
+            payload["base_content_digest"] = self.base_content_digest
+            payload["split_contract_content_digest"] = self.split_contract_content_digest
+        return canonical_digest(payload)
 
 
 @dataclass(frozen=True, slots=True)
@@ -257,8 +309,8 @@ class ResolvedModuleHandlerSource:
 class ResolvedModuleBaseHandlerSource:
     """Exact digest-verified canonical base-handler source for one module.
 
-    Participates in certification only under a proven
-    :class:`WorkspaceHandlerSplitAuthority` for the same module instance.
+    Participates in certification only under the module's content-resolved
+    :class:`ResolvedWorkspaceHandlerSplitAuthority` for the same instance.
     """
 
     artifact: AccountedArtifact
@@ -268,8 +320,35 @@ class ResolvedModuleBaseHandlerSource:
 
 
 @dataclass(frozen=True, slots=True)
+class ResolvedWorkspaceHandlerSplitAuthority:
+    """Content-resolved proof that one module uses the canonical handler split.
+
+    Produced only by :func:`resolve_workspace_handler_split_authority`, which
+    derives every field from the exact verified bytes of the module's owning
+    capability-pack contract.  This is a resolution RESULT, not an input
+    token: no public resolution API accepts a caller-authored ownership
+    claim, and the certified proof pins ``contract_content_digest`` so
+    changing the certification authority invalidates the implementation
+    identity.
+    """
+
+    contract_selection: SelectedAccountedArtifact
+    contract_content_digest: str
+    scope: ExecutionAccessScopeRef
+    contract_id: str
+    module_instance: str
+    handler_path: str
+    base_handler_path: str
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedModuleActionImplementation:
-    """One certified module action: manifest, handler source(s), export proof."""
+    """One certified module action: manifest, handler source(s), export proof.
+
+    ``split_authority`` carries the exact resolved pack-contract authority for
+    ``CANONICAL_BASE_HANDLER`` certifications so a future
+    ``ImplementationBinding`` can pin and revalidate it.
+    """
 
     module: ResolvedModuleManifest
     handler: ResolvedModuleHandlerSource
@@ -277,6 +356,7 @@ class ResolvedModuleActionImplementation:
     request_contract: ClosedContract
     export_proof: ModuleActionExportProof
     base_handler: ResolvedModuleBaseHandlerSource | None = None
+    split_authority: ResolvedWorkspaceHandlerSplitAuthority | None = None
 
 
 def _prove_canonical_layout(
@@ -593,29 +673,64 @@ async def resolve_module_manifest_artifact(
     )
 
 
+def _verify_scoped_source_selection(
+    selection: SelectedAccountedArtifact,
+    *,
+    module: ResolvedModuleManifest,
+    requesting_scope: ExecutionAccessScopeRef,
+    description: str,
+) -> tuple[SelectedAccountedArtifact, str]:
+    """Cold-verify one scope-bound source selection against both scopes.
+
+    Every certified source selection must carry the execution scope it was
+    selected under, and that scope must equal the requesting scope AND the
+    parent module selection's scope.  Identical module ids and identical bytes
+    under a different tenant or workspace scope fail closed here, before any
+    bytes are read.  Returns the verified selection and its mandatory digest.
+    """
+    try:
+        verified = SelectedAccountedArtifact.model_validate(selection.model_dump(mode="json"))
+    except (TypeError, ValueError) as exc:
+        raise ImplementationArtifactError(
+            f"{description} selection failed cold validation: {exc}"
+        ) from exc
+    if verified.scope != requesting_scope:
+        raise ImplementationArtifactError(
+            f"cross-scope {description} selection fails closed"
+        )
+    if verified.scope != module.selection.contract_ref.scope:
+        raise ImplementationArtifactError(
+            f"{description} selection scope does not equal the module "
+            "selection's execution scope"
+        )
+    if verified.artifact.content_digest is None:
+        raise ImplementationArtifactError(
+            f"certified {description} selection requires a non-null content digest"
+        )
+    return verified, verified.artifact.content_digest
+
+
 async def resolve_module_handler_source(
-    artifact: AccountedArtifact,
+    selection: SelectedAccountedArtifact,
     *,
     module: ResolvedModuleManifest,
     content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
     layout_registry: AppLayoutRegistry | None = None,
 ) -> ResolvedModuleHandlerSource:
     """Resolve the exact handler source the module manifest declares.
 
-    The selection is an ``AccountedArtifact`` whose ``content_digest`` is
-    mandatory at this boundary: an address without exact content identity is
-    not a certified selection.
+    The selection is scope-bound and its ``content_digest`` is mandatory at
+    this boundary: an address without exact content identity, or under the
+    wrong execution scope, is not a certified selection.
     """
-    try:
-        verified = AccountedArtifact.model_validate(artifact.model_dump(mode="json"))
-    except (TypeError, ValueError) as exc:
-        raise ImplementationArtifactError(
-            f"handler source artifact failed cold validation: {exc}"
-        ) from exc
-    if verified.content_digest is None:
-        raise ImplementationArtifactError(
-            "certified handler selection requires a non-null content digest"
-        )
+    verified_selection, content_digest = _verify_scoped_source_selection(
+        selection,
+        module=module,
+        requesting_scope=requesting_scope,
+        description="handler source",
+    )
+    verified = verified_selection.artifact
     _family, instance = _prove_canonical_layout(
         verified.address,
         expected_kind=ArtifactKind.MODULE_BACKEND_HANDLER,
@@ -638,7 +753,7 @@ async def resolve_module_handler_source(
             f"{expected_path!r}, not {verified.address.path!r}"
         )
     try:
-        data = await content_store.get_verified_blob(verified.content_digest)
+        data = await content_store.get_verified_blob(content_digest)
     except (ContentNotFoundError, ContentIntegrityError) as exc:
         raise ImplementationArtifactError(
             f"selected handler bytes did not resolve exactly: {exc}"
@@ -651,54 +766,90 @@ async def resolve_module_handler_source(
         artifact=verified,
         module_instance=module_instance,
         handler_class=module.handler_class,
-        content_digest=verified.content_digest,
+        content_digest=content_digest,
         source_text=source_text,
     )
 
 
-def workspace_handler_split_authority_from_pack_contract(
-    contract: Mapping[str, Any], *, module_instance: str
-) -> WorkspaceHandlerSplitAuthority:
-    """Prove the canonical workspace_handler_split ownership from a pack contract.
+async def resolve_workspace_handler_split_authority(
+    contract_selection: SelectedAccountedArtifact,
+    *,
+    module: ResolvedModuleManifest,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+) -> ResolvedWorkspaceHandlerSplitAuthority:
+    """Resolve the workspace_handler_split authority from exact contract bytes.
 
-    The owning capability-pack ``contract.yaml`` must declare, in
-    ``required_outputs``, this module's ``handler.py`` as the preserved
-    workspace-owned leaf (``owner: workspace``) and its ``base_handler.py`` as
-    the regenerated template-owned implementation (``owner: templates``, the
-    canonical materializer default).  Absent or inconsistent declarations
-    reject: the split is contract authority, never a filename coincidence.
+    The caller supplies only the exact scope-bound pack-contract selection;
+    every authority fact — contract type, contract id, canonical path, and the
+    ownership of this module's manifest, leaf, and base — is derived from the
+    digest-verified bytes.  The selection is a bounded workspace-root
+    build-context input: its path must equal
+    ``build_context/{contract_id}/contract.yaml`` for the contract id the
+    verified bytes themselves declare.  The contract must own THIS module —
+    declaring its ``module.yaml``, its ``handler.py`` as the preserved
+    workspace-owned leaf (``owner: workspace``), and its ``base_handler.py``
+    as the regenerated template-owned implementation (``owner: templates``,
+    the canonical materializer default).  Absent, inconsistent, or unrelated
+    declarations reject: the split is contract authority, never a filename
+    coincidence and never a caller assertion.
     """
-    if not isinstance(contract, Mapping):
-        raise ImplementationArtifactError("pack contract must be a mapping document")
-    contract_type = str(contract.get("contract_type") or "").strip()
+    verified_selection, contract_digest = _verify_scoped_source_selection(
+        contract_selection,
+        module=module,
+        requesting_scope=requesting_scope,
+        description="pack-contract",
+    )
+    address = verified_selection.artifact.address
+    if address.path_scope is not PathScope.WORKSPACE_ROOT:
+        raise ImplementationArtifactError(
+            "pack-contract selections are bounded workspace-root build-context "
+            f"inputs, not {address.path_scope.value!r} artifacts"
+        )
+    try:
+        data = await content_store.get_verified_blob(contract_digest)
+    except (ContentNotFoundError, ContentIntegrityError) as exc:
+        raise ImplementationArtifactError(
+            f"selected pack-contract bytes did not resolve exactly: {exc}"
+        ) from exc
+    raw = _parse_yaml_mapping(data, description="pack contract.yaml")
+    contract_type = str(raw.get("contract_type") or "").strip()
     if contract_type != "build_pack_instructions":
         raise ImplementationArtifactError(
             "workspace_handler_split authority requires a build_pack_instructions "
             f"contract, got {contract_type!r}"
         )
-    contract_id = str(contract.get("contract_id") or "").strip()
-    if not contract_id:
+    declared_id = str(raw.get("contract_id") or "").strip()
+    if not declared_id:
         raise ImplementationArtifactError("pack contract declares no contract_id")
-    instance = canonical_instance_identity_value(str(module_instance or "").strip())
-    handler_path = f"modules/{instance}/backend/handler.py"
-    base_handler_path = f"modules/{instance}/backend/base_handler.py"
+    try:
+        contract_id = canonical_instance_identity_value(declared_id)
+    except ValueError as exc:
+        raise ImplementationArtifactError(
+            f"pack contract_id {declared_id!r} is not a canonical identity: {exc}"
+        ) from exc
+    expected_contract_path = f"build_context/{contract_id}/contract.yaml"
+    if address.path != expected_contract_path:
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} lives at {expected_contract_path!r}, "
+            f"not {address.path!r}"
+        )
+    manifest_path = f"modules/{module.module_instance}/module.yaml"
+    handler_path = f"modules/{module.module_instance}/backend/handler.py"
+    base_handler_path = f"modules/{module.module_instance}/backend/base_handler.py"
     owners: dict[str, str] = {}
-    for entry in contract.get("required_outputs") or []:
+    for entry in raw.get("required_outputs") or []:
         if not isinstance(entry, Mapping):
             continue
         path = str(entry.get("path") or "").strip()
-        if path in {handler_path, base_handler_path}:
+        if path in {manifest_path, handler_path, base_handler_path}:
             owners[path] = str(entry.get("owner") or "templates").strip()
-    if handler_path not in owners:
-        raise ImplementationArtifactError(
-            f"pack contract {contract_id!r} does not declare {handler_path!r}; "
-            "the workspace_handler_split authority is absent"
-        )
-    if base_handler_path not in owners:
-        raise ImplementationArtifactError(
-            f"pack contract {contract_id!r} does not declare {base_handler_path!r}; "
-            "the workspace_handler_split authority is absent"
-        )
+    for required in (manifest_path, handler_path, base_handler_path):
+        if required not in owners:
+            raise ImplementationArtifactError(
+                f"pack contract {contract_id!r} does not declare {required!r}; "
+                "the workspace_handler_split authority is absent"
+            )
     if owners[handler_path] != "workspace":
         raise ImplementationArtifactError(
             f"pack contract {contract_id!r} declares {handler_path!r} with owner "
@@ -711,59 +862,45 @@ def workspace_handler_split_authority_from_pack_contract(
             f"{owners[base_handler_path]!r}; the canonical split requires the "
             "regenerated implementation to be template-owned"
         )
-    return WorkspaceHandlerSplitAuthority(
+    return ResolvedWorkspaceHandlerSplitAuthority(
+        contract_selection=verified_selection,
+        contract_content_digest=contract_digest,
+        scope=verified_selection.scope,
         contract_id=contract_id,
-        module_instance=instance,
+        module_instance=module.module_instance,
         handler_path=handler_path,
         base_handler_path=base_handler_path,
     )
 
 
-async def resolve_module_base_handler_source(
-    artifact: AccountedArtifact,
+async def _resolve_base_handler_with_authority(
+    selection: SelectedAccountedArtifact,
     *,
     module: ResolvedModuleManifest,
     handler: ResolvedModuleHandlerSource,
-    split_authority: WorkspaceHandlerSplitAuthority,
+    split_authority: ResolvedWorkspaceHandlerSplitAuthority,
     content_store: ArtifactContentStore,
-    layout_registry: AppLayoutRegistry | None = None,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry,
 ) -> ResolvedModuleBaseHandlerSource:
-    """Resolve the exact canonical base-handler source for one module.
-
-    The base participates only under the module's proven split authority, in
-    the SAME module scope and instance as the selected leaf handler, at the
-    canonical ``base_handler.py`` sibling of the declared handler entrypoint,
-    with a mandatory verified content digest.
-    """
-    try:
-        verified_authority = WorkspaceHandlerSplitAuthority.model_validate(
-            split_authority.model_dump(mode="json")
-        )
-    except (TypeError, ValueError) as exc:
-        raise ImplementationArtifactError(
-            f"workspace_handler_split authority failed cold validation: {exc}"
-        ) from exc
-    if verified_authority.module_instance != module.module_instance:
+    if split_authority.module_instance != module.module_instance:
         raise ImplementationArtifactError(
             f"workspace_handler_split authority for module "
-            f"{verified_authority.module_instance!r} cannot certify module "
+            f"{split_authority.module_instance!r} cannot certify module "
             f"{module.module_instance!r}"
         )
-    try:
-        verified = AccountedArtifact.model_validate(artifact.model_dump(mode="json"))
-    except (TypeError, ValueError) as exc:
-        raise ImplementationArtifactError(
-            f"base-handler source artifact failed cold validation: {exc}"
-        ) from exc
-    if verified.content_digest is None:
-        raise ImplementationArtifactError(
-            "certified base-handler selection requires a non-null content digest"
-        )
+    verified_selection, content_digest = _verify_scoped_source_selection(
+        selection,
+        module=module,
+        requesting_scope=requesting_scope,
+        description="base-handler source",
+    )
+    verified = verified_selection.artifact
     _family, instance = _prove_canonical_layout(
         verified.address,
         expected_kind=ArtifactKind.MODULE_BACKEND_BASE_HANDLER,
         expected_owner=LayoutOwner.MODULE,
-        layout_registry=layout_registry or default_app_layout_registry(),
+        layout_registry=layout_registry,
     )
     module_instance = _require_instance(instance, PlaceholderIdentifier.MODULE_ID)
     if module_instance != module.module_instance:
@@ -787,8 +924,14 @@ async def resolve_module_base_handler_source(
             f"module {module.module_instance!r} declares its canonical base handler "
             f"at {expected_path!r}, not {verified.address.path!r}"
         )
+    authorized_path = f"modules/{module.module_instance}/{base_relative}"
+    if authorized_path != split_authority.base_handler_path:
+        raise ImplementationArtifactError(
+            f"module {module.module_instance!r} declares its handler outside the "
+            f"canonical split layout {split_authority.base_handler_path!r}"
+        )
     try:
-        data = await content_store.get_verified_blob(verified.content_digest)
+        data = await content_store.get_verified_blob(content_digest)
     except (ContentNotFoundError, ContentIntegrityError) as exc:
         raise ImplementationArtifactError(
             f"selected base-handler bytes did not resolve exactly: {exc}"
@@ -800,8 +943,44 @@ async def resolve_module_base_handler_source(
     return ResolvedModuleBaseHandlerSource(
         artifact=verified,
         module_instance=module_instance,
-        content_digest=verified.content_digest,
+        content_digest=content_digest,
         source_text=source_text,
+    )
+
+
+async def resolve_module_base_handler_source(
+    selection: SelectedAccountedArtifact,
+    *,
+    module: ResolvedModuleManifest,
+    handler: ResolvedModuleHandlerSource,
+    pack_contract_selection: SelectedAccountedArtifact,
+    content_store: ArtifactContentStore,
+    requesting_scope: ExecutionAccessScopeRef,
+    layout_registry: AppLayoutRegistry | None = None,
+) -> ResolvedModuleBaseHandlerSource:
+    """Resolve the exact canonical base-handler source for one module.
+
+    The base participates only under the module's content-resolved split
+    authority — the caller supplies the exact scope-bound pack-contract
+    selection, never a preconstructed ownership claim — in the SAME module
+    scope and instance as the selected leaf handler, at the canonical
+    ``base_handler.py`` sibling of the declared handler entrypoint, with a
+    mandatory verified content digest.
+    """
+    split_authority = await resolve_workspace_handler_split_authority(
+        pack_contract_selection,
+        module=module,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+    )
+    return await _resolve_base_handler_with_authority(
+        selection,
+        module=module,
+        handler=handler,
+        split_authority=split_authority,
+        content_store=content_store,
+        requesting_scope=requesting_scope,
+        layout_registry=layout_registry or default_app_layout_registry(),
     )
 
 
@@ -817,41 +996,143 @@ def _iter_scope_statements(body: list[ast.stmt]):
         pending.extend(ast.iter_child_nodes(node))
 
 
-def _target_names(target: ast.AST) -> set[str]:
+def _assignment_target_names(target: ast.expr) -> set[str]:
+    """Names bound in the current scope by one assignment/loop/with target.
+
+    Attribute and subscript stores mutate objects, not the scope's namespace;
+    they bind no name here (the blanket protected-name reference walk rejects
+    them separately).
+    """
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, ast.Starred):
+        return _assignment_target_names(target.value)
+    if isinstance(target, ast.Tuple | ast.List):
+        names: set[str] = set()
+        for element in target.elts:
+            names |= _assignment_target_names(element)
+        return names
+    return set()
+
+
+def _pattern_binding_names(pattern: ast.pattern) -> set[str]:
+    """Every name one match pattern captures into the current scope."""
     names: set[str] = set()
-    for node in ast.walk(target):
-        if isinstance(node, ast.Name):
-            names.add(node.id)
+    if isinstance(pattern, ast.MatchAs):
+        if pattern.name is not None:
+            names.add(pattern.name)
+        if pattern.pattern is not None:
+            names |= _pattern_binding_names(pattern.pattern)
+    elif isinstance(pattern, ast.MatchStar):
+        if pattern.name is not None:
+            names.add(pattern.name)
+    elif isinstance(pattern, ast.MatchMapping):
+        if pattern.rest is not None:
+            names.add(pattern.rest)
+        for sub_pattern in pattern.patterns:
+            names |= _pattern_binding_names(sub_pattern)
+    elif isinstance(pattern, ast.MatchSequence | ast.MatchOr):
+        for sub_pattern in pattern.patterns:
+            names |= _pattern_binding_names(sub_pattern)
+    elif isinstance(pattern, ast.MatchClass):
+        for sub_pattern in (*pattern.patterns, *pattern.kwd_patterns):
+            names |= _pattern_binding_names(sub_pattern)
+    return names
+
+
+def _enclosing_scope_children(node: ast.AST) -> list[ast.AST]:
+    """Child nodes of one AST node that evaluate in the ENCLOSING scope.
+
+    Nested function/class/lambda bodies bind their own locals, not this
+    scope — but their decorators, argument defaults, annotations, and class
+    bases DO evaluate in the enclosing scope and can smuggle bindings (for
+    example a walrus inside a default argument).
+    """
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        children: list[ast.AST] = [*node.decorator_list, *node.args.defaults]
+        children.extend(default for default in node.args.kw_defaults if default is not None)
+        arguments = (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+            *((node.args.vararg,) if node.args.vararg is not None else ()),
+            *((node.args.kwarg,) if node.args.kwarg is not None else ()),
+        )
+        children.extend(arg.annotation for arg in arguments if arg.annotation is not None)
+        if node.returns is not None:
+            children.append(node.returns)
+        return children
+    if isinstance(node, ast.Lambda):
+        lambda_children: list[ast.AST] = [*node.args.defaults]
+        lambda_children.extend(
+            default for default in node.args.kw_defaults if default is not None
+        )
+        return lambda_children
+    if isinstance(node, ast.ClassDef):
+        return [*node.decorator_list, *node.bases, *node.keywords]
+    return list(ast.iter_child_nodes(node))
+
+
+def _nested_binding_names(stmt: ast.stmt) -> set[str]:
+    """Current-scope bindings created inside one statement by non-target forms.
+
+    Collects exception-handler names (``except E as name``), match-pattern
+    captures (``case name`` / ``case [*name]`` / ``case {**name}``), and
+    assignment expressions — walrus targets bind in the containing scope,
+    including from inside comprehensions.  Nested function/class/lambda
+    scopes are not entered except through their enclosing-scope expression
+    positions; comprehension iteration targets stay comprehension-local and
+    are never collected.
+    """
+    names: set[str] = set()
+    pending: list[ast.AST] = _enclosing_scope_children(stmt)
+    while pending:
+        node = pending.pop()
+        if isinstance(node, ast.ExceptHandler) and node.name is not None:
+            names.add(node.name)
+        elif isinstance(node, ast.match_case):
+            names |= _pattern_binding_names(node.pattern)
+        elif isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        pending.extend(_enclosing_scope_children(node))
     return names
 
 
 def _statement_binds_name(stmt: ast.stmt, name: str) -> bool:
-    """True when one scope statement (re)binds ``name`` in that scope."""
+    """True when one scope statement (re)binds ``name`` in the current scope.
+
+    Closed over the Python 3.12 binding forms: definition statements, import
+    aliases, assignment/annotated/augmented assignment targets, deletes, loop
+    and with-statement targets, global/nonlocal declarations, type-alias
+    statements, exception-handler names, match-pattern captures, and
+    assignment expressions.  Nested function/class/lambda scopes bind their
+    own locals, not this scope.
+    """
+    direct: set[str] = set()
     if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
-        return stmt.name == name
-    if isinstance(stmt, ast.Assign):
-        return any(name in _target_names(target) for target in stmt.targets)
-    if isinstance(stmt, ast.AnnAssign | ast.AugAssign):
-        return name in _target_names(stmt.target)
-    if isinstance(stmt, ast.Delete):
-        return any(name in _target_names(target) for target in stmt.targets)
-    if isinstance(stmt, ast.For | ast.AsyncFor):
-        return name in _target_names(stmt.target)
-    if isinstance(stmt, ast.With | ast.AsyncWith):
-        return any(
-            item.optional_vars is not None and name in _target_names(item.optional_vars)
-            for item in stmt.items
-        )
-    if isinstance(stmt, ast.Import | ast.ImportFrom):
-        return any((alias.asname or alias.name.split(".")[0]) == name for alias in stmt.names)
-    if isinstance(stmt, ast.Global | ast.Nonlocal):
-        return name in stmt.names
-    return any(
-        isinstance(node, ast.NamedExpr)
-        and isinstance(node.target, ast.Name)
-        and node.target.id == name
-        for node in ast.walk(stmt)
-    )
+        direct.add(stmt.name)
+    elif isinstance(stmt, ast.Assign | ast.Delete):
+        for target in stmt.targets:
+            direct |= _assignment_target_names(target)
+    elif isinstance(stmt, ast.AnnAssign | ast.AugAssign):
+        direct |= _assignment_target_names(stmt.target)
+    elif isinstance(stmt, ast.For | ast.AsyncFor):
+        direct |= _assignment_target_names(stmt.target)
+    elif isinstance(stmt, ast.With | ast.AsyncWith):
+        for item in stmt.items:
+            if item.optional_vars is not None:
+                direct |= _assignment_target_names(item.optional_vars)
+    elif isinstance(stmt, ast.Import | ast.ImportFrom):
+        direct |= {alias.asname or alias.name.split(".")[0] for alias in stmt.names}
+    elif isinstance(stmt, ast.Global | ast.Nonlocal):
+        direct |= set(stmt.names)
+    elif _TYPE_ALIAS_NODE is not None and isinstance(stmt, _TYPE_ALIAS_NODE):
+        alias_name = getattr(stmt, "name", None)
+        if isinstance(alias_name, ast.Name):
+            direct.add(alias_name.id)
+    if name in direct:
+        return True
+    return name in _nested_binding_names(stmt)
 
 
 def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
@@ -872,13 +1153,18 @@ def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
 def prove_module_action_export(
     handler: ResolvedModuleHandlerSource, *, handler_method: str
 ) -> ModuleActionExportProof:
-    """Prove the declared class explicitly exports ``handler_method`` in this source.
+    """Prove one TRUE STANDALONE class explicitly exports ``handler_method``.
 
-    The proof is bounded and static: the source is parsed, never executed.  It
-    fails closed on every construct that could make the visible definition not
-    be the effective export — redefinition, conditional or decorated
-    definitions, name rebinding, monkeypatching, ``__getattr__`` tricks, and
-    any further reference to the handler class name.
+    ``EXPLICIT_HANDLER`` certification means a one-source class: the declared
+    handler class must have ZERO bases — a class that declares any base
+    (single, multiple, or mixin) is not eligible for this mode even when it
+    explicitly defines the selected method, because its behavior is not
+    provable from this source alone.  The proof is bounded and static: the
+    source is parsed, never executed.  It fails closed on every construct
+    that could make the visible definition not be the effective export —
+    redefinition, conditional or decorated definitions, name rebinding,
+    monkeypatching, ``__getattr__`` tricks, and any further reference to the
+    handler class name.
     """
     handler_class = handler.handler_class
     try:
@@ -913,6 +1199,12 @@ def prove_module_action_export(
         raise ImplementationArtifactError(
             f"handler class {handler_class!r} uses decorators or class keywords; the "
             "export is not statically provable"
+        )
+    if class_def.bases:
+        raise ImplementationArtifactError(
+            f"handler class {handler_class!r} declares base classes and is not a "
+            "standalone one-source class; EXPLICIT_HANDLER certification requires "
+            "zero bases"
         )
     for stmt in module_statements:
         if stmt is class_def:
@@ -980,43 +1272,30 @@ def prove_module_action_export(
             )
     return ModuleActionExportProof(
         mode=HandlerCertificationMode.EXPLICIT_HANDLER,
+        method_source=HandlerMethodSource.HANDLER,
         handler_class=handler_class,
         handler_method=handler_method,
         content_digest=handler.content_digest,
     )
 
 
-def _leaf_explicitly_defines_method(source_text: str, *, handler_class: str, handler_method: str) -> bool:
-    """Cheap mode probe: does the leaf directly define the selected method?
-
-    Only decides WHICH bounded certification mode applies; every actual
-    guarantee is enforced by the full mode-specific proof afterwards.
-    """
-    try:
-        tree = ast.parse(source_text)
-    except SyntaxError:
-        return True  # let the explicit proof produce the canonical rejection
-    for stmt in tree.body:
-        if isinstance(stmt, ast.ClassDef) and stmt.name == handler_class:
-            return any(
-                isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef)
-                and child.name == handler_method
-                for child in stmt.body
-            )
-    return True  # absent class: the explicit proof owns that rejection too
-
-
 def _prove_canonical_leaf_subclass(
     handler: ResolvedModuleHandlerSource, *, handler_method: str
-) -> str:
-    """Prove the leaf is the bounded canonical subclass and return its base name.
+) -> tuple[str, bool]:
+    """Prove the leaf is the bounded canonical subclass.
 
     Exactly one top-level handler class with exactly one plain-name base,
-    bound by exactly one ``from .base_handler import <Base>`` — no aliasing,
-    no star imports, no second base, no mixins, no conditional or dynamic
-    construction, no rebinding, no ``__getattr__``/setattr tricks, and no
-    leaf binding of the selected method (a leaf override is certified through
-    EXPLICIT_HANDLER instead).
+    bound by exactly one ``from .base_handler import <Base>`` that is itself
+    an unconditional DIRECT member of the module body appearing BEFORE the
+    handler class definition — so the class construction provably sees the
+    exact proven base binding.  No aliasing, no star imports, no second base,
+    no mixins, no conditional/nested/late imports, no conditional or dynamic
+    construction, no rebinding, and no ``__getattr__``/setattr tricks.
+
+    A leaf override of the selected method is allowed under the same strict
+    direct-method grammar as every explicit definition; the certification
+    stays two-source (``CANONICAL_BASE_HANDLER``).  Returns the base class
+    name and whether the leaf explicitly defines the selected method.
     """
     handler_class = handler.handler_class
     try:
@@ -1066,32 +1345,17 @@ def _prove_canonical_leaf_subclass(
         )
     base_name = base_expr.id
 
-    canonical_imports: list[ast.ImportFrom] = []
+    class_index = next(
+        index for index, stmt in enumerate(tree.body) if stmt is class_def
+    )
+    canonical_import: ast.ImportFrom | None = None
     for stmt in module_statements:
         if stmt is class_def:
             continue
-        if isinstance(stmt, ast.ImportFrom):
-            if any(alias.name == "*" for alias in stmt.names):
-                raise ImplementationArtifactError(
-                    "star imports defeat static export proof"
-                )
-            binds_base = any(
-                (alias.asname or alias.name) == base_name for alias in stmt.names
-            )
-            if binds_base:
-                if (
-                    stmt.level == 1
-                    and stmt.module == "base_handler"
-                    and len(stmt.names) == 1
-                    and stmt.names[0].name == base_name
-                    and stmt.names[0].asname is None
-                ):
-                    canonical_imports.append(stmt)
-                    continue
-                raise ImplementationArtifactError(
-                    f"base class {base_name!r} must be imported exactly as "
-                    f"'from .base_handler import {base_name}'"
-                )
+        if isinstance(stmt, ast.ImportFrom) and any(
+            alias.name == "*" for alias in stmt.names
+        ):
+            raise ImplementationArtifactError("star imports defeat static export proof")
         if isinstance(stmt, ast.FunctionDef) and stmt.name == "__getattr__":
             raise ImplementationArtifactError(
                 "module-level __getattr__ defeats static export proof"
@@ -1101,10 +1365,43 @@ def _prove_canonical_leaf_subclass(
                 f"handler class {handler_class!r} is rebound outside its definition"
             )
         if _statement_binds_name(stmt, base_name):
-            raise ImplementationArtifactError(
-                f"base class {base_name!r} is rebound outside its canonical import"
+            if not isinstance(stmt, ast.ImportFrom):
+                raise ImplementationArtifactError(
+                    f"base class {base_name!r} is rebound outside its canonical import"
+                )
+            if not (
+                stmt.level == 1
+                and stmt.module == "base_handler"
+                and len(stmt.names) == 1
+                and stmt.names[0].name == base_name
+                and stmt.names[0].asname is None
+            ):
+                raise ImplementationArtifactError(
+                    f"base class {base_name!r} must be imported exactly as "
+                    f"'from .base_handler import {base_name}'"
+                )
+            import_index = next(
+                (index for index, body_stmt in enumerate(tree.body) if body_stmt is stmt),
+                None,
             )
-    if len(canonical_imports) != 1:
+            if import_index is None:
+                raise ImplementationArtifactError(
+                    f"the canonical base import of {base_name!r} must be an "
+                    "unconditional top-level module statement, not nested in "
+                    "control flow"
+                )
+            if import_index > class_index:
+                raise ImplementationArtifactError(
+                    f"the canonical base import of {base_name!r} must appear before "
+                    "the handler class definition"
+                )
+            if canonical_import is not None:
+                raise ImplementationArtifactError(
+                    f"base class {base_name!r} must be bound by exactly one "
+                    f"'from .base_handler import {base_name}' import"
+                )
+            canonical_import = stmt
+    if canonical_import is None:
         raise ImplementationArtifactError(
             f"base class {base_name!r} must be bound by exactly one "
             f"'from .base_handler import {base_name}' import"
@@ -1112,7 +1409,35 @@ def _prove_canonical_leaf_subclass(
     _reject_dynamic_builtins(module_statements, where="handler module scope")
 
     class_statements = list(_iter_scope_statements(class_def.body))
+    method_defs = [
+        stmt
+        for stmt in class_statements
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+        and stmt.name == handler_method
+    ]
+    leaf_method: ast.stmt | None = None
+    if method_defs:
+        if len(method_defs) != 1:
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is bound more than once on class "
+                f"{handler_class!r}; the export is not statically provable"
+            )
+        leaf_method = method_defs[0]
+        if leaf_method not in class_def.body:
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is defined conditionally; the "
+                "export is not statically provable"
+            )
+        if isinstance(leaf_method, ast.FunctionDef | ast.AsyncFunctionDef) and (
+            leaf_method.decorator_list
+        ):
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is decorated; the export is not "
+                "statically provable"
+            )
     for stmt in class_statements:
+        if stmt is leaf_method:
+            continue
         if (
             isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
             and stmt.name in {"__getattr__", "__getattribute__"}
@@ -1143,21 +1468,26 @@ def _prove_canonical_leaf_subclass(
                 f"handler class {handler_class!r} is referenced dynamically; the "
                 "export is not statically provable"
             )
-    return base_name
+    return base_name, leaf_method is not None
 
 
-def _prove_base_handler_method(
+def _prove_base_handler_closure(
     base_handler: ResolvedModuleBaseHandlerSource,
     *,
     base_class: str,
     handler_method: str,
+    require_method: bool,
 ) -> None:
-    """Prove the canonical base class explicitly defines the selected method.
+    """Prove the canonical base class closure, and the method when required.
 
     The base class must be the single top-level class of the regenerated
     base-handler source, with no bases of its own (no transitive
-    inheritance), no dynamic construction, and an explicit undecorated
-    definition of the selected method.
+    inheritance) and no dynamic construction.  With ``require_method`` the
+    selected method must be explicitly defined there under the strict
+    direct-method grammar; without it (the leaf override case) the base
+    remains meaning-bearing for construction, inherited helpers, and lookup —
+    the full closure proof still runs, and a base definition of the selected
+    method is allowed only in the same strict explicit form.
     """
     try:
         tree = ast.parse(base_handler.source_text)
@@ -1222,27 +1552,31 @@ def _prove_base_handler_method(
         if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
         and stmt.name == handler_method
     ]
-    if not method_defs:
+    if not method_defs and require_method:
         raise ImplementationArtifactError(
             f"action handler_method {handler_method!r} is not explicitly defined on "
             f"canonical base class {base_class!r} in the selected source"
         )
-    if len(method_defs) != 1:
-        raise ImplementationArtifactError(
-            f"handler_method {handler_method!r} is bound more than once on base "
-            f"class {base_class!r}; the export is not statically provable"
-        )
-    method_def = method_defs[0]
-    if method_def not in class_def.body:
-        raise ImplementationArtifactError(
-            f"handler_method {handler_method!r} is defined conditionally; the export "
-            "is not statically provable"
-        )
-    if method_def.decorator_list:
-        raise ImplementationArtifactError(
-            f"handler_method {handler_method!r} is decorated; the export is not "
-            "statically provable"
-        )
+    method_def: ast.stmt | None = None
+    if method_defs:
+        if len(method_defs) != 1:
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is bound more than once on base "
+                f"class {base_class!r}; the export is not statically provable"
+            )
+        method_def = method_defs[0]
+        if method_def not in class_def.body:
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is defined conditionally; the "
+                "export is not statically provable"
+            )
+        if isinstance(method_def, ast.FunctionDef | ast.AsyncFunctionDef) and (
+            method_def.decorator_list
+        ):
+            raise ImplementationArtifactError(
+                f"handler_method {handler_method!r} is decorated; the export is not "
+                "statically provable"
+            )
     for stmt in class_statements:
         if stmt is method_def:
             continue
@@ -1273,60 +1607,83 @@ def certify_module_action_export(
     *,
     handler_method: str,
     base_handler: ResolvedModuleBaseHandlerSource | None = None,
+    split_authority: ResolvedWorkspaceHandlerSplitAuthority | None = None,
 ) -> ModuleActionExportProof:
     """Certify one action export through exactly one of the two bounded modes.
 
-    A leaf that explicitly defines the selected method certifies as
-    ``EXPLICIT_HANDLER`` (the strict single-source proof).  Otherwise, and
-    only when the canonical base-handler source is selected under proven
-    split authority, the ``CANONICAL_BASE_HANDLER`` proof runs over exactly
-    the two canonical sources.  No other source may participate.
+    Without a base selection, certification is the strict standalone
+    ``EXPLICIT_HANDLER`` proof (zero bases).  With the canonical base-handler
+    source AND the content-resolved split authority — both are required
+    together — the ``CANONICAL_BASE_HANDLER`` proof runs over exactly the two
+    canonical sources.  A canonical split leaf that explicitly overrides the
+    selected method stays a two-source ``CANONICAL_BASE_HANDLER``
+    certification with ``method_source = handler``; both source digests and
+    the pack-contract digest remain meaning-bearing.  No other source may
+    participate.  The resolution APIs are the authority boundary: they derive
+    ``split_authority`` from exact verified pack-contract bytes.
     """
-    if base_handler is not None and base_handler.module_instance != handler.module_instance:
+    if base_handler is None and split_authority is None:
+        return prove_module_action_export(handler, handler_method=handler_method)
+    if base_handler is None or split_authority is None:
+        raise ImplementationArtifactError(
+            "canonical split certification requires the base-handler source and "
+            "the content-resolved workspace_handler_split authority together"
+        )
+    if base_handler.module_instance != handler.module_instance:
         raise ImplementationArtifactError(
             f"base handler of module {base_handler.module_instance!r} cannot certify "
             f"module {handler.module_instance!r}"
         )
-    if _leaf_explicitly_defines_method(
-        handler.source_text,
-        handler_class=handler.handler_class,
+    if split_authority.module_instance != handler.module_instance:
+        raise ImplementationArtifactError(
+            f"workspace_handler_split authority for module "
+            f"{split_authority.module_instance!r} cannot certify module "
+            f"{handler.module_instance!r}"
+        )
+    base_class, leaf_defines_method = _prove_canonical_leaf_subclass(
+        handler, handler_method=handler_method
+    )
+    _prove_base_handler_closure(
+        base_handler,
+        base_class=base_class,
         handler_method=handler_method,
-    ):
-        return prove_module_action_export(handler, handler_method=handler_method)
-    if base_handler is None:
-        # Preserve the strict single-source rejection.
-        return prove_module_action_export(handler, handler_method=handler_method)
-    base_class = _prove_canonical_leaf_subclass(handler, handler_method=handler_method)
-    _prove_base_handler_method(
-        base_handler, base_class=base_class, handler_method=handler_method
+        require_method=not leaf_defines_method,
     )
     return ModuleActionExportProof(
         mode=HandlerCertificationMode.CANONICAL_BASE_HANDLER,
+        method_source=(
+            HandlerMethodSource.HANDLER
+            if leaf_defines_method
+            else HandlerMethodSource.BASE_HANDLER
+        ),
         handler_class=handler.handler_class,
         handler_method=handler_method,
         content_digest=handler.content_digest,
         base_handler_class=base_class,
         base_content_digest=base_handler.content_digest,
+        split_contract_content_digest=split_authority.contract_content_digest,
     )
 
 
 async def resolve_module_action_implementation(
     module_selection: SelectedContractArtifact,
-    handler_artifact: AccountedArtifact,
+    handler_selection: SelectedAccountedArtifact,
     *,
     action_id: str,
     content_store: ArtifactContentStore,
     requesting_scope: ExecutionAccessScopeRef,
     layout_registry: AppLayoutRegistry | None = None,
-    base_handler_artifact: AccountedArtifact | None = None,
-    split_authority: WorkspaceHandlerSplitAuthority | None = None,
+    base_handler_selection: SelectedAccountedArtifact | None = None,
+    pack_contract_selection: SelectedAccountedArtifact | None = None,
 ) -> ResolvedModuleActionImplementation:
     """Resolve and prove one certified module action implementation end to end.
 
-    Without a base selection, certification is the strict single-source
-    ``EXPLICIT_HANDLER`` proof.  A ``base_handler_artifact`` participates only
-    together with the module's proven :class:`WorkspaceHandlerSplitAuthority`;
-    a base selection without split authority rejects.
+    Without a base selection, certification is the strict standalone
+    ``EXPLICIT_HANDLER`` proof.  A ``base_handler_selection`` participates
+    only together with ``pack_contract_selection`` — the exact scope-bound
+    selection of the module's owning capability-pack contract, from whose
+    verified bytes the split authority is derived.  There is no way to
+    substitute a caller-authored ownership claim for those bytes.
     """
     registry = layout_registry or default_app_layout_registry()
     module = await resolve_module_manifest_artifact(
@@ -1336,29 +1693,41 @@ async def resolve_module_action_implementation(
         layout_registry=registry,
     )
     handler = await resolve_module_handler_source(
-        handler_artifact,
+        handler_selection,
         module=module,
         content_store=content_store,
+        requesting_scope=requesting_scope,
         layout_registry=registry,
     )
+    if (base_handler_selection is None) != (pack_contract_selection is None):
+        raise ImplementationArtifactError(
+            "canonical split certification requires the base-handler selection and "
+            "the module's exact pack-contract selection together"
+        )
     base_handler: ResolvedModuleBaseHandlerSource | None = None
-    if base_handler_artifact is not None:
-        if split_authority is None:
-            raise ImplementationArtifactError(
-                "a base-handler selection requires the module's proven "
-                "workspace_handler_split authority"
-            )
-        base_handler = await resolve_module_base_handler_source(
-            base_handler_artifact,
+    split_authority: ResolvedWorkspaceHandlerSplitAuthority | None = None
+    if base_handler_selection is not None and pack_contract_selection is not None:
+        split_authority = await resolve_workspace_handler_split_authority(
+            pack_contract_selection,
+            module=module,
+            content_store=content_store,
+            requesting_scope=requesting_scope,
+        )
+        base_handler = await _resolve_base_handler_with_authority(
+            base_handler_selection,
             module=module,
             handler=handler,
             split_authority=split_authority,
             content_store=content_store,
+            requesting_scope=requesting_scope,
             layout_registry=registry,
         )
     action = module.action(action_id)
     export_proof = certify_module_action_export(
-        handler, handler_method=action.handler_method, base_handler=base_handler
+        handler,
+        handler_method=action.handler_method,
+        base_handler=base_handler,
+        split_authority=split_authority,
     )
     return ResolvedModuleActionImplementation(
         module=module,
@@ -1367,11 +1736,13 @@ async def resolve_module_action_implementation(
         request_contract=module.action_request_contract(action_id),
         export_proof=export_proof,
         base_handler=base_handler,
+        split_authority=split_authority,
     )
 
 
 __all__ = [
     "HandlerCertificationMode",
+    "HandlerMethodSource",
     "ImplementationArtifactError",
     "ModuleActionExportProof",
     "ResolvedModuleActionImplementation",
@@ -1381,8 +1752,9 @@ __all__ = [
     "ResolvedWorkflowImplementation",
     "ResolvedWorkflowOrchestrator",
     "ResolvedWorkflowStructuredOutputs",
+    "ResolvedWorkspaceHandlerSplitAuthority",
+    "SelectedAccountedArtifact",
     "SelectedContractArtifact",
-    "WorkspaceHandlerSplitAuthority",
     "certify_module_action_export",
     "pair_workflow_implementation_artifacts",
     "prove_module_action_export",
@@ -1393,4 +1765,5 @@ __all__ = [
     "resolve_selected_structured_output_contract",
     "resolve_workflow_orchestrator_artifact",
     "resolve_workflow_structured_outputs_artifact",
+    "resolve_workspace_handler_split_authority",
 ]

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -1240,34 +1240,49 @@ def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
                     )
 
 
+def _permitted_lambda_binding(stmt: ast.stmt) -> tuple[str, ast.Lambda] | None:
+    """The ONLY permitted construction-scope lambda position: a simple binding.
+
+    ``helper = lambda: ...`` or ``helper: T = lambda: ...`` — exactly one
+    plain ``Name`` storage target with the lambda as the ENTIRE direct value.
+    Returns the bound name and the lambda node, or ``None``.  A walrus
+    (``(f := lambda: ...)``) is NOT a permitted binding: it is
+    expression-valued and lets the new callable object flow directly into
+    another construction-time operation without a subsequent Name Load.
+    """
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and isinstance(stmt.value, ast.Lambda)
+    ):
+        return stmt.targets[0].id, stmt.value
+    if (
+        isinstance(stmt, ast.AnnAssign)
+        and isinstance(stmt.target, ast.Name)
+        and isinstance(stmt.value, ast.Lambda)
+    ):
+        return stmt.target.id, stmt.value
+    return None
+
+
 def _local_callable_names(body: list[ast.stmt]) -> set[str]:
     """Names bound to locally-defined callables in one lexical scope.
 
     Covers def/class statements (classes are callables too — constructing one
-    executes uninspected ``__new__``/``__init__`` bodies), simple lambda
-    bindings (``name = lambda``, ``name: T = lambda``), and walrus bindings
-    to a lambda.
+    executes uninspected ``__new__``/``__init__`` bodies) and permitted
+    simple lambda bindings (``name = lambda``, ``name: T = lambda``).  Every
+    other construction-scope lambda position rejects outright, so no other
+    form can define a callable here.
     """
     names: set[str] = set()
     for stmt in _iter_scope_statements(body):
         if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
             names.add(stmt.name)
-        elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Lambda):
-            for target in stmt.targets:
-                names |= _assignment_target_names(target)
-        elif (
-            isinstance(stmt, ast.AnnAssign)
-            and stmt.value is not None
-            and isinstance(stmt.value, ast.Lambda)
-        ):
-            names |= _assignment_target_names(stmt.target)
-        for node in _construction_expression_nodes(stmt):
-            if (
-                isinstance(node, ast.NamedExpr)
-                and isinstance(node.value, ast.Lambda)
-                and isinstance(node.target, ast.Name)
-            ):
-                names.add(node.target.id)
+        else:
+            binding = _permitted_lambda_binding(stmt)
+            if binding is not None:
+                names.add(binding[0])
     return names
 
 
@@ -1305,12 +1320,22 @@ def _reject_construction_time_local_callables(
     application, no argument laundering, no lambda invoked or applied as a
     decorator.  Any construction-time ``Name`` reference to such a callable
     fails closed (this deliberately subsumes every invocation form without
-    building a call graph or dataflow).  Deferred function/method bodies may
-    freely use local helpers — that is runtime behavior, outside this
-    import-time proof.  Class bodies execute during import, so each nested
-    class scope is scanned recursively against its own locals plus every
-    enclosing scope's (a fail-closed over-approximation of Python's actual
-    class-scope name resolution).
+    building a call graph or dataflow).
+
+    Anonymous lambdas are additionally position-restricted: a
+    construction-scope lambda is permitted ONLY as the entire direct value
+    of a simple named binding (``helper = lambda: ...``).  Every other
+    position — walrus, call arguments, containers, subscripts, conditional
+    expressions, decorators, defaults, annotations, class bases — rejects
+    generically, so a laundered lambda can never cross the construction
+    boundary as an executable object.  A stored lambda becomes an ordinary
+    local callable name covered by the Load-reference rule.
+
+    Deferred function/method bodies may freely use local helpers — that is
+    runtime behavior, outside this import-time proof.  Class bodies execute
+    during import, so each nested class scope is scanned recursively against
+    its own locals plus every enclosing scope's (a fail-closed
+    over-approximation of Python's actual class-scope name resolution).
     """
     known = frozenset(_local_callable_names(body)) | inherited
     for stmt in _iter_scope_statements(body):
@@ -1321,11 +1346,19 @@ def _reject_construction_time_local_callables(
                         f"{where} applies a lambda decorator during construction; the "
                         "effective export is not statically provable"
                     )
+        binding = _permitted_lambda_binding(stmt)
+        permitted_lambda = binding[1] if binding is not None else None
         for node in _construction_expression_nodes(stmt):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Lambda):
                 raise ImplementationArtifactError(
                     f"{where} invokes a lambda during construction; the effective "
                     "export is not statically provable"
+                )
+            if isinstance(node, ast.Lambda) and node is not permitted_lambda:
+                raise ImplementationArtifactError(
+                    f"{where} places an anonymous lambda in a construction-time "
+                    "expression; only a lambda stored directly in a simple named "
+                    "binding is certifiable"
                 )
             if (
                 isinstance(node, ast.Name)

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -787,12 +787,16 @@ async def resolve_workspace_handler_split_authority(
     build-context input: its path must equal
     ``build_context/{contract_id}/contract.yaml`` for the contract id the
     verified bytes themselves declare.  The contract must own THIS module —
-    declaring its ``module.yaml``, its ``handler.py`` as the preserved
-    workspace-owned leaf (``owner: workspace``), and its ``base_handler.py``
-    as the regenerated template-owned implementation (``owner: templates``,
-    the canonical materializer default).  Absent, inconsistent, or unrelated
-    declarations reject: the split is contract authority, never a filename
-    coincidence and never a caller assertion.
+    declaring its ``module.yaml`` (canonical ``owner: templates``), its
+    ``handler.py`` as the preserved workspace-owned leaf
+    (``owner: workspace``), and its ``base_handler.py`` as the regenerated
+    template-owned implementation (``owner: templates``).  The verified
+    bytes must be unambiguous: every ``required_outputs`` entry must be a
+    mapping with a unique path, and authority-relevant ownership must be
+    EXPLICIT — this boundary never defaults an omitted owner.  Absent,
+    duplicate, inconsistent, or unrelated declarations reject: the split is
+    contract authority, never a filename coincidence and never a caller
+    assertion.
     """
     verified_selection, contract_digest = _verify_scoped_source_selection(
         contract_selection,
@@ -838,18 +842,41 @@ async def resolve_workspace_handler_split_authority(
     handler_path = f"modules/{module.module_instance}/backend/handler.py"
     base_handler_path = f"modules/{module.module_instance}/backend/base_handler.py"
     owners: dict[str, str] = {}
+    seen_paths: set[str] = set()
     for entry in raw.get("required_outputs") or []:
         if not isinstance(entry, Mapping):
-            continue
+            raise ImplementationArtifactError(
+                f"pack contract {contract_id!r} has a non-mapping required_outputs "
+                "entry; ownership is ambiguous"
+            )
         path = str(entry.get("path") or "").strip()
+        if path in seen_paths:
+            raise ImplementationArtifactError(
+                f"pack contract {contract_id!r} declares required output {path!r} "
+                "more than once; ownership is ambiguous"
+            )
+        seen_paths.add(path)
         if path in {manifest_path, handler_path, base_handler_path}:
-            owners[path] = str(entry.get("owner") or "templates").strip()
+            declared_owner = entry.get("owner")
+            owner = declared_owner.strip() if isinstance(declared_owner, str) else ""
+            if not owner:
+                raise ImplementationArtifactError(
+                    f"pack contract {contract_id!r} declares {path!r} without an "
+                    "explicit owner; this certification authority does not default "
+                    "ownership"
+                )
+            owners[path] = owner
     for required in (manifest_path, handler_path, base_handler_path):
         if required not in owners:
             raise ImplementationArtifactError(
                 f"pack contract {contract_id!r} does not declare {required!r}; "
                 "the workspace_handler_split authority is absent"
             )
+    if owners[manifest_path] != "templates":
+        raise ImplementationArtifactError(
+            f"pack contract {contract_id!r} declares {manifest_path!r} with owner "
+            f"{owners[manifest_path]!r}; the canonical manifest owner is 'templates'"
+        )
     if owners[handler_path] != "workspace":
         raise ImplementationArtifactError(
             f"pack contract {contract_id!r} declares {handler_path!r} with owner "
@@ -1135,19 +1162,71 @@ def _statement_binds_name(stmt: ast.stmt, name: str) -> bool:
     return name in _nested_binding_names(stmt)
 
 
+def _iter_construction_nodes(stmt: ast.stmt):
+    """Every AST node of one scope statement that executes at construction time.
+
+    Class bodies execute when the module is imported, so they are entered;
+    function and lambda bodies are deferred and are inspected only through
+    their enclosing-scope expression positions (decorators, defaults,
+    annotations, bases), consistent with the binding grammar.
+    """
+    pending: list[ast.AST] = [stmt]
+    while pending:
+        node = pending.pop()
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            pending.extend(_enclosing_scope_children(node))
+        elif isinstance(node, ast.ClassDef):
+            pending.extend(_enclosing_scope_children(node))
+            pending.extend(node.body)
+        else:
+            pending.extend(ast.iter_child_nodes(node))
+
+
 def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
+    """Reject direct dynamic export/execution primitives in construction scope.
+
+    This is a bounded OWN-SOURCE export/binding proof, not a proof of
+    arbitrary imported dependency behavior.  Within the certified source's
+    module/class construction scope it fails closed on any reference to a
+    dynamic primitive name (``exec``, ``eval``, ``setattr``, ...), on
+    importing such a primitive (or ``*``) from ``builtins``, and on any use
+    of a name bound to the ``builtins`` module (including ``__builtins__``)
+    — so ``builtins.exec``, aliased imports, and simple rebinding of a
+    primitive name cannot reach the same escape.  Function and lambda bodies
+    are deferred execution and are out of scope by design.
+    """
+    builtins_aliases = {"__builtins__"}
     for stmt in statements:
-        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
-            continue
-        for node in ast.walk(stmt):
+        for node in _iter_construction_nodes(stmt):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "builtins" or alias.name.startswith("builtins."):
+                        builtins_aliases.add(alias.asname or alias.name.split(".")[0])
+    for stmt in statements:
+        for node in _iter_construction_nodes(stmt):
             if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id in _DYNAMIC_EXPORT_BUILTINS
+                isinstance(node, ast.ImportFrom)
+                and node.level == 0
+                and node.module == "builtins"
             ):
-                raise ImplementationArtifactError(
-                    f"{where} calls {node.func.id!r}; the export is not statically provable"
-                )
+                for alias in node.names:
+                    if alias.name == "*" or alias.name in _DYNAMIC_EXPORT_BUILTINS:
+                        raise ImplementationArtifactError(
+                            f"{where} imports {alias.name!r} from builtins; the export "
+                            "is not statically provable"
+                        )
+            if isinstance(node, ast.Name):
+                if node.id in _DYNAMIC_EXPORT_BUILTINS:
+                    raise ImplementationArtifactError(
+                        f"{where} references dynamic export primitive {node.id!r}; the "
+                        "export is not statically provable"
+                    )
+                if node.id in builtins_aliases:
+                    raise ImplementationArtifactError(
+                        f"{where} accesses the builtins module through {node.id!r}; the "
+                        "export is not statically provable"
+                    )
 
 
 def prove_module_action_export(
@@ -1602,7 +1681,7 @@ def _prove_base_handler_closure(
             )
 
 
-def certify_module_action_export(
+def _certify_module_action_export(
     handler: ResolvedModuleHandlerSource,
     *,
     handler_method: str,
@@ -1610,6 +1689,13 @@ def certify_module_action_export(
     split_authority: ResolvedWorkspaceHandlerSplitAuthority | None = None,
 ) -> ModuleActionExportProof:
     """Certify one action export through exactly one of the two bounded modes.
+
+    INTERNAL: :func:`resolve_module_action_implementation` is the only public
+    authority-producing API — it derives ``split_authority`` from exact
+    verified pack-contract bytes before this proof runs, so no caller can
+    substitute a preconstructed authority object for those bytes.  The public
+    standalone helper surface is :func:`prove_module_action_export`, the
+    zero-base ``EXPLICIT_HANDLER`` proof only.
 
     Without a base selection, certification is the strict standalone
     ``EXPLICIT_HANDLER`` proof (zero bases).  With the canonical base-handler
@@ -1619,8 +1705,7 @@ def certify_module_action_export(
     selected method stays a two-source ``CANONICAL_BASE_HANDLER``
     certification with ``method_source = handler``; both source digests and
     the pack-contract digest remain meaning-bearing.  No other source may
-    participate.  The resolution APIs are the authority boundary: they derive
-    ``split_authority`` from exact verified pack-contract bytes.
+    participate.
     """
     if base_handler is None and split_authority is None:
         return prove_module_action_export(handler, handler_method=handler_method)
@@ -1723,7 +1808,7 @@ async def resolve_module_action_implementation(
             layout_registry=registry,
         )
     action = module.action(action_id)
-    export_proof = certify_module_action_export(
+    export_proof = _certify_module_action_export(
         handler,
         handler_method=action.handler_method,
         base_handler=base_handler,
@@ -1755,7 +1840,6 @@ __all__ = [
     "ResolvedWorkspaceHandlerSplitAuthority",
     "SelectedAccountedArtifact",
     "SelectedContractArtifact",
-    "certify_module_action_export",
     "pair_workflow_implementation_artifacts",
     "prove_module_action_export",
     "resolve_module_action_implementation",

--- a/mozaiksai/core/semantics/implementation_artifacts.py
+++ b/mozaiksai/core/semantics/implementation_artifacts.py
@@ -96,7 +96,18 @@ _INSTANCE_PLACEHOLDER_BY_SCOPE: dict[PathScope, PlaceholderIdentifier] = {
 #: Builtins whose presence in module/class statement space defeats static
 #: export proof (they can create, replace, or hide exports at import time).
 _DYNAMIC_EXPORT_BUILTINS = frozenset(
-    {"setattr", "delattr", "getattr", "globals", "vars", "eval", "exec", "__import__", "type"}
+    {
+        "setattr",
+        "delattr",
+        "getattr",
+        "globals",
+        "locals",
+        "vars",
+        "eval",
+        "exec",
+        "__import__",
+        "type",
+    }
 )
 
 #: ``type X = ...`` statements bind ``X``; the node exists on Python >= 3.12.
@@ -1229,6 +1240,112 @@ def _reject_dynamic_builtins(statements: list[ast.stmt], *, where: str) -> None:
                     )
 
 
+def _local_callable_names(body: list[ast.stmt]) -> set[str]:
+    """Names bound to locally-defined callables in one lexical scope.
+
+    Covers def/class statements (classes are callables too — constructing one
+    executes uninspected ``__new__``/``__init__`` bodies), simple lambda
+    bindings (``name = lambda``, ``name: T = lambda``), and walrus bindings
+    to a lambda.
+    """
+    names: set[str] = set()
+    for stmt in _iter_scope_statements(body):
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            names.add(stmt.name)
+        elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Lambda):
+            for target in stmt.targets:
+                names |= _assignment_target_names(target)
+        elif (
+            isinstance(stmt, ast.AnnAssign)
+            and stmt.value is not None
+            and isinstance(stmt.value, ast.Lambda)
+        ):
+            names |= _assignment_target_names(stmt.target)
+        for node in _construction_expression_nodes(stmt):
+            if (
+                isinstance(node, ast.NamedExpr)
+                and isinstance(node.value, ast.Lambda)
+                and isinstance(node.target, ast.Name)
+            ):
+                names.add(node.target.id)
+    return names
+
+
+def _construction_expression_nodes(stmt: ast.stmt):
+    """Expression nodes of one scope statement that evaluate at construction.
+
+    Deferred function/lambda bodies are excluded (only their enclosing-scope
+    positions — decorators, defaults, annotations — are entered), and nested
+    class BODIES are excluded here because each class scope is scanned
+    recursively with its own local-callable vocabulary; class decorators,
+    bases, and keywords still evaluate in this scope and are entered.
+    """
+    if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        pending: list[ast.AST] = _enclosing_scope_children(stmt)
+    else:
+        pending = list(ast.iter_child_nodes(stmt))
+    while pending:
+        node = pending.pop()
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.ClassDef):
+            pending.extend(_enclosing_scope_children(node))
+        else:
+            pending.extend(ast.iter_child_nodes(node))
+
+
+def _reject_construction_time_local_callables(
+    body: list[ast.stmt], *, where: str, inherited: frozenset[str] = frozenset()
+) -> None:
+    """Enforce the finite construction grammar over uninspected local callables.
+
+    Locally-defined callables (functions, classes, bound lambdas) may exist,
+    but their bodies are uninspected — so nothing may reference them while
+    the certified module or a class in it is being CONSTRUCTED: no direct or
+    aliased invocation, no local class construction, no decorator
+    application, no argument laundering, no lambda invoked or applied as a
+    decorator.  Any construction-time ``Name`` reference to such a callable
+    fails closed (this deliberately subsumes every invocation form without
+    building a call graph or dataflow).  Deferred function/method bodies may
+    freely use local helpers — that is runtime behavior, outside this
+    import-time proof.  Class bodies execute during import, so each nested
+    class scope is scanned recursively against its own locals plus every
+    enclosing scope's (a fail-closed over-approximation of Python's actual
+    class-scope name resolution).
+    """
+    known = frozenset(_local_callable_names(body)) | inherited
+    for stmt in _iter_scope_statements(body):
+        if isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            for decorator in stmt.decorator_list:
+                if isinstance(decorator, ast.Lambda):
+                    raise ImplementationArtifactError(
+                        f"{where} applies a lambda decorator during construction; the "
+                        "effective export is not statically provable"
+                    )
+        for node in _construction_expression_nodes(stmt):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Lambda):
+                raise ImplementationArtifactError(
+                    f"{where} invokes a lambda during construction; the effective "
+                    "export is not statically provable"
+                )
+            if (
+                isinstance(node, ast.Name)
+                and isinstance(node.ctx, ast.Load)
+                and node.id in known
+            ):
+                # Only Load references can cause or enable execution; the
+                # binding statement's own Store target is the definition.
+                raise ImplementationArtifactError(
+                    f"{where} references locally-defined callable {node.id!r} during "
+                    "construction; its uninspected body must not execute at import "
+                    "time"
+                )
+    for stmt in _iter_scope_statements(body):
+        if isinstance(stmt, ast.ClassDef):
+            _reject_construction_time_local_callables(
+                stmt.body, where=where, inherited=known
+            )
+
+
 def prove_module_action_export(
     handler: ResolvedModuleHandlerSource, *, handler_method: str
 ) -> ModuleActionExportProof:
@@ -1349,6 +1466,7 @@ def prove_module_action_export(
                 f"handler class {handler_class!r} is referenced dynamically; the "
                 "export is not statically provable"
             )
+    _reject_construction_time_local_callables(tree.body, where="handler module scope")
     return ModuleActionExportProof(
         mode=HandlerCertificationMode.EXPLICIT_HANDLER,
         method_source=HandlerMethodSource.HANDLER,
@@ -1547,6 +1665,7 @@ def _prove_canonical_leaf_subclass(
                 f"handler class {handler_class!r} is referenced dynamically; the "
                 "export is not statically provable"
             )
+    _reject_construction_time_local_callables(tree.body, where="handler module scope")
     return base_name, leaf_method is not None
 
 
@@ -1679,6 +1798,9 @@ def _prove_base_handler_closure(
                 f"base class {base_class!r} is referenced dynamically; the export is "
                 "not statically provable"
             )
+    _reject_construction_time_local_callables(
+        tree.body, where="base-handler module scope"
+    )
 
 
 def _certify_module_action_export(

--- a/tests/test_compilation_plan.py
+++ b/tests/test_compilation_plan.py
@@ -578,6 +578,10 @@ def test_no_production_imports_no_advertisement_no_ag2() -> None:
             # through the one derivation function; offline-only, and this
             # same scan proves no production module imports it.
             Path("mozaiksai/core/semantics/plan_authority.py"),
+            # Content-resolved implementation artifact authority: offline
+            # selection proofs reuse the planner's closed instance-identity
+            # domain; no production module imports it (this scan proves so).
+            Path("mozaiksai/core/semantics/implementation_artifacts.py"),
             # Slice 5C offline immutable revision closure and persistence owner.
             Path("mozaiksai/core/semantics/artifact_revision.py"),
             Path("mozaiksai/core/artifacts/revision_store.py"),

--- a/tests/test_implementation_artifact_authority.py
+++ b/tests/test_implementation_artifact_authority.py
@@ -1,0 +1,749 @@
+"""Implementation artifacts are selected by exact content, never by path trust.
+
+Every test resolves through the required path only:
+
+    SelectedContractArtifact -> ChildContractRef -> ArtifactAddress
+    -> ArtifactContentStore.get_verified_blob() -> exact bytes -> strict parser
+
+and proves the hostile matrix fails closed: missing or tampered blobs,
+cross-scope selection, wrong family/scope/placeholders, ref/address path
+mismatch, wrong document schema versions, cross-workflow and cross-module
+borrowing, digestless handler selection, wrong handler addresses, and every
+non-explicit handler export (inherited, monkeypatched, conditional, dynamic).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+import yaml
+
+from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+from mozaiksai.core.runtime.app.layout_registry import PathScope
+from mozaiksai.core.semantics.closed_contracts import ClosedContractUnsupported, ObjectContract
+from mozaiksai.core.semantics.composition_ledger import AccountedArtifact, ArtifactAddress
+from mozaiksai.core.semantics.implementation_artifacts import (
+    ImplementationArtifactError,
+    SelectedContractArtifact,
+    pair_workflow_implementation_artifacts,
+    prove_module_action_export,
+    resolve_module_action_implementation,
+    resolve_module_handler_source,
+    resolve_module_manifest_artifact,
+    resolve_selected_structured_output_contract,
+    resolve_workflow_orchestrator_artifact,
+    resolve_workflow_structured_outputs_artifact,
+)
+from mozaiksai.core.semantics.refs import ChildContractRef, ExecutionAccessScopeRef
+from mozaiksai.core.semantics.resolver import SemanticReferenceResolver
+from mozaiksai.core.workflow.declarative.contracts import parse_structured_outputs_config
+from mozaiksai.core.workflow.structured_output_contracts import (
+    build_structured_output_contract_ref,
+)
+
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="workspace")
+OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="elsewhere")
+
+ORCHESTRATOR_DOCUMENT = {
+    "schema_version": "mozaiks.orchestrator.v1",
+    "workflow_name": "VersionProbe",
+    "workflow_startup_mode": "AgentDriven",
+}
+
+STRUCTURED_OUTPUTS_DOCUMENT = {
+    "schema_version": "mozaiks.structured_outputs.v1",
+    "registry": {"Author": "Output"},
+    "models": {"Output": {"type": "model", "fields": {"message": {"type": "str"}}}},
+}
+
+MODULE_DOCUMENT = {
+    "schema_version": "mozaiks.module.v1",
+    "module": {"id": "tasks", "handler": "backend.handler:TasksHandler"},
+    "actions": [
+        {
+            "id": "create_task",
+            "description": "Create one task.",
+            "handler_method": "create_task",
+            "input_schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+            },
+        }
+    ],
+}
+
+HANDLER_SOURCE = (
+    '"""Tasks handler."""\n'
+    "\n"
+    "class TasksHandler:\n"
+    "    async def create_task(self, ctx, payload):\n"
+    '        return {"status": "created"}\n'
+)
+
+
+@pytest.fixture
+def content_store(tmp_path):
+    return LocalArtifactContentStore(root=tmp_path)
+
+
+async def _put(content_store, data: bytes) -> str:
+    digest = hashlib.sha256(data).hexdigest()
+    await content_store.put_blob(data, expected_digest=digest)
+    return digest
+
+
+def _yaml_bytes(document: dict) -> bytes:
+    return yaml.safe_dump(document, sort_keys=False).encode("utf-8")
+
+
+def _workflow_selection(
+    *,
+    path: str,
+    family: str,
+    digest: str,
+    schema_version: str,
+    workflow: str = "versionprobe",
+    scope: ExecutionAccessScopeRef = SCOPE,
+) -> SelectedContractArtifact:
+    return SelectedContractArtifact(
+        contract_ref=ChildContractRef(
+            subject_id="probe-app",
+            subject_version=1,
+            content_digest=digest,
+            scope=scope,
+            artifact_family=family,
+            canonical_relative_path=path,
+            contract_schema_version=schema_version,
+        ),
+        address=ArtifactAddress(
+            path_scope=PathScope.WORKFLOW_RELATIVE,
+            placeholder_values=(("workflow_id", workflow),),
+            path=path,
+        ),
+    )
+
+
+def _module_selection(
+    *,
+    digest: str,
+    module: str = "tasks",
+    schema_version: str = "mozaiks.module.v1",
+    scope: ExecutionAccessScopeRef = SCOPE,
+) -> SelectedContractArtifact:
+    return SelectedContractArtifact(
+        contract_ref=ChildContractRef(
+            subject_id="probe-app",
+            subject_version=1,
+            content_digest=digest,
+            scope=scope,
+            artifact_family="module_manifest",
+            canonical_relative_path="module.yaml",
+            contract_schema_version=schema_version,
+        ),
+        address=ArtifactAddress(
+            path_scope=PathScope.MODULE_RELATIVE,
+            placeholder_values=(("module_id", module),),
+            path="module.yaml",
+        ),
+    )
+
+
+def _handler_artifact(
+    *, digest: str | None, module: str = "tasks", path: str = "backend/handler.py"
+) -> AccountedArtifact:
+    return AccountedArtifact(
+        address=ArtifactAddress(
+            path_scope=PathScope.MODULE_RELATIVE,
+            placeholder_values=(("module_id", module),),
+            path=path,
+        ),
+        content_digest=digest,
+    )
+
+
+async def _resolved_workflow_pair(content_store):
+    orchestrator_digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    outputs_digest = await _put(content_store, _yaml_bytes(STRUCTURED_OUTPUTS_DOCUMENT))
+    orchestrator = await resolve_workflow_orchestrator_artifact(
+        _workflow_selection(
+            path="orchestrator.yaml",
+            family="workflow_manifest",
+            digest=orchestrator_digest,
+            schema_version="mozaiks.orchestrator.v1",
+        ),
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    structured_outputs = await resolve_workflow_structured_outputs_artifact(
+        _workflow_selection(
+            path="structured_outputs.yaml",
+            family="workflow_config",
+            digest=outputs_digest,
+            schema_version="mozaiks.structured_outputs.v1",
+        ),
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    return orchestrator, structured_outputs
+
+
+async def _resolved_module(content_store, document=MODULE_DOCUMENT):
+    digest = await _put(content_store, _yaml_bytes(document))
+    return await resolve_module_manifest_artifact(
+        _module_selection(digest=digest),
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+
+
+async def test_workflow_documents_resolve_exact_content(content_store):
+    orchestrator, structured_outputs = await _resolved_workflow_pair(content_store)
+    assert orchestrator.workflow_name == "VersionProbe"
+    assert orchestrator.workflow_instance == "versionprobe"
+    assert orchestrator.config.workflow_startup_mode == "AgentDriven"
+    assert orchestrator.document["schema_version"] == "mozaiks.orchestrator.v1"
+    assert structured_outputs.workflow_instance == "versionprobe"
+    assert structured_outputs.document["models"] == STRUCTURED_OUTPUTS_DOCUMENT["models"]
+    implementation = pair_workflow_implementation_artifacts(orchestrator, structured_outputs)
+    assert implementation.workflow_name == "VersionProbe"
+    assert implementation.workflow_instance == "versionprobe"
+
+
+async def test_structured_output_ref_resolves_against_selected_configuration(content_store):
+    orchestrator, structured_outputs = await _resolved_workflow_pair(content_store)
+    implementation = pair_workflow_implementation_artifacts(orchestrator, structured_outputs)
+    ref = build_structured_output_contract_ref(
+        workflow_name="VersionProbe",
+        model_id="Output",
+        configs={"VersionProbe": structured_outputs.document},
+        exact_model_ids=frozenset(),
+    )
+    model = resolve_selected_structured_output_contract(implementation, ref)
+    assert model.model_validate({"message": "hello"}).message == "hello"
+
+
+async def test_structured_output_ref_from_other_workflow_rejects(content_store):
+    orchestrator, structured_outputs = await _resolved_workflow_pair(content_store)
+    implementation = pair_workflow_implementation_artifacts(orchestrator, structured_outputs)
+    foreign_name_ref = build_structured_output_contract_ref(
+        workflow_name="OtherFlow",
+        model_id="Output",
+        configs={"OtherFlow": structured_outputs.document},
+        exact_model_ids=frozenset(),
+    )
+    with pytest.raises(ImplementationArtifactError, match="not interchangeable"):
+        resolve_selected_structured_output_contract(implementation, foreign_name_ref)
+
+    foreign_schema = parse_structured_outputs_config(
+        {
+            "schema_version": "mozaiks.structured_outputs.v1",
+            "registry": {"Author": "Output"},
+            "models": {"Output": {"type": "model", "fields": {"message": {"type": "int"}}}},
+        }
+    )
+    foreign_schema_ref = build_structured_output_contract_ref(
+        workflow_name="VersionProbe",
+        model_id="Output",
+        configs={"VersionProbe": foreign_schema},
+        exact_model_ids=frozenset(),
+    )
+    with pytest.raises(ImplementationArtifactError, match="did not resolve"):
+        resolve_selected_structured_output_contract(implementation, foreign_schema_ref)
+
+
+async def test_workflow_documents_are_not_interchangeable_across_workflows(content_store):
+    orchestrator_digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    outputs_digest = await _put(content_store, _yaml_bytes(STRUCTURED_OUTPUTS_DOCUMENT))
+    orchestrator = await resolve_workflow_orchestrator_artifact(
+        _workflow_selection(
+            path="orchestrator.yaml",
+            family="workflow_manifest",
+            digest=orchestrator_digest,
+            schema_version="mozaiks.orchestrator.v1",
+            workflow="versionprobe",
+        ),
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    borrowed = await resolve_workflow_structured_outputs_artifact(
+        _workflow_selection(
+            path="structured_outputs.yaml",
+            family="workflow_config",
+            digest=outputs_digest,
+            schema_version="mozaiks.structured_outputs.v1",
+            workflow="otherflow",
+        ),
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    with pytest.raises(ImplementationArtifactError, match="cannot implement workflow"):
+        pair_workflow_implementation_artifacts(orchestrator, borrowed)
+
+
+async def test_missing_blob_rejects_even_with_opaque_registration(content_store):
+    data = _yaml_bytes(ORCHESTRATOR_DOCUMENT)
+    digest = hashlib.sha256(data).hexdigest()
+    selection = _workflow_selection(
+        path="orchestrator.yaml",
+        family="workflow_manifest",
+        digest=digest,
+        schema_version="mozaiks.orchestrator.v1",
+    )
+    resolver = SemanticReferenceResolver()
+    resolver.register_opaque_subject(
+        kind=selection.contract_ref.document_type,
+        subject_id=selection.contract_ref.subject_id,
+        version=selection.contract_ref.subject_version,
+        digest=digest,
+        scope=SCOPE,
+        artifact_family="workflow_manifest",
+        canonical_relative_path="orchestrator.yaml",
+        contract_schema_version="mozaiks.orchestrator.v1",
+    )
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await resolve_workflow_orchestrator_artifact(
+            selection, content_store=content_store, requesting_scope=SCOPE
+        )
+
+
+async def test_tampered_blob_rejects(content_store, tmp_path):
+    data = _yaml_bytes(ORCHESTRATOR_DOCUMENT)
+    digest = hashlib.sha256(data).hexdigest()
+    blob_path = tmp_path / "sha256" / digest[:2] / digest
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(b"tampered bytes")
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await resolve_workflow_orchestrator_artifact(
+            _workflow_selection(
+                path="orchestrator.yaml",
+                family="workflow_manifest",
+                digest=digest,
+                schema_version="mozaiks.orchestrator.v1",
+            ),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_cross_scope_selection_rejects(content_store):
+    digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    with pytest.raises(ImplementationArtifactError, match="cross-scope"):
+        await resolve_workflow_orchestrator_artifact(
+            _workflow_selection(
+                path="orchestrator.yaml",
+                family="workflow_manifest",
+                digest=digest,
+                schema_version="mozaiks.orchestrator.v1",
+            ),
+            content_store=content_store,
+            requesting_scope=OTHER_SCOPE,
+        )
+
+
+def test_ref_and_address_paths_must_agree():
+    digest = "0" * 64
+    with pytest.raises(ValueError, match="does not equal its artifact address path"):
+        SelectedContractArtifact(
+            contract_ref=ChildContractRef(
+                subject_id="probe-app",
+                subject_version=1,
+                content_digest=digest,
+                scope=SCOPE,
+                artifact_family="workflow_manifest",
+                canonical_relative_path="orchestrator.yaml",
+                contract_schema_version="mozaiks.orchestrator.v1",
+            ),
+            address=ArtifactAddress(
+                path_scope=PathScope.WORKFLOW_RELATIVE,
+                placeholder_values=(("workflow_id", "versionprobe"),),
+                path="structured_outputs.yaml",
+            ),
+        )
+
+
+async def test_wrong_family_rejects(content_store):
+    digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    # agents.yaml is a canonical workflow_config path, not a workflow manifest.
+    with pytest.raises(ImplementationArtifactError, match="not 'workflow_manifest'"):
+        await resolve_workflow_orchestrator_artifact(
+            _workflow_selection(
+                path="agents.yaml",
+                family="workflow_manifest",
+                digest=digest,
+                schema_version="mozaiks.orchestrator.v1",
+            ),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+    # The proven layout family must also equal the reference's claimed family.
+    with pytest.raises(ImplementationArtifactError, match="does not equal the proven layout"):
+        await resolve_workflow_orchestrator_artifact(
+            _workflow_selection(
+                path="orchestrator.yaml",
+                family="workflow_config",
+                digest=digest,
+                schema_version="mozaiks.orchestrator.v1",
+            ),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_wrong_path_scope_rejects(content_store):
+    digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    selection = SelectedContractArtifact(
+        contract_ref=ChildContractRef(
+            subject_id="probe-app",
+            subject_version=1,
+            content_digest=digest,
+            scope=SCOPE,
+            artifact_family="workflow_manifest",
+            canonical_relative_path="orchestrator.yaml",
+            contract_schema_version="mozaiks.orchestrator.v1",
+        ),
+        address=ArtifactAddress(
+            path_scope=PathScope.APP_BUNDLE_ROOT,
+            placeholder_values=(),
+            path="orchestrator.yaml",
+        ),
+    )
+    with pytest.raises(ImplementationArtifactError, match="no canonical layout row"):
+        await resolve_workflow_orchestrator_artifact(
+            selection, content_store=content_store, requesting_scope=SCOPE
+        )
+
+
+async def test_wrong_placeholders_reject(content_store):
+    digest = await _put(content_store, _yaml_bytes(ORCHESTRATOR_DOCUMENT))
+    mis_named = SelectedContractArtifact(
+        contract_ref=ChildContractRef(
+            subject_id="probe-app",
+            subject_version=1,
+            content_digest=digest,
+            scope=SCOPE,
+            artifact_family="workflow_manifest",
+            canonical_relative_path="orchestrator.yaml",
+            contract_schema_version="mozaiks.orchestrator.v1",
+        ),
+        address=ArtifactAddress(
+            path_scope=PathScope.WORKFLOW_RELATIVE,
+            placeholder_values=(("module_id", "versionprobe"),),
+            path="orchestrator.yaml",
+        ),
+    )
+    with pytest.raises(ImplementationArtifactError, match="require exactly the 'workflow_id'"):
+        await resolve_workflow_orchestrator_artifact(
+            mis_named, content_store=content_store, requesting_scope=SCOPE
+        )
+    outside_domain = _workflow_selection(
+        path="orchestrator.yaml",
+        family="workflow_manifest",
+        digest=digest,
+        schema_version="mozaiks.orchestrator.v1",
+        workflow="VersionProbe",
+    )
+    with pytest.raises(ImplementationArtifactError, match="outside the closed domain"):
+        await resolve_workflow_orchestrator_artifact(
+            outside_domain, content_store=content_store, requesting_scope=SCOPE
+        )
+
+
+@pytest.mark.parametrize(
+    "document,path,family,claimed_version",
+    [
+        (ORCHESTRATOR_DOCUMENT, "orchestrator.yaml", "workflow_manifest", "mozaiks.orchestrator.v2"),
+        (
+            STRUCTURED_OUTPUTS_DOCUMENT,
+            "structured_outputs.yaml",
+            "workflow_config",
+            "mozaiks.structured_outputs.v2",
+        ),
+    ],
+)
+async def test_wrong_workflow_schema_version_rejects(
+    content_store, document, path, family, claimed_version
+):
+    digest = await _put(content_store, _yaml_bytes(document))
+    selection = _workflow_selection(
+        path=path, family=family, digest=digest, schema_version=claimed_version
+    )
+    resolve = (
+        resolve_workflow_orchestrator_artifact
+        if path == "orchestrator.yaml"
+        else resolve_workflow_structured_outputs_artifact
+    )
+    with pytest.raises(ImplementationArtifactError, match="pins"):
+        await resolve(selection, content_store=content_store, requesting_scope=SCOPE)
+
+
+async def test_byte_variant_documents_keep_distinct_exact_identity(content_store):
+    first = _yaml_bytes(ORCHESTRATOR_DOCUMENT)
+    reordered = yaml.safe_dump(
+        dict(reversed(list(ORCHESTRATOR_DOCUMENT.items()))), sort_keys=False
+    ).encode("utf-8")
+    assert first != reordered
+    first_digest = await _put(content_store, first)
+    reordered_digest = await _put(content_store, reordered)
+    assert first_digest != reordered_digest
+    for digest in (first_digest, reordered_digest):
+        resolved = await resolve_workflow_orchestrator_artifact(
+            _workflow_selection(
+                path="orchestrator.yaml",
+                family="workflow_manifest",
+                digest=digest,
+                schema_version="mozaiks.orchestrator.v1",
+            ),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+        assert resolved.selection.contract_ref.content_digest == digest
+        assert resolved.workflow_name == "VersionProbe"
+
+
+async def test_module_manifest_resolves_exact_facts(content_store):
+    module = await _resolved_module(content_store)
+    assert module.module_instance == "tasks"
+    assert module.definition.module.id == "tasks"
+    assert module.handler_class == "TasksHandler"
+    assert module.handler_relative_path == "backend/handler.py"
+    action = module.action("create_task")
+    assert action.handler_method == "create_task"
+    contract = module.action_request_contract("create_task")
+    assert isinstance(contract, ObjectContract)
+    with pytest.raises(ImplementationArtifactError, match="declares no action"):
+        module.action("delete_task")
+
+
+async def test_module_manifest_borrowed_across_modules_rejects(content_store):
+    digest = await _put(content_store, _yaml_bytes(MODULE_DOCUMENT))
+    with pytest.raises(ImplementationArtifactError, match="cannot be selected for module"):
+        await resolve_module_manifest_artifact(
+            _module_selection(digest=digest, module="billing"),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_wrong_module_schema_version_rejects(content_store):
+    digest = await _put(content_store, _yaml_bytes(MODULE_DOCUMENT))
+    with pytest.raises(ImplementationArtifactError, match="pins 'mozaiks.module.v2'"):
+        await resolve_module_manifest_artifact(
+            _module_selection(digest=digest, schema_version="mozaiks.module.v2"),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_unsupported_action_request_schema_rejects(content_store):
+    document = {
+        **MODULE_DOCUMENT,
+        "actions": [
+            {
+                **MODULE_DOCUMENT["actions"][0],
+                "input_schema": {"type": "object", "properties": {"title": {"type": "string"}}},
+            }
+        ],
+    }
+    module = await _resolved_module(content_store, document)
+    with pytest.raises(ClosedContractUnsupported):
+        module.action_request_contract("create_task")
+
+
+async def test_handler_selection_requires_content_digest(content_store):
+    module = await _resolved_module(content_store)
+    with pytest.raises(ImplementationArtifactError, match="non-null content digest"):
+        await resolve_module_handler_source(
+            _handler_artifact(digest=None), module=module, content_store=content_store
+        )
+
+
+async def test_handler_missing_blob_rejects(content_store):
+    module = await _resolved_module(content_store)
+    absent_digest = hashlib.sha256(HANDLER_SOURCE.encode("utf-8")).hexdigest()
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await resolve_module_handler_source(
+            _handler_artifact(digest=absent_digest),
+            module=module,
+            content_store=content_store,
+        )
+
+
+async def test_handler_from_other_module_rejects(content_store):
+    module = await _resolved_module(content_store)
+    digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
+    with pytest.raises(ImplementationArtifactError, match="cannot implement module"):
+        await resolve_module_handler_source(
+            _handler_artifact(digest=digest, module="billing"),
+            module=module,
+            content_store=content_store,
+        )
+
+
+async def test_handler_at_wrong_family_or_path_rejects(content_store):
+    module = await _resolved_module(content_store)
+    digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
+    with pytest.raises(ImplementationArtifactError, match="not 'module_backend_handler'"):
+        await resolve_module_handler_source(
+            _handler_artifact(digest=digest, path="backend/service.py"),
+            module=module,
+            content_store=content_store,
+        )
+    custom_document = {
+        **MODULE_DOCUMENT,
+        "module": {"id": "tasks", "handler": "backend.custom:TasksHandler"},
+    }
+    custom_module = await _resolved_module(content_store, custom_document)
+    with pytest.raises(ImplementationArtifactError, match="declares its handler at"):
+        await resolve_module_handler_source(
+            _handler_artifact(digest=digest),
+            module=custom_module,
+            content_store=content_store,
+        )
+
+
+async def test_module_action_implementation_resolves_end_to_end(content_store):
+    module_digest = await _put(content_store, _yaml_bytes(MODULE_DOCUMENT))
+    handler_digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
+    resolved = await resolve_module_action_implementation(
+        _module_selection(digest=module_digest),
+        _handler_artifact(digest=handler_digest),
+        action_id="create_task",
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    assert resolved.module.module_instance == "tasks"
+    assert resolved.action.id == "create_task"
+    assert resolved.export_proof.handler_class == "TasksHandler"
+    assert resolved.export_proof.handler_method == "create_task"
+    assert resolved.export_proof.content_digest == handler_digest
+    assert isinstance(resolved.request_contract, ObjectContract)
+
+
+async def test_handler_at_app_bundle_scope_resolves(content_store):
+    module = await _resolved_module(content_store)
+    digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
+    artifact = AccountedArtifact(
+        address=ArtifactAddress(
+            path_scope=PathScope.APP_BUNDLE_ROOT,
+            placeholder_values=(),
+            path="modules/tasks/backend/handler.py",
+        ),
+        content_digest=digest,
+    )
+    handler = await resolve_module_handler_source(
+        artifact, module=module, content_store=content_store
+    )
+    assert handler.module_instance == "tasks"
+    proof = prove_module_action_export(handler, handler_method="create_task")
+    assert proof.content_digest == digest
+
+
+async def _handler_for_source(content_store, source: str):
+    module = await _resolved_module(content_store)
+    digest = await _put(content_store, source.encode("utf-8"))
+    return await resolve_module_handler_source(
+        _handler_artifact(digest=digest), module=module, content_store=content_store
+    )
+
+
+@pytest.mark.parametrize(
+    "source,reason",
+    [
+        # Unrelated source at a valid digest: the declared class is absent.
+        ("class OtherHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n", "absent"),
+        # Inherited action methods are not explicit exports of the selected source.
+        (
+            "from .base_handler import TasksBaseHandler\n\n"
+            "class TasksHandler(TasksBaseHandler):\n"
+            '    """Thin preserved subclass."""\n',
+            "not explicitly defined",
+        ),
+        # Method on the wrong class.
+        (
+            "class TasksHandler:\n    pass\n\n"
+            "class OtherHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n",
+            "not explicitly defined",
+        ),
+        # Dynamic monkeypatch after the definition.
+        (
+            "class TasksHandler:\n    pass\n\n"
+            "async def create_task(self, ctx, payload):\n    return {}\n\n"
+            "TasksHandler.create_task = create_task\n",
+            "referenced dynamically|rebound|not explicitly defined",
+        ),
+        # setattr-style patching.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'setattr(TasksHandler, "create_task", None)\n',
+            "not statically provable|referenced dynamically",
+        ),
+        # Module-level __getattr__ trick.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def __getattr__(name):\n    raise AttributeError(name)\n",
+            "__getattr__",
+        ),
+        # Class-level __getattr__ trick.
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            "    def __getattr__(self, name):\n        raise AttributeError(name)\n",
+            "__getattr__",
+        ),
+        # Conditional definition is not statically provable.
+        (
+            "FLAG = True\n\n"
+            "class TasksHandler:\n"
+            "    if FLAG:\n"
+            "        async def create_task(self, ctx, payload):\n"
+            "            return {}\n",
+            "conditionally",
+        ),
+        # Decorated definition is not statically provable.
+        (
+            "def wrap(fn):\n    return fn\n\n"
+            "class TasksHandler:\n"
+            "    @wrap\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n",
+            "decorated",
+        ),
+        # Duplicate definition is ambiguous.
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            "    async def create_task(self, ctx, payload):  # noqa: F811\n        return {}\n",
+            "more than once",
+        ),
+        # Rebinding the method name in the class body.
+        (
+            "def other(self, ctx, payload):\n    return {}\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            "    create_task = other\n",
+            "rebound|more than once",
+        ),
+        # Rebinding the class name after its definition.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "class _Shadow:\n    pass\n\n"
+            "TasksHandler = _Shadow\n",
+            "more than once|rebound|referenced dynamically",
+        ),
+        # Unparseable source is unprovable.
+        ("class TasksHandler(:\n", "not statically parseable"),
+    ],
+)
+async def test_static_export_proof_rejects_non_explicit_exports(content_store, source, reason):
+    handler = await _handler_for_source(content_store, source)
+    with pytest.raises(ImplementationArtifactError, match=reason):
+        prove_module_action_export(handler, handler_method="create_task")
+
+
+async def test_static_export_proof_accepts_explicit_export(content_store):
+    handler = await _handler_for_source(content_store, HANDLER_SOURCE)
+    proof = prove_module_action_export(handler, handler_method="create_task")
+    assert proof.handler_class == "TasksHandler"
+    assert proof.handler_method == "create_task"

--- a/tests/test_implementation_artifact_authority.py
+++ b/tests/test_implementation_artifact_authority.py
@@ -25,6 +25,7 @@ from mozaiksai.core.semantics.closed_contracts import ClosedContractUnsupported,
 from mozaiksai.core.semantics.composition_ledger import AccountedArtifact, ArtifactAddress
 from mozaiksai.core.semantics.implementation_artifacts import (
     ImplementationArtifactError,
+    SelectedAccountedArtifact,
     SelectedContractArtifact,
     pair_workflow_implementation_artifacts,
     prove_module_action_export,
@@ -151,16 +152,23 @@ def _module_selection(
     )
 
 
-def _handler_artifact(
-    *, digest: str | None, module: str = "tasks", path: str = "backend/handler.py"
-) -> AccountedArtifact:
-    return AccountedArtifact(
-        address=ArtifactAddress(
-            path_scope=PathScope.MODULE_RELATIVE,
-            placeholder_values=(("module_id", module),),
-            path=path,
+def _handler_selection(
+    *,
+    digest: str | None,
+    module: str = "tasks",
+    path: str = "backend/handler.py",
+    scope: ExecutionAccessScopeRef = SCOPE,
+) -> SelectedAccountedArtifact:
+    return SelectedAccountedArtifact(
+        scope=scope,
+        artifact=AccountedArtifact(
+            address=ArtifactAddress(
+                path_scope=PathScope.MODULE_RELATIVE,
+                placeholder_values=(("module_id", module),),
+                path=path,
+            ),
+            content_digest=digest,
         ),
-        content_digest=digest,
     )
 
 
@@ -556,7 +564,45 @@ async def test_handler_selection_requires_content_digest(content_store):
     module = await _resolved_module(content_store)
     with pytest.raises(ImplementationArtifactError, match="non-null content digest"):
         await resolve_module_handler_source(
-            _handler_artifact(digest=None), module=module, content_store=content_store
+            _handler_selection(digest=None),
+            module=module,
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_handler_selection_scope_must_match_both_scopes(content_store):
+    module = await _resolved_module(content_store)
+    digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
+    # Same module id and same bytes selected under another workspace scope:
+    # the selection satisfies the requesting scope but not the module's scope.
+    with pytest.raises(
+        ImplementationArtifactError, match="module selection's execution scope"
+    ):
+        await resolve_module_handler_source(
+            _handler_selection(digest=digest, scope=OTHER_SCOPE),
+            module=module,
+            content_store=content_store,
+            requesting_scope=OTHER_SCOPE,
+        )
+    # The selection scope must also equal the requesting scope itself.
+    with pytest.raises(ImplementationArtifactError, match="cross-scope"):
+        await resolve_module_handler_source(
+            _handler_selection(digest=digest, scope=OTHER_SCOPE),
+            module=module,
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+    # Same module id and same bytes under a different tenant entirely.
+    other_tenant = ExecutionAccessScopeRef(tenant_id="rival", workspace_id="workspace")
+    with pytest.raises(
+        ImplementationArtifactError, match="module selection's execution scope"
+    ):
+        await resolve_module_handler_source(
+            _handler_selection(digest=digest, scope=other_tenant),
+            module=module,
+            content_store=content_store,
+            requesting_scope=other_tenant,
         )
 
 
@@ -565,9 +611,10 @@ async def test_handler_missing_blob_rejects(content_store):
     absent_digest = hashlib.sha256(HANDLER_SOURCE.encode("utf-8")).hexdigest()
     with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
         await resolve_module_handler_source(
-            _handler_artifact(digest=absent_digest),
+            _handler_selection(digest=absent_digest),
             module=module,
             content_store=content_store,
+            requesting_scope=SCOPE,
         )
 
 
@@ -576,9 +623,10 @@ async def test_handler_from_other_module_rejects(content_store):
     digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
     with pytest.raises(ImplementationArtifactError, match="cannot implement module"):
         await resolve_module_handler_source(
-            _handler_artifact(digest=digest, module="billing"),
+            _handler_selection(digest=digest, module="billing"),
             module=module,
             content_store=content_store,
+            requesting_scope=SCOPE,
         )
 
 
@@ -587,9 +635,10 @@ async def test_handler_at_wrong_family_or_path_rejects(content_store):
     digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
     with pytest.raises(ImplementationArtifactError, match="not 'module_backend_handler'"):
         await resolve_module_handler_source(
-            _handler_artifact(digest=digest, path="backend/service.py"),
+            _handler_selection(digest=digest, path="backend/service.py"),
             module=module,
             content_store=content_store,
+            requesting_scope=SCOPE,
         )
     custom_document = {
         **MODULE_DOCUMENT,
@@ -598,9 +647,10 @@ async def test_handler_at_wrong_family_or_path_rejects(content_store):
     custom_module = await _resolved_module(content_store, custom_document)
     with pytest.raises(ImplementationArtifactError, match="declares its handler at"):
         await resolve_module_handler_source(
-            _handler_artifact(digest=digest),
+            _handler_selection(digest=digest),
             module=custom_module,
             content_store=content_store,
+            requesting_scope=SCOPE,
         )
 
 
@@ -609,7 +659,7 @@ async def test_module_action_implementation_resolves_end_to_end(content_store):
     handler_digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
     resolved = await resolve_module_action_implementation(
         _module_selection(digest=module_digest),
-        _handler_artifact(digest=handler_digest),
+        _handler_selection(digest=handler_digest),
         action_id="create_task",
         content_store=content_store,
         requesting_scope=SCOPE,
@@ -619,22 +669,26 @@ async def test_module_action_implementation_resolves_end_to_end(content_store):
     assert resolved.export_proof.handler_class == "TasksHandler"
     assert resolved.export_proof.handler_method == "create_task"
     assert resolved.export_proof.content_digest == handler_digest
+    assert resolved.split_authority is None
     assert isinstance(resolved.request_contract, ObjectContract)
 
 
 async def test_handler_at_app_bundle_scope_resolves(content_store):
     module = await _resolved_module(content_store)
     digest = await _put(content_store, HANDLER_SOURCE.encode("utf-8"))
-    artifact = AccountedArtifact(
-        address=ArtifactAddress(
-            path_scope=PathScope.APP_BUNDLE_ROOT,
-            placeholder_values=(),
-            path="modules/tasks/backend/handler.py",
+    selection = SelectedAccountedArtifact(
+        scope=SCOPE,
+        artifact=AccountedArtifact(
+            address=ArtifactAddress(
+                path_scope=PathScope.APP_BUNDLE_ROOT,
+                placeholder_values=(),
+                path="modules/tasks/backend/handler.py",
+            ),
+            content_digest=digest,
         ),
-        content_digest=digest,
     )
     handler = await resolve_module_handler_source(
-        artifact, module=module, content_store=content_store
+        selection, module=module, content_store=content_store, requesting_scope=SCOPE
     )
     assert handler.module_instance == "tasks"
     proof = prove_module_action_export(handler, handler_method="create_task")
@@ -645,7 +699,10 @@ async def _handler_for_source(content_store, source: str):
     module = await _resolved_module(content_store)
     digest = await _put(content_store, source.encode("utf-8"))
     return await resolve_module_handler_source(
-        _handler_artifact(digest=digest), module=module, content_store=content_store
+        _handler_selection(digest=digest),
+        module=module,
+        content_store=content_store,
+        requesting_scope=SCOPE,
     )
 
 
@@ -654,12 +711,29 @@ async def _handler_for_source(content_store, source: str):
     [
         # Unrelated source at a valid digest: the declared class is absent.
         ("class OtherHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n", "absent"),
-        # Inherited action methods are not explicit exports of the selected source.
+        # A subclass is never a standalone one-source class, even without the method.
         (
             "from .base_handler import TasksBaseHandler\n\n"
             "class TasksHandler(TasksBaseHandler):\n"
             '    """Thin preserved subclass."""\n',
-            "not explicitly defined",
+            "zero bases",
+        ),
+        # A subclass that explicitly overrides the method is still not standalone.
+        (
+            "from .base_handler import TasksBaseHandler\n\n"
+            "class TasksHandler(TasksBaseHandler):\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        return {"status": "created"}\n',
+            "zero bases",
+        ),
+        # Mixins/multiple inheritance are not standalone either.
+        (
+            "class _Mixin:\n    pass\n\n"
+            "class _Base:\n    pass\n\n"
+            "class TasksHandler(_Mixin, _Base):\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        return {"status": "created"}\n',
+            "zero bases",
         ),
         # Method on the wrong class.
         (
@@ -731,6 +805,55 @@ async def _handler_for_source(content_store, source: str):
             "class _Shadow:\n    pass\n\n"
             "TasksHandler = _Shadow\n",
             "more than once|rebound|referenced dynamically",
+        ),
+        # Exception-handler capture rebinds the class name in module scope.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "try:\n    pass\n"
+            "except Exception as TasksHandler:\n    pass\n",
+            "rebound|referenced dynamically",
+        ),
+        # Match-pattern mapping capture rebinds the class name.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "match {}:\n"
+            '    case {"x": TasksHandler}:\n        pass\n    case _:\n        pass\n',
+            "rebound|referenced dynamically",
+        ),
+        # Match-pattern star capture rebinds the class name.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "match []:\n"
+            "    case [*TasksHandler]:\n        pass\n    case _:\n        pass\n",
+            "rebound|referenced dynamically",
+        ),
+        # Match-pattern mapping rest capture rebinds the class name.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "match {}:\n"
+            '    case {"x": _ignored, **TasksHandler}:\n        pass\n    case _:\n        pass\n',
+            "rebound|referenced dynamically",
+        ),
+        # Exception-handler capture rebinds the method name in the class body.
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            "    try:\n        pass\n"
+            "    except Exception as create_task:\n        pass\n",
+            "rebound",
+        ),
+        # A walrus hidden in another function's default argument still rebinds.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def helper(value=(TasksHandler := None)):\n    return value\n",
+            "rebound|referenced dynamically",
+        ),
+        # A type-alias statement rebinds the class name (a syntax error on 3.11,
+        # a TypeAlias binding on 3.12+ — both fail closed).
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "type TasksHandler = int\n",
+            "rebound|referenced dynamically|not statically parseable",
         ),
         # Unparseable source is unprovable.
         ("class TasksHandler(:\n", "not statically parseable"),

--- a/tests/test_implementation_artifact_authority.py
+++ b/tests/test_implementation_artifact_authority.py
@@ -995,6 +995,93 @@ async def _handler_for_source(content_store, source: str):
             "    mutate()\n",
             "locally-defined callable",
         ),
+        # Reviewer's weaponized attack: a walrus-wrapped lambda invoked at
+        # import replaces the certified export through globals().
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "(f := lambda: globals().__setitem__(\n"
+            '    "TasksHandler",\n'
+            '    type("Evil", (), {\n'
+            '        "create_task": lambda self, ctx: "EVIL"\n'
+            "    })\n"
+            "))()\n",
+            "anonymous lambda",
+        ),
+        # Walrus-wrapped lambda invocation.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "(f := lambda: mutate())()\n",
+            "anonymous lambda",
+        ),
+        # Lambda laundered through a list subscript.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "[lambda: mutate()][0]()\n",
+            "anonymous lambda",
+        ),
+        # Lambda laundered through a tuple subscript.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "(lambda: mutate(),)[0]()\n",
+            "anonymous lambda",
+        ),
+        # Lambda laundered through a dict subscript.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "{0: lambda: mutate()}[0]()\n",
+            "anonymous lambda",
+        ),
+        # Lambda laundered through a conditional expression.
+        (
+            "def mutate():\n    pass\n\n"
+            "def other():\n    pass\n\n"
+            "cond = True\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "((lambda: mutate()) if cond else (lambda: other()))()\n",
+            "anonymous lambda",
+        ),
+        # Own-source lambda passed to an imported construction-time call.
+        (
+            "from typing import cast as external\n\n"
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "external(lambda: mutate())\n",
+            "anonymous lambda",
+        ),
+        # Own-source lambda inside an imported decorator factory.
+        (
+            "from typing import cast as external\n\n"
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "@external(lambda cls: mutate() or cls)\n"
+            "class Sibling:\n    pass\n",
+            "anonymous lambda",
+        ),
+        # Lambda in a function default evaluates at construction time.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def f(cb=lambda: mutate()):\n    return cb\n",
+            "anonymous lambda",
+        ),
+        # Lambda invoked inside a sibling class base expression.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "class Sibling((lambda: object)()):\n    pass\n",
+            "anonymous lambda|invokes a lambda",
+        ),
+        # Lambda stored in a container binding, even without invocation.
+        (
+            "def mutate():\n    pass\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "value = [lambda: mutate()]\n",
+            "anonymous lambda",
+        ),
         # Unparseable source is unprovable.
         ("class TasksHandler(:\n", "not statically parseable"),
     ],
@@ -1047,6 +1134,33 @@ async def test_static_export_proof_accepts_explicit_export(content_store):
             '        logger.debug("create")\n'
             "        return {}\n",
             id="imported-callable-at-construction",
+        ),
+        # An annotated simple lambda binding is the other permitted form.
+        pytest.param(
+            "from typing import Callable\n\n"
+            "helper: Callable[..., object] = lambda: 1\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        return {"value": helper()}\n',
+            id="annotated-lambda-binding",
+        ),
+        # Lambdas inside deferred method bodies are runtime behavior.
+        pytest.param(
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            "        local = lambda: 1\n"
+            "        return {\"value\": local()}\n",
+            id="lambda-inside-method-body",
+        ),
+        # Lambdas inside deferred function bodies are runtime behavior.
+        pytest.param(
+            "def runtime_helper():\n"
+            "    local = lambda: 1\n"
+            "    return local()\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        return {"value": runtime_helper()}\n',
+            id="lambda-inside-function-body",
         ),
     ],
 )

--- a/tests/test_implementation_artifact_authority.py
+++ b/tests/test_implementation_artifact_authority.py
@@ -855,6 +855,68 @@ async def _handler_for_source(content_store, source: str):
             "type TasksHandler = int\n",
             "rebound|referenced dynamically|not statically parseable",
         ),
+        # Bare exec at module scope.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'exec("TasksHandler = 1")\n',
+            "dynamic export primitive",
+        ),
+        # exec reached through the builtins module.
+        (
+            "import builtins\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'builtins.exec("TasksHandler = 1")\n',
+            "accesses the builtins module",
+        ),
+        # exec reached through an aliased builtins import.
+        (
+            "import builtins as b\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'b.exec("TasksHandler = 1")\n',
+            "accesses the builtins module",
+        ),
+        # exec imported from builtins.
+        (
+            "from builtins import exec\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'exec("TasksHandler = 1")\n',
+            "imports 'exec' from builtins|dynamic export primitive",
+        ),
+        # exec imported from builtins under an alias.
+        (
+            "from builtins import exec as e\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'e("TasksHandler = 1")\n',
+            "imports 'exec' from builtins",
+        ),
+        # exec laundered through a simple rebinding.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "e = exec\n"
+            'e("TasksHandler = 1")\n',
+            "dynamic export primitive",
+        ),
+        # exec fetched via getattr on the builtins module.
+        (
+            "import builtins\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'getattr(builtins, "exec")("TasksHandler = 1")\n',
+            "dynamic export primitive|accesses the builtins module",
+        ),
+        # exec inside the class body binds in the class namespace at import.
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            '    exec("create_task = 1")\n',
+            "dynamic export primitive",
+        ),
+        # Import-time execution hidden inside another class body.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "class _Evil:\n"
+            '    exec("TasksHandler = 1", globals())\n',
+            "dynamic export primitive",
+        ),
         # Unparseable source is unprovable.
         ("class TasksHandler(:\n", "not statically parseable"),
     ],

--- a/tests/test_implementation_artifact_authority.py
+++ b/tests/test_implementation_artifact_authority.py
@@ -917,6 +917,84 @@ async def _handler_for_source(content_store, source: str):
             '    exec("TasksHandler = 1", globals())\n',
             "dynamic export primitive",
         ),
+        # A local function invoked during module construction executes an
+        # uninspected body at import time.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def mutate():\n"
+            '    globals()["TasksHandler"] = None\n\n'
+            "mutate()\n",
+            "locally-defined callable",
+        ),
+        # Constructing a local class executes uninspected __init__ at import.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "class Mutator:\n"
+            "    def __init__(self):\n"
+            '        globals()["TasksHandler"] = None\n\n'
+            "Mutator()\n",
+            "locally-defined callable",
+        ),
+        # A lambda decorator executes during sibling class construction.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            '@(lambda c: exec("TasksHandler = None", globals()) or c)\n'
+            "class Sibling:\n    pass\n",
+            "lambda decorator",
+        ),
+        # A local function applied as a decorator executes at import.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def decorate(c):\n"
+            '    globals()["TasksHandler"] = None\n'
+            "    return c\n\n"
+            "@decorate\n"
+            "class Sibling:\n    pass\n",
+            "locally-defined callable",
+        ),
+        # Alias laundering of a local callable before invocation.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "def mutate():\n    pass\n\n"
+            "alias = mutate\n"
+            "alias()\n",
+            "locally-defined callable",
+        ),
+        # A locally-bound lambda invoked during construction.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "mutate = lambda: None\n"
+            "mutate()\n",
+            "locally-defined callable",
+        ),
+        # A lambda invoked directly during construction.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            '(lambda: globals().update(TasksHandler=None))()\n',
+            "invokes a lambda|dynamic export primitive",
+        ),
+        # locals() is a dynamic introspection primitive at construction scope.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            'locals()["TasksHandler"] = None\n',
+            "dynamic export primitive",
+        ),
+        # A class-scope local callable invoked while the class constructs.
+        (
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n        return {}\n"
+            "    def _mutate():\n        pass\n"
+            "    _mutate()\n",
+            "locally-defined callable",
+        ),
+        # A sibling class body invoking its own local callable at import.
+        (
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n\n"
+            "class Evil:\n"
+            "    def mutate():\n        pass\n"
+            "    mutate()\n",
+            "locally-defined callable",
+        ),
         # Unparseable source is unprovable.
         ("class TasksHandler(:\n", "not statically parseable"),
     ],
@@ -932,3 +1010,47 @@ async def test_static_export_proof_accepts_explicit_export(content_store):
     proof = prove_module_action_export(handler, handler_method="create_task")
     assert proof.handler_class == "TasksHandler"
     assert proof.handler_method == "create_task"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # An uninvoked local helper may exist.
+        pytest.param(
+            "def helper():\n    return 1\n\n"
+            "class TasksHandler:\n    async def create_task(self, ctx, payload):\n        return {}\n",
+            id="uninvoked-local-helper",
+        ),
+        # A helper invoked only from the selected method body is deferred
+        # runtime behavior, outside the import-time proof.
+        pytest.param(
+            "def helper():\n    return 1\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        return {"value": helper()}\n',
+            id="helper-used-from-method-body",
+        ),
+        # A lambda stored but never invoked or applied during construction.
+        pytest.param(
+            "fallback = lambda: {}\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            "        return fallback()\n",
+            id="stored-lambda-never-construction-invoked",
+        ),
+        # Imported external callables stay outside the own-source proof.
+        pytest.param(
+            "import logging\n\n"
+            "logger = logging.getLogger(__name__)\n\n"
+            "class TasksHandler:\n"
+            "    async def create_task(self, ctx, payload):\n"
+            '        logger.debug("create")\n'
+            "        return {}\n",
+            id="imported-callable-at-construction",
+        ),
+    ],
+)
+async def test_deferred_local_helpers_remain_certifiable(content_store, source):
+    handler = await _handler_for_source(content_store, source)
+    proof = prove_module_action_export(handler, handler_method="create_task")
+    assert proof.handler_class == "TasksHandler"

--- a/tests/test_pack_implementation_certification.py
+++ b/tests/test_pack_implementation_certification.py
@@ -1055,6 +1055,54 @@ async def test_override_and_inherited_certifications_have_distinct_identity(
             "dynamic export primitive",
             id="leaf-class-body-exec-of-method",
         ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "def mutate():\n"
+            '    globals()["FilesHandler"] = None\n'
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "mutate()\n",
+            "locally-defined callable",
+            id="leaf-construction-call-of-local-function",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class Mutator:\n"
+            "    def __init__(self):\n"
+            '        globals()["FilesHandler"] = None\n'
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "Mutator()\n",
+            "locally-defined callable",
+            id="leaf-local-class-construction",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "def mutate():\n    pass\n"
+            "alias_one = mutate\n"
+            "alias_two = alias_one\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "alias_two()\n",
+            "locally-defined callable",
+            id="leaf-alias-chain-invocation",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            '@(lambda c: exec("FilesHandler = None", globals()) or c)\n'
+            "class Sibling:\n    pass\n",
+            "lambda decorator",
+            id="leaf-lambda-decorator-on-sibling",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "def decorate(c):\n"
+            '    globals()["FilesHandler"] = None\n'
+            "    return c\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "@decorate\n"
+            "class Sibling:\n    pass\n",
+            "locally-defined callable",
+            id="leaf-local-decorator-on-sibling",
+        ),
     ],
 )
 async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reason: str) -> None:
@@ -1149,8 +1197,55 @@ async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reas
             "dynamic export primitive",
             id="base-class-body-exec-of-method",
         ),
+        pytest.param(
+            "def mutate():\n"
+            '    globals()["FilesBaseHandler"] = None\n'
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "mutate()\n",
+            "locally-defined callable",
+            id="base-construction-call-of-local-function",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "    def _mutate():\n        pass\n"
+            "    _mutate()\n",
+            "locally-defined callable",
+            id="base-class-scope-local-call",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            '@(lambda c: exec("FilesBaseHandler = None", globals()) or c)\n'
+            "class Sibling:\n    pass\n",
+            "lambda decorator",
+            id="base-lambda-decorator-on-sibling",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            'locals()["FilesBaseHandler"] = None\n',
+            "dynamic export primitive",
+            id="base-locals-mutation",
+        ),
     ],
 )
 async def test_base_split_grammar_hostiles_reject(content_store, base: str, reason: str) -> None:
     with pytest.raises(ImplementationArtifactError, match=reason):
         await _certify_sources(content_store, CANONICAL_LEAF, base)
+
+
+async def test_deferred_base_helper_remains_certifiable(content_store) -> None:
+    """A local helper used only from a deferred method body stays certifiable:
+    runtime behavior is outside the import-time effective-export proof."""
+    base = (
+        "def _normalize(value):\n"
+        "    return value or {}\n"
+        "class FilesBaseHandler:\n"
+        "    async def get_file(self, ctx, file_id=None):\n"
+        '        return {"file": _normalize(file_id)}\n'
+    )
+    resolved = await _certify_sources(content_store, CANONICAL_LEAF, base)
+    assert resolved.export_proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
+    assert resolved.export_proof.method_source is HandlerMethodSource.BASE_HANDLER

--- a/tests/test_pack_implementation_certification.py
+++ b/tests/test_pack_implementation_certification.py
@@ -1,0 +1,570 @@
+"""Real canonical capability-pack implementation certification.
+
+Every workspace_handler_split pack module certifies through the bounded
+CANONICAL_BASE_HANDLER mode: the preserved workspace-owned ``handler.py``
+leaf directly subclasses the regenerated template-owned ``base_handler.py``
+class, which explicitly defines each declared ``handler_method``. Exactly
+those two verified sources participate — no general Python source closure —
+and the certified implementation identity covers BOTH source digests.
+
+The corpus is discovered independently from the checked-in factory packs and
+pinned: 10 modules, 63 actions, all certifying end to end through
+``resolve_module_action_implementation`` with exact verified bytes, the #484
+closed request import, and the pack contract's workspace_handler_split
+ownership authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mozaiksai.core.artifacts.content_store import LocalArtifactContentStore
+from mozaiksai.core.runtime.app.layout_registry import PathScope
+from mozaiksai.core.semantics.composition_ledger import AccountedArtifact, ArtifactAddress
+from mozaiksai.core.semantics.implementation_artifacts import (
+    HandlerCertificationMode,
+    ImplementationArtifactError,
+    SelectedContractArtifact,
+    resolve_module_action_implementation,
+    workspace_handler_split_authority_from_pack_contract,
+)
+from mozaiksai.core.semantics.refs import ChildContractRef, ExecutionAccessScopeRef
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+BUILD_CONTEXT = WORKSPACE / "factory_app" / "build_context"
+
+SCOPE = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="workspace")
+
+EXPECTED_MODULE_COUNT = 10
+EXPECTED_ACTION_COUNT = 63
+
+
+def _discover_split_modules() -> list[tuple[str, str]]:
+    """Independently discover the canonical workspace_handler_split corpus."""
+    discovered: list[tuple[str, str]] = []
+    for base_handler in sorted(BUILD_CONTEXT.glob("*/templates/modules/*/backend/base_handler.py")):
+        module_dir = base_handler.parent.parent
+        pack_dir = base_handler.parents[4]
+        discovered.append((pack_dir.name, module_dir.name))
+    return discovered
+
+
+SPLIT_MODULES = _discover_split_modules()
+SPLIT_IDS = [f"{pack}/{module}" for pack, module in SPLIT_MODULES]
+
+
+def _module_root(pack: str, module: str) -> Path:
+    return BUILD_CONTEXT / pack / "templates" / "modules" / module
+
+
+def _pack_contract(pack: str) -> dict:
+    return yaml.safe_load((BUILD_CONTEXT / pack / "contract.yaml").read_text(encoding="utf-8")) or {}
+
+
+@pytest.fixture
+def content_store(tmp_path):
+    return LocalArtifactContentStore(root=tmp_path)
+
+
+async def _put(content_store, data: bytes) -> str:
+    digest = hashlib.sha256(data).hexdigest()
+    await content_store.put_blob(data, expected_digest=digest)
+    return digest
+
+
+# Selections use APP_BUNDLE_ROOT: the canonical layout registry registers the
+# module_backend_base_handler family at app scope (the module-relative sibling
+# row does not exist yet — a registry asymmetry outside this slice's scope).
+def _module_selection(*, digest: str, module: str) -> SelectedContractArtifact:
+    return SelectedContractArtifact(
+        contract_ref=ChildContractRef(
+            subject_id="pack-app",
+            subject_version=1,
+            content_digest=digest,
+            scope=SCOPE,
+            artifact_family="module_manifest",
+            canonical_relative_path=f"modules/{module}/module.yaml",
+            contract_schema_version="mozaiks.module.v1",
+        ),
+        address=ArtifactAddress(
+            path_scope=PathScope.APP_BUNDLE_ROOT,
+            placeholder_values=(),
+            path=f"modules/{module}/module.yaml",
+        ),
+    )
+
+
+def _backend_artifact(*, digest: str | None, module: str, file_name: str) -> AccountedArtifact:
+    return AccountedArtifact(
+        address=ArtifactAddress(
+            path_scope=PathScope.APP_BUNDLE_ROOT,
+            placeholder_values=(),
+            path=f"modules/{module}/backend/{file_name}",
+        ),
+        content_digest=digest,
+    )
+
+
+async def _stage_module(content_store, pack: str, module: str):
+    """Load the real pack module into the content store and build selections."""
+    root = _module_root(pack, module)
+    manifest_bytes = (root / "module.yaml").read_bytes()
+    handler_bytes = (root / "backend" / "handler.py").read_bytes()
+    base_bytes = (root / "backend" / "base_handler.py").read_bytes()
+    manifest_digest = await _put(content_store, manifest_bytes)
+    handler_digest = await _put(content_store, handler_bytes)
+    base_digest = await _put(content_store, base_bytes)
+    authority = workspace_handler_split_authority_from_pack_contract(
+        _pack_contract(pack), module_instance=module
+    )
+    return {
+        "module_selection": _module_selection(digest=manifest_digest, module=module),
+        "handler_artifact": _backend_artifact(
+            digest=handler_digest, module=module, file_name="handler.py"
+        ),
+        "base_artifact": _backend_artifact(
+            digest=base_digest, module=module, file_name="base_handler.py"
+        ),
+        "authority": authority,
+        "handler_digest": handler_digest,
+        "base_digest": base_digest,
+    }
+
+
+def test_census_is_pinned() -> None:
+    """The canonical corpus is exactly 10 split modules carrying 63 actions."""
+    assert len(SPLIT_MODULES) == EXPECTED_MODULE_COUNT, SPLIT_MODULES
+    total_actions = 0
+    for pack, module in SPLIT_MODULES:
+        manifest = yaml.safe_load(
+            (_module_root(pack, module) / "module.yaml").read_text(encoding="utf-8")
+        )
+        total_actions += len(manifest.get("actions") or [])
+    assert total_actions == EXPECTED_ACTION_COUNT
+
+
+@pytest.mark.parametrize("pack,module", SPLIT_MODULES, ids=SPLIT_IDS)
+async def test_every_real_pack_action_certifies(content_store, pack: str, module: str) -> None:
+    staged = await _stage_module(content_store, pack, module)
+    manifest = yaml.safe_load(
+        (_module_root(pack, module) / "module.yaml").read_text(encoding="utf-8")
+    )
+    action_ids = [action["id"] for action in manifest.get("actions") or []]
+    assert action_ids
+    for action_id in action_ids:
+        resolved = await resolve_module_action_implementation(
+            staged["module_selection"],
+            staged["handler_artifact"],
+            action_id=action_id,
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            base_handler_artifact=staged["base_artifact"],
+            split_authority=staged["authority"],
+        )
+        proof = resolved.export_proof
+        assert proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER, (
+            f"{pack}/{module}:{action_id} certified as {proof.mode}"
+        )
+        assert proof.content_digest == staged["handler_digest"]
+        assert proof.base_content_digest == staged["base_digest"]
+        assert proof.base_handler_class
+        assert resolved.request_contract is not None
+        assert resolved.base_handler is not None
+        assert len(proof.implementation_digest) == 64
+
+
+async def test_implementation_identity_covers_both_sources(content_store) -> None:
+    """Changing ONLY the base — or ONLY the preserved leaf — changes identity."""
+    staged = await _stage_module(content_store, "files", "files")
+    baseline = await resolve_module_action_implementation(
+        staged["module_selection"],
+        staged["handler_artifact"],
+        action_id="get_file",
+        content_store=content_store,
+        requesting_scope=SCOPE,
+        base_handler_artifact=staged["base_artifact"],
+        split_authority=staged["authority"],
+    )
+    root = _module_root("files", "files")
+
+    changed_base = (root / "backend" / "base_handler.py").read_text(encoding="utf-8") + "\n# regenerated\n"
+    changed_base_digest = await _put(content_store, changed_base.encode("utf-8"))
+    with_new_base = await resolve_module_action_implementation(
+        staged["module_selection"],
+        staged["handler_artifact"],
+        action_id="get_file",
+        content_store=content_store,
+        requesting_scope=SCOPE,
+        base_handler_artifact=_backend_artifact(
+            digest=changed_base_digest, module="files", file_name="base_handler.py"
+        ),
+        split_authority=staged["authority"],
+    )
+    changed_leaf = (root / "backend" / "handler.py").read_text(encoding="utf-8") + "\n# workspace note\n"
+    changed_leaf_digest = await _put(content_store, changed_leaf.encode("utf-8"))
+    with_new_leaf = await resolve_module_action_implementation(
+        staged["module_selection"],
+        _backend_artifact(digest=changed_leaf_digest, module="files", file_name="handler.py"),
+        action_id="get_file",
+        content_store=content_store,
+        requesting_scope=SCOPE,
+        base_handler_artifact=staged["base_artifact"],
+        split_authority=staged["authority"],
+    )
+    identities = {
+        baseline.export_proof.implementation_digest,
+        with_new_base.export_proof.implementation_digest,
+        with_new_leaf.export_proof.implementation_digest,
+    }
+    assert len(identities) == 3
+
+
+# ---------------------------------------------------------------------------
+# Split authority hostile matrix
+# ---------------------------------------------------------------------------
+
+
+def test_split_authority_requires_canonical_ownership() -> None:
+    contract = _pack_contract("files")
+    # Wrong leaf ownership cannot establish the split.
+    tampered = yaml.safe_load(yaml.safe_dump(contract))
+    for entry in tampered["required_outputs"]:
+        if entry.get("path") == "modules/files/backend/handler.py":
+            entry["owner"] = "templates"
+    with pytest.raises(ImplementationArtifactError, match="workspace-owned"):
+        workspace_handler_split_authority_from_pack_contract(tampered, module_instance="files")
+    # Workspace-owned base cannot establish the split.
+    tampered = yaml.safe_load(yaml.safe_dump(contract))
+    for entry in tampered["required_outputs"]:
+        if entry.get("path") == "modules/files/backend/base_handler.py":
+            entry["owner"] = "workspace"
+    with pytest.raises(ImplementationArtifactError, match="template-owned"):
+        workspace_handler_split_authority_from_pack_contract(tampered, module_instance="files")
+    # Absent declarations reject.
+    with pytest.raises(ImplementationArtifactError, match="absent"):
+        workspace_handler_split_authority_from_pack_contract(
+            contract, module_instance="undeclared_module"
+        )
+    # Non-pack contract types carry no split authority.
+    with pytest.raises(ImplementationArtifactError, match="build_pack_instructions"):
+        workspace_handler_split_authority_from_pack_contract(
+            {"contract_type": "provider_api_contract", "contract_id": "x"},
+            module_instance="files",
+        )
+
+
+async def test_base_selection_without_split_authority_rejects(content_store) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+    with pytest.raises(ImplementationArtifactError, match="split authority"):
+        await resolve_module_action_implementation(
+            staged["module_selection"],
+            staged["handler_artifact"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            base_handler_artifact=staged["base_artifact"],
+            split_authority=None,
+        )
+
+
+async def test_without_base_selection_the_single_source_rejection_is_preserved(
+    content_store,
+) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+    with pytest.raises(ImplementationArtifactError, match="not explicitly defined"):
+        await resolve_module_action_implementation(
+            staged["module_selection"],
+            staged["handler_artifact"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_base_content_hostiles_reject(content_store, tmp_path) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+
+    async def _resolve(base_artifact, authority=None):
+        return await resolve_module_action_implementation(
+            staged["module_selection"],
+            staged["handler_artifact"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            base_handler_artifact=base_artifact,
+            split_authority=authority or staged["authority"],
+        )
+
+    # Missing digest.
+    with pytest.raises(ImplementationArtifactError, match="non-null content digest"):
+        await _resolve(_backend_artifact(digest=None, module="files", file_name="base_handler.py"))
+
+    # Missing bytes (stale ref after base regeneration).
+    absent = "e" * 64
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await _resolve(
+            _backend_artifact(digest=absent, module="files", file_name="base_handler.py")
+        )
+
+    # Tampered bytes under a valid digest path.
+    digest = hashlib.sha256(b"real base bytes").hexdigest()
+    blob_path = tmp_path / "sha256" / digest[:2] / digest
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(b"tampered base bytes")
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await _resolve(
+            _backend_artifact(digest=digest, module="files", file_name="base_handler.py")
+        )
+
+    # Base from another module instance.
+    with pytest.raises(ImplementationArtifactError, match="cannot implement module"):
+        await _resolve(
+            _backend_artifact(
+                digest=staged["base_digest"], module="messages", file_name="base_handler.py"
+            )
+        )
+
+    # Base path outside the canonical family.
+    with pytest.raises(ImplementationArtifactError, match="not 'module_backend_base_handler'"):
+        await _resolve(
+            _backend_artifact(
+                digest=staged["base_digest"], module="files", file_name="service.py"
+            )
+        )
+
+    # Authority borrowed from another module.
+    other_authority = workspace_handler_split_authority_from_pack_contract(
+        _pack_contract("messaging"), module_instance="messages"
+    )
+    with pytest.raises(ImplementationArtifactError, match="cannot certify module"):
+        await _resolve(staged["base_artifact"], authority=other_authority)
+
+    # Scope mismatch between leaf and base selections: the module-relative
+    # base row is unregistered today, so the mismatch rejects at the layout
+    # proof; the explicit same-scope rule remains as defense-in-depth.
+    module_scope_base = AccountedArtifact(
+        address=ArtifactAddress(
+            path_scope=PathScope.MODULE_RELATIVE,
+            placeholder_values=(("module_id", "files"),),
+            path="backend/base_handler.py",
+        ),
+        content_digest=staged["base_digest"],
+    )
+    with pytest.raises(
+        ImplementationArtifactError, match="no canonical layout row|same module scope"
+    ):
+        await _resolve(module_scope_base)
+
+
+# ---------------------------------------------------------------------------
+# Bounded AST hostile matrix for the split grammar
+# ---------------------------------------------------------------------------
+
+
+BASE_SOURCE = (
+    "class FilesBaseHandler:\n"
+    "    async def get_file(self, ctx, file_id=None):\n"
+    "        return {\"file\": None}\n"
+)
+
+
+async def _certify_sources(
+    content_store, leaf_source: str, base_source: str = BASE_SOURCE, *, action_id: str = "get_file"
+):
+    staged = await _stage_module(content_store, "files", "files")
+    leaf_digest = await _put(content_store, leaf_source.encode("utf-8"))
+    base_digest = await _put(content_store, base_source.encode("utf-8"))
+    return await resolve_module_action_implementation(
+        staged["module_selection"],
+        _backend_artifact(digest=leaf_digest, module="files", file_name="handler.py"),
+        action_id=action_id,
+        content_store=content_store,
+        requesting_scope=SCOPE,
+        base_handler_artifact=_backend_artifact(
+            digest=base_digest, module="files", file_name="base_handler.py"
+        ),
+        split_authority=staged["authority"],
+    )
+
+
+CANONICAL_LEAF = (
+    "from .base_handler import FilesBaseHandler\n\n\n"
+    "class FilesHandler(FilesBaseHandler):\n"
+    "    \"\"\"Preserved workspace leaf.\"\"\"\n"
+)
+
+
+async def test_canonical_minimal_split_certifies(content_store) -> None:
+    resolved = await _certify_sources(content_store, CANONICAL_LEAF)
+    assert resolved.export_proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
+    assert resolved.export_proof.base_handler_class == "FilesBaseHandler"
+
+
+async def test_leaf_override_certifies_as_explicit_handler(content_store) -> None:
+    leaf = (
+        "from .base_handler import FilesBaseHandler\n\n\n"
+        "class FilesHandler(FilesBaseHandler):\n"
+        "    async def get_file(self, ctx, file_id=None):\n"
+        "        return {\"file\": {\"overridden\": True}}\n"
+    )
+    resolved = await _certify_sources(content_store, leaf)
+    assert resolved.export_proof.mode is HandlerCertificationMode.EXPLICIT_HANDLER
+    assert resolved.export_proof.base_content_digest is None
+
+
+@pytest.mark.parametrize(
+    "leaf,reason",
+    [
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class OtherMixin:\n    pass\n"
+            "class FilesHandler(FilesBaseHandler, OtherMixin):\n    pass\n",
+            "exactly one base|multiple inheritance",
+            id="multiple-inheritance-mixin",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler.__class__):\n    pass\n",
+            "plain imported name",
+            id="non-name-base",
+        ),
+        pytest.param(
+            "from .other_module import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "from .base_handler import",
+            id="base-imported-from-wrong-module",
+        ),
+        pytest.param(
+            "from .base_handler import WrongBase as FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "from .base_handler import",
+            id="aliased-import",
+        ),
+        pytest.param(
+            "from .base_handler import *\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "star imports",
+            id="star-import",
+        ),
+        pytest.param(
+            "import importlib\n"
+            "FilesBaseHandler = importlib.import_module('x').Base\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "rebound outside its canonical import",
+            id="dynamic-import",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "if True:\n"
+            "    class FilesHandler(FilesBaseHandler):\n        pass\n",
+            "conditionally",
+            id="conditional-class",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "FilesHandler.get_file = None\n",
+            "rebound|referenced dynamically",
+            id="monkeypatch",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "setattr(FilesHandler, 'get_file', None)\n",
+            "not statically provable|referenced dynamically",
+            id="setattr",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "def __getattr__(name):\n    raise AttributeError(name)\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "__getattr__",
+            id="module-getattr",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "class _Shadow:\n    pass\n"
+            "FilesHandler = _Shadow\n",
+            "more than once|rebound",
+            id="class-rebinding",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "AliasBase = FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "referenced only as the leaf's single base",
+            id="base-alias-reference",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n"
+            "    get_file = FilesBaseHandler\n",
+            "bound dynamically|referenced only",
+            id="leaf-method-rebinding",
+        ),
+    ],
+)
+async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reason: str) -> None:
+    with pytest.raises(ImplementationArtifactError, match=reason):
+        await _certify_sources(content_store, leaf)
+
+
+@pytest.mark.parametrize(
+    "base,reason",
+    [
+        pytest.param(
+            "class WrongBase:\n"
+            "    async def get_file(self, ctx):\n        return {}\n",
+            "absent from the selected base-handler source",
+            id="base-class-missing",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n    pass\n"
+            "class Helper:\n"
+            "    async def get_file(self, ctx):\n        return {}\n",
+            "not explicitly defined on canonical base class",
+            id="method-on-wrong-class",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n    pass\n",
+            "not explicitly defined on canonical base class",
+            id="base-method-missing",
+        ),
+        pytest.param(
+            "class Grandparent:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "class FilesBaseHandler(Grandparent):\n    pass\n",
+            "must not inherit",
+            id="transitive-inheritance",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "FilesBaseHandler.get_file = None\n",
+            "rebound|referenced dynamically",
+            id="base-monkeypatch",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    def __getattr__(self, name):\n        raise AttributeError(name)\n"
+            "    async def get_file(self, ctx):\n        return {}\n",
+            "__getattr__",
+            id="base-class-getattr",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    if True:\n"
+            "        async def get_file(self, ctx):\n            return {}\n",
+            "conditionally",
+            id="base-conditional-method",
+        ),
+    ],
+)
+async def test_base_split_grammar_hostiles_reject(content_store, base: str, reason: str) -> None:
+    with pytest.raises(ImplementationArtifactError, match=reason):
+        await _certify_sources(content_store, CANONICAL_LEAF, base)

--- a/tests/test_pack_implementation_certification.py
+++ b/tests/test_pack_implementation_certification.py
@@ -220,6 +220,26 @@ def test_public_resolution_accepts_no_authority_token() -> None:
     assert "split_authority" not in base.parameters
 
 
+def test_public_surface_has_no_fabricated_authority_entry_point() -> None:
+    """No exported function accepts a ResolvedWorkspaceHandlerSplitAuthority:
+    the split-capable certifier is internal, prove_module_action_export stays
+    the only standalone proof helper (zero-base EXPLICIT_HANDLER), and
+    resolve_module_action_implementation is the public authority boundary."""
+    import mozaiksai.core.semantics.implementation_artifacts as impl
+
+    assert "certify_module_action_export" not in impl.__all__
+    assert not hasattr(impl, "certify_module_action_export")
+    assert "prove_module_action_export" in impl.__all__
+    assert "resolve_module_action_implementation" in impl.__all__
+    for name in impl.__all__:
+        exported = getattr(impl, name)
+        if callable(exported) and not isinstance(exported, type):
+            for parameter in inspect.signature(exported).parameters.values():
+                assert "ResolvedWorkspaceHandlerSplitAuthority" not in str(
+                    parameter.annotation
+                ), (name, parameter.name)
+
+
 @pytest.mark.parametrize("pack,module", SPLIT_MODULES, ids=SPLIT_IDS)
 async def test_every_real_pack_action_certifies(content_store, pack: str, module: str) -> None:
     staged = await _stage_module(content_store, pack, module)
@@ -521,6 +541,82 @@ async def test_standalone_base_resolver_derives_authority_from_contract_bytes(
             ),
             content_store=content_store,
             requesting_scope=SCOPE,
+        )
+
+
+async def test_ambiguous_or_implicit_required_outputs_reject(content_store) -> None:
+    """The verified pack-contract bytes must be unambiguous at this boundary:
+    duplicate required_outputs paths reject globally, and authority-relevant
+    ownership must be explicit — omitted, null, or empty owners never default."""
+    staged = await _stage_module(content_store, "files", "files")
+    handler_path = "modules/files/backend/handler.py"
+    base_path = "modules/files/backend/base_handler.py"
+    manifest_path = "modules/files/module.yaml"
+
+    def _append_dup(path: str, owner: str):
+        def mutate(document):
+            document["required_outputs"].append({"path": path, "owner": owner})
+
+        return mutate
+
+    def _prepend_dup(path: str, owner: str):
+        def mutate(document):
+            document["required_outputs"].insert(0, {"path": path, "owner": owner})
+
+        return mutate
+
+    duplicate_cases = [
+        _append_dup(handler_path, "templates"),  # workspace then templates
+        _prepend_dup(handler_path, "templates"),  # templates then workspace
+        _append_dup(base_path, "workspace"),
+        _append_dup(manifest_path, "templates"),
+        # ANY duplicate path is structurally ambiguous, relevant or not.
+        _append_dup("modules/files/backend/service.py", "templates"),
+    ]
+    for mutate in duplicate_cases:
+        digest = await _stage_tampered_contract(content_store, "files", mutate)
+        with pytest.raises(ImplementationArtifactError, match="more than once"):
+            await _resolve_authority(
+                content_store, staged, _contract_selection(digest=digest, pack="files")
+            )
+
+    def _strip_owner(path: str):
+        def mutate(document):
+            for entry in document["required_outputs"]:
+                if entry.get("path") == path:
+                    entry.pop("owner", None)
+
+        return mutate
+
+    def _set_owner_value(path: str, value):
+        def mutate(document):
+            for entry in document["required_outputs"]:
+                if entry.get("path") == path:
+                    entry["owner"] = value
+
+        return mutate
+
+    implicit_cases = [
+        _strip_owner(handler_path),
+        _strip_owner(base_path),
+        _strip_owner(manifest_path),
+        _set_owner_value(handler_path, None),
+        _set_owner_value(base_path, ""),
+    ]
+    for mutate in implicit_cases:
+        digest = await _stage_tampered_contract(content_store, "files", mutate)
+        with pytest.raises(ImplementationArtifactError, match="explicit owner"):
+            await _resolve_authority(
+                content_store, staged, _contract_selection(digest=digest, pack="files")
+            )
+
+    # The manifest owner must be the exact canonical owner, not merely present.
+    digest = await _stage_tampered_contract(
+        content_store, "files", _set_owner_value(manifest_path, "workspace")
+    )
+    with pytest.raises(ImplementationArtifactError, match="canonical manifest owner"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
         )
 
 
@@ -936,6 +1032,29 @@ async def test_override_and_inherited_certifications_have_distinct_identity(
             "rebound outside its canonical import",
             id="match-mapping-rest-capture-of-base",
         ),
+        pytest.param(
+            "import builtins\n"
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            'builtins.exec("FilesHandler = 1")\n',
+            "accesses the builtins module",
+            id="leaf-builtins-exec",
+        ),
+        pytest.param(
+            "from builtins import exec as e\n"
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            'e("FilesHandler = 1")\n',
+            "imports 'exec' from builtins",
+            id="leaf-aliased-builtins-exec-import",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n"
+            '    exec("get_file = 1")\n',
+            "dynamic export primitive",
+            id="leaf-class-body-exec-of-method",
+        ),
     ],
 )
 async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reason: str) -> None:
@@ -1007,6 +1126,28 @@ async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reas
             "    case [*FilesBaseHandler]:\n        pass\n    case _:\n        pass\n",
             "rebound|referenced dynamically",
             id="base-match-star-capture-of-class",
+        ),
+        pytest.param(
+            "e = eval\n"
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n",
+            "dynamic export primitive",
+            id="base-rebound-eval",
+        ),
+        pytest.param(
+            "import builtins as b\n"
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            'b.setattr(FilesBaseHandler, "get_file", None)\n',
+            "accesses the builtins module|referenced dynamically",
+            id="base-builtins-setattr",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            '    exec("get_file = 1")\n',
+            "dynamic export primitive",
+            id="base-class-body-exec-of-method",
         ),
     ],
 )

--- a/tests/test_pack_implementation_certification.py
+++ b/tests/test_pack_implementation_certification.py
@@ -1103,6 +1103,20 @@ async def test_override_and_inherited_certifications_have_distinct_identity(
             "locally-defined callable",
             id="leaf-local-decorator-on-sibling",
         ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "(f := lambda: None)()\n",
+            "anonymous lambda",
+            id="leaf-walrus-lambda-invocation",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "[lambda: None][0]()\n",
+            "anonymous lambda",
+            id="leaf-list-laundered-lambda",
+        ),
     ],
 )
 async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reason: str) -> None:
@@ -1228,6 +1242,21 @@ async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reas
             'locals()["FilesBaseHandler"] = None\n',
             "dynamic export primitive",
             id="base-locals-mutation",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "{0: lambda: None}[0]()\n",
+            "anonymous lambda",
+            id="base-dict-laundered-lambda",
+        ),
+        pytest.param(
+            "from typing import cast as external\n"
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "external(lambda: None)\n",
+            "anonymous lambda",
+            id="base-lambda-passed-to-external-call",
         ),
     ],
 )

--- a/tests/test_pack_implementation_certification.py
+++ b/tests/test_pack_implementation_certification.py
@@ -3,20 +3,27 @@
 Every workspace_handler_split pack module certifies through the bounded
 CANONICAL_BASE_HANDLER mode: the preserved workspace-owned ``handler.py``
 leaf directly subclasses the regenerated template-owned ``base_handler.py``
-class, which explicitly defines each declared ``handler_method``. Exactly
-those two verified sources participate — no general Python source closure —
-and the certified implementation identity covers BOTH source digests.
+class.  Exactly those two verified sources participate — no general Python
+source closure — and the certified implementation identity covers BOTH
+source digests plus the exact pack-contract digest that authorized the
+split.
+
+The split authority itself is content-resolved: the caller supplies only the
+exact scope-bound pack-contract selection, and every ownership fact is
+derived from digest-verified bytes.  There is no caller-constructible
+authority token anywhere on the public resolution API.
 
 The corpus is discovered independently from the checked-in factory packs and
 pinned: 10 modules, 63 actions, all certifying end to end through
-``resolve_module_action_implementation`` with exact verified bytes, the #484
-closed request import, and the pack contract's workspace_handler_split
-ownership authority.
+``resolve_module_action_implementation`` with exact verified bytes for the
+manifest, leaf, base, AND pack contract (the blob-read count proves the
+contract bytes are actually read), and the #484 closed request import.
 """
 
 from __future__ import annotations
 
 import hashlib
+import inspect
 from pathlib import Path
 
 import pytest
@@ -27,10 +34,14 @@ from mozaiksai.core.runtime.app.layout_registry import PathScope
 from mozaiksai.core.semantics.composition_ledger import AccountedArtifact, ArtifactAddress
 from mozaiksai.core.semantics.implementation_artifacts import (
     HandlerCertificationMode,
+    HandlerMethodSource,
     ImplementationArtifactError,
+    SelectedAccountedArtifact,
     SelectedContractArtifact,
     resolve_module_action_implementation,
-    workspace_handler_split_authority_from_pack_contract,
+    resolve_module_base_handler_source,
+    resolve_module_manifest_artifact,
+    resolve_workspace_handler_split_authority,
 )
 from mozaiksai.core.semantics.refs import ChildContractRef, ExecutionAccessScopeRef
 
@@ -38,6 +49,8 @@ WORKSPACE = Path(__file__).resolve().parents[1]
 BUILD_CONTEXT = WORKSPACE / "factory_app" / "build_context"
 
 SCOPE = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="workspace")
+OTHER_SCOPE = ExecutionAccessScopeRef(tenant_id="tenant", workspace_id="elsewhere")
+OTHER_TENANT = ExecutionAccessScopeRef(tenant_id="rival", workspace_id="workspace")
 
 EXPECTED_MODULE_COUNT = 10
 EXPECTED_ACTION_COUNT = 63
@@ -61,13 +74,25 @@ def _module_root(pack: str, module: str) -> Path:
     return BUILD_CONTEXT / pack / "templates" / "modules" / module
 
 
-def _pack_contract(pack: str) -> dict:
-    return yaml.safe_load((BUILD_CONTEXT / pack / "contract.yaml").read_text(encoding="utf-8")) or {}
+def _pack_contract_bytes(pack: str) -> bytes:
+    return (BUILD_CONTEXT / pack / "contract.yaml").read_bytes()
+
+
+class _CountingContentStore(LocalArtifactContentStore):
+    """Records every verified blob read so tests can prove reads happen."""
+
+    def __init__(self, *, root) -> None:
+        super().__init__(root=root)
+        self.verified_reads: list[str] = []
+
+    async def get_verified_blob(self, digest: str) -> bytes:
+        self.verified_reads.append(digest)
+        return await super().get_verified_blob(digest)
 
 
 @pytest.fixture
 def content_store(tmp_path):
-    return LocalArtifactContentStore(root=tmp_path)
+    return _CountingContentStore(root=tmp_path)
 
 
 async def _put(content_store, data: bytes) -> str:
@@ -76,9 +101,11 @@ async def _put(content_store, data: bytes) -> str:
     return digest
 
 
-# Selections use APP_BUNDLE_ROOT: the canonical layout registry registers the
-# module_backend_base_handler family at app scope (the module-relative sibling
-# row does not exist yet — a registry asymmetry outside this slice's scope).
+# Source selections use APP_BUNDLE_ROOT: the canonical layout registry
+# registers the module_backend_base_handler family at app scope (the
+# module-relative sibling row does not exist yet — a registry asymmetry
+# outside this slice's scope).  Pack-contract selections are bounded
+# workspace-root build-context inputs.
 def _module_selection(*, digest: str, module: str) -> SelectedContractArtifact:
     return SelectedContractArtifact(
         contract_ref=ChildContractRef(
@@ -98,41 +125,75 @@ def _module_selection(*, digest: str, module: str) -> SelectedContractArtifact:
     )
 
 
-def _backend_artifact(*, digest: str | None, module: str, file_name: str) -> AccountedArtifact:
-    return AccountedArtifact(
-        address=ArtifactAddress(
-            path_scope=PathScope.APP_BUNDLE_ROOT,
-            placeholder_values=(),
-            path=f"modules/{module}/backend/{file_name}",
+def _source_selection(
+    *,
+    digest: str | None,
+    module: str,
+    file_name: str,
+    scope: ExecutionAccessScopeRef = SCOPE,
+) -> SelectedAccountedArtifact:
+    return SelectedAccountedArtifact(
+        scope=scope,
+        artifact=AccountedArtifact(
+            address=ArtifactAddress(
+                path_scope=PathScope.APP_BUNDLE_ROOT,
+                placeholder_values=(),
+                path=f"modules/{module}/backend/{file_name}",
+            ),
+            content_digest=digest,
         ),
-        content_digest=digest,
+    )
+
+
+def _contract_selection(
+    *,
+    digest: str | None,
+    pack: str,
+    scope: ExecutionAccessScopeRef = SCOPE,
+    path: str | None = None,
+    path_scope: PathScope = PathScope.WORKSPACE_ROOT,
+) -> SelectedAccountedArtifact:
+    return SelectedAccountedArtifact(
+        scope=scope,
+        artifact=AccountedArtifact(
+            address=ArtifactAddress(
+                path_scope=path_scope,
+                placeholder_values=(),
+                path=path or f"build_context/{pack}/contract.yaml",
+            ),
+            content_digest=digest,
+        ),
     )
 
 
 async def _stage_module(content_store, pack: str, module: str):
-    """Load the real pack module into the content store and build selections."""
+    """Load the real pack module AND its pack contract into the content store."""
     root = _module_root(pack, module)
-    manifest_bytes = (root / "module.yaml").read_bytes()
-    handler_bytes = (root / "backend" / "handler.py").read_bytes()
-    base_bytes = (root / "backend" / "base_handler.py").read_bytes()
-    manifest_digest = await _put(content_store, manifest_bytes)
-    handler_digest = await _put(content_store, handler_bytes)
-    base_digest = await _put(content_store, base_bytes)
-    authority = workspace_handler_split_authority_from_pack_contract(
-        _pack_contract(pack), module_instance=module
-    )
+    manifest_digest = await _put(content_store, (root / "module.yaml").read_bytes())
+    handler_digest = await _put(content_store, (root / "backend" / "handler.py").read_bytes())
+    base_digest = await _put(content_store, (root / "backend" / "base_handler.py").read_bytes())
+    contract_digest = await _put(content_store, _pack_contract_bytes(pack))
     return {
         "module_selection": _module_selection(digest=manifest_digest, module=module),
-        "handler_artifact": _backend_artifact(
+        "handler_selection": _source_selection(
             digest=handler_digest, module=module, file_name="handler.py"
         ),
-        "base_artifact": _backend_artifact(
+        "base_selection": _source_selection(
             digest=base_digest, module=module, file_name="base_handler.py"
         ),
-        "authority": authority,
+        "contract_selection": _contract_selection(digest=contract_digest, pack=pack),
         "handler_digest": handler_digest,
         "base_digest": base_digest,
+        "contract_digest": contract_digest,
     }
+
+
+async def _resolved_module_for(content_store, staged):
+    return await resolve_module_manifest_artifact(
+        staged["module_selection"],
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
 
 
 def test_census_is_pinned() -> None:
@@ -147,6 +208,18 @@ def test_census_is_pinned() -> None:
     assert total_actions == EXPECTED_ACTION_COUNT
 
 
+def test_public_resolution_accepts_no_authority_token() -> None:
+    """The public resolution APIs take pack-contract selections, never a
+    preconstructed ownership result — fabricated authority strings have no
+    entry point."""
+    aggregate = inspect.signature(resolve_module_action_implementation)
+    assert "pack_contract_selection" in aggregate.parameters
+    assert "split_authority" not in aggregate.parameters
+    base = inspect.signature(resolve_module_base_handler_source)
+    assert "pack_contract_selection" in base.parameters
+    assert "split_authority" not in base.parameters
+
+
 @pytest.mark.parametrize("pack,module", SPLIT_MODULES, ids=SPLIT_IDS)
 async def test_every_real_pack_action_certifies(content_store, pack: str, module: str) -> None:
     staged = await _stage_module(content_store, pack, module)
@@ -156,158 +229,409 @@ async def test_every_real_pack_action_certifies(content_store, pack: str, module
     action_ids = [action["id"] for action in manifest.get("actions") or []]
     assert action_ids
     for action_id in action_ids:
+        reads_before = len(content_store.verified_reads)
         resolved = await resolve_module_action_implementation(
             staged["module_selection"],
-            staged["handler_artifact"],
+            staged["handler_selection"],
             action_id=action_id,
             content_store=content_store,
             requesting_scope=SCOPE,
-            base_handler_artifact=staged["base_artifact"],
-            split_authority=staged["authority"],
+            base_handler_selection=staged["base_selection"],
+            pack_contract_selection=staged["contract_selection"],
         )
         proof = resolved.export_proof
         assert proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER, (
             f"{pack}/{module}:{action_id} certified as {proof.mode}"
         )
+        # No checked-in pack leaf overrides an action today.
+        assert proof.method_source is HandlerMethodSource.BASE_HANDLER
         assert proof.content_digest == staged["handler_digest"]
         assert proof.base_content_digest == staged["base_digest"]
+        assert proof.split_contract_content_digest == staged["contract_digest"]
         assert proof.base_handler_class
         assert resolved.request_contract is not None
         assert resolved.base_handler is not None
+        assert resolved.split_authority is not None
+        assert resolved.split_authority.contract_id == pack
+        assert resolved.split_authority.contract_content_digest == staged["contract_digest"]
         assert len(proof.implementation_digest) == 64
+        # The certification actually read the pack-contract bytes, plus the
+        # manifest, leaf, and base bytes, through the verified blob store.
+        reads = content_store.verified_reads[reads_before:]
+        assert staged["contract_digest"] in reads
+        assert staged["handler_digest"] in reads
+        assert staged["base_digest"] in reads
 
 
-async def test_implementation_identity_covers_both_sources(content_store) -> None:
-    """Changing ONLY the base — or ONLY the preserved leaf — changes identity."""
+async def test_implementation_identity_covers_both_sources_and_authority(content_store) -> None:
+    """Changing ONLY the base, ONLY the preserved leaf, or ONLY the pack
+    contract changes the certified identity."""
     staged = await _stage_module(content_store, "files", "files")
-    baseline = await resolve_module_action_implementation(
-        staged["module_selection"],
-        staged["handler_artifact"],
-        action_id="get_file",
-        content_store=content_store,
-        requesting_scope=SCOPE,
-        base_handler_artifact=staged["base_artifact"],
-        split_authority=staged["authority"],
-    )
+
+    async def _resolve(
+        *, handler_selection=None, base_selection=None, contract_selection=None
+    ):
+        return await resolve_module_action_implementation(
+            staged["module_selection"],
+            handler_selection or staged["handler_selection"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            base_handler_selection=base_selection or staged["base_selection"],
+            pack_contract_selection=contract_selection or staged["contract_selection"],
+        )
+
+    baseline = await _resolve()
     root = _module_root("files", "files")
 
-    changed_base = (root / "backend" / "base_handler.py").read_text(encoding="utf-8") + "\n# regenerated\n"
+    changed_base = (
+        (root / "backend" / "base_handler.py").read_text(encoding="utf-8") + "\n# regenerated\n"
+    )
     changed_base_digest = await _put(content_store, changed_base.encode("utf-8"))
-    with_new_base = await resolve_module_action_implementation(
-        staged["module_selection"],
-        staged["handler_artifact"],
-        action_id="get_file",
-        content_store=content_store,
-        requesting_scope=SCOPE,
-        base_handler_artifact=_backend_artifact(
+    with_new_base = await _resolve(
+        base_selection=_source_selection(
             digest=changed_base_digest, module="files", file_name="base_handler.py"
-        ),
-        split_authority=staged["authority"],
+        )
     )
-    changed_leaf = (root / "backend" / "handler.py").read_text(encoding="utf-8") + "\n# workspace note\n"
+
+    changed_leaf = (
+        (root / "backend" / "handler.py").read_text(encoding="utf-8") + "\n# workspace note\n"
+    )
     changed_leaf_digest = await _put(content_store, changed_leaf.encode("utf-8"))
-    with_new_leaf = await resolve_module_action_implementation(
-        staged["module_selection"],
-        _backend_artifact(digest=changed_leaf_digest, module="files", file_name="handler.py"),
-        action_id="get_file",
-        content_store=content_store,
-        requesting_scope=SCOPE,
-        base_handler_artifact=staged["base_artifact"],
-        split_authority=staged["authority"],
+    with_new_leaf = await _resolve(
+        handler_selection=_source_selection(
+            digest=changed_leaf_digest, module="files", file_name="handler.py"
+        )
     )
+
+    changed_contract = _pack_contract_bytes("files") + b"\n# authority revision\n"
+    changed_contract_digest = await _put(content_store, changed_contract)
+    with_new_contract = await _resolve(
+        contract_selection=_contract_selection(digest=changed_contract_digest, pack="files")
+    )
+
     identities = {
         baseline.export_proof.implementation_digest,
         with_new_base.export_proof.implementation_digest,
         with_new_leaf.export_proof.implementation_digest,
+        with_new_contract.export_proof.implementation_digest,
     }
-    assert len(identities) == 3
+    assert len(identities) == 4
 
 
 # ---------------------------------------------------------------------------
-# Split authority hostile matrix
+# Content-resolved split authority hostile matrix
 # ---------------------------------------------------------------------------
 
 
-def test_split_authority_requires_canonical_ownership() -> None:
-    contract = _pack_contract("files")
-    # Wrong leaf ownership cannot establish the split.
-    tampered = yaml.safe_load(yaml.safe_dump(contract))
-    for entry in tampered["required_outputs"]:
-        if entry.get("path") == "modules/files/backend/handler.py":
-            entry["owner"] = "templates"
-    with pytest.raises(ImplementationArtifactError, match="workspace-owned"):
-        workspace_handler_split_authority_from_pack_contract(tampered, module_instance="files")
-    # Workspace-owned base cannot establish the split.
-    tampered = yaml.safe_load(yaml.safe_dump(contract))
-    for entry in tampered["required_outputs"]:
-        if entry.get("path") == "modules/files/backend/base_handler.py":
-            entry["owner"] = "workspace"
-    with pytest.raises(ImplementationArtifactError, match="template-owned"):
-        workspace_handler_split_authority_from_pack_contract(tampered, module_instance="files")
-    # Absent declarations reject.
-    with pytest.raises(ImplementationArtifactError, match="absent"):
-        workspace_handler_split_authority_from_pack_contract(
-            contract, module_instance="undeclared_module"
-        )
-    # Non-pack contract types carry no split authority.
-    with pytest.raises(ImplementationArtifactError, match="build_pack_instructions"):
-        workspace_handler_split_authority_from_pack_contract(
-            {"contract_type": "provider_api_contract", "contract_id": "x"},
-            module_instance="files",
-        )
+async def _resolve_authority(content_store, staged, contract_selection):
+    module = await _resolved_module_for(content_store, staged)
+    return await resolve_workspace_handler_split_authority(
+        contract_selection,
+        module=module,
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
 
 
-async def test_base_selection_without_split_authority_rejects(content_store) -> None:
+async def _stage_tampered_contract(content_store, pack: str, mutate) -> str:
+    document = yaml.safe_load(_pack_contract_bytes(pack).decode("utf-8"))
+    mutate(document)
+    return await _put(
+        content_store, yaml.safe_dump(document, sort_keys=False).encode("utf-8")
+    )
+
+
+async def test_split_authority_resolves_from_exact_contract_bytes(content_store) -> None:
     staged = await _stage_module(content_store, "files", "files")
-    with pytest.raises(ImplementationArtifactError, match="split authority"):
+    authority = await _resolve_authority(content_store, staged, staged["contract_selection"])
+    assert authority.contract_id == "files"
+    assert authority.module_instance == "files"
+    assert authority.contract_content_digest == staged["contract_digest"]
+    assert authority.handler_path == "modules/files/backend/handler.py"
+    assert authority.base_handler_path == "modules/files/backend/base_handler.py"
+    assert staged["contract_digest"] in content_store.verified_reads
+
+
+async def test_split_authority_ownership_hostiles_reject(content_store) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+
+    def _set_owner(path: str, owner: str):
+        def mutate(document):
+            for entry in document["required_outputs"]:
+                if entry.get("path") == path:
+                    entry["owner"] = owner
+
+        return mutate
+
+    # Wrong leaf ownership cannot establish the split.
+    digest = await _stage_tampered_contract(
+        content_store, "files", _set_owner("modules/files/backend/handler.py", "templates")
+    )
+    with pytest.raises(ImplementationArtifactError, match="workspace-owned"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
+        )
+
+    # Workspace-owned base cannot establish the split.
+    digest = await _stage_tampered_contract(
+        content_store,
+        "files",
+        _set_owner("modules/files/backend/base_handler.py", "workspace"),
+    )
+    with pytest.raises(ImplementationArtifactError, match="template-owned"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
+        )
+
+    # A contract that does not declare the module manifest owns nothing here.
+    def _drop_manifest(document):
+        document["required_outputs"] = [
+            entry
+            for entry in document["required_outputs"]
+            if entry.get("path") != "modules/files/module.yaml"
+        ]
+
+    digest = await _stage_tampered_contract(content_store, "files", _drop_manifest)
+    with pytest.raises(ImplementationArtifactError, match="module.yaml.*absent"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
+        )
+
+    # An unrelated pack contract does not own this module at all.
+    messaging_digest = await _put(content_store, _pack_contract_bytes("messaging"))
+    with pytest.raises(ImplementationArtifactError, match="absent"):
+        await _resolve_authority(
+            content_store,
+            staged,
+            _contract_selection(digest=messaging_digest, pack="messaging"),
+        )
+
+    # Non-pack contract types carry no split authority.
+    non_pack = yaml.safe_dump(
+        {"contract_type": "provider_api_contract", "contract_id": "files"}
+    ).encode("utf-8")
+    digest = await _put(content_store, non_pack)
+    with pytest.raises(ImplementationArtifactError, match="build_pack_instructions"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
+        )
+
+
+async def test_split_authority_content_hostiles_reject(content_store, tmp_path) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+
+    # Absent digest: the selection carries no content identity.
+    with pytest.raises(ImplementationArtifactError, match="non-null content digest"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=None, pack="files")
+        )
+
+    # Correct filename, no exact bytes behind the digest.
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest="e" * 64, pack="files")
+        )
+
+    # Tampered bytes under a valid digest path.
+    digest = hashlib.sha256(b"real contract bytes").hexdigest()
+    blob_path = tmp_path / "sha256" / digest[:2] / digest
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(b"tampered contract bytes")
+    with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
+        await _resolve_authority(
+            content_store, staged, _contract_selection(digest=digest, pack="files")
+        )
+
+    # Correct filename whose bytes are not a pack contract document.
+    with pytest.raises(
+        ImplementationArtifactError, match="not valid YAML|mapping|build_pack_instructions"
+    ):
+        await _resolve_authority(
+            content_store,
+            staged,
+            _contract_selection(digest=staged["base_digest"], pack="files"),
+        )
+
+    # The address must equal the canonical path for the contract id the bytes
+    # declare — the files contract cannot be smuggled under another pack path.
+    with pytest.raises(ImplementationArtifactError, match="lives at"):
+        await _resolve_authority(
+            content_store,
+            staged,
+            _contract_selection(
+                digest=staged["contract_digest"],
+                pack="files",
+                path="build_context/messaging/contract.yaml",
+            ),
+        )
+
+    # Pack contracts are workspace-root build-context inputs, not app-bundle
+    # artifacts.
+    with pytest.raises(ImplementationArtifactError, match="workspace-root build-context"):
+        await _resolve_authority(
+            content_store,
+            staged,
+            _contract_selection(
+                digest=staged["contract_digest"],
+                pack="files",
+                path_scope=PathScope.APP_BUNDLE_ROOT,
+            ),
+        )
+
+
+async def test_standalone_base_resolver_derives_authority_from_contract_bytes(
+    content_store,
+) -> None:
+    """The public base resolver takes the pack-contract selection and derives
+    authority internally — and refuses a contract smuggled under another
+    pack's canonical path."""
+    staged = await _stage_module(content_store, "files", "files")
+    module = await _resolved_module_for(content_store, staged)
+    from mozaiksai.core.semantics.implementation_artifacts import (
+        resolve_module_handler_source,
+    )
+
+    handler = await resolve_module_handler_source(
+        staged["handler_selection"],
+        module=module,
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    base = await resolve_module_base_handler_source(
+        staged["base_selection"],
+        module=module,
+        handler=handler,
+        pack_contract_selection=staged["contract_selection"],
+        content_store=content_store,
+        requesting_scope=SCOPE,
+    )
+    assert base.module_instance == "files"
+    assert base.content_digest == staged["base_digest"]
+    assert staged["contract_digest"] in content_store.verified_reads
+    with pytest.raises(ImplementationArtifactError, match="lives at"):
+        await resolve_module_base_handler_source(
+            staged["base_selection"],
+            module=module,
+            handler=handler,
+            pack_contract_selection=_contract_selection(
+                digest=staged["contract_digest"],
+                pack="files",
+                path="build_context/messaging/contract.yaml",
+            ),
+            content_store=content_store,
+            requesting_scope=SCOPE,
+        )
+
+
+async def test_split_certification_requires_both_selections_together(content_store) -> None:
+    staged = await _stage_module(content_store, "files", "files")
+    with pytest.raises(ImplementationArtifactError, match="together"):
         await resolve_module_action_implementation(
             staged["module_selection"],
-            staged["handler_artifact"],
+            staged["handler_selection"],
             action_id="get_file",
             content_store=content_store,
             requesting_scope=SCOPE,
-            base_handler_artifact=staged["base_artifact"],
-            split_authority=None,
+            base_handler_selection=staged["base_selection"],
+        )
+    with pytest.raises(ImplementationArtifactError, match="together"):
+        await resolve_module_action_implementation(
+            staged["module_selection"],
+            staged["handler_selection"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            pack_contract_selection=staged["contract_selection"],
         )
 
 
-async def test_without_base_selection_the_single_source_rejection_is_preserved(
+async def test_without_base_selection_the_standalone_rejection_is_preserved(
     content_store,
 ) -> None:
     staged = await _stage_module(content_store, "files", "files")
-    with pytest.raises(ImplementationArtifactError, match="not explicitly defined"):
+    with pytest.raises(ImplementationArtifactError, match="zero bases"):
         await resolve_module_action_implementation(
             staged["module_selection"],
-            staged["handler_artifact"],
+            staged["handler_selection"],
             action_id="get_file",
             content_store=content_store,
             requesting_scope=SCOPE,
         )
+
+
+async def test_cross_scope_source_selections_reject(content_store) -> None:
+    """Same module id and same bytes under another scope fail closed for the
+    leaf, the base, and the pack contract."""
+    staged = await _stage_module(content_store, "files", "files")
+
+    async def _resolve(
+        *, handler_selection=None, base_selection=None, contract_selection=None
+    ):
+        return await resolve_module_action_implementation(
+            staged["module_selection"],
+            handler_selection or staged["handler_selection"],
+            action_id="get_file",
+            content_store=content_store,
+            requesting_scope=SCOPE,
+            base_handler_selection=base_selection or staged["base_selection"],
+            pack_contract_selection=contract_selection or staged["contract_selection"],
+        )
+
+    scope_error = "cross-scope|module selection's execution scope"
+    for hostile_scope in (OTHER_SCOPE, OTHER_TENANT):
+        with pytest.raises(ImplementationArtifactError, match=scope_error):
+            await _resolve(
+                handler_selection=_source_selection(
+                    digest=staged["handler_digest"],
+                    module="files",
+                    file_name="handler.py",
+                    scope=hostile_scope,
+                )
+            )
+        # Leaf in the correct scope, base selected from another scope.
+        with pytest.raises(ImplementationArtifactError, match=scope_error):
+            await _resolve(
+                base_selection=_source_selection(
+                    digest=staged["base_digest"],
+                    module="files",
+                    file_name="base_handler.py",
+                    scope=hostile_scope,
+                )
+            )
+        # Correct sources, pack contract selected from another scope.
+        with pytest.raises(ImplementationArtifactError, match=scope_error):
+            await _resolve(
+                contract_selection=_contract_selection(
+                    digest=staged["contract_digest"], pack="files", scope=hostile_scope
+                )
+            )
 
 
 async def test_base_content_hostiles_reject(content_store, tmp_path) -> None:
     staged = await _stage_module(content_store, "files", "files")
 
-    async def _resolve(base_artifact, authority=None):
+    async def _resolve(base_selection, contract_selection=None):
         return await resolve_module_action_implementation(
             staged["module_selection"],
-            staged["handler_artifact"],
+            staged["handler_selection"],
             action_id="get_file",
             content_store=content_store,
             requesting_scope=SCOPE,
-            base_handler_artifact=base_artifact,
-            split_authority=authority or staged["authority"],
+            base_handler_selection=base_selection,
+            pack_contract_selection=contract_selection or staged["contract_selection"],
         )
 
     # Missing digest.
     with pytest.raises(ImplementationArtifactError, match="non-null content digest"):
-        await _resolve(_backend_artifact(digest=None, module="files", file_name="base_handler.py"))
+        await _resolve(
+            _source_selection(digest=None, module="files", file_name="base_handler.py")
+        )
 
     # Missing bytes (stale ref after base regeneration).
-    absent = "e" * 64
     with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
         await _resolve(
-            _backend_artifact(digest=absent, module="files", file_name="base_handler.py")
+            _source_selection(digest="e" * 64, module="files", file_name="base_handler.py")
         )
 
     # Tampered bytes under a valid digest path.
@@ -317,13 +641,13 @@ async def test_base_content_hostiles_reject(content_store, tmp_path) -> None:
     blob_path.write_bytes(b"tampered base bytes")
     with pytest.raises(ImplementationArtifactError, match="did not resolve exactly"):
         await _resolve(
-            _backend_artifact(digest=digest, module="files", file_name="base_handler.py")
+            _source_selection(digest=digest, module="files", file_name="base_handler.py")
         )
 
     # Base from another module instance.
     with pytest.raises(ImplementationArtifactError, match="cannot implement module"):
         await _resolve(
-            _backend_artifact(
+            _source_selection(
                 digest=staged["base_digest"], module="messages", file_name="base_handler.py"
             )
         )
@@ -331,28 +655,32 @@ async def test_base_content_hostiles_reject(content_store, tmp_path) -> None:
     # Base path outside the canonical family.
     with pytest.raises(ImplementationArtifactError, match="not 'module_backend_base_handler'"):
         await _resolve(
-            _backend_artifact(
+            _source_selection(
                 digest=staged["base_digest"], module="files", file_name="service.py"
             )
         )
 
-    # Authority borrowed from another module.
-    other_authority = workspace_handler_split_authority_from_pack_contract(
-        _pack_contract("messaging"), module_instance="messages"
-    )
-    with pytest.raises(ImplementationArtifactError, match="cannot certify module"):
-        await _resolve(staged["base_artifact"], authority=other_authority)
+    # Authority borrowed from another module's pack contract.
+    messaging_digest = await _put(content_store, _pack_contract_bytes("messaging"))
+    with pytest.raises(ImplementationArtifactError, match="absent"):
+        await _resolve(
+            staged["base_selection"],
+            contract_selection=_contract_selection(digest=messaging_digest, pack="messaging"),
+        )
 
     # Scope mismatch between leaf and base selections: the module-relative
     # base row is unregistered today, so the mismatch rejects at the layout
     # proof; the explicit same-scope rule remains as defense-in-depth.
-    module_scope_base = AccountedArtifact(
-        address=ArtifactAddress(
-            path_scope=PathScope.MODULE_RELATIVE,
-            placeholder_values=(("module_id", "files"),),
-            path="backend/base_handler.py",
+    module_scope_base = SelectedAccountedArtifact(
+        scope=SCOPE,
+        artifact=AccountedArtifact(
+            address=ArtifactAddress(
+                path_scope=PathScope.MODULE_RELATIVE,
+                placeholder_values=(("module_id", "files"),),
+                path="backend/base_handler.py",
+            ),
+            content_digest=staged["base_digest"],
         ),
-        content_digest=staged["base_digest"],
     )
     with pytest.raises(
         ImplementationArtifactError, match="no canonical layout row|same module scope"
@@ -380,14 +708,14 @@ async def _certify_sources(
     base_digest = await _put(content_store, base_source.encode("utf-8"))
     return await resolve_module_action_implementation(
         staged["module_selection"],
-        _backend_artifact(digest=leaf_digest, module="files", file_name="handler.py"),
+        _source_selection(digest=leaf_digest, module="files", file_name="handler.py"),
         action_id=action_id,
         content_store=content_store,
         requesting_scope=SCOPE,
-        base_handler_artifact=_backend_artifact(
+        base_handler_selection=_source_selection(
             digest=base_digest, module="files", file_name="base_handler.py"
         ),
-        split_authority=staged["authority"],
+        pack_contract_selection=staged["contract_selection"],
     )
 
 
@@ -397,23 +725,54 @@ CANONICAL_LEAF = (
     "    \"\"\"Preserved workspace leaf.\"\"\"\n"
 )
 
+OVERRIDE_LEAF = (
+    "from .base_handler import FilesBaseHandler\n\n\n"
+    "class FilesHandler(FilesBaseHandler):\n"
+    "    async def get_file(self, ctx, file_id=None):\n"
+    "        return {\"file\": {\"overridden\": True}}\n"
+)
+
 
 async def test_canonical_minimal_split_certifies(content_store) -> None:
     resolved = await _certify_sources(content_store, CANONICAL_LEAF)
-    assert resolved.export_proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
-    assert resolved.export_proof.base_handler_class == "FilesBaseHandler"
+    proof = resolved.export_proof
+    assert proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
+    assert proof.method_source is HandlerMethodSource.BASE_HANDLER
+    assert proof.base_handler_class == "FilesBaseHandler"
+    assert proof.split_contract_content_digest is not None
 
 
-async def test_leaf_override_certifies_as_explicit_handler(content_store) -> None:
-    leaf = (
-        "from .base_handler import FilesBaseHandler\n\n\n"
-        "class FilesHandler(FilesBaseHandler):\n"
-        "    async def get_file(self, ctx, file_id=None):\n"
-        "        return {\"file\": {\"overridden\": True}}\n"
+async def test_split_leaf_override_stays_two_source(content_store) -> None:
+    """A canonical split leaf override is still a CANONICAL_BASE_HANDLER
+    certification: both source digests and the pack-contract digest stay
+    meaning-bearing; only the method source moves to the leaf."""
+    resolved = await _certify_sources(content_store, OVERRIDE_LEAF)
+    proof = resolved.export_proof
+    assert proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
+    assert proof.method_source is HandlerMethodSource.HANDLER
+    assert proof.base_content_digest is not None
+    assert proof.split_contract_content_digest is not None
+    assert resolved.base_handler is not None
+    assert resolved.split_authority is not None
+
+
+async def test_leaf_override_certifies_even_when_base_lacks_the_method(content_store) -> None:
+    base_without_method = "class FilesBaseHandler:\n    pass\n"
+    resolved = await _certify_sources(content_store, OVERRIDE_LEAF, base_without_method)
+    proof = resolved.export_proof
+    assert proof.mode is HandlerCertificationMode.CANONICAL_BASE_HANDLER
+    assert proof.method_source is HandlerMethodSource.HANDLER
+
+
+async def test_override_and_inherited_certifications_have_distinct_identity(
+    content_store,
+) -> None:
+    inherited = await _certify_sources(content_store, CANONICAL_LEAF)
+    overridden = await _certify_sources(content_store, OVERRIDE_LEAF)
+    assert (
+        inherited.export_proof.implementation_digest
+        != overridden.export_proof.implementation_digest
     )
-    resolved = await _certify_sources(content_store, leaf)
-    assert resolved.export_proof.mode is HandlerCertificationMode.EXPLICIT_HANDLER
-    assert resolved.export_proof.base_content_digest is None
 
 
 @pytest.mark.parametrize(
@@ -465,6 +824,44 @@ async def test_leaf_override_certifies_as_explicit_handler(content_store) -> Non
             id="conditional-class",
         ),
         pytest.param(
+            "if True:\n"
+            "    from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "unconditional top-level",
+            id="conditional-import",
+        ),
+        pytest.param(
+            "try:\n"
+            "    from .base_handler import FilesBaseHandler\n"
+            "finally:\n"
+            "    pass\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "unconditional top-level",
+            id="try-import",
+        ),
+        pytest.param(
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "unconditional top-level",
+            id="type-checking-import",
+        ),
+        pytest.param(
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "from .base_handler import FilesBaseHandler\n",
+            "before the handler class definition",
+            id="import-after-class",
+        ),
+        pytest.param(
+            "def _load():\n"
+            "    from .base_handler import FilesBaseHandler\n"
+            "    return FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "exactly one",
+            id="nested-function-import",
+        ),
+        pytest.param(
             "from .base_handler import FilesBaseHandler\n"
             "class FilesHandler(FilesBaseHandler):\n    pass\n"
             "FilesHandler.get_file = None\n",
@@ -506,6 +903,38 @@ async def test_leaf_override_certifies_as_explicit_handler(content_store) -> Non
             "    get_file = FilesBaseHandler\n",
             "bound dynamically|referenced only",
             id="leaf-method-rebinding",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "try:\n    pass\n"
+            "except Exception as FilesBaseHandler:\n    pass\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "rebound outside its canonical import",
+            id="except-capture-of-base",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n"
+            "match {}:\n"
+            "    case {\"x\": FilesHandler}:\n        pass\n    case _:\n        pass\n",
+            "rebound|referenced dynamically",
+            id="match-capture-of-handler",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "match []:\n"
+            "    case [*FilesBaseHandler]:\n        pass\n    case _:\n        pass\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "rebound outside its canonical import",
+            id="match-star-capture-of-base",
+        ),
+        pytest.param(
+            "from .base_handler import FilesBaseHandler\n"
+            "match {}:\n"
+            "    case {\"x\": _v, **FilesBaseHandler}:\n        pass\n    case _:\n        pass\n"
+            "class FilesHandler(FilesBaseHandler):\n    pass\n",
+            "rebound outside its canonical import",
+            id="match-mapping-rest-capture-of-base",
         ),
     ],
 )
@@ -562,6 +991,22 @@ async def test_leaf_split_grammar_hostiles_reject(content_store, leaf: str, reas
             "        async def get_file(self, ctx):\n            return {}\n",
             "conditionally",
             id="base-conditional-method",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "    try:\n        pass\n"
+            "    except Exception as get_file:\n        pass\n",
+            "rebound",
+            id="base-except-capture-of-method",
+        ),
+        pytest.param(
+            "class FilesBaseHandler:\n"
+            "    async def get_file(self, ctx):\n        return {}\n"
+            "match []:\n"
+            "    case [*FilesBaseHandler]:\n        pass\n    case _:\n        pass\n",
+            "rebound|referenced dynamically",
+            id="base-match-star-capture-of-class",
         ),
     ],
 )


### PR DESCRIPTION
## What

Content-resolved implementation artifact authority + exact static module handler
export validation — the accepted prerequisite so a future ImplementationBinding v2
can truthfully claim **"this exact implementation realizes this semantic
workflow/action."** A `ChildContractRef`/digest alone is not sufficient; this PR
makes implementation selection prove exact scope, canonical artifact family,
canonical `ArtifactAddress`, exact verified bytes, exact document schema version,
exact parsed public contract, exact module action export, and exact selected
handler source(s).

Base: main `f90281c9ff151dcc33e8744f1be325de3c4b5a42` (#489 + #491 merged).
Head: `9d5cfe41` — includes the Codex 4 correction round (below).

## Correction round (Codex 4 Astra findings — all five fixed)

1. **Split authority is content-resolved, never caller-asserted.** The
   caller-constructible `WorkspaceHandlerSplitAuthority` token is REMOVED. The
   public resolution APIs (`resolve_module_action_implementation`,
   `resolve_module_base_handler_source`) accept only the exact scope-bound
   **pack-contract selection**; `resolve_workspace_handler_split_authority`
   derives contract type, canonical contract id, the canonical
   `build_context/{contract_id}/contract.yaml` path (from the PARSED bytes,
   so a contract cannot be smuggled under another pack`'`s path), and this
   module`'`s manifest/leaf/base ownership — all from
   `get_verified_blob`-resolved bytes. The resolved authority (an internal
   frozen dataclass carrying the contract digest, scope, contract id, module
   instance, and both paths) is stored on
   `ResolvedModuleActionImplementation.split_authority` for future pinning.
   Signature-guard test proves no `split_authority` parameter exists on any
   public resolution API.
2. **EXPLICIT_HANDLER = true standalone one-source class: ZERO bases.**
   `class Handler(Base)` / `class Handler(Mixin, Base)` never certify
   explicit, even with an explicit override of the selected method.
3. **Canonical base import placement is proven.** The single
   `from .base_handler import <Base>` must be an unconditional DIRECT member
   of the module body appearing BEFORE the handler class definition.
   Conditional / try / TYPE_CHECKING / nested-function / after-class imports
   all reject (permanent tests for each).
4. **Closed scope-aware binding grammar.** The rebinding detector now covers
   the full Python 3.12 binding surface: def/class/import/assign/ann-assign/
   aug-assign/delete/for/with targets, global/nonlocal, `type` aliases
   (guarded — the node exists on 3.12+; the same attack is a parse failure
   on 3.11), **exception-handler names**, **match-pattern captures**
   (`case name`, `[*name]`, `{**name}`), and **walrus targets** including
   comprehension positions and another function`'`s default arguments.
   Nested function/class/lambda scopes bind their own locals only;
   comprehension iteration targets stay comprehension-local.
5. **Execution-scope-bound source selection.** Handler, base-handler, and
   pack-contract sources are `SelectedAccountedArtifact` values
   (`ExecutionAccessScopeRef` + digest-mandatory `AccountedArtifact`); the
   selection scope must equal BOTH the requesting scope and the module
   selection`'`s scope. Same bytes + same module id under another tenant or
   workspace scope fail closed — tested for leaf, base, and contract
   independently.

**Corrected split-override rule** (supersedes the earlier body): a canonical
split leaf that explicitly defines the selected method remains a two-source
**CANONICAL_BASE_HANDLER** certification — both source digests and the
pack-contract digest stay meaning-bearing; the proof records
`method_source: handler | base_handler`. `EXPLICIT_HANDLER` is reserved for
zero-base standalone classes. There is no third mode.

## Implementation identity

`ModuleActionExportProof.implementation_digest` (canonical JSON digest):
- EXPLICIT_HANDLER: mode, method_source, handler class, handler method,
  handler digest — no irrelevant base fields.
- CANONICAL_BASE_HANDLER: those plus base class, base digest, and
  `split_contract_content_digest` — changing only the leaf, only the base,
  or only the certification authority changes identity (proven: 4 distinct
  identities). Module/action identity stays outside the digest for
  ImplementationBinding v2 to pin separately.

## Real canonical pack acceptance

`tests/test_pack_implementation_certification.py` independently discovers and
pins the corpus: **10 workspace_handler_split modules, 63 actions**. Every
action certifies end to end — #484 request import, exact manifest, split
authority from the real pack contract bytes, both-source verified bytes,
`method_source = base_handler` (no checked-in leaf overrides exist), all
three digests in the proof — and a counting content store proves the
pack-contract blob is READ for every certification (a zero-contract-read
certification is now impossible). The commerce `module.yaml` capability
repair from the previous round is unchanged (Codex 4: CLEAN), as are the
app-scope base-handler layout selections (CLEAN; the module-relative
registry row asymmetry remains deliberately out of scope).

## Hostile matrix (all rejecting, permanently tested)

Round-1 matrix unchanged. Split-authority: absent/tampered/missing-blob
contract bytes; non-YAML bytes at the correct filename; wrong ownership
(leaf not workspace / base not templates); required_outputs omitting the
module manifest; unrelated pack contracts; wrong canonical path; wrong path
scope; non-pack contract types; base/contract selections without each other.
Cross-scope: leaf, base, and contract each under another workspace or
tenant. Grammar: mixins, multiple/transitive inheritance, aliased/wrong-
module/star/dynamic/conditional/try/TYPE_CHECKING/nested/late imports,
monkeypatch, setattr, `__getattr__`, class/method rebinding, base alias
references, exception-handler captures, match-pattern captures (star and
mapping-rest), walrus-in-default smuggling, type-alias rebinding.

## Pre-Astra hardening (head `82317525`)

Three nonblocking observations from the independent Fable review, hardened
before final review:

1. **Split-capable certifier made internal.** `certify_module_action_export`
   is now `_certify_module_action_export` and is removed from the public
   surface; `resolve_module_action_implementation` is the ONLY public
   authority-producing module-action API, and `prove_module_action_export`
   (zero-base EXPLICIT_HANDLER) is the only standalone helper. The
   fabricated-authority path — building a
   `ResolvedWorkspaceHandlerSplitAuthority` in memory and obtaining a split
   proof with zero pack-contract blob reads — no longer exists on the public
   surface; a permanent test proves no exported function accepts that type.
2. **Direct dynamic-execution escapes closed.** In construction scope
   (module/class bodies, plus enclosing-scope expression positions of defs;
   class bodies are entered as import-time execution, function/lambda bodies
   stay out of scope by design), certification now rejects: any reference to
   a dynamic export primitive (`exec`/`eval`/`setattr`/`delattr`/`getattr`/
   `globals`/`vars`/`__import__`/`type`), `from builtins import` of any such
   primitive (or `*`), and any use of a name bound to the `builtins` module
   (`builtins.exec`, `import builtins as b; b.exec`, `__builtins__`, and
   `e = exec` rebinds). Hostile tests cover all seven reviewer attack forms
   against the handler class plus base-class/method equivalents. Documented
   truthfully as a bounded own-source export/binding proof — not a proof of
   arbitrary imported dependency behavior.
3. **Ambiguous/implicit `required_outputs` ownership rejected.** At the
   certification authority boundary the verified contract bytes must be
   unambiguous: non-mapping entries and ANY duplicate `required_outputs.path`
   reject (duplicate ownership declarations are structurally ambiguous), and
   authority-relevant ownership must be EXPLICIT — omitted/null/empty owners
   never default; the module manifest owner must be the exact canonical
   `templates`. Real-contract census first: no pack contract has duplicates
   and every relevant entry declares an explicit owner, so all 10 modules /
   63 actions still certify unchanged.

## Final finite correction (head `955fd312`)

Codex 4 Astra found one remaining effective-export escape (architecture
disposition A — the two-mode design stands): locally-defined callable bodies
are uninspected, yet a module-scope call (`mutate()`), local class
construction (`Mutator()`), or decorator application (`@decorate`,
`@(lambda c: ...)`) executes them DURING import and could rebind the
certified export.

Closed with a **finite construction grammar — no call graph, no dataflow, no
import following**: uninspected locally-defined callables (functions,
classes, bound lambdas) may exist, but any construction-time `Load`
reference to one fails closed — deliberately subsuming direct calls, alias
chains (`alias = mutate; alias()`), decorator application and factories,
local class construction, and argument laundering. Direct lambda invocation
and lambda decorators reject. Class bodies are scanned recursively against
their own locals plus every enclosing scope (sibling classes included);
`locals` joins the dynamic-primitive set. **Deferred runtime helpers remain
allowed**: a helper called only from a method body, an uninvoked local
function, a stored-but-never-construction-invoked lambda, and imported
external callables all stay certifiable (permanent positive tests). The
effective-export claim is now stated precisely in the ADR: within the
bounded own-source construction grammar, the certified visible binding IS
the import-time export; imported dependency behavior and deferred bodies
remain outside the proof. The 10/63 real corpus recertifies unchanged.

## Anonymous-lambda closure (head `c8c46a3c`)

Independent micro-review confirmed the named-local-callable rule sound but
found one remaining category: **anonymous lambda laundering** — wrapping a
lambda before invoking it (`(f := lambda: ...)()`, `[lambda: ...][0]()`,
`{0: lambda: ...}[0]()`, conditional expressions) evaded the direct
`Call.func is Lambda` check and could execute an uninspected body at import.

Closed with ONE finite syntactic whitelist, not per-case enumeration: a
construction-scope lambda is permitted only as the entire direct value of a
simple named binding (`helper = lambda: ...`, one plain `Name` target;
annotated form included). Any other construction-time lambda position —
walrus, call func/args/kwargs, containers, subscripts, conditionals,
decorators and factories, defaults, annotations, class bases,
comprehensions — rejects generically. Walrus-to-lambda is out of the
callable vocabulary entirely and rejects regardless of invocation. A stored
lambda becomes an ordinary local callable name owned by the Load-reference
rule (`helper()` at construction still rejects); lambdas inside deferred
method/function bodies remain runtime behavior outside the proof.

Permanent tests: the reviewer`'`s weaponized `globals().__setitem__`/`type()`
regression, the ten-form laundering matrix in EXPLICIT mode, representative
attacks in split `handler.py` and `base_handler.py`, and positives for
annotated bindings, stored-never-invoked lambdas, and deferred-body lambdas.
The 10/63 corpus recertifies unchanged — no canonical source uses
construction-time anonymous lambdas.

## Validation

- Both #488 suites: **163 tests** (public-surface guard, dynamic-execution
  hostiles, and ambiguous-contract hostiles included); real corpus 10/63
  green with proven pack-contract blob reads.
- Preservation slice (#484/#485/#486/#489/#491, layout registry, compilation
  plan): **583 passed**.
- ruff, scoped mypy (new module), strict MkDocs, governance guardrails,
  `git diff --check`: all clean. Exact-head CI on `82317525` is mandatory.

## Notes for reviewers

Start at `implementation_artifacts.py`: `SelectedAccountedArtifact`,
`resolve_workspace_handler_split_authority` (the new authority boundary),
`_statement_binds_name` + `_nested_binding_names` (the closed binding
grammar), `_prove_canonical_leaf_subclass` (import placement + override),
and `certify_module_action_export` (method_source disposition). The
pack-contract selection is a bounded workspace-root build-context INPUT
(no layout-registry row was added; the registry has no contract.yaml family
and adding one would ripple compilation-plan identity fixtures — the
resolver instead proves scope + derived canonical path + verified bytes).

Draft. DCO signed. Auto-merge intentionally NOT enabled — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
