### PR TITLE
fix(runtime): enforce exact structured-output auto-tool contracts

### DIFF
--- a/.agents/skills/create-workflow/SKILL.md
+++ b/.agents/skills/create-workflow/SKILL.md
@@ -144,6 +144,11 @@ Rules:
 
 Declare the workflow state and which agents can see which variables.
 
+`structured_output` is RESERVED runtime vocabulary: declaring it (in
+`definitions` or agent `variables`) is rejected at workflow load. Auto tools
+receive it transiently via `context_variables.get("structured_output")` with
+no declaration.
+
 ```yaml
 definitions:
   artifact_request:

--- a/.claude/skills/create-workflow/SKILL.md
+++ b/.claude/skills/create-workflow/SKILL.md
@@ -142,6 +142,11 @@ Rules:
 
 Declare the workflow state and which agents can see which variables.
 
+`structured_output` is RESERVED runtime vocabulary: declaring it (in
+`definitions` or agent `variables`) is rejected at workflow load. Auto tools
+receive it transiently via `context_variables.get("structured_output")` with
+no declaration.
+
 ```yaml
 definitions:
   artifact_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,9 @@ products, and customer workspaces use the same shape:
   owning workflow's `ui/` folder.
 - `context_variables.yaml` declares runtime/session state. Large static prompt
   catalogs are injected by deterministic hooks; do not stuff them into context
-  variables.
+  variables. `structured_output` is reserved runtime vocabulary — auto tools
+  receive it as a transient read-only projection; declaring it as a context
+  variable fails workflow validation.
 - Reusable OSS build packs are named build contexts. `context.yaml` owns the
   pack descriptor through a `pack:` section plus capabilities and facades. It
   should be useful LLM/build context, not a placeholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,23 @@ This project follows a practical pre-1.0 changelog format:
   `structured_output` is reserved runtime vocabulary: declaring it in
   `context_variables.yaml` now fails workflow validation with no metadata
   override, and overlay enumeration/snapshots never expose a colliding stale
-  base key. Auto-tool binding caches self-validate against the live
-  structured-output registry and tool declarations (reload, unload,
-  refresh_all, and failed reloads can never execute a stale binding or stale
-  callable), each binding receives its own detached copy of the validated
+  base key. Auto-tool binding caches hold declarative metadata only,
+  self-validated against the live structured-output registry and tool
+  declarations (reload, unload, refresh_all, and failed reloads can never
+  execute a stale binding); the executable tool callable is resolved fresh
+  through the canonical loader on every dispatch, so workflow-owned tool and
+  imported helper changes (in both the `workflows.*` and derived real package
+  namespaces such as `factory_app.workflows.*`) are observed without restart,
+  while external installed packages remain a documented process-restart
+  boundary. Each binding receives its own detached copy of the validated
   payload (explicit-argument mutation cannot contaminate another binding or
-  the audit record), and turns are claimed in-flight atomically so concurrent
-  duplicate deliveries produce exactly one tool side effect.
+  the audit record), turns are claimed in-flight atomically, and every
+  binding keeps a finite process-local execution checkpoint: once a tool
+  returns a truthful terminal result (success or failure) it is never
+  re-invoked for that turn — retries after cancellation resume unfinished
+  post-processing stages (write-back, persistence, result emission) instead
+  of re-running the tool. This is process-local runtime idempotency, not
+  distributed exactly-once delivery.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ This project follows a practical pre-1.0 changelog format:
   output: context-only auto tools work without declaring context variables,
   explicit-param auto tools receive the same values, and the projection can
   never be written, persisted, or replayed as workflow state.
+  `structured_output` is reserved runtime vocabulary: declaring it in
+  `context_variables.yaml` now fails workflow validation with no metadata
+  override, and overlay enumeration/snapshots never expose a colliding stale
+  base key. Auto-tool binding caches self-validate against the live
+  structured-output registry and tool declarations (reload, unload,
+  refresh_all, and failed reloads can never execute a stale binding or stale
+  callable), each binding receives its own detached copy of the validated
+  payload (explicit-argument mutation cannot contaminate another binding or
+  the audit record), and turns are claimed in-flight atomically so concurrent
+  duplicate deliveries produce exactly one tool side effect.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- **Exact structured-output auto-tool contracts**: declared workflow
+  structured outputs are now exact at runtime — an agent output carrying an
+  undeclared field (top-level or nested) rejects before any normalization, so
+  no `agent_output_validated` event, auto tool, UI emission, or persistence
+  can run on silently stripped data. Deliberately declared open
+  `dict`/`optional_dict` fields keep accepting arbitrary keys inside. The
+  documented auto-tool contract
+  `context_variables.get("structured_output")` is now truthfully served as a
+  transient, runtime-owned, read-only projection of the exact validated
+  output: context-only auto tools work without declaring context variables,
+  explicit-param auto tools receive the same values, and the projection can
+  never be written, persisted, or replayed as workflow state.
+
 ### Changed
 
 - **Canonical capability-pack action requests are closed**: all 63 actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,6 +527,11 @@ async def save_my_output(context_variables=None):
     )
 ```
 
+`structured_output` is reserved runtime vocabulary: auto tools receive it as a
+transient read-only projection. Never declare it in `context_variables.yaml`
+(workflow validation rejects it); persist chosen data under your own declared
+context keys.
+
 ## Tool Design Philosophy
 
 **Tools are dumb. LLMs reason.**

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -969,7 +969,15 @@ candidate fields — top-level and nested — reject and are never silently
 discarded before an exact acceptance boundary sees the original candidate.
 There is no permissive mode, per-workflow acceptance override, or dual
 registry behavior, and reload/unload/refresh can never revive a permissive
-cached model. Deliberately declared open `dict`/`optional_dict` fields keep their
+cached model. ``structured_output`` is reserved runtime vocabulary
+(`mozaiksai/core/workflow/reserved_context_keys.py`): every canonical context
+declaration surface rejects an application claim of it, with no metadata
+override. Auto-tool binding caches are self-validating — a cached binding is
+reusable only while its authority fingerprint (exact model class identity,
+tool declarations, tool file bytes) still matches — and each auto-tool turn
+is claimed atomically before its first await, so concurrent duplicate
+deliveries of one turn produce exactly one side effect while unexpected
+interruptions release the claim for a legitimate retry. Deliberately declared open `dict`/`optional_dict` fields keep their
 semantics: the field is closed at its containing object level while arbitrary
 keys inside the declared open dict remain valid runtime data.
 `get_provider_response_model` remains the sole provider adapter. It creates

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -972,12 +972,24 @@ registry behavior, and reload/unload/refresh can never revive a permissive
 cached model. ``structured_output`` is reserved runtime vocabulary
 (`mozaiksai/core/workflow/reserved_context_keys.py`): every canonical context
 declaration surface rejects an application claim of it, with no metadata
-override. Auto-tool binding caches are self-validating — a cached binding is
-reusable only while its authority fingerprint (exact model class identity,
-tool declarations, tool file bytes) still matches — and each auto-tool turn
-is claimed atomically before its first await, so concurrent duplicate
-deliveries of one turn produce exactly one side effect while unexpected
-interruptions release the claim for a legitimate retry. Deliberately declared open `dict`/`optional_dict` fields keep their
+override. Auto-tool binding caches hold DECLARATIVE metadata only, self-validated
+against the live exact-model identity and tools.yaml declaration; Python
+callable authority is never cached across dispatches — the executable
+function is resolved fresh through the canonical workflow tool loader, whose
+namespace refresh derives the workflow root's real package chain (for example
+``factory_app.workflows``) as well as the synthetic ``workflows`` namespace,
+so workflow-owned source and imported helper changes are observed without a
+process restart. Changes to external installed third-party packages remain a
+process-restart boundary. Each auto-tool turn is claimed atomically before
+its first await, and each binding keeps a finite process-local execution
+checkpoint (PENDING → TOOL_TERMINAL → COMPLETE, with per-stage
+write-back/persistence/emission marks): once a tool returns a truthful
+terminal result — success or failure — that binding is never invoked again
+for the same turn; retries resume the first unfinished binding/stage. This is
+process-local runtime idempotency, not distributed exactly-once delivery: a
+crash after an external non-idempotent side effect but before durable
+recording is out of scope, and such tools must use their owning service's
+idempotency contract. Deliberately declared open `dict`/`optional_dict` fields keep their
 semantics: the field is closed at its containing object level while arbitrary
 keys inside the declared open dict remain valid runtime data.
 `get_provider_response_model` remains the sole provider adapter. It creates

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -967,9 +967,9 @@ structured outputs are exact at runtime**: `load_workflow_structured_outputs`
 compiles every declared model id with closed-object acceptance, so unknown
 candidate fields — top-level and nested — reject and are never silently
 discarded before an exact acceptance boundary sees the original candidate.
-There is no legacy mode, per-workflow permissive fallback, or dual registry
-behavior, and reload/unload/refresh can never fall back to a permissive cached
-model. Deliberately declared open `dict`/`optional_dict` fields keep their
+There is no permissive mode, per-workflow acceptance override, or dual
+registry behavior, and reload/unload/refresh can never revive a permissive
+cached model. Deliberately declared open `dict`/`optional_dict` fields keep their
 semantics: the field is closed at its containing object level while arbitrary
 keys inside the declared open dict remain valid runtime data.
 `get_provider_response_model` remains the sole provider adapter. It creates

--- a/docs/adr/0007-generalized-semantic-compiler.md
+++ b/docs/adr/0007-generalized-semantic-compiler.md
@@ -961,12 +961,23 @@ the compatibility report.
 
 `build_models_from_config` now returns unpatched canonical Pydantic models.
 Explicit `exact_model_ids` applies `extra="forbid"` when models are created,
-before a parent can capture a child schema. Generic runtime loading keeps its
-existing default acceptance policy; this is not the global strictness flip.
+before a parent can capture a child schema. The original #485 staging decision
+left generic runtime loading permissive; that decision is retired. **Declared
+structured outputs are exact at runtime**: `load_workflow_structured_outputs`
+compiles every declared model id with closed-object acceptance, so unknown
+candidate fields — top-level and nested — reject and are never silently
+discarded before an exact acceptance boundary sees the original candidate.
+There is no legacy mode, per-workflow permissive fallback, or dual registry
+behavior, and reload/unload/refresh can never fall back to a permissive cached
+model. Deliberately declared open `dict`/`optional_dict` fields keep their
+semantics: the field is closed at its containing object level while arbitrary
+keys inside the declared open dict remain valid runtime data.
 `get_provider_response_model` remains the sole provider adapter. It creates
 separate response models with the current OpenAI strict required fields,
-reference inlining, and object closure. Production agent construction continues
-to use that adapter.
+reference inlining, and object closure, and its local parse honors the same
+`additionalProperties: false` claim its advertised schema makes — a permissive
+provider-side parse cannot become the first lossy normalization. Production
+agent construction continues to use that adapter.
 
 `canonical_structured_output_schema` invokes the unmodified Pydantic validation
 schema compiler directly. Acceptance profile
@@ -1382,7 +1393,8 @@ AppGenerator; production-dead AgentGenerator converter normalizers
 (`workflow_converter.py`); lossy, unpersisted `AppBuildPlan` planning path;
 the four control-plane glob taxonomies; `BuildRecordStore`/`ArtifactStore`
 alias duplication in `mozaiksai/core/artifacts/store.py`; multiple event and
-taxonomy registries; structured-output permissiveness; incomplete
+taxonomy registries; structured-output permissiveness (resolved: declared
+structured outputs are exact at runtime); incomplete
 provenance/ownership use in refinement (the `refinement` provenance mode and
 `last_refined_with` field in `mozaiksai/core/runtime/app/provenance.py` are
 declared but never read or written by any control-plane code); lack of refinement replay; dual builder persistence

--- a/docs/architecture/mozaiksai/auto-tool-execution.md
+++ b/docs/architecture/mozaiksai/auto-tool-execution.md
@@ -12,6 +12,35 @@ When an auto-tool agent outputs structured JSON:
 3. `AutoToolEventHandler` automatically invokes the tool
 4. Tool reads from `context_variables["structured_output"]` and persists/emits
 
+## Runtime Contracts
+
+**Declared structured outputs are exact at runtime.** Every model declared in
+`structured_outputs.yaml` compiles with closed-object acceptance: an output
+carrying an undeclared field — at the top level or nested — is rejected before
+any normalization, no `agent_output_validated` event fires, and no auto tool
+runs. Unknown fields are never silently discarded. A field deliberately
+declared as `dict`/`optional_dict` stays open inside: arbitrary keys within
+that declared open dict remain valid data.
+
+**`structured_output` is a transient, runtime-owned, read-only projection —
+not application state.** The runtime exposes the exact validated
+`structured_data` for the current turn through a read-only overlay on the
+live context:
+
+- tools read it with `context_variables.get("structured_output")`; no
+  `context_variables.yaml` declaration is needed (or allowed to seize it);
+- tools cannot set, delete, replace, or mutate it — attempts fail closed;
+- it is never written into AG2 workflow state, never persisted, never
+  replayed, and never appears in context snapshots; to keep any of it, a tool
+  must deliberately save selected data under a different declared application
+  key (ordinary declared context writes work unchanged);
+- explicit function parameters that match model fields (for example
+  `async def save_output(title: str, status: str, context_variables=None)`)
+  keep working and receive the same exact validated values — the two views
+  never disagree. A context-only tool whose only parameter is
+  `context_variables` also works: the structured-output model validates the
+  agent's output, not the tool's argument list.
+
 ## Configuration
 
 **tools.yaml** - Mark tool for auto-invocation:

--- a/docs/architecture/mozaiksai/auto-tool-execution.md
+++ b/docs/architecture/mozaiksai/auto-tool-execution.md
@@ -43,6 +43,27 @@ live context:
   `context_variables` also works: the structured-output model validates the
   agent's output, not the tool's argument list.
 
+**Callable freshness.** Declarative binding metadata may be cached, but the
+executable Python function is resolved fresh through the canonical workflow
+tool loader on every dispatch. The loader refreshes workflow-owned modules —
+per-workflow tool files and the workflows root's `_shared` helpers — under
+both the synthetic `workflows.<name>` namespace and the derived real package
+chain (for example `factory_app.workflows.<name>`), so changing a tool file
+or an imported workflow helper is observed on the next dispatch without a
+process restart. **Changes to external installed third-party packages are a
+process-restart boundary** — they are never hot-replaced.
+
+**Execution idempotency.** Each turn is claimed atomically, and every binding
+keeps a finite process-local checkpoint (PENDING → TOOL_TERMINAL → COMPLETE,
+with per-stage write-back/persistence/result-emission marks). Once a tool
+returns a truthful terminal result — success or failure — that binding is
+never invoked again for the same turn; a retry after cancellation resumes at
+the first unfinished binding/stage instead of re-running completed tools.
+**This guarantee is process-local**: a process crash after an external
+non-idempotent tool side effect but before durable recording cannot be
+solved by this in-memory handler. Tools that need cross-process exactly-once
+semantics must rely on their owning service's idempotency contract.
+
 ## Configuration
 
 **tools.yaml** - Mark tool for auto-invocation:

--- a/docs/architecture/mozaiksai/auto-tool-execution.md
+++ b/docs/architecture/mozaiksai/auto-tool-execution.md
@@ -27,8 +27,10 @@ not application state.** The runtime exposes the exact validated
 `structured_data` for the current turn through a read-only overlay on the
 live context:
 
-- tools read it with `context_variables.get("structured_output")`; no
-  `context_variables.yaml` declaration is needed (or allowed to seize it);
+- tools read it with `context_variables.get("structured_output")`;
+  `structured_output` is reserved runtime vocabulary — declaring it in
+  `context_variables.yaml` (definitions or agent views) is rejected at
+  workflow load, with no metadata override;
 - tools cannot set, delete, replace, or mutate it — attempts fail closed;
 - it is never written into AG2 workflow state, never persisted, never
   replayed, and never appears in context snapshots; to keep any of it, a tool

--- a/docs/architecture/workflows/workflow-authoring-contracts.md
+++ b/docs/architecture/workflows/workflow-authoring-contracts.md
@@ -297,6 +297,16 @@ models:
 Rules:
 - `models.<Name>.type` must be `model`.
 - `registry` values must reference existing `models` keys.
+- Declared models are exact at runtime: an agent output carrying a field the
+  model does not declare (top-level or nested) is rejected — never silently
+  stripped — and no auto tool runs for that turn. Declare every field the
+  agent may emit, or declare a deliberate open `dict`/`optional_dict` field
+  when arbitrary keys are genuinely part of the contract.
+- Auto tools read the exact validated output through
+  `context_variables.get("structured_output")` — a transient, read-only,
+  runtime-owned projection. Do not declare `structured_output` in
+  `context_variables.yaml`, and do not try to write it from tools; persist
+  chosen data under your own declared context keys instead.
 
 ### `tools.yaml`
 

--- a/docs/architecture/workflows/workflow-authoring-contracts.md
+++ b/docs/architecture/workflows/workflow-authoring-contracts.md
@@ -304,9 +304,11 @@ Rules:
   when arbitrary keys are genuinely part of the contract.
 - Auto tools read the exact validated output through
   `context_variables.get("structured_output")` — a transient, read-only,
-  runtime-owned projection. Do not declare `structured_output` in
-  `context_variables.yaml`, and do not try to write it from tools; persist
-  chosen data under your own declared context keys instead.
+  runtime-owned projection. `structured_output` is RESERVED runtime
+  vocabulary: declaring it in `context_variables.yaml` (as a definition or an
+  agent view variable) is rejected at workflow load, no declaration metadata
+  can claim it, and tools cannot write it; persist chosen data under your own
+  declared context keys instead.
 
 ### `tools.yaml`
 

--- a/mozaiksai/core/events/auto_tool_handler.py
+++ b/mozaiksai/core/events/auto_tool_handler.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
@@ -25,6 +26,7 @@ from mozaiksai.core.workflow.context.authority import (
     DETERMINISTIC_TOOL_WRITER,
     build_context_authority_policy,
 )
+from mozaiksai.core.workflow.context.frozen import detach
 from mozaiksai.core.workflow.context.structured_output_overlay import (
     StructuredOutputOverlay,
 )
@@ -65,9 +67,17 @@ class AutoToolEventHandler:
     _CACHE_LIMIT = 512
 
     def __init__(self) -> None:
-        self._workflow_bindings: dict[str, dict[str, list[AutoToolBinding]]] = {}
+        # Self-validating binding cache: each entry pairs the built bindings
+        # with the authority fingerprint they were built from. A cached entry
+        # is reusable only while the current authority inputs still match.
+        self._workflow_bindings: dict[
+            str, tuple[tuple[Any, ...], dict[str, list[AutoToolBinding]]]
+        ] = {}
         self._processed_keys: set[str] = set()
         self._processed_order: asyncio.Queue[str] = asyncio.Queue()
+        # Turns claimed atomically before the first await: a duplicate
+        # delivery observing an IN_FLIGHT (or COMPLETED) turn never executes.
+        self._in_flight_keys: set[str] = set()
 
     async def handle_tool_dispatch(self, event: dict[str, Any]) -> None:
         """Process an agent_output_validated event and trigger the corresponding tool."""
@@ -109,10 +119,46 @@ class AutoToolEventHandler:
             return
 
         cache_key = f"{chat_id}:{turn_key}"
-        if cache_key in self._processed_keys:
+        # Atomic in-flight claim: check-and-add with no await in between is
+        # atomic within one event loop, and all handler access is loop-local.
+        # A concurrent duplicate delivery of the same turn observes IN_FLIGHT
+        # (or COMPLETED) and never executes the tool.
+        if cache_key in self._processed_keys or cache_key in self._in_flight_keys:
             logger.debug("[AUTO_TOOL] Duplicate turn detected -> skipping (key=%s)", cache_key)
             return
+        self._in_flight_keys.add(cache_key)
+        try:
+            await self._dispatch_claimed_turn(
+                cache_key=cache_key,
+                workflow_name=workflow_name,
+                model_name=model_name,
+                agent_name=agent_name,
+                structured_data=structured_data,
+                context=context,
+                chat_id=chat_id,
+                turn_key=turn_key,
+                pattern_context_ref=pattern_context_ref,
+            )
+        finally:
+            # An unexpected interruption (cancellation, unforeseen exception)
+            # before a truthful terminal result releases the claim so a
+            # legitimate retry can execute. Terminal outcomes have already
+            # registered COMPLETED via _register_turn by this point.
+            self._in_flight_keys.discard(cache_key)
 
+    async def _dispatch_claimed_turn(
+        self,
+        *,
+        cache_key: str,
+        workflow_name: str,
+        model_name: str,
+        agent_name: str,
+        structured_data: dict[str, Any],
+        context: dict[str, Any],
+        chat_id: Any,
+        turn_key: str,
+        pattern_context_ref: Any,
+    ) -> None:
         bindings = await self._resolve_bindings(workflow_name, model_name, agent_name)
         if not bindings:
             logger.warning(
@@ -126,7 +172,9 @@ class AutoToolEventHandler:
 
         try:
             validated = bindings[0].model_cls.model_validate(structured_data)
-            normalized = validated.model_dump(mode='json')  # type: ignore[attr-defined] - Force JSON serialization for enums
+            # ONE untouched canonical detached payload represents the accepted
+            # event result. It is never handed to a tool by mutable reference.
+            canonical_payload = detach(validated.model_dump(mode='json'))  # type: ignore[attr-defined] - Force JSON serialization for enums
         except ValidationError as err:
             logger.error(
                 "[AUTO_TOOL] Structured data failed validation for model=%s agent=%s errors=%s",
@@ -147,7 +195,12 @@ class AutoToolEventHandler:
 
         for binding in bindings:
             logger.debug("[AUTO_TOOL] Binding resolved for agent=%s tool=%s model=%s", agent_name, binding.tool_name, binding.model_name)
-            kwargs = self._build_tool_kwargs(binding, normalized, {
+            # Each binding gets its own detached copy: a tool mutating an
+            # explicit nested argument can never contaminate the canonical
+            # payload, another binding's arguments, or another binding's
+            # structured_output overlay.
+            binding_payload = detach(canonical_payload)
+            kwargs = self._build_tool_kwargs(binding, binding_payload, {
                 **context,
                 "turn_idempotency_key": turn_key,
                 "agent_name": agent_name,
@@ -203,27 +256,112 @@ class AutoToolEventHandler:
         matched = [binding for binding in candidates if binding.agent_name == agent_name]
         return matched
 
-    async def _load_bindings_for_workflow(self, workflow_name: str) -> dict[str, list[AutoToolBinding]]:
-        cached = self._workflow_bindings.get(workflow_name)
-        if cached is not None:
-            logger.debug("[AUTO_TOOL] Returning cached bindings for workflow=%s (count=%d)", workflow_name, len(cached))
-            return cached
+    def _resolve_registry(self, workflow_name: str) -> tuple[dict[str, Any], bool]:
+        """Resolve the current structured-output registry authority.
 
-        mapping: dict[str, list[AutoToolBinding]] = {}
+        Returns ``(registry, resolved)``. ``resolved=False`` means the current
+        configuration could not be loaded (unloaded workflow, failed reload):
+        a cached binding must never be reused on top of that failure, and the
+        empty result must not be cached as authority either.
+        """
         try:
             registry = get_structured_outputs_for_workflow(workflow_name)
-            logger.debug("[AUTO_TOOL] Loaded structured outputs registry for workflow=%s: %s", workflow_name, list(registry.keys()))
+            logger.debug(
+                "[AUTO_TOOL] Loaded structured outputs registry for workflow=%s: %s",
+                workflow_name,
+                list(registry.keys()),
+            )
+            return dict(registry), True
         except Exception as err:
             logger.debug(
                 "[AUTO_TOOL] Structured outputs unavailable for workflow %s: %s",
                 workflow_name,
                 err,
             )
-            registry = {}
+            return {}, False
 
+    @staticmethod
+    def _file_digest(path: Any) -> str | None:
+        try:
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            return None
+
+    def _binding_authority_fingerprint(
+        self, workflow_name: str, registry: dict[str, Any]
+    ) -> tuple[Any, ...]:
+        """Current authority inputs that decide whether cached bindings are reusable.
+
+        Covers the exact structured-output model class identity per agent, the
+        workflow's tools.yaml declaration bytes, and the bytes of every tool
+        file it names (rebuilt callables come from those bytes, so byte
+        identity is callable identity for this cache). Any change discards and
+        rebuilds the workflow's bindings.
+        """
+        registry_identity = tuple(
+            sorted(
+                (agent, getattr(model_cls, "__name__", str(model_cls)), id(model_cls))
+                for agent, model_cls in registry.items()
+            )
+        )
+        workflow_path = workflow_manager.resolve_workflow_path(workflow_name)
+        tools_digest: str | None = None
+        tool_file_digests: tuple[tuple[str, str], ...] = ()
+        if workflow_path is not None:
+            tools_yaml_path = workflow_path / "tools.yaml"
+            tools_digest = self._file_digest(tools_yaml_path)
+            file_names: set[str] = set()
+            if tools_digest is not None:
+                try:
+                    raw = yaml.safe_load(tools_yaml_path.read_text(encoding="utf-8")) or {}
+                    for entry in raw.get("tools") or []:
+                        if isinstance(entry, dict) and entry.get("file"):
+                            file_names.add(str(entry["file"]))
+                except Exception:
+                    file_names = set()
+            digests: list[tuple[str, str]] = []
+            for file_name in sorted(file_names):
+                for candidate in (workflow_path / file_name, workflow_path / "tools" / file_name):
+                    digest = self._file_digest(candidate)
+                    if digest is not None:
+                        digests.append((file_name, digest))
+                        break
+            tool_file_digests = tuple(digests)
+        return (
+            str(workflow_path or ""),
+            registry_identity,
+            tools_digest,
+            tool_file_digests,
+        )
+
+    async def _load_bindings_for_workflow(self, workflow_name: str) -> dict[str, list[AutoToolBinding]]:
+        # Self-validating cache: resolve the current authority BEFORE any
+        # cached binding is reused. A cached workflow binding is reusable only
+        # while its authority fingerprint still matches the live registry and
+        # tool declarations.
+        registry, registry_resolved = self._resolve_registry(workflow_name)
+        fingerprint = self._binding_authority_fingerprint(workflow_name, registry)
+        cached = self._workflow_bindings.get(workflow_name)
+        if cached is not None:
+            cached_fingerprint, cached_mapping = cached
+            if registry_resolved and cached_fingerprint == fingerprint:
+                logger.debug(
+                    "[AUTO_TOOL] Returning cached bindings for workflow=%s (count=%d)",
+                    workflow_name,
+                    len(cached_mapping),
+                )
+                return cached_mapping
+            logger.debug(
+                "[AUTO_TOOL] Binding authority changed for workflow=%s -> rebuilding",
+                workflow_name,
+            )
+            self._workflow_bindings.pop(workflow_name, None)
+
+        mapping: dict[str, list[AutoToolBinding]] = {}
         if not registry:
             logger.warning("[AUTO_TOOL] Empty registry for workflow=%s - no bindings possible", workflow_name)
-            self._workflow_bindings[workflow_name] = mapping
+            if registry_resolved:
+                self._workflow_bindings[workflow_name] = (fingerprint, mapping)
             return mapping
 
         tool_functions = load_agent_tool_functions(workflow_name, include_auto_only=True)
@@ -238,7 +376,7 @@ class AutoToolEventHandler:
         workflow_path = workflow_manager.resolve_workflow_path(workflow_name)
         if workflow_path is None:
             logger.warning("[AUTO_TOOL] Workflow path not found for workflow=%s", workflow_name)
-            self._workflow_bindings[workflow_name] = mapping
+            self._workflow_bindings[workflow_name] = (fingerprint, mapping)
             return mapping
         tools_yaml_path = workflow_path / "tools.yaml"
         tools_data: dict[str, Any] = {}
@@ -329,7 +467,7 @@ class AutoToolEventHandler:
                 logger.debug("AUTO_TOOL_BINDING_CREATED model=%s agent=%s tool=%s", model_name, agent_name, binding.tool_name)
 
         logger.debug("[AUTO_TOOL] Loaded %d total bindings for workflow=%s: %s", len(mapping), workflow_name, list(mapping.keys()))
-        self._workflow_bindings[workflow_name] = mapping
+        self._workflow_bindings[workflow_name] = (fingerprint, mapping)
         return mapping
 
     def _build_tool_kwargs(

--- a/mozaiksai/core/events/auto_tool_handler.py
+++ b/mozaiksai/core/events/auto_tool_handler.py
@@ -25,6 +25,9 @@ from mozaiksai.core.workflow.context.authority import (
     DETERMINISTIC_TOOL_WRITER,
     build_context_authority_policy,
 )
+from mozaiksai.core.workflow.context.structured_output_overlay import (
+    StructuredOutputOverlay,
+)
 from mozaiksai.core.workflow.declarative import parse_tools_config
 from mozaiksai.core.workflow.outputs.structured import get_structured_outputs_for_workflow
 from mozaiksai.core.workflow.workflow_manager import workflow_manager
@@ -364,9 +367,18 @@ class AutoToolEventHandler:
             if matched and matched not in kwargs:
                 kwargs[matched] = value
         if binding.accepts_context:
+            # The documented auto-tool contract is
+            # context_variables.get("structured_output") -> the exact validated
+            # structured_data for THIS turn. The runtime satisfies it with a
+            # transient read-only overlay over the live context: no
+            # application-declared variable is required, the key is never
+            # written into pattern/workflow state, and snapshots/persistence
+            # never include it. All other keys keep ordinary context behavior.
             # Prefer using the pattern's actual context reference if available
             if pattern_context_ref and hasattr(pattern_context_ref, "get") and hasattr(pattern_context_ref, "set"):
-                kwargs["context_variables"] = pattern_context_ref
+                kwargs["context_variables"] = StructuredOutputOverlay(
+                    pattern_context_ref, normalized_payload
+                )
                 logger.debug("[AUTO_TOOL] Using live pattern context reference for %s", binding.tool_name)
             else:
                 # Fallback: create ephemeral container from snapshot
@@ -397,7 +409,9 @@ class AutoToolEventHandler:
                             container.set(key, value)
                         except Exception as _cs_err:
                             logger.debug("[AUTO_TOOL] Container seed failed key=%s: %s", key, _cs_err)
-                kwargs["context_variables"] = container
+                kwargs["context_variables"] = StructuredOutputOverlay(
+                    container, normalized_payload
+                )
         return kwargs
 
     async def _invoke_tool(

--- a/mozaiksai/core/events/auto_tool_handler.py
+++ b/mozaiksai/core/events/auto_tool_handler.py
@@ -49,7 +49,12 @@ async def _get_simple_transport() -> SimpleTransport | None:
 
 @dataclass(frozen=True)
 class AutoToolBinding:
-    """Represents the runtime contract for auto-invoked UI tools."""
+    """Represents the runtime contract for auto-invoked UI tools.
+
+    This is the per-dispatch EXECUTION binding: its ``function`` is resolved
+    fresh through the canonical workflow tool loader for each dispatch and is
+    never cached across dispatches.
+    """
 
     model_name: str
     agent_name: str
@@ -61,23 +66,80 @@ class AutoToolBinding:
     model_cls: Any
 
 
+@dataclass(frozen=True)
+class AutoToolBindingDescriptor:
+    """Cached DECLARATIVE auto-tool binding metadata.
+
+    Python callable authority is never cached: descriptors carry only the
+    declarative facts (workflow tool declaration + exact model identity), and
+    the executable function comes from the current canonical loader/runtime
+    namespace at dispatch time.
+    """
+
+    model_name: str
+    agent_name: str
+    tool_name: str
+    function_name: str
+    ui_config: dict[str, Any]
+    model_cls: Any
+
+
+#: Per-binding execution checkpoint states. "PENDING" is the absence of a
+#: record. Once a binding reaches TOOL_TERMINAL, that binding must never be
+#: invoked again for the same turn; COMPLETE means post-processing finished.
+_TOOL_TERMINAL = "tool_terminal"
+_COMPLETE = "complete"
+
+
+@dataclass
+class _BindingExecutionRecord:
+    """Process-local finite execution checkpoint for one binding of one turn.
+
+    The record is captured synchronously after the tool returns a truthful
+    terminal result — before the next cancellable await — and holds detached
+    facts only (no live mutable aliases), so a retry resumes post-processing
+    without re-running the tool.
+
+    This guarantee is PROCESS-LOCAL runtime idempotency, not distributed
+    exactly-once delivery: a process crash after an external non-idempotent
+    tool side effect but before durable recording cannot be solved by this
+    in-memory handler. Tools requiring cross-process exactly-once semantics
+    must use their owning service's idempotency contract.
+    """
+
+    status: str
+    result_payload: Any
+    result_status: str
+    context_snapshot: dict[str, Any] | None
+    tool_call_emitted: bool = False
+    writeback_done: bool = False
+    persisted: bool = False
+    result_emitted: bool = False
+
+
 class AutoToolEventHandler:
     """Handle runtime.agent_output_validated events by running the mapped UI tool."""
 
     _CACHE_LIMIT = 512
 
     def __init__(self) -> None:
-        # Self-validating binding cache: each entry pairs the built bindings
-        # with the authority fingerprint they were built from. A cached entry
-        # is reusable only while the current authority inputs still match.
-        self._workflow_bindings: dict[
-            str, tuple[tuple[Any, ...], dict[str, list[AutoToolBinding]]]
+        # Self-validating DECLARATIVE binding cache: each entry pairs built
+        # binding descriptors with the declarative authority fingerprint they
+        # were built from (exact model identity + tools.yaml declaration). A
+        # cached entry is reusable only while those inputs still match; the
+        # executable callable is never part of the cache.
+        self._workflow_binding_descriptors: dict[
+            str, tuple[tuple[Any, ...], dict[str, list[AutoToolBindingDescriptor]]]
         ] = {}
         self._processed_keys: set[str] = set()
         self._processed_order: asyncio.Queue[str] = asyncio.Queue()
         # Turns claimed atomically before the first await: a duplicate
         # delivery observing an IN_FLIGHT (or COMPLETED) turn never executes.
         self._in_flight_keys: set[str] = set()
+        # Per-turn, per-binding execution checkpoints (process-local). Popped
+        # when a turn completes; bounded by _CACHE_LIMIT with active in-flight
+        # state never evicted.
+        self._turn_checkpoints: dict[str, dict[str, _BindingExecutionRecord]] = {}
 
     async def handle_tool_dispatch(self, event: dict[str, Any]) -> None:
         """Process an agent_output_validated event and trigger the corresponding tool."""
@@ -193,68 +255,185 @@ class AutoToolEventHandler:
             await self._register_turn(cache_key)
             return
 
-        for binding in bindings:
-            logger.debug("[AUTO_TOOL] Binding resolved for agent=%s tool=%s model=%s", agent_name, binding.tool_name, binding.model_name)
-            # Each binding gets its own detached copy: a tool mutating an
-            # explicit nested argument can never contaminate the canonical
-            # payload, another binding's arguments, or another binding's
-            # structured_output overlay.
-            binding_payload = detach(canonical_payload)
-            kwargs = self._build_tool_kwargs(binding, binding_payload, {
-                **context,
-                "turn_idempotency_key": turn_key,
-                "agent_name": agent_name,
-            }, pattern_context_ref)
-            logger.debug("[AUTO_TOOL] Prepared kwargs for %s: %s", binding.tool_name, {k: v for k, v in kwargs.items() if k != 'context_variables'})
-            await self._emit_tool_call(binding, agent_name, chat_id, kwargs, turn_key)
-            result_payload, status = await self._invoke_tool(binding, kwargs)
+        # Per-turn execution checkpoints: a retry after cancellation resumes
+        # at the first unfinished binding/stage; a binding whose tool already
+        # returned a terminal result is NEVER invoked again for this turn.
+        self._trim_turn_checkpoints()
+        checkpoints = self._turn_checkpoints.setdefault(cache_key, {})
 
-            # Write back context changes to pattern context if available
-            container = kwargs.get("context_variables")
-            if pattern_context_ref and container:
-                try:
-                    if hasattr(container, "snapshot") and callable(getattr(container, "snapshot", None)):
-                        container_snapshot = container.snapshot()
-                    elif hasattr(container, "to_dict") and callable(getattr(container, "to_dict", None)):
-                        container_snapshot = container.to_dict()
-                    else:
-                        container_snapshot = {}
-                    if not isinstance(container_snapshot, dict):
-                        container_snapshot = {}
-                    # Copy changes from tool's container back to the shared pattern context
-                    for key, value in container_snapshot.items():
-                        try:
-                            pattern_context_ref.set(key, value)
-                        except Exception as _set_err:
-                            logger.debug("[AUTO_TOOL] Context write-back failed key=%s: %s", key, _set_err)
-                    logger.debug(
-                        "[AUTO_TOOL] Wrote back %d context keys to pattern context after %s execution",
-                        len(container_snapshot),
-                        binding.tool_name,
+        for index, binding in enumerate(bindings):
+            binding_key = f"{index}:{binding.agent_name}:{binding.tool_name}"
+            record = checkpoints.get(binding_key)
+            if record is not None and record.status == _COMPLETE:
+                continue
+
+            if record is None:
+                # PENDING: execute the tool. Pre-execution interruption keeps
+                # the binding PENDING, so a retry may execute it.
+                logger.debug("[AUTO_TOOL] Binding resolved for agent=%s tool=%s model=%s", agent_name, binding.tool_name, binding.model_name)
+                # Each binding gets its own detached copy: a tool mutating an
+                # explicit nested argument can never contaminate the canonical
+                # payload, another binding's arguments, or another binding's
+                # structured_output overlay.
+                binding_payload = detach(canonical_payload)
+                kwargs = self._build_tool_kwargs(binding, binding_payload, {
+                    **context,
+                    "turn_idempotency_key": turn_key,
+                    "agent_name": agent_name,
+                }, pattern_context_ref)
+                logger.debug("[AUTO_TOOL] Prepared kwargs for %s: %s", binding.tool_name, {k: v for k, v in kwargs.items() if k != 'context_variables'})
+                await self._emit_tool_call(binding, agent_name, chat_id, kwargs, turn_key)
+                result_payload, status = await self._invoke_tool(binding, kwargs)
+                # TOOL_TERMINAL: recorded SYNCHRONOUSLY before the next
+                # cancellable await, with detached facts only. A truthful tool
+                # failure is also a terminal execution result for this turn.
+                record = _BindingExecutionRecord(
+                    status=_TOOL_TERMINAL,
+                    result_payload=self._detached_or_original(result_payload),
+                    result_status=status,
+                    context_snapshot=self._container_snapshot(kwargs.get("context_variables")),
+                    tool_call_emitted=True,
+                )
+                checkpoints[binding_key] = record
+
+            # TOOL_TERMINAL: finish post-processing stages exactly once each.
+            if not record.writeback_done:
+                # Synchronous write-back from the detached terminal snapshot.
+                if pattern_context_ref and record.context_snapshot:
+                    self._write_back_context(
+                        pattern_context_ref, record.context_snapshot, binding.tool_name
                     )
-                except Exception as wb_err:
-                    logger.debug("[AUTO_TOOL] Failed to write back context changes to pattern: %s", wb_err)
+                record.writeback_done = True
 
-            await self._persist_context_variables(
-                chat_id=chat_id,
-                app_id=context.get("app_id"),
-                workflow_name=workflow_name,
-                context_variables=container,
-            )
+            if not record.persisted:
+                await self._persist_context_variables(
+                    chat_id=chat_id,
+                    app_id=context.get("app_id"),
+                    workflow_name=workflow_name,
+                    context_variables=record.context_snapshot,
+                )
+                record.persisted = True
 
-            await self._emit_tool_result(binding, agent_name, chat_id, result_payload, status, turn_key)
+            if not record.result_emitted:
+                await self._emit_tool_result(
+                    binding, agent_name, chat_id, record.result_payload, record.result_status, turn_key
+                )
+                record.result_emitted = True
+
+            record.status = _COMPLETE
         await self._register_turn(cache_key)
+
+    @staticmethod
+    def _detached_or_original(value: Any) -> Any:
+        try:
+            return detach(value)
+        except Exception:  # pragma: no cover - non-copyable tool result
+            logger.debug("[AUTO_TOOL] Tool result could not be detached; storing original")
+            return value
+
+    @staticmethod
+    def _container_snapshot(container: Any) -> dict[str, Any] | None:
+        """Detached context facts captured at the terminal-record boundary."""
+        if container is None:
+            return None
+        try:
+            for method_name in ("snapshot", "to_dict"):
+                method = getattr(container, method_name, None)
+                if callable(method):
+                    data = method()
+                    if isinstance(data, dict):
+                        return data
+            if isinstance(container, dict):
+                return dict(container)
+        except Exception as snap_err:  # pragma: no cover - defensive
+            logger.debug("[AUTO_TOOL] Context snapshot capture failed: %s", snap_err)
+        return None
+
+    @staticmethod
+    def _write_back_context(
+        pattern_context_ref: Any, snapshot: dict[str, Any], tool_name: str
+    ) -> None:
+        try:
+            for key, value in snapshot.items():
+                try:
+                    pattern_context_ref.set(key, value)
+                except Exception as _set_err:
+                    logger.debug("[AUTO_TOOL] Context write-back failed key=%s: %s", key, _set_err)
+            logger.debug(
+                "[AUTO_TOOL] Wrote back %d context keys to pattern context after %s execution",
+                len(snapshot),
+                tool_name,
+            )
+        except Exception as wb_err:
+            logger.debug("[AUTO_TOOL] Failed to write back context changes to pattern: %s", wb_err)
+
+    def _trim_turn_checkpoints(self) -> None:
+        """Bounded checkpoint bookkeeping: never evict active in-flight state."""
+        if len(self._turn_checkpoints) <= self._CACHE_LIMIT:
+            return
+        for key in list(self._turn_checkpoints):
+            if len(self._turn_checkpoints) <= self._CACHE_LIMIT:
+                break
+            if key in self._in_flight_keys:
+                continue
+            self._turn_checkpoints.pop(key, None)
 
     async def _resolve_bindings(
         self, workflow_name: str, model_name: str, agent_name: str
     ) -> list[AutoToolBinding]:
-        bindings = await self._load_bindings_for_workflow(workflow_name)
-        candidates = bindings.get(model_name) or []
+        descriptors = await self._load_binding_descriptors(workflow_name)
+        candidates = [
+            descriptor
+            for descriptor in descriptors.get(model_name) or []
+            if descriptor.agent_name == agent_name
+        ]
         if not candidates:
             logger.debug("[AUTO_TOOL] No cached binding for workflow=%s model=%s agent=%s", workflow_name, model_name, agent_name)
             return []
-        matched = [binding for binding in candidates if binding.agent_name == agent_name]
-        return matched
+        # Python callable authority is never cached across dispatches: the
+        # executable function is resolved fresh through the canonical
+        # workflow tool loader so workflow-owned source/helper changes are
+        # observed without a process restart. (External installed packages
+        # remain a restart boundary.)
+        tool_functions = load_agent_tool_functions(workflow_name, include_auto_only=True)
+        function_index: dict[str, dict[str, Callable[..., Any]]] = {}
+        for agent, funcs in tool_functions.items():
+            function_index[agent] = {
+                getattr(fn, "__name__", f"fn_{idx}"): fn for idx, fn in enumerate(funcs)
+            }
+        bindings: list[AutoToolBinding] = []
+        for descriptor in candidates:
+            func = function_index.get(descriptor.agent_name, {}).get(descriptor.function_name)
+            if func is None:
+                logger.warning(
+                    "[AUTO_TOOL] Tool function '%s' not currently loadable for agent %s",
+                    descriptor.function_name,
+                    descriptor.agent_name,
+                )
+                continue
+            sig = inspect.signature(func)
+            param_names = tuple(
+                name
+                for name, param in sig.parameters.items()
+                if param.kind in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+                and name not in {"self"}
+            )
+            bindings.append(
+                AutoToolBinding(
+                    model_name=descriptor.model_name,
+                    agent_name=descriptor.agent_name,
+                    tool_name=descriptor.tool_name,
+                    function=func,
+                    param_names=param_names,
+                    accepts_context="context_variables" in sig.parameters,
+                    ui_config=descriptor.ui_config,
+                    model_cls=descriptor.model_cls,
+                )
+            )
+        return bindings
 
     def _resolve_registry(self, workflow_name: str) -> tuple[dict[str, Any], bool]:
         """Resolve the current structured-output registry authority.
@@ -290,13 +469,14 @@ class AutoToolEventHandler:
     def _binding_authority_fingerprint(
         self, workflow_name: str, registry: dict[str, Any]
     ) -> tuple[Any, ...]:
-        """Current authority inputs that decide whether cached bindings are reusable.
+        """Declarative authority inputs that decide descriptor-cache reuse.
 
-        Covers the exact structured-output model class identity per agent, the
-        workflow's tools.yaml declaration bytes, and the bytes of every tool
-        file it names (rebuilt callables come from those bytes, so byte
-        identity is callable identity for this cache). Any change discards and
-        rebuilds the workflow's bindings.
+        Covers the exact structured-output model class identity per agent and
+        the workflow's tools.yaml declaration bytes. Callable behavior is
+        deliberately NOT fingerprinted here — file bytes cannot prove full
+        callable behavior (imported helpers change behavior without touching
+        the tool file), so the executable function is resolved fresh through
+        the canonical loader at every dispatch instead of being cached.
         """
         registry_identity = tuple(
             sorted(
@@ -306,47 +486,30 @@ class AutoToolEventHandler:
         )
         workflow_path = workflow_manager.resolve_workflow_path(workflow_name)
         tools_digest: str | None = None
-        tool_file_digests: tuple[tuple[str, str], ...] = ()
         if workflow_path is not None:
-            tools_yaml_path = workflow_path / "tools.yaml"
-            tools_digest = self._file_digest(tools_yaml_path)
-            file_names: set[str] = set()
-            if tools_digest is not None:
-                try:
-                    raw = yaml.safe_load(tools_yaml_path.read_text(encoding="utf-8")) or {}
-                    for entry in raw.get("tools") or []:
-                        if isinstance(entry, dict) and entry.get("file"):
-                            file_names.add(str(entry["file"]))
-                except Exception:
-                    file_names = set()
-            digests: list[tuple[str, str]] = []
-            for file_name in sorted(file_names):
-                for candidate in (workflow_path / file_name, workflow_path / "tools" / file_name):
-                    digest = self._file_digest(candidate)
-                    if digest is not None:
-                        digests.append((file_name, digest))
-                        break
-            tool_file_digests = tuple(digests)
+            tools_digest = self._file_digest(workflow_path / "tools.yaml")
         return (
             str(workflow_path or ""),
             registry_identity,
             tools_digest,
-            tool_file_digests,
         )
 
-    async def _load_bindings_for_workflow(self, workflow_name: str) -> dict[str, list[AutoToolBinding]]:
-        # Self-validating cache: resolve the current authority BEFORE any
-        # cached binding is reused. A cached workflow binding is reusable only
-        # while its authority fingerprint still matches the live registry and
-        # tool declarations.
+    async def _load_binding_descriptors(
+        self, workflow_name: str
+    ) -> dict[str, list[AutoToolBindingDescriptor]]:
+        # Self-validating DECLARATIVE cache: resolve the current authority
+        # BEFORE any cached descriptors are reused. Cached descriptors are
+        # reusable only while the declarative fingerprint (exact model
+        # identity + tools.yaml declaration) still matches; the executable
+        # callable is never cached here.
         registry, registry_resolved = self._resolve_registry(workflow_name)
         fingerprint = self._binding_authority_fingerprint(workflow_name, registry)
-        cached = self._workflow_bindings.get(workflow_name)
+        cached = self._workflow_binding_descriptors.get(workflow_name)
         if cached is not None:
             cached_fingerprint, cached_mapping = cached
             if registry_resolved and cached_fingerprint == fingerprint:
                 logger.debug(
-                    "[AUTO_TOOL] Returning cached bindings for workflow=%s (count=%d)",
+                    "[AUTO_TOOL] Returning cached binding descriptors for workflow=%s (count=%d)",
                     workflow_name,
                     len(cached_mapping),
                 )
@@ -355,28 +518,19 @@ class AutoToolEventHandler:
                 "[AUTO_TOOL] Binding authority changed for workflow=%s -> rebuilding",
                 workflow_name,
             )
-            self._workflow_bindings.pop(workflow_name, None)
+            self._workflow_binding_descriptors.pop(workflow_name, None)
 
-        mapping: dict[str, list[AutoToolBinding]] = {}
+        mapping: dict[str, list[AutoToolBindingDescriptor]] = {}
         if not registry:
             logger.warning("[AUTO_TOOL] Empty registry for workflow=%s - no bindings possible", workflow_name)
             if registry_resolved:
-                self._workflow_bindings[workflow_name] = (fingerprint, mapping)
+                self._workflow_binding_descriptors[workflow_name] = (fingerprint, mapping)
             return mapping
-
-        tool_functions = load_agent_tool_functions(workflow_name, include_auto_only=True)
-        logger.debug("[AUTO_TOOL] Loaded tool functions for workflow=%s: agents=%s", workflow_name, list(tool_functions.keys()))
-        agent_function_index: dict[str, dict[str, Callable[..., Any]]] = {}
-        for agent, funcs in tool_functions.items():
-            agent_function_index[agent] = {
-                getattr(fn, "__name__", f"fn_{idx}"): fn for idx, fn in enumerate(funcs)
-            }
-            logger.debug("[AUTO_TOOL] Agent %s has functions: %s", agent, list(agent_function_index[agent].keys()))
 
         workflow_path = workflow_manager.resolve_workflow_path(workflow_name)
         if workflow_path is None:
             logger.warning("[AUTO_TOOL] Workflow path not found for workflow=%s", workflow_name)
-            self._workflow_bindings[workflow_name] = (fingerprint, mapping)
+            self._workflow_binding_descriptors[workflow_name] = (fingerprint, mapping)
             return mapping
         tools_yaml_path = workflow_path / "tools.yaml"
         tools_data: dict[str, Any] = {}
@@ -431,43 +585,20 @@ class AutoToolEventHandler:
                     continue
                 model_name = getattr(model_cls, "__name__", str(model_cls))
                 logger.debug("[AUTO_TOOL] Agent %s has model_name=%s", agent_name, model_name)
-                fn_lookup = agent_function_index.get(agent_name, {})
-                func = fn_lookup.get(function_name)
-                if not func:
-                    logger.debug(
-                        "[AUTO_TOOL] Tool function '%s' not loaded for agent %s",
-                        function_name,
-                        agent_name,
-                    )
-                    continue
-                logger.debug("[AUTO_TOOL] Found function %s for agent %s", function_name, agent_name)
-                sig = inspect.signature(func)
-                param_names = [
-                    name
-                    for name, param in sig.parameters.items()
-                    if param.kind in (
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        inspect.Parameter.KEYWORD_ONLY,
-                    )
-                    and name not in {"self"}
-                ]
-                accepts_context = "context_variables" in sig.parameters
                 ui_cfg = entry.get("ui") if isinstance(entry.get("ui"), dict) else {}
-                binding = AutoToolBinding(
+                descriptor = AutoToolBindingDescriptor(
                     model_name=model_name,
                     agent_name=agent_name,
                     tool_name=entry.get("name") or function_name,
-                    function=func,
-                    param_names=tuple(param_names),
-                    accepts_context=accepts_context,
+                    function_name=function_name,
                     ui_config=ui_cfg,
                     model_cls=model_cls,
                 )
-                mapping.setdefault(model_name, []).append(binding)
-                logger.debug("AUTO_TOOL_BINDING_CREATED model=%s agent=%s tool=%s", model_name, agent_name, binding.tool_name)
+                mapping.setdefault(model_name, []).append(descriptor)
+                logger.debug("AUTO_TOOL_BINDING_CREATED model=%s agent=%s tool=%s", model_name, agent_name, descriptor.tool_name)
 
-        logger.debug("[AUTO_TOOL] Loaded %d total bindings for workflow=%s: %s", len(mapping), workflow_name, list(mapping.keys()))
-        self._workflow_bindings[workflow_name] = (fingerprint, mapping)
+        logger.debug("[AUTO_TOOL] Loaded %d total binding descriptors for workflow=%s: %s", len(mapping), workflow_name, list(mapping.keys()))
+        self._workflow_binding_descriptors[workflow_name] = (fingerprint, mapping)
         return mapping
 
     def _build_tool_kwargs(
@@ -717,6 +848,9 @@ class AutoToolEventHandler:
             logger.debug("[AUTO_TOOL] Failed to emit tool_result for agent=%s", agent_name)
 
     async def _register_turn(self, cache_key: str) -> None:
+        # A completed (or terminally consumed) turn keeps only its bounded
+        # membership in the processed set; per-binding checkpoints are dropped.
+        self._turn_checkpoints.pop(cache_key, None)
         if cache_key in self._processed_keys:
             return
         self._processed_keys.add(cache_key)
@@ -732,4 +866,4 @@ class AutoToolEventHandler:
                 break
 
 
-__all__ = ["AutoToolEventHandler", "AutoToolBinding"]
+__all__ = ["AutoToolEventHandler", "AutoToolBinding", "AutoToolBindingDescriptor"]

--- a/mozaiksai/core/workflow/agents/tools.py
+++ b/mozaiksai/core/workflow/agents/tools.py
@@ -420,7 +420,18 @@ def load_agent_tool_functions(
             # For agent tools that are manually invoked (auto_tool_call=false), validating kwargs against the
             # agent's structured output model will reject legitimate tool payloads. Only enforce schema
             # for auto-invoked tools where kwargs are expected to match the agent's structured output.
-            enforce_schema = ag in structured_registry and should_auto_tool_call and not is_ui_tool
+            # include_auto_only=True is the AutoToolEventHandler load path: its
+            # payload already passed exact agent-output acceptance, and its
+            # kwargs are runtime-decomposed (possibly context-only), so the
+            # wrapper must not re-validate them against the agent OUTPUT model.
+            # Agent-bound loads (include_auto_only=False) keep validating
+            # LLM-requested tool-call arguments for auto-tagged agent tools.
+            enforce_schema = (
+                ag in structured_registry
+                and should_auto_tool_call
+                and not is_ui_tool
+                and not include_auto_only
+            )
             wrapped_func = _wrap_with_validation(
                 workflow_name=workflow_name,
                 agent_name=ag,

--- a/mozaiksai/core/workflow/agents/tools.py
+++ b/mozaiksai/core/workflow/agents/tools.py
@@ -63,14 +63,54 @@ def _ensure_workflow_import_paths(*, base_dir: Path, file_path: Path) -> None:
             sys.path.insert(0, value)
 
 
-def _reset_workflow_package_namespace(*, base_dir: Path, workflow_name: str) -> None:
-    """Bind ``workflows.<workflow_name>`` imports to the active repo workflow root.
+def _workflow_root_package_names(workflows_root: Path) -> list[str]:
+    """Derive the importable dotted package names of one workflows root.
 
-    Some local environments have another checkout on ``sys.path`` that also exposes a
-    top-level ``workflows`` package. Tool modules use relative imports like
-    ``from .workflow_converter import ...``; if Python resolves the parent package from
-    the wrong checkout, the live workflow pulls stale code. Rebinding the workflow
-    package namespace here keeps dynamic tool imports pinned to the active root.
+    Workflow-owned Python (per-workflow tool modules and the shared
+    ``_shared`` helpers beside them) can be imported both through the
+    synthetic ``workflows.<name>`` namespace this loader binds and through the
+    real package chain that contains the workflows root on disk (for example
+    ``factory_app.workflows.<name>``). The real chain is derived from the
+    filesystem — walking up while ``__init__.py`` parents exist — rather than
+    hardcoding any repository-specific package name.
+    """
+    names = ["workflows"]
+    parts: list[str] = []
+    current = workflows_root
+    try:
+        while (current / "__init__.py").exists():
+            parts.append(current.name)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+    except OSError:
+        parts = []
+    if parts:
+        dotted = ".".join(reversed(parts))
+        if dotted and dotted not in names:
+            names.append(dotted)
+    return names
+
+
+def _reset_workflow_package_namespace(*, base_dir: Path, workflow_name: str) -> None:
+    """Refresh workflow-owned Python modules for the workflow being loaded.
+
+    Two freshness rules:
+
+    - the synthetic ``workflows.<workflow_name>`` namespace is rebound to the
+      active workflow root so relative tool imports resolve against the live
+      checkout;
+    - every cached module under this workflow (and the workflows root's shared
+      ``_shared`` helpers) is dropped from ``sys.modules`` for EVERY dotted
+      package name that reaches this workflows root — both the synthetic
+      ``workflows`` namespace and the derived real package chain (for example
+      ``factory_app.workflows``). A tool whose behavior lives in an imported
+      workflow helper therefore observes helper changes on the next load
+      without a process restart.
+
+    Unrelated workflows are not cleared. External installed third-party
+    packages are never hot-replaced: changing them requires a process restart.
     """
 
     workflows_root = base_dir.parent
@@ -82,10 +122,17 @@ def _reset_workflow_package_namespace(*, base_dir: Path, workflow_name: str) -> 
     if tools_root.exists():
         package_roots[f"workflows.{workflow_name}.tools"] = tools_root
 
-    workflow_prefix = f"workflows.{workflow_name}"
-    for module_name in list(sys.modules):
-        if module_name == "workflows" or module_name == workflow_prefix or module_name.startswith(f"{workflow_prefix}."):
-            sys.modules.pop(module_name, None)
+    for root_package in _workflow_root_package_names(workflows_root):
+        stale_prefixes = (
+            f"{root_package}.{workflow_name}",
+            f"{root_package}._shared",
+        )
+        for module_name in list(sys.modules):
+            if module_name == "workflows" or any(
+                module_name == prefix or module_name.startswith(f"{prefix}.")
+                for prefix in stale_prefixes
+            ):
+                sys.modules.pop(module_name, None)
 
     for package_name, package_root in package_roots.items():
         module = types.ModuleType(package_name)

--- a/mozaiksai/core/workflow/context/schema.py
+++ b/mozaiksai/core/workflow/context/schema.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from ..declarative import parse_context_variables_config
+from ..reserved_context_keys import require_application_context_name_allowed
 from .authority import ContextAuthorityClass, ContextWriterId
 
 
@@ -188,7 +189,12 @@ class ContextAgentView(ContextModel):
     @field_validator("variables")
     @classmethod
     def _normalize_variables(cls, value: list[str]) -> list[str]:
-        return _normalize_string_list(value)
+        normalized = _normalize_string_list(value)
+        for name in normalized:
+            require_application_context_name_allowed(
+                name, where="context plan agents.<name>.variables"
+            )
+        return normalized
 
 
 class ContextVariablesPlan(ContextModel):
@@ -204,6 +210,9 @@ class ContextVariablesPlan(ContextModel):
     ) -> dict[str, ContextVariableDefinition]:
         for key in value.keys():
             _required_text(key, field_name="context variable name")
+            require_application_context_name_allowed(
+                key, where="context plan definitions"
+            )
         return value
 
     @model_validator(mode="after")

--- a/mozaiksai/core/workflow/context/structured_output_overlay.py
+++ b/mozaiksai/core/workflow/context/structured_output_overlay.py
@@ -26,11 +26,14 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any, cast
 
+from ..reserved_context_keys import STRUCTURED_OUTPUT_CONTEXT_KEY
 from .authority import ContextAuthorityError
 from .frozen import detach, freeze
 
 #: The documented public auto-tool context key for validated agent output.
-STRUCTURED_OUTPUT_KEY = "structured_output"
+#: The canonical vocabulary lives in ``reserved_context_keys``; this alias is
+#: kept for existing overlay consumers.
+STRUCTURED_OUTPUT_KEY = STRUCTURED_OUTPUT_CONTEXT_KEY
 
 
 class StructuredOutputWriteError(ContextAuthorityError):
@@ -80,11 +83,20 @@ class StructuredOutputOverlay:
         return self.contains(key)
 
     def keys(self) -> Iterable[str]:
-        """Underlying context keys only — the projection is not enumerable state."""
+        """Underlying context keys only — the projection is not enumerable state.
+
+        A base key named ``structured_output`` is illegal application state
+        (stale, caller-planted, or replayed); the overlay shadows it for reads
+        and excludes it from enumeration without mutating the base.
+        """
         base_keys = getattr(self._base, "keys", None)
-        if callable(base_keys):
-            return cast(Iterable[str], base_keys())
-        return ()
+        if not callable(base_keys):
+            return ()
+        return tuple(
+            key
+            for key in cast(Iterable[str], base_keys())
+            if key != STRUCTURED_OUTPUT_KEY
+        )
 
     # -- writes --------------------------------------------------------------
 

--- a/mozaiksai/core/workflow/context/structured_output_overlay.py
+++ b/mozaiksai/core/workflow/context/structured_output_overlay.py
@@ -1,0 +1,144 @@
+"""Turn-local read-only ``structured_output`` projection over a live context.
+
+The documented public auto-tool contract is::
+
+    data = context_variables.get("structured_output")
+
+``structured_output`` is NOT ordinary application workflow state. It is a
+runtime-owned TRANSIENT input projection carrying the exact validated
+``structured_data`` for the current auto-tool invocation. Applications never
+declare it in ``context_variables.yaml``, no writer may set or replace it, and
+it must not survive the invocation as durable, replayable, or agent-visible
+state.
+
+:class:`StructuredOutputOverlay` is the smallest reusable context abstraction
+that makes the documented contract true without seizing application context
+authority: it wraps the live workflow context (a pattern context bridge or an
+ephemeral runtime container), serves ``structured_output`` reads from the
+runtime-held exact payload, fails every mutation of that key closed, and
+delegates all other keys — reads, writes, snapshots, and persistence
+extraction — to the underlying context unchanged. Snapshots and iteration
+never include the projection, so persistence and replay cannot inherit it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+from .authority import ContextAuthorityError
+from .frozen import detach, freeze
+
+#: The documented public auto-tool context key for validated agent output.
+STRUCTURED_OUTPUT_KEY = "structured_output"
+
+
+class StructuredOutputWriteError(ContextAuthorityError):
+    """Raised when anything attempts to mutate the transient runtime projection."""
+
+
+def _reject_write(operation: str) -> None:
+    raise StructuredOutputWriteError(
+        f"context_variables[{STRUCTURED_OUTPUT_KEY!r}] is a runtime-owned "
+        f"read-only projection of the validated structured output; {operation} "
+        "is not allowed. Save selected data under a declared application key "
+        "instead."
+    )
+
+
+class StructuredOutputOverlay:
+    """Live workflow context plus a read-only ``structured_output`` overlay."""
+
+    def __init__(self, base: Any, structured_data: Mapping[str, Any]) -> None:
+        if not isinstance(structured_data, Mapping):
+            raise TypeError("structured_data must be a mapping of validated output")
+        self._base = base
+        self._structured_data: dict[str, Any] = detach(dict(structured_data))
+
+    # -- reads ---------------------------------------------------------------
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        if key == STRUCTURED_OUTPUT_KEY:
+            return freeze(self._structured_data)
+        base_get = getattr(self._base, "get", None)
+        if callable(base_get):
+            return base_get(key, default)
+        return default
+
+    def contains(self, key: str) -> bool:
+        if key == STRUCTURED_OUTPUT_KEY:
+            return True
+        base_contains = getattr(self._base, "contains", None)
+        if callable(base_contains):
+            return bool(base_contains(key))
+        try:
+            return key in self._base
+        except TypeError:
+            return False
+
+    def __contains__(self, key: str) -> bool:
+        return self.contains(key)
+
+    def keys(self) -> Iterable[str]:
+        """Underlying context keys only — the projection is not enumerable state."""
+        base_keys = getattr(self._base, "keys", None)
+        if callable(base_keys):
+            return cast(Iterable[str], base_keys())
+        return ()
+
+    # -- writes --------------------------------------------------------------
+
+    def set(self, key: str, value: Any) -> None:
+        if key == STRUCTURED_OUTPUT_KEY:
+            _reject_write("set")
+        self._base.set(key, value)
+
+    def remove(self, key: str) -> bool:
+        if key == STRUCTURED_OUTPUT_KEY:
+            _reject_write("delete")
+        base_remove = getattr(self._base, "remove", None)
+        if callable(base_remove):
+            return bool(base_remove(key))
+        return False
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.set(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        self.remove(key)
+
+    # -- snapshots / persistence extraction ----------------------------------
+
+    def _base_snapshot(self) -> dict[str, Any]:
+        for method_name in ("snapshot", "to_dict"):
+            method = getattr(self._base, method_name, None)
+            if callable(method):
+                data = method()
+                if isinstance(data, dict):
+                    return data
+        if isinstance(self._base, Mapping):
+            return dict(self._base)
+        return {}
+
+    def snapshot(self) -> dict[str, Any]:
+        """Durable state only: the runtime projection is never part of a snapshot."""
+        data = self._base_snapshot()
+        data.pop(STRUCTURED_OUTPUT_KEY, None)
+        return data
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.snapshot()
+
+    @property
+    def data(self) -> dict[str, Any]:
+        raise AttributeError(
+            "StructuredOutputOverlay.data is not exposed; use snapshot() for "
+            "detached serialization of the underlying context."
+        )
+
+
+__all__ = [
+    "STRUCTURED_OUTPUT_KEY",
+    "StructuredOutputOverlay",
+    "StructuredOutputWriteError",
+]

--- a/mozaiksai/core/workflow/declarative/contracts.py
+++ b/mozaiksai/core/workflow/declarative/contracts.py
@@ -12,6 +12,9 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from mozaiksai.core.media.types import MediaPromotionTargetValue
+from mozaiksai.core.workflow.reserved_context_keys import (
+    require_application_context_name_allowed,
+)
 from mozaiksai.core.workflow.workflow_ui_catalog import (
     infer_workflow_ui_realization,
     validate_workflow_renderable_primitive_ids,
@@ -423,7 +426,12 @@ class ContextAgentViewSpec(DeclarativeModel):
     @field_validator("variables")
     @classmethod
     def _normalize_variables(cls, value: list[str]) -> list[str]:
-        return _normalize_string_list(value)
+        normalized = _normalize_string_list(value)
+        for name in normalized:
+            require_application_context_name_allowed(
+                name, where="context_variables.yaml agents.<name>.variables"
+            )
+        return normalized
 
 
 class ContextVariablesConfig(DeclarativeModel):
@@ -437,6 +445,9 @@ class ContextVariablesConfig(DeclarativeModel):
     ) -> dict[str, ContextVariableDefinitionSpec]:
         for key in value.keys():
             _required_text(key, field_name="context variable name")
+            require_application_context_name_allowed(
+                key, where="context_variables.yaml definitions"
+            )
         return value
 
 

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -390,22 +390,6 @@ def _safe_handoff_context_preview(
     return preview
 
 
-def _set_context_value(context_ref: Any, key: str, value: Any) -> None:
-    if context_ref is None or not key:
-        return
-    try:
-        if hasattr(context_ref, "set"):
-            context_ref.set(key, value)
-            return
-    except Exception:
-        pass
-    try:
-        if hasattr(context_ref, "__setitem__"):
-            context_ref[key] = value
-    except Exception:
-        return
-
-
 def _structured_model_for_agent(
     structured_registry: dict[str, Any] | None,
     agent_name: str,
@@ -483,15 +467,11 @@ async def _emit_validated_structured_outputs_from_runner_result(
             continue
 
         model_name = str(entry.get("model_name") or getattr(model_cls, "__name__", "") or "").strip()
-        if model_name:
-            _set_context_value(context_vars_dict, model_name, structured_data)
-            _set_context_value(context_bridge, model_name, structured_data)
-        _set_context_value(context_vars_dict, "structured_output", structured_data)
-        _set_context_value(context_vars_dict, "structured_output_agent", agent_name)
-        _set_context_value(context_vars_dict, "structured_output_model", model_name)
-        _set_context_value(context_bridge, "structured_output", structured_data)
-        _set_context_value(context_bridge, "structured_output_agent", agent_name)
-        _set_context_value(context_bridge, "structured_output_model", model_name)
+        # structured_output is a runtime-owned transient projection, not
+        # application context state. It reaches auto tools through the
+        # read-only overlay in AutoToolEventHandler, never through
+        # pattern/workflow context writes (which would collide with declared
+        # context authority and leak into persistence and replay).
 
         auto_tool_enabled = _normalized_agent_name(agent_name) in auto_tool_agent_keys
         _conv_logger.info(

--- a/mozaiksai/core/workflow/outputs/structured.py
+++ b/mozaiksai/core/workflow/outputs/structured.py
@@ -282,7 +282,14 @@ def get_provider_response_model(model_cls: type[BaseModel]) -> type[BaseModel]:
             field_kwargs["description"] = description
         fields[field_name] = (field_annotation, Field(..., **field_kwargs))
 
-    strict_model = create_model(model_cls.__name__, **fields)  # type: ignore[arg-type]
+    # The wire projection's advertised JSON schema already declares
+    # additionalProperties: false at every object level; its local parse must
+    # honor the same claim. Otherwise a permissive provider-side parse becomes
+    # the first lossy normalization: extras are stripped before the exact
+    # runtime acceptance model ever sees the original candidate.
+    strict_model = create_model(
+        model_cls.__name__, __config__=ConfigDict(extra="forbid"), **fields
+    )  # type: ignore[call-overload]
     _patch_model_schema(strict_model)
     _provider_response_model_cache[model_cls] = strict_model
     return strict_model
@@ -552,8 +559,14 @@ def load_workflow_structured_outputs(workflow_name: str) -> tuple[dict[str, type
         _workflow_structured_agents[workflow_name] = set()
         return {}, {}
     
-    # Build models from json config
-    models = build_models_from_config(models_config)
+    # Build models from json config. Runtime acceptance is EXACT: every
+    # declared model id compiles with closed-object acceptance so unknown
+    # candidate fields reject instead of being silently discarded. Nested
+    # named models become exact before any parent captures their definition
+    # (build_models_from_config applies closure at construction).
+    models = build_models_from_config(
+        models_config, exact_model_ids=frozenset(models_config)
+    )
     
     # Build registry mapping agent names to models
     registry = {}
@@ -680,9 +693,12 @@ def build_dynamic_models(spec_models: list[dict[str, Any]], existing_models: dic
             'fields': fields
         }
     
-    # Build models using existing logic, combining with existing models
+    # Build models using existing logic, combining with existing models.
+    # Dynamic runtime models share the one exact acceptance contract.
     combined_models = existing_models.copy()
-    new_models = build_models_from_config(models_config)
+    new_models = build_models_from_config(
+        models_config, exact_model_ids=frozenset(models_config)
+    )
     combined_models.update(new_models)
     
     return new_models

--- a/mozaiksai/core/workflow/reserved_context_keys.py
+++ b/mozaiksai/core/workflow/reserved_context_keys.py
@@ -1,0 +1,50 @@
+"""Runtime-reserved context identifier vocabulary.
+
+Some context identifiers are runtime-owned: the runtime serves them as
+transient projections and applications must never declare them as ordinary
+context state. ``structured_output`` is the auto-tool projection of the exact
+validated agent output — declaring it in ``context_variables.yaml`` would give
+one identifier two meanings (application state vs runtime projection), so
+every canonical context declaration surface rejects it through this single
+shared authority.
+
+This module is a dependency-free leaf so declarative contract validation,
+typed context schema validation, and runtime context code can all consume the
+same vocabulary without import cycles.
+"""
+
+from __future__ import annotations
+
+#: The documented public auto-tool context key for validated agent output.
+STRUCTURED_OUTPUT_CONTEXT_KEY = "structured_output"
+
+#: Context identifiers owned by the runtime. Applications must not declare
+#: them in context_variables.yaml definitions or agent views; no authority
+#: metadata (authority_class, writer_ids, persisted, source, triggers) can
+#: legalize such a declaration.
+RUNTIME_RESERVED_CONTEXT_KEYS = frozenset({STRUCTURED_OUTPUT_CONTEXT_KEY})
+
+
+def require_application_context_name_allowed(name: object, *, where: str) -> str:
+    """Fail closed when an application declares a runtime-reserved identifier.
+
+    Returns the (unmodified) name so validators can use this as a pass-through
+    check. ``where`` names the declaring surface for the error message.
+    """
+    key = str(name or "").strip()
+    if key in RUNTIME_RESERVED_CONTEXT_KEYS:
+        raise ValueError(
+            f"{where} must not declare {key!r}: it is reserved runtime "
+            "vocabulary. The auto-tool structured_output projection is "
+            "runtime-owned and transient; tools read it via "
+            "context_variables.get(\"structured_output\") without any "
+            "declaration, and no declaration metadata can claim it."
+        )
+    return str(name)
+
+
+__all__ = [
+    "RUNTIME_RESERVED_CONTEXT_KEYS",
+    "STRUCTURED_OUTPUT_CONTEXT_KEY",
+    "require_application_context_name_allowed",
+]

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -284,10 +284,15 @@ async def test_ag2_structured_outputs_emit_runtime_event_and_update_context(
         wf_logger=SimpleNamespace(debug=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None),
     )
 
-    assert context_dict["structured_output"] == {"app_name": "ContractorFlow CRM"}
-    assert context_dict["_ConceptBlueprintLite"] == {"app_name": "ContractorFlow CRM"}
-    assert context_bridge.get("structured_output") == {"app_name": "ContractorFlow CRM"}
-    assert context_bridge.get("_ConceptBlueprintLite") == {"app_name": "ContractorFlow CRM"}
+    # structured_output is a runtime-owned transient projection: it must NOT
+    # be written into application context state or the pattern bridge. Auto
+    # tools observe it through the read-only overlay instead.
+    assert "structured_output" not in context_dict
+    assert "_ConceptBlueprintLite" not in context_dict
+    assert "structured_output_agent" not in context_dict
+    assert "structured_output_model" not in context_dict
+    assert context_bridge.get("structured_output") is None
+    assert context_bridge.get("_ConceptBlueprintLite") is None
     assert len(dispatcher.calls) == 1
     kind, payload = dispatcher.calls[0]
     assert kind == "runtime.agent_output_validated"

--- a/tests/test_auto_tool_binding_cache_and_concurrency.py
+++ b/tests/test_auto_tool_binding_cache_and_concurrency.py
@@ -16,7 +16,9 @@ terminal result releases the claim so a legitimate retry can run.
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -215,7 +217,7 @@ def _reload(tmp_path: Path, **kwargs) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_a_unchanged_workflow_reuses_cached_binding(
+async def test_a_unchanged_workflow_reuses_descriptors_with_fresh_callables(
     probe_manager, quiet_side_effects, build_counter
 ):
     handler = AutoToolEventHandler()
@@ -223,11 +225,16 @@ async def test_a_unchanged_workflow_reuses_cached_binding(
     await handler.handle_tool_dispatch(
         _event(structured_data=PAYLOAD, turn="turn-a1", pattern_context=pattern)
     )
+    first_entry = handler._workflow_binding_descriptors[WORKFLOW]
     await handler.handle_tool_dispatch(
         _event(structured_data=PAYLOAD, turn="turn-a2", pattern_context=pattern)
     )
     assert pattern.data["cache_probe_runs"] == 2
-    assert build_counter["count"] == 1
+    # Declarative descriptors are cached (same entry object reused)...
+    assert handler._workflow_binding_descriptors[WORKFLOW] is first_entry
+    # ...while the executable callable is resolved fresh through the canonical
+    # loader on EVERY dispatch — Python callable authority is never cached.
+    assert build_counter["count"] == 2
 
 
 async def test_b_structured_output_change_rebuilds_binding(
@@ -246,7 +253,6 @@ async def test_b_structured_output_change_rebuilds_binding(
         _event(structured_data=refreshed, turn="turn-b2", pattern_context=pattern)
     )
     assert pattern.data["cache_probe_runs"] == 2
-    assert build_counter["count"] == 2
 
     # The stale-shape payload cannot execute against the refreshed model.
     await handler.handle_tool_dispatch(
@@ -265,14 +271,14 @@ async def test_c_tool_declaration_and_code_changes_replace_the_callable(
     )
     assert pattern.data["cache_probe_marker"] == "v1"
 
-    # Tool CODE change with an unchanged tools.yaml: the cached callable must
-    # not be reused.
-    _reload(tmp_path, marker="v2-longer-content")
+    # Tool CODE change with an unchanged tools.yaml AND no workflow reload:
+    # the callable is resolved fresh per dispatch, so a stale function object
+    # never survives as execution authority.
+    _write_workflow(tmp_path, marker="v2-longer-content")
     await handler.handle_tool_dispatch(
         _event(structured_data=PAYLOAD, turn="turn-c2", pattern_context=pattern)
     )
     assert pattern.data["cache_probe_marker"] == "v2-longer-content"
-    assert build_counter["count"] == 2
 
     # tools.yaml binding change: the newly declared function executes.
     _reload(tmp_path, marker="v2-longer-content", function="record_run_alt")
@@ -280,7 +286,6 @@ async def test_c_tool_declaration_and_code_changes_replace_the_callable(
         _event(structured_data=PAYLOAD, turn="turn-c3", pattern_context=pattern)
     )
     assert pattern.data["cache_probe_marker"] == "alt-function"
-    assert build_counter["count"] == 3
 
 
 async def test_d_unload_then_reload_leaves_no_stale_binding(
@@ -350,6 +355,170 @@ async def test_f_failed_reload_cannot_serve_the_stale_binding(
         _event(structured_data=PAYLOAD, turn="turn-f3", pattern_context=pattern)
     )
     assert pattern.data["cache_probe_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Imported-helper freshness: callable behavior beyond direct tool-file bytes
+# ---------------------------------------------------------------------------
+
+_HELPER_TOOL_SOURCE = '''
+from .helper_mod import helper_marker
+
+
+async def record_run(context_variables=None):
+    context_variables.set("cache_probe_marker", helper_marker())
+    return {"status": "ok"}
+'''
+
+_HELPER_MOD_TEMPLATE = '''
+def helper_marker():
+    return "{marker}"
+'''
+
+_SHARED_TOOL_SOURCE = '''
+from factpkg_ns.workflows._shared.shared_helper import helper_marker
+
+
+async def record_run(context_variables=None):
+    context_variables.set("cache_probe_marker", helper_marker())
+    return {"status": "ok"}
+'''
+
+
+def _write_helper_workflow(root: Path, *, helper_marker: str, tool_source: str = _HELPER_TOOL_SOURCE) -> None:
+    _write_workflow(root)
+    workflow_dir = root / WORKFLOW
+    (workflow_dir / "tools" / "cache_tool.py").write_text(tool_source, encoding="utf-8")
+    (workflow_dir / "tools" / "helper_mod.py").write_text(
+        _HELPER_MOD_TEMPLATE.format(marker=helper_marker), encoding="utf-8"
+    )
+
+
+async def test_imported_workflow_helper_change_is_observed_without_reload(
+    probe_manager, quiet_side_effects, tmp_path
+):
+    """Same direct tool file, imported workflow helper changes -> next dispatch
+    executes the NEW helper behavior (workflows.* namespace)."""
+    _write_helper_workflow(tmp_path, helper_marker="helper-v1")
+    info = workflow_manager.reload_workflow(WORKFLOW)
+    assert not info.get("error"), info
+
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-h1", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_marker"] == "helper-v1"
+
+    # Change ONLY the imported helper: tools.yaml and the direct tool file
+    # stay byte-identical, and no workflow reload happens.
+    (tmp_path / WORKFLOW / "tools" / "helper_mod.py").write_text(
+        _HELPER_MOD_TEMPLATE.format(marker="helper-v2-longer"), encoding="utf-8"
+    )
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-h2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_marker"] == "helper-v2-longer"
+
+
+async def test_shared_helper_change_in_real_package_namespace_is_observed(
+    quiet_side_effects, tmp_path, monkeypatch
+):
+    """Helper changes reached through the derived real package chain (the
+    factory_app.workflows-style namespace) are observed on the next dispatch."""
+    package_root = tmp_path / "factpkg_ns"
+    workflows_root = package_root / "workflows"
+    shared_root = workflows_root / "_shared"
+    shared_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (workflows_root / "__init__.py").write_text("", encoding="utf-8")
+    (shared_root / "__init__.py").write_text("", encoding="utf-8")
+    (shared_root / "shared_helper.py").write_text(
+        _HELPER_MOD_TEMPLATE.format(marker="shared-v1"), encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = workflows_root
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        _write_helper_workflow(workflows_root, helper_marker="unused", tool_source=_SHARED_TOOL_SOURCE)
+        info = workflow_manager.reload_workflow(WORKFLOW)
+        assert not info.get("error"), info
+
+        handler = AutoToolEventHandler()
+        pattern = _PatternContext()
+        await handler.handle_tool_dispatch(
+            _event(structured_data=PAYLOAD, turn="turn-s1", pattern_context=pattern)
+        )
+        assert pattern.data["cache_probe_marker"] == "shared-v1"
+
+        (shared_root / "shared_helper.py").write_text(
+            _HELPER_MOD_TEMPLATE.format(marker="shared-v2-longer"), encoding="utf-8"
+        )
+        await handler.handle_tool_dispatch(
+            _event(structured_data=PAYLOAD, turn="turn-s2", pattern_context=pattern)
+        )
+        assert pattern.data["cache_probe_marker"] == "shared-v2-longer"
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+        for module_name in [m for m in list(sys.modules) if m == "factpkg_ns" or m.startswith("factpkg_ns.")]:
+            sys.modules.pop(module_name, None)
+
+
+async def test_unrelated_workflow_helper_modules_are_not_disturbed(
+    probe_manager, quiet_side_effects, tmp_path
+):
+    """Loading another workflow's tools does not clear this workflow's cached
+    helper modules."""
+    _write_helper_workflow(tmp_path, helper_marker="helper-v1")
+    info = workflow_manager.reload_workflow(WORKFLOW)
+    assert not info.get("error"), info
+
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-i1", pattern_context=pattern)
+    )
+    helper_module = sys.modules.get(f"workflows.{WORKFLOW}.tools.helper_mod")
+    assert helper_module is not None
+
+    # A second, unrelated workflow loads its own tools.
+    other_dir = tmp_path / "OtherProbeWf"
+    (other_dir / "tools").mkdir(parents=True)
+    (other_dir / "orchestrator.yaml").write_text(
+        "schema_version: mozaiks.orchestrator.v1\nworkflow_name: OtherProbeWf\n"
+        "workflow_startup_mode: BackendOnly\nmax_turns: 1\n",
+        encoding="utf-8",
+    )
+    (other_dir / "tools.yaml").write_text(
+        "tools:\n- agent: OtherAgent\n  file: other_tool.py\n  function: other_tool\n"
+        "  description: Unrelated tool.\n  tool_type: Agent_Tool\n  auto_tool_call: true\n",
+        encoding="utf-8",
+    )
+    (other_dir / "tools" / "other_tool.py").write_text(
+        "async def other_tool(context_variables=None):\n    return {\"status\": \"ok\"}\n",
+        encoding="utf-8",
+    )
+    from mozaiksai.core.workflow.agents.tools import load_agent_tool_functions
+
+    load_agent_tool_functions("OtherProbeWf", include_auto_only=True)
+    assert sys.modules.get(f"workflows.{WORKFLOW}.tools.helper_mod") is helper_module
 
 
 # ---------------------------------------------------------------------------
@@ -508,3 +677,216 @@ async def test_completed_turn_remains_suppressed_across_resume(monkeypatch):
     assert tool.started == 1
     assert tool.completed == 1
     assert handler._in_flight_keys == set()
+    # Completed turns keep only bounded processed-set membership.
+    assert handler._turn_checkpoints == {}
+
+
+# ---------------------------------------------------------------------------
+# Per-binding execution checkpoints: cancellation attack matrix
+# ---------------------------------------------------------------------------
+
+
+class _Barrier:
+    """Deterministic stage barrier (no timing sleeps)."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def wait(self) -> None:
+        self.entered.set()
+        await self.release.wait()
+
+
+class _CountingTool:
+    def __init__(self, name: str, *, fail: bool = False) -> None:
+        self.name = name
+        self.invocations = 0
+        self.fail = fail
+
+    async def __call__(self, context_variables=None):
+        self.invocations += 1
+        if self.fail:
+            raise RuntimeError(f"{self.name} truthful terminal failure")
+        return {"status": "ok", "tool": self.name}
+
+
+class _StageProbes:
+    """Per-stage call counters with optional one-shot blocking barriers."""
+
+    def __init__(self) -> None:
+        self.tool_call_emits: list[str] = []
+        self.persist_calls: list[Any] = []
+        self.result_emits: list[str] = []
+        self.block_tool_call: _Barrier | None = None
+        self.block_persist_on_call: tuple[int, _Barrier] | None = None
+        self.block_result_on_call: tuple[int, _Barrier] | None = None
+
+
+def _handler_with_stage_probes(
+    monkeypatch, tools: list[_CountingTool]
+) -> tuple[AutoToolEventHandler, _StageProbes]:
+    handler = AutoToolEventHandler()
+    probes = _StageProbes()
+
+    class _Validated:
+        @staticmethod
+        def model_dump(mode="json"):
+            return dict(PAYLOAD)
+
+    class _Model:
+        @staticmethod
+        def model_validate(data):
+            return _Validated()
+
+    bindings = [
+        AutoToolBinding(
+            model_name="CacheOutput",
+            agent_name="CacheAgent",
+            tool_name=tool.name,
+            function=tool,
+            param_names=("context_variables",),
+            accepts_context=True,
+            ui_config={},
+            model_cls=_Model,
+        )
+        for tool in tools
+    ]
+
+    async def resolve(workflow_name, model_name, agent_name):
+        return list(bindings)
+
+    async def emit_tool_call(binding, agent_name, chat_id, kwargs, turn_key):
+        probes.tool_call_emits.append(binding.tool_name)
+        if probes.block_tool_call is not None:
+            await probes.block_tool_call.wait()
+
+    async def persist(**kwargs):
+        probes.persist_calls.append(kwargs.get("context_variables"))
+        if probes.block_persist_on_call is not None:
+            call_number, barrier = probes.block_persist_on_call
+            if len(probes.persist_calls) == call_number:
+                await barrier.wait()
+
+    async def emit_tool_result(binding, agent_name, chat_id, result, status, turn_key):
+        probes.result_emits.append(f"{binding.tool_name}:{status}")
+        if probes.block_result_on_call is not None:
+            call_number, barrier = probes.block_result_on_call
+            if len(probes.result_emits) == call_number:
+                await barrier.wait()
+
+    monkeypatch.setattr(handler, "_resolve_bindings", resolve)
+    monkeypatch.setattr(handler, "_emit_tool_call", emit_tool_call)
+    monkeypatch.setattr(handler, "_persist_context_variables", persist)
+    monkeypatch.setattr(handler, "_emit_tool_result", emit_tool_result)
+    return handler, probes
+
+
+async def _cancel_at(barrier: _Barrier, task: asyncio.Task) -> None:
+    await barrier.entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_cancel_before_tool_invocation_allows_retry_single_invocation(monkeypatch):
+    tool = _CountingTool("alpha")
+    handler, probes = _handler_with_stage_probes(monkeypatch, [tool])
+    probes.block_tool_call = _Barrier()
+    task = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-m1")))
+    await _cancel_at(probes.block_tool_call, task)
+    assert tool.invocations == 0  # interrupted pre-execution
+
+    probes.block_tool_call = None
+    await handler.handle_tool_dispatch(_raw_event("turn-m1"))
+    assert tool.invocations == 1
+
+
+async def test_cancel_during_persistence_never_reinvokes_the_tool(monkeypatch):
+    tool = _CountingTool("alpha")
+    handler, probes = _handler_with_stage_probes(monkeypatch, [tool])
+    barrier = _Barrier()
+    probes.block_persist_on_call = (1, barrier)
+    task = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-m2")))
+    await _cancel_at(barrier, task)
+    assert tool.invocations == 1  # tool returned before the cancelled persist
+
+    probes.block_persist_on_call = None
+    await handler.handle_tool_dispatch(_raw_event("turn-m2"))
+    # tool returned successfully -> cancellation during persistence -> retry
+    # -> total tool invocations = 1; persistence retried; result emitted once.
+    assert tool.invocations == 1
+    assert len(probes.persist_calls) == 2
+    assert probes.result_emits == ["alpha:ok"]
+    # The tool-call emission stage completed pre-cancellation and is not
+    # needlessly duplicated on resume.
+    assert probes.tool_call_emits == ["alpha"]
+
+
+async def test_cancel_during_result_emission_never_reinvokes_or_repersists(monkeypatch):
+    tool = _CountingTool("alpha")
+    handler, probes = _handler_with_stage_probes(monkeypatch, [tool])
+    barrier = _Barrier()
+    probes.block_result_on_call = (1, barrier)
+    task = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-m3")))
+    await _cancel_at(barrier, task)
+    assert tool.invocations == 1
+
+    probes.block_result_on_call = None
+    await handler.handle_tool_dispatch(_raw_event("turn-m3"))
+    assert tool.invocations == 1
+    # Persistence completed before the cancelled emission stage: not redone.
+    assert len(probes.persist_calls) == 1
+    # Result emission was interrupted mid-flight (completion unknown), so the
+    # retry re-emits it exactly once.
+    assert probes.result_emits == ["alpha:ok", "alpha:ok"]
+
+
+async def test_multi_binding_resume_never_restarts_executed_bindings(monkeypatch):
+    tool_a = _CountingTool("alpha")
+    tool_b = _CountingTool("beta")
+    tool_c = _CountingTool("gamma")
+    handler, probes = _handler_with_stage_probes(monkeypatch, [tool_a, tool_b, tool_c])
+    barrier = _Barrier()
+    # Block B's persistence: cancel after B's tool result, before B's
+    # post-processing completes (A is fully COMPLETE by then).
+    probes.block_persist_on_call = (2, barrier)
+    task = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-m4")))
+    await _cancel_at(barrier, task)
+    assert (tool_a.invocations, tool_b.invocations, tool_c.invocations) == (1, 1, 0)
+
+    probes.block_persist_on_call = None
+    await handler.handle_tool_dispatch(_raw_event("turn-m4"))
+    # A never re-ran, B never re-ran (post-processing resumed), C ran once.
+    assert (tool_a.invocations, tool_b.invocations, tool_c.invocations) == (1, 1, 1)
+    assert probes.result_emits == ["alpha:ok", "beta:ok", "gamma:ok"]
+
+
+async def test_truthful_tool_failure_is_terminal_and_never_reinvoked(monkeypatch):
+    tool = _CountingTool("alpha", fail=True)
+    handler, probes = _handler_with_stage_probes(monkeypatch, [tool])
+    barrier = _Barrier()
+    probes.block_persist_on_call = (1, barrier)
+    task = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-m5")))
+    await _cancel_at(barrier, task)
+    assert tool.invocations == 1
+
+    probes.block_persist_on_call = None
+    await handler.handle_tool_dispatch(_raw_event("turn-m5"))
+    # A truthful failure is still a terminal execution result for this turn.
+    assert tool.invocations == 1
+    assert probes.result_emits == ["alpha:error"]
+
+
+async def test_checkpoint_bookkeeping_is_bounded_and_never_evicts_active_state(monkeypatch):
+    handler, probes = _handler_with_stage_probes(monkeypatch, [_CountingTool("alpha")])
+    handler._CACHE_LIMIT = 3  # instance override for the bound proof
+    active_key = "chat-active:turn-active"
+    handler._in_flight_keys.add(active_key)
+    handler._turn_checkpoints[active_key] = {}
+    for index in range(5):
+        handler._turn_checkpoints[f"chat-old:turn-{index}"] = {}
+    handler._trim_turn_checkpoints()
+    assert len(handler._turn_checkpoints) <= 3
+    assert active_key in handler._turn_checkpoints  # active state never evicted
+    handler._in_flight_keys.discard(active_key)

--- a/tests/test_auto_tool_binding_cache_and_concurrency.py
+++ b/tests/test_auto_tool_binding_cache_and_concurrency.py
@@ -1,0 +1,510 @@
+"""Auto-tool binding cache self-validation and in-flight turn idempotency.
+
+The AutoToolEventHandler binding cache resolves the CURRENT structured-output
+registry and tool-declaration authority before any cached binding is reused:
+a cached workflow binding is reusable only while its authority fingerprint
+(exact model class identity per agent, tools.yaml bytes, referenced tool file
+bytes, workflow path) still matches. reload/unload/refresh/failed-reload can
+never leave a stale binding or stale callable executing.
+
+Turn idempotency claims each ``chat_id + turn_idempotency_key`` atomically
+BEFORE the first await: concurrent duplicate deliveries observe IN_FLIGHT (or
+COMPLETED) and never execute; an unexpected interruption before a truthful
+terminal result releases the claim so a legitimate retry can run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.events import auto_tool_handler as _auto_tool_mod
+from mozaiksai.core.events.runtime_events import (
+    build_runtime_agent_output_validated_event,
+)
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+AutoToolBinding = _auto_tool_mod.AutoToolBinding
+AutoToolEventHandler = _auto_tool_mod.AutoToolEventHandler
+
+WORKFLOW = "CacheProbeWf"
+
+_AGENT_TEMPLATE = (
+    "  - name: CacheAgent\n"
+    "    structured_outputs_required: true\n"
+    "    prompt_sections:\n"
+    "      - id: role\n"
+    "        heading: ROLE\n"
+    "        content: probe\n"
+)
+
+_TOOL_SOURCE_TEMPLATE = '''
+async def record_run(context_variables=None):
+    runs = context_variables.get("cache_probe_runs") or 0
+    context_variables.set("cache_probe_runs", runs + 1)
+    context_variables.set("cache_probe_marker", "{marker}")
+    return {{"status": "ok"}}
+
+
+async def record_run_alt(context_variables=None):
+    context_variables.set("cache_probe_marker", "alt-function")
+    return {{"status": "ok"}}
+'''
+
+_TOOLS_YAML_TEMPLATE = """tools:
+- agent: CacheAgent
+  file: cache_tool.py
+  function: {function}
+  description: Cache probe auto tool.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+"""
+
+
+def _write_workflow(
+    root: Path,
+    *,
+    fields: str = "title: { type: str }",
+    marker: str = "v1",
+    function: str = "record_run",
+    structured_outputs_text: str | None = None,
+) -> None:
+    workflow_dir = root / WORKFLOW
+    (workflow_dir / "tools").mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "orchestrator.yaml").write_text(
+        f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {WORKFLOW}\n"
+        "workflow_startup_mode: BackendOnly\nmax_turns: 1\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "agents.yaml").write_text("agents:\n" + _AGENT_TEMPLATE, encoding="utf-8")
+    if structured_outputs_text is None:
+        structured_outputs_text = (
+            "schema_version: mozaiks.structured_outputs.v1\n"
+            "registry:\n  CacheAgent: CacheOutput\n"
+            "models:\n  CacheOutput:\n    type: model\n    fields:\n"
+            f"      {fields}\n"
+        )
+    (workflow_dir / "structured_outputs.yaml").write_text(structured_outputs_text, encoding="utf-8")
+    (workflow_dir / "context_variables.yaml").write_text(
+        "definitions:\n"
+        "  cache_probe_runs:\n"
+        "    type: number\n"
+        "    description: Executions counted by the cache probe tool.\n"
+        "    writer_ids: [deterministic_tool]\n"
+        "    source: { type: state, default: null }\n"
+        "  cache_probe_marker:\n"
+        "    type: string\n"
+        "    description: Marker written by the loaded tool version.\n"
+        "    writer_ids: [deterministic_tool]\n"
+        "    source: { type: state, default: null }\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "tools.yaml").write_text(
+        _TOOLS_YAML_TEMPLATE.format(function=function), encoding="utf-8"
+    )
+    (workflow_dir / "tools" / "cache_tool.py").write_text(
+        _TOOL_SOURCE_TEMPLATE.format(marker=marker), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def probe_manager(tmp_path: Path):
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = tmp_path
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        _write_workflow(tmp_path)
+        info = workflow_manager.reload_workflow(WORKFLOW)
+        assert not info.get("error"), info
+        yield workflow_manager
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+@pytest.fixture
+def quiet_side_effects(monkeypatch):
+    class _FakePersistenceManager:
+        async def persist_context_variables(self, **kwargs):
+            return None
+
+    async def _no_transport():
+        return None
+
+    monkeypatch.setattr(_auto_tool_mod, "AG2PersistenceManager", _FakePersistenceManager)
+    monkeypatch.setattr(_auto_tool_mod, "_get_simple_transport", _no_transport)
+
+
+@pytest.fixture
+def build_counter(monkeypatch):
+    calls = {"count": 0}
+    real_loader = _auto_tool_mod.load_agent_tool_functions
+
+    def counting_loader(*args, **kwargs):
+        calls["count"] += 1
+        return real_loader(*args, **kwargs)
+
+    monkeypatch.setattr(_auto_tool_mod, "load_agent_tool_functions", counting_loader)
+    return calls
+
+
+class _PatternContext:
+    def __init__(self) -> None:
+        self.data: dict = {}
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def snapshot(self):
+        return dict(self.data)
+
+    def to_dict(self):
+        return self.snapshot()
+
+
+def _event(
+    *,
+    structured_data: dict,
+    turn: str,
+    chat_id: str = "chat-1",
+    pattern_context=None,
+):
+    return build_runtime_agent_output_validated_event(
+        agent="CacheAgent",
+        model_name="CacheOutput",
+        structured_data=structured_data,
+        auto_tool_call=True,
+        context={"chat_id": chat_id, "app_id": "app-1", "workflow_name": WORKFLOW},
+        turn_idempotency_key=turn,
+        pattern_context_ref=pattern_context,
+        validation_passed=True,
+    )
+
+
+PAYLOAD = {"title": "Cache Probe"}
+
+
+def _reload(tmp_path: Path, **kwargs) -> None:
+    _write_workflow(tmp_path, **kwargs)
+    info = workflow_manager.reload_workflow(WORKFLOW)
+    assert not info.get("error"), info
+
+
+# ---------------------------------------------------------------------------
+# Binding-cache lifecycle (cases A-F)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_unchanged_workflow_reuses_cached_binding(
+    probe_manager, quiet_side_effects, build_counter
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-a1", pattern_context=pattern)
+    )
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-a2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+    assert build_counter["count"] == 1
+
+
+async def test_b_structured_output_change_rebuilds_binding(
+    probe_manager, quiet_side_effects, build_counter, tmp_path
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-b1", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 1
+
+    _reload(tmp_path, fields="title: { type: str }\n      status: { type: str }")
+    refreshed = {"title": "Cache Probe", "status": "ready"}
+    await handler.handle_tool_dispatch(
+        _event(structured_data=refreshed, turn="turn-b2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+    assert build_counter["count"] == 2
+
+    # The stale-shape payload cannot execute against the refreshed model.
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-b3", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+
+
+async def test_c_tool_declaration_and_code_changes_replace_the_callable(
+    probe_manager, quiet_side_effects, build_counter, tmp_path
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-c1", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_marker"] == "v1"
+
+    # Tool CODE change with an unchanged tools.yaml: the cached callable must
+    # not be reused.
+    _reload(tmp_path, marker="v2-longer-content")
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-c2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_marker"] == "v2-longer-content"
+    assert build_counter["count"] == 2
+
+    # tools.yaml binding change: the newly declared function executes.
+    _reload(tmp_path, marker="v2-longer-content", function="record_run_alt")
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-c3", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_marker"] == "alt-function"
+    assert build_counter["count"] == 3
+
+
+async def test_d_unload_then_reload_leaves_no_stale_binding(
+    probe_manager, quiet_side_effects, tmp_path
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-d1", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 1
+
+    workflow_manager.unload_workflow(WORKFLOW)
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-d2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 1  # no stale execution
+
+    _reload(tmp_path)
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-d3", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+
+
+async def test_e_refresh_all_rebuilds_bindings(
+    probe_manager, quiet_side_effects, build_counter
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-e1", pattern_context=pattern)
+    )
+    workflow_manager.refresh_all()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-e2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+    assert build_counter["count"] == 2
+
+
+async def test_f_failed_reload_cannot_serve_the_stale_binding(
+    probe_manager, quiet_side_effects, tmp_path
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-f1", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 1
+
+    # Replacement configuration fails validation: the prior binding must not
+    # silently remain authority for the failed replacement.
+    _write_workflow(
+        tmp_path,
+        structured_outputs_text="schema_version: mozaiks.structured_outputs.v1\nregistry: [broken\n",
+    )
+    info = workflow_manager.reload_workflow(WORKFLOW)
+    assert info.get("error")
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-f2", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 1  # nothing executed
+
+    _reload(tmp_path)
+    await handler.handle_tool_dispatch(
+        _event(structured_data=PAYLOAD, turn="turn-f3", pattern_context=pattern)
+    )
+    assert pattern.data["cache_probe_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# In-flight idempotency (concurrency proofs)
+# ---------------------------------------------------------------------------
+
+
+class _BlockingTool:
+    """Event-controlled tool: deterministically holds executions in flight."""
+
+    def __init__(self) -> None:
+        self.started = 0
+        self.completed = 0
+        self.release = asyncio.Event()
+        self.entered = asyncio.Event()
+
+    async def __call__(self, context_variables=None):
+        self.started += 1
+        self.entered.set()
+        await self.release.wait()
+        self.completed += 1
+        return {"status": "ok"}
+
+
+def _handler_with_blocking_tool(monkeypatch) -> tuple[AutoToolEventHandler, _BlockingTool]:
+    handler = AutoToolEventHandler()
+    tool = _BlockingTool()
+
+    class _Validated:
+        @staticmethod
+        def model_dump(mode="json"):
+            return dict(PAYLOAD)
+
+    class _Model:
+        @staticmethod
+        def model_validate(data):
+            return _Validated()
+
+    binding = AutoToolBinding(
+        model_name="CacheOutput",
+        agent_name="CacheAgent",
+        tool_name="blocking_tool",
+        function=tool,
+        param_names=("context_variables",),
+        accepts_context=True,
+        ui_config={},
+        model_cls=_Model,
+    )
+
+    async def resolve(workflow_name, model_name, agent_name):
+        return [binding]
+
+    monkeypatch.setattr(handler, "_resolve_bindings", resolve)
+    monkeypatch.setattr(handler, "_emit_tool_call", _async_noop)
+    monkeypatch.setattr(handler, "_emit_tool_result", _async_noop)
+    monkeypatch.setattr(handler, "_persist_context_variables", _async_noop_kw)
+    return handler, tool
+
+
+async def _async_noop(*args, **kwargs):
+    return None
+
+
+async def _async_noop_kw(*args, **kwargs):
+    return None
+
+
+def _raw_event(turn: str, chat_id: str = "chat-1"):
+    return _event(structured_data=PAYLOAD, turn=turn, chat_id=chat_id, pattern_context=_PatternContext())
+
+
+async def test_two_concurrent_same_key_deliveries_execute_once(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    first = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-x")))
+    second = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-x")))
+    await tool.entered.wait()
+    tool.release.set()
+    await asyncio.gather(first, second)
+    assert tool.started == 1
+    assert tool.completed == 1
+
+
+async def test_n_concurrent_same_key_deliveries_execute_once(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    tasks = [
+        asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-n")))
+        for _ in range(8)
+    ]
+    await tool.entered.wait()
+    tool.release.set()
+    await asyncio.gather(*tasks)
+    assert tool.started == 1
+    assert tool.completed == 1
+
+
+async def test_same_chat_different_turn_keys_both_execute(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    tool.release.set()
+    await handler.handle_tool_dispatch(_raw_event("turn-1"))
+    await handler.handle_tool_dispatch(_raw_event("turn-2"))
+    assert tool.started == 2
+
+
+async def test_different_chat_same_turn_key_text_execute_independently(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    tool.release.set()
+    await handler.handle_tool_dispatch(_raw_event("turn-same", chat_id="chat-a"))
+    await handler.handle_tool_dispatch(_raw_event("turn-same", chat_id="chat-b"))
+    assert tool.started == 2
+
+
+async def test_cancellation_releases_claim_for_legitimate_retry(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    first = asyncio.create_task(handler.handle_tool_dispatch(_raw_event("turn-c")))
+    await tool.entered.wait()
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert handler._in_flight_keys == set()  # no permanently stuck claim
+
+    tool.release.set()
+    await handler.handle_tool_dispatch(_raw_event("turn-c"))
+    assert tool.started == 2
+    assert tool.completed == 1
+
+
+async def test_unexpected_failure_before_terminal_result_allows_retry(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    tool.release.set()
+    boom = {"raise": True}
+
+    async def exploding_emit(*args, **kwargs):
+        if boom["raise"]:
+            raise RuntimeError("unexpected interruption before terminal result")
+
+    monkeypatch.setattr(handler, "_emit_tool_call", exploding_emit)
+    with pytest.raises(RuntimeError):
+        await handler.handle_tool_dispatch(_raw_event("turn-u"))
+    assert handler._in_flight_keys == set()
+
+    boom["raise"] = False
+    await handler.handle_tool_dispatch(_raw_event("turn-u"))
+    assert tool.completed == 1
+
+
+async def test_completed_turn_remains_suppressed_across_resume(monkeypatch):
+    handler, tool = _handler_with_blocking_tool(monkeypatch)
+    tool.release.set()
+    event = _raw_event("turn-done")
+    await handler.handle_tool_dispatch(event)
+    assert tool.completed == 1
+    # Sequential duplicate, and a HITL-style resume redelivery of the same
+    # completed turn, both suppress: exactly one side effect.
+    await handler.handle_tool_dispatch(event)
+    await handler.handle_tool_dispatch(_raw_event("turn-done"))
+    assert tool.started == 1
+    assert tool.completed == 1
+    assert handler._in_flight_keys == set()

--- a/tests/test_auto_tool_structured_output_contract.py
+++ b/tests/test_auto_tool_structured_output_contract.py
@@ -1,0 +1,564 @@
+"""structured_output is a runtime-owned transient read-only auto-tool projection.
+
+The documented public contract — ``context_variables.get("structured_output")``
+returns the exact validated ``structured_data`` for the current auto-tool
+turn — is satisfied by a read-only overlay over the live workflow context.
+No application-declared context variable is required, no writer can set or
+replace the key, snapshots and persistence never include it, and the next
+turn cannot inherit it as ordinary state. Ordinary context behavior for all
+other keys is preserved, including deliberate tool writes under different
+declared application keys.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from mozaiksai.core.events import auto_tool_handler as _auto_tool_mod
+from mozaiksai.core.events.runtime_events import (
+    build_runtime_agent_output_validated_event,
+    build_turn_idempotency_key,
+)
+from mozaiksai.core.workflow.context.adapter import create_context_container
+from mozaiksai.core.workflow.context.structured_output_overlay import (
+    STRUCTURED_OUTPUT_KEY,
+    StructuredOutputOverlay,
+    StructuredOutputWriteError,
+)
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+AutoToolEventHandler = _auto_tool_mod.AutoToolEventHandler
+
+WORKFLOW = "AutoToolProbe"
+
+_AGENT_TEMPLATE = (
+    "  - name: {name}\n"
+    "    structured_outputs_required: true\n"
+    "    prompt_sections:\n"
+    "      - id: role\n"
+    "        heading: ROLE\n"
+    "        content: probe\n"
+)
+
+_TOOL_SOURCE = '''
+"""Probe auto tools exercising the documented structured_output contract."""
+
+
+async def save_context_only(context_variables=None):
+    data = context_variables.get("structured_output")
+    if not data:
+        return {"status": "error", "message": "no structured_output visible"}
+    context_variables.set("observed_structured_output", dict(data))
+    runs = context_variables.get("context_only_runs") or 0
+    context_variables.set("context_only_runs", runs + 1)
+    return {"status": "ok"}
+
+
+async def save_explicit(title: str, status: str, context_variables=None):
+    data = context_variables.get("structured_output")
+    context_variables.set(
+        "explicit_matches_context",
+        bool(data) and data.get("title") == title and data.get("status") == status,
+    )
+    return {"status": "ok"}
+
+
+async def try_mutation(context_variables=None):
+    outcomes = {}
+    try:
+        context_variables.set("structured_output", {"forged": True})
+        outcomes["set"] = "allowed"
+    except Exception as exc:
+        outcomes["set"] = type(exc).__name__
+    try:
+        context_variables.remove("structured_output")
+        outcomes["remove"] = "allowed"
+    except Exception as exc:
+        outcomes["remove"] = type(exc).__name__
+    frozen = context_variables.get("structured_output")
+    try:
+        frozen["title"] = "mutated"
+        outcomes["item_assignment"] = "allowed"
+    except TypeError:
+        outcomes["item_assignment"] = "TypeError"
+    after = context_variables.get("structured_output")
+    outcomes["value_after_attempts"] = dict(after) if after else None
+    context_variables.set("mutation_outcomes", outcomes)
+    return {"status": "ok"}
+'''
+
+_TOOLS_YAML = """tools:
+- agent: ContextOnlyAgent
+  file: probe_tools.py
+  function: save_context_only
+  description: Context-only auto tool.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+- agent: ExplicitAgent
+  file: probe_tools.py
+  function: save_explicit
+  description: Explicit-param auto tool.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+- agent: MutatorAgent
+  file: probe_tools.py
+  function: try_mutation
+  description: Mutation-attempt auto tool.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+"""
+
+_STRUCTURED_OUTPUTS = """schema_version: mozaiks.structured_outputs.v1
+registry:
+  ContextOnlyAgent: ProbeOutput
+  ExplicitAgent: ProbeOutput
+  MutatorAgent: ProbeOutput
+models:
+  ProbeOutput:
+    type: model
+    fields:
+      title: { type: str }
+      status: { type: str }
+"""
+
+# The declared application keys the probe tools write. structured_output is
+# deliberately NOT declared: it is runtime-owned and needs no declaration.
+_CONTEXT_VARIABLES = """definitions:
+  observed_structured_output:
+    type: object
+    description: Tool-saved copy of the validated output under a declared key.
+    writer_ids: [deterministic_tool]
+    source:
+      type: state
+      default: null
+  context_only_runs:
+    type: number
+    description: How many times the context-only probe tool executed.
+    writer_ids: [deterministic_tool]
+    source:
+      type: state
+      default: null
+  explicit_matches_context:
+    type: boolean
+    description: Whether explicit params matched the context projection.
+    writer_ids: [deterministic_tool]
+    source:
+      type: state
+      default: null
+  mutation_outcomes:
+    type: object
+    description: Outcomes of attempted projection mutations.
+    writer_ids: [deterministic_tool]
+    source:
+      type: state
+      default: null
+"""
+
+
+def _write_workflow(root: Path) -> None:
+    workflow_dir = root / WORKFLOW
+    (workflow_dir / "tools").mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "orchestrator.yaml").write_text(
+        f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {WORKFLOW}\n"
+        "workflow_startup_mode: BackendOnly\n"
+        "initial_agent: ContextOnlyAgent\n"
+        "max_turns: 1\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "agents.yaml").write_text(
+        "agents:\n"
+        + _AGENT_TEMPLATE.format(name="ContextOnlyAgent")
+        + _AGENT_TEMPLATE.format(name="ExplicitAgent")
+        + _AGENT_TEMPLATE.format(name="MutatorAgent"),
+        encoding="utf-8",
+    )
+    (workflow_dir / "structured_outputs.yaml").write_text(_STRUCTURED_OUTPUTS, encoding="utf-8")
+    (workflow_dir / "context_variables.yaml").write_text(_CONTEXT_VARIABLES, encoding="utf-8")
+    (workflow_dir / "tools.yaml").write_text(_TOOLS_YAML, encoding="utf-8")
+    (workflow_dir / "tools" / "probe_tools.py").write_text(_TOOL_SOURCE, encoding="utf-8")
+
+
+@pytest.fixture
+def probe_manager(tmp_path: Path):
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = tmp_path
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        _write_workflow(tmp_path)
+        info = workflow_manager.reload_workflow(WORKFLOW)
+        assert not info.get("error"), info
+        yield workflow_manager
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+class _PatternContext:
+    """Minimal live pattern context stand-in (AG2 WorkflowState surface)."""
+
+    def __init__(self, initial: dict | None = None) -> None:
+        self.data = dict(initial or {})
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def remove(self, key):
+        return self.data.pop(key, None) is not None
+
+    def contains(self, key):
+        return key in self.data
+
+    def keys(self):
+        return self.data.keys()
+
+    def snapshot(self):
+        return dict(self.data)
+
+    def to_dict(self):
+        return self.snapshot()
+
+
+@pytest.fixture
+def persisted_snapshots(monkeypatch):
+    captured: list[dict] = []
+
+    class _FakePersistenceManager:
+        async def persist_context_variables(self, **kwargs):
+            captured.append(dict(kwargs.get("variables") or {}))
+
+    monkeypatch.setattr(_auto_tool_mod, "AG2PersistenceManager", _FakePersistenceManager)
+    return captured
+
+
+@pytest.fixture
+def quiet_transport(monkeypatch):
+    async def _no_transport():
+        return None
+
+    monkeypatch.setattr(_auto_tool_mod, "_get_simple_transport", _no_transport)
+
+
+def _event(
+    agent: str,
+    *,
+    structured_data: dict,
+    turn: int = 1,
+    pattern_context=None,
+    context_variables: dict | None = None,
+):
+    context = {
+        "chat_id": "chat-1",
+        "app_id": "app-1",
+        "workflow_name": WORKFLOW,
+    }
+    if context_variables is not None:
+        context["context_variables"] = context_variables
+    return build_runtime_agent_output_validated_event(
+        agent=agent,
+        model_name="ProbeOutput",
+        structured_data=structured_data,
+        auto_tool_call=True,
+        context=context,
+        turn_idempotency_key=build_turn_idempotency_key("chat-1", turn),
+        pattern_context_ref=pattern_context,
+        validation_passed=True,
+    )
+
+
+PAYLOAD = {"title": "Exact Title", "status": "ready"}
+
+
+# ---------------------------------------------------------------------------
+# Overlay unit contract
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_reads_exact_payload_and_delegates_other_keys():
+    base = create_context_container({"declared_key": "value"})
+    overlay = StructuredOutputOverlay(base, PAYLOAD)
+    assert dict(overlay.get(STRUCTURED_OUTPUT_KEY)) == PAYLOAD
+    assert isinstance(overlay.get(STRUCTURED_OUTPUT_KEY), MappingProxyType)
+    assert overlay.get("declared_key") == "value"
+    assert overlay.contains(STRUCTURED_OUTPUT_KEY)
+    assert STRUCTURED_OUTPUT_KEY in overlay
+    assert STRUCTURED_OUTPUT_KEY not in list(overlay.keys())
+    overlay.set("another_key", 5)
+    assert base.get("another_key") == 5
+
+
+def test_overlay_fails_every_projection_mutation_closed():
+    overlay = StructuredOutputOverlay(create_context_container({}), PAYLOAD)
+    with pytest.raises(StructuredOutputWriteError):
+        overlay.set(STRUCTURED_OUTPUT_KEY, {"forged": True})
+    with pytest.raises(StructuredOutputWriteError):
+        overlay.remove(STRUCTURED_OUTPUT_KEY)
+    with pytest.raises(StructuredOutputWriteError):
+        overlay[STRUCTURED_OUTPUT_KEY] = {"forged": True}
+    with pytest.raises(StructuredOutputWriteError):
+        del overlay[STRUCTURED_OUTPUT_KEY]
+    with pytest.raises(TypeError):
+        overlay.get(STRUCTURED_OUTPUT_KEY)["title"] = "mutated"
+    assert dict(overlay.get(STRUCTURED_OUTPUT_KEY)) == PAYLOAD
+
+
+def test_overlay_snapshot_and_to_dict_never_expose_the_projection():
+    base = create_context_container({"declared_key": "value"})
+    overlay = StructuredOutputOverlay(base, PAYLOAD)
+    overlay.set("written_by_tool", True)
+    for snap in (overlay.snapshot(), overlay.to_dict()):
+        assert STRUCTURED_OUTPUT_KEY not in snap
+        assert snap["declared_key"] == "value"
+        assert snap["written_by_tool"] is True
+    with pytest.raises(AttributeError):
+        _ = overlay.data
+
+
+def test_overlay_shadows_caller_seeded_projection_without_erasing_base():
+    base = _PatternContext({STRUCTURED_OUTPUT_KEY: {"planted": "by-caller"}})
+    overlay = StructuredOutputOverlay(base, PAYLOAD)
+    assert dict(overlay.get(STRUCTURED_OUTPUT_KEY)) == PAYLOAD
+    assert STRUCTURED_OUTPUT_KEY not in overlay.snapshot()
+    # The base is not silently erased; only the turn-local view is shadowed.
+    assert base.data[STRUCTURED_OUTPUT_KEY] == {"planted": "by-caller"}
+
+
+# ---------------------------------------------------------------------------
+# Handler contract through real bindings (temp workflow on disk)
+# ---------------------------------------------------------------------------
+
+
+async def test_context_only_auto_tool_sees_structured_output_and_succeeds(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext({"declared_key": "value"})
+    await handler.handle_tool_dispatch(
+        _event("ContextOnlyAgent", structured_data=PAYLOAD, pattern_context=pattern)
+    )
+    assert pattern.data["observed_structured_output"] == PAYLOAD
+    assert pattern.data["context_only_runs"] == 1
+    # structured_output never became pattern/workflow state.
+    assert STRUCTURED_OUTPUT_KEY not in pattern.data
+    # Persistence captured the tool's declared writes, never the projection.
+    assert persisted_snapshots, "context persistence did not run"
+    for snapshot in persisted_snapshots:
+        assert STRUCTURED_OUTPUT_KEY not in snapshot
+    assert persisted_snapshots[-1]["observed_structured_output"] == PAYLOAD
+
+
+async def test_explicit_param_auto_tool_receives_matching_fields(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event("ExplicitAgent", structured_data=PAYLOAD, pattern_context=pattern)
+    )
+    assert pattern.data["explicit_matches_context"] is True
+    assert STRUCTURED_OUTPUT_KEY not in pattern.data
+
+
+async def test_auto_tool_cannot_mutate_or_replace_the_projection(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event("MutatorAgent", structured_data=PAYLOAD, pattern_context=pattern)
+    )
+    outcomes = pattern.data["mutation_outcomes"]
+    assert outcomes["set"] == "StructuredOutputWriteError"
+    assert outcomes["remove"] == "StructuredOutputWriteError"
+    assert outcomes["item_assignment"] == "TypeError"
+    assert outcomes["value_after_attempts"] == PAYLOAD
+    assert STRUCTURED_OUTPUT_KEY not in pattern.data
+
+
+async def test_caller_cannot_seed_or_replace_the_transient_projection(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    """A planted structured_output in the event context snapshot (no live
+    pattern ref) must not reach the tool or persistence — the runtime payload
+    is the only source."""
+    handler = AutoToolEventHandler()
+    await handler.handle_tool_dispatch(
+        _event(
+            "ContextOnlyAgent",
+            structured_data=PAYLOAD,
+            pattern_context=None,
+            context_variables={STRUCTURED_OUTPUT_KEY: {"planted": "by-caller"}},
+        )
+    )
+    assert persisted_snapshots, "context persistence did not run"
+    last = persisted_snapshots[-1]
+    assert last["observed_structured_output"] == PAYLOAD
+    assert STRUCTURED_OUTPUT_KEY not in last
+
+
+async def test_duplicate_runtime_event_cannot_duplicate_tool_execution(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    event = _event("ContextOnlyAgent", structured_data=PAYLOAD, pattern_context=pattern, turn=7)
+    await handler.handle_tool_dispatch(event)
+    await handler.handle_tool_dispatch(event)
+    assert pattern.data["context_only_runs"] == 1
+
+
+async def test_extra_field_in_event_payload_triggers_no_tool_ui_or_persistence(
+    probe_manager, persisted_snapshots, monkeypatch
+):
+    """The handler re-validates against the same exact model: a payload with
+    an undeclared field cannot reach the tool, UI emission, or persistence."""
+    handler = AutoToolEventHandler()
+    ui_calls: list = []
+
+    async def _record_tool_call(*args, **kwargs):
+        ui_calls.append(("tool_call", args))
+
+    async def _record_tool_result(*args, **kwargs):
+        ui_calls.append(("tool_result", args))
+
+    monkeypatch.setattr(handler, "_emit_tool_call", _record_tool_call)
+    monkeypatch.setattr(handler, "_emit_tool_result", _record_tool_result)
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event(
+            "ContextOnlyAgent",
+            structured_data={**PAYLOAD, "undeclared_extra": 1},
+            pattern_context=pattern,
+            turn=9,
+        )
+    )
+    assert ui_calls == []
+    assert pattern.data == {}
+    assert persisted_snapshots == []
+
+
+async def test_hitl_style_resequencing_keeps_distinct_turns_independent(
+    probe_manager, persisted_snapshots, quiet_transport
+):
+    """Distinct turn keys still dispatch independently (pause/resume safety),
+    while each turn stays exactly-once."""
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    await handler.handle_tool_dispatch(
+        _event("ContextOnlyAgent", structured_data=PAYLOAD, pattern_context=pattern, turn=1)
+    )
+    await handler.handle_tool_dispatch(
+        _event("ContextOnlyAgent", structured_data=PAYLOAD, pattern_context=pattern, turn=2)
+    )
+    assert pattern.data["context_only_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Failed exact validation upstream cannot emit the runtime event at all
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_exact_validation_emits_no_runtime_event(probe_manager, monkeypatch):
+    from mozaiksai.core.workflow.outputs.runtime_events import emit_validated_agent_output
+
+    emitted: list = []
+
+    class _RecordingDispatcher:
+        async def emit(self, event_type, payload):
+            emitted.append((event_type, payload))
+
+    monkeypatch.setattr(
+        "mozaiksai.core.events.unified_event_dispatcher.get_event_dispatcher",
+        lambda: _RecordingDispatcher(),
+    )
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+
+    class _Logger:
+        def warning(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+    result = await emit_validated_agent_output(
+        current_agent_name="ContextOnlyAgent",
+        last_reply={**PAYLOAD, "undeclared_extra": 1},
+        workflow_name=WORKFLOW,
+        chat_id="chat-1",
+        app_id="app-1",
+        user_id=None,
+        turn_sequence=1,
+        context_vars_dict={},
+        context_bridge=None,
+        structured_registry=registry,
+        auto_tool_agents={"ContextOnlyAgent"},
+        wf_logger=_Logger(),
+    )
+    assert result is None
+    assert emitted == []
+
+
+async def test_valid_payload_emits_the_runtime_event_exactly_once(probe_manager, monkeypatch):
+    from mozaiksai.core.workflow.outputs.runtime_events import emit_validated_agent_output
+
+    emitted: list = []
+
+    class _RecordingDispatcher:
+        async def emit(self, event_type, payload):
+            emitted.append((event_type, payload))
+
+    monkeypatch.setattr(
+        "mozaiksai.core.events.unified_event_dispatcher.get_event_dispatcher",
+        lambda: _RecordingDispatcher(),
+    )
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+
+    class _Logger:
+        def warning(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+    result = await emit_validated_agent_output(
+        current_agent_name="ContextOnlyAgent",
+        last_reply=dict(PAYLOAD),
+        workflow_name=WORKFLOW,
+        chat_id="chat-1",
+        app_id="app-1",
+        user_id=None,
+        turn_sequence=1,
+        context_vars_dict={"declared_key": "value"},
+        context_bridge=None,
+        structured_registry=registry,
+        auto_tool_agents={"ContextOnlyAgent"},
+        wf_logger=_Logger(),
+    )
+    assert result == PAYLOAD
+    assert len(emitted) == 1
+    event_type, payload = emitted[0]
+    assert event_type == "runtime.agent_output_validated"
+    assert payload["structured_data"] == PAYLOAD
+    assert payload["auto_tool_call"] is True
+    # The event's context snapshot carries declared context only.
+    assert STRUCTURED_OUTPUT_KEY not in payload["context"].get("context_variables", {})

--- a/tests/test_auto_tool_structured_output_contract.py
+++ b/tests/test_auto_tool_structured_output_contract.py
@@ -67,6 +67,23 @@ async def save_explicit(title: str, status: str, context_variables=None):
     return {"status": "ok"}
 
 
+async def mutate_nested(meta=None, context_variables=None):
+    if meta is not None:
+        meta["label"] = "MUTATED"
+        meta["injected_temp"] = True
+    overlay_view = context_variables.get("structured_output")
+    context_variables.set(
+        "mutator_overlay_after_own_mutation", dict(dict(overlay_view)["meta"])
+    )
+    return {"status": "ok"}
+
+
+async def read_nested(context_variables=None):
+    data = context_variables.get("structured_output")
+    context_variables.set("reader_saw_meta", dict(dict(data)["meta"]))
+    return {"status": "ok"}
+
+
 async def try_mutation(context_variables=None):
     outcomes = {}
     try:
@@ -110,6 +127,30 @@ _TOOLS_YAML = """tools:
   description: Mutation-attempt auto tool.
   tool_type: Agent_Tool
   auto_tool_call: true
+- agent: PairMutateFirstAgent
+  file: probe_tools.py
+  function: mutate_nested
+  description: Explicit-param tool that mutates its nested argument.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+- agent: PairMutateFirstAgent
+  file: probe_tools.py
+  function: read_nested
+  description: Context-only tool reading structured_output after the mutator.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+- agent: PairReadFirstAgent
+  file: probe_tools.py
+  function: read_nested
+  description: Context-only tool reading structured_output before the mutator.
+  tool_type: Agent_Tool
+  auto_tool_call: true
+- agent: PairReadFirstAgent
+  file: probe_tools.py
+  function: mutate_nested
+  description: Explicit-param tool that mutates its nested argument.
+  tool_type: Agent_Tool
+  auto_tool_call: true
 """
 
 _STRUCTURED_OUTPUTS = """schema_version: mozaiks.structured_outputs.v1
@@ -117,12 +158,23 @@ registry:
   ContextOnlyAgent: ProbeOutput
   ExplicitAgent: ProbeOutput
   MutatorAgent: ProbeOutput
+  PairMutateFirstAgent: NestedOutput
+  PairReadFirstAgent: NestedOutput
 models:
   ProbeOutput:
     type: model
     fields:
       title: { type: str }
       status: { type: str }
+  MetaLeaf:
+    type: model
+    fields:
+      label: { type: str }
+  NestedOutput:
+    type: model
+    fields:
+      title: { type: str }
+      meta: { type: MetaLeaf }
 """
 
 # The declared application keys the probe tools write. structured_output is
@@ -173,7 +225,9 @@ def _write_workflow(root: Path) -> None:
         "agents:\n"
         + _AGENT_TEMPLATE.format(name="ContextOnlyAgent")
         + _AGENT_TEMPLATE.format(name="ExplicitAgent")
-        + _AGENT_TEMPLATE.format(name="MutatorAgent"),
+        + _AGENT_TEMPLATE.format(name="MutatorAgent")
+        + _AGENT_TEMPLATE.format(name="PairMutateFirstAgent")
+        + _AGENT_TEMPLATE.format(name="PairReadFirstAgent"),
         encoding="utf-8",
     )
     (workflow_dir / "structured_outputs.yaml").write_text(_STRUCTURED_OUTPUTS, encoding="utf-8")
@@ -335,12 +389,23 @@ def test_overlay_snapshot_and_to_dict_never_expose_the_projection():
 
 
 def test_overlay_shadows_caller_seeded_projection_without_erasing_base():
-    base = _PatternContext({STRUCTURED_OUTPUT_KEY: {"planted": "by-caller"}})
+    """A stale/caller-planted/replayed base structured_output key is shadowed
+    for reads and excluded from every enumeration-derived durable view."""
+    base = _PatternContext(
+        {STRUCTURED_OUTPUT_KEY: {"planted": "by-caller"}, "declared_key": "value"}
+    )
     overlay = StructuredOutputOverlay(base, PAYLOAD)
+    # get() serves the runtime transient projection, never the planted value.
     assert dict(overlay.get(STRUCTURED_OUTPUT_KEY)) == PAYLOAD
+    # keys(), snapshot(), and to_dict() never expose the colliding base key.
+    assert STRUCTURED_OUTPUT_KEY not in list(overlay.keys())
+    assert "declared_key" in list(overlay.keys())
     assert STRUCTURED_OUTPUT_KEY not in overlay.snapshot()
+    assert STRUCTURED_OUTPUT_KEY not in overlay.to_dict()
+    assert overlay.snapshot()["declared_key"] == "value"
     # The base is not silently erased; only the turn-local view is shadowed.
     assert base.data[STRUCTURED_OUTPUT_KEY] == {"planted": "by-caller"}
+    assert base.data["declared_key"] == "value"
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +536,54 @@ async def test_hitl_style_resequencing_keeps_distinct_turns_independent(
         _event("ContextOnlyAgent", structured_data=PAYLOAD, pattern_context=pattern, turn=2)
     )
     assert pattern.data["context_only_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Cross-binding payload isolation: one validated output, multiple bindings
+# ---------------------------------------------------------------------------
+
+NESTED_PAYLOAD = {"title": "Nested Probe", "meta": {"label": "ORIGINAL"}}
+
+
+def _nested_event(agent: str, pattern, *, turn: int = 21):
+    return build_runtime_agent_output_validated_event(
+        agent=agent,
+        model_name="NestedOutput",
+        structured_data={
+            "title": NESTED_PAYLOAD["title"],
+            "meta": dict(NESTED_PAYLOAD["meta"]),
+        },
+        auto_tool_call=True,
+        context={"chat_id": "chat-1", "app_id": "app-1", "workflow_name": WORKFLOW},
+        turn_idempotency_key=build_turn_idempotency_key("chat-1", turn),
+        pattern_context_ref=pattern,
+        validation_passed=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "agent", ["PairMutateFirstAgent", "PairReadFirstAgent"], ids=["mutate-first", "read-first"]
+)
+async def test_explicit_mutation_cannot_contaminate_other_bindings(
+    probe_manager, persisted_snapshots, quiet_transport, agent
+):
+    """One exact validated payload, two bindings, both orders: the mutator's
+    explicit nested-argument mutation never reaches the canonical payload,
+    the other binding's structured_output overlay, or the event audit data."""
+    handler = AutoToolEventHandler()
+    pattern = _PatternContext()
+    event = _nested_event(agent, pattern)
+    await handler.handle_tool_dispatch(event)
+
+    # The context-only binding saw the ORIGINAL accepted nested object.
+    assert pattern.data["reader_saw_meta"] == {"label": "ORIGINAL"}
+    # Same-binding consistency: the mutator's own overlay projection is
+    # unaffected by its explicit-argument mutation.
+    assert pattern.data["mutator_overlay_after_own_mutation"] == {"label": "ORIGINAL"}
+    # Event audit data keeps the exact accepted content — no shared alias.
+    assert event["structured_data"] == NESTED_PAYLOAD
+    assert "injected_temp" not in event["structured_data"]["meta"]
+    assert STRUCTURED_OUTPUT_KEY not in pattern.data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_exact_structured_output_runtime.py
+++ b/tests/test_exact_structured_output_runtime.py
@@ -4,8 +4,8 @@ The generic runtime registry compiles every declared structured-output model
 with closed-object acceptance: unknown candidate fields reject — top-level and
 nested — before any operation capable of deleting unknown information runs.
 The #485 staging decision that left generic runtime loading permissive is
-retired; there is no legacy mode, no per-workflow fallback, and no permissive
-cached model after reload.
+retired; there is no permissive mode, no per-workflow acceptance override,
+and no permissive cached model after reload.
 
 Deliberately-open ``dict``/``optional_dict`` fields keep their semantics: the
 FIELD is closed at its containing object level, while arbitrary keys inside

--- a/tests/test_exact_structured_output_runtime.py
+++ b/tests/test_exact_structured_output_runtime.py
@@ -1,0 +1,277 @@
+"""Declared structured outputs are EXACT at runtime.
+
+The generic runtime registry compiles every declared structured-output model
+with closed-object acceptance: unknown candidate fields reject — top-level and
+nested — before any operation capable of deleting unknown information runs.
+The #485 staging decision that left generic runtime loading permissive is
+retired; there is no legacy mode, no per-workflow fallback, and no permissive
+cached model after reload.
+
+Deliberately-open ``dict``/``optional_dict`` fields keep their semantics: the
+FIELD is closed at its containing object level, while arbitrary keys inside
+the declared open dict remain valid runtime data.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.outputs.runtime_validation import (
+    validate_agent_structured_output,
+)
+from mozaiksai.core.workflow.task_batches import _structured_registry_for_agent
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+WORKFLOW = "ExactRuntimeProbe"
+
+_AGENT_TEMPLATE = (
+    "  - name: {name}\n"
+    "    structured_outputs_required: true\n"
+    "    prompt_sections:\n"
+    "      - id: role\n"
+    "        heading: ROLE\n"
+    "        content: probe\n"
+)
+
+_STRUCTURED_OUTPUTS = """schema_version: mozaiks.structured_outputs.v1
+registry:
+  ProbeAgent: Envelope
+models:
+  Status:
+    type: literal
+    values: [ready, blocked]
+  Leaf:
+    type: model
+    fields:
+      label: { type: str }
+      note: { type: optional_str }
+  Branch:
+    type: model
+    fields:
+      title: { type: str }
+      leaf: { type: Leaf }
+  Payload:
+    type: union
+    variants: [Leaf, Branch]
+  Envelope:
+    type: model
+    fields:
+      status: { type: Status }
+      child: { type: Leaf }
+      payload: { type: Payload }
+      attempts: { type: int, default: 1 }
+      extras: { type: dict }
+      annotations: { type: optional_dict }
+      rows: { type: optional_list, items: Leaf }
+"""
+
+
+def _write_probe_workflow(root: Path, *, structured_outputs: str = _STRUCTURED_OUTPUTS) -> None:
+    workflow_dir = root / WORKFLOW
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "orchestrator.yaml").write_text(
+        f"schema_version: mozaiks.orchestrator.v1\nworkflow_name: {WORKFLOW}\n"
+        "workflow_startup_mode: BackendOnly\n"
+        "initial_agent: ProbeAgent\n"
+        "max_turns: 1\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "agents.yaml").write_text(
+        "agents:\n" + _AGENT_TEMPLATE.format(name="ProbeAgent"),
+        encoding="utf-8",
+    )
+    (workflow_dir / "structured_outputs.yaml").write_text(structured_outputs, encoding="utf-8")
+
+
+@pytest.fixture
+def probe_manager(tmp_path: Path):
+    """Point the live manager singleton at a tmp workflow root (state-restoring)."""
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = tmp_path
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        _write_probe_workflow(tmp_path)
+        info = workflow_manager.reload_workflow(WORKFLOW)
+        assert not info.get("error"), info
+        yield workflow_manager
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+def _valid_candidate() -> dict:
+    return {
+        "status": "ready",
+        "child": {"label": "leaf-1", "note": None},
+        "payload": {"title": "branch-1", "leaf": {"label": "leaf-2", "note": "n"}},
+        "attempts": 2,
+        "extras": {"anything": {"nested": True}, "another_key": 3},
+        "annotations": None,
+        "rows": [{"label": "leaf-3", "note": None}],
+    }
+
+
+def _validate(candidate: dict):
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+    return validate_agent_structured_output(
+        agent_name="ProbeAgent",
+        reply=json.dumps(candidate),
+        structured_registry=registry,
+    )
+
+
+def test_exact_valid_output_accepted(probe_manager):
+    validation = _validate(_valid_candidate())
+    assert validation is not None and validation.validation_passed
+    assert validation.structured_data["status"] == "ready"
+    assert validation.structured_data["extras"] == {
+        "anything": {"nested": True},
+        "another_key": 3,
+    }
+
+
+def test_every_declared_runtime_model_is_exact(probe_manager):
+    models, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+    assert set(models) >= {"Leaf", "Branch", "Envelope"}
+    for name, model_cls in models.items():
+        assert model_cls.model_config.get("extra") == "forbid", (
+            f"runtime model {name!r} compiled permissive"
+        )
+    assert registry["ProbeAgent"] is models["Envelope"]
+
+
+def test_top_level_extra_field_rejects_before_normalization(probe_manager):
+    candidate = {**_valid_candidate(), "undeclared_top": "x"}
+    validation = _validate(candidate)
+    assert validation is not None
+    assert validation.validation_passed is False
+    assert validation.structured_data is None
+    # The original candidate is retained verbatim for diagnostics — no
+    # stripped "clean" payload exists anywhere in the result.
+    assert validation.raw_data["undeclared_top"] == "x"
+    assert "undeclared_top" in str(validation.error)
+
+
+def test_nested_extra_field_rejects_before_normalization(probe_manager):
+    candidate = _valid_candidate()
+    candidate["child"] = {"label": "leaf-1", "note": None, "undeclared_nested": True}
+    validation = _validate(candidate)
+    assert validation is not None
+    assert validation.validation_passed is False
+    assert validation.structured_data is None
+    assert validation.raw_data["child"]["undeclared_nested"] is True
+
+
+def test_declared_open_dict_contents_remain_valid(probe_manager):
+    candidate = _valid_candidate()
+    candidate["extras"] = {"free_form_key": [1, 2, 3], "deep": {"unknown": "ok"}}
+    candidate["annotations"] = {"any": "value"}
+    validation = _validate(candidate)
+    assert validation is not None and validation.validation_passed
+    assert validation.structured_data["extras"]["deep"] == {"unknown": "ok"}
+    assert validation.structured_data["annotations"] == {"any": "value"}
+
+
+@pytest.mark.parametrize(
+    "mutation,description",
+    [
+        (lambda c: c.__setitem__("status", "unknown_literal"), "wrong literal"),
+        (lambda c: c.__setitem__("child", {"note": None}), "wrong nested model shape"),
+        (
+            lambda c: c.__setitem__("payload", {"neither": "variant"}),
+            "wrong union variant",
+        ),
+        (lambda c: c.__setitem__("attempts", "not-an-int"), "wrong scalar type"),
+    ],
+)
+def test_exact_literal_and_shape_attacks_reject(probe_manager, mutation, description):
+    candidate = _valid_candidate()
+    mutation(candidate)
+    validation = _validate(candidate)
+    assert validation is not None
+    assert validation.validation_passed is False, description
+    assert validation.structured_data is None
+
+
+def test_reload_never_falls_back_to_a_permissive_model(probe_manager, tmp_path):
+    models_first, _ = _so.load_workflow_structured_outputs(WORKFLOW)
+    assert models_first["Envelope"].model_config.get("extra") == "forbid"
+
+    # Reload the workflow and prove the replacement compile is exact too.
+    _write_probe_workflow(tmp_path)
+    info = workflow_manager.reload_workflow(WORKFLOW)
+    assert not info.get("error"), info
+    models_second, _ = _so.load_workflow_structured_outputs(WORKFLOW)
+    assert models_second["Envelope"] is not models_first["Envelope"]
+    for name, model_cls in models_second.items():
+        assert model_cls.model_config.get("extra") == "forbid", name
+    with pytest.raises(ValidationError):
+        models_second["Envelope"].model_validate(
+            {**_valid_candidate(), "undeclared_top": "x"}
+        )
+
+    # Same proof across a full cache flush.
+    _so.invalidate_all_workflow_structured_outputs()
+    models_third, _ = _so.load_workflow_structured_outputs(WORKFLOW)
+    for name, model_cls in models_third.items():
+        assert model_cls.model_config.get("extra") == "forbid", name
+
+
+def test_task_batch_registry_serves_the_same_exact_models(probe_manager):
+    registry = _structured_registry_for_agent(WORKFLOW, "ProbeAgent")
+    model_cls = registry["ProbeAgent"]
+    assert model_cls.model_config.get("extra") == "forbid"
+    with pytest.raises(ValidationError):
+        model_cls.model_validate({**_valid_candidate(), "undeclared_top": "x"})
+    assert model_cls is _so.load_workflow_structured_outputs(WORKFLOW)[1]["ProbeAgent"]
+
+
+def test_provider_wire_projection_parse_matches_its_advertised_schema(probe_manager):
+    """The wire model advertises additionalProperties: false and must parse
+    the same way — otherwise a permissive provider-side parse becomes the
+    first lossy normalization before exact runtime acceptance."""
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+    wire = _so.get_provider_response_model(registry["ProbeAgent"])
+    schema = wire.model_json_schema()
+    assert schema["additionalProperties"] is False
+    with pytest.raises(ValidationError):
+        wire.model_validate({**_valid_candidate(), "undeclared_top": "x"})
+    nested_extra = _valid_candidate()
+    nested_extra["child"] = {"label": "leaf-1", "note": None, "undeclared": 1}
+    with pytest.raises(ValidationError):
+        wire.model_validate(nested_extra)
+
+
+def test_dynamic_models_share_the_exact_acceptance_contract():
+    dynamic = _so.build_dynamic_models(
+        [
+            {
+                "model_name": "DynamicProbe",
+                "fields": [{"name": "value", "type": "str"}],
+            }
+        ],
+        existing_models={},
+    )
+    model_cls = dynamic["DynamicProbe"]
+    assert model_cls.model_config.get("extra") == "forbid"
+    with pytest.raises(ValidationError):
+        model_cls.model_validate({"value": "ok", "undeclared": 1})

--- a/tests/test_factory_auto_tool_acceptance.py
+++ b/tests/test_factory_auto_tool_acceptance.py
@@ -1,0 +1,259 @@
+"""Real OSS Factory auto-tool acceptance through the runtime event path.
+
+ThemeCapture is a checked-in Factory workflow whose auto tool reads
+``context_variables.get("structured_output")``. This suite proves the
+documented chain against the real workflow assets and the real runtime:
+
+    valid agent output
+    -> exact validation (emit_validated_agent_output)
+    -> runtime.agent_output_validated (real UnifiedEventDispatcher)
+    -> AutoToolEventHandler (real bindings from tools.yaml)
+    -> save_captured_theme sees structured_output
+    -> tool succeeds (UI card emitted, artifact persisted, context written)
+
+and the permanent extra-field regression: a valid payload plus one
+undeclared nested property must REJECT BEFORE NORMALIZATION — no
+agent_output_validated event, no auto-tool execution, no persistence, no UI
+emission, and no stripped "clean" payload accepted later.
+"""
+
+from __future__ import annotations
+
+import types
+from enum import Enum
+from pathlib import Path
+from typing import Any, Union, get_args, get_origin
+
+import pytest
+from pydantic import BaseModel
+
+from mozaiksai.core.events import auto_tool_handler as _auto_tool_mod
+from mozaiksai.core.workflow.context.structured_output_overlay import (
+    STRUCTURED_OUTPUT_KEY,
+)
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.outputs.runtime_events import emit_validated_agent_output
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+FACTORY_WORKFLOWS = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
+WORKFLOW = "ThemeCapture"
+AGENT = "ThemeConfigAssemblerAgent"
+
+_UNION_ORIGINS = (Union, types.UnionType)
+
+
+def _value_for(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin in _UNION_ORIGINS:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) < len(get_args(annotation)):
+            return None
+        return _value_for(args[0])
+    if origin is list:
+        return []
+    if origin is dict:
+        return {}
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return _payload_for(annotation)
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return next(iter(annotation)).value
+    if annotation is str:
+        return "probe"
+    if annotation is int:
+        return 1
+    if annotation is float:
+        return 1.0
+    if annotation is bool:
+        return False
+    return "probe"
+
+
+def _payload_for(model_cls: type[BaseModel]) -> dict[str, Any]:
+    return {
+        name: _value_for(field.annotation)
+        for name, field in model_cls.model_fields.items()
+    }
+
+
+class _PatternContext:
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def snapshot(self):
+        return dict(self.data)
+
+    def to_dict(self):
+        return self.snapshot()
+
+
+class _Logger:
+    def warning(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+
+@pytest.fixture
+def factory_manager():
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = FACTORY_WORKFLOWS
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        info = workflow_manager.reload_workflow(WORKFLOW)
+        assert not info.get("error"), info
+        yield workflow_manager
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+@pytest.fixture
+def side_effect_probes(monkeypatch):
+    """Fake the tool's persistence/UI seams before its module is loaded."""
+    probes: dict[str, list] = {"summary_artifacts": [], "ui_surfaces": [], "theme_saves": [], "context_persists": []}
+
+    async def fake_persist_summary_artifact(**kwargs):
+        probes["summary_artifacts"].append(kwargs)
+
+    async def fake_emit_ui_surface(component, payload, **kwargs):
+        probes["ui_surfaces"].append({"component": component, "payload": payload, **kwargs})
+
+    class _FakeStore:
+        async def save_theme_capture(self, **kwargs):
+            probes["theme_saves"].append(kwargs)
+
+    class _FakePersistenceManager:
+        async def persist_context_variables(self, **kwargs):
+            probes["context_persists"].append(dict(kwargs.get("variables") or {}))
+
+    async def _no_transport():
+        return None
+
+    monkeypatch.setattr(
+        "mozaiksai.core.artifacts.persist_summary_artifact", fake_persist_summary_artifact
+    )
+    monkeypatch.setattr(
+        "mozaiksai.core.workflow.ui_tools.emit_ui_surface", fake_emit_ui_surface
+    )
+    monkeypatch.setattr(
+        "mozaiksai.core.data.persistence.artifact_store.BuilderArtifactStore", _FakeStore
+    )
+    monkeypatch.setattr(_auto_tool_mod, "AG2PersistenceManager", _FakePersistenceManager)
+    monkeypatch.setattr(_auto_tool_mod, "_get_simple_transport", _no_transport)
+    return probes
+
+
+def _valid_theme_payload() -> dict[str, Any]:
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+    model_cls = registry[AGENT]
+    payload = _payload_for(model_cls)
+    validated = model_cls.model_validate(payload)
+    assert validated is not None
+    return payload
+
+
+async def _drive_runtime(payload: dict[str, Any], pattern: _PatternContext) -> Any:
+    _, registry = _so.load_workflow_structured_outputs(WORKFLOW)
+    return await emit_validated_agent_output(
+        current_agent_name=AGENT,
+        last_reply=payload,
+        workflow_name=WORKFLOW,
+        chat_id="chat-theme-1",
+        app_id="app-theme-1",
+        user_id="user-1",
+        turn_sequence=1,
+        context_vars_dict={"app_id": "app-theme-1"},
+        context_bridge=pattern,
+        structured_registry=registry,
+        auto_tool_agents={AGENT},
+        wf_logger=_Logger(),
+    )
+
+
+async def test_theme_capture_auto_tool_succeeds_through_real_runtime_path(
+    factory_manager, side_effect_probes
+):
+    payload = _valid_theme_payload()
+    pattern = _PatternContext()
+
+    result = await _drive_runtime(payload, pattern)
+    assert result == payload
+
+    # The real save_captured_theme executed through the real dispatcher and
+    # handler: it saw structured_output, emitted the preview card, persisted
+    # the artifact set, and wrote its declared context keys.
+    assert len(side_effect_probes["ui_surfaces"]) == 1
+    assert side_effect_probes["ui_surfaces"][0]["component"] == "ThemePreviewCard"
+    assert len(side_effect_probes["summary_artifacts"]) == 1
+    assert side_effect_probes["summary_artifacts"][0]["artifact_kind"] == "theme_capture"
+    assert pattern.data.get("theme_capture_persisted") is True
+    expected_theme_config = {k: v for k, v in payload.items() if k != "agent_message"}
+    assert pattern.data.get("captured_theme_config") == expected_theme_config
+
+    # The projection never became pattern/workflow state or persisted state.
+    assert STRUCTURED_OUTPUT_KEY not in pattern.data
+    assert side_effect_probes["context_persists"], "context persistence did not run"
+    for snapshot in side_effect_probes["context_persists"]:
+        assert STRUCTURED_OUTPUT_KEY not in snapshot
+
+
+@pytest.mark.parametrize(
+    "inject",
+    [
+        pytest.param(lambda p: p.__setitem__("undeclared_top", "x"), id="top-level-extra"),
+        pytest.param(
+            lambda p: p["identity"].__setitem__("undeclared_nested", True),
+            id="nested-extra",
+        ),
+    ],
+)
+async def test_extra_field_attack_rejects_before_normalization(
+    factory_manager, side_effect_probes, monkeypatch, inject
+):
+    emitted: list = []
+
+    class _RecordingDispatcher:
+        async def emit(self, event_type, event_payload):
+            emitted.append((event_type, event_payload))
+
+    monkeypatch.setattr(
+        "mozaiksai.core.events.unified_event_dispatcher.get_event_dispatcher",
+        lambda: _RecordingDispatcher(),
+    )
+
+    payload = _valid_theme_payload()
+    inject(payload)
+    pattern = _PatternContext()
+
+    result = await _drive_runtime(payload, pattern)
+
+    # Rejected before any normalization: no success event, no auto tool, no
+    # persistence, no UI emission, and no stripped "clean" payload accepted.
+    assert result is None
+    assert emitted == []
+    assert side_effect_probes["ui_surfaces"] == []
+    assert side_effect_probes["summary_artifacts"] == []
+    assert side_effect_probes["theme_saves"] == []
+    assert side_effect_probes["context_persists"] == []
+    assert pattern.data == {}

--- a/tests/test_reserved_context_keys.py
+++ b/tests/test_reserved_context_keys.py
@@ -1,0 +1,165 @@
+"""``structured_output`` is reserved runtime vocabulary — never application state.
+
+One shared authority (``mozaiksai.core.workflow.reserved_context_keys``)
+rejects the reserved identifier at every canonical context declaration
+surface: declarative contract validation, typed context schema validation,
+and therefore normal workflow declaration loading. No declaration metadata
+(authority_class, writer_ids, persisted, source, trigger metadata) can
+legalize it, and agent views cannot reference it. The runtime auto-tool
+projection needs no declaration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mozaiksai.core.workflow.context.schema import load_context_variables_config
+from mozaiksai.core.workflow.context.structured_output_overlay import (
+    STRUCTURED_OUTPUT_KEY,
+)
+from mozaiksai.core.workflow.declarative import parse_context_variables_config
+from mozaiksai.core.workflow.outputs import structured as _so
+from mozaiksai.core.workflow.reserved_context_keys import (
+    RUNTIME_RESERVED_CONTEXT_KEYS,
+    STRUCTURED_OUTPUT_CONTEXT_KEY,
+    require_application_context_name_allowed,
+)
+from mozaiksai.core.workflow.workflow_manager import workflow_manager
+
+WORKFLOWS_ROOT = Path(__file__).resolve().parents[1] / "factory_app" / "workflows"
+
+
+def _reserved_definition(**extra: object) -> dict:
+    return {
+        "definitions": {
+            "structured_output": {
+                "type": "object",
+                "description": "illegal application claim of the runtime key",
+                "source": {"type": "state", "default": None},
+                **extra,
+            }
+        }
+    }
+
+
+def test_shared_vocabulary_is_the_single_authority():
+    assert STRUCTURED_OUTPUT_CONTEXT_KEY == "structured_output"
+    assert STRUCTURED_OUTPUT_KEY is STRUCTURED_OUTPUT_CONTEXT_KEY
+    assert RUNTIME_RESERVED_CONTEXT_KEYS == frozenset({"structured_output"})
+    with pytest.raises(ValueError, match="reserved runtime"):
+        require_application_context_name_allowed("structured_output", where="probe")
+    assert require_application_context_name_allowed("ordinary_key", where="probe") == "ordinary_key"
+
+
+def test_declarative_definition_of_reserved_key_rejects():
+    with pytest.raises(ValueError, match="reserved runtime"):
+        parse_context_variables_config(_reserved_definition())
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"authority_class": "mutable_workflow_state"},
+        {"writer_ids": ["deterministic_tool"]},
+        {"writer_ids": ["structured_output"]},
+        {"persisted": False},
+        {"authority_class": "tool_only_information", "persisted": False, "model_visible": False},
+        {
+            "source": {
+                "type": "state",
+                "default": None,
+                "triggers": [
+                    {"type": "agent_text", "agent": "ProbeAgent", "match": {"equals": "DONE"}}
+                ],
+            }
+        },
+    ],
+)
+def test_no_declaration_metadata_legalizes_the_reserved_key(metadata: dict):
+    document = _reserved_definition()
+    document["definitions"]["structured_output"].update(metadata)
+    with pytest.raises(ValueError, match="reserved runtime"):
+        parse_context_variables_config(document)
+    with pytest.raises(ValueError, match="reserved runtime"):
+        load_context_variables_config(document)
+
+
+def test_agent_view_reference_to_reserved_key_rejects():
+    document = {
+        "definitions": {
+            "ordinary_key": {"type": "string", "source": {"type": "state", "default": None}}
+        },
+        "agents": {"ProbeAgent": {"variables": ["ordinary_key", "structured_output"]}},
+    }
+    with pytest.raises(ValueError, match="reserved runtime"):
+        parse_context_variables_config(document)
+    with pytest.raises(ValueError, match="reserved runtime"):
+        load_context_variables_config(document)
+
+
+def test_typed_context_schema_rejects_reserved_definition():
+    with pytest.raises(ValueError, match="reserved runtime"):
+        load_context_variables_config(_reserved_definition())
+
+
+def test_workflow_declaration_validation_rejects_reserved_key(tmp_path: Path):
+    """The failure occurs during normal workflow declaration loading."""
+    saved_manager_state = dict(workflow_manager.__dict__)
+    saved_structured = (
+        dict(_so._workflow_models),
+        dict(_so._workflow_registries),
+        dict(_so._workflow_structured_agents),
+        dict(_so._provider_response_model_cache),
+    )
+    try:
+        workflow_manager.workflows_base_path = tmp_path
+        workflow_manager._workflows = {}
+        workflow_manager._workflow_paths = {}
+        workflow_manager._config_cache = {}
+        _so.invalidate_all_workflow_structured_outputs()
+        workflow_dir = tmp_path / "ReservedProbe"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "orchestrator.yaml").write_text(
+            "schema_version: mozaiks.orchestrator.v1\nworkflow_name: ReservedProbe\n"
+            "workflow_startup_mode: BackendOnly\nmax_turns: 1\n",
+            encoding="utf-8",
+        )
+        (workflow_dir / "context_variables.yaml").write_text(
+            "definitions:\n"
+            "  structured_output:\n"
+            "    type: object\n"
+            "    description: illegal\n"
+            "    source:\n"
+            "      type: state\n"
+            "      default: null\n",
+            encoding="utf-8",
+        )
+        info = workflow_manager.reload_workflow("ReservedProbe")
+        assert info.get("error"), "reserved declaration must fail workflow loading"
+        assert "reserved runtime" in str(info)
+    finally:
+        workflow_manager.__dict__.clear()
+        workflow_manager.__dict__.update(saved_manager_state)
+        _so.invalidate_all_workflow_structured_outputs()
+        _so._workflow_models.update(saved_structured[0])
+        _so._workflow_registries.update(saved_structured[1])
+        _so._workflow_structured_agents.update(saved_structured[2])
+        _so._provider_response_model_cache.update(saved_structured[3])
+
+
+def test_first_party_workflow_corpus_declares_no_reserved_keys():
+    """Permanent census: no shipped OSS workflow claims runtime vocabulary."""
+    import yaml
+
+    offenders: list[str] = []
+    for path in sorted(WORKFLOWS_ROOT.glob("*/context_variables.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        declared = set((document.get("definitions") or {}).keys())
+        for view in (document.get("agents") or {}).values():
+            declared.update((view or {}).get("variables") or [])
+        reserved = declared & RUNTIME_RESERVED_CONTEXT_KEYS
+        if reserved:
+            offenders.append(f"{path.parent.name}: {sorted(reserved)}")
+    assert offenders == []

--- a/tests/test_structured_output_provider_boundary.py
+++ b/tests/test_structured_output_provider_boundary.py
@@ -111,15 +111,18 @@ def test_workflow_and_provider_cache_order_preserves_canonical_schema(monkeypatc
         "models": copy.deepcopy(MODELS), "registry": {"ProbeAgent": "Envelope"},
     }}
     monkeypatch.setattr(structured.workflow_manager, "get_config", lambda _name: config)
+    # Runtime acceptance is exact: the canonical authority baseline compiles
+    # every declared model id with closed-object acceptance, matching what
+    # load_workflow_structured_outputs registers for the live runtime.
     expected_model = structured.build_models_from_config(
-        copy.deepcopy(MODELS), exact_model_ids=frozenset(),
+        copy.deepcopy(MODELS), exact_model_ids=frozenset(MODELS),
     )["Envelope"]
     expected = expected_model.model_json_schema()
     expected_acceptance = canonical_structured_output_schema(expected_model)
     expected_digest = structured_output_schema_digest(expected_model)
     authority = {
         "configs": {"ProviderBoundaryProbe": config["structured_outputs"]},
-        "exact_model_ids": frozenset(),
+        "exact_model_ids": frozenset(MODELS),
     }
     expected_ref = build_structured_output_contract_ref(
         workflow_name="ProviderBoundaryProbe", model_id="Envelope", **authority,


### PR DESCRIPTION
## What

Fixes the two generic OSS runtime defects the independent App Zero Astra
runtime review exposed, without any App Zero workaround. Base: verified main
`5d51e740`. **CORRECTION ROUND 2 applied** — head `05130f16` supersedes the
round-1 reviewed head `c201479b` (which superseded `7d462758`). The two
remaining material findings are fixed; every area Astra confirmed clean is
preserved unchanged.

## Accepted architecture (confirmed clean, unchanged)

Declared structured outputs are exact at runtime (top-level/nested extras
reject before lossy normalization; open `dict`/`optional_dict` stay open
internally; provider wire models parse `extra="forbid"`); `structured_output`
is RESERVED runtime vocabulary (declaration rejection at both canonical
validators, no metadata override) served as a transient runtime-owned
read-only overlay (enumeration/snapshots never expose it); per-binding
payload isolation; context-only + explicit-param auto tools;
`include_auto_only`; real ThemeCapture Factory execution; #485 identity;
task batches; sequential/concurrent duplicate suppression.

## Round 2 — Defect A: callable authority is never cached

Declarative binding metadata may be cached; **Python callable authority may
not be cached across dispatches**. The binding cache now holds
`AutoToolBindingDescriptor`s only (agent, exact model identity, tool
declaration, ui config), self-validated against the live registry +
tools.yaml bytes. The executable function is resolved fresh through the
canonical workflow tool loader at EVERY dispatch (parameter metadata derived
from the fresh signature). Tool-file byte fingerprinting is removed — bytes
cannot prove callable behavior when an imported helper changes — and no
import/AST/transitive source-closure fingerprinting was added.

The canonical loader (`load_agent_tool_functions`) now refreshes
workflow-owned modules under every dotted package chain that reaches the
workflows root: the synthetic `workflows.<name>` namespace AND the real chain
derived from the filesystem (`__init__.py` walk — e.g.
`factory_app.workflows.<name>` plus the shared `_shared` helpers). Unrelated
workflows are not cleared. **External installed third-party packages are a
documented process-restart boundary** — never hot-replaced.

## Round 2 — Defect B: per-binding execution checkpoints

Each `(chat_id, turn_idempotency_key, binding)` tracks a finite process-local
checkpoint: PENDING → TOOL_TERMINAL → COMPLETE, with per-stage marks
(tool-call emission, context write-back, persistence, result emission). The
terminal record — detached result payload, status, and context snapshot — is
stored **synchronously after the tool returns, before the next cancellable
await**. Invariant: once a tool returns a truthful terminal result (success
OR failure), that binding is never invoked again for the same turn; retries
resume at the first unfinished binding/stage. Pre-execution interruption
still releases the claim so a retry may execute. Checkpoints pop on turn
completion and are bounded by `_CACHE_LIMIT` without evicting active
in-flight state. Documented explicitly as **process-local runtime
idempotency, not distributed exactly-once delivery** (crash-after-effect
before durable recording is the owning service`'`s idempotency contract).

## Round-2 proofs (tests/test_auto_tool_binding_cache_and_concurrency.py, now 22)

- Imported workflow helper changes observed on the next dispatch with
  byte-identical tools.yaml + tool file and NO reload — in the synthetic
  `workflows.*` namespace and the derived real package namespace; unrelated
  workflows` helper modules untouched; fresh-callable-per-dispatch with
  descriptor-cache reuse proven; tool-code change without reload observed.
- Cancellation attack matrix with deterministic barriers (no sleeps): cancel
  before invocation (retry executes, 1 total invocation), while blocked in
  the tool (pre-terminal, retry may execute), during persistence after tool
  success (**total tool invocations = 1**, persistence retried, result
  emitted once, tool-call not re-emitted), during result emission (no
  re-invoke, no re-persist, emission retried), multi-binding A/B/C with
  cancel after B`'`s result (A and B never re-run, B post-processing resumed,
  C exactly once), truthful tool FAILURE terminal (never re-invoked because
  it failed), bounded checkpoint cleanup that never evicts active state.

## Validation

Round-2 battery (auto-tool suites, loader/reload, cache invalidation, tool
routing #487, agent-factory web tools, context exposure, declarative
fallbacks, fail-closed, context authority + hostile + compile, task batches,
structured-output identity/provider/migration #485/#486, ThemeCapture,
capability packs #489): **583 passed**. Full `pytest -q --no-cov`:
**15,520 passed, 93 skipped**. ruff, scoped mypy (handler + loader), strict
MkDocs, governance guardrails, source hygiene, `git diff --check`: all clean.

## Docs

Auto-tool execution doc gains **Callable freshness** and **Execution
idempotency** sections (restart boundary + process-local crash boundary);
ADR 0007 and CHANGELOG updated to the round-2 invariants.

## Reviewer handoff (round 3)

Review head `05130f16`. Start at `_resolve_bindings` (fresh callable
resolution) + `_load_binding_descriptors` (declarative fingerprint), then
`_workflow_root_package_names`/`_reset_workflow_package_namespace` in
`agents/tools.py`, then the checkpoint machine in `_dispatch_claimed_turn`
(`_BindingExecutionRecord`). Highest-leverage questions: (1) is clearing
`<root>._shared` on every workflow load acceptably scoped for concurrent
in-process workflows sharing those helpers? (2) the tool-call emission stage
is marked complete only in the terminal record — is re-emitting on
pre-execution retry acceptable event-order truthfulness? (3) per-dispatch
loader cost (fresh module exec per auto-tool event) — acceptable for current
event rates?

Draft. DCO signed. Auto-merge remains disabled — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)