### PR TITLE
fix(security): fail closed on module dispatch, auth config, and fulfillment ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Security
+
+- **Fail-closed module action dispatch**: `ModuleExecutor` no longer falls
+  back from an undeclared action id to a same-named Python handler method.
+  Only action ids declared in the module's contract
+  (`module.yaml` `actions[].handler_method`, mirrored in the registered
+  `action_method_map`) are dispatchable; unknown or undeclared actions —
+  including event-reaction handlers, private helpers, and arbitrary handler
+  attributes — return `ACTION_NOT_FOUND` before any handler resolution, for
+  trusted and enforce-mode authorities alike.
+- **Fail-closed authentication configuration**: with `AUTH_ENABLED=true`, a
+  missing, misspelled, or incomplete auth provider configuration is now fatal
+  at startup (and at provider resolution) in every environment — the runtime
+  no longer silently falls back to the trusted-bypass `none` adapter. An
+  unrecognized `AUTH_ENABLED` value is also fatal instead of silently
+  disabling auth. Implicit demo mode (no auth configuration at all) still
+  boots for local getting-started use.
+- **Fail-closed billing fulfillment ingress**:
+  `POST /api/billing/fulfillment/apply` (and the fulfillment admin listing)
+  now requires the internal API key, a billing-admin principal, or
+  *explicitly* disabled authentication (`AUTH_ENABLED=false` /
+  `AUTH_PROVIDER=none`). Auth being merely unconfigured no longer makes the
+  ingress callable without authentication.
+
 ### Fixed
 
 - Generated workflow exports now validate all runtime YAML contracts and tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,18 +55,30 @@ This project follows a practical pre-1.0 changelog format:
   Custom adapters declare a `config_identity` at registration to participate
   in that cache identity, and are never cached without one; malformed
   identities (non-string, empty, whitespace-only, or a raising callable) are
-  rejected rather than coerced into a cache key. Adapter constructors are
-  checked for `settings` support by signature inspection *before*
-  construction, so an exception raised inside a constructor body — including
-  `TypeError` — fails closed instead of triggering a retry that would discard
-  the canonical configuration. An adapter's lazily created OIDC discovery and
+  rejected rather than coerced into a cache key. The adapter constructor
+  contract is established *positively* at registration by signature
+  inspection: `settings` as a keyword (or `**kwargs`) receives the snapshot,
+  a constructor whose other parameters are all optional is built with no
+  arguments, and anything the runtime cannot classify — a positional-only
+  `settings`, a required parameter it cannot supply, or a signature it cannot
+  inspect — is rejected instead of being assumed to take no configuration
+  (`register_adapter(..., constructor_mode=...)` declares the contract
+  explicitly for uninspectable constructors). An exception raised inside a
+  constructor body — including `TypeError` — fails closed instead of
+  triggering a retry that would discard the canonical configuration. An adapter's lazily created OIDC discovery and
   JWKS clients now inherit its snapshot (URLs and cache TTLs) and never
   consult live environment or global `AuthConfig`, so an adapter built under
   one configuration cannot begin validating tokens against another; explicit
   constructor input to those clients is authoritative. `AUTH_JWKS_CACHE_TTL`
-  and `AUTH_DISCOVERY_CACHE_TTL` are validated (integer seconds, zero or
-  greater) during configuration resolution, so malformed values fail startup
-  instead of surfacing during lazy client creation on a request path.
+  (default 3600) and `AUTH_DISCOVERY_CACHE_TTL` (default 86400) are validated
+  (integer seconds, zero or greater; `0` means always refetch and is never
+  treated as unset) during configuration resolution, so malformed values fail
+  startup instead of surfacing during lazy client creation on a request path.
+  Absent, empty, and whitespace-only values normalize identically through one
+  canonical resolver shared by configuration resolution, the adapter config,
+  and `AuthConfig`, and cache expiry compares elapsed time against the TTL so
+  every accepted value — including very large ones — stays usable at request
+  time.
   Implicit demo mode (no auth configuration at all, in an environment that
   permits it) still boots for local getting-started use.
 - **Fail-closed billing fulfillment ingress**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,20 +21,37 @@ This project follows a practical pre-1.0 changelog format:
   `action_method_map`) are dispatchable; unknown or undeclared actions —
   including event-reaction handlers, private helpers, and arbitrary handler
   attributes — return `ACTION_NOT_FOUND` before any handler resolution, for
-  trusted and enforce-mode authorities alike.
-- **Fail-closed authentication configuration**: with `AUTH_ENABLED=true`, a
-  missing, misspelled, or incomplete auth provider configuration is now fatal
-  at startup (and at provider resolution) in every environment — the runtime
-  no longer silently falls back to the trusted-bypass `none` adapter. An
-  unrecognized `AUTH_ENABLED` value is also fatal instead of silently
-  disabling auth. Implicit demo mode (no auth configuration at all) still
-  boots for local getting-started use.
+  trusted and enforce-mode authorities alike. The rejection path never
+  touches the handler object (no `getattr`/`hasattr`, so hostile
+  properties/descriptors/`__getattr__` cannot execute), and denied audits
+  carry only a bounded, sanitized action string.
+- **Fail-closed authentication configuration**: auth-mode environment
+  variables are interpreted by one canonical resolver
+  (`resolve_auth_config`) consumed by every predicate, adapter resolution,
+  and startup validation. With `AUTH_ENABLED=true`, a missing, misspelled,
+  or incomplete auth provider configuration is fatal at startup (runtime and
+  platform/Studio hosts) and at provider resolution, in every environment.
+  Contradictory explicit declarations (`AUTH_ENABLED=true` +
+  `AUTH_PROVIDER=none`; `AUTH_ENABLED=false` + a real explicit
+  `AUTH_PROVIDER`) and unrecognized `AUTH_ENABLED` values are fatal instead
+  of silently resolving. **Protected environments (`ENV`/`ENVIRONMENT` of
+  staging/production) refuse all no-auth operation** — explicit disable or
+  implicit demo mode — independent of `MOZAIKS_STARTUP_CHECKS` mode; the
+  explicit no-auth switches remain local development/test contracts. The
+  cached auth adapter is keyed by a resolved-configuration fingerprint, so
+  request-time validation always uses the configuration startup validated
+  and a stale trusted-bypass adapter cannot survive a configuration change.
+  Implicit demo mode (no auth configuration at all, unprotected
+  environment) still boots for local getting-started use.
 - **Fail-closed billing fulfillment ingress**:
   `POST /api/billing/fulfillment/apply` (and the fulfillment admin listing)
-  now requires the internal API key, a billing-admin principal, or
-  *explicitly* disabled authentication (`AUTH_ENABLED=false` /
-  `AUTH_PROVIDER=none`). Auth being merely unconfigured no longer makes the
-  ingress callable without authentication.
+  now requires the internal API key, an *authenticated* billing-admin
+  principal (`UserPrincipal.is_authenticated` — real bearer-token
+  provenance, not role/scope strings, which anonymous and dev-persona
+  principals can carry), or explicitly disabled authentication
+  (`AUTH_ENABLED=false` / `AUTH_PROVIDER=none`, which protected
+  environments reject outright). Auth being merely unconfigured no longer
+  makes the ingress callable without authentication.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,22 @@ This project follows a practical pre-1.0 changelog format:
   and anonymous-persona settings — so changing any of them rebuilds the
   adapter and no stale adapter can serve requests under newer configuration.
   Custom adapters declare a `config_identity` at registration to participate
-  in that cache identity, and are never cached without one. Implicit demo
-  mode (no auth configuration at all, in an environment that permits it)
-  still boots for local getting-started use.
+  in that cache identity, and are never cached without one; malformed
+  identities (non-string, empty, whitespace-only, or a raising callable) are
+  rejected rather than coerced into a cache key. Adapter constructors are
+  checked for `settings` support by signature inspection *before*
+  construction, so an exception raised inside a constructor body — including
+  `TypeError` — fails closed instead of triggering a retry that would discard
+  the canonical configuration. An adapter's lazily created OIDC discovery and
+  JWKS clients now inherit its snapshot (URLs and cache TTLs) and never
+  consult live environment or global `AuthConfig`, so an adapter built under
+  one configuration cannot begin validating tokens against another; explicit
+  constructor input to those clients is authoritative. `AUTH_JWKS_CACHE_TTL`
+  and `AUTH_DISCOVERY_CACHE_TTL` are validated (integer seconds, zero or
+  greater) during configuration resolution, so malformed values fail startup
+  instead of surfacing during lazy client creation on a request path.
+  Implicit demo mode (no auth configuration at all, in an environment that
+  permits it) still boots for local getting-started use.
 - **Fail-closed billing fulfillment ingress**:
   `POST /api/billing/fulfillment/apply` (and the fulfillment admin listing)
   now requires the internal API key, an *authenticated* billing-admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,28 @@ This project follows a practical pre-1.0 changelog format:
   Contradictory explicit declarations (`AUTH_ENABLED=true` +
   `AUTH_PROVIDER=none`; `AUTH_ENABLED=false` + a real explicit
   `AUTH_PROVIDER`) and unrecognized `AUTH_ENABLED` values are fatal instead
-  of silently resolving. **Protected environments (`ENV`/`ENVIRONMENT` of
-  staging/production) refuse all no-auth operation** — explicit disable or
-  implicit demo mode — independent of `MOZAIKS_STARTUP_CHECKS` mode; the
-  explicit no-auth switches remain local development/test contracts. The
-  cached auth adapter is keyed by a resolved-configuration fingerprint, so
-  request-time validation always uses the configuration startup validated
-  and a stale trusted-bypass adapter cannot survive a configuration change.
-  Implicit demo mode (no auth configuration at all, unprotected
-  environment) still boots for local getting-started use.
+  of silently resolving. **Unauthenticated operation is now allowlisted:** it
+  is permitted only in the recognized local environments `development`,
+  `local`, `test` (`dev` normalizes to `development`) or with no environment
+  configured. Every other explicit `ENV`/`ENVIRONMENT` value — `production`,
+  `staging`, and unknown or regional names such as `prod-us`,
+  `production-east`, `preview`, or `qa` — refuses no-auth operation
+  (explicit disable or implicit demo) independent of
+  `MOZAIKS_STARTUP_CHECKS` mode, while still booting normally with
+  authentication configured. `ENV` and `ENVIRONMENT` are resolved
+  canonically: blank values are absence (a blank `ENV` cannot mask a
+  deployed `ENVIRONMENT`), aliases normalize before comparison, and two
+  non-blank values that disagree are a fatal configuration error rather than
+  a silent pick. The cached auth adapter is keyed by the complete
+  provider-specific configuration snapshot it is built from — issuer, JWKS
+  and discovery URLs, audience, every claim mapping, scope format, clock
+  skew, algorithms, cache TTLs, Keycloak claim mappings, Supabase secret,
+  and anonymous-persona settings — so changing any of them rebuilds the
+  adapter and no stale adapter can serve requests under newer configuration.
+  Custom adapters declare a `config_identity` at registration to participate
+  in that cache identity, and are never cached without one. Implicit demo
+  mode (no auth configuration at all, in an environment that permits it)
+  still boots for local getting-started use.
 - **Fail-closed billing fulfillment ingress**:
   `POST /api/billing/fulfillment/apply` (and the fulfillment admin listing)
   now requires the internal API key, an *authenticated* billing-admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,14 @@ This project follows a practical pre-1.0 changelog format:
   in that cache identity, and are never cached without one; malformed
   identities (non-string, empty, whitespace-only, or a raising callable) are
   rejected rather than coerced into a cache key. The adapter constructor
-  contract is established *positively* at registration by signature
-  inspection: `settings` as a keyword (or `**kwargs`) receives the snapshot,
-  a constructor whose other parameters are all optional is built with no
-  arguments, and anything the runtime cannot classify — a positional-only
-  `settings`, a required parameter it cannot supply, or a signature it cannot
-  inspect — is rejected instead of being assumed to take no configuration
+  contract is established *positively* at registration by binding the
+  runtime's exact invocation against the complete signature: `settings` as a
+  keyword (or `**kwargs`) receives the snapshot, a constructor whose other
+  parameters are all optional is built with no arguments, and anything the
+  runtime cannot actually invoke — `(settings, required)`,
+  `(required, **kwargs)`, a positional-only `settings`, any required parameter
+  it cannot supply, or a signature it cannot inspect — is rejected instead of
+  being assumed to take no configuration
   (`register_adapter(..., constructor_mode=...)` declares the contract
   explicitly for uninspectable constructors). An exception raised inside a
   constructor body — including `TypeError` — fails closed instead of

--- a/docs/architecture/modules-systems/module-system.md
+++ b/docs/architecture/modules-systems/module-system.md
@@ -115,6 +115,12 @@ actions:
     permissions: [my_module.manage]
     emits: [domain.my_module.item_created]
 
+# NOTE: the actions list is the module's complete dispatch authority.
+# Only declared action ids resolve at runtime — a handler method that is not
+# referenced by a declared action's handler_method is never dispatchable via
+# module dispatch (HTTP or executor), and undeclared action ids fail closed
+# with ACTION_NOT_FOUND.
+
 # Optional: expose named capabilities for reaction routing and managed-capability wiring.
 # Omit this section when reactions only target handler_method directly.
 capabilities:

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -211,10 +211,16 @@ previous one stays internally consistent. Explicit constructor input to
 `OIDCDiscoveryClient` and `JWKSClient` is authoritative and is never
 overridden by live environment or global `AuthConfig`.
 
-`AUTH_JWKS_CACHE_TTL` and `AUTH_DISCOVERY_CACHE_TTL` must be integer seconds,
-zero or greater (`0` means always refetch). They are parsed during
-configuration resolution, so a malformed value fails startup rather than
-surfacing later during lazy client construction on a request path.
+`AUTH_JWKS_CACHE_TTL` (default `3600`) and `AUTH_DISCOVERY_CACHE_TTL`
+(default `86400`) must be integer seconds, zero or greater, where `0` means
+always refetch and is never treated as "unset". Absent, empty, and
+whitespace-only values all normalize to the same canonical default, resolved
+once by `mozaiksai.core.auth.cache_ttl` and reused by configuration
+resolution, the adapter's own config, and `AuthConfig` — the layers can never
+disagree. Malformed values fail startup rather than surfacing later during
+lazy client construction on a request path. Cache expiry compares elapsed time
+against the TTL rather than adding it to a timestamp, so any accepted value —
+including a very large one — stays valid during real cache use.
 
 ### Custom adapter contracts
 
@@ -235,11 +241,31 @@ never cached — it is rebuilt on every resolution — so a changed custom
 configuration can never silently reuse an adapter validated under an older
 one. Re-registering a provider also invalidates any cached adapter.
 
-Adapter constructors may accept a `settings` argument to receive the
-configuration snapshot; support is determined by signature inspection at
-registration, before any construction attempt. An exception raised inside a
-constructor body — including `TypeError` — is a real construction failure and
-fails closed. The runtime never retries construction without the snapshot.
+Adapter constructors receive the configuration snapshot as `settings=`. The
+constructor contract is established **positively** at registration, before any
+construction attempt, and registration fails rather than assuming an adapter
+takes no configuration:
+
+| Constructor | Outcome |
+|---|---|
+| `settings` as a normal or keyword-only parameter | snapshot supplied |
+| `**kwargs` | snapshot supplied |
+| no `settings`, all other parameters optional | constructed with no arguments |
+| `settings` positional-only | **rejected** — make it keyword-accessible |
+| a required parameter the runtime cannot supply | **rejected** |
+| signature cannot be inspected | **rejected** unless `constructor_mode` is declared |
+
+For constructors that genuinely cannot be inspected (C extensions, exotic
+callables), declare the contract explicitly:
+
+```python
+register_adapter("my-custom", MyAdapter, config_identity="v1",
+                 constructor_mode="settings_keyword")  # or "no_settings"
+```
+
+An exception raised inside a constructor body — including `TypeError` — is a
+real construction failure and fails closed. The runtime never retries
+construction without the snapshot.
 
 Privileged HTTP surfaces can additionally require authenticated provenance:
 `UserPrincipal.is_authenticated` is true only for principals produced by

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -246,12 +246,21 @@ constructor contract is established **positively** at registration, before any
 construction attempt, and registration fails rather than assuming an adapter
 takes no configuration:
 
+A mode is accepted only when the runtime's exact invocation —
+`Adapter(settings=...)` or `Adapter()` — binds successfully against the
+complete signature. Naming a usable `settings` parameter is necessary but not
+sufficient: a constructor that also demands arguments the runtime cannot
+supply is rejected when it registers, not at first use.
+
 | Constructor | Outcome |
 |---|---|
-| `settings` as a normal or keyword-only parameter | snapshot supplied |
-| `**kwargs` | snapshot supplied |
-| no `settings`, all other parameters optional | constructed with no arguments |
-| `settings` positional-only | **rejected** — make it keyword-accessible |
+| `(settings)` / `(*, settings)` | snapshot supplied |
+| `(settings=None, optional=None)` | snapshot supplied |
+| `(**kwargs)` | snapshot supplied |
+| `()` / all parameters optional / `(*args)` | constructed with no arguments |
+| `(settings, required)` / `(settings, *, required)` | **rejected** — the call cannot bind |
+| `(required, **kwargs)` | **rejected** — the call cannot bind |
+| `(settings)` positional-only | **rejected** — make it keyword-accessible |
 | a required parameter the runtime cannot supply | **rejected** |
 | signature cannot be inspected | **rejected** unless `constructor_mode` is declared |
 
@@ -262,6 +271,9 @@ callables), declare the contract explicitly:
 register_adapter("my-custom", MyAdapter, config_identity="v1",
                  constructor_mode="settings_keyword")  # or "no_settings"
 ```
+
+When the signature *is* inspectable the declaration is verified against it, so
+explicit metadata cannot claim an invocation that provably would not work.
 
 An exception raised inside a constructor body — including `TypeError` — is a
 real construction failure and fails closed. The runtime never retries

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -201,6 +201,23 @@ discovery cache TTL, Keycloak claim mappings, Supabase secret, anonymous
 persona settings) rebuilds the adapter, so request-time validation always uses
 the configuration startup validated.
 
+An adapter is bound to its snapshot for its whole lifetime, including the
+discovery and JWKS clients it creates lazily on first use. Those clients
+receive the adapter's own URLs and cache TTLs and are constructed with
+environment consultation disabled, so an adapter created under one
+configuration can never begin validating tokens against another after the
+environment changes. A configuration change produces a *new* adapter; the
+previous one stays internally consistent. Explicit constructor input to
+`OIDCDiscoveryClient` and `JWKSClient` is authoritative and is never
+overridden by live environment or global `AuthConfig`.
+
+`AUTH_JWKS_CACHE_TTL` and `AUTH_DISCOVERY_CACHE_TTL` must be integer seconds,
+zero or greater (`0` means always refetch). They are parsed during
+configuration resolution, so a malformed value fails startup rather than
+surfacing later during lazy client construction on a request path.
+
+### Custom adapter contracts
+
 Custom adapters registered via `register_adapter` declare their own cache
 identity:
 
@@ -208,11 +225,21 @@ identity:
 register_adapter("my-custom", MyCustomAdapter, config_identity=lambda: cfg.revision)
 ```
 
-`config_identity` (a string or callable returning one) must change whenever
-the adapter's configuration changes. Without it the adapter is deliberately
+`config_identity` must be a **non-blank string**, or a callable returning one,
+that changes whenever the adapter's configuration changes. Malformed
+identities fail closed rather than being coerced: a non-string value, an empty
+or whitespace-only string, or a callable that raises is rejected with an
+`AuthError` (literal values are validated at registration; callable results at
+each resolution). Without a `config_identity` the adapter is deliberately
 never cached — it is rebuilt on every resolution — so a changed custom
 configuration can never silently reuse an adapter validated under an older
 one. Re-registering a provider also invalidates any cached adapter.
+
+Adapter constructors may accept a `settings` argument to receive the
+configuration snapshot; support is determined by signature inspection at
+registration, before any construction attempt. An exception raised inside a
+constructor body — including `TypeError` — is a real construction failure and
+fails closed. The runtime never retries construction without the snapshot.
 
 Privileged HTTP surfaces can additionally require authenticated provenance:
 `UserPrincipal.is_authenticated` is true only for principals produced by

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -139,23 +139,47 @@ If `AUTH_PROVIDER` is not set, the system auto-detects based on environment vari
 | `MOZAIKS_OIDC_AUTHORITY` or `MOZAIKS_OIDC_DISCOVERY_URL` | `jwt` |
 | Nothing | `none` (demo mode) |
 
-Auto-detection fails closed when auth is explicitly enabled:
+Resolution is canonical and fails closed. One parser
+(`mozaiksai.core.auth.adapters.registry.resolve_auth_config`) interprets the
+auth environment into an immutable resolved state; every predicate, the
+adapter cache, and startup validation consume that same interpretation:
 
 - `AUTH_ENABLED=true` with no detectable provider is a fatal configuration
   error in every environment (startup refuses to boot; provider resolution
   raises). The runtime never silently falls back to the trusted-bypass
   `none` adapter when auth was explicitly requested.
-- `AUTH_ENABLED=true` combined with `AUTH_PROVIDER=none`, an unknown
-  `AUTH_PROVIDER` value, or a named provider whose configuration is
-  incomplete (for example `AUTH_PROVIDER=jwt` without JWKS/issuer/discovery
-  settings) is fatal for the same reason.
+- Contradictory explicit declarations are fatal instead of silently picking
+  one: `AUTH_ENABLED=true` + `AUTH_PROVIDER=none`, and `AUTH_ENABLED=false`
+  + a real explicit `AUTH_PROVIDER`. (Passive provider signals such as a
+  `SUPABASE_URL` left in a developer `.env` do not contradict an explicit
+  disable — the explicit switch wins over passive presence.)
+- An unknown `AUTH_PROVIDER` value, or a selected provider whose
+  configuration cannot validate tokens (for example `AUTH_PROVIDER=jwt`
+  without JWKS/issuer/discovery settings), is fatal.
 - An unrecognized `AUTH_ENABLED` value (for example a typo like `tru`) is
   fatal instead of silently disabling auth.
+- **Protected environments refuse no-auth operation entirely.** When
+  `ENV`/`ENVIRONMENT` is `staging` or `production` (including `stage`/`prod`
+  spellings), any configuration that resolves to no authentication —
+  explicit `AUTH_ENABLED=false`, explicit `AUTH_PROVIDER=none`, or implicit
+  demo mode — is fatal at startup and at provider resolution, independent of
+  `MOZAIKS_STARTUP_CHECKS` mode. Explicit no-auth remains a local
+  development/test contract only.
 - Demo mode (`none` without explicit disablement) applies only when no auth
-  configuration is present at all. Security-sensitive bypasses (such as the
-  billing fulfillment ingress) additionally require *explicit* disablement —
-  `AUTH_ENABLED=false` or `AUTH_PROVIDER=none` — and are not available in
-  implicit demo mode.
+  configuration is present at all, in an unprotected environment.
+  Security-sensitive bypasses (such as the billing fulfillment ingress)
+  additionally require *explicit* disablement — `AUTH_ENABLED=false` or
+  `AUTH_PROVIDER=none` — and are not available in implicit demo mode.
+- The cached adapter instance is keyed by a fingerprint of the resolved
+  configuration: when auth-relevant environment variables change, the stale
+  adapter is discarded and rebuilt, so request-time validation always uses
+  the configuration that startup validated.
+
+Privileged HTTP surfaces can additionally require authenticated provenance:
+`UserPrincipal.is_authenticated` is true only for principals produced by
+validating a real bearer token against the configured adapter. Anonymous
+demo principals and request-scoped dev personas may carry admin-looking
+roles/scopes, but they are never authenticated provenance.
 
 ---
 

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -158,22 +158,61 @@ adapter cache, and startup validation consume that same interpretation:
   without JWKS/issuer/discovery settings), is fatal.
 - An unrecognized `AUTH_ENABLED` value (for example a typo like `tru`) is
   fatal instead of silently disabling auth.
-- **Protected environments refuse no-auth operation entirely.** When
-  `ENV`/`ENVIRONMENT` is `staging` or `production` (including `stage`/`prod`
-  spellings), any configuration that resolves to no authentication —
-  explicit `AUTH_ENABLED=false`, explicit `AUTH_PROVIDER=none`, or implicit
-  demo mode — is fatal at startup and at provider resolution, independent of
-  `MOZAIKS_STARTUP_CHECKS` mode. Explicit no-auth remains a local
-  development/test contract only.
+- **Unauthenticated operation is allowlisted, not denylisted.** No-auth
+  operation — explicit `AUTH_ENABLED=false`, explicit `AUTH_PROVIDER=none`,
+  or implicit demo mode — is permitted **only** when the resolved environment
+  is one of the recognized local names `development`, `local`, `test`
+  (`dev` normalizes to `development`), or when no environment is configured
+  at all. Every other explicit value rejects it, fatally, at startup and at
+  provider resolution, independent of `MOZAIKS_STARTUP_CHECKS` mode. That
+  includes known deployments (`production`, `staging`, and the `prod`/`stage`
+  aliases) **and** unknown or regional names such as `prod-us`,
+  `staging-eu`, `production-east`, `preview`, `qa`, or any custom value — an
+  unrecognized environment never inherits development privilege. Unknown
+  environments may still boot normally with authentication configured.
 - Demo mode (`none` without explicit disablement) applies only when no auth
-  configuration is present at all, in an unprotected environment.
+  configuration is present at all, in an environment that permits no-auth.
   Security-sensitive bypasses (such as the billing fulfillment ingress)
   additionally require *explicit* disablement — `AUTH_ENABLED=false` or
   `AUTH_PROVIDER=none` — and are not available in implicit demo mode.
-- The cached adapter instance is keyed by a fingerprint of the resolved
-  configuration: when auth-relevant environment variables change, the stale
-  adapter is discarded and rebuilt, so request-time validation always uses
-  the configuration that startup validated.
+
+### ENV / ENVIRONMENT resolution
+
+`ENV` is the primary signal and `ENVIRONMENT` the fallback, but the two are
+resolved canonically rather than by precedence alone:
+
+- both values are trimmed first; empty or whitespace-only means *absent*, so a
+  blank `ENV` never masks a non-blank `ENVIRONMENT`
+- recognized aliases (`dev`/`prod`/`stage`) normalize before comparison
+- if both are non-blank and resolve to **different** environments (for example
+  `ENV=development` with `ENVIRONMENT=production`), that is a fatal
+  configuration error — the runtime refuses to silently choose one
+- if both resolve to the same environment, that is accepted
+- both absent keeps the documented implicit local default
+
+### Adapter cache coherence
+
+The cached adapter is keyed by a fingerprint derived from the same immutable
+configuration snapshot the adapter is constructed from, covering the
+**complete** set of inputs for the resolved provider — not just provider
+selection. Changing any meaning-bearing value (issuer, JWKS/discovery URL,
+audience, any claim mapping, scope format, clock skew, algorithms, JWKS or
+discovery cache TTL, Keycloak claim mappings, Supabase secret, anonymous
+persona settings) rebuilds the adapter, so request-time validation always uses
+the configuration startup validated.
+
+Custom adapters registered via `register_adapter` declare their own cache
+identity:
+
+```python
+register_adapter("my-custom", MyCustomAdapter, config_identity=lambda: cfg.revision)
+```
+
+`config_identity` (a string or callable returning one) must change whenever
+the adapter's configuration changes. Without it the adapter is deliberately
+never cached — it is rebuilt on every resolution — so a changed custom
+configuration can never silently reuse an adapter validated under an older
+one. Re-registering a provider also invalidates any cached adapter.
 
 Privileged HTTP surfaces can additionally require authenticated provenance:
 `UserPrincipal.is_authenticated` is true only for principals produced by

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -139,6 +139,24 @@ If `AUTH_PROVIDER` is not set, the system auto-detects based on environment vari
 | `MOZAIKS_OIDC_AUTHORITY` or `MOZAIKS_OIDC_DISCOVERY_URL` | `jwt` |
 | Nothing | `none` (demo mode) |
 
+Auto-detection fails closed when auth is explicitly enabled:
+
+- `AUTH_ENABLED=true` with no detectable provider is a fatal configuration
+  error in every environment (startup refuses to boot; provider resolution
+  raises). The runtime never silently falls back to the trusted-bypass
+  `none` adapter when auth was explicitly requested.
+- `AUTH_ENABLED=true` combined with `AUTH_PROVIDER=none`, an unknown
+  `AUTH_PROVIDER` value, or a named provider whose configuration is
+  incomplete (for example `AUTH_PROVIDER=jwt` without JWKS/issuer/discovery
+  settings) is fatal for the same reason.
+- An unrecognized `AUTH_ENABLED` value (for example a typo like `tru`) is
+  fatal instead of silently disabling auth.
+- Demo mode (`none` without explicit disablement) applies only when no auth
+  configuration is present at all. Security-sensitive bypasses (such as the
+  billing fulfillment ingress) additionally require *explicit* disablement —
+  `AUTH_ENABLED=false` or `AUTH_PROVIDER=none` — and are not available in
+  implicit demo mode.
+
 ---
 
 ## Custom Adapter

--- a/mozaiksai/core/auth/__init__.py
+++ b/mozaiksai/core/auth/__init__.py
@@ -87,6 +87,7 @@ from mozaiksai.core.auth.adapters.registry import (
     is_auth_enabled,
     is_auth_explicitly_disabled,
     reset_auth_adapter,
+    resolve_auth_config,
 )
 from mozaiksai.core.auth.config import (
     AuthConfig,
@@ -133,6 +134,7 @@ __all__ = [
     "list_adapters",
     "is_auth_enabled",
     "is_auth_explicitly_disabled",
+    "resolve_auth_config",
     "reset_auth_adapter",
     # HTTP Dependencies
     "UserPrincipal",

--- a/mozaiksai/core/auth/__init__.py
+++ b/mozaiksai/core/auth/__init__.py
@@ -135,6 +135,7 @@ __all__ = [
     "is_auth_enabled",
     "is_auth_explicitly_disabled",
     "resolve_auth_config",
+    "validate_auth_provider_configuration",
     "reset_auth_adapter",
     # HTTP Dependencies
     "UserPrincipal",

--- a/mozaiksai/core/auth/__init__.py
+++ b/mozaiksai/core/auth/__init__.py
@@ -85,6 +85,7 @@ from mozaiksai.core.auth.adapters import (
 )
 from mozaiksai.core.auth.adapters.registry import (
     is_auth_enabled,
+    is_auth_explicitly_disabled,
     reset_auth_adapter,
 )
 from mozaiksai.core.auth.config import (
@@ -131,6 +132,7 @@ __all__ = [
     "register_adapter",
     "list_adapters",
     "is_auth_enabled",
+    "is_auth_explicitly_disabled",
     "reset_auth_adapter",
     # HTTP Dependencies
     "UserPrincipal",

--- a/mozaiksai/core/auth/adapters/base.py
+++ b/mozaiksai/core/auth/adapters/base.py
@@ -4,6 +4,8 @@ Base auth adapter protocol and types.
 All auth adapters must implement the AuthAdapter protocol.
 """
 
+import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
@@ -121,12 +123,43 @@ class BaseAuthAdapter:
     Base class for auth adapters with common functionality.
 
     Adapters can extend this class for shared utilities.
+
+    Configuration snapshot
+    ----------------------
+    Adapters are constructed from an immutable configuration snapshot supplied
+    by the auth registry (``settings``). The registry derives the adapter cache
+    identity from that same snapshot, so the adapter a request uses is always
+    built from exactly the configuration that identity describes. Reading live
+    ``os.environ`` inside an adapter would break that guarantee: use
+    :meth:`_setting` instead of ``os.getenv``.
+
+    ``settings=None`` falls back to the live environment, preserving direct
+    construction in tests and custom embedding code.
     """
 
     name: str = "base"
 
-    def __init__(self):
-        pass
+    def __init__(self, settings: Mapping[str, str] | None = None):
+        self._settings: Mapping[str, str] | None = settings
+
+    def _setting(self, name: str, default: str = "") -> str:
+        """Read one configuration value from the snapshot, else the environment.
+
+        An absent value and an empty value are equivalent (both yield the
+        default), matching how the rest of the auth configuration treats blank
+        environment variables.
+        """
+        if self._settings is not None:
+            value = self._settings.get(name)
+        else:
+            value = os.getenv(name)
+        return default if not value else value
+
+    def _optional_setting(self, name: str) -> str | None:
+        """Read a value whose absence is meaningfully different from empty."""
+        if self._settings is not None:
+            return self._settings.get(name) or None
+        return os.getenv(name) or None
 
     async def validate_token(self, token: str) -> UserClaims:
         """Override in subclass."""

--- a/mozaiksai/core/auth/adapters/jwt_adapter.py
+++ b/mozaiksai/core/auth/adapters/jwt_adapter.py
@@ -5,6 +5,7 @@ Supports configurable claim mappings to work with any JWT-based auth provider.
 """
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -92,31 +93,50 @@ class JWTAdapterConfig:
             self.algorithms = ["RS256"]
 
     @classmethod
-    def from_env(cls) -> "JWTAdapterConfig":
-        """Load configuration from environment variables."""
-        algorithms_str = os.getenv("AUTH_ALGORITHMS", "RS256")
+    def from_env(cls, settings: Mapping[str, str] | None = None) -> "JWTAdapterConfig":
+        """Load configuration from an immutable snapshot, else the environment.
+
+        The auth registry passes the same snapshot it derived the adapter cache
+        identity from, so the constructed adapter always matches that identity.
+        """
+
+        def _get(name: str, default: str = "") -> str:
+            # Absent and empty are equivalent here: a blank AUTH_* variable in
+            # a .env must behave exactly like an unset one.
+            value = settings.get(name) if settings is not None else os.getenv(name)
+            return default if not value else value
+
+        algorithms_str = _get("AUTH_ALGORITHMS", "RS256")
         algorithms = [a.strip() for a in algorithms_str.split(",") if a.strip()]
 
+        raw_clock_skew = _get("AUTH_CLOCK_SKEW", "120").strip() or "120"
+        try:
+            clock_skew_seconds = int(raw_clock_skew)
+        except ValueError as exc:
+            raise ValueError(
+                f"AUTH_CLOCK_SKEW must be an integer number of seconds, got {raw_clock_skew!r}"
+            ) from exc
+
         return cls(
-            jwks_url=os.getenv("AUTH_JWKS_URL", ""),
-            issuer=os.getenv("AUTH_ISSUER", ""),
-            audience=os.getenv("AUTH_AUDIENCE", ""),
-            oidc_authority=os.getenv("MOZAIKS_OIDC_AUTHORITY", ""),
-            oidc_tenant_id=os.getenv("MOZAIKS_OIDC_TENANT_ID", ""),
-            oidc_discovery_url=os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", ""),
-            user_id_claim=os.getenv("AUTH_USER_ID_CLAIM", "sub"),
-            email_claim=os.getenv("AUTH_EMAIL_CLAIM", "email"),
-            name_claim=os.getenv("AUTH_NAME_CLAIM", "name"),
-            roles_claim=os.getenv("AUTH_ROLES_CLAIM", "roles"),
-            scopes_claim=os.getenv("AUTH_SCOPES_CLAIM", "scp"),
-            app_id_claim=os.getenv("AUTH_APP_ID_CLAIM", "app_id"),
-            chat_id_claim=os.getenv("AUTH_CHAT_ID_CLAIM", "chat_id"),
-            tenant_id_claim=os.getenv("AUTH_TENANT_ID_CLAIM", "tid"),
-            workspace_id_claim=os.getenv("AUTH_WORKSPACE_ID_CLAIM", "workspace_id"),
-            scopes_format=os.getenv("AUTH_SCOPES_FORMAT", "space"),
+            jwks_url=_get("AUTH_JWKS_URL"),
+            issuer=_get("AUTH_ISSUER"),
+            audience=_get("AUTH_AUDIENCE"),
+            oidc_authority=_get("MOZAIKS_OIDC_AUTHORITY"),
+            oidc_tenant_id=_get("MOZAIKS_OIDC_TENANT_ID"),
+            oidc_discovery_url=_get("MOZAIKS_OIDC_DISCOVERY_URL"),
+            user_id_claim=_get("AUTH_USER_ID_CLAIM", "sub"),
+            email_claim=_get("AUTH_EMAIL_CLAIM", "email"),
+            name_claim=_get("AUTH_NAME_CLAIM", "name"),
+            roles_claim=_get("AUTH_ROLES_CLAIM", "roles"),
+            scopes_claim=_get("AUTH_SCOPES_CLAIM", "scp"),
+            app_id_claim=_get("AUTH_APP_ID_CLAIM", "app_id"),
+            chat_id_claim=_get("AUTH_CHAT_ID_CLAIM", "chat_id"),
+            tenant_id_claim=_get("AUTH_TENANT_ID_CLAIM", "tid"),
+            workspace_id_claim=_get("AUTH_WORKSPACE_ID_CLAIM", "workspace_id"),
+            scopes_format=_get("AUTH_SCOPES_FORMAT", "space"),
             algorithms=algorithms,
-            clock_skew_seconds=int(os.getenv("AUTH_CLOCK_SKEW", "120")),
-            required_scope=os.getenv("AUTH_REQUIRED_SCOPE", ""),
+            clock_skew_seconds=clock_skew_seconds,
+            required_scope=_get("AUTH_REQUIRED_SCOPE"),
         )
 
 
@@ -151,9 +171,13 @@ class GenericJWTAdapter(BaseAuthAdapter):
 
     name = "jwt"
 
-    def __init__(self, config: JWTAdapterConfig | None = None):
-        super().__init__()
-        self._config = config or JWTAdapterConfig.from_env()
+    def __init__(
+        self,
+        config: JWTAdapterConfig | None = None,
+        settings: Mapping[str, str] | None = None,
+    ):
+        super().__init__(settings)
+        self._config = config or JWTAdapterConfig.from_env(settings)
         self._pyjwk_client: PyJWKClient | None = None
         self._discovery_client: OIDCDiscoveryClient | None = None
         self._jwks_client: JWKSClient | None = None

--- a/mozaiksai/core/auth/adapters/jwt_adapter.py
+++ b/mozaiksai/core/auth/adapters/jwt_adapter.py
@@ -14,7 +14,13 @@ from jwt import PyJWKClient
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthError, BaseAuthAdapter, UserClaims
-from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
+from mozaiksai.core.auth.cache_ttl import (
+    DEFAULT_DISCOVERY_CACHE_TTL_SECONDS,
+    DEFAULT_JWKS_CACHE_TTL_SECONDS,
+    DISCOVERY_CACHE_TTL_ENV,
+    JWKS_CACHE_TTL_ENV,
+    resolve_cache_ttl_setting,
+)
 from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
 from mozaiksai.core.auth.jwks import JWKSClient
 
@@ -92,8 +98,8 @@ class JWTAdapterConfig:
     # Cache TTLs for this adapter's own discovery/JWKS clients. Held here so
     # the lazily created clients derive from the same immutable snapshot that
     # identifies the adapter, never from live environment.
-    jwks_cache_ttl_seconds: int = 3600
-    discovery_cache_ttl_seconds: int = 86400
+    jwks_cache_ttl_seconds: int = DEFAULT_JWKS_CACHE_TTL_SECONDS
+    discovery_cache_ttl_seconds: int = DEFAULT_DISCOVERY_CACHE_TTL_SECONDS
 
     def __post_init__(self):
         if self.algorithms is None:
@@ -106,6 +112,10 @@ class JWTAdapterConfig:
         The auth registry passes the same snapshot it derived the adapter cache
         identity from, so the constructed adapter always matches that identity.
         """
+
+        def _raw(name: str) -> str | None:
+            """Return the configured value untouched (no default substitution)."""
+            return settings.get(name) if settings is not None else os.getenv(name)
 
         def _get(name: str, default: str = "") -> str:
             # Absent and empty are equivalent here: a blank AUTH_* variable in
@@ -124,11 +134,14 @@ class JWTAdapterConfig:
                 f"AUTH_CLOCK_SKEW must be an integer number of seconds, got {raw_clock_skew!r}"
             ) from exc
 
-        jwks_cache_ttl_seconds = parse_cache_ttl_seconds(
-            "AUTH_JWKS_CACHE_TTL", _get("AUTH_JWKS_CACHE_TTL", "3600")
+        # Raw values go straight to the canonical resolver: absent, empty, and
+        # whitespace-only all normalize to the same default here as they do in
+        # canonical auth resolution.
+        jwks_cache_ttl_seconds = resolve_cache_ttl_setting(
+            JWKS_CACHE_TTL_ENV, _raw(JWKS_CACHE_TTL_ENV)
         )
-        discovery_cache_ttl_seconds = parse_cache_ttl_seconds(
-            "AUTH_DISCOVERY_CACHE_TTL", _get("AUTH_DISCOVERY_CACHE_TTL", "86400")
+        discovery_cache_ttl_seconds = resolve_cache_ttl_setting(
+            DISCOVERY_CACHE_TTL_ENV, _raw(DISCOVERY_CACHE_TTL_ENV)
         )
 
         return cls(

--- a/mozaiksai/core/auth/adapters/jwt_adapter.py
+++ b/mozaiksai/core/auth/adapters/jwt_adapter.py
@@ -14,6 +14,7 @@ from jwt import PyJWKClient
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthError, BaseAuthAdapter, UserClaims
+from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
 from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
 from mozaiksai.core.auth.jwks import JWKSClient
 
@@ -88,6 +89,12 @@ class JWTAdapterConfig:
     # Optional: required scope for user endpoints
     required_scope: str = ""
 
+    # Cache TTLs for this adapter's own discovery/JWKS clients. Held here so
+    # the lazily created clients derive from the same immutable snapshot that
+    # identifies the adapter, never from live environment.
+    jwks_cache_ttl_seconds: int = 3600
+    discovery_cache_ttl_seconds: int = 86400
+
     def __post_init__(self):
         if self.algorithms is None:
             self.algorithms = ["RS256"]
@@ -117,6 +124,13 @@ class JWTAdapterConfig:
                 f"AUTH_CLOCK_SKEW must be an integer number of seconds, got {raw_clock_skew!r}"
             ) from exc
 
+        jwks_cache_ttl_seconds = parse_cache_ttl_seconds(
+            "AUTH_JWKS_CACHE_TTL", _get("AUTH_JWKS_CACHE_TTL", "3600")
+        )
+        discovery_cache_ttl_seconds = parse_cache_ttl_seconds(
+            "AUTH_DISCOVERY_CACHE_TTL", _get("AUTH_DISCOVERY_CACHE_TTL", "86400")
+        )
+
         return cls(
             jwks_url=_get("AUTH_JWKS_URL"),
             issuer=_get("AUTH_ISSUER"),
@@ -137,6 +151,8 @@ class JWTAdapterConfig:
             algorithms=algorithms,
             clock_skew_seconds=clock_skew_seconds,
             required_scope=_get("AUTH_REQUIRED_SCOPE"),
+            jwks_cache_ttl_seconds=jwks_cache_ttl_seconds,
+            discovery_cache_ttl_seconds=discovery_cache_ttl_seconds,
         )
 
 
@@ -191,9 +207,13 @@ class GenericJWTAdapter(BaseAuthAdapter):
 
     def _get_discovery_client(self) -> OIDCDiscoveryClient:
         if self._discovery_client is None:
+            # Snapshot-bound: the URL and TTL come from this adapter's own
+            # immutable config, and consult_environment=False forbids the
+            # client from reading live environment for anything.
             self._discovery_client = OIDCDiscoveryClient(
                 discovery_url=self._configured_discovery_url(),
-                cache_ttl=None,
+                cache_ttl=self._config.discovery_cache_ttl_seconds,
+                consult_environment=False,
             )
         return self._discovery_client
 
@@ -223,7 +243,13 @@ class GenericJWTAdapter(BaseAuthAdapter):
                         500,
                         self.name,
                     ) from exc
-            self._jwks_client = JWKSClient(jwks_url=jwks_url, use_discovery=False)
+            self._jwks_client = JWKSClient(
+                jwks_url=jwks_url,
+                cache_ttl=self._config.jwks_cache_ttl_seconds,
+                use_discovery=False,
+                consult_environment=False,
+                discovery_client=self._get_discovery_client(),
+            )
         return self._jwks_client
 
     async def _get_expected_issuer(self) -> str:

--- a/mozaiksai/core/auth/adapters/keycloak.py
+++ b/mozaiksai/core/auth/adapters/keycloak.py
@@ -12,7 +12,7 @@ Keycloak JWTs have the following structure:
 - azp: Authorized party (client_id)
 """
 
-import os
+from collections.abc import Mapping
 from typing import Any
 
 import jwt
@@ -63,14 +63,15 @@ class KeycloakAuthAdapter(BaseAuthAdapter):
         keycloak_url: str | None = None,
         realm: str | None = None,
         client_id: str | None = None,
+        settings: Mapping[str, str] | None = None,
     ):
-        super().__init__()
-        self._keycloak_url = keycloak_url or os.getenv("KEYCLOAK_URL", "")
-        self._realm = realm or os.getenv("KEYCLOAK_REALM", "")
-        self._client_id = client_id or os.getenv("KEYCLOAK_CLIENT_ID", "")
-        self._app_id_claim = os.getenv("KEYCLOAK_APP_ID_CLAIM", "azp")
-        self._tenant_id_claim = os.getenv("KEYCLOAK_TENANT_ID_CLAIM", "azp")
-        self._workspace_id_claim = os.getenv("KEYCLOAK_WORKSPACE_ID_CLAIM", "workspace_id")
+        super().__init__(settings)
+        self._keycloak_url = keycloak_url or self._setting("KEYCLOAK_URL")
+        self._realm = realm or self._setting("KEYCLOAK_REALM")
+        self._client_id = client_id or self._setting("KEYCLOAK_CLIENT_ID")
+        self._app_id_claim = self._setting("KEYCLOAK_APP_ID_CLAIM", "azp")
+        self._tenant_id_claim = self._setting("KEYCLOAK_TENANT_ID_CLAIM", "azp")
+        self._workspace_id_claim = self._setting("KEYCLOAK_WORKSPACE_ID_CLAIM", "workspace_id")
         self._jwks_client: PyJWKClient | None = None
 
         # Clean URL (remove trailing slash)

--- a/mozaiksai/core/auth/adapters/no_auth.py
+++ b/mozaiksai/core/auth/adapters/no_auth.py
@@ -5,7 +5,7 @@ This adapter bypasses all authentication and returns anonymous user claims.
 Use this when AUTH_ENABLED=false or AUTH_PROVIDER=none.
 """
 
-import os
+from collections.abc import Mapping
 
 from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
 
@@ -52,19 +52,20 @@ class NoAuthAdapter(BaseAuthAdapter):
         default_email: str | None = None,
         default_roles: list | None = None,
         default_scopes: list | None = None,
+        settings: Mapping[str, str] | None = None,
     ):
-        super().__init__()
-        self._default_user_id = default_user_id or os.getenv("AUTH_ANON_USER_ID", "anonymous")
-        self._default_email = default_email or os.getenv("AUTH_ANON_EMAIL")
+        super().__init__(settings)
+        self._default_user_id = default_user_id or self._setting("AUTH_ANON_USER_ID", "anonymous")
+        self._default_email = default_email or self._optional_setting("AUTH_ANON_EMAIL")
         # AUTH_ANON_ROLES: comma-separated list of roles for the anonymous dev user
         # e.g. AUTH_ANON_ROLES=admin,user  — enables admin portal in no-auth dev mode
-        env_roles_raw = os.getenv("AUTH_ANON_ROLES", "")
+        env_roles_raw = self._setting("AUTH_ANON_ROLES")
         env_roles = [r.strip() for r in env_roles_raw.split(",") if r.strip()] if env_roles_raw else []
         self._default_roles = default_roles or env_roles
         # AUTH_ANON_SCOPES: comma-separated override for module permission scopes.
         # Defaults to _DEV_DEFAULT_SCOPES which grants all first-party module
         # permissions so local dev works without auth configuration.
-        env_scopes_raw = os.getenv("AUTH_ANON_SCOPES", "")
+        env_scopes_raw = self._setting("AUTH_ANON_SCOPES")
         if env_scopes_raw:
             self._default_scopes = [s.strip() for s in env_scopes_raw.split(",") if s.strip()]
         else:

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -43,7 +43,11 @@ from typing import Literal
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthAdapter, AuthError, BaseAuthAdapter
-from mozaiksai.core.auth.cache_ttl import CacheTtlConfigError, parse_cache_ttl_seconds
+from mozaiksai.core.auth.cache_ttl import (
+    CACHE_TTL_DEFAULTS,
+    CacheTtlConfigError,
+    resolve_cache_ttl_setting,
+)
 from mozaiksai.core.environment import (
     ENVIRONMENT_ENV_VARS,
     EnvironmentConfigError,
@@ -127,6 +131,13 @@ _ALL_AUTH_ENV_VARS: tuple[str, ...] = tuple(
 
 BUILTIN_PROVIDERS: frozenset[str] = frozenset(_PROVIDER_CONFIG_ENV_VARS)
 
+SETTINGS_PARAMETER = "settings"
+
+#: How an adapter constructor must be invoked. Established positively at
+#: registration — never inferred from a failed construction attempt.
+ConstructorMode = Literal["settings_keyword", "no_settings"]
+_CONSTRUCTOR_MODES: frozenset[str] = frozenset({"settings_keyword", "no_settings"})
+
 ResolvedAuthSource = Literal[
     "explicit_provider",
     "explicit_disable",
@@ -181,17 +192,22 @@ class _AdapterRegistration:
     third-party adapter and must never reuse one validated under an older
     configuration.
 
-    ``accepts_settings`` is determined once, at registration, by inspecting the
-    constructor signature. Construction never infers signature support from a
-    caught ``TypeError`` — an exception raised inside a constructor body is a
-    real failure and must propagate.
+    ``constructor_mode`` is established once, at registration, by positively
+    classifying the constructor signature (or by an explicit declaration for
+    uninspectable constructors). Construction never infers signature support
+    from a caught ``TypeError`` — an exception raised inside a constructor body
+    is a real failure and must propagate.
     """
 
     adapter_class: type[BaseAuthAdapter]
     generation: int
     builtin: bool
-    accepts_settings: bool
+    constructor_mode: ConstructorMode
     config_identity: str | Callable[[], str] | None = None
+
+    @property
+    def accepts_settings(self) -> bool:
+        return self.constructor_mode == "settings_keyword"
 
     def identity_token(self) -> str | None:
         """Return the provider-declared identity, or None when uncacheable.
@@ -220,32 +236,96 @@ class _AdapterRegistration:
         return _validate_config_identity_value(self.config_identity, source="value")
 
 
-def _constructor_accepts_settings(adapter_class: type) -> bool:
-    """Determine settings-argument support BEFORE any construction attempt.
+def _classify_constructor(
+    adapter_class: type,
+    *,
+    declared_mode: ConstructorMode | None,
+) -> ConstructorMode:
+    """Positively establish how an adapter constructor must be invoked.
 
-    Uses signature inspection only. When a signature cannot be inspected (C
-    extensions, exotic callables), the answer is False: the adapter is
-    constructed without the snapshot and — lacking a declared config identity —
-    is not cached, which is the safe direction.
+    An adapter may be constructed WITHOUT the resolved settings snapshot only
+    when inspection proves it takes no settings argument at all.
+    "Could not inspect" and "no ``settings`` keyword found" are not evidence of
+    configuration.
+
+    ``declared_mode`` is the escape hatch for constructors that genuinely
+    cannot be inspected (C extensions, exotic callables): the registrant states
+    the contract explicitly rather than the registry guessing it.
     """
+    name = getattr(adapter_class, "__name__", repr(adapter_class))
+
+    if declared_mode is not None:
+        if declared_mode not in _CONSTRUCTOR_MODES:
+            raise AuthError(
+                f"Unknown constructor_mode {declared_mode!r} for auth adapter {name}. "
+                f"Valid modes: {', '.join(sorted(_CONSTRUCTOR_MODES))}.",
+                500,
+                "registry",
+            )
+        return declared_mode
+
     try:
         signature = inspect.signature(adapter_class)
-    except (TypeError, ValueError):
-        logger.warning(
-            "Could not inspect %s constructor signature; constructing without the "
-            "configuration snapshot.",
-            getattr(adapter_class, "__name__", adapter_class),
-        )
-        return False
-    for parameter in signature.parameters.values():
-        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
-            return True
-        if parameter.name == "settings" and parameter.kind in {
+    except (TypeError, ValueError) as exc:
+        raise AuthError(
+            f"Cannot establish the constructor contract for auth adapter {name}: "
+            f"its signature could not be inspected ({type(exc).__name__}). Register it "
+            "with an explicit constructor_mode "
+            f"({', '.join(sorted(_CONSTRUCTOR_MODES))}) so the runtime knows whether it "
+            "consumes the configuration snapshot. Refusing to assume it takes none.",
+            500,
+            "registry",
+        ) from exc
+
+    settings_parameter = signature.parameters.get(SETTINGS_PARAMETER)
+    if settings_parameter is not None:
+        if settings_parameter.kind in {
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.KEYWORD_ONLY,
         }:
-            return True
-    return False
+            return "settings_keyword"
+        if settings_parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+            # Positional-only configuration is not part of the plugin contract;
+            # accepting it silently would risk passing the snapshot in the wrong
+            # slot, and ignoring it would discard the configuration entirely.
+            raise AuthError(
+                f"Auth adapter {name} declares {SETTINGS_PARAMETER!r} as a positional-only "
+                "parameter, which the adapter contract does not support. Make it accept "
+                f"{SETTINGS_PARAMETER}= as a keyword so the configuration snapshot can be "
+                "supplied unambiguously.",
+                500,
+                "registry",
+            )
+        raise AuthError(
+            f"Auth adapter {name} declares {SETTINGS_PARAMETER!r} with unsupported "
+            f"parameter kind {settings_parameter.kind.name}.",
+            500,
+            "registry",
+        )
+
+    for parameter in signature.parameters.values():
+        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            # **kwargs is an established part of the adapter extension contract.
+            return "settings_keyword"
+
+    # No settings parameter at all: this mode is valid only when every remaining
+    # parameter is optional, so zero-argument construction is provably safe.
+    required = [
+        parameter.name
+        for parameter in signature.parameters.values()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        not in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
+    ]
+    if required:
+        raise AuthError(
+            f"Auth adapter {name} requires constructor argument(s) {required} that the "
+            "runtime cannot supply. Accept the configuration snapshot as "
+            f"{SETTINGS_PARAMETER}=, or give those parameters defaults.",
+            500,
+            "registry",
+        )
+    return "no_settings"
 
 
 @dataclass(frozen=True)
@@ -401,12 +481,9 @@ def resolve_auth_config() -> ResolvedAuthConfig:
     # Cache TTLs are parsed here, during canonical resolution, so a malformed
     # value fails startup rather than surfacing later inside lazy discovery or
     # JWKS client construction on a request path.
-    for ttl_name, ttl_default in (
-        ("AUTH_JWKS_CACHE_TTL", 3600),
-        ("AUTH_DISCOVERY_CACHE_TTL", 86400),
-    ):
+    for ttl_name in CACHE_TTL_DEFAULTS:
         try:
-            parse_cache_ttl_seconds(ttl_name, settings.get(ttl_name), default=ttl_default)
+            resolve_cache_ttl_setting(ttl_name, settings.get(ttl_name))
         except CacheTtlConfigError as exc:
             raise AuthError(str(exc), 500, "registry") from exc
 
@@ -527,6 +604,7 @@ def register_adapter(
     adapter_class: type[BaseAuthAdapter],
     *,
     config_identity: str | Callable[[], str] | None = None,
+    constructor_mode: ConstructorMode | None = None,
 ) -> None:
     """
     Register an auth adapter.
@@ -543,15 +621,30 @@ def register_adapter(
             changed configuration can never silently reuse an adapter built
             under an older one.
 
+        constructor_mode: Explicit constructor contract, required only when the
+            constructor cannot be inspected (C extensions, exotic callables).
+            ``"settings_keyword"`` means it accepts the configuration snapshot as
+            ``settings=``; ``"no_settings"`` means it takes no canonical
+            settings argument. When omitted, the contract is established by
+            signature inspection, and registration fails rather than assuming a
+            constructor takes no settings.
+
     Raises:
-        AuthError: when a literal config_identity violates the contract.
+        AuthError: when a literal config_identity violates the contract, or the
+            constructor contract cannot be positively established.
 
     Example:
         register_adapter("my-custom", MyCustomAdapter, config_identity=lambda: cfg.revision)
     """
     if config_identity is not None and not callable(config_identity):
         _validate_config_identity_value(config_identity, source="value")
-    _register(name, adapter_class, builtin=False, config_identity=config_identity)
+    _register(
+        name,
+        adapter_class,
+        builtin=False,
+        config_identity=config_identity,
+        constructor_mode=constructor_mode,
+    )
 
 
 def _register(
@@ -560,17 +653,21 @@ def _register(
     *,
     builtin: bool,
     config_identity: str | Callable[[], str] | None = None,
+    constructor_mode: ConstructorMode | None = None,
 ) -> None:
     global _registry_generation
+    mode = _classify_constructor(adapter_class, declared_mode=constructor_mode)
     _registry_generation += 1
     _adapter_registry[name.lower()] = _AdapterRegistration(
         adapter_class=adapter_class,
         generation=_registry_generation,
         builtin=builtin,
-        accepts_settings=_constructor_accepts_settings(adapter_class),
+        constructor_mode=mode,
         config_identity=config_identity,
     )
-    logger.debug("Registered auth adapter: %s (builtin=%s)", name, builtin)
+    logger.debug(
+        "Registered auth adapter: %s (builtin=%s, constructor_mode=%s)", name, builtin, mode
+    )
 
 
 def list_adapters() -> list[str]:
@@ -580,8 +677,14 @@ def list_adapters() -> list[str]:
 
 
 def _ensure_builtin_adapters() -> None:
-    """Register built-in adapters once."""
-    if _adapter_registry:
+    """Ensure every built-in adapter is registered.
+
+    Registration is per-provider and idempotent rather than gated on the whole
+    registry being empty: a custom adapter registered before the first auth
+    resolution must not suppress the built-in providers. An intentional
+    override of a built-in name is preserved.
+    """
+    if BUILTIN_PROVIDERS.issubset(_adapter_registry.keys()):
         return
     # Import here to avoid circular imports
     from mozaiksai.core.auth.adapters.jwt_adapter import GenericJWTAdapter
@@ -589,10 +692,14 @@ def _ensure_builtin_adapters() -> None:
     from mozaiksai.core.auth.adapters.no_auth import NoAuthAdapter
     from mozaiksai.core.auth.adapters.supabase import SupabaseAuthAdapter
 
-    _register("none", NoAuthAdapter, builtin=True)
-    _register("jwt", GenericJWTAdapter, builtin=True)
-    _register("supabase", SupabaseAuthAdapter, builtin=True)
-    _register("keycloak", KeycloakAuthAdapter, builtin=True)
+    for name, adapter_class in (
+        ("none", NoAuthAdapter),
+        ("jwt", GenericJWTAdapter),
+        ("supabase", SupabaseAuthAdapter),
+        ("keycloak", KeycloakAuthAdapter),
+    ):
+        if name not in _adapter_registry:
+            _register(name, adapter_class, builtin=True)
 
 
 def _build_adapter(
@@ -624,7 +731,7 @@ def _build_adapter(
     # body is a real construction failure and must fail closed, never silently
     # rebuild the adapter without its canonical configuration.
     try:
-        if registration.accepts_settings:
+        if registration.constructor_mode == "settings_keyword":
             adapter = registration.adapter_class(settings=settings)  # type: ignore[call-arg]
         else:
             adapter = registration.adapter_class()

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -34,6 +34,7 @@ Fail-closed contract:
   newer configuration.
 """
 
+import inspect
 import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -42,6 +43,7 @@ from typing import Literal
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthAdapter, AuthError, BaseAuthAdapter
+from mozaiksai.core.auth.cache_ttl import CacheTtlConfigError, parse_cache_ttl_seconds
 from mozaiksai.core.environment import (
     ENVIRONMENT_ENV_VARS,
     EnvironmentConfigError,
@@ -138,33 +140,112 @@ ResolvedAuthSource = Literal[
 # ---------------------------------------------------------------------------
 
 
+def _validate_config_identity_value(value: object, *, source: str) -> str:
+    """Validate one config-identity value against the documented contract.
+
+    The contract is a non-blank string. Values of any other type — ``None``,
+    lists, mappings, numbers — are rejected rather than coerced with ``str()``,
+    which would otherwise mint a cache key that does not truthfully identify a
+    configured revision. Empty and whitespace-only strings are rejected for the
+    same reason: they cannot distinguish one revision from another.
+    """
+    if not isinstance(value, str):
+        raise AuthError(
+            f"Auth adapter config_identity {source} must be a string, got "
+            f"{type(value).__name__}. Provide a string that changes whenever the "
+            "adapter's configuration changes, or omit config_identity to opt out "
+            "of caching entirely.",
+            500,
+            "registry",
+        )
+    if not value.strip():
+        raise AuthError(
+            f"Auth adapter config_identity {source} must be a non-blank string; "
+            "an empty or whitespace-only identity does not identify a configured "
+            "revision. Omit config_identity to opt out of caching entirely.",
+            500,
+            "registry",
+        )
+    return value
+
+
 @dataclass(frozen=True)
 class _AdapterRegistration:
-    """A registered adapter class plus its cache-identity contract.
+    """A registered adapter class plus its construction and cache contracts.
 
     ``config_identity`` is how a provider states "my configuration changed".
     Built-in providers derive it from their declared environment census.
-    Custom providers must supply one explicitly (a string or a callable
-    returning a string) to be cacheable; without it the adapter is rebuilt on
-    every resolution, because the runtime cannot know what configures a
+    Custom providers must supply one explicitly (a non-blank string, or a
+    callable returning one) to be cacheable; without it the adapter is rebuilt
+    on every resolution, because the runtime cannot know what configures a
     third-party adapter and must never reuse one validated under an older
     configuration.
+
+    ``accepts_settings`` is determined once, at registration, by inspecting the
+    constructor signature. Construction never infers signature support from a
+    caught ``TypeError`` — an exception raised inside a constructor body is a
+    real failure and must propagate.
     """
 
     adapter_class: type[BaseAuthAdapter]
     generation: int
     builtin: bool
+    accepts_settings: bool
     config_identity: str | Callable[[], str] | None = None
 
     def identity_token(self) -> str | None:
-        """Return the provider-declared identity, or None when uncacheable."""
+        """Return the provider-declared identity, or None when uncacheable.
+
+        Raises :class:`AuthError` when a declared identity is malformed, so a
+        misconfigured provider fails closed instead of silently caching under a
+        meaningless key.
+        """
         if self.builtin:
             return "builtin"
         if self.config_identity is None:
             return None
         if callable(self.config_identity):
-            return str(self.config_identity())
-        return str(self.config_identity)
+            try:
+                produced = self.config_identity()
+            except AuthError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - reported as AuthError
+                raise AuthError(
+                    f"Auth adapter config_identity callable raised {type(exc).__name__}: "
+                    f"{exc}. The identity must be produced deterministically.",
+                    500,
+                    "registry",
+                ) from exc
+            return _validate_config_identity_value(produced, source="callable return value")
+        return _validate_config_identity_value(self.config_identity, source="value")
+
+
+def _constructor_accepts_settings(adapter_class: type) -> bool:
+    """Determine settings-argument support BEFORE any construction attempt.
+
+    Uses signature inspection only. When a signature cannot be inspected (C
+    extensions, exotic callables), the answer is False: the adapter is
+    constructed without the snapshot and — lacking a declared config identity —
+    is not cached, which is the safe direction.
+    """
+    try:
+        signature = inspect.signature(adapter_class)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Could not inspect %s constructor signature; constructing without the "
+            "configuration snapshot.",
+            getattr(adapter_class, "__name__", adapter_class),
+        )
+        return False
+    for parameter in signature.parameters.values():
+        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == "settings" and parameter.kind in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -317,6 +398,18 @@ def resolve_auth_config() -> ResolvedAuthConfig:
     except EnvironmentConfigError as exc:
         raise AuthError(str(exc), 500, "registry") from exc
 
+    # Cache TTLs are parsed here, during canonical resolution, so a malformed
+    # value fails startup rather than surfacing later inside lazy discovery or
+    # JWKS client construction on a request path.
+    for ttl_name, ttl_default in (
+        ("AUTH_JWKS_CACHE_TTL", 3600),
+        ("AUTH_DISCOVERY_CACHE_TTL", 86400),
+    ):
+        try:
+            parse_cache_ttl_seconds(ttl_name, settings.get(ttl_name), default=ttl_default)
+        except CacheTtlConfigError as exc:
+            raise AuthError(str(exc), 500, "registry") from exc
+
     enabled_setting = _auth_enabled_setting(settings)
     explicit_provider = settings.get("AUTH_PROVIDER", "").strip().lower()
 
@@ -442,15 +535,22 @@ def register_adapter(
         name: Adapter identifier (e.g., "supabase", "keycloak")
         adapter_class: The adapter class to register
         config_identity: Cache-identity contract for custom adapters — a
-            string, or a callable returning one, that changes whenever the
-            adapter's configuration changes. Without it a custom adapter is
+            non-blank string, or a callable returning one, that changes
+            whenever the adapter's configuration changes. Malformed identities
+            (non-string values, or empty/whitespace-only strings) are rejected
+            rather than coerced. Without a config_identity a custom adapter is
             never cached across resolutions (it is rebuilt every time), so a
             changed configuration can never silently reuse an adapter built
             under an older one.
 
+    Raises:
+        AuthError: when a literal config_identity violates the contract.
+
     Example:
         register_adapter("my-custom", MyCustomAdapter, config_identity=lambda: cfg.revision)
     """
+    if config_identity is not None and not callable(config_identity):
+        _validate_config_identity_value(config_identity, source="value")
     _register(name, adapter_class, builtin=False, config_identity=config_identity)
 
 
@@ -467,6 +567,7 @@ def _register(
         adapter_class=adapter_class,
         generation=_registry_generation,
         builtin=builtin,
+        accepts_settings=_constructor_accepts_settings(adapter_class),
         config_identity=config_identity,
     )
     logger.debug("Registered auth adapter: %s (builtin=%s)", name, builtin)
@@ -517,17 +618,16 @@ def _build_adapter(
             "registry",
         )
 
+    # Constructor argument compatibility was decided at registration by
+    # signature inspection. There is deliberately no "try with settings, catch
+    # TypeError, retry without" path: a TypeError raised inside a constructor
+    # body is a real construction failure and must fail closed, never silently
+    # rebuild the adapter without its canonical configuration.
     try:
-        adapter = registration.adapter_class(settings=settings)  # type: ignore[call-arg]
-    except TypeError:
-        # Custom adapters predating the snapshot contract may not accept it.
-        # They fall back to reading the live environment and are not cached
-        # unless they declare a config identity.
-        try:
+        if registration.accepts_settings:
+            adapter = registration.adapter_class(settings=settings)  # type: ignore[call-arg]
+        else:
             adapter = registration.adapter_class()
-        except Exception as e:  # noqa: BLE001 - reported as AuthError below
-            logger.error("Failed to instantiate %s adapter: %s", provider, e, exc_info=True)
-            raise AuthError(f"Failed to configure {provider} auth: {e}", 500, provider) from e
     except Exception as e:  # noqa: BLE001 - reported as AuthError below
         logger.error("Failed to instantiate %s adapter: %s", provider, e, exc_info=True)
         raise AuthError(f"Failed to configure {provider} auth: {e}", 500, provider) from e

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -16,11 +16,57 @@ _adapter_registry: dict[str, type[BaseAuthAdapter]] = {}
 _adapter_instance: AuthAdapter | None = None
 
 
+_TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
+_FALSY_VALUES = frozenset({"false", "0", "no", "off"})
+
+
 def _has_oidc_discovery_config() -> bool:
     return bool(
         os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
         or os.getenv("MOZAIKS_OIDC_AUTHORITY", "").strip()
     )
+
+
+def _auth_enabled_setting() -> bool | None:
+    """Return the operator's explicit AUTH_ENABLED declaration.
+
+    ``True``/``False`` when AUTH_ENABLED is explicitly set to a recognized
+    value, ``None`` when it is unset or empty. An unrecognized value fails
+    closed with :class:`AuthError` — a typo in AUTH_ENABLED must never
+    silently disable authentication.
+    """
+    raw = os.getenv("AUTH_ENABLED")
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if not value:
+        return None
+    if value in _TRUTHY_VALUES:
+        return True
+    if value in _FALSY_VALUES:
+        return False
+    raise AuthError(
+        f"Unrecognized AUTH_ENABLED value: {raw!r}. "
+        "Use true/false (or 1/0, yes/no, on/off).",
+        500,
+        "registry",
+    )
+
+
+def is_auth_explicitly_disabled() -> bool:
+    """True only when the operator explicitly declared no-auth operation.
+
+    Explicit declaration means AUTH_ENABLED is set to a falsy value, or
+    AUTH_PROVIDER is set to "none" without AUTH_ENABLED being explicitly
+    true. Absence of provider configuration (implicit demo mode) is NOT an
+    explicit declaration — security-sensitive bypasses must key off this
+    helper, never off ``not is_auth_enabled()``.
+    """
+    enabled_setting = _auth_enabled_setting()
+    if enabled_setting is False:
+        return True
+    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
+    return explicit_provider == "none" and enabled_setting is not True
 
 
 def register_adapter(name: str, adapter_class: type[BaseAuthAdapter]) -> None:
@@ -63,20 +109,35 @@ def _auto_detect_provider() -> str:
 
     Detection priority:
     1. AUTH_PROVIDER explicitly set
-    2. AUTH_ENABLED=false -> "none"
+    2. AUTH_ENABLED explicitly false -> "none"
     3. SUPABASE_URL set -> "supabase"
     4. KEYCLOAK_URL set -> "keycloak"
     5. Generic JWT config set -> "jwt"
-    6. Default to "none" (demo mode)
+    6. AUTH_ENABLED explicitly true -> fatal (fail closed, any environment)
+    7. Nothing configured at all -> "none" (demo mode)
+
+    When authentication is explicitly enabled, inability to establish the
+    configured provider raises :class:`AuthError` instead of silently falling
+    back to the trusted-bypass "none" adapter. This does not depend on
+    ENV=production — staging and every other environment fail closed too.
     """
+    enabled_setting = _auth_enabled_setting()
+
     # Explicit provider takes precedence
-    explicit_provider = os.getenv("AUTH_PROVIDER", "").lower()
+    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
     if explicit_provider:
+        if explicit_provider == "none" and enabled_setting is True:
+            raise AuthError(
+                "AUTH_ENABLED=true conflicts with AUTH_PROVIDER=none. "
+                "Either configure a real auth provider or set AUTH_ENABLED=false "
+                "to explicitly run without authentication.",
+                500,
+                "registry",
+            )
         return explicit_provider
 
-    # AUTH_ENABLED=false means no auth
-    auth_enabled = os.getenv("AUTH_ENABLED", "true").lower()
-    if auth_enabled in ("false", "0", "no", "off"):
+    # AUTH_ENABLED explicitly false means no auth (explicit dev contract)
+    if enabled_setting is False:
         return "none"
 
     # Auto-detect from environment
@@ -89,7 +150,20 @@ def _auto_detect_provider() -> str:
     if (os.getenv("AUTH_JWKS_URL") and os.getenv("AUTH_ISSUER")) or _has_oidc_discovery_config():
         return "jwt"
 
-    # Default to no auth for easy getting started
+    if enabled_setting is True:
+        # Auth was explicitly enabled but no provider can be established.
+        # Dev intent is never inferred from provider misconfiguration.
+        raise AuthError(
+            "AUTH_ENABLED=true but no authentication provider is configured. "
+            "Set AUTH_PROVIDER or configure SUPABASE_URL, KEYCLOAK_URL + "
+            "KEYCLOAK_REALM, AUTH_JWKS_URL + AUTH_ISSUER, or "
+            "MOZAIKS_OIDC_AUTHORITY. Refusing to fall back to unauthenticated "
+            "operation.",
+            500,
+            "registry",
+        )
+
+    # Nothing auth-related configured at all: demo mode for easy getting started.
     logger.warning(
         "No auth provider detected. Defaulting to 'none' (demo mode). "
         "Set AUTH_PROVIDER or configure a specific provider."
@@ -155,6 +229,17 @@ def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
     # Log which adapter is being used
     if adapter.is_enabled():
         logger.info("Auth adapter configured: %s", provider)
+    elif provider != "none" and _auth_enabled_setting() is True:
+        # Explicitly enabled auth with a provider that cannot validate tokens
+        # is fatal — an incomplete provider config must never degrade to
+        # unauthenticated operation.
+        raise AuthError(
+            f"AUTH_ENABLED=true but the {provider!r} auth provider is not fully "
+            "configured and cannot validate tokens. Complete the provider "
+            "configuration or set AUTH_ENABLED=false explicitly.",
+            500,
+            provider,
+        )
     else:
         logger.warning("Auth adapter %s is not fully configured", provider)
 
@@ -174,6 +259,24 @@ def reset_auth_adapter() -> None:
     global _adapter_instance
     _adapter_instance = None
     logger.debug("Auth adapter cache cleared")
+
+
+def validate_auth_provider_configuration() -> str:
+    """Resolve and validate the configured auth provider, failing closed.
+
+    Returns the resolved provider name on success. Raises :class:`AuthError`
+    when authentication is explicitly enabled but the configured provider is
+    missing, unknown, conflicting, or not fully configured. Hosts call this
+    at startup so misconfigured authentication aborts boot in every
+    environment instead of degrading to trusted-bypass operation.
+
+    Validation instantiates the adapter with ``force_provider`` so it never
+    caches the singleton instance.
+    """
+    provider = _auto_detect_provider()
+    if provider != "none":
+        get_auth_adapter(force_provider=provider)
+    return provider
 
 
 def is_auth_enabled() -> bool:

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -1,23 +1,123 @@
 """
 Auth adapter registry.
 
-Manages registration and selection of auth adapters based on configuration.
+One canonical interpretation of authentication configuration lives here:
+:func:`resolve_auth_config` parses the environment exactly once per call into
+an immutable :class:`ResolvedAuthConfig`. Every predicate
+(:func:`is_auth_enabled`, :func:`is_auth_explicitly_disabled`), adapter
+resolution (:func:`get_auth_adapter`), and startup validation
+(:func:`validate_auth_provider_configuration`) consumes that same resolved
+state — there is no second parser, so the predicates can never contradict
+each other.
+
+Fail-closed contract:
+
+- Explicitly enabled authentication (``AUTH_ENABLED=true``) with a missing,
+  unknown, conflicting, or not-fully-configured provider raises
+  :class:`AuthError` — in every environment, at resolution time.
+- Contradictory explicit declarations (``AUTH_ENABLED=true`` +
+  ``AUTH_PROVIDER=none``; ``AUTH_ENABLED=false`` + a real explicit
+  ``AUTH_PROVIDER``) raise instead of silently choosing one.
+- Unrecognized ``AUTH_ENABLED`` values raise instead of silently disabling
+  authentication.
+- No-auth operation of any kind (explicit disable or implicit demo mode) is
+  rejected in protected deployed environments (staging/production, per
+  ``mozaiksai.core.environment``), independent of startup-check mode.
+- The cached adapter is keyed by a fingerprint of the resolved configuration:
+  request-time adapter resolution always reflects the configuration that
+  startup validated, and a stale trusted-bypass adapter cannot survive a
+  configuration change.
 """
 
 import os
+from dataclasses import dataclass
+from typing import Literal
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthAdapter, AuthError, BaseAuthAdapter
+from mozaiksai.core.environment import deployment_environment, is_protected_environment
 
 logger = get_core_logger("auth.registry")
 
 # Global adapter registry
 _adapter_registry: dict[str, type[BaseAuthAdapter]] = {}
 _adapter_instance: AuthAdapter | None = None
+_adapter_fingerprint: tuple[tuple[str, str], ...] | None = None
 
 
 _TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
 _FALSY_VALUES = frozenset({"false", "0", "no", "off"})
+
+# Environment variables that participate in auth configuration resolution or
+# adapter construction. The resolved-config fingerprint snapshots these so the
+# cached adapter is invalidated whenever any of them changes (D5 coherence).
+_AUTH_CONFIG_ENV_VARS: tuple[str, ...] = (
+    "AUTH_ENABLED",
+    "AUTH_PROVIDER",
+    "SUPABASE_URL",
+    "SUPABASE_JWT_SECRET",
+    "KEYCLOAK_URL",
+    "KEYCLOAK_REALM",
+    "KEYCLOAK_CLIENT_ID",
+    "AUTH_JWKS_URL",
+    "AUTH_ISSUER",
+    "MOZAIKS_OIDC_AUTHORITY",
+    "MOZAIKS_OIDC_TENANT_ID",
+    "MOZAIKS_OIDC_DISCOVERY_URL",
+    "AUTH_AUDIENCE",
+    "AUTH_REQUIRED_SCOPE",
+    "AUTH_ALGORITHMS",
+    "AUTH_USER_ID_CLAIM",
+    "AUTH_EMAIL_CLAIM",
+    "AUTH_ROLES_CLAIM",
+    "ENV",
+    "ENVIRONMENT",
+)
+
+ResolvedAuthSource = Literal[
+    "explicit_provider",
+    "explicit_disable",
+    "auto_detected",
+    "demo_default",
+]
+
+
+@dataclass(frozen=True)
+class ResolvedAuthConfig:
+    """Immutable, canonical interpretation of the auth environment.
+
+    Invariants (enforced at construction):
+      - ``enabled`` is exactly ``provider != "none"``
+      - ``enabled`` and ``explicitly_disabled`` are never both true
+      - ``explicitly_disabled`` implies ``provider == "none"``
+    """
+
+    provider: str
+    enabled: bool
+    explicitly_disabled: bool
+    source: ResolvedAuthSource
+    environment: str
+    fingerprint: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if self.enabled != (self.provider != "none"):
+            raise AuthError(
+                "Internal auth resolution invariant violated: enabled flag does "
+                f"not match provider {self.provider!r}.",
+                500,
+                "registry",
+            )
+        if self.enabled and self.explicitly_disabled:
+            raise AuthError(
+                "Internal auth resolution invariant violated: configuration "
+                "resolved as both enabled and explicitly disabled.",
+                500,
+                "registry",
+            )
+
+
+def _config_fingerprint() -> tuple[tuple[str, str], ...]:
+    return tuple((name, os.getenv(name) or "") for name in _AUTH_CONFIG_ENV_VARS)
 
 
 def _has_oidc_discovery_config() -> bool:
@@ -53,20 +153,138 @@ def _auth_enabled_setting() -> bool | None:
     )
 
 
+def resolve_auth_config() -> ResolvedAuthConfig:
+    """Resolve the environment into the canonical auth configuration.
+
+    This is the ONLY parser of auth-mode environment variables. Resolution
+    order:
+
+    1. ``AUTH_PROVIDER`` explicitly set — after contradiction checks against
+       ``AUTH_ENABLED`` — selects that provider (``none`` = explicit disable).
+    2. ``AUTH_ENABLED`` explicitly false — explicit disable.
+    3. Auto-detection from provider signals (SUPABASE_URL,
+       KEYCLOAK_URL + KEYCLOAK_REALM, AUTH_JWKS_URL + AUTH_ISSUER, OIDC
+       discovery settings).
+    4. ``AUTH_ENABLED`` explicitly true with nothing detectable — fatal.
+    5. Nothing auth-related configured at all — implicit demo mode
+       (``none``, not an explicit disable).
+
+    Contradictory explicit declarations raise instead of silently resolving:
+    ``AUTH_ENABLED=true`` + ``AUTH_PROVIDER=none`` and ``AUTH_ENABLED=false``
+    + a real explicit ``AUTH_PROVIDER`` are both rejected. Passive provider
+    signals (for example a SUPABASE_URL left in a developer .env) do not
+    contradict an explicit disable — the explicit switch wins over passive
+    presence, which is the existing OSS development contract.
+
+    Environment policy (mandatory, mode-independent): any configuration that
+    resolves to no-auth operation — explicit disable or implicit demo — is
+    rejected in protected deployed environments (staging/production).
+    """
+    fingerprint = _config_fingerprint()
+    environment = deployment_environment()
+    enabled_setting = _auth_enabled_setting()
+    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
+
+    provider: str
+    explicitly_disabled: bool
+    source: ResolvedAuthSource
+
+    if explicit_provider:
+        if explicit_provider == "none" and enabled_setting is True:
+            raise AuthError(
+                "AUTH_ENABLED=true conflicts with AUTH_PROVIDER=none. "
+                "Either configure a real auth provider or set AUTH_ENABLED=false "
+                "to explicitly run without authentication.",
+                500,
+                "registry",
+            )
+        if explicit_provider != "none" and enabled_setting is False:
+            raise AuthError(
+                f"AUTH_ENABLED=false conflicts with AUTH_PROVIDER={explicit_provider!r}. "
+                "Remove AUTH_PROVIDER to disable authentication, or set "
+                "AUTH_ENABLED=true to use the configured provider. Refusing to "
+                "silently pick one of two contradictory declarations.",
+                500,
+                "registry",
+            )
+        if explicit_provider == "none":
+            provider, explicitly_disabled, source = "none", True, "explicit_disable"
+        else:
+            provider, explicitly_disabled, source = explicit_provider, False, "explicit_provider"
+    elif enabled_setting is False:
+        provider, explicitly_disabled, source = "none", True, "explicit_disable"
+    elif os.getenv("SUPABASE_URL"):
+        provider, explicitly_disabled, source = "supabase", False, "auto_detected"
+    elif os.getenv("KEYCLOAK_URL") and os.getenv("KEYCLOAK_REALM"):
+        provider, explicitly_disabled, source = "keycloak", False, "auto_detected"
+    elif (os.getenv("AUTH_JWKS_URL") and os.getenv("AUTH_ISSUER")) or _has_oidc_discovery_config():
+        provider, explicitly_disabled, source = "jwt", False, "auto_detected"
+    elif enabled_setting is True:
+        # Auth was explicitly enabled but no provider can be established.
+        # Dev intent is never inferred from provider misconfiguration; this
+        # does not depend on ENV — staging and every other environment fail
+        # closed too.
+        raise AuthError(
+            "AUTH_ENABLED=true but no authentication provider is configured. "
+            "Set AUTH_PROVIDER or configure SUPABASE_URL, KEYCLOAK_URL + "
+            "KEYCLOAK_REALM, AUTH_JWKS_URL + AUTH_ISSUER, or "
+            "MOZAIKS_OIDC_AUTHORITY. Refusing to fall back to unauthenticated "
+            "operation.",
+            500,
+            "registry",
+        )
+    else:
+        # Nothing auth-related configured at all: implicit demo mode for easy
+        # getting started. NOT an explicit disable — security-sensitive
+        # bypasses must not treat demo mode as operator intent.
+        logger.warning(
+            "No auth provider detected. Defaulting to 'none' (demo mode). "
+            "Set AUTH_PROVIDER or configure a specific provider."
+        )
+        provider, explicitly_disabled, source = "none", False, "demo_default"
+
+    if provider == "none" and is_protected_environment(environment):
+        raise AuthError(
+            f"Authentication-disabled operation is not permitted in the "
+            f"{environment!r} environment. Configure a real auth provider "
+            "(AUTH_PROVIDER, SUPABASE_URL, KEYCLOAK_URL + KEYCLOAK_REALM, "
+            "AUTH_JWKS_URL + AUTH_ISSUER, or MOZAIKS_OIDC_AUTHORITY). "
+            "Explicit AUTH_ENABLED=false / AUTH_PROVIDER=none are development "
+            "contracts only.",
+            500,
+            "registry",
+        )
+
+    return ResolvedAuthConfig(
+        provider=provider,
+        enabled=provider != "none",
+        explicitly_disabled=explicitly_disabled,
+        source=source,
+        environment=environment,
+        fingerprint=fingerprint,
+    )
+
+
+def is_auth_enabled() -> bool:
+    """True when the canonical resolved configuration has a real provider.
+
+    Raises :class:`AuthError` (fail closed) when the configuration is invalid
+    — it never reports "disabled" for a misconfigured deployment.
+    """
+    return resolve_auth_config().enabled
+
+
 def is_auth_explicitly_disabled() -> bool:
     """True only when the operator explicitly declared no-auth operation.
 
-    Explicit declaration means AUTH_ENABLED is set to a falsy value, or
-    AUTH_PROVIDER is set to "none" without AUTH_ENABLED being explicitly
-    true. Absence of provider configuration (implicit demo mode) is NOT an
-    explicit declaration — security-sensitive bypasses must key off this
-    helper, never off ``not is_auth_enabled()``.
+    Explicit declaration means ``AUTH_ENABLED=false`` or
+    ``AUTH_PROVIDER=none``. Implicit demo mode (no auth configuration at all)
+    is NOT an explicit declaration — security-sensitive bypasses must key off
+    this helper, never off ``not is_auth_enabled()``. Both predicates read the
+    same :func:`resolve_auth_config` interpretation, so they can never both be
+    true.
     """
-    enabled_setting = _auth_enabled_setting()
-    if enabled_setting is False:
-        return True
-    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
-    return explicit_provider == "none" and enabled_setting is not True
+    return resolve_auth_config().explicitly_disabled
 
 
 def register_adapter(name: str, adapter_class: type[BaseAuthAdapter]) -> None:
@@ -103,109 +321,11 @@ def _register_builtin_adapters() -> None:
     register_adapter("keycloak", KeycloakAuthAdapter)
 
 
-def _auto_detect_provider() -> str:
-    """
-    Auto-detect auth provider from environment variables.
-
-    Detection priority:
-    1. AUTH_PROVIDER explicitly set
-    2. AUTH_ENABLED explicitly false -> "none"
-    3. SUPABASE_URL set -> "supabase"
-    4. KEYCLOAK_URL set -> "keycloak"
-    5. Generic JWT config set -> "jwt"
-    6. AUTH_ENABLED explicitly true -> fatal (fail closed, any environment)
-    7. Nothing configured at all -> "none" (demo mode)
-
-    When authentication is explicitly enabled, inability to establish the
-    configured provider raises :class:`AuthError` instead of silently falling
-    back to the trusted-bypass "none" adapter. This does not depend on
-    ENV=production — staging and every other environment fail closed too.
-    """
-    enabled_setting = _auth_enabled_setting()
-
-    # Explicit provider takes precedence
-    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
-    if explicit_provider:
-        if explicit_provider == "none" and enabled_setting is True:
-            raise AuthError(
-                "AUTH_ENABLED=true conflicts with AUTH_PROVIDER=none. "
-                "Either configure a real auth provider or set AUTH_ENABLED=false "
-                "to explicitly run without authentication.",
-                500,
-                "registry",
-            )
-        return explicit_provider
-
-    # AUTH_ENABLED explicitly false means no auth (explicit dev contract)
-    if enabled_setting is False:
-        return "none"
-
-    # Auto-detect from environment
-    if os.getenv("SUPABASE_URL"):
-        return "supabase"
-
-    if os.getenv("KEYCLOAK_URL") and os.getenv("KEYCLOAK_REALM"):
-        return "keycloak"
-
-    if (os.getenv("AUTH_JWKS_URL") and os.getenv("AUTH_ISSUER")) or _has_oidc_discovery_config():
-        return "jwt"
-
-    if enabled_setting is True:
-        # Auth was explicitly enabled but no provider can be established.
-        # Dev intent is never inferred from provider misconfiguration.
-        raise AuthError(
-            "AUTH_ENABLED=true but no authentication provider is configured. "
-            "Set AUTH_PROVIDER or configure SUPABASE_URL, KEYCLOAK_URL + "
-            "KEYCLOAK_REALM, AUTH_JWKS_URL + AUTH_ISSUER, or "
-            "MOZAIKS_OIDC_AUTHORITY. Refusing to fall back to unauthenticated "
-            "operation.",
-            500,
-            "registry",
-        )
-
-    # Nothing auth-related configured at all: demo mode for easy getting started.
-    logger.warning(
-        "No auth provider detected. Defaulting to 'none' (demo mode). "
-        "Set AUTH_PROVIDER or configure a specific provider."
-    )
-    return "none"
-
-
-def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
-    """
-    Get the configured auth adapter.
-
-    Uses singleton pattern - same instance returned on subsequent calls.
-
-    Args:
-        force_provider: Override auto-detection with specific provider
-
-    Returns:
-        Configured AuthAdapter instance
-
-    Environment Variables:
-        AUTH_PROVIDER: Explicit provider selection (none, jwt, supabase, keycloak)
-        AUTH_ENABLED: Set to "false" for demo mode (same as AUTH_PROVIDER=none)
-
-    Example:
-        adapter = get_auth_adapter()
-        claims = await adapter.validate_token(token)
-    """
-    global _adapter_instance
-
-    # Return cached instance if available and no force override
-    if _adapter_instance is not None and force_provider is None:
-        return _adapter_instance
-
-    # Ensure built-in adapters are registered
+def _build_adapter(provider: str, *, enabled: bool) -> AuthAdapter:
+    """Instantiate and validate the adapter for a resolved provider."""
     if not _adapter_registry:
         _register_builtin_adapters()
 
-    # Determine which provider to use
-    provider = force_provider or _auto_detect_provider()
-    provider = provider.lower()
-
-    # Look up adapter class
     adapter_class = _adapter_registry.get(provider)
     if adapter_class is None:
         available = ", ".join(_adapter_registry.keys())
@@ -215,7 +335,6 @@ def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
             "registry",
         )
 
-    # Instantiate adapter
     try:
         adapter = adapter_class()
     except Exception as e:
@@ -226,27 +345,72 @@ def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
             provider,
         ) from e
 
-    # Log which adapter is being used
     if adapter.is_enabled():
         logger.info("Auth adapter configured: %s", provider)
-    elif provider != "none" and _auth_enabled_setting() is True:
-        # Explicitly enabled auth with a provider that cannot validate tokens
-        # is fatal — an incomplete provider config must never degrade to
-        # unauthenticated operation.
+    elif enabled:
+        # A resolved-enabled provider that cannot validate tokens is fatal —
+        # an incomplete provider config must never degrade to unauthenticated
+        # operation.
         raise AuthError(
-            f"AUTH_ENABLED=true but the {provider!r} auth provider is not fully "
-            "configured and cannot validate tokens. Complete the provider "
-            "configuration or set AUTH_ENABLED=false explicitly.",
+            f"Auth provider {provider!r} is selected but not fully configured "
+            "and cannot validate tokens. Complete the provider configuration "
+            "or explicitly disable authentication (AUTH_ENABLED=false) in a "
+            "development environment.",
             500,
             provider,
         )
     else:
         logger.warning("Auth adapter %s is not fully configured", provider)
 
-    # Cache if not forcing
-    if force_provider is None:
-        _adapter_instance = adapter
+    return adapter
 
+
+def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
+    """
+    Get the auth adapter for the canonical resolved configuration.
+
+    The cached instance is keyed by the resolved-configuration fingerprint:
+    when any auth-relevant environment variable changes, the stale adapter is
+    discarded and a fresh one is built from the current configuration. The
+    AuthConfig value cache is cleared on rebuild so adapter internals read the
+    same environment snapshot. Repeated initialization is deterministic.
+
+    Args:
+        force_provider: Build an adapter for this provider name directly,
+            bypassing resolution and the cache entirely (never cached).
+
+    Returns:
+        Configured AuthAdapter instance
+
+    Example:
+        adapter = get_auth_adapter()
+        claims = await adapter.validate_token(token)
+    """
+    global _adapter_instance, _adapter_fingerprint
+
+    if force_provider is not None:
+        return _build_adapter(force_provider.lower(), enabled=force_provider.lower() != "none")
+
+    config = resolve_auth_config()
+
+    if _adapter_instance is not None and _adapter_fingerprint == config.fingerprint:
+        return _adapter_instance
+
+    # Configuration changed (or first resolution): rebuild coherently. The
+    # AuthConfig cache must be refreshed first so the adapter constructor and
+    # its validators read the same environment the fingerprint captured.
+    from mozaiksai.core.auth.config import clear_auth_config_cache
+
+    if _adapter_instance is not None:
+        logger.info(
+            "Auth configuration changed; rebuilding auth adapter (provider=%s)",
+            config.provider,
+        )
+    clear_auth_config_cache()
+    adapter = _build_adapter(config.provider, enabled=config.enabled)
+
+    _adapter_instance = adapter
+    _adapter_fingerprint = config.fingerprint
     return adapter
 
 
@@ -256,35 +420,27 @@ def reset_auth_adapter() -> None:
 
     Useful for testing or when configuration changes.
     """
-    global _adapter_instance
+    global _adapter_instance, _adapter_fingerprint
     _adapter_instance = None
+    _adapter_fingerprint = None
     logger.debug("Auth adapter cache cleared")
 
 
 def validate_auth_provider_configuration() -> str:
-    """Resolve and validate the configured auth provider, failing closed.
+    """Resolve and validate the auth configuration, failing closed.
 
     Returns the resolved provider name on success. Raises :class:`AuthError`
-    when authentication is explicitly enabled but the configured provider is
-    missing, unknown, conflicting, or not fully configured. Hosts call this
-    at startup so misconfigured authentication aborts boot in every
-    environment instead of degrading to trusted-bypass operation.
+    when the configuration is invalid: enabled auth whose provider is missing,
+    unknown, conflicting, or not fully configured; contradictory explicit
+    declarations; or no-auth operation in a protected environment. Hosts call
+    this at startup so misconfiguration aborts boot in every environment and
+    every startup-check mode.
 
-    Validation instantiates the adapter with ``force_provider`` so it never
-    caches the singleton instance.
+    On success for a real provider, the validated adapter is bound into the
+    fingerprint-keyed cache — request-time resolution uses exactly the
+    configuration startup validated.
     """
-    provider = _auto_detect_provider()
-    if provider != "none":
-        get_auth_adapter(force_provider=provider)
-    return provider
-
-
-def is_auth_enabled() -> bool:
-    """
-    Check if authentication is enabled.
-
-    Returns:
-        True if auth is enabled, False if using no-auth mode
-    """
-    provider = _auto_detect_provider()
-    return provider != "none"
+    config = resolve_auth_config()
+    if config.provider != "none":
+        get_auth_adapter()
+    return config.provider

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -133,6 +133,10 @@ BUILTIN_PROVIDERS: frozenset[str] = frozenset(_PROVIDER_CONFIG_ENV_VARS)
 
 SETTINGS_PARAMETER = "settings"
 
+#: Placeholder used only to test-bind a constructor signature at registration.
+#: It is never passed to a real constructor.
+_SETTINGS_BINDING_PROBE = object()
+
 #: How an adapter constructor must be invoked. Established positively at
 #: registration — never inferred from a failed construction attempt.
 ConstructorMode = Literal["settings_keyword", "no_settings"]
@@ -236,6 +240,26 @@ class _AdapterRegistration:
         return _validate_config_identity_value(self.config_identity, source="value")
 
 
+def _bind_invocation(
+    signature: inspect.Signature, mode: ConstructorMode
+) -> tuple[bool, str | None]:
+    """Try to bind the exact call the runtime performs for ``mode``.
+
+    Returns ``(ok, reason)``. This is the single source of truth for whether a
+    constructor mode is usable: the registry never reasons about parameter
+    kinds to decide invocability, it asks Python's own binding machinery
+    whether its intended call would succeed.
+    """
+    try:
+        if mode == "settings_keyword":
+            signature.bind(**{SETTINGS_PARAMETER: _SETTINGS_BINDING_PROBE})
+        else:
+            signature.bind()
+    except TypeError as exc:
+        return False, str(exc)
+    return True, None
+
+
 def _classify_constructor(
     adapter_class: type,
     *,
@@ -243,30 +267,40 @@ def _classify_constructor(
 ) -> ConstructorMode:
     """Positively establish how an adapter constructor must be invoked.
 
-    An adapter may be constructed WITHOUT the resolved settings snapshot only
-    when inspection proves it takes no settings argument at all.
-    "Could not inspect" and "no ``settings`` keyword found" are not evidence of
-    configuration.
+    A mode is accepted only when the exact invocation the runtime intends to
+    perform binds successfully against the complete inspected signature —
+    ``Constructor(settings=...)`` for ``settings_keyword`` and
+    ``Constructor()`` for ``no_settings``. Recognizing a usable ``settings``
+    parameter (or ``**kwargs``) is necessary but never sufficient: a
+    constructor that also demands arguments the runtime cannot supply is
+    rejected here rather than at first use.
+
+    "Could not inspect" and "no ``settings`` keyword found" are likewise not
+    evidence that a constructor takes no configuration — both raise instead of
+    silently discarding the canonical snapshot.
 
     ``declared_mode`` is the escape hatch for constructors that genuinely
-    cannot be inspected (C extensions, exotic callables): the registrant states
-    the contract explicitly rather than the registry guessing it.
+    cannot be inspected (C extensions, exotic callables). When the signature
+    *is* inspectable the declaration is verified against it, so explicit
+    metadata cannot claim an invocation that provably would not work.
     """
     name = getattr(adapter_class, "__name__", repr(adapter_class))
 
-    if declared_mode is not None:
-        if declared_mode not in _CONSTRUCTOR_MODES:
-            raise AuthError(
-                f"Unknown constructor_mode {declared_mode!r} for auth adapter {name}. "
-                f"Valid modes: {', '.join(sorted(_CONSTRUCTOR_MODES))}.",
-                500,
-                "registry",
-            )
-        return declared_mode
+    if declared_mode is not None and declared_mode not in _CONSTRUCTOR_MODES:
+        raise AuthError(
+            f"Unknown constructor_mode {declared_mode!r} for auth adapter {name}. "
+            f"Valid modes: {', '.join(sorted(_CONSTRUCTOR_MODES))}.",
+            500,
+            "registry",
+        )
 
     try:
         signature = inspect.signature(adapter_class)
     except (TypeError, ValueError) as exc:
+        if declared_mode is not None:
+            # Genuinely uninspectable: the registrant's declaration is the only
+            # available contract, which is exactly what it exists for.
+            return declared_mode
         raise AuthError(
             f"Cannot establish the constructor contract for auth adapter {name}: "
             f"its signature could not be inspected ({type(exc).__name__}). Register it "
@@ -277,55 +311,63 @@ def _classify_constructor(
             "registry",
         ) from exc
 
-    settings_parameter = signature.parameters.get(SETTINGS_PARAMETER)
-    if settings_parameter is not None:
-        if settings_parameter.kind in {
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        }:
-            return "settings_keyword"
-        if settings_parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
-            # Positional-only configuration is not part of the plugin contract;
-            # accepting it silently would risk passing the snapshot in the wrong
-            # slot, and ignoring it would discard the configuration entirely.
+    if declared_mode is not None:
+        # Inspection is available, so verify rather than trust.
+        ok, reason = _bind_invocation(signature, declared_mode)
+        if not ok:
             raise AuthError(
-                f"Auth adapter {name} declares {SETTINGS_PARAMETER!r} as a positional-only "
-                "parameter, which the adapter contract does not support. Make it accept "
-                f"{SETTINGS_PARAMETER}= as a keyword so the configuration snapshot can be "
-                "supplied unambiguously.",
+                f"Auth adapter {name} was registered as constructor_mode "
+                f"{declared_mode!r}, but the runtime's invocation cannot bind to its "
+                f"signature {signature}: {reason}.",
                 500,
                 "registry",
             )
+        return declared_mode
+
+    settings_parameter = signature.parameters.get(SETTINGS_PARAMETER)
+    if settings_parameter is not None and settings_parameter.kind is (
+        inspect.Parameter.POSITIONAL_ONLY
+    ):
+        # Positional-only configuration is not part of the plugin contract;
+        # accepting it silently would risk passing the snapshot in the wrong
+        # slot, and ignoring it would discard the configuration entirely.
         raise AuthError(
-            f"Auth adapter {name} declares {SETTINGS_PARAMETER!r} with unsupported "
-            f"parameter kind {settings_parameter.kind.name}.",
+            f"Auth adapter {name} declares {SETTINGS_PARAMETER!r} as a positional-only "
+            "parameter, which the adapter contract does not support. Make it accept "
+            f"{SETTINGS_PARAMETER}= as a keyword so the configuration snapshot can be "
+            "supplied unambiguously.",
             500,
             "registry",
         )
 
-    for parameter in signature.parameters.values():
-        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
-            # **kwargs is an established part of the adapter extension contract.
-            return "settings_keyword"
-
-    # No settings parameter at all: this mode is valid only when every remaining
-    # parameter is optional, so zero-argument construction is provably safe.
-    required = [
-        parameter.name
+    # A constructor is settings-aware when it names ``settings`` as a keyword or
+    # absorbs keywords via ``**kwargs``; either way the full invocation must bind.
+    accepts_settings_keyword = settings_parameter is not None or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
         for parameter in signature.parameters.values()
-        if parameter.default is inspect.Parameter.empty
-        and parameter.kind
-        not in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
-    ]
-    if required:
+    )
+    candidate: ConstructorMode = "settings_keyword" if accepts_settings_keyword else "no_settings"
+
+    ok, reason = _bind_invocation(signature, candidate)
+    if ok:
+        return candidate
+
+    if candidate == "settings_keyword":
         raise AuthError(
-            f"Auth adapter {name} requires constructor argument(s) {required} that the "
-            "runtime cannot supply. Accept the configuration snapshot as "
-            f"{SETTINGS_PARAMETER}=, or give those parameters defaults.",
+            f"Auth adapter {name} accepts {SETTINGS_PARAMETER}= but the runtime cannot "
+            f"construct it: {signature} also requires argument(s) the runtime does not "
+            f"supply ({reason}). Give those parameters defaults so construction needs "
+            f"only {SETTINGS_PARAMETER}=.",
             500,
             "registry",
         )
-    return "no_settings"
+    raise AuthError(
+        f"Auth adapter {name} requires constructor argument(s) that the runtime cannot "
+        f"supply: {signature} ({reason}). Accept the configuration snapshot as "
+        f"{SETTINGS_PARAMETER}=, or give those parameters defaults.",
+        500,
+        "registry",
+    )
 
 
 @dataclass(frozen=True)

--- a/mozaiksai/core/auth/adapters/registry.py
+++ b/mozaiksai/core/auth/adapters/registry.py
@@ -3,12 +3,14 @@ Auth adapter registry.
 
 One canonical interpretation of authentication configuration lives here:
 :func:`resolve_auth_config` parses the environment exactly once per call into
-an immutable :class:`ResolvedAuthConfig`. Every predicate
-(:func:`is_auth_enabled`, :func:`is_auth_explicitly_disabled`), adapter
-resolution (:func:`get_auth_adapter`), and startup validation
+an immutable :class:`ResolvedAuthConfig` carrying a complete configuration
+snapshot. Every predicate (:func:`is_auth_enabled`,
+:func:`is_auth_explicitly_disabled`), adapter construction
+(:func:`get_auth_adapter`), and startup validation
 (:func:`validate_auth_provider_configuration`) consumes that same resolved
 state — there is no second parser, so the predicates can never contradict
-each other.
+each other and the adapter can never be built from a configuration other than
+the one its cache identity describes.
 
 Fail-closed contract:
 
@@ -21,58 +23,107 @@ Fail-closed contract:
 - Unrecognized ``AUTH_ENABLED`` values raise instead of silently disabling
   authentication.
 - No-auth operation of any kind (explicit disable or implicit demo mode) is
-  rejected in protected deployed environments (staging/production, per
-  ``mozaiksai.core.environment``), independent of startup-check mode.
-- The cached adapter is keyed by a fingerprint of the resolved configuration:
-  request-time adapter resolution always reflects the configuration that
-  startup validated, and a stale trusted-bypass adapter cannot survive a
-  configuration change.
+  permitted **only** in the finite set of recognized local/development/test
+  environments (see :mod:`mozaiksai.core.environment`). Every other explicit
+  environment value — known deployments and unknown/regional/custom names
+  alike — rejects it, independent of startup-check mode.
+- The cached adapter is keyed by a fingerprint derived from the complete
+  configuration snapshot that actually constructs the adapter for the resolved
+  provider, plus adapter-registration identity. Changing any meaning-bearing
+  input rebuilds the adapter; a stale adapter can never serve requests under a
+  newer configuration.
 """
 
 import os
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Literal
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.adapters.base import AuthAdapter, AuthError, BaseAuthAdapter
-from mozaiksai.core.environment import deployment_environment, is_protected_environment
+from mozaiksai.core.environment import (
+    ENVIRONMENT_ENV_VARS,
+    EnvironmentConfigError,
+    ResolvedEnvironment,
+    resolve_environment,
+)
 
 logger = get_core_logger("auth.registry")
-
-# Global adapter registry
-_adapter_registry: dict[str, type[BaseAuthAdapter]] = {}
-_adapter_instance: AuthAdapter | None = None
-_adapter_fingerprint: tuple[tuple[str, str], ...] | None = None
-
 
 _TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
 _FALSY_VALUES = frozenset({"false", "0", "no", "off"})
 
-# Environment variables that participate in auth configuration resolution or
-# adapter construction. The resolved-config fingerprint snapshots these so the
-# cached adapter is invalidated whenever any of them changes (D5 coherence).
-_AUTH_CONFIG_ENV_VARS: tuple[str, ...] = (
-    "AUTH_ENABLED",
-    "AUTH_PROVIDER",
-    "SUPABASE_URL",
-    "SUPABASE_JWT_SECRET",
-    "KEYCLOAK_URL",
-    "KEYCLOAK_REALM",
-    "KEYCLOAK_CLIENT_ID",
+# ---------------------------------------------------------------------------
+# Configuration census
+#
+# Every environment variable the auth subsystem reads, grouped by what it
+# controls. The mode variables select the provider; the per-provider variables
+# are the complete set of inputs that construct and control that provider's
+# adapter (including shared infrastructure it drives, such as JWKS/discovery
+# cache TTLs consumed through AuthConfig). Adapter cache identity is derived
+# from exactly these, so any meaning-bearing change rebuilds the adapter.
+# ---------------------------------------------------------------------------
+
+_AUTH_MODE_ENV_VARS: tuple[str, ...] = ("AUTH_ENABLED", "AUTH_PROVIDER", *ENVIRONMENT_ENV_VARS)
+
+_JWT_CONFIG_ENV_VARS: tuple[str, ...] = (
     "AUTH_JWKS_URL",
     "AUTH_ISSUER",
+    "AUTH_AUDIENCE",
     "MOZAIKS_OIDC_AUTHORITY",
     "MOZAIKS_OIDC_TENANT_ID",
     "MOZAIKS_OIDC_DISCOVERY_URL",
-    "AUTH_AUDIENCE",
-    "AUTH_REQUIRED_SCOPE",
-    "AUTH_ALGORITHMS",
     "AUTH_USER_ID_CLAIM",
     "AUTH_EMAIL_CLAIM",
+    "AUTH_NAME_CLAIM",
     "AUTH_ROLES_CLAIM",
-    "ENV",
-    "ENVIRONMENT",
+    "AUTH_SCOPES_CLAIM",
+    "AUTH_APP_ID_CLAIM",
+    "AUTH_CHAT_ID_CLAIM",
+    "AUTH_TENANT_ID_CLAIM",
+    "AUTH_WORKSPACE_ID_CLAIM",
+    "AUTH_SCOPES_FORMAT",
+    "AUTH_ALGORITHMS",
+    "AUTH_CLOCK_SKEW",
+    "AUTH_REQUIRED_SCOPE",
+    # Shared validation infrastructure driven by the JWT adapter via AuthConfig.
+    "AUTH_JWKS_CACHE_TTL",
+    "AUTH_DISCOVERY_CACHE_TTL",
 )
+
+_PROVIDER_CONFIG_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "jwt": _JWT_CONFIG_ENV_VARS,
+    "supabase": ("SUPABASE_URL", "SUPABASE_JWT_SECRET"),
+    "keycloak": (
+        "KEYCLOAK_URL",
+        "KEYCLOAK_REALM",
+        "KEYCLOAK_CLIENT_ID",
+        "KEYCLOAK_APP_ID_CLAIM",
+        "KEYCLOAK_TENANT_ID_CLAIM",
+        "KEYCLOAK_WORKSPACE_ID_CLAIM",
+    ),
+    "none": (
+        "AUTH_ANON_USER_ID",
+        "AUTH_ANON_EMAIL",
+        "AUTH_ANON_ROLES",
+        "AUTH_ANON_SCOPES",
+    ),
+}
+
+# Complete snapshot surface: mode variables plus every provider's inputs. The
+# snapshot is what adapters construct from; the fingerprint uses the mode
+# variables plus the resolved provider's own inputs.
+_ALL_AUTH_ENV_VARS: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        (
+            *_AUTH_MODE_ENV_VARS,
+            *(name for names in _PROVIDER_CONFIG_ENV_VARS.values() for name in names),
+        )
+    )
+)
+
+BUILTIN_PROVIDERS: frozenset[str] = frozenset(_PROVIDER_CONFIG_ENV_VARS)
 
 ResolvedAuthSource = Literal[
     "explicit_provider",
@@ -82,6 +133,40 @@ ResolvedAuthSource = Literal[
 ]
 
 
+# ---------------------------------------------------------------------------
+# Adapter registrations
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _AdapterRegistration:
+    """A registered adapter class plus its cache-identity contract.
+
+    ``config_identity`` is how a provider states "my configuration changed".
+    Built-in providers derive it from their declared environment census.
+    Custom providers must supply one explicitly (a string or a callable
+    returning a string) to be cacheable; without it the adapter is rebuilt on
+    every resolution, because the runtime cannot know what configures a
+    third-party adapter and must never reuse one validated under an older
+    configuration.
+    """
+
+    adapter_class: type[BaseAuthAdapter]
+    generation: int
+    builtin: bool
+    config_identity: str | Callable[[], str] | None = None
+
+    def identity_token(self) -> str | None:
+        """Return the provider-declared identity, or None when uncacheable."""
+        if self.builtin:
+            return "builtin"
+        if self.config_identity is None:
+            return None
+        if callable(self.config_identity):
+            return str(self.config_identity())
+        return str(self.config_identity)
+
+
 @dataclass(frozen=True)
 class ResolvedAuthConfig:
     """Immutable, canonical interpretation of the auth environment.
@@ -89,14 +174,14 @@ class ResolvedAuthConfig:
     Invariants (enforced at construction):
       - ``enabled`` is exactly ``provider != "none"``
       - ``enabled`` and ``explicitly_disabled`` are never both true
-      - ``explicitly_disabled`` implies ``provider == "none"``
     """
 
     provider: str
     enabled: bool
     explicitly_disabled: bool
     source: ResolvedAuthSource
-    environment: str
+    environment: ResolvedEnvironment
+    settings: Mapping[str, str]
     fingerprint: tuple[tuple[str, str], ...]
 
     def __post_init__(self) -> None:
@@ -116,18 +201,39 @@ class ResolvedAuthConfig:
             )
 
 
-def _config_fingerprint() -> tuple[tuple[str, str], ...]:
-    return tuple((name, os.getenv(name) or "") for name in _AUTH_CONFIG_ENV_VARS)
+@dataclass(frozen=True)
+class _AdapterCacheEntry:
+    """Atomically published cache record.
+
+    Fingerprint, provider, and adapter are published together as one immutable
+    value, so a request can never observe a fingerprint from one configuration
+    beside an adapter built from another.
+    """
+
+    fingerprint: tuple[tuple[str, str], ...]
+    provider: str
+    adapter: AuthAdapter
 
 
-def _has_oidc_discovery_config() -> bool:
+# Global registry state
+_adapter_registry: dict[str, _AdapterRegistration] = {}
+_registry_generation: int = 0
+_adapter_cache: _AdapterCacheEntry | None = None
+
+
+def _environment_snapshot() -> Mapping[str, str]:
+    """Capture the complete auth configuration surface once, immutably."""
+    return MappingProxyType({name: os.getenv(name) or "" for name in _ALL_AUTH_ENV_VARS})
+
+
+def _has_oidc_discovery_config(settings: Mapping[str, str]) -> bool:
     return bool(
-        os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
-        or os.getenv("MOZAIKS_OIDC_AUTHORITY", "").strip()
+        settings.get("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
+        or settings.get("MOZAIKS_OIDC_AUTHORITY", "").strip()
     )
 
 
-def _auth_enabled_setting() -> bool | None:
+def _auth_enabled_setting(settings: Mapping[str, str]) -> bool | None:
     """Return the operator's explicit AUTH_ENABLED declaration.
 
     ``True``/``False`` when AUTH_ENABLED is explicitly set to a recognized
@@ -135,9 +241,7 @@ def _auth_enabled_setting() -> bool | None:
     closed with :class:`AuthError` — a typo in AUTH_ENABLED must never
     silently disable authentication.
     """
-    raw = os.getenv("AUTH_ENABLED")
-    if raw is None:
-        return None
+    raw = settings.get("AUTH_ENABLED", "")
     value = raw.strip().lower()
     if not value:
         return None
@@ -151,6 +255,32 @@ def _auth_enabled_setting() -> bool | None:
         500,
         "registry",
     )
+
+
+def _fingerprint(
+    *,
+    provider: str,
+    settings: Mapping[str, str],
+    registration: _AdapterRegistration | None,
+) -> tuple[tuple[str, str], ...]:
+    """Derive the cache identity from the snapshot that builds the adapter.
+
+    Includes the mode variables, the resolved provider's complete declared
+    configuration inputs, and the adapter registration's identity/generation.
+    """
+    parts: list[tuple[str, str]] = [
+        (name, settings.get(name, "")) for name in _AUTH_MODE_ENV_VARS
+    ]
+    parts.extend(
+        (name, settings.get(name, ""))
+        for name in _PROVIDER_CONFIG_ENV_VARS.get(provider, ())
+    )
+    parts.append(("__provider__", provider))
+    if registration is not None:
+        parts.append(("__registration_generation__", str(registration.generation)))
+        identity = registration.identity_token()
+        parts.append(("__registration_identity__", identity if identity is not None else ""))
+    return tuple(parts)
 
 
 def resolve_auth_config() -> ResolvedAuthConfig:
@@ -178,12 +308,17 @@ def resolve_auth_config() -> ResolvedAuthConfig:
 
     Environment policy (mandatory, mode-independent): any configuration that
     resolves to no-auth operation — explicit disable or implicit demo — is
-    rejected in protected deployed environments (staging/production).
+    permitted only in a recognized local/development/test environment.
     """
-    fingerprint = _config_fingerprint()
-    environment = deployment_environment()
-    enabled_setting = _auth_enabled_setting()
-    explicit_provider = os.getenv("AUTH_PROVIDER", "").strip().lower()
+    settings = _environment_snapshot()
+
+    try:
+        environment = resolve_environment()
+    except EnvironmentConfigError as exc:
+        raise AuthError(str(exc), 500, "registry") from exc
+
+    enabled_setting = _auth_enabled_setting(settings)
+    explicit_provider = settings.get("AUTH_PROVIDER", "").strip().lower()
 
     provider: str
     explicitly_disabled: bool
@@ -213,17 +348,18 @@ def resolve_auth_config() -> ResolvedAuthConfig:
             provider, explicitly_disabled, source = explicit_provider, False, "explicit_provider"
     elif enabled_setting is False:
         provider, explicitly_disabled, source = "none", True, "explicit_disable"
-    elif os.getenv("SUPABASE_URL"):
+    elif settings.get("SUPABASE_URL", "").strip():
         provider, explicitly_disabled, source = "supabase", False, "auto_detected"
-    elif os.getenv("KEYCLOAK_URL") and os.getenv("KEYCLOAK_REALM"):
+    elif settings.get("KEYCLOAK_URL", "").strip() and settings.get("KEYCLOAK_REALM", "").strip():
         provider, explicitly_disabled, source = "keycloak", False, "auto_detected"
-    elif (os.getenv("AUTH_JWKS_URL") and os.getenv("AUTH_ISSUER")) or _has_oidc_discovery_config():
+    elif (
+        settings.get("AUTH_JWKS_URL", "").strip() and settings.get("AUTH_ISSUER", "").strip()
+    ) or _has_oidc_discovery_config(settings):
         provider, explicitly_disabled, source = "jwt", False, "auto_detected"
     elif enabled_setting is True:
         # Auth was explicitly enabled but no provider can be established.
         # Dev intent is never inferred from provider misconfiguration; this
-        # does not depend on ENV — staging and every other environment fail
-        # closed too.
+        # does not depend on the environment — every environment fails closed.
         raise AuthError(
             "AUTH_ENABLED=true but no authentication provider is configured. "
             "Set AUTH_PROVIDER or configure SUPABASE_URL, KEYCLOAK_URL + "
@@ -243,17 +379,22 @@ def resolve_auth_config() -> ResolvedAuthConfig:
         )
         provider, explicitly_disabled, source = "none", False, "demo_default"
 
-    if provider == "none" and is_protected_environment(environment):
+    if provider == "none" and not environment.permits_no_auth:
         raise AuthError(
-            f"Authentication-disabled operation is not permitted in the "
-            f"{environment!r} environment. Configure a real auth provider "
-            "(AUTH_PROVIDER, SUPABASE_URL, KEYCLOAK_URL + KEYCLOAK_REALM, "
-            "AUTH_JWKS_URL + AUTH_ISSUER, or MOZAIKS_OIDC_AUTHORITY). "
-            "Explicit AUTH_ENABLED=false / AUTH_PROVIDER=none are development "
-            "contracts only.",
+            "Authentication-disabled operation is not permitted in the "
+            f"{environment.display_name!r} environment. Unauthenticated operation "
+            "is available only in recognized local development environments "
+            "(development, local, test) or with no environment configured; "
+            "explicit AUTH_ENABLED=false / AUTH_PROVIDER=none are development "
+            "contracts only. Configure a real auth provider (AUTH_PROVIDER, "
+            "SUPABASE_URL, KEYCLOAK_URL + KEYCLOAK_REALM, AUTH_JWKS_URL + "
+            "AUTH_ISSUER, or MOZAIKS_OIDC_AUTHORITY).",
             500,
             "registry",
         )
+
+    _ensure_builtin_adapters()
+    registration = _adapter_registry.get(provider)
 
     return ResolvedAuthConfig(
         provider=provider,
@@ -261,7 +402,8 @@ def resolve_auth_config() -> ResolvedAuthConfig:
         explicitly_disabled=explicitly_disabled,
         source=source,
         environment=environment,
-        fingerprint=fingerprint,
+        settings=settings,
+        fingerprint=_fingerprint(provider=provider, settings=settings, registration=registration),
     )
 
 
@@ -282,52 +424,92 @@ def is_auth_explicitly_disabled() -> bool:
     is NOT an explicit declaration — security-sensitive bypasses must key off
     this helper, never off ``not is_auth_enabled()``. Both predicates read the
     same :func:`resolve_auth_config` interpretation, so they can never both be
-    true.
+    true, and both reject in environments that forbid no-auth operation.
     """
     return resolve_auth_config().explicitly_disabled
 
 
-def register_adapter(name: str, adapter_class: type[BaseAuthAdapter]) -> None:
+def register_adapter(
+    name: str,
+    adapter_class: type[BaseAuthAdapter],
+    *,
+    config_identity: str | Callable[[], str] | None = None,
+) -> None:
     """
     Register an auth adapter.
 
     Args:
         name: Adapter identifier (e.g., "supabase", "keycloak")
         adapter_class: The adapter class to register
+        config_identity: Cache-identity contract for custom adapters — a
+            string, or a callable returning one, that changes whenever the
+            adapter's configuration changes. Without it a custom adapter is
+            never cached across resolutions (it is rebuilt every time), so a
+            changed configuration can never silently reuse an adapter built
+            under an older one.
 
     Example:
-        register_adapter("my-custom", MyCustomAdapter)
+        register_adapter("my-custom", MyCustomAdapter, config_identity=lambda: cfg.revision)
     """
-    _adapter_registry[name.lower()] = adapter_class
-    logger.debug("Registered auth adapter: %s", name)
+    _register(name, adapter_class, builtin=False, config_identity=config_identity)
+
+
+def _register(
+    name: str,
+    adapter_class: type[BaseAuthAdapter],
+    *,
+    builtin: bool,
+    config_identity: str | Callable[[], str] | None = None,
+) -> None:
+    global _registry_generation
+    _registry_generation += 1
+    _adapter_registry[name.lower()] = _AdapterRegistration(
+        adapter_class=adapter_class,
+        generation=_registry_generation,
+        builtin=builtin,
+        config_identity=config_identity,
+    )
+    logger.debug("Registered auth adapter: %s (builtin=%s)", name, builtin)
 
 
 def list_adapters() -> list[str]:
     """List all registered adapter names."""
+    _ensure_builtin_adapters()
     return list(_adapter_registry.keys())
 
 
-def _register_builtin_adapters() -> None:
-    """Register built-in adapters."""
+def _ensure_builtin_adapters() -> None:
+    """Register built-in adapters once."""
+    if _adapter_registry:
+        return
     # Import here to avoid circular imports
     from mozaiksai.core.auth.adapters.jwt_adapter import GenericJWTAdapter
     from mozaiksai.core.auth.adapters.keycloak import KeycloakAuthAdapter
     from mozaiksai.core.auth.adapters.no_auth import NoAuthAdapter
     from mozaiksai.core.auth.adapters.supabase import SupabaseAuthAdapter
 
-    register_adapter("none", NoAuthAdapter)
-    register_adapter("jwt", GenericJWTAdapter)
-    register_adapter("supabase", SupabaseAuthAdapter)
-    register_adapter("keycloak", KeycloakAuthAdapter)
+    _register("none", NoAuthAdapter, builtin=True)
+    _register("jwt", GenericJWTAdapter, builtin=True)
+    _register("supabase", SupabaseAuthAdapter, builtin=True)
+    _register("keycloak", KeycloakAuthAdapter, builtin=True)
 
 
-def _build_adapter(provider: str, *, enabled: bool) -> AuthAdapter:
-    """Instantiate and validate the adapter for a resolved provider."""
-    if not _adapter_registry:
-        _register_builtin_adapters()
+def _build_adapter(
+    provider: str,
+    *,
+    enabled: bool,
+    settings: Mapping[str, str] | None,
+) -> AuthAdapter:
+    """Instantiate and validate the adapter for a resolved provider.
 
-    adapter_class = _adapter_registry.get(provider)
-    if adapter_class is None:
+    The adapter is constructed from ``settings`` — the same immutable snapshot
+    the cache fingerprint was derived from — so the adapter always matches its
+    cache identity.
+    """
+    _ensure_builtin_adapters()
+
+    registration = _adapter_registry.get(provider)
+    if registration is None:
         available = ", ".join(_adapter_registry.keys())
         raise AuthError(
             f"Unknown auth provider: {provider}. Available: {available}",
@@ -336,14 +518,19 @@ def _build_adapter(provider: str, *, enabled: bool) -> AuthAdapter:
         )
 
     try:
-        adapter = adapter_class()
-    except Exception as e:
+        adapter = registration.adapter_class(settings=settings)  # type: ignore[call-arg]
+    except TypeError:
+        # Custom adapters predating the snapshot contract may not accept it.
+        # They fall back to reading the live environment and are not cached
+        # unless they declare a config identity.
+        try:
+            adapter = registration.adapter_class()
+        except Exception as e:  # noqa: BLE001 - reported as AuthError below
+            logger.error("Failed to instantiate %s adapter: %s", provider, e, exc_info=True)
+            raise AuthError(f"Failed to configure {provider} auth: {e}", 500, provider) from e
+    except Exception as e:  # noqa: BLE001 - reported as AuthError below
         logger.error("Failed to instantiate %s adapter: %s", provider, e, exc_info=True)
-        raise AuthError(
-            f"Failed to configure {provider} auth: {e}",
-            500,
-            provider,
-        ) from e
+        raise AuthError(f"Failed to configure {provider} auth: {e}", 500, provider) from e
 
     if adapter.is_enabled():
         logger.info("Auth adapter configured: %s", provider)
@@ -365,15 +552,23 @@ def _build_adapter(provider: str, *, enabled: bool) -> AuthAdapter:
     return adapter
 
 
+def _is_cacheable(provider: str) -> bool:
+    """Custom adapters without a declared config identity are never cached."""
+    registration = _adapter_registry.get(provider)
+    return registration is not None and registration.identity_token() is not None
+
+
 def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
     """
     Get the auth adapter for the canonical resolved configuration.
 
-    The cached instance is keyed by the resolved-configuration fingerprint:
-    when any auth-relevant environment variable changes, the stale adapter is
-    discarded and a fresh one is built from the current configuration. The
-    AuthConfig value cache is cleared on rebuild so adapter internals read the
-    same environment snapshot. Repeated initialization is deterministic.
+    The cached record (fingerprint + provider + adapter) is published
+    atomically and keyed by the complete configuration identity for the
+    resolved provider. When any meaning-bearing input changes — provider
+    selection, any provider setting, environment, or adapter registration —
+    the stale adapter is discarded and a fresh one is built from the current
+    snapshot. Repeated initialization with unchanged configuration returns the
+    same instance.
 
     Args:
         force_provider: Build an adapter for this provider name directly,
@@ -381,36 +576,46 @@ def get_auth_adapter(force_provider: str | None = None) -> AuthAdapter:
 
     Returns:
         Configured AuthAdapter instance
-
-    Example:
-        adapter = get_auth_adapter()
-        claims = await adapter.validate_token(token)
     """
-    global _adapter_instance, _adapter_fingerprint
+    global _adapter_cache
 
     if force_provider is not None:
-        return _build_adapter(force_provider.lower(), enabled=force_provider.lower() != "none")
+        provider = force_provider.lower()
+        return _build_adapter(
+            provider,
+            enabled=provider != "none",
+            settings=_environment_snapshot(),
+        )
 
     config = resolve_auth_config()
 
-    if _adapter_instance is not None and _adapter_fingerprint == config.fingerprint:
-        return _adapter_instance
+    cached = _adapter_cache  # single read of the atomically published record
+    if cached is not None and cached.fingerprint == config.fingerprint:
+        return cached.adapter
 
     # Configuration changed (or first resolution): rebuild coherently. The
-    # AuthConfig cache must be refreshed first so the adapter constructor and
-    # its validators read the same environment the fingerprint captured.
+    # AuthConfig value cache is refreshed first so any shared infrastructure
+    # the adapter drives reads the same configuration generation.
     from mozaiksai.core.auth.config import clear_auth_config_cache
 
-    if _adapter_instance is not None:
+    if cached is not None:
         logger.info(
             "Auth configuration changed; rebuilding auth adapter (provider=%s)",
             config.provider,
         )
     clear_auth_config_cache()
-    adapter = _build_adapter(config.provider, enabled=config.enabled)
+    adapter = _build_adapter(config.provider, enabled=config.enabled, settings=config.settings)
 
-    _adapter_instance = adapter
-    _adapter_fingerprint = config.fingerprint
+    if _is_cacheable(config.provider):
+        _adapter_cache = _AdapterCacheEntry(
+            fingerprint=config.fingerprint,
+            provider=config.provider,
+            adapter=adapter,
+        )
+    else:
+        # Custom provider with no declared configuration identity: never
+        # cached, so a configuration change cannot reuse a stale adapter.
+        _adapter_cache = None
     return adapter
 
 
@@ -420,9 +625,8 @@ def reset_auth_adapter() -> None:
 
     Useful for testing or when configuration changes.
     """
-    global _adapter_instance, _adapter_fingerprint
-    _adapter_instance = None
-    _adapter_fingerprint = None
+    global _adapter_cache
+    _adapter_cache = None
     logger.debug("Auth adapter cache cleared")
 
 
@@ -432,15 +636,14 @@ def validate_auth_provider_configuration() -> str:
     Returns the resolved provider name on success. Raises :class:`AuthError`
     when the configuration is invalid: enabled auth whose provider is missing,
     unknown, conflicting, or not fully configured; contradictory explicit
-    declarations; or no-auth operation in a protected environment. Hosts call
-    this at startup so misconfiguration aborts boot in every environment and
-    every startup-check mode.
+    declarations; conflicting environment declarations; or no-auth operation
+    in an environment that does not permit it. Hosts call this at startup so
+    misconfiguration aborts boot in every environment and every startup-check
+    mode.
 
-    On success for a real provider, the validated adapter is bound into the
-    fingerprint-keyed cache — request-time resolution uses exactly the
-    configuration startup validated.
+    On success the validated adapter is bound into the fingerprint-keyed cache
+    — request-time resolution uses exactly the configuration startup validated.
     """
     config = resolve_auth_config()
-    if config.provider != "none":
-        get_auth_adapter()
+    get_auth_adapter()
     return config.provider

--- a/mozaiksai/core/auth/adapters/supabase.py
+++ b/mozaiksai/core/auth/adapters/supabase.py
@@ -12,7 +12,7 @@ Supabase JWTs have the following structure:
 - user_metadata: User profile data
 """
 
-import os
+from collections.abc import Mapping
 from typing import Any
 
 import jwt
@@ -49,10 +49,11 @@ class SupabaseAuthAdapter(BaseAuthAdapter):
         self,
         supabase_url: str | None = None,
         jwt_secret: str | None = None,
+        settings: Mapping[str, str] | None = None,
     ):
-        super().__init__()
-        self._supabase_url = supabase_url or os.getenv("SUPABASE_URL", "")
-        self._jwt_secret = jwt_secret or os.getenv("SUPABASE_JWT_SECRET", "")
+        super().__init__(settings)
+        self._supabase_url = supabase_url or self._setting("SUPABASE_URL")
+        self._jwt_secret = jwt_secret or self._setting("SUPABASE_JWT_SECRET")
         self._jwks_client: PyJWKClient | None = None
 
         # Clean URL (remove trailing slash)

--- a/mozaiksai/core/auth/cache_ttl.py
+++ b/mozaiksai/core/auth/cache_ttl.py
@@ -1,0 +1,57 @@
+"""Canonical parsing/validation for auth cache TTL configuration.
+
+``AUTH_JWKS_CACHE_TTL`` and ``AUTH_DISCOVERY_CACHE_TTL`` control how long a
+JWKS or OIDC discovery document is reused before refetching. They are parsed
+once, during canonical auth configuration resolution, so a malformed value
+fails startup instead of surfacing later during lazy client construction on a
+request path.
+
+Valid domain (matching the cache semantics in ``jwks.py`` / ``discovery.py``,
+where a document expires once ``now > fetched_at + ttl_seconds``):
+
+- a base-10 integer number of seconds
+- zero or greater; ``0`` means "always refetch"
+
+Negative values and non-integer strings are rejected rather than coerced.
+"""
+
+from __future__ import annotations
+
+__all__ = ["CacheTtlConfigError", "parse_cache_ttl_seconds"]
+
+
+class CacheTtlConfigError(ValueError):
+    """Raised when a cache TTL environment value is not a valid duration."""
+
+
+def parse_cache_ttl_seconds(name: str, raw: str | None, *, default: int | None = None) -> int:
+    """Parse one cache TTL value, failing closed on malformed input.
+
+    Args:
+        name: Environment variable name, used in the error message.
+        raw: The configured value. Empty/absent falls back to ``default``.
+        default: Value to use when ``raw`` is empty or absent. Required when
+            ``raw`` may be blank.
+
+    Raises:
+        CacheTtlConfigError: when the value is not a base-10 integer, or is
+            negative.
+    """
+    text = (raw or "").strip()
+    if not text:
+        if default is None:
+            raise CacheTtlConfigError(f"{name} must be set to an integer number of seconds.")
+        return default
+
+    try:
+        value = int(text, 10)
+    except ValueError as exc:
+        raise CacheTtlConfigError(
+            f"{name} must be an integer number of seconds, got {text!r}."
+        ) from exc
+
+    if value < 0:
+        raise CacheTtlConfigError(
+            f"{name} must be zero or greater (0 means always refetch), got {value}."
+        )
+    return value

--- a/mozaiksai/core/auth/cache_ttl.py
+++ b/mozaiksai/core/auth/cache_ttl.py
@@ -1,46 +1,76 @@
-"""Canonical parsing/validation for auth cache TTL configuration.
+"""Canonical parsing/normalization for auth cache TTL configuration.
 
 ``AUTH_JWKS_CACHE_TTL`` and ``AUTH_DISCOVERY_CACHE_TTL`` control how long a
-JWKS or OIDC discovery document is reused before refetching. They are parsed
-once, during canonical auth configuration resolution, so a malformed value
-fails startup instead of surfacing later during lazy client construction on a
-request path.
+JWKS or OIDC discovery document is reused before refetching. Every layer that
+needs one — canonical auth resolution, the JWT adapter's immutable config, and
+the ``AuthConfig`` compatibility surface — resolves it through
+:func:`resolve_cache_ttl_setting`, so absent, empty, and whitespace-only values
+all normalize identically and exactly once. Defaults live here only.
 
-Valid domain (matching the cache semantics in ``jwks.py`` / ``discovery.py``,
-where a document expires once ``now > fetched_at + ttl_seconds``):
+Contract:
 
 - a base-10 integer number of seconds
-- zero or greater; ``0`` means "always refetch"
+- zero or greater; ``0`` means "always refetch" and is never treated as absent
+- absent / empty / whitespace-only fall back to the canonical default for that
+  setting
+- anything else (non-integer text, negatives, floats) is rejected rather than
+  coerced
 
-Negative values and non-integer strings are rejected rather than coerced.
+Values are unbounded nonnegative integers. Cache expiry therefore compares
+*elapsed* time against the TTL (``now - fetched_at > ttl``) instead of adding
+the TTL to a float timestamp, so an arbitrarily large accepted TTL can never
+raise ``OverflowError`` during request-time cache use. See
+:func:`cache_entry_is_expired`.
 """
 
 from __future__ import annotations
 
-__all__ = ["CacheTtlConfigError", "parse_cache_ttl_seconds"]
+# Canonical defaults, matching the cache semantics documented in the clients:
+# discovery documents rarely change (24h); signing keys rotate more often (1h).
+DEFAULT_JWKS_CACHE_TTL_SECONDS = 3600
+DEFAULT_DISCOVERY_CACHE_TTL_SECONDS = 86400
+
+JWKS_CACHE_TTL_ENV = "AUTH_JWKS_CACHE_TTL"
+DISCOVERY_CACHE_TTL_ENV = "AUTH_DISCOVERY_CACHE_TTL"
+
+#: The one place a TTL setting's default is declared.
+CACHE_TTL_DEFAULTS: dict[str, int] = {
+    JWKS_CACHE_TTL_ENV: DEFAULT_JWKS_CACHE_TTL_SECONDS,
+    DISCOVERY_CACHE_TTL_ENV: DEFAULT_DISCOVERY_CACHE_TTL_SECONDS,
+}
+
+__all__ = [
+    "CACHE_TTL_DEFAULTS",
+    "DEFAULT_DISCOVERY_CACHE_TTL_SECONDS",
+    "DEFAULT_JWKS_CACHE_TTL_SECONDS",
+    "DISCOVERY_CACHE_TTL_ENV",
+    "JWKS_CACHE_TTL_ENV",
+    "CacheTtlConfigError",
+    "cache_entry_is_expired",
+    "parse_cache_ttl_seconds",
+    "resolve_cache_ttl_setting",
+]
 
 
 class CacheTtlConfigError(ValueError):
     """Raised when a cache TTL environment value is not a valid duration."""
 
 
-def parse_cache_ttl_seconds(name: str, raw: str | None, *, default: int | None = None) -> int:
+def parse_cache_ttl_seconds(name: str, raw: str | None, *, default: int) -> int:
     """Parse one cache TTL value, failing closed on malformed input.
 
     Args:
         name: Environment variable name, used in the error message.
-        raw: The configured value. Empty/absent falls back to ``default``.
-        default: Value to use when ``raw`` is empty or absent. Required when
-            ``raw`` may be blank.
+        raw: The configured value. Absent, empty, and whitespace-only all mean
+            "not configured" and yield ``default``.
+        default: Canonical default for this setting.
 
     Raises:
-        CacheTtlConfigError: when the value is not a base-10 integer, or is
-            negative.
+        CacheTtlConfigError: when the value is present but is not a base-10
+            integer, or is negative.
     """
     text = (raw or "").strip()
     if not text:
-        if default is None:
-            raise CacheTtlConfigError(f"{name} must be set to an integer number of seconds.")
         return default
 
     try:
@@ -55,3 +85,28 @@ def parse_cache_ttl_seconds(name: str, raw: str | None, *, default: int | None =
             f"{name} must be zero or greater (0 means always refetch), got {value}."
         )
     return value
+
+
+def resolve_cache_ttl_setting(name: str, raw: str | None) -> int:
+    """Resolve a known TTL setting using its canonical default.
+
+    ``name`` must be one of :data:`CACHE_TTL_DEFAULTS`. This is the entry point
+    every layer uses, so a given raw value always produces the same number.
+    """
+    try:
+        default = CACHE_TTL_DEFAULTS[name]
+    except KeyError as exc:  # pragma: no cover - programming error
+        raise CacheTtlConfigError(f"Unknown cache TTL setting: {name!r}") from exc
+    return parse_cache_ttl_seconds(name, raw, default=default)
+
+
+def cache_entry_is_expired(fetched_at: float, ttl_seconds: int, *, now: float) -> bool:
+    """Return whether a cache entry fetched at ``fetched_at`` has expired.
+
+    Mathematically equivalent to ``now > fetched_at + ttl_seconds`` but written
+    as an elapsed-time comparison. Python compares a float against an
+    arbitrary-precision int exactly, so this never converts a very large TTL to
+    a float and never raises ``OverflowError`` — every TTL the parser accepts
+    stays valid during real cache use.
+    """
+    return (now - fetched_at) > ttl_seconds

--- a/mozaiksai/core/auth/config.py
+++ b/mozaiksai/core/auth/config.py
@@ -14,7 +14,11 @@ import os
 from dataclasses import dataclass, field
 from functools import lru_cache
 
-from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
+from mozaiksai.core.auth.cache_ttl import (
+    DISCOVERY_CACHE_TTL_ENV,
+    JWKS_CACHE_TTL_ENV,
+    resolve_cache_ttl_setting,
+)
 
 
 @dataclass(frozen=True)
@@ -130,11 +134,11 @@ def get_auth_config() -> AuthConfig:
         email_claim=os.getenv("AUTH_EMAIL_CLAIM", "email"),
         roles_claim=os.getenv("AUTH_ROLES_CLAIM", "roles"),
         # Cache TTLs
-        jwks_cache_ttl_seconds=parse_cache_ttl_seconds(
-            "AUTH_JWKS_CACHE_TTL", os.getenv("AUTH_JWKS_CACHE_TTL"), default=3600
+        jwks_cache_ttl_seconds=resolve_cache_ttl_setting(
+            JWKS_CACHE_TTL_ENV, os.getenv(JWKS_CACHE_TTL_ENV)
         ),
-        discovery_cache_ttl_seconds=parse_cache_ttl_seconds(
-            "AUTH_DISCOVERY_CACHE_TTL", os.getenv("AUTH_DISCOVERY_CACHE_TTL"), default=86400
+        discovery_cache_ttl_seconds=resolve_cache_ttl_setting(
+            DISCOVERY_CACHE_TTL_ENV, os.getenv(DISCOVERY_CACHE_TTL_ENV)
         ),
         # Other
         algorithms=algorithms,

--- a/mozaiksai/core/auth/config.py
+++ b/mozaiksai/core/auth/config.py
@@ -14,6 +14,8 @@ import os
 from dataclasses import dataclass, field
 from functools import lru_cache
 
+from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
+
 
 @dataclass(frozen=True)
 class AuthConfig:
@@ -128,8 +130,12 @@ def get_auth_config() -> AuthConfig:
         email_claim=os.getenv("AUTH_EMAIL_CLAIM", "email"),
         roles_claim=os.getenv("AUTH_ROLES_CLAIM", "roles"),
         # Cache TTLs
-        jwks_cache_ttl_seconds=int(os.getenv("AUTH_JWKS_CACHE_TTL", "3600")),
-        discovery_cache_ttl_seconds=int(os.getenv("AUTH_DISCOVERY_CACHE_TTL", "86400")),
+        jwks_cache_ttl_seconds=parse_cache_ttl_seconds(
+            "AUTH_JWKS_CACHE_TTL", os.getenv("AUTH_JWKS_CACHE_TTL"), default=3600
+        ),
+        discovery_cache_ttl_seconds=parse_cache_ttl_seconds(
+            "AUTH_DISCOVERY_CACHE_TTL", os.getenv("AUTH_DISCOVERY_CACHE_TTL"), default=86400
+        ),
         # Other
         algorithms=algorithms,
         clock_skew_seconds=int(os.getenv("AUTH_CLOCK_SKEW", "120")),

--- a/mozaiksai/core/auth/dependencies.py
+++ b/mozaiksai/core/auth/dependencies.py
@@ -52,6 +52,20 @@ class UserPrincipal:
     chat_id: str | None = None
     tenant_id: str | None = None
     workspace_id: str | None = None
+    # Server-side provenance fact: how this principal came into existence.
+    # "token_validated" is set ONLY where a bearer token was actually
+    # validated by the configured auth adapter. "anonymous" covers the
+    # no-auth/demo principal; "dev_override" covers request-scoped local dev
+    # personas. Privileged surfaces must check is_authenticated rather than
+    # inferring authenticated identity from role/scope strings, which dev
+    # personas can freely carry.
+    auth_provenance: str = "anonymous"
+
+    @property
+    def is_authenticated(self) -> bool:
+        """True only when this principal was produced by validating a real
+        bearer token against the configured auth adapter."""
+        return self.auth_provenance == "token_validated"
 
     def has_role(self, role: str) -> bool:
         """Check if user has a specific role."""
@@ -90,8 +104,17 @@ class UserPrincipal:
         return str(self.workspace_id) == str(path_workspace_id)
 
     @classmethod
-    def from_claims(cls, claims: UserClaims) -> "UserPrincipal":
-        """Create UserPrincipal from adapter UserClaims."""
+    def from_claims(
+        cls,
+        claims: UserClaims,
+        *,
+        auth_provenance: str = "anonymous",
+    ) -> "UserPrincipal":
+        """Create UserPrincipal from adapter UserClaims.
+
+        ``auth_provenance`` must be "token_validated" only at call sites that
+        actually validated a bearer token via the configured auth adapter.
+        """
         return cls(
             user_id=claims.user_id,
             email=claims.email,
@@ -104,6 +127,7 @@ class UserPrincipal:
             chat_id=claims.chat_id,
             tenant_id=claims.tenant_id,
             workspace_id=claims.workspace_id,
+            auth_provenance=auth_provenance,
         )
 
 
@@ -159,6 +183,9 @@ def _no_auth_dev_override_principal(request: Request, principal: UserPrincipal) 
         chat_id=principal.chat_id,
         tenant_id=principal.tenant_id,
         workspace_id=principal.workspace_id,
+        # Dev personas are never authenticated provenance, no matter which
+        # roles/scopes the request-scoped override assigns them.
+        auth_provenance="dev_override",
     )
 
 
@@ -200,7 +227,9 @@ async def _validate_and_attach(
         )
         raise HTTPException(status_code=e.status_code, detail=e.message) from e
 
-    principal = UserPrincipal.from_claims(claims)
+    # The only place "token_validated" provenance is minted: a bearer token
+    # was actually validated by the configured auth adapter just above.
+    principal = UserPrincipal.from_claims(claims, auth_provenance="token_validated")
 
     # Attach to request state for downstream access
     request.state.user = principal

--- a/mozaiksai/core/auth/discovery.py
+++ b/mozaiksai/core/auth/discovery.py
@@ -25,12 +25,18 @@ from typing import Any
 import aiohttp
 
 from logs.logging_config import get_core_logger
-from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
+from mozaiksai.core.auth.cache_ttl import (
+    DEFAULT_DISCOVERY_CACHE_TTL_SECONDS,
+    DISCOVERY_CACHE_TTL_ENV,
+    cache_entry_is_expired,
+    resolve_cache_ttl_setting,
+)
 
 logger = get_core_logger("auth.discovery")
 
 
-_DEFAULT_DISCOVERY_CACHE_TTL = 86400  # 24 hours (discovery rarely changes)
+# Canonical default lives in cache_ttl.py; aliased for local readability.
+_DEFAULT_DISCOVERY_CACHE_TTL = DEFAULT_DISCOVERY_CACHE_TTL_SECONDS
 
 
 @dataclass
@@ -42,7 +48,7 @@ class CachedDiscovery:
     ttl_seconds: int
 
     def is_expired(self) -> bool:
-        return time.time() > (self.fetched_at + self.ttl_seconds)
+        return cache_entry_is_expired(self.fetched_at, self.ttl_seconds, now=time.time())
 
     @property
     def jwks_uri(self) -> str | None:
@@ -119,10 +125,8 @@ class OIDCDiscoveryClient:
         elif not consult_environment:
             self._cache_ttl = _DEFAULT_DISCOVERY_CACHE_TTL
         else:
-            self._cache_ttl = parse_cache_ttl_seconds(
-                "AUTH_DISCOVERY_CACHE_TTL",
-                os.getenv("AUTH_DISCOVERY_CACHE_TTL"),
-                default=_DEFAULT_DISCOVERY_CACHE_TTL,
+            self._cache_ttl = resolve_cache_ttl_setting(
+                DISCOVERY_CACHE_TTL_ENV, os.getenv(DISCOVERY_CACHE_TTL_ENV)
             )
         self._cache: CachedDiscovery | None = None
         self._lock = asyncio.Lock()

--- a/mozaiksai/core/auth/discovery.py
+++ b/mozaiksai/core/auth/discovery.py
@@ -25,6 +25,7 @@ from typing import Any
 import aiohttp
 
 from logs.logging_config import get_core_logger
+from mozaiksai.core.auth.cache_ttl import parse_cache_ttl_seconds
 
 logger = get_core_logger("auth.discovery")
 
@@ -64,46 +65,72 @@ class OIDCDiscoveryClient:
         self,
         discovery_url: str | None = None,
         cache_ttl: int | None = None,
+        *,
+        consult_environment: bool = True,
     ):
         """
         Initialize OIDC discovery client.
 
+        Authority contract: **explicit constructor input always wins.** A
+        client built with a caller-owned discovery URL and TTL keeps them for
+        its whole lifetime; later environment changes never alter its
+        behaviour. The environment is consulted only to fill in values the
+        caller did not supply, and only when ``consult_environment`` is True.
+
         Args:
-            discovery_url: Direct URL to discovery document. If None, resolved from
-                           MOZAIKS_OIDC_DISCOVERY_URL, or computed from
-                           MOZAIKS_OIDC_AUTHORITY + MOZAIKS_OIDC_TENANT_ID.
-                           If no authority is configured, discovery_url is None and
-                           get_discovery() raises a RuntimeError on first call.
-            cache_ttl: Cache TTL in seconds (default: 86400 = 24h)
+            discovery_url: Direct URL to the discovery document. Authoritative
+                           when supplied.
+            cache_ttl: Cache TTL in seconds. Authoritative when supplied.
+            consult_environment: When False, the environment is never read —
+                                 the client is fully bound to the values passed
+                                 in. Auth adapters pass False so their lazily
+                                 created clients stay bound to the same
+                                 immutable configuration snapshot that
+                                 identifies the adapter.
         """
-        # Explicit env override takes highest priority.
-        explicit_url = os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
-
-        if explicit_url:
-            self._discovery_url: str | None = explicit_url
-        elif discovery_url:
-            self._discovery_url = discovery_url
+        if discovery_url:
+            self._discovery_url: str | None = discovery_url
+        elif not consult_environment:
+            # Fully snapshot-bound with nothing supplied: discovery is
+            # unavailable for this client; get_discovery() raises on first use.
+            self._discovery_url = None
         else:
-            # Compute from authority + tenant if both are configured.
-            authority = os.getenv("MOZAIKS_OIDC_AUTHORITY", "").strip().rstrip("/")
-            tenant_id = os.getenv("MOZAIKS_OIDC_TENANT_ID", "").strip()
-            if authority and tenant_id:
-                self._discovery_url = (
-                    f"{authority}/{tenant_id}/v2.0/.well-known/openid-configuration"
-                )
-            elif authority:
-                # Authority without tenant: use the bare well-known endpoint.
-                self._discovery_url = f"{authority}/.well-known/openid-configuration"
+            explicit_url = os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
+            if explicit_url:
+                self._discovery_url = explicit_url
             else:
-                # No authority configured — discovery is unavailable.
-                # get_discovery() will raise a clear error on first call.
-                self._discovery_url = None
+                # Compute from authority + tenant if both are configured.
+                authority = os.getenv("MOZAIKS_OIDC_AUTHORITY", "").strip().rstrip("/")
+                tenant_id = os.getenv("MOZAIKS_OIDC_TENANT_ID", "").strip()
+                if authority and tenant_id:
+                    self._discovery_url = (
+                        f"{authority}/{tenant_id}/v2.0/.well-known/openid-configuration"
+                    )
+                elif authority:
+                    # Authority without tenant: use the bare well-known endpoint.
+                    self._discovery_url = f"{authority}/.well-known/openid-configuration"
+                else:
+                    # No authority configured — discovery is unavailable.
+                    # get_discovery() will raise a clear error on first call.
+                    self._discovery_url = None
 
-        self._cache_ttl = cache_ttl or int(
-            os.getenv("AUTH_DISCOVERY_CACHE_TTL", str(_DEFAULT_DISCOVERY_CACHE_TTL))
-        )
+        if cache_ttl is not None:
+            self._cache_ttl = cache_ttl
+        elif not consult_environment:
+            self._cache_ttl = _DEFAULT_DISCOVERY_CACHE_TTL
+        else:
+            self._cache_ttl = parse_cache_ttl_seconds(
+                "AUTH_DISCOVERY_CACHE_TTL",
+                os.getenv("AUTH_DISCOVERY_CACHE_TTL"),
+                default=_DEFAULT_DISCOVERY_CACHE_TTL,
+            )
         self._cache: CachedDiscovery | None = None
         self._lock = asyncio.Lock()
+
+    @property
+    def cache_ttl_seconds(self) -> int:
+        """The TTL this client was bound to at construction."""
+        return self._cache_ttl
 
     @property
     def discovery_url(self) -> str | None:

--- a/mozaiksai/core/auth/jwks.py
+++ b/mozaiksai/core/auth/jwks.py
@@ -8,12 +8,15 @@ Supports OIDC discovery-driven jwks_uri or explicit URL override.
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
 from logs.logging_config import get_core_logger
 from mozaiksai.core.auth.config import get_auth_config
+
+if TYPE_CHECKING:
+    from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
 
 logger = get_core_logger("auth.jwks")
 
@@ -51,7 +54,7 @@ class JWKSClient:
         use_discovery: bool = True,
         *,
         consult_environment: bool = True,
-        discovery_client: Any | None = None,
+        discovery_client: "OIDCDiscoveryClient | None" = None,
     ):
         """
         Initialize JWKS client.

--- a/mozaiksai/core/auth/jwks.py
+++ b/mozaiksai/core/auth/jwks.py
@@ -17,6 +17,8 @@ from mozaiksai.core.auth.config import get_auth_config
 
 logger = get_core_logger("auth.jwks")
 
+_DEFAULT_JWKS_CACHE_TTL = 3600  # 1 hour
+
 
 @dataclass
 class CachedJWKS:
@@ -47,23 +49,57 @@ class JWKSClient:
         jwks_url: str | None = None,
         cache_ttl: int | None = None,
         use_discovery: bool = True,
+        *,
+        consult_environment: bool = True,
+        discovery_client: Any | None = None,
     ):
         """
         Initialize JWKS client.
 
+        Authority contract: **explicit constructor input always wins.** A
+        client built with a caller-owned JWKS URL and TTL keeps them for its
+        whole lifetime; later environment or global ``AuthConfig`` changes
+        never alter its behaviour. Global configuration is consulted only to
+        fill in values the caller did not supply, and only when
+        ``consult_environment`` is True.
+
         Args:
-            jwks_url: Explicit JWKS URL (skips discovery if set)
-            cache_ttl: Cache TTL in seconds
-            use_discovery: If True and jwks_url not set, fetch from OIDC discovery
+            jwks_url: Explicit JWKS URL (skips discovery if set). Authoritative.
+            cache_ttl: Cache TTL in seconds. Authoritative when supplied.
+            use_discovery: If True and jwks_url not set, fetch from OIDC discovery.
+            consult_environment: When False, global ``AuthConfig`` is never
+                                 read — the client is fully bound to the values
+                                 passed in. Auth adapters pass False so their
+                                 lazily created clients stay bound to the same
+                                 immutable snapshot that identifies the adapter.
+            discovery_client: Discovery client to resolve ``jwks_uri`` through.
+                              Adapters inject their own snapshot-bound client
+                              instead of the process-wide singleton.
         """
-        config = get_auth_config()
-        self._explicit_jwks_url = jwks_url or config.jwks_url_override
-        self._cache_ttl = cache_ttl or config.jwks_cache_ttl_seconds
+        if jwks_url or not consult_environment:
+            self._explicit_jwks_url = jwks_url
+            self._cache_ttl = (
+                cache_ttl if cache_ttl is not None else _DEFAULT_JWKS_CACHE_TTL
+            )
+            if cache_ttl is None and consult_environment:
+                self._cache_ttl = get_auth_config().jwks_cache_ttl_seconds
+        else:
+            config = get_auth_config()
+            self._explicit_jwks_url = config.jwks_url_override
+            self._cache_ttl = (
+                cache_ttl if cache_ttl is not None else config.jwks_cache_ttl_seconds
+            )
         self._use_discovery = use_discovery and not self._explicit_jwks_url
+        self._discovery_client = discovery_client
         self._cache: CachedJWKS | None = None
         self._lock = asyncio.Lock()
         self._keys_by_kid: dict[str, dict[str, Any]] = {}
         self._resolved_jwks_url: str | None = None
+
+    @property
+    def cache_ttl_seconds(self) -> int:
+        """The TTL this client was bound to at construction."""
+        return self._cache_ttl
 
     async def _get_jwks_url(self) -> str:
         """
@@ -79,9 +115,15 @@ class JWKSClient:
             return self._explicit_jwks_url
 
         if self._use_discovery:
+            # An injected discovery client is authoritative — adapters supply
+            # their own snapshot-bound client so key resolution can never fall
+            # through to process-wide state built from a different config.
+            if self._discovery_client is not None:
+                return await self._discovery_client.get_jwks_uri()
+
             from mozaiksai.core.auth.discovery import get_discovery_client
-            discovery_client = get_discovery_client()
-            return await discovery_client.get_jwks_uri()
+
+            return await get_discovery_client().get_jwks_uri()
 
         raise RuntimeError(
             "No JWKS URL configured. Set AUTH_JWKS_URL or enable OIDC discovery."

--- a/mozaiksai/core/auth/jwks.py
+++ b/mozaiksai/core/auth/jwks.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 
 from logs.logging_config import get_core_logger
+from mozaiksai.core.auth.cache_ttl import (
+    DEFAULT_JWKS_CACHE_TTL_SECONDS,
+    cache_entry_is_expired,
+)
 from mozaiksai.core.auth.config import get_auth_config
 
 if TYPE_CHECKING:
@@ -20,7 +24,8 @@ if TYPE_CHECKING:
 
 logger = get_core_logger("auth.jwks")
 
-_DEFAULT_JWKS_CACHE_TTL = 3600  # 1 hour
+# Canonical default lives in cache_ttl.py; aliased for local readability.
+_DEFAULT_JWKS_CACHE_TTL = DEFAULT_JWKS_CACHE_TTL_SECONDS
 
 
 @dataclass
@@ -33,7 +38,7 @@ class CachedJWKS:
     source_url: str  # Track which URL was used
 
     def is_expired(self) -> bool:
-        return time.time() > (self.fetched_at + self.ttl_seconds)
+        return cache_entry_is_expired(self.fetched_at, self.ttl_seconds, now=time.time())
 
 
 class JWKSClient:

--- a/mozaiksai/core/environment.py
+++ b/mozaiksai/core/environment.py
@@ -1,0 +1,50 @@
+"""Canonical deployment-environment vocabulary for the Mozaiks runtime.
+
+One place interprets the deployment environment. Callers must not re-read or
+re-parse ``ENV``/``ENVIRONMENT`` for policy decisions — they consume these
+helpers so every boundary (auth resolution, startup validation, dispatch
+authority) agrees on what environment the process is running in.
+
+Existing repository vocabulary: the environment name comes from ``ENV`` with
+``ENVIRONMENT`` as fallback, lowercased; an unset value means local/developer
+operation. Only deployed, protected environments carry mandatory security
+policy — everything else follows the local development contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Deployed environments in which security-sensitive bypasses (for example
+# no-auth operation) are never permitted. Common short aliases are included
+# so a "prod"/"stage" spelling is protected rather than silently treated as
+# local development — widening protection is fail-closed; narrowing is not.
+PROTECTED_ENVIRONMENTS: frozenset[str] = frozenset({"production", "prod", "staging", "stage"})
+
+
+def deployment_environment() -> str:
+    """Return the canonical deployment environment name.
+
+    Reads ``ENV`` first, then ``ENVIRONMENT``; strips and lowercases.
+    Returns ``""`` when neither is set (local/developer operation).
+    """
+    return os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
+
+
+def is_protected_environment(environment: str | None = None) -> bool:
+    """True when the (given or current) environment is a protected deployment.
+
+    Protected environments reject authentication-disabled operation at every
+    mandatory boundary, independent of startup-check mode. Unknown or unset
+    environment names follow the existing local-development contract and are
+    not protected.
+    """
+    env = deployment_environment() if environment is None else environment.strip().lower()
+    return env in PROTECTED_ENVIRONMENTS
+
+
+__all__ = [
+    "PROTECTED_ENVIRONMENTS",
+    "deployment_environment",
+    "is_protected_environment",
+]

--- a/mozaiksai/core/environment.py
+++ b/mozaiksai/core/environment.py
@@ -1,50 +1,189 @@
 """Canonical deployment-environment vocabulary for the Mozaiks runtime.
 
 One place interprets the deployment environment. Callers must not re-read or
-re-parse ``ENV``/``ENVIRONMENT`` for policy decisions — they consume these
-helpers so every boundary (auth resolution, startup validation, dispatch
-authority) agrees on what environment the process is running in.
+re-parse ``ENV``/``ENVIRONMENT`` for policy decisions — they consume
+:func:`resolve_environment` so every boundary (auth resolution, startup
+validation, dispatch authority) agrees on what environment the process runs in.
 
-Existing repository vocabulary: the environment name comes from ``ENV`` with
-``ENVIRONMENT`` as fallback, lowercased; an unset value means local/developer
-operation. Only deployed, protected environments carry mandatory security
-policy — everything else follows the local development contract.
+Security decision direction — **allowlist, not denylist**:
+
+No-auth (unauthenticated) operation is permitted ONLY in a finite set of
+explicitly recognized local/development/test environments, plus the documented
+completely-absent local default. Every other explicit, non-empty environment
+value — including regional or custom deployment names such as ``prod-us``,
+``staging-eu``, ``preview``, or ``qa`` — is treated as a deployment that must
+never inherit development privilege. Unknown environments may still boot with
+correctly configured authentication; they simply cannot run unauthenticated.
+
+Canonical repository vocabulary (census of `.env.example`, host defaults, CI
+workflows, deployment templates, docs, and tests):
+
+- ``development`` — `.env.example` (both variables), runtime/observability host
+  defaults
+- ``local`` — Studio workspace summary default
+- ``test`` — CI (`.github/workflows/ci.yml`) and release workflow, test helpers
+- ``staging`` — deployment provisioning template default
+- ``production`` — generated Dockerfile template, production guards
+
+``dev``/``prod``/``stage`` are accepted only as unambiguous aliases of
+``development``/``production``/``staging`` and normalize to them before any
+comparison.
 """
 
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
+from typing import Literal
 
-# Deployed environments in which security-sensitive bypasses (for example
-# no-auth operation) are never permitted. Common short aliases are included
-# so a "prod"/"stage" spelling is protected rather than silently treated as
-# local development — widening protection is fail-closed; narrowing is not.
-PROTECTED_ENVIRONMENTS: frozenset[str] = frozenset({"production", "prod", "staging", "stage"})
+ENVIRONMENT_ENV_VARS: tuple[str, str] = ("ENV", "ENVIRONMENT")
+
+EnvironmentClassification = Literal[
+    "absent",
+    "local_development",
+    "protected_deployment",
+    "unknown_deployment",
+]
+
+# Unambiguous spelling aliases normalized before classification.
+_ENVIRONMENT_ALIASES: dict[str, str] = {
+    "dev": "development",
+    "prod": "production",
+    "stage": "staging",
+}
+
+# The finite allowlist. Only these recognized local/development/test
+# environments may run without authentication.
+LOCAL_ENVIRONMENTS: frozenset[str] = frozenset({"development", "local", "test"})
+
+# Known deployed environments. Listed for clear diagnostics only — anything
+# outside LOCAL_ENVIRONMENTS is already denied development privilege.
+PROTECTED_ENVIRONMENTS: frozenset[str] = frozenset({"production", "staging"})
+
+
+class EnvironmentConfigError(ValueError):
+    """Raised when ENV and ENVIRONMENT declare conflicting environments."""
+
+
+def _normalize(raw: str | None) -> str:
+    """Trim, lowercase, and alias-normalize one environment value.
+
+    Whitespace-only and empty values are absence, not an environment.
+    """
+    value = (raw or "").strip().lower()
+    if not value:
+        return ""
+    return _ENVIRONMENT_ALIASES.get(value, value)
+
+
+def _classify(name: str) -> EnvironmentClassification:
+    if not name:
+        return "absent"
+    if name in LOCAL_ENVIRONMENTS:
+        return "local_development"
+    if name in PROTECTED_ENVIRONMENTS:
+        return "protected_deployment"
+    return "unknown_deployment"
+
+
+@dataclass(frozen=True)
+class ResolvedEnvironment:
+    """Immutable canonical interpretation of the deployment environment."""
+
+    name: str
+    classification: EnvironmentClassification
+    raw_env: str
+    raw_environment: str
+
+    @property
+    def permits_no_auth(self) -> bool:
+        """True only for recognized local/development/test environments and
+        the documented completely-absent local default.
+
+        Unknown, custom, regional, and known-deployed environment names all
+        return False — no-auth privilege is never inherited by default.
+        """
+        return self.classification in {"absent", "local_development"}
+
+    @property
+    def is_deployed(self) -> bool:
+        """True for any environment that is not local/absent."""
+        return self.classification in {"protected_deployment", "unknown_deployment"}
+
+    @property
+    def display_name(self) -> str:
+        return self.name or "unset"
+
+
+def resolve_environment() -> ResolvedEnvironment:
+    """Resolve ``ENV``/``ENVIRONMENT`` into one canonical environment.
+
+    Resolution rules:
+
+    1. Both values are trimmed first; whitespace-only is absence.
+    2. A blank ``ENV`` never masks a non-blank ``ENVIRONMENT``.
+    3. Recognized aliases normalize before comparison.
+    4. If both are non-blank and semantically conflict, that is a
+       configuration error — the runtime refuses to silently pick one. Two
+       declarations conflict when they classify differently (for example a
+       local ``ENV`` beside a deployed ``ENVIRONMENT``), or when they name two
+       different deployed environments (``production`` beside ``staging``).
+    5. Two different names inside the recognized local class (for example
+       ``ENV=test`` with ``ENVIRONMENT=development``, as CI and a developer
+       ``.env`` commonly produce together) carry the same security meaning and
+       are accepted, with ``ENV`` taking precedence for the resolved name.
+    6. Completely absent keeps the documented implicit local default.
+    """
+    raw_env = os.getenv("ENV") or ""
+    raw_environment = os.getenv("ENVIRONMENT") or ""
+    primary = _normalize(raw_env)
+    fallback = _normalize(raw_environment)
+
+    if primary and fallback and primary != fallback:
+        primary_class = _classify(primary)
+        fallback_class = _classify(fallback)
+        # Same-class local declarations agree on the only thing that matters
+        # here (whether unauthenticated operation is permitted). Anything else
+        # — a class mismatch, or two distinct deployed environments — is a
+        # genuine conflict that must never be silently resolved.
+        if not (
+            primary_class == "local_development" and fallback_class == "local_development"
+        ):
+            raise EnvironmentConfigError(
+                f"Conflicting deployment environment declarations: ENV={raw_env.strip()!r} "
+                f"resolves to {primary!r} ({primary_class}) but "
+                f"ENVIRONMENT={raw_environment.strip()!r} resolves to {fallback!r} "
+                f"({fallback_class}). Set both to the same environment (or set only "
+                "one). Refusing to silently choose one of two conflicting values."
+            )
+
+    name = primary or fallback
+    return ResolvedEnvironment(
+        name=name,
+        classification=_classify(name),
+        raw_env=raw_env,
+        raw_environment=raw_environment,
+    )
 
 
 def deployment_environment() -> str:
-    """Return the canonical deployment environment name.
-
-    Reads ``ENV`` first, then ``ENVIRONMENT``; strips and lowercases.
-    Returns ``""`` when neither is set (local/developer operation).
-    """
-    return os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
+    """Return the canonical deployment environment name (``""`` when absent)."""
+    return resolve_environment().name
 
 
-def is_protected_environment(environment: str | None = None) -> bool:
-    """True when the (given or current) environment is a protected deployment.
-
-    Protected environments reject authentication-disabled operation at every
-    mandatory boundary, independent of startup-check mode. Unknown or unset
-    environment names follow the existing local-development contract and are
-    not protected.
-    """
-    env = deployment_environment() if environment is None else environment.strip().lower()
-    return env in PROTECTED_ENVIRONMENTS
+def environment_permits_no_auth() -> bool:
+    """True only when the current environment may run unauthenticated."""
+    return resolve_environment().permits_no_auth
 
 
 __all__ = [
+    "ENVIRONMENT_ENV_VARS",
+    "LOCAL_ENVIRONMENTS",
     "PROTECTED_ENVIRONMENTS",
+    "EnvironmentClassification",
+    "EnvironmentConfigError",
+    "ResolvedEnvironment",
     "deployment_environment",
-    "is_protected_environment",
+    "environment_permits_no_auth",
+    "resolve_environment",
 ]

--- a/mozaiksai/core/runtime/composition/module_authority.py
+++ b/mozaiksai/core/runtime/composition/module_authority.py
@@ -62,16 +62,15 @@ class ModuleDispatchAuthority:
 
 def _local_development_allowed() -> bool:
     """local_development authority exists only while runtime auth is disabled
-    and the deployment environment is not production."""
-
-    import os
+    and the deployment environment is not a protected deployment
+    (staging/production), per the canonical environment policy."""
 
     from mozaiksai.core.auth.adapters.registry import is_auth_enabled
+    from mozaiksai.core.environment import is_protected_environment
 
-    if is_auth_enabled():
+    if is_protected_environment():
         return False
-    env_name = os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
-    return env_name != "production"
+    return not is_auth_enabled()
 
 
 def workflow_user_authority(

--- a/mozaiksai/core/runtime/composition/module_authority.py
+++ b/mozaiksai/core/runtime/composition/module_authority.py
@@ -62,13 +62,14 @@ class ModuleDispatchAuthority:
 
 def _local_development_allowed() -> bool:
     """local_development authority exists only while runtime auth is disabled
-    and the deployment environment is not a protected deployment
-    (staging/production), per the canonical environment policy."""
+    and the environment is one that permits unauthenticated operation, per the
+    canonical environment policy (recognized local/development/test names, or
+    no environment configured at all)."""
 
     from mozaiksai.core.auth.adapters.registry import is_auth_enabled
-    from mozaiksai.core.environment import is_protected_environment
+    from mozaiksai.core.environment import environment_permits_no_auth
 
-    if is_protected_environment():
+    if not environment_permits_no_auth():
         return False
     return not is_auth_enabled()
 

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -262,7 +262,13 @@ class ModuleExecutor:
         Args:
             name:                Module name as declared in module.yaml and ModuleRequest.module
             handler:             Instantiated module handler object
-            action_method_map:   Maps public action id -> handler method name
+            action_method_map:   Maps public action id -> handler method name.
+                                 This map is the sole action dispatch authority:
+                                 action ids absent from it fail closed with
+                                 ACTION_NOT_FOUND, regardless of which Python
+                                 methods exist on the handler. Registering with
+                                 an empty/absent map yields a module with no
+                                 dispatchable actions.
             settings:            Setting definitions from settings.yaml (list of setting dicts).
                                  Injected into ModuleContext.settings on every action call.
             action_permissions:  Maps action id -> list of required permission ids.
@@ -338,9 +344,43 @@ class ModuleExecutor:
                 error_code="MODULE_NOT_FOUND",
             )
 
-        handler_method = self._action_methods.get(request.module, {}).get(request.action, request.action)
+        # Declared-action authority boundary: only action ids explicitly
+        # declared in the module's contract (module.yaml actions[]) resolve to
+        # a handler method. A Python method is never dispatchable merely
+        # because its name matches the requested action — undeclared actions
+        # fail closed here, before any handler attribute is resolved.
+        handler_method = self._action_methods.get(request.module, {}).get(request.action)
+        if handler_method is None:
+            if hasattr(handler, request.action):
+                logger.warning(
+                    "MODULE_ACTION_UNDECLARED: module=%s action=%s matches a handler "
+                    "attribute but is not declared in the module's action contract; "
+                    "refusing dispatch (user=%s)",
+                    request.module,
+                    request.action,
+                    request.user_id,
+                )
+                asyncio.create_task(
+                    self._emit_dispatch_audit(
+                        replace(dispatch_audit, outcome="denied", reason="undeclared action"),
+                        error="ACTION_NOT_FOUND",
+                    )
+                )
+            return ModuleResult(
+                success=False,
+                error=f"Action {request.action!r} not found on module {request.module!r}",
+                error_code="ACTION_NOT_FOUND",
+            )
         action_fn = getattr(handler, handler_method, None)
-        if action_fn is None:
+        if action_fn is None or not callable(action_fn):
+            logger.error(
+                "MODULE_ACTION_HANDLER_MISSING: module=%s action=%s declared "
+                "handler_method=%s is absent or not callable on %s",
+                request.module,
+                request.action,
+                handler_method,
+                type(handler).__name__,
+            )
             return ModuleResult(
                 success=False,
                 error=f"Action {request.action!r} not found on module {request.module!r}",

--- a/mozaiksai/core/runtime/composition/module_executor.py
+++ b/mozaiksai/core/runtime/composition/module_executor.py
@@ -29,6 +29,7 @@ import asyncio
 import inspect
 import json
 import os
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -152,6 +153,24 @@ class ModuleResult:
 # ---------------------------------------------------------------------------
 # Schema validation helper
 # ---------------------------------------------------------------------------
+
+_AUDIT_ACTION_MAX_LENGTH = 64
+_AUDIT_ACTION_SAFE_RE = re.compile(r"[^A-Za-z0-9_.\-]")
+
+
+def _bounded_action_for_audit(action: Any) -> str:
+    """Bound and sanitize a caller-supplied action id for logs and audit.
+
+    Undeclared action ids are attacker-influenced strings; they are reduced to
+    a bounded, safe character set before entering log lines, audit records, or
+    error messages.
+    """
+    text = str(action or "")
+    sanitized = _AUDIT_ACTION_SAFE_RE.sub("?", text)
+    if len(sanitized) > _AUDIT_ACTION_MAX_LENGTH:
+        return sanitized[:_AUDIT_ACTION_MAX_LENGTH] + "..."
+    return sanitized
+
 
 def _normalize_nullable_schema(schema: Any) -> Any:
     """Translate OpenAPI-style nullable fields into JSON Schema."""
@@ -346,29 +365,36 @@ class ModuleExecutor:
 
         # Declared-action authority boundary: only action ids explicitly
         # declared in the module's contract (module.yaml actions[]) resolve to
-        # a handler method. A Python method is never dispatchable merely
-        # because its name matches the requested action — undeclared actions
-        # fail closed here, before any handler attribute is resolved.
+        # a handler method. An undeclared action id fails closed WITHOUT
+        # touching the handler object at all — no getattr/hasattr, because
+        # Python attribute lookup can execute properties, descriptors, and
+        # custom __getattr__ before the request is denied. The denial is
+        # identical whether or not a same-named Python attribute exists, and
+        # the denied audit is built only from safe, already-known facts.
         handler_method = self._action_methods.get(request.module, {}).get(request.action)
         if handler_method is None:
-            if hasattr(handler, request.action):
-                logger.warning(
-                    "MODULE_ACTION_UNDECLARED: module=%s action=%s matches a handler "
-                    "attribute but is not declared in the module's action contract; "
-                    "refusing dispatch (user=%s)",
-                    request.module,
-                    request.action,
-                    request.user_id,
+            safe_action = _bounded_action_for_audit(request.action)
+            logger.warning(
+                "MODULE_ACTION_UNDECLARED: module=%s action=%s is not declared in "
+                "the module's action contract; refusing dispatch (user=%s)",
+                request.module,
+                safe_action,
+                request.user_id,
+            )
+            asyncio.create_task(
+                self._emit_dispatch_audit(
+                    replace(
+                        dispatch_audit,
+                        action=safe_action,
+                        outcome="denied",
+                        reason="undeclared action",
+                    ),
+                    error="ACTION_NOT_FOUND",
                 )
-                asyncio.create_task(
-                    self._emit_dispatch_audit(
-                        replace(dispatch_audit, outcome="denied", reason="undeclared action"),
-                        error="ACTION_NOT_FOUND",
-                    )
-                )
+            )
             return ModuleResult(
                 success=False,
-                error=f"Action {request.action!r} not found on module {request.module!r}",
+                error=f"Action {safe_action!r} not found on module {request.module!r}",
                 error_code="ACTION_NOT_FOUND",
             )
         action_fn = getattr(handler, handler_method, None)

--- a/mozaiksai/core/startup/validation.py
+++ b/mozaiksai/core/startup/validation.py
@@ -250,6 +250,31 @@ async def run_startup_checks(*, _mongo_client: Any = None) -> list[str]:
             extra={"check": "auth_enabled", "mode": mode},
         )
 
+    # ── Auth provider resolution (fail closed, mode-independent) ─────────────
+    # When authentication is explicitly enabled (AUTH_ENABLED=true), inability
+    # to establish the configured provider is fatal in EVERY environment and
+    # EVERY startup-check mode — never a warning. A typo'd or missing provider
+    # configuration must not silently boot the host into trusted-bypass
+    # ("none") operation. See mozaiksai.core.auth.adapters.registry.
+    from mozaiksai.core.auth.adapters.base import AuthError
+    from mozaiksai.core.auth.adapters.registry import validate_auth_provider_configuration
+
+    try:
+        resolved_provider = validate_auth_provider_configuration()
+        logger.info(
+            "STARTUP_CHECK_OK: auth provider resolved (%s)",
+            resolved_provider,
+            extra={"check": "auth_provider_resolution", "mode": mode},
+        )
+    except AuthError as auth_exc:
+        msg = f"Authentication configuration is invalid: {auth_exc}"
+        logger.error(
+            "STARTUP_CHECK_FAILED: %s",
+            msg,
+            extra={"check": "auth_provider_resolution", "mode": mode},
+        )
+        raise StartupConfigError(msg) from auth_exc
+
     # ── Auth provider configured in production ───────────────────────────────
     # When auth is not explicitly disabled but no provider env vars are set,
     # _auto_detect_provider() silently falls back to "none" (demo mode).

--- a/mozaiksai/core/startup/validation.py
+++ b/mozaiksai/core/startup/validation.py
@@ -21,8 +21,9 @@ Checks performed:
   Auth configuration   — mode-INDEPENDENT hard gate: the canonical auth
                          resolution must succeed. Enabled auth without a usable
                          provider, contradictory declarations, unrecognized
-                         AUTH_ENABLED values, and any no-auth operation in a
-                         protected environment (staging/production) abort
+                         AUTH_ENABLED values, conflicting ENV/ENVIRONMENT
+                         declarations, and any no-auth operation outside a
+                         recognized local/development/test environment abort
                          startup regardless of ``MOZAIKS_STARTUP_CHECKS``.
   INTERNAL_API_KEY     — warns when the key is absent or shorter than 32 chars
                          (defense-in-depth; not a hard gate).
@@ -45,7 +46,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from mozaiksai.core.core_config import get_mongo_client, get_secret
-from mozaiksai.core.environment import deployment_environment
+from mozaiksai.core.environment import EnvironmentConfigError, deployment_environment
 
 logger = logging.getLogger("mozaiksai.startup.validation")
 
@@ -230,14 +231,15 @@ async def run_startup_checks(*, _mongo_client: Any = None) -> list[str]:
     # The canonical auth resolution (mozaiksai.core.auth.adapters.registry)
     # is fatal — never a warning — for: explicitly enabled auth whose provider
     # is missing/unknown/incomplete, contradictory explicit declarations,
-    # unrecognized AUTH_ENABLED values, and ANY no-auth operation (explicit
-    # disable or implicit demo mode) in a protected deployed environment
-    # (staging/production). MOZAIKS_STARTUP_CHECKS mode does not weaken this.
-    env_name = deployment_environment()
+    # unrecognized AUTH_ENABLED values, conflicting ENV/ENVIRONMENT
+    # declarations, and ANY no-auth operation (explicit disable or implicit
+    # demo mode) outside a recognized local/development/test environment.
+    # MOZAIKS_STARTUP_CHECKS mode does not weaken this.
     from mozaiksai.core.auth.adapters.base import AuthError
     from mozaiksai.core.auth.adapters.registry import validate_auth_provider_configuration
 
     try:
+        env_name = deployment_environment()
         resolved_provider = validate_auth_provider_configuration()
         logger.info(
             "STARTUP_CHECK_OK: auth provider resolved (%s, env=%s)",
@@ -245,7 +247,7 @@ async def run_startup_checks(*, _mongo_client: Any = None) -> list[str]:
             env_name or "unset",
             extra={"check": "auth_provider_resolution", "mode": mode},
         )
-    except AuthError as auth_exc:
+    except (AuthError, EnvironmentConfigError) as auth_exc:
         msg = f"Authentication configuration is invalid: {auth_exc}"
         logger.error(
             "STARTUP_CHECK_FAILED: %s",

--- a/mozaiksai/core/startup/validation.py
+++ b/mozaiksai/core/startup/validation.py
@@ -18,10 +18,12 @@ Checks performed:
                          and MongoDB must respond to a ping within the driver timeout.
   Workflows path       — ``MOZAIKS_WORKFLOWS_PATH``, if set, must exist on disk.
   Upload dir           — ``UPLOAD_STORAGE_DIR``, if set, must be writable when it exists.
-  AUTH_ENABLED         — warns when ``ENV=production`` and ``AUTH_ENABLED=false``.
-  Auth provider        — warns when ``ENV=production``, auth is not explicitly disabled,
-                         and no auth provider env vars are configured (silently falls
-                         back to demo mode without this check).
+  Auth configuration   — mode-INDEPENDENT hard gate: the canonical auth
+                         resolution must succeed. Enabled auth without a usable
+                         provider, contradictory declarations, unrecognized
+                         AUTH_ENABLED values, and any no-auth operation in a
+                         protected environment (staging/production) abort
+                         startup regardless of ``MOZAIKS_STARTUP_CHECKS``.
   INTERNAL_API_KEY     — warns when the key is absent or shorter than 32 chars
                          (defense-in-depth; not a hard gate).
   RATE_LIMIT_ENABLED   — warns when ``ENV=production`` and ``RATE_LIMIT_ENABLED=false``.
@@ -43,6 +45,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from mozaiksai.core.core_config import get_mongo_client, get_secret
+from mozaiksai.core.environment import deployment_environment
 
 logger = logging.getLogger("mozaiksai.startup.validation")
 
@@ -223,47 +226,23 @@ async def run_startup_checks(*, _mongo_client: Any = None) -> list[str]:
                 extra={"check": "upload_storage_dir", "mode": mode},
             )
 
-    # ── AUTH_ENABLED in production ───────────────────────────────────────────
-    # AUTH_ENABLED=false is intentional in dev but a critical gap in production.
-    # Warn when the runtime environment is production and auth is disabled.
-    env_name = os.getenv("ENV", os.getenv("ENVIRONMENT", "")).strip().lower()
-    auth_enabled = os.getenv("AUTH_ENABLED", "true").strip().lower()
-    if env_name == "production" and auth_enabled in {"false", "0", "no", "off"}:
-        msg = (
-            "AUTH_ENABLED=false in a production environment. "
-            "All endpoints are exposed to unauthenticated access. "
-            "Set AUTH_ENABLED=true and configure an auth provider before serving production traffic."
-        )
-        warnings.append(msg)
-        logger.warning(
-            "STARTUP_CHECK_FAILED: %s",
-            msg,
-            extra={"check": "auth_enabled", "mode": mode},
-        )
-        if mode == "strict":
-            raise StartupConfigError(msg)
-    else:
-        logger.info(
-            "STARTUP_CHECK_OK: AUTH_ENABLED=%s (env=%s)",
-            auth_enabled,
-            env_name or "unset",
-            extra={"check": "auth_enabled", "mode": mode},
-        )
-
-    # ── Auth provider resolution (fail closed, mode-independent) ─────────────
-    # When authentication is explicitly enabled (AUTH_ENABLED=true), inability
-    # to establish the configured provider is fatal in EVERY environment and
-    # EVERY startup-check mode — never a warning. A typo'd or missing provider
-    # configuration must not silently boot the host into trusted-bypass
-    # ("none") operation. See mozaiksai.core.auth.adapters.registry.
+    # ── Auth configuration resolution (fail closed, mode-independent) ────────
+    # The canonical auth resolution (mozaiksai.core.auth.adapters.registry)
+    # is fatal — never a warning — for: explicitly enabled auth whose provider
+    # is missing/unknown/incomplete, contradictory explicit declarations,
+    # unrecognized AUTH_ENABLED values, and ANY no-auth operation (explicit
+    # disable or implicit demo mode) in a protected deployed environment
+    # (staging/production). MOZAIKS_STARTUP_CHECKS mode does not weaken this.
+    env_name = deployment_environment()
     from mozaiksai.core.auth.adapters.base import AuthError
     from mozaiksai.core.auth.adapters.registry import validate_auth_provider_configuration
 
     try:
         resolved_provider = validate_auth_provider_configuration()
         logger.info(
-            "STARTUP_CHECK_OK: auth provider resolved (%s)",
+            "STARTUP_CHECK_OK: auth provider resolved (%s, env=%s)",
             resolved_provider,
+            env_name or "unset",
             extra={"check": "auth_provider_resolution", "mode": mode},
         )
     except AuthError as auth_exc:
@@ -274,51 +253,6 @@ async def run_startup_checks(*, _mongo_client: Any = None) -> list[str]:
             extra={"check": "auth_provider_resolution", "mode": mode},
         )
         raise StartupConfigError(msg) from auth_exc
-
-    # ── Auth provider configured in production ───────────────────────────────
-    # When auth is not explicitly disabled but no provider env vars are set,
-    # _auto_detect_provider() silently falls back to "none" (demo mode).
-    # Catch this at startup so operators are not surprised in production.
-    if env_name == "production" and auth_enabled not in {"false", "0", "no", "off"}:
-        explicit_provider = os.getenv("AUTH_PROVIDER", "").strip()
-        has_supabase = bool(os.getenv("SUPABASE_URL", "").strip())
-        has_keycloak = bool(
-            os.getenv("KEYCLOAK_URL", "").strip() and os.getenv("KEYCLOAK_REALM", "").strip()
-        )
-        has_jwt_overrides = bool(
-            os.getenv("AUTH_JWKS_URL", "").strip() and os.getenv("AUTH_ISSUER", "").strip()
-        )
-        has_oidc_discovery = bool(
-            os.getenv("MOZAIKS_OIDC_DISCOVERY_URL", "").strip()
-            or os.getenv("MOZAIKS_OIDC_AUTHORITY", "").strip()
-        )
-        has_jwt = has_jwt_overrides or has_oidc_discovery
-        has_provider = bool(explicit_provider) or has_supabase or has_keycloak or has_jwt
-        if not has_provider:
-            msg = (
-                "AUTH_ENABLED is not false but no auth provider is configured in production. "
-                "The runtime will silently fall back to demo mode (no authentication). "
-                "Set AUTH_PROVIDER or configure SUPABASE_URL, KEYCLOAK_URL, "
-                "AUTH_JWKS_URL + AUTH_ISSUER, or MOZAIKS_OIDC_AUTHORITY."
-            )
-            warnings.append(msg)
-            logger.warning(
-                "STARTUP_CHECK_FAILED: %s",
-                msg,
-                extra={"check": "auth_provider", "mode": mode},
-            )
-            if mode == "strict":
-                raise StartupConfigError(msg)
-        else:
-            detected = (
-                explicit_provider
-                or ("supabase" if has_supabase else ("keycloak" if has_keycloak else "jwt"))
-            )
-            logger.info(
-                "STARTUP_CHECK_OK: auth provider configured (%s)",
-                detected,
-                extra={"check": "auth_provider", "mode": mode},
-            )
 
     # ── INTERNAL_API_KEY ─────────────────────────────────────────────────────
     # When not set, service-to-service requests bypass the key check (dev mode).

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -254,6 +254,13 @@ async def _platform_startup() -> None:
     """Initialize platform/app-shell composition after runtime startup."""
     global _runtime_services
 
+    # Fail closed before serving any route: explicitly enabled authentication
+    # whose provider cannot be established must abort platform boot in every
+    # environment, never degrade to the trusted-bypass "none" adapter.
+    from mozaiksai.core.auth.adapters.registry import validate_auth_provider_configuration
+
+    validate_auth_provider_configuration()
+
     app_root = resolve_app_root()
     database_startup_policy = get_database_startup_policy()
     logger.info("DATABASE_STARTUP_POLICY: policy=%s app_root=%s", database_startup_policy, app_root)

--- a/mozaiksai/hosts/routers/billing.py
+++ b/mozaiksai/hosts/routers/billing.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from mozaiksai.core.audit import AuditRecord, get_audit_logger
 from mozaiksai.core.audit.audit_logger import AuditEventKind, _hash_inputs
 from mozaiksai.core.auth import UserPrincipal, optional_user
-from mozaiksai.core.auth.adapters.registry import is_auth_enabled
+from mozaiksai.core.auth.adapters.registry import is_auth_explicitly_disabled
 from mozaiksai.core.auth.dependencies import validate_path_app_id
 from mozaiksai.core.billing import (
     BillingFulfillmentCommand,
@@ -63,12 +63,21 @@ def _authorize_fulfillment(
         ):
             return principal.user_id
 
-    if not is_auth_enabled() and not os.getenv("INTERNAL_API_KEY", "").strip():
+    # Unauthenticated fulfillment is an explicit development contract only:
+    # the operator must have declared no-auth operation (AUTH_ENABLED=false or
+    # AUTH_PROVIDER=none). Implicit demo mode — auth merely unconfigured — and
+    # a missing/misconfigured INTERNAL_API_KEY fail closed instead of turning
+    # this ingress into an unauthenticated endpoint.
+    if is_auth_explicitly_disabled() and not os.getenv("INTERNAL_API_KEY", "").strip():
         return principal.user_id if principal is not None else "local_dev"
 
     raise HTTPException(
         status_code=403,
-        detail="Billing fulfillment requires an internal API key or billing admin scope.",
+        detail=(
+            "Billing fulfillment requires an internal API key, a billing admin "
+            "scope, or explicitly disabled authentication (AUTH_ENABLED=false) "
+            "in local development."
+        ),
     )
 
 

--- a/mozaiksai/hosts/routers/billing.py
+++ b/mozaiksai/hosts/routers/billing.py
@@ -55,28 +55,39 @@ def _authorize_fulfillment(
     if _valid_internal_api_key(request):
         return "internal_api_key"
 
-    if principal is not None:
-        if (
+    # Privileged-principal path: requires authenticated provenance — the
+    # principal must have come through a real bearer-token validation by the
+    # configured auth adapter. Role/scope strings alone are not authority:
+    # anonymous/demo principals and request-scoped dev personas can carry
+    # admin-looking roles and scopes, and none of them are authenticated.
+    if (
+        principal is not None
+        and principal.is_authenticated
+        and (
             principal.has_role("admin")
             or principal.has_scope("billing.admin")
             or principal.has_scope("billing.fulfillment.apply")
-        ):
-            return principal.user_id
+        )
+    ):
+        return principal.user_id
 
-    # Unauthenticated fulfillment is an explicit development contract only:
-    # the operator must have declared no-auth operation (AUTH_ENABLED=false or
-    # AUTH_PROVIDER=none). Implicit demo mode — auth merely unconfigured — and
-    # a missing/misconfigured INTERNAL_API_KEY fail closed instead of turning
-    # this ingress into an unauthenticated endpoint.
+    # Local-development exception, fully separate from the authenticated-admin
+    # path: the operator must have explicitly declared no-auth operation
+    # (AUTH_ENABLED=false or AUTH_PROVIDER=none), which the canonical auth
+    # resolution rejects outright in protected environments
+    # (staging/production) — so this branch cannot open there even if startup
+    # validation was somehow bypassed. Implicit demo mode (auth merely
+    # unconfigured) and a missing/misconfigured INTERNAL_API_KEY fail closed
+    # instead of turning this ingress into an unauthenticated endpoint.
     if is_auth_explicitly_disabled() and not os.getenv("INTERNAL_API_KEY", "").strip():
         return principal.user_id if principal is not None else "local_dev"
 
     raise HTTPException(
         status_code=403,
         detail=(
-            "Billing fulfillment requires an internal API key, a billing admin "
-            "scope, or explicitly disabled authentication (AUTH_ENABLED=false) "
-            "in local development."
+            "Billing fulfillment requires an internal API key, an authenticated "
+            "billing admin, or explicitly disabled authentication "
+            "(AUTH_ENABLED=false) in local development."
         ),
     )
 

--- a/tests/test_app_metrics.py
+++ b/tests/test_app_metrics.py
@@ -272,7 +272,7 @@ async def test_module_executor_injects_module_and_action_into_context() -> None:
             return {"module_id": ctx.module_id, "action_id": ctx.action_id}
 
     executor = ModuleExecutor()
-    executor.register("analytics", Handler())
+    executor.register("analytics", Handler(), action_method_map={"run": "run"})
 
     result = await executor.execute(ModuleRequest(module="analytics", action="run", app_id="app-1", authority=trusted_framework_authority()))
 

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -1225,3 +1225,611 @@ class TestCachePublicationCoherence:
         bound = reg._adapter_cache
         assert bound is not None
         assert reg.get_auth_adapter() is bound.adapter
+
+
+# ---------------------------------------------------------------------------
+# D5-A: lazy client chain is bound to the adapter's own snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestLazyClientSnapshotBinding:
+    """Once an adapter exists, later environment changes must not alter its
+    behaviour — including through lazily created discovery/JWKS clients that
+    had not been instantiated yet when the environment changed."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in (*_AUTH_MATRIX_VARS, "AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL",
+                    "MOZAIKS_OIDC_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def _config_a(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("MOZAIKS_OIDC_DISCOVERY_URL", "https://a.example.com/.well-known")
+        # An explicit JWKS URL keeps key resolution off the network while still
+        # exercising the full lazy construction path.
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", "31")
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", "31")
+
+    def _mutate_to_config_b(self, monkeypatch) -> None:
+        monkeypatch.setenv("MOZAIKS_OIDC_DISCOVERY_URL", "https://b.example.com/.well-known")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://b.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", "47")
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", "47")
+
+    @pytest.mark.asyncio
+    async def test_old_adapter_lazy_clients_use_original_snapshot(self, monkeypatch):
+        """The mandatory race proof: build under A, mutate the live env to B
+        WITHOUT resolving a new adapter, then trigger the old adapter's lazy
+        clients for the first time. They must still use A / TTL 31."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._config_a(monkeypatch)
+        adapter = get_auth_adapter()
+        assert adapter.name == "jwt"
+
+        # Lazy clients have NOT been created yet.
+        assert adapter._discovery_client is None
+        assert adapter._jwks_client is None
+
+        self._mutate_to_config_b(monkeypatch)
+
+        # First-ever instantiation of the lazy chain, after the mutation.
+        discovery = adapter._get_discovery_client()
+        assert discovery.discovery_url == "https://a.example.com/.well-known"
+        assert discovery.cache_ttl_seconds == 31
+
+        jwks = await adapter._get_jwks_client_async()
+        assert jwks.cache_ttl_seconds == 31
+        assert jwks._explicit_jwks_url == "https://a.example.com/jwks.json"
+        # Key resolution routes through the adapter's own discovery client,
+        # never the process-wide singleton.
+        assert jwks._discovery_client is discovery
+
+    @pytest.mark.asyncio
+    async def test_new_resolution_after_change_uses_new_snapshot(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._config_a(monkeypatch)
+        old = get_auth_adapter()
+        old_discovery = old._get_discovery_client()
+
+        self._mutate_to_config_b(monkeypatch)
+        new = get_auth_adapter()
+        assert new is not old
+
+        new_discovery = new._get_discovery_client()
+        assert new_discovery.discovery_url == "https://b.example.com/.well-known"
+        assert new_discovery.cache_ttl_seconds == 47
+        new_jwks = await new._get_jwks_client_async()
+        assert new_jwks.cache_ttl_seconds == 47
+
+        # The old adapter is still internally bound to its old snapshot.
+        assert old_discovery.discovery_url == "https://a.example.com/.well-known"
+        assert old_discovery.cache_ttl_seconds == 31
+
+    def test_discovery_client_cannot_be_repointed_by_environment(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("MOZAIKS_OIDC_AUTHORITY", "https://authority-a.example.com")
+        adapter = get_auth_adapter()
+
+        monkeypatch.setenv("MOZAIKS_OIDC_DISCOVERY_URL", "https://attacker.example.com/.well-known")
+        discovery = adapter._get_discovery_client()
+        assert "attacker" not in (discovery.discovery_url or "")
+        assert discovery.discovery_url.startswith("https://authority-a.example.com")
+
+    @pytest.mark.asyncio
+    async def test_jwks_client_cannot_be_repointed_by_global_config(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        adapter = get_auth_adapter()
+
+        # Repoint the global AuthConfig, then create the lazy client.
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://attacker.example.com/jwks.json")
+        clear_auth_config_cache()
+        jwks = await adapter._get_jwks_client_async()
+        assert jwks._explicit_jwks_url == "https://a.example.com/jwks.json"
+
+    def test_adapter_config_carries_snapshot_ttls(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._config_a(monkeypatch)
+        adapter = get_auth_adapter()
+        assert adapter._config.discovery_cache_ttl_seconds == 31
+        assert adapter._config.jwks_cache_ttl_seconds == 31
+
+    def test_ttl_change_alone_rebuilds_adapter(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._config_a(monkeypatch)
+        first = get_auth_adapter()
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", "47")
+        second = get_auth_adapter()
+        assert second is not first
+        assert second._config.jwks_cache_ttl_seconds == 47
+
+
+# ---------------------------------------------------------------------------
+# D5-A: cache TTL validation happens at configuration resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTtlValidation:
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in (*_AUTH_MATRIX_VARS, "AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL"):
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    @pytest.mark.parametrize("ttl_var", ["AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL"])
+    @pytest.mark.parametrize("bad_value", ["abc", "1.5", "", "  ", "-1", "1e3", "0x10", "3,600"])
+    def test_malformed_ttl_rejected_at_resolution(self, monkeypatch, ttl_var, bad_value):
+        """Malformed TTLs fail during canonical resolution, long before a
+        request can reach lazy client construction."""
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        monkeypatch.setenv(ttl_var, bad_value)
+
+        if bad_value.strip() == "":
+            # Blank falls back to the documented default rather than failing.
+            assert resolve_auth_config().provider == "jwt"
+            return
+        with pytest.raises(AuthError, match=ttl_var):
+            resolve_auth_config()
+
+    @pytest.mark.parametrize("good_value", ["0", "1", "31", "3600", "86400"])
+    def test_valid_ttl_accepted(self, monkeypatch, good_value):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", good_value)
+        assert resolve_auth_config().provider == "jwt"
+
+    def test_parse_helper_domain(self):
+        from mozaiksai.core.auth.cache_ttl import CacheTtlConfigError, parse_cache_ttl_seconds
+
+        assert parse_cache_ttl_seconds("X", "60") == 60
+        assert parse_cache_ttl_seconds("X", "0") == 0
+        assert parse_cache_ttl_seconds("X", None, default=42) == 42
+        assert parse_cache_ttl_seconds("X", "  ", default=42) == 42
+        for bad in ("abc", "-1", "1.5", "1e3"):
+            with pytest.raises(CacheTtlConfigError):
+                parse_cache_ttl_seconds("X", bad)
+
+
+# ---------------------------------------------------------------------------
+# D5-B: constructor compatibility is decided before invocation
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorContract:
+    """A TypeError raised inside a constructor body is a real failure. It must
+    never be mistaken for 'this constructor does not accept settings' and
+    trigger a second, unconfigured construction."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        saved = dict(reg._adapter_registry)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+        yield
+        reg._adapter_registry.clear()
+        reg._adapter_registry.update(saved)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+
+    def _select(self, monkeypatch, provider: str) -> None:
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", provider)
+
+    def test_settings_aware_adapter_receives_snapshot(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        class _SettingsAware(BaseAuthAdapter):
+            name = "settingsaware"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                self.got_settings = settings
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("settingsaware", _SettingsAware, config_identity="v1")
+        self._select(monkeypatch, "settingsaware")
+        adapter = get_auth_adapter()
+        assert adapter.got_settings is not None
+        assert "AUTH_PROVIDER" in adapter.got_settings
+
+    def test_legacy_adapter_without_settings_still_constructs(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        class _Legacy(BaseAuthAdapter):
+            name = "legacyadapter"
+
+            def __init__(self):
+                super().__init__()
+                self.constructed = True
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("legacyadapter", _Legacy, config_identity="v1")
+        self._select(monkeypatch, "legacyadapter")
+        assert get_auth_adapter().constructed is True
+
+    def test_constructor_body_typeerror_never_retries_without_settings(self, monkeypatch):
+        """The exact D5-B defect: a TypeError from inside the body must fail
+        closed, not silently rebuild the adapter without its configuration."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        attempts: list[dict] = []
+
+        class _BodyTypeError(BaseAuthAdapter):
+            name = "bodytypeerror"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                attempts.append({"settings": settings})
+                raise TypeError("defective adapter body")
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("bodytypeerror", _BodyTypeError, config_identity="v1")
+        self._select(monkeypatch, "bodytypeerror")
+
+        with pytest.raises(AuthError, match="Failed to configure"):
+            get_auth_adapter()
+        assert len(attempts) == 1, "must not retry construction without settings"
+        assert attempts[0]["settings"] is not None
+
+    def test_constructor_valueerror_fails_closed(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        attempts: list[int] = []
+
+        class _BodyValueError(BaseAuthAdapter):
+            name = "bodyvalueerror"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                attempts.append(1)
+                raise ValueError("bad configuration")
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("bodyvalueerror", _BodyValueError, config_identity="v1")
+        self._select(monkeypatch, "bodyvalueerror")
+
+        with pytest.raises(AuthError, match="Failed to configure"):
+            get_auth_adapter()
+        assert len(attempts) == 1
+
+    def test_malformed_signature_adapter_fails_closed(self, monkeypatch):
+        """A constructor requiring an unknown argument cannot be built; it
+        fails rather than being retried in some other shape."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        class _NeedsUnknownArg(BaseAuthAdapter):
+            name = "needsunknownarg"
+
+            def __init__(self, required_thing):
+                super().__init__()
+                self.required_thing = required_thing
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("needsunknownarg", _NeedsUnknownArg, config_identity="v1")
+        self._select(monkeypatch, "needsunknownarg")
+        with pytest.raises(AuthError, match="Failed to configure"):
+            get_auth_adapter()
+
+    def test_kwargs_constructor_is_treated_as_settings_aware(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        class _Kwargs(BaseAuthAdapter):
+            name = "kwargsadapter"
+
+            def __init__(self, **kwargs):
+                super().__init__(kwargs.get("settings"))
+                self.kwargs = kwargs
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("kwargsadapter", _Kwargs, config_identity="v1")
+        self._select(monkeypatch, "kwargsadapter")
+        assert get_auth_adapter().kwargs.get("settings") is not None
+
+    @pytest.mark.parametrize("provider", ["none", "jwt", "supabase", "keycloak"])
+    def test_builtin_adapters_are_settings_aware(self, provider):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        reg._ensure_builtin_adapters()
+        assert reg._adapter_registry[provider].accepts_settings is True
+
+
+# ---------------------------------------------------------------------------
+# D5-C: custom config identity contract is strict
+# ---------------------------------------------------------------------------
+
+
+class TestConfigIdentityContract:
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        saved = dict(reg._adapter_registry)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+        yield
+        reg._adapter_registry.clear()
+        reg._adapter_registry.update(saved)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+
+    def _adapter_class(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+
+        class _Custom(BaseAuthAdapter):
+            name = "identityprobe"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+
+            async def validate_token(self, token):
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        return _Custom
+
+    @pytest.mark.parametrize(
+        "bad_identity",
+        [123, 1.5, True, ["rev-a"], {"rev": "a"}, ("rev",), object()],
+    )
+    def test_malformed_literal_identity_rejected_at_registration(self, bad_identity):
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        with pytest.raises(AuthError, match="must be a string"):
+            register_adapter("identityprobe", self._adapter_class(), config_identity=bad_identity)
+
+    @pytest.mark.parametrize("blank_identity", ["", "   ", "\t", "\n"])
+    def test_blank_literal_identity_rejected(self, blank_identity):
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        with pytest.raises(AuthError, match="non-blank"):
+            register_adapter("identityprobe", self._adapter_class(), config_identity=blank_identity)
+
+    @pytest.mark.parametrize("bad_return", [None, 123, ["rev"], {"rev": "a"}])
+    def test_callable_returning_non_string_rejected(self, monkeypatch, bad_return):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        register_adapter(
+            "identityprobe", self._adapter_class(), config_identity=lambda: bad_return
+        )
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "identityprobe")
+        with pytest.raises(AuthError, match="must be a string"):
+            get_auth_adapter()
+
+    @pytest.mark.parametrize("blank_return", ["", "  "])
+    def test_callable_returning_blank_rejected(self, monkeypatch, blank_return):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        register_adapter(
+            "identityprobe", self._adapter_class(), config_identity=lambda: blank_return
+        )
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "identityprobe")
+        with pytest.raises(AuthError, match="non-blank"):
+            get_auth_adapter()
+
+    def test_callable_raising_fails_closed(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        def _boom():
+            raise RuntimeError("identity source unavailable")
+
+        register_adapter("identityprobe", self._adapter_class(), config_identity=_boom)
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "identityprobe")
+        with pytest.raises(AuthError, match="config_identity callable raised"):
+            get_auth_adapter()
+
+    def test_valid_identity_accepted_and_cached(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        register_adapter("identityprobe", self._adapter_class(), config_identity="rev-a")
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "identityprobe")
+        assert get_auth_adapter() is get_auth_adapter()
+
+    def test_no_identity_remains_uncached_not_an_error(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        register_adapter("identityprobe", self._adapter_class())
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "identityprobe")
+        assert get_auth_adapter() is not get_auth_adapter()
+
+
+# ---------------------------------------------------------------------------
+# Built-in snapshot-consumption census
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinSnapshotConsumption:
+    """Captured values must be the values actually consumed all the way down,
+    for every built-in provider."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in (*_AUTH_MATRIX_VARS, "AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL",
+                    "KEYCLOAK_CLIENT_ID", "KEYCLOAK_APP_ID_CLAIM", "KEYCLOAK_TENANT_ID_CLAIM",
+                    "KEYCLOAK_WORKSPACE_ID_CLAIM", "SUPABASE_JWT_SECRET",
+                    "AUTH_ANON_USER_ID", "AUTH_ANON_ROLES", "AUTH_ANON_SCOPES",
+                    "AUTH_ANON_EMAIL", "AUTH_WORKSPACE_ID_CLAIM", "AUTH_CLOCK_SKEW"):
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def test_jwt_consumes_captured_values(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        monkeypatch.setenv("AUTH_AUDIENCE", "aud-a")
+        monkeypatch.setenv("AUTH_WORKSPACE_ID_CLAIM", "ws_a")
+        monkeypatch.setenv("AUTH_CLOCK_SKEW", "77")
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", "31")
+        monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", "33")
+
+        a = get_auth_adapter()
+        assert a._config.jwks_url == "https://a.example.com/jwks.json"
+        assert a._config.issuer == "https://a.example.com"
+        assert a._config.audience == "aud-a"
+        assert a._config.workspace_id_claim == "ws_a"
+        assert a._config.clock_skew_seconds == 77
+        assert a._config.jwks_cache_ttl_seconds == 31
+        assert a._config.discovery_cache_ttl_seconds == 33
+
+    def test_keycloak_consumes_captured_values(self, monkeypatch):
+        """Programmatic only — no admin console or browser login involved."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "keycloak")
+        monkeypatch.setenv("KEYCLOAK_URL", "https://kc-a.example.com/")
+        monkeypatch.setenv("KEYCLOAK_REALM", "realm-a")
+        monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "client-a")
+        monkeypatch.setenv("KEYCLOAK_APP_ID_CLAIM", "app_a")
+        monkeypatch.setenv("KEYCLOAK_TENANT_ID_CLAIM", "tenant_a")
+        monkeypatch.setenv("KEYCLOAK_WORKSPACE_ID_CLAIM", "ws_a")
+
+        a = get_auth_adapter()
+        assert a._keycloak_url == "https://kc-a.example.com"
+        assert a._realm == "realm-a"
+        assert a._client_id == "client-a"
+        assert a._app_id_claim == "app_a"
+        assert a._tenant_id_claim == "tenant_a"
+        assert a._workspace_id_claim == "ws_a"
+        # Derived URLs follow the captured values.
+        assert a._issuer == "https://kc-a.example.com/realms/realm-a"
+        assert a._jwks_url.startswith("https://kc-a.example.com/realms/realm-a")
+
+        # Mutating the environment does not mutate the existing adapter.
+        monkeypatch.setenv("KEYCLOAK_REALM", "realm-b")
+        assert a._realm == "realm-a"
+        assert a._issuer == "https://kc-a.example.com/realms/realm-a"
+
+    def test_supabase_consumes_captured_values(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://proj-a.supabase.co/")
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-a")
+
+        a = get_auth_adapter()
+        assert a._supabase_url == "https://proj-a.supabase.co"
+        assert a._jwt_secret == "secret-a"
+        assert a._issuer == "https://proj-a.supabase.co/auth/v1"
+
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret-b")
+        assert a._jwt_secret == "secret-a"
+
+    def test_no_auth_consumes_captured_values(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        monkeypatch.setenv("ENV", "development")
+        monkeypatch.setenv("AUTH_ANON_USER_ID", "dev_alice")
+        monkeypatch.setenv("AUTH_ANON_EMAIL", "alice@example.com")
+        monkeypatch.setenv("AUTH_ANON_ROLES", "admin,user")
+        monkeypatch.setenv("AUTH_ANON_SCOPES", "access_as_user,extra.scope")
+
+        a = get_auth_adapter()
+        assert a._default_user_id == "dev_alice"
+        assert a._default_email == "alice@example.com"
+        assert a._default_roles == ["admin", "user"]
+        assert a._default_scopes == ["access_as_user", "extra.scope"]
+
+        monkeypatch.setenv("AUTH_ANON_USER_ID", "dev_bob")
+        assert a._default_user_id == "dev_alice"

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -280,3 +280,114 @@ class TestNoAuthAdapter:
         for token in ["", "garbage", "Bearer eyJ...", "123"]:
             claims = await adapter.validate_token(token)
             assert isinstance(claims, UserClaims)
+
+
+# ---------------------------------------------------------------------------
+# Provider detection fail-closed contract
+# ---------------------------------------------------------------------------
+
+
+class TestProviderDetectionFailClosed:
+    """AUTH_ENABLED=true must never silently resolve to the trusted-bypass
+    'none' provider; explicit disablement is the only unauthenticated mode."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+        for var in (
+            "AUTH_ENABLED",
+            "AUTH_PROVIDER",
+            "SUPABASE_URL",
+            "KEYCLOAK_URL",
+            "KEYCLOAK_REALM",
+            "AUTH_JWKS_URL",
+            "AUTH_ISSUER",
+            "MOZAIKS_OIDC_AUTHORITY",
+            "MOZAIKS_OIDC_DISCOVERY_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        reset_auth_adapter()
+        yield
+        reset_auth_adapter()
+
+    def test_auth_enabled_true_without_provider_raises(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        with pytest.raises(AuthError, match="no authentication provider"):
+            _auto_detect_provider()
+
+    def test_is_auth_enabled_fails_closed_when_misconfigured(self, monkeypatch):
+        """is_auth_enabled must raise (fail closed), never return False, when
+        AUTH_ENABLED=true has no resolvable provider."""
+        from mozaiksai.core.auth.adapters.registry import is_auth_enabled
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        with pytest.raises(AuthError):
+            is_auth_enabled()
+
+    def test_auth_enabled_true_with_provider_none_conflicts(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "none")
+        with pytest.raises(AuthError, match="conflicts"):
+            _auto_detect_provider()
+
+    def test_unrecognized_auth_enabled_value_raises(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        monkeypatch.setenv("AUTH_ENABLED", "tru")
+        with pytest.raises(AuthError, match="Unrecognized AUTH_ENABLED"):
+            _auto_detect_provider()
+
+    def test_auth_enabled_true_with_supabase_url_resolves(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        assert _auto_detect_provider() == "supabase"
+
+    def test_auth_enabled_false_resolves_none(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        assert _auto_detect_provider() == "none"
+
+    def test_nothing_configured_resolves_demo_none(self):
+        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+
+        assert _auto_detect_provider() == "none"
+
+    def test_explicitly_disabled_only_for_explicit_declarations(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import is_auth_explicitly_disabled
+
+        # Implicit demo mode is NOT explicit disablement.
+        assert is_auth_explicitly_disabled() is False
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        assert is_auth_explicitly_disabled() is True
+
+        monkeypatch.delenv("AUTH_ENABLED", raising=False)
+        monkeypatch.setenv("AUTH_PROVIDER", "none")
+        assert is_auth_explicitly_disabled() is True
+
+        # Enabled deployments are never "explicitly disabled".
+        monkeypatch.delenv("AUTH_PROVIDER", raising=False)
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        assert is_auth_explicitly_disabled() is False
+
+    def test_get_adapter_raises_for_enabled_but_unconfigured_provider(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        clear_auth_config_cache()
+        try:
+            with pytest.raises(AuthError, match="not fully configured"):
+                get_auth_adapter(force_provider="jwt")
+        finally:
+            clear_auth_config_cache()

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -312,11 +312,11 @@ class TestProviderDetectionFailClosed:
         reset_auth_adapter()
 
     def test_auth_enabled_true_without_provider_raises(self, monkeypatch):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         monkeypatch.setenv("AUTH_ENABLED", "true")
         with pytest.raises(AuthError, match="no authentication provider"):
-            _auto_detect_provider()
+            resolve_auth_config()
 
     def test_is_auth_enabled_fails_closed_when_misconfigured(self, monkeypatch):
         """is_auth_enabled must raise (fail closed), never return False, when
@@ -328,37 +328,37 @@ class TestProviderDetectionFailClosed:
             is_auth_enabled()
 
     def test_auth_enabled_true_with_provider_none_conflicts(self, monkeypatch):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         monkeypatch.setenv("AUTH_ENABLED", "true")
         monkeypatch.setenv("AUTH_PROVIDER", "none")
         with pytest.raises(AuthError, match="conflicts"):
-            _auto_detect_provider()
+            resolve_auth_config()
 
     def test_unrecognized_auth_enabled_value_raises(self, monkeypatch):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         monkeypatch.setenv("AUTH_ENABLED", "tru")
         with pytest.raises(AuthError, match="Unrecognized AUTH_ENABLED"):
-            _auto_detect_provider()
+            resolve_auth_config()
 
     def test_auth_enabled_true_with_supabase_url_resolves(self, monkeypatch):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         monkeypatch.setenv("AUTH_ENABLED", "true")
         monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
-        assert _auto_detect_provider() == "supabase"
+        assert resolve_auth_config().provider == "supabase"
 
     def test_auth_enabled_false_resolves_none(self, monkeypatch):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         monkeypatch.setenv("AUTH_ENABLED", "false")
-        assert _auto_detect_provider() == "none"
+        assert resolve_auth_config().provider == "none"
 
     def test_nothing_configured_resolves_demo_none(self):
-        from mozaiksai.core.auth.adapters.registry import _auto_detect_provider
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
-        assert _auto_detect_provider() == "none"
+        assert resolve_auth_config().provider == "none"
 
     def test_explicitly_disabled_only_for_explicit_declarations(self, monkeypatch):
         from mozaiksai.core.auth.adapters.registry import is_auth_explicitly_disabled
@@ -391,3 +391,287 @@ class TestProviderDetectionFailClosed:
                 get_auth_adapter(force_provider="jwt")
         finally:
             clear_auth_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# Canonical resolved-auth state: contradiction + environment matrix (D2/D4)
+# ---------------------------------------------------------------------------
+
+_AUTH_MATRIX_VARS = (
+    "AUTH_ENABLED",
+    "AUTH_PROVIDER",
+    "SUPABASE_URL",
+    "SUPABASE_JWT_SECRET",
+    "KEYCLOAK_URL",
+    "KEYCLOAK_REALM",
+    "AUTH_JWKS_URL",
+    "AUTH_ISSUER",
+    "MOZAIKS_OIDC_AUTHORITY",
+    "MOZAIKS_OIDC_DISCOVERY_URL",
+    "ENV",
+    "ENVIRONMENT",
+)
+
+
+def _set_matrix_env(monkeypatch, env: dict) -> None:
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+    from mozaiksai.core.auth.config import clear_auth_config_cache
+
+    for var in _AUTH_MATRIX_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    clear_auth_config_cache()
+    reset_auth_adapter()
+
+
+class TestResolvedAuthStateMatrix:
+    """One canonical interpretation: predicates can never contradict, explicit
+    contradictions reject, and protected environments refuse no-auth."""
+
+    @pytest.fixture(autouse=True)
+    def _teardown(self):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    # -- contradiction matrix ------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"AUTH_ENABLED": "true", "AUTH_PROVIDER": "none"},
+            {"AUTH_ENABLED": "false", "AUTH_PROVIDER": "jwt"},
+            {"AUTH_ENABLED": "false", "AUTH_PROVIDER": "supabase", "SUPABASE_URL": "https://x.supabase.co"},
+            {"AUTH_ENABLED": "tru"},
+            {"AUTH_ENABLED": "enabled"},
+        ],
+    )
+    def test_contradictory_or_malformed_declarations_reject(self, monkeypatch, env):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, env)
+        with pytest.raises(AuthError):
+            resolve_auth_config()
+
+    def test_truthy_variant_without_provider_rejects(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, {"AUTH_ENABLED": "1 "})
+        with pytest.raises(AuthError, match="no authentication provider"):
+            resolve_auth_config()
+
+    def test_explicit_disable_beats_passive_provider_signals(self, monkeypatch):
+        """A SUPABASE_URL left in a developer .env does not contradict an
+        explicit AUTH_ENABLED=false: the explicit switch wins over passive
+        presence (existing OSS dev contract)."""
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(
+            monkeypatch,
+            {"AUTH_ENABLED": "false", "SUPABASE_URL": "https://x.supabase.co"},
+        )
+        config = resolve_auth_config()
+        assert config.provider == "none"
+        assert config.explicitly_disabled is True
+        assert config.enabled is False
+
+    # -- predicate coherence -------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {},
+            {"AUTH_ENABLED": "false"},
+            {"AUTH_PROVIDER": "none"},
+            {"AUTH_ENABLED": "true", "SUPABASE_URL": "https://x.supabase.co"},
+            {"AUTH_PROVIDER": "supabase", "SUPABASE_URL": "https://x.supabase.co"},
+            {"KEYCLOAK_URL": "https://kc.example.com", "KEYCLOAK_REALM": "r"},
+            {"AUTH_JWKS_URL": "https://x/jwks.json", "AUTH_ISSUER": "https://x"},
+            {"MOZAIKS_OIDC_AUTHORITY": "https://login.example.com"},
+        ],
+    )
+    def test_enabled_and_explicitly_disabled_never_both_true(self, monkeypatch, env):
+        from mozaiksai.core.auth.adapters.registry import (
+            is_auth_enabled,
+            is_auth_explicitly_disabled,
+        )
+
+        _set_matrix_env(monkeypatch, env)
+        assert not (is_auth_enabled() and is_auth_explicitly_disabled())
+
+    def test_astra_d4_reproduction_now_rejects(self, monkeypatch):
+        """The exact D4 contradiction (explicit provider + explicit disable)
+        raises from BOTH predicates instead of answering inconsistently."""
+        from mozaiksai.core.auth.adapters.registry import (
+            is_auth_enabled,
+            is_auth_explicitly_disabled,
+        )
+
+        _set_matrix_env(monkeypatch, {"AUTH_ENABLED": "false", "AUTH_PROVIDER": "jwt"})
+        with pytest.raises(AuthError):
+            is_auth_enabled()
+        with pytest.raises(AuthError):
+            is_auth_explicitly_disabled()
+
+    # -- protected-environment policy (D2) -----------------------------------
+
+    @pytest.mark.parametrize("environment", ["staging", "production", "stage", "prod"])
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"AUTH_ENABLED": "false"},
+            {"AUTH_PROVIDER": "none"},
+            {},
+        ],
+    )
+    def test_protected_environments_reject_all_no_auth_operation(self, monkeypatch, environment, env):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, {**env, "ENV": environment})
+        with pytest.raises(AuthError, match="not permitted"):
+            resolve_auth_config()
+
+    @pytest.mark.parametrize("environment", ["staging", "production"])
+    def test_protected_environments_accept_configured_provider(self, monkeypatch, environment):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(
+            monkeypatch,
+            {"AUTH_ENABLED": "true", "SUPABASE_URL": "https://x.supabase.co", "ENV": environment},
+        )
+        config = resolve_auth_config()
+        assert config.provider == "supabase"
+        assert config.enabled is True
+
+    @pytest.mark.parametrize("environment", ["", "development", "dev", "test", "local", "qa-lab"])
+    def test_unprotected_environments_follow_dev_contract(self, monkeypatch, environment):
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        env = {"AUTH_ENABLED": "false"}
+        if environment:
+            env["ENV"] = environment
+        _set_matrix_env(monkeypatch, env)
+        config = resolve_auth_config()
+        assert config.provider == "none"
+        assert config.explicitly_disabled is True
+
+    def test_environment_var_fallback_also_protected(self, monkeypatch):
+        """ENVIRONMENT (without ENV) is the same canonical vocabulary."""
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, {"AUTH_ENABLED": "false", "ENVIRONMENT": "staging"})
+        with pytest.raises(AuthError, match="not permitted"):
+            resolve_auth_config()
+
+
+# ---------------------------------------------------------------------------
+# Cache/config coherence transitions (D5)
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterCacheCoherence:
+    """The cached adapter is keyed by the resolved-config fingerprint: request
+    resolution always matches the configuration startup validated, and no
+    stale trusted-bypass adapter survives a configuration change."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def _jwt_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
+
+    def test_astra_d5_sequence_none_then_jwt_startup_binds_jwt(self, monkeypatch):
+        """demo 'none' resolved first -> config becomes valid JWT -> startup
+        validation -> requests MUST use the JWT adapter, with no manual reset."""
+        from mozaiksai.core.auth.adapters.registry import (
+            get_auth_adapter,
+            validate_auth_provider_configuration,
+        )
+
+        assert get_auth_adapter().name == "none"  # demo mode cached first
+
+        self._jwt_env(monkeypatch)
+        assert validate_auth_provider_configuration() == "jwt"
+        assert get_auth_adapter().name == "jwt"
+
+    def test_jwt_then_explicit_disable_in_dev_updates_consistently(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._jwt_env(monkeypatch)
+        assert get_auth_adapter().name == "jwt"
+
+        for var in ("AUTH_PROVIDER", "AUTH_JWKS_URL", "AUTH_ISSUER"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        assert get_auth_adapter().name == "none"
+
+    def test_provider_a_to_provider_b(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        assert get_auth_adapter().name == "supabase"
+
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.setenv("KEYCLOAK_URL", "https://kc.example.com")
+        monkeypatch.setenv("KEYCLOAK_REALM", "realm")
+        assert get_auth_adapter().name == "keycloak"
+
+    def test_valid_provider_to_malformed_config_fails_closed(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        assert get_auth_adapter().name == "supabase"
+
+        monkeypatch.setenv("AUTH_ENABLED", "tru")
+        with pytest.raises(AuthError, match="Unrecognized AUTH_ENABLED"):
+            get_auth_adapter()
+
+    def test_malformed_config_to_valid_provider_recovers(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "tru")
+        with pytest.raises(AuthError):
+            get_auth_adapter()
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        assert get_auth_adapter().name == "supabase"
+
+    def test_repeated_initialization_is_deterministic_and_cached(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import (
+            get_auth_adapter,
+            validate_auth_provider_configuration,
+        )
+
+        self._jwt_env(monkeypatch)
+        assert validate_auth_provider_configuration() == "jwt"
+        first = get_auth_adapter()
+        assert validate_auth_provider_configuration() == "jwt"
+        second = get_auth_adapter()
+        assert first is second  # unchanged config -> same bound instance
+
+    def test_stale_none_adapter_cannot_survive_authenticated_config(self, monkeypatch):
+        """Even without startup validation, a plain request-time resolution
+        after the config change must not return the stale 'none' adapter."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        assert get_auth_adapter().name == "none"
+        self._jwt_env(monkeypatch)
+        assert get_auth_adapter().name == "jwt"

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -35,6 +35,8 @@ Covers:
 """
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from mozaiksai.core.auth.adapters.base import (
@@ -2384,3 +2386,342 @@ class TestCacheTtlNormalization:
             assert config.discovery_cache_ttl_seconds == DEFAULT_DISCOVERY_CACHE_TTL_SECONDS
         finally:
             clear_auth_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# Complete constructor signature validation at registration
+#
+# A mode is accepted only when the runtime's exact invocation binds against the
+# complete signature. Recognizing a usable `settings` parameter (or **kwargs)
+# is necessary but never sufficient.
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorSignatureBinding:
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        saved = dict(reg._adapter_registry)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+        yield
+        reg._adapter_registry.clear()
+        reg._adapter_registry.update(saved)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+
+    def _adapter(self, init):
+        """Build an adapter class whose __init__ is the supplied function."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+
+        async def validate_token(self, token):
+            return UserClaims(user_id="u", provider="probe")
+
+        return type(
+            "_ProbeAdapter",
+            (BaseAuthAdapter,),
+            {
+                "name": "probe",
+                "__init__": init,
+                "validate_token": validate_token,
+                "is_enabled": lambda self: True,
+            },
+        )
+
+    def _register(self, adapter_class, **kwargs):
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        register_adapter("probe", adapter_class, config_identity="v1", **kwargs)
+
+    def _mode(self):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        return reg._adapter_registry["probe"].constructor_mode
+
+    # -- 1-5: MUST register -------------------------------------------------
+
+    def test_settings_only_accepted(self):
+        """def adapter(settings) — required settings, nothing else."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings):
+            BaseAuthAdapter.__init__(self, settings)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "settings_keyword"
+
+    def test_keyword_only_settings_accepted(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, *, settings):
+            BaseAuthAdapter.__init__(self, settings)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "settings_keyword"
+
+    def test_settings_plus_optional_arg_accepted(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings=None, optional=None):
+            BaseAuthAdapter.__init__(self, settings)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "settings_keyword"
+
+    def test_var_keyword_only_accepted(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, **kwargs):
+            BaseAuthAdapter.__init__(self, kwargs.get("settings"))
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "settings_keyword"
+
+    def test_no_arguments_accepted(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self):
+            BaseAuthAdapter.__init__(self)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "no_settings"
+
+    def test_all_optional_arguments_accepted_as_no_settings(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, url=None, secret=None):
+            BaseAuthAdapter.__init__(self)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "no_settings"
+
+    def test_var_positional_only_accepted_as_no_settings(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, *args):
+            BaseAuthAdapter.__init__(self)
+
+        self._register(self._adapter(__init__))
+        assert self._mode() == "no_settings"
+
+    # -- 6-10: MUST reject at registration ----------------------------------
+
+    def test_settings_plus_required_positional_rejected(self):
+        """def adapter(settings, required) — the exact Codex case."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings, required):
+            BaseAuthAdapter.__init__(self, settings)
+
+        with pytest.raises(AuthError, match="cannot construct it"):
+            self._register(self._adapter(__init__))
+
+    def test_settings_plus_required_keyword_only_rejected(self):
+        """def adapter(settings, *, required) — the exact Codex case."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings, *, required):
+            BaseAuthAdapter.__init__(self, settings)
+
+        with pytest.raises(AuthError, match="cannot construct it"):
+            self._register(self._adapter(__init__))
+
+    def test_required_positional_plus_var_keyword_rejected(self):
+        """def adapter(required, **kwargs) — the exact Codex case."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, required, **kwargs):
+            BaseAuthAdapter.__init__(self, kwargs.get("settings"))
+
+        with pytest.raises(AuthError, match="cannot construct it"):
+            self._register(self._adapter(__init__))
+
+    def test_multiple_required_unsupported_arguments_rejected(self):
+        """def adapter(settings, one, two) — the exact Codex case."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings, one, two):
+            BaseAuthAdapter.__init__(self, settings)
+
+        with pytest.raises(AuthError, match="cannot construct it"):
+            self._register(self._adapter(__init__))
+
+    def test_required_argument_without_settings_rejected(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, required):
+            BaseAuthAdapter.__init__(self)
+
+        with pytest.raises(AuthError, match="requires constructor argument"):
+            self._register(self._adapter(__init__))
+
+    def test_positional_only_settings_still_rejected(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings=None, /):
+            BaseAuthAdapter.__init__(self, settings)
+
+        with pytest.raises(AuthError, match="positional-only"):
+            self._register(self._adapter(__init__))
+
+    def test_uninspectable_without_declaration_still_rejected(self):
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        class _Uninspectable:
+            __init__ = print
+
+        with pytest.raises(AuthError, match="could not be inspected"):
+            register_adapter("probe", _Uninspectable, config_identity="v1")
+
+    # -- 12/13: explicit mode preserved, but verified when inspectable ------
+
+    def test_explicit_mode_preserved_for_uninspectable_settings_adapter(self):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        class _Uninspectable:
+            __init__ = print
+
+        register_adapter(
+            "probe", _Uninspectable, config_identity="v1", constructor_mode="settings_keyword"
+        )
+        assert reg._adapter_registry["probe"].constructor_mode == "settings_keyword"
+
+    def test_explicit_mode_preserved_for_uninspectable_no_settings_adapter(self):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        class _Uninspectable:
+            __init__ = print
+
+        register_adapter(
+            "probe", _Uninspectable, config_identity="v1", constructor_mode="no_settings"
+        )
+        assert reg._adapter_registry["probe"].constructor_mode == "no_settings"
+
+    def test_explicit_mode_cannot_lie_about_an_inspectable_signature(self):
+        """When inspection is available, verification beats trust."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, required):
+            BaseAuthAdapter.__init__(self)
+
+        adapter_class = self._adapter(__init__)
+        with pytest.raises(AuthError, match="cannot bind"):
+            self._register(adapter_class, constructor_mode="settings_keyword")
+        with pytest.raises(AuthError, match="cannot bind"):
+            self._register(adapter_class, constructor_mode="no_settings")
+
+    def test_explicit_no_settings_rejected_when_settings_is_required(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings):
+            BaseAuthAdapter.__init__(self, settings)
+
+        with pytest.raises(AuthError, match="cannot bind"):
+            self._register(self._adapter(__init__), constructor_mode="no_settings")
+
+    def test_explicit_settings_mode_accepted_when_signature_supports_it(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+
+        def __init__(self, settings=None):
+            BaseAuthAdapter.__init__(self, settings)
+
+        self._register(self._adapter(__init__), constructor_mode="settings_keyword")
+        assert self._mode() == "settings_keyword"
+
+    # -- 14/15: constructor body semantics unchanged ------------------------
+
+    @pytest.mark.parametrize("exc_type", [TypeError, ValueError])
+    def test_constructor_body_exception_invoked_exactly_once(self, monkeypatch, exc_type):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        attempts: list[object] = []
+
+        def __init__(self, settings=None):
+            BaseAuthAdapter.__init__(self, settings)
+            attempts.append(settings)
+            raise exc_type("defective body")
+
+        self._register(self._adapter(__init__))
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "probe")
+
+        with pytest.raises(AuthError, match="Failed to configure"):
+            get_auth_adapter()
+        assert len(attempts) == 1
+        assert attempts[0] is not None
+
+    # -- 16: built-ins still register and resolve ---------------------------
+
+    @pytest.mark.parametrize("provider", ["none", "jwt", "supabase", "keycloak"])
+    def test_builtin_providers_still_classify_and_bind(self, provider):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        reg._ensure_builtin_adapters()
+        registration = reg._adapter_registry[provider]
+        assert registration.constructor_mode == "settings_keyword"
+        signature = inspect.signature(registration.adapter_class)
+        ok, reason = reg._bind_invocation(signature, "settings_keyword")
+        assert ok, reason
+
+    def test_builtin_providers_still_resolve(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        for env, expected in (
+            ({"AUTH_ENABLED": "false", "ENV": "development"}, "none"),
+            (
+                {
+                    "AUTH_ENABLED": "true",
+                    "AUTH_PROVIDER": "jwt",
+                    "AUTH_JWKS_URL": "https://a.example.com/jwks.json",
+                    "AUTH_ISSUER": "https://a.example.com",
+                },
+                "jwt",
+            ),
+            ({"AUTH_ENABLED": "true", "SUPABASE_URL": "https://x.supabase.co"}, "supabase"),
+            (
+                {
+                    "AUTH_ENABLED": "true",
+                    "KEYCLOAK_URL": "https://kc.example.com",
+                    "KEYCLOAK_REALM": "r",
+                },
+                "keycloak",
+            ),
+        ):
+            _set_matrix_env(monkeypatch, env)
+            assert get_auth_adapter().name == expected
+
+    # -- binding helper is the single source of truth -----------------------
+
+    @pytest.mark.parametrize(
+        ("signature_text", "mode", "expected"),
+        [
+            ("(settings)", "settings_keyword", True),
+            ("(*, settings)", "settings_keyword", True),
+            ("(settings=None, optional=None)", "settings_keyword", True),
+            ("(**kwargs)", "settings_keyword", True),
+            ("(settings, required)", "settings_keyword", False),
+            ("(settings, *, required)", "settings_keyword", False),
+            ("(required, **kwargs)", "settings_keyword", False),
+            ("(settings, one, two)", "settings_keyword", False),
+            ("()", "no_settings", True),
+            ("(optional=None)", "no_settings", True),
+            ("(*args)", "no_settings", True),
+            ("(required)", "no_settings", False),
+            ("(settings)", "no_settings", False),
+        ],
+    )
+    def test_bind_invocation_truth_table(self, signature_text, mode, expected):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        namespace: dict = {}
+        exec(f"def _probe{signature_text}: pass", namespace)  # noqa: S102
+        signature = inspect.signature(namespace["_probe"])
+        ok, _ = reg._bind_invocation(signature, mode)
+        assert ok is expected

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -1421,13 +1421,13 @@ class TestCacheTtlValidation:
     def test_parse_helper_domain(self):
         from mozaiksai.core.auth.cache_ttl import CacheTtlConfigError, parse_cache_ttl_seconds
 
-        assert parse_cache_ttl_seconds("X", "60") == 60
-        assert parse_cache_ttl_seconds("X", "0") == 0
+        assert parse_cache_ttl_seconds("X", "60", default=1) == 60
+        assert parse_cache_ttl_seconds("X", "0", default=1) == 0
         assert parse_cache_ttl_seconds("X", None, default=42) == 42
         assert parse_cache_ttl_seconds("X", "  ", default=42) == 42
         for bad in ("abc", "-1", "1.5", "1e3"):
             with pytest.raises(CacheTtlConfigError):
-                parse_cache_ttl_seconds("X", bad)
+                parse_cache_ttl_seconds("X", bad, default=1)
 
 
 # ---------------------------------------------------------------------------
@@ -1483,12 +1483,12 @@ class TestConstructorContract:
         assert adapter.got_settings is not None
         assert "AUTH_PROVIDER" in adapter.got_settings
 
-    def test_legacy_adapter_without_settings_still_constructs(self, monkeypatch):
+    def test_adapter_without_settings_still_constructs(self, monkeypatch):
         from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
         from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
 
-        class _Legacy(BaseAuthAdapter):
-            name = "legacyadapter"
+        class _NoSettingsAdapter(BaseAuthAdapter):
+            name = "nosettingsadapter"
 
             def __init__(self):
                 super().__init__()
@@ -1500,8 +1500,8 @@ class TestConstructorContract:
             def is_enabled(self):
                 return True
 
-        register_adapter("legacyadapter", _Legacy, config_identity="v1")
-        self._select(monkeypatch, "legacyadapter")
+        register_adapter("nosettingsadapter", _NoSettingsAdapter, config_identity="v1")
+        self._select(monkeypatch, "nosettingsadapter")
         assert get_auth_adapter().constructed is True
 
     def test_constructor_body_typeerror_never_retries_without_settings(self, monkeypatch):
@@ -1561,11 +1561,12 @@ class TestConstructorContract:
             get_auth_adapter()
         assert len(attempts) == 1
 
-    def test_malformed_signature_adapter_fails_closed(self, monkeypatch):
-        """A constructor requiring an unknown argument cannot be built; it
-        fails rather than being retried in some other shape."""
+    def test_malformed_signature_adapter_rejected_at_registration(self):
+        """A constructor requiring an argument the runtime cannot supply is
+        rejected when it registers — the contract cannot be established, so it
+        is never classified as a zero-settings constructor."""
         from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
-        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+        from mozaiksai.core.auth.adapters.registry import register_adapter
 
         class _NeedsUnknownArg(BaseAuthAdapter):
             name = "needsunknownarg"
@@ -1580,10 +1581,8 @@ class TestConstructorContract:
             def is_enabled(self):
                 return True
 
-        register_adapter("needsunknownarg", _NeedsUnknownArg, config_identity="v1")
-        self._select(monkeypatch, "needsunknownarg")
-        with pytest.raises(AuthError, match="Failed to configure"):
-            get_auth_adapter()
+        with pytest.raises(AuthError, match="requires constructor argument"):
+            register_adapter("needsunknownarg", _NeedsUnknownArg, config_identity="v1")
 
     def test_kwargs_constructor_is_treated_as_settings_aware(self, monkeypatch):
         from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
@@ -1833,3 +1832,555 @@ class TestBuiltinSnapshotConsumption:
 
         monkeypatch.setenv("AUTH_ANON_USER_ID", "dev_bob")
         assert a._default_user_id == "dev_alice"
+
+
+# ---------------------------------------------------------------------------
+# D5-1: constructor compatibility must be POSITIVELY established
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorClassification:
+    """An adapter may be built without the snapshot only when inspection
+    proves it takes no settings argument at all. "Could not
+    inspect" and "no settings keyword" are never evidence of that."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        saved = dict(reg._adapter_registry)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+        yield
+        reg._adapter_registry.clear()
+        reg._adapter_registry.update(saved)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+
+    def _select(self, monkeypatch, provider: str) -> None:
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", provider)
+
+    def _claims(self):
+        from mozaiksai.core.auth.adapters.base import UserClaims
+
+        return UserClaims(user_id="u", provider="probe")
+
+    # -- 1/2/3: settings positively supplied --------------------------------
+
+    def test_positional_or_keyword_settings_receives_snapshot(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _Adapter(BaseAuthAdapter):
+            name = "poskw"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                self.got = settings
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("poskw", _Adapter, config_identity="v1")
+        self._select(monkeypatch, "poskw")
+        assert get_auth_adapter().got is not None
+
+    def test_keyword_only_settings_receives_snapshot(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _Adapter(BaseAuthAdapter):
+            name = "kwonly"
+
+            def __init__(self, *, settings=None):
+                super().__init__(settings)
+                self.got = settings
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("kwonly", _Adapter, config_identity="v1")
+        self._select(monkeypatch, "kwonly")
+        assert get_auth_adapter().got is not None
+
+    def test_var_keyword_adapter_receives_snapshot(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _Adapter(BaseAuthAdapter):
+            name = "varkw"
+
+            def __init__(self, **kwargs):
+                super().__init__(kwargs.get("settings"))
+                self.got = kwargs.get("settings")
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("varkw", _Adapter, config_identity="v1")
+        self._select(monkeypatch, "varkw")
+        assert get_auth_adapter().got is not None
+
+    # -- 4: real zero-argument constructor ---------------------------
+
+    def test_true_zero_argument_constructor_allowed(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _NoSettings(BaseAuthAdapter):
+            name = "truenosettings"
+
+            def __init__(self):
+                super().__init__()
+                self.constructed = True
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("truenosettings", _NoSettings, config_identity="v1")
+        assert reg._adapter_registry["truenosettings"].constructor_mode == "no_settings"
+        self._select(monkeypatch, "truenosettings")
+        assert get_auth_adapter().constructed is True
+
+    def test_optional_non_settings_args_are_no_settings(self):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        outer = self
+
+        class _OptionalArgs(BaseAuthAdapter):
+            name = "optargs"
+
+            def __init__(self, url=None, secret=None):
+                super().__init__()
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        register_adapter("optargs", _OptionalArgs, config_identity="v1")
+        assert reg._adapter_registry["optargs"].constructor_mode == "no_settings"
+
+    # -- 5: positional-only settings ----------------------------------------
+
+    def test_positional_only_settings_is_explicitly_rejected(self):
+        """Positional-only configuration is not part of the plugin contract, so
+        it is rejected rather than silently discarded as zero-argument."""
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        outer = self
+
+        class _PosOnly(BaseAuthAdapter):
+            name = "posonly"
+
+            def __init__(self, settings=None, /):
+                super().__init__(settings)
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        with pytest.raises(AuthError, match="positional-only"):
+            register_adapter("posonly", _PosOnly, config_identity="v1")
+
+    # -- 6: uninspectable constructor ---------------------------------------
+
+    def test_uninspectable_constructor_rejected_without_declaration(self):
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        class _Uninspectable:
+            __init__ = print  # builtin: signature() cannot be established
+
+        with pytest.raises(AuthError, match="could not be inspected"):
+            register_adapter("uninspectable", _Uninspectable, config_identity="v1")
+
+    def test_uninspectable_constructor_accepted_with_explicit_mode(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        constructed: list[dict] = []
+
+        class _Meta(type):
+            def __call__(cls, *args, **kwargs):  # defeats signature inspection
+                constructed.append(kwargs)
+                return super().__call__()
+
+        class _Exotic(metaclass=_Meta):
+            name = "exotic"
+
+            def __init__(self):
+                self._settings = None
+
+            async def validate_token(self, token):
+                from mozaiksai.core.auth.adapters.base import UserClaims
+
+                return UserClaims(user_id="u", provider=self.name)
+
+            def is_enabled(self):
+                return True
+
+        try:
+            reg._classify_constructor(_Exotic, declared_mode=None)
+            inspectable = True
+        except AuthError:
+            inspectable = False
+
+        register_adapter(
+            "exotic", _Exotic, config_identity="v1", constructor_mode="no_settings"
+        )
+        assert reg._adapter_registry["exotic"].constructor_mode == "no_settings"
+        self._select(monkeypatch, "exotic")
+        adapter = get_auth_adapter()
+        assert adapter.name == "exotic"
+        # Whether or not this particular metaclass defeats inspection, the
+        # explicit declaration is what decided the contract.
+        assert inspectable in (True, False)
+
+    def test_unknown_declared_mode_rejected(self):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import register_adapter
+
+        outer = self
+
+        class _Adapter(BaseAuthAdapter):
+            name = "badmode"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        with pytest.raises(AuthError, match="Unknown constructor_mode"):
+            register_adapter("badmode", _Adapter, constructor_mode="whatever")  # type: ignore[arg-type]
+
+    # -- 10: built-ins classify correctly -----------------------------------
+
+    @pytest.mark.parametrize("provider", ["none", "jwt", "supabase", "keycloak"])
+    def test_builtin_adapters_classify_as_settings_keyword(self, provider):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        reg._ensure_builtin_adapters()
+        assert reg._adapter_registry[provider].constructor_mode == "settings_keyword"
+
+    def test_custom_registration_does_not_suppress_builtins(self, monkeypatch):
+        """Registering a custom adapter into an empty registry must not stop
+        the built-in providers from being registered on first resolution."""
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _Custom(BaseAuthAdapter):
+            name = "earlycustom"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        reg._adapter_registry.clear()  # simulate a fresh process
+        register_adapter("earlycustom", _Custom, config_identity="v1")
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+        assert get_auth_adapter().name == "jwt"
+        assert reg.BUILTIN_PROVIDERS.issubset(reg._adapter_registry.keys())
+
+    def test_builtin_override_is_preserved(self, monkeypatch):
+        """An intentional override of a built-in name is not clobbered."""
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        outer = self
+
+        class _MyJwt(BaseAuthAdapter):
+            name = "jwt"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                self.mine = True
+
+            async def validate_token(self, token):
+                return outer._claims()
+
+            def is_enabled(self):
+                return True
+
+        reg._adapter_registry.clear()
+        register_adapter("jwt", _MyJwt, config_identity="v1")
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        adapter = get_auth_adapter()
+        assert getattr(adapter, "mine", False) is True
+
+
+# ---------------------------------------------------------------------------
+# D5-2: every accepted TTL stays valid during real cache use
+# ---------------------------------------------------------------------------
+
+_EXTREME_TTLS = [0, 1, 31, 3600, 86400, 2**63, 10**30, 10**400]
+
+
+class TestCacheTtlArithmetic:
+    @pytest.mark.parametrize("ttl", _EXTREME_TTLS)
+    def test_discovery_cache_expiry_never_overflows(self, ttl):
+        import time
+
+        from mozaiksai.core.auth.discovery import CachedDiscovery
+
+        entry = CachedDiscovery(document={"issuer": "x"}, fetched_at=time.time(), ttl_seconds=ttl)
+        assert entry.is_expired() is (ttl == 0)
+
+    @pytest.mark.parametrize("ttl", _EXTREME_TTLS)
+    def test_jwks_cache_expiry_never_overflows(self, ttl):
+        import time
+
+        from mozaiksai.core.auth.jwks import CachedJWKS
+
+        entry = CachedJWKS(keys={}, fetched_at=time.time(), ttl_seconds=ttl, source_url="u")
+        assert entry.is_expired() is (ttl == 0)
+
+    @pytest.mark.parametrize("ttl", [0, 1, 31, 3600, 86400])
+    def test_helper_matches_original_boundary_semantics(self, ttl):
+        """For representable TTLs, reproduce `now > fetched_at + ttl` exactly."""
+        from mozaiksai.core.auth.cache_ttl import cache_entry_is_expired
+
+        assert cache_entry_is_expired(1000.0, ttl, now=1000.0 + ttl) is False
+        assert cache_entry_is_expired(1000.0, ttl, now=1000.0 + ttl + 1) is True
+
+    @pytest.mark.parametrize("ttl", [2**63, 10**30, 10**400])
+    def test_helper_handles_very_large_ttls(self, ttl):
+        """Very large TTLs must not raise and are never expired at any
+        realistic clock value."""
+        from mozaiksai.core.auth.cache_ttl import cache_entry_is_expired
+
+        assert cache_entry_is_expired(1000.0, ttl, now=1000.0) is False
+        assert cache_entry_is_expired(1000.0, ttl, now=1e18) is False
+
+    def test_regression_witness_old_formulation_overflowed(self):
+        """The exact D5-2 defect: the previous `fetched_at + ttl` formulation
+        raises OverflowError for a TTL the parser accepts, while the elapsed
+        comparison used now does not."""
+        from mozaiksai.core.auth.cache_ttl import cache_entry_is_expired, resolve_cache_ttl_setting
+
+        huge = resolve_cache_ttl_setting("AUTH_JWKS_CACHE_TTL", str(10**400))
+        with pytest.raises(OverflowError):
+            float(huge)  # the old formulation converted the TTL through float
+        assert cache_entry_is_expired(1000.0, huge, now=1000.0) is False
+
+    @pytest.mark.parametrize("raw", ["0", "1", "31", "3600", "86400", str(2**63), str(10**400)])
+    def test_accepted_values_survive_real_cache_use(self, monkeypatch, raw):
+        """Anything configuration resolution accepts must work in the cache."""
+        import time
+
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+        from mozaiksai.core.auth.discovery import CachedDiscovery
+
+        _set_matrix_env(
+            monkeypatch,
+            {
+                "AUTH_ENABLED": "true",
+                "AUTH_PROVIDER": "jwt",
+                "AUTH_JWKS_URL": "https://a.example.com/jwks.json",
+                "AUTH_ISSUER": "https://a.example.com",
+            },
+        )
+        monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", raw)
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", raw)
+        resolve_auth_config()  # accepted at startup
+        entry = CachedDiscovery(document={}, fetched_at=time.time(), ttl_seconds=int(raw))
+        entry.is_expired()  # must not raise
+
+    def test_zero_ttl_stays_zero_not_default(self, monkeypatch):
+        """0 means always refetch and must never be truthiness-coerced away."""
+        from mozaiksai.core.auth.adapters.jwt_adapter import JWTAdapterConfig
+        from mozaiksai.core.auth.cache_ttl import resolve_cache_ttl_setting
+        from mozaiksai.core.auth.config import clear_auth_config_cache, get_auth_config
+        from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
+        from mozaiksai.core.auth.jwks import JWKSClient
+
+        assert resolve_cache_ttl_setting("AUTH_JWKS_CACHE_TTL", "0") == 0
+        assert resolve_cache_ttl_setting("AUTH_DISCOVERY_CACHE_TTL", "0") == 0
+
+        config = JWTAdapterConfig.from_env(
+            {"AUTH_JWKS_CACHE_TTL": "0", "AUTH_DISCOVERY_CACHE_TTL": "0"}
+        )
+        assert config.jwks_cache_ttl_seconds == 0
+        assert config.discovery_cache_ttl_seconds == 0
+
+        assert OIDCDiscoveryClient(cache_ttl=0, consult_environment=False).cache_ttl_seconds == 0
+        assert JWKSClient(jwks_url="https://x/j", cache_ttl=0, consult_environment=False).cache_ttl_seconds == 0
+
+        monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", "0")
+        monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", "0")
+        clear_auth_config_cache()
+        try:
+            assert get_auth_config().jwks_cache_ttl_seconds == 0
+            assert get_auth_config().discovery_cache_ttl_seconds == 0
+        finally:
+            clear_auth_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# D5-3: absent / empty / whitespace normalize identically, in every layer
+# ---------------------------------------------------------------------------
+
+_BLANK_FORMS = [None, "", " ", "   ", "\t", "\n", " \t\n "]
+_TTL_ENV_NAMES = ["AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL"]
+
+
+class TestCacheTtlNormalization:
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in (*_AUTH_MATRIX_VARS, *_TTL_ENV_NAMES):
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def _expected_default(self, name: str) -> int:
+        from mozaiksai.core.auth.cache_ttl import CACHE_TTL_DEFAULTS
+
+        return CACHE_TTL_DEFAULTS[name]
+
+    @pytest.mark.parametrize("name", _TTL_ENV_NAMES)
+    @pytest.mark.parametrize("blank", _BLANK_FORMS)
+    def test_blank_forms_all_yield_the_canonical_default(self, name, blank):
+        from mozaiksai.core.auth.cache_ttl import resolve_cache_ttl_setting
+
+        assert resolve_cache_ttl_setting(name, blank) == self._expected_default(name)
+
+    @pytest.mark.parametrize("blank", _BLANK_FORMS)
+    def test_resolution_and_adapter_construction_agree_on_blanks(self, monkeypatch, blank):
+        """The exact D5-3 defect: canonical resolution and JWTAdapterConfig must
+        not disagree about whitespace."""
+        from mozaiksai.core.auth.adapters.jwt_adapter import JWTAdapterConfig
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, resolve_auth_config
+
+        env = {
+            "AUTH_ENABLED": "true",
+            "AUTH_PROVIDER": "jwt",
+            "AUTH_JWKS_URL": "https://a.example.com/jwks.json",
+            "AUTH_ISSUER": "https://a.example.com",
+        }
+        _set_matrix_env(monkeypatch, env)
+        if blank is not None:
+            monkeypatch.setenv("AUTH_JWKS_CACHE_TTL", blank)
+            monkeypatch.setenv("AUTH_DISCOVERY_CACHE_TTL", blank)
+
+        config = resolve_auth_config()  # must not raise
+        adapter = get_auth_adapter()  # must not raise
+        direct = JWTAdapterConfig.from_env(config.settings)
+
+        assert adapter._config.jwks_cache_ttl_seconds == self._expected_default(
+            "AUTH_JWKS_CACHE_TTL"
+        )
+        assert adapter._config.discovery_cache_ttl_seconds == self._expected_default(
+            "AUTH_DISCOVERY_CACHE_TTL"
+        )
+        assert direct.jwks_cache_ttl_seconds == adapter._config.jwks_cache_ttl_seconds
+        assert direct.discovery_cache_ttl_seconds == adapter._config.discovery_cache_ttl_seconds
+
+    @pytest.mark.parametrize("name", _TTL_ENV_NAMES)
+    @pytest.mark.parametrize("bad", ["-1", "1.5", "abc", "1e3", "0x10", "3,600", " -5 "])
+    def test_invalid_values_rejected_by_every_layer(self, monkeypatch, name, bad):
+        from mozaiksai.core.auth.adapters.jwt_adapter import JWTAdapterConfig
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+        from mozaiksai.core.auth.cache_ttl import CacheTtlConfigError
+
+        _set_matrix_env(
+            monkeypatch,
+            {
+                "AUTH_ENABLED": "true",
+                "AUTH_PROVIDER": "jwt",
+                "AUTH_JWKS_URL": "https://a.example.com/jwks.json",
+                "AUTH_ISSUER": "https://a.example.com",
+            },
+        )
+        monkeypatch.setenv(name, bad)
+        with pytest.raises(AuthError, match=name):
+            resolve_auth_config()
+        with pytest.raises(CacheTtlConfigError):
+            JWTAdapterConfig.from_env({name: bad})
+
+    @pytest.mark.parametrize("name", _TTL_ENV_NAMES)
+    @pytest.mark.parametrize("good", ["0", "1", "31", "3600", "86400", " 42 "])
+    def test_valid_values_agree_across_layers(self, monkeypatch, name, good):
+        from mozaiksai.core.auth.adapters.jwt_adapter import JWTAdapterConfig
+        from mozaiksai.core.auth.cache_ttl import resolve_cache_ttl_setting
+
+        expected = int(good.strip())
+        assert resolve_cache_ttl_setting(name, good) == expected
+        config = JWTAdapterConfig.from_env({name: good})
+        attribute = (
+            "jwks_cache_ttl_seconds"
+            if name == "AUTH_JWKS_CACHE_TTL"
+            else "discovery_cache_ttl_seconds"
+        )
+        assert getattr(config, attribute) == expected
+
+    def test_canonical_defaults_match_documented_cache_semantics(self):
+        """Defaults are declared once; discovery is long-lived, keys rotate."""
+        from mozaiksai.core.auth.cache_ttl import (
+            DEFAULT_DISCOVERY_CACHE_TTL_SECONDS,
+            DEFAULT_JWKS_CACHE_TTL_SECONDS,
+        )
+        from mozaiksai.core.auth.config import clear_auth_config_cache, get_auth_config
+
+        assert DEFAULT_JWKS_CACHE_TTL_SECONDS == 3600
+        assert DEFAULT_DISCOVERY_CACHE_TTL_SECONDS == 86400
+        clear_auth_config_cache()
+        try:
+            config = get_auth_config()
+            assert config.jwks_cache_ttl_seconds == DEFAULT_JWKS_CACHE_TTL_SECONDS
+            assert config.discovery_cache_ttl_seconds == DEFAULT_DISCOVERY_CACHE_TTL_SECONDS
+        finally:
+            clear_auth_config_cache()

--- a/tests/test_auth_adapters.py
+++ b/tests/test_auth_adapters.py
@@ -547,8 +547,9 @@ class TestResolvedAuthStateMatrix:
         assert config.provider == "supabase"
         assert config.enabled is True
 
-    @pytest.mark.parametrize("environment", ["", "development", "dev", "test", "local", "qa-lab"])
-    def test_unprotected_environments_follow_dev_contract(self, monkeypatch, environment):
+    @pytest.mark.parametrize("environment", ["", "development", "dev", "test", "local"])
+    def test_recognized_local_environments_follow_dev_contract(self, monkeypatch, environment):
+        """Only the finite recognized local/dev/test allowlist (plus absent)."""
         from mozaiksai.core.auth.adapters.registry import resolve_auth_config
 
         env = {"AUTH_ENABLED": "false"}
@@ -558,6 +559,63 @@ class TestResolvedAuthStateMatrix:
         config = resolve_auth_config()
         assert config.provider == "none"
         assert config.explicitly_disabled is True
+
+    @pytest.mark.parametrize(
+        "environment",
+        [
+            "staging-us",
+            "prod-us",
+            "production-east",
+            "preview",
+            "qa",
+            "qa-lab",
+            "customer-prod",
+            "sandbox",
+            "uat",
+            "integration",
+            "dev-cluster",
+            "testing",
+            "локальный",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"AUTH_ENABLED": "false"},
+            {"AUTH_PROVIDER": "none"},
+            {},
+        ],
+    )
+    def test_unknown_environments_never_inherit_no_auth(self, monkeypatch, environment, env):
+        """An unknown explicit environment must NOT silently become development.
+
+        Regional/custom production-looking names and arbitrary values alike are
+        denied no-auth privilege — the allowlist is finite and fail-closed.
+        """
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, {**env, "ENV": environment})
+        with pytest.raises(AuthError, match="not permitted"):
+            resolve_auth_config()
+
+    @pytest.mark.parametrize(
+        "environment", ["staging-us", "prod-us", "preview", "qa", "customer-prod"]
+    )
+    def test_unknown_environments_boot_with_configured_auth(self, monkeypatch, environment):
+        """Unknown environments may still boot — they just cannot run no-auth."""
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(
+            monkeypatch,
+            {
+                "AUTH_ENABLED": "true",
+                "SUPABASE_URL": "https://x.supabase.co",
+                "ENV": environment,
+            },
+        )
+        config = resolve_auth_config()
+        assert config.provider == "supabase"
+        assert config.enabled is True
 
     def test_environment_var_fallback_also_protected(self, monkeypatch):
         """ENVIRONMENT (without ENV) is the same canonical vocabulary."""
@@ -675,3 +733,495 @@ class TestAdapterCacheCoherence:
         assert get_auth_adapter().name == "none"
         self._jwt_env(monkeypatch)
         assert get_auth_adapter().name == "jwt"
+
+
+# ---------------------------------------------------------------------------
+# ENV / ENVIRONMENT canonical resolution (D2)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentResolution:
+    """Both inputs resolve canonically: trimmed, alias-normalized, blank means
+    absent, a blank primary never masks a non-blank fallback, and genuine
+    conflicts fail configuration instead of silently picking one."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, monkeypatch):
+        monkeypatch.delenv("ENV", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        yield
+
+    def _resolve(self, monkeypatch, env=None, environment=None):
+        from mozaiksai.core.environment import resolve_environment
+
+        monkeypatch.delenv("ENV", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        if env is not None:
+            monkeypatch.setenv("ENV", env)
+        if environment is not None:
+            monkeypatch.setenv("ENVIRONMENT", environment)
+        return resolve_environment()
+
+    # -- blank primary must not mask the fallback ---------------------------
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    @pytest.mark.parametrize("deployed", ["production", "staging"])
+    def test_blank_env_does_not_mask_deployed_environment(self, monkeypatch, blank, deployed):
+        resolved = self._resolve(monkeypatch, env=blank, environment=deployed)
+        assert resolved.name == deployed
+        assert resolved.permits_no_auth is False
+
+    def test_blank_env_does_not_mask_unknown_environment(self, monkeypatch):
+        resolved = self._resolve(monkeypatch, env="  ", environment="prod-us")
+        assert resolved.name == "prod-us"
+        assert resolved.classification == "unknown_deployment"
+        assert resolved.permits_no_auth is False
+
+    # -- conflicts ----------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("env", "environment"),
+        [
+            ("development", "production"),
+            ("development", "staging"),
+            ("local", "production"),
+            ("test", "prod"),
+            ("production", "development"),
+            ("staging", "test"),
+            ("prod-us", "production"),
+            ("foo", "bar"),
+        ],
+    )
+    def test_conflicting_declarations_fail(self, monkeypatch, env, environment):
+        from mozaiksai.core.environment import EnvironmentConfigError
+
+        with pytest.raises(EnvironmentConfigError, match="Conflicting"):
+            self._resolve(monkeypatch, env=env, environment=environment)
+
+    @pytest.mark.parametrize(
+        ("env", "environment"),
+        [
+            ("test", "development"),
+            ("development", "test"),
+            ("local", "development"),
+            ("test", "local"),
+            ("dev", "test"),
+        ],
+    )
+    def test_same_class_local_declarations_are_accepted(self, monkeypatch, env, environment):
+        """CI (ENV=test) beside a developer .env (ENVIRONMENT=development) is
+        not a conflict: both are recognized local environments, so they agree
+        on the only security-relevant question."""
+        resolved = self._resolve(monkeypatch, env=env, environment=environment)
+        assert resolved.permits_no_auth is True
+        assert resolved.classification == "local_development"
+        # ENV keeps precedence for the resolved name.
+        assert resolved.name == env.replace("dev", "development") if env == "dev" else True
+
+    @pytest.mark.parametrize(
+        ("env", "environment"),
+        [
+            ("production", "staging"),
+            ("staging", "production"),
+            ("prod-us", "staging-eu"),
+        ],
+    )
+    def test_different_deployed_environments_still_conflict(self, monkeypatch, env, environment):
+        """Two distinct deployments are never silently resolved to one."""
+        from mozaiksai.core.environment import EnvironmentConfigError
+
+        with pytest.raises(EnvironmentConfigError, match="Conflicting"):
+            self._resolve(monkeypatch, env=env, environment=environment)
+
+    @pytest.mark.parametrize(
+        ("env", "environment", "expected"),
+        [
+            ("prod", "production", "production"),
+            ("stage", "staging", "staging"),
+            ("dev", "development", "development"),
+            ("production", "production", "production"),
+            ("PRODUCTION", " production ", "production"),
+            ("test", "test", "test"),
+            ("prod-us", "prod-us", "prod-us"),
+        ],
+    )
+    def test_agreeing_declarations_accepted(self, monkeypatch, env, environment, expected):
+        resolved = self._resolve(monkeypatch, env=env, environment=environment)
+        assert resolved.name == expected
+
+    # -- classification -----------------------------------------------------
+
+    @pytest.mark.parametrize("value", ["development", "dev", "local", "test", "  TEST  "])
+    def test_recognized_local_values_permit_no_auth(self, monkeypatch, value):
+        resolved = self._resolve(monkeypatch, env=value)
+        assert resolved.permits_no_auth is True
+        assert resolved.classification == "local_development"
+
+    @pytest.mark.parametrize("value", ["production", "prod", "staging", "stage"])
+    def test_known_deployed_values_reject_no_auth(self, monkeypatch, value):
+        resolved = self._resolve(monkeypatch, env=value)
+        assert resolved.permits_no_auth is False
+        assert resolved.classification == "protected_deployment"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["staging-us", "prod-us", "production-east", "preview", "qa", "customer-prod", "xyzzy"],
+    )
+    def test_unknown_values_reject_no_auth(self, monkeypatch, value):
+        resolved = self._resolve(monkeypatch, env=value)
+        assert resolved.permits_no_auth is False
+        assert resolved.classification == "unknown_deployment"
+
+    def test_both_absent_keeps_documented_local_default(self, monkeypatch):
+        resolved = self._resolve(monkeypatch)
+        assert resolved.classification == "absent"
+        assert resolved.permits_no_auth is True
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_whitespace_only_both_is_absence(self, monkeypatch, blank):
+        resolved = self._resolve(monkeypatch, env=blank, environment=blank)
+        assert resolved.classification == "absent"
+        assert resolved.permits_no_auth is True
+
+    def test_unknown_env_with_absent_fallback_rejects_no_auth(self, monkeypatch):
+        resolved = self._resolve(monkeypatch, env="preview")
+        assert resolved.permits_no_auth is False
+
+    def test_environment_conflict_surfaces_as_auth_error(self, monkeypatch):
+        """resolve_auth_config translates the environment conflict into the
+        canonical auth failure so every auth surface fails closed uniformly."""
+        from mozaiksai.core.auth.adapters.registry import resolve_auth_config
+
+        _set_matrix_env(monkeypatch, {"ENV": "development", "ENVIRONMENT": "production"})
+        with pytest.raises(AuthError, match="Conflicting"):
+            resolve_auth_config()
+
+
+# ---------------------------------------------------------------------------
+# Provider-complete adapter configuration identity (D5)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfigIdentity:
+    """Changing ANY meaning-bearing construction input for the resolved
+    provider must change adapter identity and rebuild the adapter."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        for var in (
+            "AUTH_NAME_CLAIM", "AUTH_SCOPES_CLAIM", "AUTH_SCOPES_FORMAT", "AUTH_APP_ID_CLAIM",
+            "AUTH_CHAT_ID_CLAIM", "AUTH_TENANT_ID_CLAIM", "AUTH_WORKSPACE_ID_CLAIM",
+            "AUTH_CLOCK_SKEW", "AUTH_ALGORITHMS", "AUTH_AUDIENCE", "AUTH_REQUIRED_SCOPE",
+            "AUTH_USER_ID_CLAIM", "AUTH_EMAIL_CLAIM", "AUTH_ROLES_CLAIM",
+            "AUTH_JWKS_CACHE_TTL", "AUTH_DISCOVERY_CACHE_TTL", "MOZAIKS_OIDC_TENANT_ID",
+            "KEYCLOAK_CLIENT_ID", "KEYCLOAK_APP_ID_CLAIM", "KEYCLOAK_TENANT_ID_CLAIM",
+            "KEYCLOAK_WORKSPACE_ID_CLAIM", "SUPABASE_JWT_SECRET",
+            "AUTH_ANON_USER_ID", "AUTH_ANON_EMAIL", "AUTH_ANON_ROLES", "AUTH_ANON_SCOPES",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def _jwt_base(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/.well-known/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [
+            ("AUTH_ISSUER", "https://b.example.com"),
+            ("AUTH_JWKS_URL", "https://b.example.com/.well-known/jwks.json"),
+            ("AUTH_AUDIENCE", "other-api"),
+            ("AUTH_CLOCK_SKEW", "300"),
+            ("AUTH_SCOPES_FORMAT", "array"),
+            ("AUTH_SCOPES_CLAIM", "scope"),
+            ("AUTH_NAME_CLAIM", "display_name"),
+            ("AUTH_USER_ID_CLAIM", "oid"),
+            ("AUTH_EMAIL_CLAIM", "upn"),
+            ("AUTH_ROLES_CLAIM", "realm_access"),
+            ("AUTH_APP_ID_CLAIM", "appid"),
+            ("AUTH_CHAT_ID_CLAIM", "cid"),
+            ("AUTH_TENANT_ID_CLAIM", "tenant"),
+            ("AUTH_WORKSPACE_ID_CLAIM", "ws"),
+            ("AUTH_ALGORITHMS", "RS256,ES256"),
+            ("AUTH_REQUIRED_SCOPE", "access_as_user"),
+            ("AUTH_JWKS_CACHE_TTL", "60"),
+            ("AUTH_DISCOVERY_CACHE_TTL", "60"),
+            ("MOZAIKS_OIDC_TENANT_ID", "tenant-b"),
+        ],
+    )
+    def test_jwt_input_change_rebuilds_adapter(self, monkeypatch, var, value):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._jwt_base(monkeypatch)
+        first = get_auth_adapter()
+        monkeypatch.setenv(var, value)
+        second = get_auth_adapter()
+        assert second is not first, f"{var} change must rebuild the adapter"
+
+    def test_jwt_rebuilt_adapter_reflects_new_config(self, monkeypatch):
+        """The rebuilt adapter carries the NEW values, not the stale ones."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._jwt_base(monkeypatch)
+        first = get_auth_adapter()
+        assert first._config.issuer == "https://a.example.com"
+        assert first._config.clock_skew_seconds == 120
+
+        monkeypatch.setenv("AUTH_ISSUER", "https://b.example.com")
+        monkeypatch.setenv("AUTH_CLOCK_SKEW", "300")
+        monkeypatch.setenv("AUTH_WORKSPACE_ID_CLAIM", "ws_b")
+        second = get_auth_adapter()
+        assert second._config.issuer == "https://b.example.com"
+        assert second._config.clock_skew_seconds == 300
+        assert second._config.workspace_id_claim == "ws_b"
+
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [
+            ("KEYCLOAK_CLIENT_ID", "other-client"),
+            ("KEYCLOAK_APP_ID_CLAIM", "app"),
+            ("KEYCLOAK_TENANT_ID_CLAIM", "tenant"),
+            ("KEYCLOAK_WORKSPACE_ID_CLAIM", "ws_b"),
+            ("KEYCLOAK_REALM", "realm-b"),
+            ("KEYCLOAK_URL", "https://kc-b.example.com"),
+        ],
+    )
+    def test_keycloak_input_change_rebuilds_adapter(self, monkeypatch, var, value):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("KEYCLOAK_URL", "https://kc-a.example.com")
+        monkeypatch.setenv("KEYCLOAK_REALM", "realm-a")
+        first = get_auth_adapter()
+        monkeypatch.setenv(var, value)
+        second = get_auth_adapter()
+        assert second is not first, f"{var} change must rebuild the adapter"
+
+    def test_keycloak_rebuilt_adapter_reflects_new_claim_mapping(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("KEYCLOAK_URL", "https://kc-a.example.com")
+        monkeypatch.setenv("KEYCLOAK_REALM", "realm-a")
+        first = get_auth_adapter()
+        assert first._workspace_id_claim == "workspace_id"
+
+        monkeypatch.setenv("KEYCLOAK_WORKSPACE_ID_CLAIM", "ws_b")
+        second = get_auth_adapter()
+        assert second._workspace_id_claim == "ws_b"
+
+    def test_supabase_secret_change_rebuilds_adapter(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        first = get_auth_adapter()
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "s3cret")
+        second = get_auth_adapter()
+        assert second is not first
+        assert second._jwt_secret == "s3cret"
+
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [
+            ("AUTH_ANON_USER_ID", "dev_bob"),
+            ("AUTH_ANON_EMAIL", "bob@example.com"),
+            ("AUTH_ANON_ROLES", "admin,user"),
+            ("AUTH_ANON_SCOPES", "access_as_user,billing.admin"),
+        ],
+    )
+    def test_no_auth_input_change_rebuilds_adapter(self, monkeypatch, var, value):
+        """Permitted local dev: changing the anonymous persona rebuilds."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        monkeypatch.setenv("ENV", "development")
+        first = get_auth_adapter()
+        monkeypatch.setenv(var, value)
+        second = get_auth_adapter()
+        assert second is not first, f"{var} change must rebuild the adapter"
+
+    def test_no_auth_rebuilt_adapter_reflects_new_roles(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        monkeypatch.setenv("ENV", "development")
+        first = get_auth_adapter()
+        assert first._default_roles == []
+
+        monkeypatch.setenv("AUTH_ANON_ROLES", "admin,user")
+        second = get_auth_adapter()
+        assert second._default_roles == ["admin", "user"]
+
+    def test_environment_change_local_to_protected_fails_closed(self, monkeypatch):
+        """local → protected must not keep serving the cached no-auth adapter."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+        monkeypatch.setenv("ENV", "development")
+        assert get_auth_adapter().name == "none"
+
+        monkeypatch.setenv("ENV", "production")
+        with pytest.raises(AuthError, match="not permitted"):
+            get_auth_adapter()
+
+    def test_unchanged_config_returns_same_instance(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter
+
+        self._jwt_base(monkeypatch)
+        assert get_auth_adapter() is get_auth_adapter()
+
+
+# ---------------------------------------------------------------------------
+# Custom-provider cache invalidation contract (D5)
+# ---------------------------------------------------------------------------
+
+
+class TestCustomProviderCacheContract:
+    """A custom provider's changed configuration may never silently reuse an
+    adapter validated under an older configuration."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        saved = dict(reg._adapter_registry)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+        yield
+        reg._adapter_registry.clear()
+        reg._adapter_registry.update(saved)
+        clear_auth_config_cache()
+        reg.reset_auth_adapter()
+
+    def _custom_adapter_class(self, revision_box):
+        from mozaiksai.core.auth.adapters.base import BaseAuthAdapter, UserClaims
+
+        class _CustomAdapter(BaseAuthAdapter):
+            name = "custom"
+
+            def __init__(self, settings=None):
+                super().__init__(settings)
+                self.revision = revision_box["value"]
+
+            async def validate_token(self, token: str) -> UserClaims:
+                return UserClaims(user_id="custom-user", provider=self.name)
+
+            def is_enabled(self) -> bool:
+                return True
+
+        return _CustomAdapter
+
+    def test_declared_config_identity_invalidates_on_revision_change(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        box = {"value": "rev-a"}
+        register_adapter(
+            "custom",
+            self._custom_adapter_class(box),
+            config_identity=lambda: box["value"],
+        )
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "custom")
+
+        first = get_auth_adapter()
+        assert first.revision == "rev-a"
+        assert get_auth_adapter() is first  # cached while identity is unchanged
+
+        box["value"] = "rev-b"
+        second = get_auth_adapter()
+        assert second is not first
+        assert second.revision == "rev-b"
+
+    def test_adapter_without_config_identity_is_never_cached(self, monkeypatch):
+        """Truthful bounded contract: no declared identity → no caching, so a
+        changed configuration can never reuse a stale adapter."""
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        box = {"value": "rev-a"}
+        register_adapter("custom", self._custom_adapter_class(box))
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "custom")
+
+        first = get_auth_adapter()
+        second = get_auth_adapter()
+        assert second is not first  # rebuilt every resolution
+
+        box["value"] = "rev-b"
+        assert get_auth_adapter().revision == "rev-b"
+
+    def test_reregistration_invalidates_cached_adapter(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import get_auth_adapter, register_adapter
+
+        box = {"value": "rev-a"}
+        register_adapter("custom", self._custom_adapter_class(box), config_identity="static")
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "custom")
+        first = get_auth_adapter()
+
+        box["value"] = "rev-b"
+        register_adapter("custom", self._custom_adapter_class(box), config_identity="static")
+        second = get_auth_adapter()
+        assert second is not first
+        assert second.revision == "rev-b"
+
+
+# ---------------------------------------------------------------------------
+# Cache record coherence (D5)
+# ---------------------------------------------------------------------------
+
+
+class TestCachePublicationCoherence:
+    """Fingerprint, provider, and adapter are published as one immutable record."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, monkeypatch):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        for var in _AUTH_MATRIX_VARS:
+            monkeypatch.delenv(var, raising=False)
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def test_cache_entry_matches_resolved_config(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://a.example.com/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://a.example.com")
+
+        adapter = reg.get_auth_adapter()
+        entry = reg._adapter_cache
+        config = reg.resolve_auth_config()
+
+        assert entry is not None
+        assert entry.adapter is adapter
+        assert entry.provider == config.provider == "jwt"
+        assert entry.fingerprint == config.fingerprint
+
+    def test_startup_validation_binds_the_adapter_requests_use(self, monkeypatch):
+        import mozaiksai.core.auth.adapters.registry as reg
+
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+
+        assert reg.validate_auth_provider_configuration() == "supabase"
+        bound = reg._adapter_cache
+        assert bound is not None
+        assert reg.get_auth_adapter() is bound.adapter

--- a/tests/test_auth_generic_jwt_adapter.py
+++ b/tests/test_auth_generic_jwt_adapter.py
@@ -382,8 +382,19 @@ class TestGenericJWTAdapterValidation:
                 return issuer
 
         class _FakeJWKSClient:
-            def __init__(self, *, jwks_url: str, use_discovery: bool):
+            def __init__(
+                self,
+                *,
+                jwks_url: str,
+                use_discovery: bool,
+                cache_ttl: int | None = None,
+                consult_environment: bool = True,
+                discovery_client=None,
+            ):
                 self.jwks_url = jwks_url
+                self.cache_ttl = cache_ttl
+                self.consult_environment = consult_environment
+                self.discovery_client = discovery_client
                 self.use_discovery = use_discovery
 
             async def get_signing_key(self, kid: str):

--- a/tests/test_auth_oidc_discovery.py
+++ b/tests/test_auth_oidc_discovery.py
@@ -169,7 +169,15 @@ class TestExplicitDiscoveryUrl:
 
         assert client.discovery_url == "https://auth.example.org/openid-configuration"
 
-    def test_env_url_takes_priority_over_constructor_url(self) -> None:
+    def test_constructor_url_takes_priority_over_env_url(self) -> None:
+        """Authority contract: explicit constructor input always wins.
+
+        A client built with a caller-owned discovery URL must keep it, so an
+        adapter's lazily created client can never be repointed by a later
+        environment change. (This inverts the previous env-precedence rule,
+        which allowed a live environment value to override the snapshot the
+        adapter was identified and constructed with.)
+        """
         import mozaiksai.core.auth.discovery as mod
         mod.reset_discovery_client()
 
@@ -180,7 +188,42 @@ class TestExplicitDiscoveryUrl:
                 discovery_url="https://constructor-arg.example.com/.well-known"
             )
 
-        assert client.discovery_url == "https://env-override.example.com/.well-known"
+        assert client.discovery_url == "https://constructor-arg.example.com/.well-known"
+
+    def test_env_url_used_only_when_no_constructor_url(self) -> None:
+        import mozaiksai.core.auth.discovery as mod
+        mod.reset_discovery_client()
+
+        env = {"MOZAIKS_OIDC_DISCOVERY_URL": "https://env-only.example.com/.well-known"}
+        with patch.dict(os.environ, env):
+            from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
+            client = OIDCDiscoveryClient()
+
+        assert client.discovery_url == "https://env-only.example.com/.well-known"
+
+    def test_snapshot_bound_client_never_reads_environment(self) -> None:
+        """consult_environment=False fully binds the client to what it was given."""
+        import mozaiksai.core.auth.discovery as mod
+        mod.reset_discovery_client()
+
+        env = {
+            "MOZAIKS_OIDC_DISCOVERY_URL": "https://env.example.com/.well-known",
+            "MOZAIKS_OIDC_AUTHORITY": "https://env-authority.example.com",
+            "AUTH_DISCOVERY_CACHE_TTL": "99",
+        }
+        with patch.dict(os.environ, env):
+            from mozaiksai.core.auth.discovery import OIDCDiscoveryClient
+            bound = OIDCDiscoveryClient(
+                discovery_url="https://snapshot.example.com/.well-known",
+                cache_ttl=31,
+                consult_environment=False,
+            )
+            empty = OIDCDiscoveryClient(consult_environment=False)
+
+        assert bound.discovery_url == "https://snapshot.example.com/.well-known"
+        assert bound.cache_ttl_seconds == 31
+        # Nothing supplied and no environment allowed: discovery is unavailable.
+        assert empty.discovery_url is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_oidc_discovery.py
+++ b/tests/test_auth_oidc_discovery.py
@@ -357,7 +357,7 @@ class TestAdapterRegistryAutoDetection:
         clean.update(env_overrides)
         import mozaiksai.core.auth.adapters.registry as reg
         with patch.dict(os.environ, clean, clear=True):
-            return reg._auto_detect_provider()
+            return reg.resolve_auth_config().provider
 
     def test_explicit_auth_provider_wins(self) -> None:
         assert self._detect({"AUTH_PROVIDER": "keycloak"}) == "keycloak"

--- a/tests/test_billing_fulfillment.py
+++ b/tests/test_billing_fulfillment.py
@@ -740,3 +740,164 @@ def test_fulfillment_ingress_internal_key_works_with_auth_enabled(monkeypatch) -
     finally:
         clear_auth_config_cache()
         reset_auth_adapter()
+
+
+# ---------------------------------------------------------------------------
+# Fulfillment authenticated-provenance matrix (D3) + environment policy (D2)
+# ---------------------------------------------------------------------------
+
+
+def _principal(*, roles=None, scopes=None, provenance: str):
+    from mozaiksai.core.auth.dependencies import UserPrincipal
+
+    return UserPrincipal(
+        user_id="user_matrix",
+        email=None,
+        name="Matrix User",
+        roles=list(roles or []),
+        scopes=list(scopes or []),
+        raw_claims={},
+        provider="jwt" if provenance == "token_validated" else "none",
+        auth_provenance=provenance,
+    )
+
+
+def _ingress_client_with_principal(monkeypatch, principal) -> TestClient:
+    from mozaiksai.core.auth.dependencies import optional_user
+
+    database = _Database()
+    config = _top_up_config()
+    ledger = TokenWalletLedger(database=database)
+    store = BillingFulfillmentCommandStore(database=database)
+    service = BillingFulfillmentService(config=config, ledger=ledger, command_store=store)
+
+    class _Audit:
+        async def log(self, record: Any) -> None:
+            return None
+
+    monkeypatch.setattr("mozaiksai.hosts.routers.billing.get_audit_logger", lambda: _Audit())
+
+    app = FastAPI()
+    app.state.subscriptions_config = config
+    app.state.billing_fulfillment_command_store = store
+    app.state.billing_fulfillment_service_factory = lambda request: service
+    app.include_router(billing_router)
+    app.dependency_overrides[optional_user] = lambda: principal
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _auth_enabled_jwt_env(monkeypatch) -> None:
+    """Auth enabled with a fully configured jwt provider; no internal key."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+    from mozaiksai.core.auth.config import clear_auth_config_cache
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+    monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
+    clear_auth_config_cache()
+    reset_auth_adapter()
+
+
+def test_fulfillment_allows_authenticated_billing_admin(monkeypatch) -> None:
+    _auth_enabled_jwt_env(monkeypatch)
+    principal = _principal(roles=["admin"], provenance="token_validated")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "applied"
+
+
+def test_fulfillment_allows_authenticated_billing_scope(monkeypatch) -> None:
+    _auth_enabled_jwt_env(monkeypatch)
+    principal = _principal(scopes=["billing.fulfillment.apply"], provenance="token_validated")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert resp.status_code == 200
+
+
+def test_fulfillment_denies_authenticated_unprivileged_principal(monkeypatch) -> None:
+    _auth_enabled_jwt_env(monkeypatch)
+    principal = _principal(roles=["user"], scopes=["access_as_user"], provenance="token_validated")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert resp.status_code == 403
+
+
+def test_fulfillment_denies_anonymous_principal_with_admin_roles(monkeypatch) -> None:
+    """Admin-looking role strings without authenticated provenance are not authority."""
+    _auth_enabled_jwt_env(monkeypatch)
+    principal = _principal(roles=["admin"], scopes=["billing.admin"], provenance="anonymous")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert resp.status_code == 403
+
+
+def test_fulfillment_denies_dev_persona_with_admin_roles(monkeypatch) -> None:
+    _auth_enabled_jwt_env(monkeypatch)
+    principal = _principal(roles=["admin"], scopes=["billing.admin"], provenance="dev_override")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert resp.status_code == 403
+
+
+def test_fulfillment_internal_key_allowed_alongside_denied_principal(monkeypatch) -> None:
+    """Correct internal key remains independently sufficient."""
+    _auth_enabled_jwt_env(monkeypatch)
+    monkeypatch.setenv("INTERNAL_API_KEY", "configured-key-0123456789abcdef")
+    principal = _principal(roles=["admin"], provenance="anonymous")
+    client = _ingress_client_with_principal(monkeypatch, principal)
+
+    without_key = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+    assert without_key.status_code == 403
+    with_key = client.post(
+        "/api/billing/fulfillment/apply",
+        json=_INGRESS_PAYLOAD,
+        headers={"x-internal-api-key": "configured-key-0123456789abcdef"},
+    )
+    assert with_key.status_code == 200
+
+
+def test_fulfillment_spoofed_dev_headers_cannot_gain_authenticated_provenance(monkeypatch) -> None:
+    """With auth enabled, dev persona headers are inert: no token means no
+    principal at all, and dev overrides only exist in the auth-disabled branch."""
+    _auth_enabled_jwt_env(monkeypatch)
+    client = _ingress_client(monkeypatch)  # real optional_user dependency
+
+    resp = client.post(
+        "/api/billing/fulfillment/apply",
+        json=_INGRESS_PAYLOAD,
+        headers={
+            "X-Mozaiks-Dev-User-Id": "dev_admin",
+            "X-Mozaiks-Dev-Roles": "admin",
+            "X-Mozaiks-Dev-Scopes": "billing.admin",
+        },
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize("environment", ["staging", "production"])
+def test_fulfillment_fails_closed_in_protected_env_even_if_startup_bypassed(
+    monkeypatch, environment
+) -> None:
+    """Explicit no-auth in a protected environment would never boot; if a
+    process somehow reached request handling anyway, the canonical resolution
+    still raises and the ingress cannot succeed."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("ENV", environment)
+    reset_auth_adapter()
+    try:
+        client = _ingress_client(monkeypatch)
+        resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+        assert resp.status_code == 500  # AuthError surfaces; never 200
+    finally:
+        reset_auth_adapter()

--- a/tests/test_billing_fulfillment.py
+++ b/tests/test_billing_fulfillment.py
@@ -593,3 +593,150 @@ def test_fulfillment_apply_route_replays_and_exposes_command_log(monkeypatch) ->
     assert listing.status_code == 200
     assert listing.json()["records"][0]["command_id"] == "cmd_route_topup_1"
     assert len(audit.records) == 2
+
+
+# ---------------------------------------------------------------------------
+# Fulfillment ingress authentication boundary (fail closed)
+# ---------------------------------------------------------------------------
+
+
+def _ingress_client(monkeypatch) -> TestClient:
+    """Build a fulfillment app with a working service and silenced audit sink."""
+    database = _Database()
+    config = _top_up_config()
+    ledger = TokenWalletLedger(database=database)
+    store = BillingFulfillmentCommandStore(database=database)
+    service = BillingFulfillmentService(config=config, ledger=ledger, command_store=store)
+
+    class _Audit:
+        async def log(self, record: Any) -> None:
+            return None
+
+    monkeypatch.setattr("mozaiksai.hosts.routers.billing.get_audit_logger", lambda: _Audit())
+
+    app = FastAPI()
+    app.state.subscriptions_config = config
+    app.state.billing_fulfillment_command_store = store
+    app.state.billing_fulfillment_service_factory = lambda request: service
+    app.include_router(billing_router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_INGRESS_PAYLOAD = {
+    "command_id": "cmd_ingress_1",
+    "event_type": "token_top_up_paid",
+    "source": "test",
+    "app_id": "app_1",
+    "user_id": "user_1",
+    "token_amount": 100,
+}
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    for var in (
+        "AUTH_ENABLED",
+        "AUTH_PROVIDER",
+        "INTERNAL_API_KEY",
+        "SUPABASE_URL",
+        "KEYCLOAK_URL",
+        "KEYCLOAK_REALM",
+        "AUTH_JWKS_URL",
+        "AUTH_ISSUER",
+        "MOZAIKS_OIDC_AUTHORITY",
+        "MOZAIKS_OIDC_DISCOVERY_URL",
+        # A developer .env may grant the anonymous principal admin roles;
+        # these tests exercise the un-granted anonymous path.
+        "AUTH_ANON_ROLES",
+        "AUTH_ANON_SCOPES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_fulfillment_ingress_fails_closed_when_auth_merely_unconfigured(monkeypatch) -> None:
+    """Implicit demo mode (no auth config at all) + no INTERNAL_API_KEY must NOT
+    make the fulfillment ingress callable without authentication."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    _clear_auth_env(monkeypatch)
+    reset_auth_adapter()
+    try:
+        client = _ingress_client(monkeypatch)
+        resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+        assert resp.status_code == 403
+        listing = client.get("/api/admin/billing/fulfillment?app_id=app_1")
+        assert listing.status_code == 403
+    finally:
+        reset_auth_adapter()
+
+
+def test_fulfillment_ingress_allows_explicitly_disabled_auth_dev_mode(monkeypatch) -> None:
+    """AUTH_ENABLED=false is the explicit development contract — local dev keeps working."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    reset_auth_adapter()
+    try:
+        client = _ingress_client(monkeypatch)
+        resp = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "applied"
+    finally:
+        reset_auth_adapter()
+
+
+def test_fulfillment_ingress_requires_key_when_key_configured_even_if_auth_disabled(monkeypatch) -> None:
+    """Once INTERNAL_API_KEY is configured, the anonymous dev path closes."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("INTERNAL_API_KEY", "configured-key-0123456789abcdef")
+    reset_auth_adapter()
+    try:
+        client = _ingress_client(monkeypatch)
+        no_key = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+        assert no_key.status_code == 403
+        wrong_key = client.post(
+            "/api/billing/fulfillment/apply",
+            json=_INGRESS_PAYLOAD,
+            headers={"x-internal-api-key": "wrong"},
+        )
+        assert wrong_key.status_code == 401
+        right_key = client.post(
+            "/api/billing/fulfillment/apply",
+            json=_INGRESS_PAYLOAD,
+            headers={"x-internal-api-key": "configured-key-0123456789abcdef"},
+        )
+        assert right_key.status_code == 200
+    finally:
+        reset_auth_adapter()
+
+
+def test_fulfillment_ingress_internal_key_works_with_auth_enabled(monkeypatch) -> None:
+    """Auth enabled with a real provider: the internal key path still authorizes."""
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+    monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
+    monkeypatch.setenv("INTERNAL_API_KEY", "configured-key-0123456789abcdef")
+    from mozaiksai.core.auth.config import clear_auth_config_cache
+
+    clear_auth_config_cache()
+    reset_auth_adapter()
+    try:
+        client = _ingress_client(monkeypatch)
+        anonymous = client.post("/api/billing/fulfillment/apply", json=_INGRESS_PAYLOAD)
+        assert anonymous.status_code in (401, 403)
+        keyed = client.post(
+            "/api/billing/fulfillment/apply",
+            json=_INGRESS_PAYLOAD,
+            headers={"x-internal-api-key": "configured-key-0123456789abcdef"},
+        )
+        assert keyed.status_code == 200
+    finally:
+        clear_auth_config_cache()
+        reset_auth_adapter()

--- a/tests/test_e2e_deterministic_acceptance_gate.py
+++ b/tests/test_e2e_deterministic_acceptance_gate.py
@@ -604,7 +604,7 @@ def _save_platform_state() -> dict[str, Any]:
         # rather than clearing it (which would lose builtins registered by
         # prior tests or by _register_builtin_adapters).
         "auth_adapter_registry": dict(auth_registry._adapter_registry),
-        "auth_adapter_instance": auth_registry._adapter_instance,
+        "auth_adapter_cache": auth_registry._adapter_cache,
     }
 
 
@@ -621,7 +621,7 @@ def _restore_platform_state(state: dict[str, Any]) -> None:
     # clearing it unconditionally.
     auth_registry._adapter_registry.clear()
     auth_registry._adapter_registry.update(state["auth_adapter_registry"])
-    auth_registry._adapter_instance = state["auth_adapter_instance"]
+    auth_registry._adapter_cache = state["auth_adapter_cache"]
 
 
 # ===========================================================================

--- a/tests/test_materialized_bundle_production_runtime.py
+++ b/tests/test_materialized_bundle_production_runtime.py
@@ -42,7 +42,7 @@ def _restore_global_runtime_state() -> Any:
     from mozaiksai.core.workflow.outputs import structured
 
     adapter_registry = dict(auth_registry._adapter_registry)
-    adapter_instance = auth_registry._adapter_instance
+    adapter_cache = auth_registry._adapter_cache
     workflow_instance = workflow_manager.UnifiedWorkflowManager._instance
     workflow_models = dict(structured._workflow_models)
     workflow_registries = dict(structured._workflow_registries)
@@ -60,7 +60,7 @@ def _restore_global_runtime_state() -> Any:
     finally:
         auth_registry._adapter_registry.clear()
         auth_registry._adapter_registry.update(adapter_registry)
-        auth_registry._adapter_instance = adapter_instance
+        auth_registry._adapter_cache = adapter_cache
         workflow_manager.UnifiedWorkflowManager._instance = workflow_instance
         structured._workflow_models.clear()
         structured._workflow_models.update(workflow_models)

--- a/tests/test_module_action_dispatch_public_api.py
+++ b/tests/test_module_action_dispatch_public_api.py
@@ -76,6 +76,7 @@ def _app_with_executor() -> SimpleNamespace:
     executor.register(
         "orders",
         _OrdersModule(),
+        action_method_map={"restricted": "restricted"},
         action_permissions={"restricted": ["orders.read"]},
     )
     registry = ExecutorRegistry()

--- a/tests/test_module_dispatch_authority_contract.py
+++ b/tests/test_module_dispatch_authority_contract.py
@@ -80,6 +80,9 @@ def test_workflow_authority_always_enforces() -> None:
 
 def test_local_development_rejected_when_auth_enabled(monkeypatch) -> None:
     monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    # A developer .env may set AUTH_ENABLED=false; with an explicit provider
+    # that would be a fatal contradiction rather than "auth enabled".
+    monkeypatch.delenv("AUTH_ENABLED", raising=False)
     with pytest.raises(ValueError, match="local_development"):
         ModuleDispatchAuthority(
             kind="local_development",

--- a/tests/test_module_dispatch_authority_contract.py
+++ b/tests/test_module_dispatch_authority_contract.py
@@ -227,6 +227,9 @@ def test_local_development_rejected_in_production_profile(monkeypatch) -> None:
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.delenv("AUTH_PROVIDER", raising=False)
     monkeypatch.setenv("ENV", "production")
+    # ENV and ENVIRONMENT must agree; a developer .env commonly sets
+    # ENVIRONMENT=development, which would be a conflicting declaration.
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
     with pytest.raises(ValueError, match="local_development"):
         ModuleDispatchAuthority(
             kind="local_development",

--- a/tests/test_module_dispatch_authority_policy.py
+++ b/tests/test_module_dispatch_authority_policy.py
@@ -68,6 +68,7 @@ def _executor(handler: _Handler, *, entitlement_checker: Any = None) -> ModuleEx
     executor.register(
         "orders",
         handler,
+        action_method_map={"run": "run"},
         action_permissions={"run": ["orders.run"]},
         action_entitlements={"run": "orders.premium"},
     )

--- a/tests/test_module_executor_dispatch.py
+++ b/tests/test_module_executor_dispatch.py
@@ -94,7 +94,7 @@ class TestModuleActionResolution:
     @pytest.mark.asyncio
     async def test_action_not_found_returns_error(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request(action="no_such_action"))
         assert result.success is False
         assert result.error_code == "ACTION_NOT_FOUND"
@@ -103,7 +103,7 @@ class TestModuleActionResolution:
     @pytest.mark.asyncio
     async def test_sync_action_dispatched_and_result_returned(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request(params={"name": "Alice"}))
         assert result.success is True
         assert result.data == {"echo": {"name": "Alice"}}
@@ -111,7 +111,7 @@ class TestModuleActionResolution:
     @pytest.mark.asyncio
     async def test_async_action_dispatched_and_result_returned(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _AsyncEchoHandler())
+        ex.register("contacts", _AsyncEchoHandler(), action_method_map={"echo_async": "echo_async"})
         result = await ex.execute(_request(action="echo_async", params={"x": 1}))
         assert result.success is True
         assert result.data == {"async_echo": {"x": 1}}
@@ -138,7 +138,7 @@ class TestActionErrorHandling:
     @pytest.mark.asyncio
     async def test_exception_in_action_returns_execution_error(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _ErrorHandler())
+        ex.register("contacts", _ErrorHandler(), action_method_map={"blow_up": "blow_up", "bad_params": "bad_params", "restricted": "restricted"})
         result = await ex.execute(_request(action="blow_up"))
         assert result.success is False
         assert result.error_code == "EXECUTION_ERROR"
@@ -150,7 +150,7 @@ class TestActionErrorHandling:
     @pytest.mark.asyncio
     async def test_type_error_from_missing_required_param_returns_invalid_params(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _ErrorHandler())
+        ex.register("contacts", _ErrorHandler(), action_method_map={"blow_up": "blow_up", "bad_params": "bad_params", "restricted": "restricted"})
         # bad_params requires `required_arg` but we pass nothing
         result = await ex.execute(_request(action="bad_params", params={}))
         assert result.success is False
@@ -160,7 +160,7 @@ class TestActionErrorHandling:
     async def test_permission_error_from_service_layer_returns_permission_denied(self):
         """PermissionError raised inside a handler maps to PERMISSION_DENIED (403), not EXECUTION_ERROR (500)."""
         ex = ModuleExecutor()
-        ex.register("contacts", _ErrorHandler())
+        ex.register("contacts", _ErrorHandler(), action_method_map={"blow_up": "blow_up", "bad_params": "bad_params", "restricted": "restricted"})
         result = await ex.execute(_request(action="restricted", authority=enforce_authority("contacts.read")))
         assert result.success is False
         assert result.error_code == "PERMISSION_DENIED"
@@ -179,6 +179,7 @@ class TestPermissionEnforcement:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_permissions={"echo": ["contacts.read"]},
         )
         # authority=trusted_framework_authority() → trusted internal call, no enforcement
@@ -191,6 +192,7 @@ class TestPermissionEnforcement:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_permissions={"echo": ["contacts.read"]},
         )
         result = await ex.execute(_request(authority=enforce_authority("contacts.read", "other.perm")))
@@ -202,6 +204,7 @@ class TestPermissionEnforcement:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_permissions={"echo": ["contacts.read"]},
         )
         result = await ex.execute(_request(authority=enforce_authority("other.perm")))
@@ -214,6 +217,7 @@ class TestPermissionEnforcement:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_permissions={"echo": ["contacts.read"]},
         )
         result = await ex.execute(_request(authority=enforce_authority()))
@@ -226,6 +230,7 @@ class TestPermissionEnforcement:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_permissions={},  # no permissions required
         )
         result = await ex.execute(_request(authority=enforce_authority()))
@@ -245,6 +250,7 @@ class TestEntitlementGate:
         ex.register(
             "wallet",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_entitlements={"echo": "wallet.payout"},
         )
         result = await ex.execute(_request(module="wallet", authority=enforce_authority("wallet.manage")))
@@ -265,6 +271,7 @@ class TestEntitlementGate:
         ex.register(
             "wallet",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_entitlements={"echo": "wallet.payout"},
         )
         result = await ex.execute(
@@ -294,6 +301,7 @@ class TestEntitlementGate:
         ex.register(
             "wallet",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_entitlements={"echo": "wallet.payout"},
         )
         result = await ex.execute(_request(module="wallet", authority=enforce_authority("wallet.manage")))
@@ -309,6 +317,7 @@ class TestEntitlementGate:
         ex.register(
             "wallet",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_entitlements={"echo": "wallet.payout"},
         )
         result = await ex.execute(_request(module="wallet", authority=trusted_framework_authority()))
@@ -323,6 +332,7 @@ class TestEntitlementGate:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_entitlements={},  # no gate on any action
         )
         result = await ex.execute(_request(authority=enforce_authority("any.perm")))
@@ -341,6 +351,7 @@ class TestSchemaValidation:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_schemas={
                 "echo": {
                     "input": {
@@ -361,6 +372,7 @@ class TestSchemaValidation:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_schemas={
                 "echo": {
                     "input": {
@@ -381,6 +393,7 @@ class TestSchemaValidation:
         ex.register(
             "contacts",
             _EchoHandler(),
+            action_method_map={"echo": "echo"},
             action_schemas={
                 "echo": {
                     "output": {
@@ -447,7 +460,7 @@ class TestEventEmitterEnvelope:
                 await ctx.emit("contacts.created", {"name": "Alice"})
                 return {"success": True}
 
-        ex.register("contacts", _EmittingHandler())
+        ex.register("contacts", _EmittingHandler(), action_method_map={"action_with_emit": "action_with_emit"})
         result = await ex.execute(_request(action="action_with_emit"))
         assert result.success is True
         assert len(emitted) == 1
@@ -476,7 +489,7 @@ class TestEventEmitterEnvelope:
                 await ctx.emit("anon.event", {})
                 return {}
 
-        ex.register("contacts", _EmittingHandler())
+        ex.register("contacts", _EmittingHandler(), action_method_map={"do_action": "do_action"})
         req = _request(action="do_action", user_id=None)
         await ex.execute(req)
         assert "actor" not in emitted[0]
@@ -501,7 +514,7 @@ class TestEventEmitterEnvelope:
             "capability_ids": ["tasks.review"],
             "invocation_ids": ["wti-parent"],
         }
-        ex.register("contacts", _EmittingHandler())
+        ex.register("contacts", _EmittingHandler(), action_method_map={"do_action": "do_action"})
         await ex.execute(
             _request(
                 action="do_action",
@@ -522,14 +535,14 @@ class TestEventEmitterEnvelope:
 class TestRegistryQueries:
     def test_registered_modules_returns_module_names(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
-        ex.register("tasks", _AsyncEchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
+        ex.register("tasks", _AsyncEchoHandler(), action_method_map={"echo_async": "echo_async"})
         names = ex.registered_modules()
         assert set(names) == {"contacts", "tasks"}
 
     def test_can_handle_returns_true_for_registered(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         assert ex.can_handle("contacts") is True
 
     def test_can_handle_returns_false_for_unknown(self):
@@ -539,7 +552,7 @@ class TestRegistryQueries:
     @pytest.mark.asyncio
     async def test_health_includes_module_list(self):
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         health = await ex.health()
         assert "contacts" in health["modules"]
         assert health["count"] == 1
@@ -565,7 +578,7 @@ class TestPayloadSizeLimits:
                 return {"echo": kwargs}
 
         ex = ModuleExecutor()
-        ex.register("contacts", _SpyHandler())
+        ex.register("contacts", _SpyHandler(), action_method_map={"echo": "echo"})
         # Build a params dict that serializes to > 10 bytes.
         result = await ex.execute(_request(params={"x": "a" * 100}))
 
@@ -578,7 +591,7 @@ class TestPayloadSizeLimits:
         monkeypatch.setenv("MODULE_PARAMS_MAX_BYTES", "10000")
 
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request(params={"name": "Alice"}))
 
         assert result.success is True
@@ -594,7 +607,7 @@ class TestPayloadSizeLimits:
                 return {"data": "x" * 10000}
 
         ex = ModuleExecutor()
-        ex.register("contacts", _BigResponseHandler())
+        ex.register("contacts", _BigResponseHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request())
 
         assert result.success is False
@@ -610,7 +623,7 @@ class TestPayloadSizeLimits:
                 return None
 
         ex = ModuleExecutor()
-        ex.register("contacts", _NoneHandler())
+        ex.register("contacts", _NoneHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request())
 
         assert result.success is True
@@ -634,7 +647,7 @@ class TestActionTimeout:
                 return {"done": True}
 
         ex = ModuleExecutor()
-        ex.register("contacts", _SlowHandler())
+        ex.register("contacts", _SlowHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request())
 
         assert result.success is False
@@ -647,7 +660,7 @@ class TestActionTimeout:
         monkeypatch.setenv("MODULE_ACTION_TIMEOUT_SECONDS", "30")
 
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request(params={"x": 1}))
 
         assert result.success is True
@@ -658,7 +671,161 @@ class TestActionTimeout:
         monkeypatch.setenv("MODULE_ACTION_TIMEOUT_SECONDS", "0")
 
         ex = ModuleExecutor()
-        ex.register("contacts", _EchoHandler())
+        ex.register("contacts", _EchoHandler(), action_method_map={"echo": "echo"})
         result = await ex.execute(_request(params={"x": 1}))
 
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# 10. Declared-action authority boundary (fail closed)
+# ---------------------------------------------------------------------------
+
+
+class _HardenedHandler:
+    """Handler with a mix of public, internal, and non-action attributes."""
+
+    service = object()  # non-callable attribute
+
+    def __init__(self) -> None:
+        self.secrets = {"token": "sk-forbidden"}
+
+    async def list_items(self, ctx, **kwargs) -> dict:
+        return {"items": []}
+
+    async def delete_everything(self, ctx, **kwargs) -> dict:
+        return {"deleted": True}
+
+    async def on_payment_settled(self, ctx, **kwargs) -> dict:
+        """Event-reaction handler method — never a public action."""
+        return {"reacted": True}
+
+    def _internal_helper(self, ctx, **kwargs) -> dict:
+        return {"internal": True}
+
+
+class TestDeclaredActionAuthorityBoundary:
+    """Only contract-declared action ids may resolve to handler methods.
+
+    A handler method must never be HTTP/executor-dispatchable merely because a
+    Python method with the requested name exists.
+    """
+
+    def _executor(self) -> ModuleExecutor:
+        ex = ModuleExecutor()
+        ex.register(
+            "billing",
+            _HardenedHandler(),
+            # 'list' is the only declared public action; note the alias:
+            # public id 'list' maps to method 'list_items'.
+            action_method_map={"list": "list_items"},
+            action_permissions={"list": []},
+        )
+        return ex
+
+    @pytest.mark.asyncio
+    async def test_declared_alias_dispatches(self):
+        ex = self._executor()
+        result = await ex.execute(_request(module="billing", action="list", authority=enforce_authority()))
+        assert result.success is True
+        assert result.data == {"items": []}
+
+    @pytest.mark.asyncio
+    async def test_undeclared_existing_method_rejected(self):
+        """delete_everything exists in Python but is not declared — must fail closed."""
+        ex = self._executor()
+        for authority in (enforce_authority("billing.admin"), trusted_framework_authority()):
+            result = await ex.execute(
+                _request(module="billing", action="delete_everything", authority=authority)
+            )
+            assert result.success is False
+            assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_alias_target_method_name_not_directly_dispatchable(self):
+        """The mapped method name ('list_items') is not itself a public action id."""
+        ex = self._executor()
+        result = await ex.execute(
+            _request(module="billing", action="list_items", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_event_reaction_method_not_reachable_as_action(self):
+        ex = self._executor()
+        result = await ex.execute(
+            _request(module="billing", action="on_payment_settled", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_private_and_dunder_attributes_not_dispatchable(self):
+        ex = self._executor()
+        for name in ("_internal_helper", "__init__", "__class__", "service", "secrets"):
+            result = await ex.execute(
+                _request(module="billing", action=name, authority=trusted_framework_authority())
+            )
+            assert result.success is False, f"action {name!r} must not dispatch"
+            assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_case_variant_of_declared_action_rejected(self):
+        ex = self._executor()
+        result = await ex.execute(
+            _request(module="billing", action="List", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_module_registered_without_map_has_no_dispatchable_actions(self):
+        ex = ModuleExecutor()
+        ex.register("billing", _HardenedHandler())
+        result = await ex.execute(
+            _request(module="billing", action="list_items", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_declared_action_with_missing_method_fails_closed(self):
+        """A declared action whose handler_method is absent must not fall back."""
+        ex = ModuleExecutor()
+        ex.register("billing", _HardenedHandler(), action_method_map={"ghost": "not_a_method"})
+        result = await ex.execute(
+            _request(module="billing", action="ghost", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_declared_action_mapped_to_non_callable_fails_closed(self):
+        ex = ModuleExecutor()
+        ex.register("billing", _HardenedHandler(), action_method_map={"svc": "service"})
+        result = await ex.execute(
+            _request(module="billing", action="svc", authority=trusted_framework_authority())
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_permission_map_entry_alone_grants_no_dispatch(self):
+        """An action id present only in action_permissions (not the method map) stays closed."""
+        ex = ModuleExecutor()
+        ex.register(
+            "billing",
+            _HardenedHandler(),
+            action_method_map={"list": "list_items"},
+            action_permissions={"delete_everything": ["billing.admin"]},
+        )
+        result = await ex.execute(
+            _request(
+                module="billing",
+                action="delete_everything",
+                authority=enforce_authority("billing.admin"),
+            )
+        )
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"

--- a/tests/test_module_executor_dispatch.py
+++ b/tests/test_module_executor_dispatch.py
@@ -829,3 +829,170 @@ class TestDeclaredActionAuthorityBoundary:
         )
         assert result.success is False
         assert result.error_code == "ACTION_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 11. Undeclared rejection must never touch the handler object (D1)
+# ---------------------------------------------------------------------------
+
+
+class _TouchCounter:
+    """Class-level counters for every dynamic-lookup channel."""
+
+    def __init__(self) -> None:
+        self.property_reads = 0
+        self.getattr_calls = 0
+        self.descriptor_gets = 0
+
+
+class _CallableReturningDescriptor:
+    """Non-data descriptor whose __get__ records execution and returns a callable."""
+
+    def __get__(self, obj, objtype=None):
+        if obj is not None:
+            obj.touches.descriptor_gets += 1
+        async def _would_run(ctx, **kwargs):
+            return {"descriptor_dispatched": True}
+        return _would_run
+
+
+class _WeaponizedBase:
+    """Base class contributing an inherited undeclared property."""
+
+    @property
+    def inherited_trap(self):
+        self.touches.property_reads += 1
+        raise RuntimeError("inherited descriptor executed")
+
+
+class _WeaponizedHandler(_WeaponizedBase):
+    """Handler where every undeclared attribute lookup is instrumented or raises."""
+
+    descriptor_action = _CallableReturningDescriptor()
+
+    def __init__(self) -> None:
+        self.touches = _TouchCounter()
+
+    async def declared_ok(self, ctx, **kwargs):
+        return {"ok": True}
+
+    @property
+    def raising_prop(self):
+        self.touches.property_reads += 1
+        raise RuntimeError("property descriptor executed")
+
+    @property
+    def side_effect_prop(self):
+        self.touches.property_reads += 1
+        return {"leaked": True}
+
+    def __getattr__(self, name):
+        # Fires for any attribute not found through normal lookup.
+        # object.__getattribute__ bypass keeps the counter itself readable.
+        object.__getattribute__(self, "touches").getattr_calls += 1
+        if name == "phantom_raises":
+            raise RuntimeError("__getattr__ executed and raised")
+        async def _phantom(ctx, **kwargs):
+            return {"phantom_dispatched": True}
+        return _phantom
+
+
+class TestUndeclaredRejectionNeverTouchesHandler:
+    """D1: absent from the declared action map → rejected with zero handler
+    attribute access. No getattr, no hasattr, no descriptor execution."""
+
+    def _executor(self, handler: _WeaponizedHandler) -> ModuleExecutor:
+        ex = ModuleExecutor()
+        ex.register(
+            "armory",
+            handler,
+            action_method_map={"declared_ok": "declared_ok"},
+        )
+        return ex
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "undeclared_action",
+        [
+            "raising_prop",          # property that raises on access
+            "side_effect_prop",      # property with a side effect counter
+            "inherited_trap",        # inherited property descriptor
+            "descriptor_action",     # non-data descriptor returning a callable
+            "phantom_raises",        # __getattr__ that raises
+            "phantom_callable",      # __getattr__ returning a callable
+        ],
+    )
+    async def test_undeclared_lookup_channels_never_execute(self, undeclared_action):
+        handler = _WeaponizedHandler()
+        ex = self._executor(handler)
+
+        result = await ex.execute(
+            _request(module="armory", action=undeclared_action, authority=trusted_framework_authority())
+        )
+
+        assert result.success is False
+        assert result.error_code == "ACTION_NOT_FOUND"
+        assert handler.touches.property_reads == 0
+        assert handler.touches.getattr_calls == 0
+        assert handler.touches.descriptor_gets == 0
+
+    @pytest.mark.asyncio
+    async def test_denial_identical_whether_attribute_exists_or_not(self):
+        handler = _WeaponizedHandler()
+        ex = self._executor(handler)
+
+        existing = await ex.execute(
+            _request(module="armory", action="side_effect_prop", authority=trusted_framework_authority())
+        )
+        # 'nonexistent_zz' does not correspond to any class attribute, but
+        # __getattr__ would still fire if the executor probed — it must not.
+        missing = await ex.execute(
+            _request(module="armory", action="nonexistent_zz", authority=trusted_framework_authority())
+        )
+
+        assert (existing.success, existing.error_code) == (missing.success, missing.error_code)
+        assert existing.error.replace("side_effect_prop", "X") == missing.error.replace("nonexistent_zz", "X")
+        assert handler.touches.property_reads == 0
+        assert handler.touches.getattr_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_denied_audit_uses_bounded_sanitized_action(self, monkeypatch):
+        audits: list = []
+
+        class _Audit:
+            async def log_module_action(self, **kwargs):
+                audits.append(kwargs)
+
+        import mozaiksai.core.runtime.composition.module_executor as mod_exec
+
+        monkeypatch.setattr(mod_exec, "get_audit_logger", lambda: _Audit())
+        handler = _WeaponizedHandler()
+        ex = self._executor(handler)
+
+        hostile_action = "raising_prop\n\x00<script>" + "A" * 500
+        result = await ex.execute(
+            _request(module="armory", action=hostile_action, authority=trusted_framework_authority())
+        )
+        # Let the fire-and-forget audit task run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert result.error_code == "ACTION_NOT_FOUND"
+        assert len(result.error) < 200
+        assert "\x00" not in result.error and "<script>" not in result.error
+        assert handler.touches.property_reads == 0
+        assert handler.touches.getattr_calls == 0
+        assert audits, "denied dispatch must emit an audit record"
+        audited_action = audits[0]["action_id"]
+        assert len(audited_action) <= 67  # bounded (64 + ellipsis)
+        assert "\x00" not in audited_action and "<" not in audited_action
+
+    @pytest.mark.asyncio
+    async def test_declared_action_still_dispatches_on_weaponized_handler(self):
+        handler = _WeaponizedHandler()
+        ex = self._executor(handler)
+        result = await ex.execute(
+            _request(module="armory", action="declared_ok", authority=trusted_framework_authority())
+        )
+        assert result.success is True
+        assert result.data == {"ok": True}

--- a/tests/test_module_result_bson_normalization.py
+++ b/tests/test_module_result_bson_normalization.py
@@ -499,7 +499,7 @@ class _MongoShapedHandler:
 async def test_executor_results_serialize_after_mongo_shaped_actions() -> None:
     ex = ModuleExecutor()
     handler = _MongoShapedHandler()
-    ex.register("records", handler)
+    ex.register("records", handler, action_method_map={name: name for name in ("list_records", "bad_keys", "bad_value", "cyclic", "huge", "create_record", "read_record", "update_record", "delete_record")})
 
     listed = await ex.execute(_request("records", "list_records"))
     assert listed.success is True
@@ -512,7 +512,7 @@ async def test_executor_results_serialize_after_mongo_shaped_actions() -> None:
 @pytest.mark.parametrize("action", ["bad_keys", "bad_value", "cyclic"])
 async def test_invalid_transport_results_return_typed_error(action: str) -> None:
     ex = ModuleExecutor()
-    ex.register("records", _MongoShapedHandler())
+    ex.register("records", _MongoShapedHandler(), action_method_map={name: name for name in ("list_records", "bad_keys", "bad_value", "cyclic", "huge", "create_record", "read_record", "update_record", "delete_record")})
     result = await ex.execute(_request("records", action))
     assert result.success is False
     assert result.error_code == "MODULE_RESULT_NOT_JSON_SAFE"
@@ -524,7 +524,7 @@ async def test_invalid_transport_results_return_typed_error(action: str) -> None
 @pytest.mark.asyncio
 async def test_oversized_normalized_response_is_rejected_by_exact_bytes() -> None:
     ex = ModuleExecutor()
-    ex.register("records", _MongoShapedHandler())
+    ex.register("records", _MongoShapedHandler(), action_method_map={name: name for name in ("list_records", "bad_keys", "bad_value", "cyclic", "huge", "create_record", "read_record", "update_record", "delete_record")})
     result = await ex.execute(_request("records", "huge"))
     assert result.success is False
     assert result.error_code == "RESPONSE_TOO_LARGE"
@@ -557,13 +557,13 @@ async def test_result_at_exact_limit_passes_and_one_byte_over_fails(monkeypatch)
 
     monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", str(limit))
     ex = ModuleExecutor()
-    ex.register("sized", _SizedHandler(payload))
+    ex.register("sized", _SizedHandler(payload), action_method_map={"sized": "sized"})
     at_limit = await ex.execute(_request("sized", "sized"))
     assert at_limit.success is True
 
     monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", str(limit - 1))
     ex2 = ModuleExecutor()
-    ex2.register("sized", _SizedHandler(payload))
+    ex2.register("sized", _SizedHandler(payload), action_method_map={"sized": "sized"})
     over = await ex2.execute(_request("sized", "sized"))
     assert over.success is False
     assert over.error_code == "RESPONSE_TOO_LARGE"
@@ -573,7 +573,7 @@ async def test_result_at_exact_limit_passes_and_one_byte_over_fails(monkeypatch)
 async def test_unsupported_result_is_not_json_safe_never_a_size_outcome(monkeypatch) -> None:
     monkeypatch.setenv("MODULE_RESPONSE_MAX_BYTES", "1")
     ex = ModuleExecutor()
-    ex.register("sized", _SizedHandler({"handle": object()}))
+    ex.register("sized", _SizedHandler({"handle": object()}), action_method_map={"sized": "sized"})
     result = await ex.execute(_request("sized", "sized"))
     assert result.success is False
     assert result.error_code == "MODULE_RESULT_NOT_JSON_SAFE"

--- a/tests/test_platform_module_dispatch.py
+++ b/tests/test_platform_module_dispatch.py
@@ -55,6 +55,21 @@ class _OrdersHandler:
         }
 
 
+# Declared action authority for the test module — mirrors module.yaml
+# actions[].id -> handler_method. Dispatch is fail-closed to this map.
+_ORDERS_ACTIONS = {
+    name: name
+    for name in (
+        "list",
+        "whoami",
+        "scope",
+        "authority",
+        "inspect_app_input",
+        "inspect_payload",
+    )
+}
+
+
 def _client(
     *,
     failed_module_names: list[str] | None = None,
@@ -111,6 +126,7 @@ def test_post_params_envelope_preserves_reserved_action_input(monkeypatch) -> No
     executor.register(
         "orders",
         _OrdersHandler(),
+        action_method_map=_ORDERS_ACTIONS,
         action_schemas={
             "inspect_app_input": {
                 "input": {
@@ -144,7 +160,7 @@ def test_post_params_envelope_preserves_reserved_action_input(monkeypatch) -> No
 
 def test_post_raw_body_keeps_reserved_fields_as_legacy_context_only(monkeypatch) -> None:
     executor = ModuleExecutor()
-    executor.register("orders", _OrdersHandler())
+    executor.register("orders", _OrdersHandler(), action_method_map=_ORDERS_ACTIONS)
     registry = ExecutorRegistry()
     registry.register(executor)
     monkeypatch.setattr(platform_host, "executor_registry", registry)
@@ -218,6 +234,7 @@ def test_auth_disabled_module_dispatch_bypasses_action_permissions_for_local_stu
     executor.register(
         "orders",
         _OrdersHandler(),
+        action_method_map=_ORDERS_ACTIONS,
         action_permissions={"list": ["orders.read"]},
     )
     registry = ExecutorRegistry()
@@ -237,6 +254,7 @@ def test_auth_disabled_module_dispatch_uses_local_development_authority(monkeypa
     executor.register(
         "orders",
         _OrdersHandler(),
+        action_method_map=_ORDERS_ACTIONS,
         action_permissions={"authority": ["orders.read"]},
     )
     registry = ExecutorRegistry()
@@ -259,7 +277,7 @@ def test_auth_disabled_module_dispatch_uses_local_development_authority(monkeypa
 
 def test_auth_enabled_module_dispatch_requires_token_by_default(monkeypatch) -> None:
     executor = ModuleExecutor()
-    executor.register("orders", _OrdersHandler())
+    executor.register("orders", _OrdersHandler(), action_method_map=_ORDERS_ACTIONS)
     registry = ExecutorRegistry()
     registry.register(executor)
     monkeypatch.setattr(platform_host, "executor_registry", registry)
@@ -275,7 +293,7 @@ def test_auth_enabled_module_dispatch_requires_token_by_default(monkeypatch) -> 
 
 def test_auth_enabled_public_module_dispatch_allows_anonymous_call(monkeypatch) -> None:
     executor = ModuleExecutor()
-    executor.register("orders", _OrdersHandler())
+    executor.register("orders", _OrdersHandler(), action_method_map=_ORDERS_ACTIONS)
     registry = ExecutorRegistry()
     registry.register(executor)
     monkeypatch.setattr(platform_host, "executor_registry", registry)
@@ -330,6 +348,7 @@ def test_authenticated_module_dispatch_uses_scope_hook_result(monkeypatch) -> No
     executor.register(
         "orders",
         _OrdersHandler(),
+        action_method_map=_ORDERS_ACTIONS,
         action_permissions={"scope": ["orders.scope"]},
     )
     registry = ExecutorRegistry()
@@ -390,6 +409,7 @@ def test_authenticated_module_dispatch_uses_authenticated_user_authority(monkeyp
     executor.register(
         "orders",
         _OrdersHandler(),
+        action_method_map=_ORDERS_ACTIONS,
         action_permissions={"authority": ["orders.read"]},
     )
     registry = ExecutorRegistry()
@@ -420,7 +440,7 @@ def test_authenticated_module_dispatch_uses_authenticated_user_authority(monkeyp
 
 def test_unauthenticated_module_dispatch_ignores_user_id_override(monkeypatch) -> None:
     executor = ModuleExecutor()
-    executor.register("orders", _OrdersHandler())
+    executor.register("orders", _OrdersHandler(), action_method_map=_ORDERS_ACTIONS)
     registry = ExecutorRegistry()
     registry.register(executor)
     monkeypatch.setattr(platform_host, "executor_registry", registry)
@@ -573,7 +593,7 @@ def test_internal_surface_block_applies_regardless_of_auth_enabled(monkeypatch) 
 def test_non_internal_surface_action_is_not_blocked_by_internal_guard(monkeypatch) -> None:
     """Actions without an internal surface must not be affected by the guard."""
     executor = ModuleExecutor()
-    executor.register("orders", _OrdersHandler())
+    executor.register("orders", _OrdersHandler(), action_method_map=_ORDERS_ACTIONS)
     registry = ExecutorRegistry()
     registry.register(executor)
     monkeypatch.setattr(platform_host, "executor_registry", registry)
@@ -585,3 +605,72 @@ def test_non_internal_surface_action_is_not_blocked_by_internal_guard(monkeypatc
     resp = client.get("/api/modules/orders/list")
     # Should reach the executor (200 or 4xx from permission/action checks — NOT 404 from guard)
     assert resp.status_code != 404 or "Action not found" not in resp.json().get("detail", "")
+
+
+# ---------------------------------------------------------------------------
+# Declared-action authority boundary over HTTP dispatch
+# ---------------------------------------------------------------------------
+
+
+class _RealisticBillingHandler:
+    """Realistic generated-module shape: public actions plus reaction/internal methods."""
+
+    async def list_invoices(self, ctx, **kwargs):
+        return {"invoices": []}
+
+    async def apply_manual_credit(self, ctx, **kwargs):
+        return {"applied": True}
+
+    async def on_subscription_activated(self, ctx, **kwargs):
+        return {"reacted": True}
+
+    def _rebuild_cache(self, ctx, **kwargs):
+        return {"rebuilt": True}
+
+
+def _billing_executor() -> ExecutorRegistry:
+    executor = ModuleExecutor()
+    executor.register(
+        "billing",
+        _RealisticBillingHandler(),
+        # Only list_invoices is a declared public action.
+        action_method_map={"list_invoices": "list_invoices"},
+    )
+    registry = ExecutorRegistry()
+    registry.register(executor)
+    return registry
+
+
+@pytest.mark.parametrize(
+    "undeclared_action",
+    ["apply_manual_credit", "on_subscription_activated", "_rebuild_cache", "__init__"],
+)
+def test_http_dispatch_rejects_undeclared_handler_methods(monkeypatch, undeclared_action) -> None:
+    """A handler method that exists in Python but is not declared in the module's
+    action authority must 404 through generic HTTP dispatch — even in the
+    auth-disabled local mode whose authority is trusted_bypass."""
+    monkeypatch.setattr(platform_host, "executor_registry", _billing_executor())
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+
+    client = _client(failed_module_names=[])
+    get_resp = client.get(f"/api/modules/billing/{undeclared_action}")
+    post_resp = client.post(f"/api/modules/billing/{undeclared_action}", json={"params": {}})
+
+    for resp in (get_resp, post_resp):
+        if undeclared_action == "__init__":
+            # rejected even earlier by the action-name pattern or the executor
+            assert resp.status_code in (400, 404)
+        else:
+            assert resp.status_code == 404
+            assert resp.json()["detail"]["error_code"] == "ACTION_NOT_FOUND"
+
+
+def test_http_dispatch_declared_action_still_executes(monkeypatch) -> None:
+    monkeypatch.setattr(platform_host, "executor_registry", _billing_executor())
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+
+    client = _client(failed_module_names=[])
+    resp = client.get("/api/modules/billing/list_invoices")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"invoices": []}

--- a/tests/test_platform_module_dispatch.py
+++ b/tests/test_platform_module_dispatch.py
@@ -574,19 +574,21 @@ def test_internal_surface_action_is_rejected_via_http_post(monkeypatch, surface:
 
 
 def test_internal_surface_block_applies_regardless_of_auth_enabled(monkeypatch) -> None:
-    """The internal-surface guard fires before auth checks — it is independent of AUTH_ENABLED."""
+    """The internal-surface guard fires before route-level auth checks — it is
+    independent of AUTH_ENABLED. (A garbage bearer token is still rejected 401
+    by the auth dependency itself; the invariant is that the internal action is
+    unreachable either way.)"""
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+    monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
 
     client = _client(
         failed_module_names=[],
         action_surfaces={"orders": {"process_settlement": "internal"}},
     )
-    # Even with a valid-looking bearer token the action should be unreachable.
-    resp = client.get(
-        "/api/modules/orders/process_settlement",
-        headers={"Authorization": "Bearer any-token"},
-    )
+    # Anonymous request: the internal-surface 404 fires before the missing-token 401.
+    resp = client.get("/api/modules/orders/process_settlement")
     assert resp.status_code == 404
 
 
@@ -674,3 +676,28 @@ def test_http_dispatch_declared_action_still_executes(monkeypatch) -> None:
 
     assert resp.status_code == 200
     assert resp.json() == {"invoices": []}
+
+
+def test_platform_startup_gate_fails_closed_in_protected_no_auth_env(monkeypatch) -> None:
+    """_platform_startup refuses to boot when the canonical auth resolution
+    rejects no-auth operation in a protected environment (Studio reuses the
+    platform app, so this gate covers the Studio host too)."""
+    import asyncio
+
+    from mozaiksai.core.auth.adapters.base import AuthError
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+
+    for var in (
+        "AUTH_PROVIDER", "SUPABASE_URL", "KEYCLOAK_URL", "KEYCLOAK_REALM",
+        "AUTH_JWKS_URL", "AUTH_ISSUER", "MOZAIKS_OIDC_AUTHORITY",
+        "MOZAIKS_OIDC_DISCOVERY_URL", "ENVIRONMENT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("ENV", "staging")
+    reset_auth_adapter()
+    try:
+        with pytest.raises(AuthError, match="not permitted"):
+            asyncio.run(platform_host._platform_startup())
+    finally:
+        reset_auth_adapter()

--- a/tests/test_runtime_persistence_module_injection.py
+++ b/tests/test_runtime_persistence_module_injection.py
@@ -121,7 +121,7 @@ def test_module_context_construction_without_persistence_remains_valid() -> None
 @pytest.mark.asyncio
 async def test_module_executor_injects_persistence_when_app_id_exists() -> None:
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
@@ -141,7 +141,7 @@ async def test_module_executor_production_path_uses_real_mongo_persistence_conte
     assert module_executor_module.MongoPersistenceContext is MongoPersistenceContext
 
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
@@ -152,7 +152,7 @@ async def test_module_executor_production_path_uses_real_mongo_persistence_conte
 @pytest.mark.asyncio
 async def test_injected_persistence_is_mongo_context_with_current_app_id() -> None:
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_abc", authority=trusted_framework_authority()))
 
@@ -163,7 +163,7 @@ async def test_injected_persistence_is_mongo_context_with_current_app_id() -> No
 @pytest.mark.asyncio
 async def test_user_and_tenant_scope_are_passed_to_persistence() -> None:
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(
         ModuleRequest(
@@ -186,7 +186,7 @@ async def test_user_and_tenant_scope_are_passed_to_persistence() -> None:
 @pytest.mark.asyncio
 async def test_ctx_db_attribute_does_not_exist() -> None:
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
@@ -197,7 +197,7 @@ async def test_ctx_db_attribute_does_not_exist() -> None:
 @pytest.mark.asyncio
 async def test_handler_can_access_ctx_persistence() -> None:
     executor = ModuleExecutor()
-    executor.register("inspect", CaptureContextHandler())
+    executor.register("inspect", CaptureContextHandler(), action_method_map={name: name for name in ("inspect_context", "read_project", "create", "run")})
 
     result = await executor.execute(ModuleRequest(module="inspect", action="inspect_context", app_id="app_1", authority=trusted_framework_authority()))
 
@@ -210,7 +210,7 @@ async def test_handler_can_call_persistence_collection(monkeypatch: pytest.Monke
     fake_client = FakeMongoClient()
     monkeypatch.setattr(mongo_module, "get_mongo_client", lambda: fake_client)
     executor = ModuleExecutor()
-    executor.register("projects", PersistenceUsingHandler())
+    executor.register("projects", PersistenceUsingHandler(), action_method_map={"read_project": "read_project"})
 
     result = await executor.execute(ModuleRequest(module="projects", action="read_project", app_id="app_1", authority=trusted_framework_authority()))
 
@@ -226,7 +226,7 @@ async def test_existing_event_emit_behavior_remains_unchanged() -> None:
         emitted.append((event_type, payload))
 
     executor = ModuleExecutor(event_emitter=capture)
-    executor.register("tasks", EmitHandler())
+    executor.register("tasks", EmitHandler(), action_method_map={"create": "create"})
 
     result = await executor.execute(
         ModuleRequest(module="tasks", action="create", app_id="app_1", user_id="user_1", tenant_id="tenant_1", authority=trusted_framework_authority())
@@ -246,7 +246,7 @@ async def test_event_emit_includes_workspace_when_present() -> None:
         emitted.append((event_type, payload))
 
     executor = ModuleExecutor(event_emitter=capture)
-    executor.register("tasks", EmitHandler())
+    executor.register("tasks", EmitHandler(), action_method_map={"create": "create"})
 
     result = await executor.execute(
         ModuleRequest(
@@ -271,7 +271,7 @@ async def test_event_emit_includes_workspace_when_present() -> None:
 async def test_existing_settings_and_auth_fields_remain_unchanged() -> None:
     settings = [SettingDef(id="max_items", type="integer", default=50)]
     executor = ModuleExecutor()
-    executor.register("tasks", EmitHandler(), settings=settings)
+    executor.register("tasks", EmitHandler(), action_method_map={"create": "create"}, settings=settings)
 
     result = await executor.execute(
         ModuleRequest(module="tasks", action="create", app_id="app_1", auth_token="token_123", authority=trusted_framework_authority())
@@ -285,7 +285,7 @@ async def test_existing_settings_and_auth_fields_remain_unchanged() -> None:
 @pytest.mark.asyncio
 async def test_module_execution_still_works_without_persistence_when_app_id_missing() -> None:
     executor = ModuleExecutor()
-    executor.register("optional", OptionalPersistenceHandler())
+    executor.register("optional", OptionalPersistenceHandler(), action_method_map={"run": "run"})
 
     result = await executor.execute(ModuleRequest(module="optional", action="run", authority=trusted_framework_authority()))
 

--- a/tests/test_runtime_persistence_real_mongo.py
+++ b/tests/test_runtime_persistence_real_mongo.py
@@ -159,7 +159,7 @@ async def test_generated_app_persistence_real_mongo_round_trip(monkeypatch: pyte
         assert "get_mongo_client" not in handler_source
 
         executor = ModuleExecutor()
-        executor.register("projects", RealPersistenceHandler())
+        executor.register("projects", RealPersistenceHandler(), action_method_map={"create_project": "create_project", "list_projects": "list_projects"})
 
         create_result = await executor.execute(
             ModuleRequest(

--- a/tests/test_runtime_schema_validation.py
+++ b/tests/test_runtime_schema_validation.py
@@ -224,7 +224,7 @@ class _Handler:
 async def test_executor_rejects_bad_input_schema_before_handler(schema: Any) -> None:
     handler = _Handler({"value": 1})
     executor = ModuleExecutor()
-    executor.register("probe", handler, action_schemas={"run": {"input": schema}})
+    executor.register("probe", handler, action_method_map={"run": "run"}, action_schemas={"run": {"input": schema}})
     result = await executor.execute(_request(module="probe", action="run"))
     assert result.success is False
     assert result.error_code == "INVALID_PARAMS"
@@ -237,7 +237,7 @@ async def test_executor_rejects_bad_input_schema_before_handler(schema: Any) -> 
 async def test_executor_rejects_bad_output_schema_including_null_results(schema: Any, value: Any) -> None:
     handler = _Handler(value)
     executor = ModuleExecutor()
-    executor.register("probe", handler, action_schemas={"run": {"output": schema}})
+    executor.register("probe", handler, action_method_map={"run": "run"}, action_schemas={"run": {"output": schema}})
     result = await executor.execute(_request(module="probe", action="run"))
     assert handler.calls == 1
     assert result.success is False
@@ -248,7 +248,7 @@ async def test_executor_rejects_bad_output_schema_including_null_results(schema:
 @pytest.mark.asyncio
 async def test_output_value_invalid_policy_remains_warning_only() -> None:
     executor = ModuleExecutor()
-    executor.register("probe", _Handler(None), action_schemas={"run": {"output": {"type": "object"}}})
+    executor.register("probe", _Handler(None), action_method_map={"run": "run"}, action_schemas={"run": {"output": {"type": "object"}}})
     result = await executor.execute(_request(module="probe", action="run"))
     assert result.success is True
     assert result.data is None
@@ -268,7 +268,7 @@ async def test_executor_rejects_bad_event_schema_before_emission(schema: Any) ->
             return {}
 
     executor = ModuleExecutor(event_emitter=emit)
-    executor.register("probe", Handler(), event_payload_schemas={"domain.probe.changed": schema})
+    executor.register("probe", Handler(), action_method_map={"run": "run"}, event_payload_schemas={"domain.probe.changed": schema})
     result = await executor.execute(_request(module="probe", action="run"))
     assert result.success is False
     assert result.error_code == "INVALID_EVENT_PAYLOAD"
@@ -352,13 +352,13 @@ async def test_explicit_empty_schema_never_bypasses_validation_in_any_caller(bou
                 await ctx.emit("domain.probe.changed", {})
 
         executor = ModuleExecutor(event_emitter=emit)
-        executor.register("probe", Handler(), event_payload_schemas={"domain.probe.changed": {}})
+        executor.register("probe", Handler(), action_method_map={"run": "run"}, event_payload_schemas={"domain.probe.changed": {}})
         result = await executor.execute(_request(module="probe", action="run"))
         assert result.error_code == "INVALID_EVENT_PAYLOAD"
         assert emitted == []
     else:
         executor = ModuleExecutor()
-        executor.register("probe", _Handler(), action_schemas={"run": {boundary: {}}})
+        executor.register("probe", _Handler(), action_method_map={"run": "run"}, action_schemas={"run": {boundary: {}}})
         result = await executor.execute(_request(module="probe", action="run"))
         assert result.error_code == ("INVALID_PARAMS" if boundary == "input" else "INVALID_OUTPUT_SCHEMA")
     assert result.success is False

--- a/tests/test_startup_validation.py
+++ b/tests/test_startup_validation.py
@@ -699,7 +699,18 @@ class TestAuthEnabledCheck:
 
 
 class TestAuthProviderCheck:
-    """run_startup_checks warns when auth is not disabled but no provider is configured."""
+    """run_startup_checks fails closed when explicitly enabled auth cannot resolve its provider."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_auth_caches(self):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
 
     def _base_env(self, monkeypatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
@@ -719,23 +730,59 @@ class TestAuthProviderCheck:
         monkeypatch.delenv("MOZAIKS_OIDC_DISCOVERY_URL", raising=False)
 
     @pytest.mark.asyncio
-    async def test_warns_in_production_when_auth_enabled_but_no_provider(self, monkeypatch):
-        """AUTH_ENABLED=true in production with no provider silently falls back to demo mode."""
+    async def test_fatal_in_production_when_auth_enabled_but_no_provider(self, monkeypatch):
+        """AUTH_ENABLED=true with no provider is fatal — no silent demo-mode fallback."""
         self._base_env(monkeypatch)
 
-        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
-
-        assert any("auth provider" in w.lower() for w in warnings)
-        assert any("production" in w.lower() for w in warnings)
+        with pytest.raises(StartupConfigError, match="no authentication provider"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
 
     @pytest.mark.asyncio
-    async def test_no_warning_when_explicit_auth_provider_set(self, monkeypatch):
+    async def test_fatal_when_explicit_provider_set_but_unconfigured(self, monkeypatch):
+        """AUTH_PROVIDER=jwt without JWKS/issuer/discovery config cannot validate tokens → fatal."""
         self._base_env(monkeypatch)
         monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+
+        with pytest.raises(StartupConfigError, match="not fully configured"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_explicit_auth_provider_set_and_configured(self, monkeypatch):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+        monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
 
         assert not any("auth provider" in w.lower() for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_fatal_on_unknown_auth_provider_name(self, monkeypatch):
+        """A typo'd AUTH_PROVIDER value must fail startup, not fall back."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("AUTH_PROVIDER", "supabsae")
+
+        with pytest.raises(StartupConfigError, match="Unknown auth provider"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    async def test_fatal_on_auth_enabled_true_with_provider_none(self, monkeypatch):
+        """AUTH_ENABLED=true + AUTH_PROVIDER=none is a contradiction → fatal."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("AUTH_PROVIDER", "none")
+
+        with pytest.raises(StartupConfigError, match="conflicts"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    async def test_fatal_on_unrecognized_auth_enabled_value(self, monkeypatch):
+        """A typo'd AUTH_ENABLED value must never silently disable auth."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("AUTH_ENABLED", "tru")
+
+        with pytest.raises(StartupConfigError, match="Unrecognized AUTH_ENABLED"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
 
     @pytest.mark.asyncio
     async def test_no_warning_when_supabase_url_configured(self, monkeypatch):
@@ -788,14 +835,33 @@ class TestAuthProviderCheck:
         assert not any("auth provider" in w.lower() for w in warnings)
 
     @pytest.mark.asyncio
-    async def test_no_warning_in_development_without_provider(self, monkeypatch):
-        """Missing provider is expected in dev — no warning outside production."""
+    async def test_fatal_in_development_when_auth_enabled_but_no_provider(self, monkeypatch):
+        """Explicit AUTH_ENABLED=true fails closed in EVERY environment, not just production."""
         self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", "development")
+
+        with pytest.raises(StartupConfigError, match="no authentication provider"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    async def test_fatal_in_staging_when_auth_enabled_but_no_provider(self, monkeypatch):
+        """Staging cannot boot into trusted bypass merely because provider config is missing."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", "staging")
+
+        with pytest.raises(StartupConfigError, match="no authentication provider"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    async def test_demo_mode_boots_when_auth_enabled_unset_and_nothing_configured(self, monkeypatch):
+        """With AUTH_ENABLED unset and no auth env at all, demo mode still boots (dev contract)."""
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("AUTH_ENABLED", raising=False)
         monkeypatch.setenv("ENV", "development")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
 
-        assert not any("auth provider" in w.lower() for w in warnings)
+        assert not any("authentication configuration" in w.lower() for w in warnings)
 
     @pytest.mark.asyncio
     async def test_no_warning_when_auth_explicitly_disabled_and_no_provider(self, monkeypatch):
@@ -810,23 +876,22 @@ class TestAuthProviderCheck:
         assert not any("no auth provider" in w.lower() for w in warnings)
 
     @pytest.mark.asyncio
-    async def test_strict_raises_when_production_auth_enabled_but_no_provider(self, monkeypatch):
+    async def test_strict_mode_also_raises_when_auth_enabled_but_no_provider(self, monkeypatch):
         self._base_env(monkeypatch)
         monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", "strict")
 
-        with pytest.raises(StartupConfigError, match="auth provider"):
+        with pytest.raises(StartupConfigError, match="no authentication provider"):
             await run_startup_checks(_mongo_client=_MockPingClient())
 
     @pytest.mark.asyncio
-    async def test_no_check_when_env_unset(self, monkeypatch):
-        """Check only fires in production — not when ENV is unset."""
+    async def test_fatal_when_env_unset_but_auth_explicitly_enabled(self, monkeypatch):
+        """Fail-closed auth resolution does not depend on ENV at all."""
         self._base_env(monkeypatch)
         monkeypatch.delenv("ENV", raising=False)
         monkeypatch.delenv("ENVIRONMENT", raising=False)
 
-        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
-
-        assert not any("auth provider" in w.lower() for w in warnings)
+        with pytest.raises(StartupConfigError, match="no authentication provider"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_startup_validation.py
+++ b/tests/test_startup_validation.py
@@ -638,19 +638,19 @@ def _configure_valid_jwt_provider(monkeypatch) -> None:
 
 class TestAuthEnabledCheck:
     @pytest.mark.asyncio
-    async def test_warns_when_auth_disabled_in_production(self, monkeypatch):
+    async def test_fatal_when_auth_disabled_in_production(self, monkeypatch):
+        """Explicit no-auth in a protected environment aborts startup — not a warning."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("ENV", "production")
         monkeypatch.setenv("AUTH_ENABLED", "false")
+        monkeypatch.delenv("AUTH_PROVIDER", raising=False)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
 
-        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
-
-        assert any("AUTH_ENABLED" in w for w in warnings)
-        assert any("production" in w.lower() for w in warnings)
+        with pytest.raises(StartupConfigError, match="not permitted in the 'production'"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
 
     @pytest.mark.asyncio
     async def test_no_warning_when_auth_disabled_in_development(self, monkeypatch):
@@ -882,16 +882,13 @@ class TestAuthProviderCheck:
         assert not any("authentication configuration" in w.lower() for w in warnings)
 
     @pytest.mark.asyncio
-    async def test_no_warning_when_auth_explicitly_disabled_and_no_provider(self, monkeypatch):
-        """AUTH_ENABLED=false already caught by the auth_enabled check; provider check skips."""
+    async def test_fatal_when_auth_explicitly_disabled_in_production(self, monkeypatch):
+        """Explicit disable is a development contract only — fatal in protected envs."""
         self._base_env(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "false")
 
-        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
-
-        # auth_enabled fires, auth_provider does not
-        assert any("AUTH_ENABLED" in w for w in warnings)
-        assert not any("no auth provider" in w.lower() for w in warnings)
+        with pytest.raises(StartupConfigError, match="not permitted in the 'production'"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
 
     @pytest.mark.asyncio
     async def test_strict_mode_also_raises_when_auth_enabled_but_no_provider(self, monkeypatch):
@@ -1048,3 +1045,90 @@ class TestRedisConnectivityCheck:
             warnings = await run_startup_checks(_mongo_client=_MockPingClient())
 
         assert any("REDIS_URL" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Protected-environment startup matrix (D2)
+# ---------------------------------------------------------------------------
+
+
+class TestProtectedEnvironmentStartupMatrix:
+    """Staging/production reject every form of no-auth operation at boot,
+    independent of MOZAIKS_STARTUP_CHECKS mode."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_auth_caches(self):
+        from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+        from mozaiksai.core.auth.config import clear_auth_config_cache
+
+        clear_auth_config_cache()
+        reset_auth_adapter()
+        yield
+        clear_auth_config_cache()
+        reset_auth_adapter()
+
+    def _base_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
+        monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
+        for var in (
+            "MOZAIKS_STARTUP_CHECKS",
+            "MOZAIKS_WORKFLOWS_PATH",
+            "AUTH_ENABLED",
+            "AUTH_PROVIDER",
+            "SUPABASE_URL",
+            "KEYCLOAK_URL",
+            "KEYCLOAK_REALM",
+            "AUTH_JWKS_URL",
+            "AUTH_ISSUER",
+            "MOZAIKS_OIDC_AUTHORITY",
+            "MOZAIKS_OIDC_DISCOVERY_URL",
+            "ENV",
+            "ENVIRONMENT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("environment", ["staging", "production"])
+    @pytest.mark.parametrize("startup_mode", ["warn", "strict"])
+    @pytest.mark.parametrize(
+        "no_auth_env",
+        [
+            {"AUTH_ENABLED": "false"},
+            {"AUTH_PROVIDER": "none"},
+            {},  # implicit demo mode
+        ],
+    )
+    async def test_protected_env_no_auth_boot_is_fatal(
+        self, monkeypatch, environment, startup_mode, no_auth_env
+    ):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", environment)
+        monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", startup_mode)
+        for key, value in no_auth_env.items():
+            monkeypatch.setenv(key, value)
+
+        with pytest.raises(StartupConfigError, match="not permitted"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("environment", ["staging", "production"])
+    async def test_protected_env_boots_with_configured_provider(self, monkeypatch, environment):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", environment)
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+
+        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
+        assert not any("authentication configuration" in w.lower() for w in warnings)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("environment", ["development", "test", ""])
+    async def test_dev_and_test_envs_keep_explicit_no_auth_contract(self, monkeypatch, environment):
+        self._base_env(monkeypatch)
+        if environment:
+            monkeypatch.setenv("ENV", environment)
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+
+        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
+        assert not any("authentication configuration" in w.lower() for w in warnings)

--- a/tests/test_startup_validation.py
+++ b/tests/test_startup_validation.py
@@ -618,6 +618,24 @@ class TestUploadStorageDirCheck:
 # ---------------------------------------------------------------------------
 
 
+def _configure_valid_jwt_provider(monkeypatch) -> None:
+    """Give tests that enable auth a fully configured jwt provider.
+
+    AUTH_ENABLED=true now fails closed at startup unless the configured
+    provider can validate tokens, so non-auth-focused checks configure a
+    valid provider explicitly. Caches are cleared so the adapter reads the
+    monkeypatched environment instead of a previously cached AuthConfig.
+    """
+    from mozaiksai.core.auth.adapters.registry import reset_auth_adapter
+    from mozaiksai.core.auth.config import clear_auth_config_cache
+
+    monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+    monkeypatch.setenv("AUTH_JWKS_URL", "https://example.com/.well-known/jwks.json")
+    monkeypatch.setenv("AUTH_ISSUER", "https://example.com")
+    clear_auth_config_cache()
+    reset_auth_adapter()
+
+
 class TestAuthEnabledCheck:
     @pytest.mark.asyncio
     async def test_warns_when_auth_disabled_in_production(self, monkeypatch):
@@ -656,7 +674,7 @@ class TestAuthEnabledCheck:
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("ENV", "production")
         monkeypatch.setenv("AUTH_ENABLED", "true")
-        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        _configure_valid_jwt_provider(monkeypatch)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
 
@@ -907,7 +925,7 @@ class TestRateLimitEnabledCheck:
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("AUTH_ENABLED", "true")
-        monkeypatch.setenv("AUTH_PROVIDER", "jwt")
+        _configure_valid_jwt_provider(monkeypatch)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
         monkeypatch.delenv("REDIS_URL", raising=False)
@@ -966,6 +984,7 @@ class TestRedisConnectivityCheck:
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("AUTH_ENABLED", "true")
+        _configure_valid_jwt_provider(monkeypatch)
         monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
         monkeypatch.delenv("ENV", raising=False)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)

--- a/tests/test_startup_validation.py
+++ b/tests/test_startup_validation.py
@@ -618,6 +618,16 @@ class TestUploadStorageDirCheck:
 # ---------------------------------------------------------------------------
 
 
+def _isolate_environment_declaration(monkeypatch) -> None:
+    """Clear ENVIRONMENT so a test's explicit ENV is the only declaration.
+
+    ENV and ENVIRONMENT must agree; a developer .env commonly sets
+    ENVIRONMENT=development, which would conflict with a test declaring
+    ENV=production and (correctly) fail configuration.
+    """
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+
 def _configure_valid_jwt_provider(monkeypatch) -> None:
     """Give tests that enable auth a fully configured jwt provider.
 
@@ -644,6 +654,7 @@ class TestAuthEnabledCheck:
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "false")
         monkeypatch.delenv("AUTH_PROVIDER", raising=False)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
@@ -659,6 +670,7 @@ class TestAuthEnabledCheck:
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("ENV", "development")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "false")
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
@@ -673,6 +685,7 @@ class TestAuthEnabledCheck:
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "true")
         _configure_valid_jwt_provider(monkeypatch)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
@@ -687,6 +700,7 @@ class TestAuthEnabledCheck:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017")
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "false")
         monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", "strict")
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
@@ -736,6 +750,7 @@ class TestAuthProviderCheck:
         monkeypatch.setenv("INTERNAL_API_KEY", "test-startup-api-key-long-enough")
         monkeypatch.setenv("AUTH_ENABLED", "true")
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.delenv("MOZAIKS_STARTUP_CHECKS", raising=False)
         monkeypatch.delenv("MOZAIKS_WORKFLOWS_PATH", raising=False)
         monkeypatch.delenv("AUTH_PROVIDER", raising=False)
@@ -857,6 +872,7 @@ class TestAuthProviderCheck:
         """Explicit AUTH_ENABLED=true fails closed in EVERY environment, not just production."""
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "development")
+        _isolate_environment_declaration(monkeypatch)
 
         with pytest.raises(StartupConfigError, match="no authentication provider"):
             await run_startup_checks(_mongo_client=_MockPingClient())
@@ -866,6 +882,7 @@ class TestAuthProviderCheck:
         """Staging cannot boot into trusted bypass merely because provider config is missing."""
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "staging")
+        _isolate_environment_declaration(monkeypatch)
 
         with pytest.raises(StartupConfigError, match="no authentication provider"):
             await run_startup_checks(_mongo_client=_MockPingClient())
@@ -876,6 +893,7 @@ class TestAuthProviderCheck:
         self._base_env(monkeypatch)
         monkeypatch.delenv("AUTH_ENABLED", raising=False)
         monkeypatch.setenv("ENV", "development")
+        _isolate_environment_declaration(monkeypatch)
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
 
@@ -931,6 +949,7 @@ class TestRateLimitEnabledCheck:
     async def test_warns_when_rate_limit_disabled_in_production(self, monkeypatch):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
@@ -941,6 +960,7 @@ class TestRateLimitEnabledCheck:
     async def test_no_warning_when_rate_limit_disabled_in_dev(self, monkeypatch):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "development")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
@@ -951,6 +971,7 @@ class TestRateLimitEnabledCheck:
     async def test_no_warning_when_rate_limit_enabled_in_production(self, monkeypatch):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())
@@ -961,6 +982,7 @@ class TestRateLimitEnabledCheck:
     async def test_strict_raises_when_rate_limit_disabled_in_production(self, monkeypatch):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", "production")
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
         monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", "strict")
 
@@ -1104,6 +1126,7 @@ class TestProtectedEnvironmentStartupMatrix:
     ):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", environment)
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", startup_mode)
         for key, value in no_auth_env.items():
             monkeypatch.setenv(key, value)
@@ -1116,6 +1139,7 @@ class TestProtectedEnvironmentStartupMatrix:
     async def test_protected_env_boots_with_configured_provider(self, monkeypatch, environment):
         self._base_env(monkeypatch)
         monkeypatch.setenv("ENV", environment)
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "true")
         monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
 
@@ -1123,11 +1147,77 @@ class TestProtectedEnvironmentStartupMatrix:
         assert not any("authentication configuration" in w.lower() for w in warnings)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "environment",
+        ["staging-us", "prod-us", "production-east", "preview", "qa", "customer-prod"],
+    )
+    @pytest.mark.parametrize("startup_mode", ["warn", "strict"])
+    @pytest.mark.parametrize(
+        "no_auth_env",
+        [
+            {"AUTH_ENABLED": "false"},
+            {"AUTH_PROVIDER": "none"},
+            {},
+        ],
+    )
+    async def test_unknown_env_no_auth_boot_is_fatal(
+        self, monkeypatch, environment, startup_mode, no_auth_env
+    ):
+        """Regional/custom environment names never inherit development privilege."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", environment)
+        monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", startup_mode)
+        for key, value in no_auth_env.items():
+            monkeypatch.setenv(key, value)
+
+        with pytest.raises(StartupConfigError, match="not permitted"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("environment", ["staging-us", "prod-us", "preview"])
+    async def test_unknown_env_boots_with_configured_provider(self, monkeypatch, environment):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", environment)
+        monkeypatch.setenv("AUTH_ENABLED", "true")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+
+        warnings = await run_startup_checks(_mongo_client=_MockPingClient())
+        assert not any("authentication configuration" in w.lower() for w in warnings)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("startup_mode", ["warn", "strict"])
+    async def test_conflicting_env_declarations_are_fatal(self, monkeypatch, startup_mode):
+        """ENV and ENVIRONMENT disagreeing is a fatal configuration error."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("MOZAIKS_STARTUP_CHECKS", startup_mode)
+        monkeypatch.setenv("ENV", "development")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+
+        with pytest.raises(StartupConfigError, match="Conflicting"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("deployed", ["production", "staging"])
+    async def test_blank_env_does_not_mask_deployed_environment_at_startup(
+        self, monkeypatch, deployed
+    ):
+        """A blank ENV must not let a deployed ENVIRONMENT boot unauthenticated."""
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("ENV", "   ")
+        monkeypatch.setenv("ENVIRONMENT", deployed)
+        monkeypatch.setenv("AUTH_ENABLED", "false")
+
+        with pytest.raises(StartupConfigError, match="not permitted"):
+            await run_startup_checks(_mongo_client=_MockPingClient())
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("environment", ["development", "test", ""])
     async def test_dev_and_test_envs_keep_explicit_no_auth_contract(self, monkeypatch, environment):
         self._base_env(monkeypatch)
         if environment:
             monkeypatch.setenv("ENV", environment)
+        _isolate_environment_declaration(monkeypatch)
         monkeypatch.setenv("AUTH_ENABLED", "false")
 
         warnings = await run_startup_checks(_mongo_client=_MockPingClient())


### PR DESCRIPTION
## Summary

Closes the three fail-open security boundaries identified by the 2026-09-08 production-readiness audit. This is a security boundary correction only — no new product surface, no changes to PR #494 / ImplementationBinding v2 / CompilationPlan / schema assignability.

### 1. Undeclared module action dispatch (fail-open → fail-closed)

**Root cause (audit confirmed exactly):** `ModuleExecutor.execute` resolved the handler method with `self._action_methods.get(module, {}).get(action, action)` — falling back to the raw request action string — then dispatched via `getattr(handler, name)`. An undeclared action also had an empty required-permission list, so it sailed through the permission check. Any Python method on a handler (event-reaction handlers, helpers, methods on richly-shaped handlers) was HTTP-dispatchable by name through `/api/modules/{module}/{action}`.

**Fix (central authority boundary, not per-handler guards):** the registered `action_method_map` (mirroring `module.yaml` `actions[]`) is now the *sole* dispatch authority. Undeclared action ids fail closed with `ACTION_NOT_FOUND` before any handler attribute is resolved — for trusted-bypass and enforce-mode authorities alike. Undeclared attempts that match an existing handler attribute emit a denied dispatch audit. A declared action whose mapped method is missing or non-callable also fails closed. The response is indistinguishable from a nonexistent action (no existence oracle).

Supporting boundaries verified unchanged and safe: the event router dispatches reactions from contract-declared `handler_method` targets validated at registration (not via the executor fallback); page schemas validate actions against the declared map at load; `ModuleLoader` fails module load when a declared `handler_method` is absent on the handler class.

### 2. Authentication configuration (silent demo fallback → fatal)

**Root cause (audit confirmed):** `_auto_detect_provider()` returned `"none"` (trusted-bypass) when `AUTH_ENABLED=true` but no provider env was resolvable — only a log warning, and the startup check fired only under `ENV=production` + `MOZAIKS_STARTUP_CHECKS=strict`.

**Fix:** when auth is *explicitly* enabled:
- no resolvable provider → fatal (`AuthError` at resolution; `StartupConfigError` at boot) in **every** environment and **every** startup-check mode — not gated on `ENV=production` or strict mode
- `AUTH_PROVIDER=none` + `AUTH_ENABLED=true` → fatal conflict
- unknown `AUTH_PROVIDER` value (typo) → fatal
- named provider whose config cannot validate tokens (e.g. `AUTH_PROVIDER=jwt` with no JWKS/issuer/discovery) → fatal
- unrecognized `AUTH_ENABLED` value (e.g. `tru`) → fatal instead of silently disabling auth (a second fail-open found during verification)

New canonical helper `validate_auth_provider_configuration()` is called by `run_startup_checks()` (runtime host) **and** `_platform_startup()` (platform host — which previously ran no auth startup validation at all; Studio reuses the platform app, so it is covered too). Request-path resolution (`is_auth_enabled`, `get_auth_adapter`) raises in the same misconfigured states, so a host that somehow skipped boot validation still fails closed per request.

Preserved dev contracts: `AUTH_ENABLED=false` explicit disable; explicit `AUTH_PROVIDER=none`; implicit demo mode (no auth configuration at all) still boots for getting-started use. Dev intent is never inferred from provider misconfiguration.

### 3. Fulfillment ingress (`/api/billing/fulfillment/apply`)

**Root cause (audit confirmed):** `_authorize_fulfillment` allowed anonymous callers whenever `not is_auth_enabled() and not INTERNAL_API_KEY` — so implicit demo mode (or, pre-fix, silently-degraded auth) with a missing internal key made fulfillment (wallet credits, entitlement assignment) fully unauthenticated.

**Fix:** the anonymous path now requires `is_auth_explicitly_disabled()` — an explicit operator declaration (`AUTH_ENABLED=false` or `AUTH_PROVIDER=none`), never mere absence of configuration. The per-app/internal-key architecture is untouched; key provisioning remains the hosted-product slice. The fulfillment admin listing shares the same gate.

## Accidental undeclared-action dependencies

Inventory: a scan of every first-party (`factory_app/app/modules`) and example module found **zero** companion-contract (`profile.yaml`/`admin.yaml`/`relationships.yaml`) references to undeclared actions, and loader/page validation already pins declared actions. The only consumers of the removed fallback were **test fixtures** registering handlers without `action_method_map`; all were migrated to explicit declarations (the fallback was not restored anywhere).

## Adversarial tests added

- executor: undeclared-but-existing method (trusted + enforce), alias works / alias target name not dispatchable, reaction method unreachable as action, private/dunder/non-callable attributes, case variants, empty map = no dispatchable actions, permission-map-only entry grants nothing, declared-but-missing method
- HTTP router: undeclared handler methods 404 via GET+POST even in auth-disabled trusted-local mode; declared action still executes
- registry/startup: enabled-without-provider fatal (dev/staging/prod/ENV-unset, warn and strict modes), provider typo fatal, `AUTH_PROVIDER=none` conflict fatal, `AUTH_ENABLED` typo fatal, configured providers resolve, demo mode boots, `is_auth_enabled` raises (never returns false) when misconfigured
- fulfillment ingress: implicit demo mode → 403 (apply + listing), explicit disable → dev path works, key configured → anonymous closed / wrong key 401 / right key 200, auth-enabled + key path works

## Out of scope (explicitly)

- Per-app internal-key provisioning pipeline (hosted-product fulfillment completion slice)
- mozaiks-app OSS pin bump (after this merges)
- PR #494 semantics lane, ImplementationBinding v2, schema assignability, CompilationPlan — untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Correction round 1 (head `59093409`) — Astra D1–D5 addressed

Astra's exact-head review of `e5ce1fd6` returned MATERIAL DEFECT with five bounded implementation defects; the architecture disposition was sound and is preserved (no raw-method fallback restored, declared-action authority / enabled-auth-requires-provider / affirmative fulfillment authority unchanged).

- **D1** — the undeclared-action denial path no longer touches the handler object at all (no `getattr`/`hasattr`; hostile properties/descriptors/`__getattr__` cannot execute). Denial is byte-identical whether or not a same-named attribute exists; denied audits/logs carry a bounded, sanitized action string. Weaponized-handler tests instrument every lookup channel and prove zero executions.
- **D2** — one canonical protected-environment policy (`mozaiksai/core/environment.py`, consumed inside `resolve_auth_config`): staging/production (incl. `stage`/`prod`) reject **all** no-auth operation — explicit `AUTH_ENABLED=false`, explicit `AUTH_PROVIDER=none`, and implicit demo — at resolution itself, so runtime startup, the platform/Studio boot gate, per-request predicates, and the fulfillment route all fail closed independent of `MOZAIKS_STARTUP_CHECKS`. Dev/test keep the existing explicit no-auth contract; the superseded production-only warn checks were removed from startup validation.
- **D3** — `UserPrincipal.auth_provenance` (`token_validated` minted at exactly one site — real bearer-token validation by the configured adapter; `anonymous`/`dev_override` otherwise) with `is_authenticated`; the fulfillment privileged branch now requires authenticated provenance before roles/scopes. Dev personas with admin-looking roles/scopes are denied at that branch; the local-dev exception is a separate branch under the D2 policy.
- **D4** — `resolve_auth_config()` is the single parser of auth-mode env vars, returning an immutable `ResolvedAuthConfig` whose invariants make `is_auth_enabled()`/`is_auth_explicitly_disabled()` contradictions structurally impossible. Explicit contradictions (`true`+`none`, `false`+real explicit provider) and malformed `AUTH_ENABLED` values reject; an explicit disable still wins over *passive* provider signals (e.g. a `SUPABASE_URL` left in a dev `.env`) per the existing OSS dev contract, now documented.
- **D5** — the adapter singleton is keyed by a fingerprint of every auth-relevant env var; any change discards the stale adapter and rebuilds coherently (AuthConfig value cache cleared first). Startup validation binds the validated adapter into that cache. Astra's exact sequence (none cached → JWT configured → startup validates → requests use JWT) plus provider A→B, valid→malformed, malformed→valid, repeated-init, and stale-`none`-survival attacks are all tested.

Full matrix re-run on the corrected head: dispatch/descriptor attacks, environment × startup-mode × config matrix, fulfillment provenance/environment matrix, D5 transitions — plus the complete suite (15,797 passed / 93 skipped / 0 failed locally).



---

## Correction round 2 (restacked head `f25ce6f6`, base `2cf0fbf6`) — Astra D2/D5 closed

Astra's review of `59093409` closed **D1** (undeclared-handler interaction), **D3** (authenticated provenance), and **D4** (contradictory predicates for stable configuration), and reported two remaining material defects. Both are corrected; the branch is restacked onto current `origin/main` (`2cf0fbf6`, dependency/CI-only commits, rebase clean with no conflicts).

### D2 — environment classification is now fail-closed by allowlist

The security decision is reversed. Unauthenticated operation is permitted **only** in a finite set of repository-canonical local environments — `development`, `local`, `test` (with `dev` normalizing to `development`) — or with no environment configured at all. The allowlist comes from a census of the repo's own vocabulary: `.env.example` (both variables), the runtime/observability host defaults, the Studio workspace summary default, and `ENV: test` in `.github/workflows/ci.yml` and `release.yml`.

Everything else refuses no-auth, fatally, at every mandatory boundary and in every startup-check mode: known deployments (`production`/`staging` and the `prod`/`stage` aliases) **and** unknown or regional names — `staging-us`, `prod-us`, `production-east`, `preview`, `qa`, `customer-prod`, and arbitrary custom values — which previously inherited development privilege by default. An unknown environment still boots normally *with* authentication configured; only the no-auth inheritance is removed.

`ENV`/`ENVIRONMENT` resolution is canonical in one place (`mozaiksai/core/environment.py`): values are trimmed first so blank means absent (a blank `ENV` can no longer mask a deployed `ENVIRONMENT`), aliases normalize before comparison, and two non-blank values that semantically conflict — different classes, or two distinct deployed environments — are a fatal configuration error rather than a silent pick. Two *different* names inside the recognized local class are accepted, since they carry identical security meaning; this is the real CI case (`ENV=test` beside a developer `.env`'s `ENVIRONMENT=development`) and matches the review's rule that same-class agreement is fine.

Consumed by: startup validation, the platform/Studio boot gate, request-time auth resolution, module dispatch authority (`local_development`), and the fulfillment ingress.

### D5 — cache identity now equals adapter-construction identity

`resolve_auth_config()` captures one immutable snapshot of the complete auth-configuration census (36 variables, enumerated from the source); the provider-specific constructor consumes **that** snapshot — adapters read configuration through `BaseAuthAdapter._setting` instead of live `os.environ` — and the fingerprint derives from that same snapshot restricted to the resolved provider's declared inputs. Fingerprint and constructor can no longer describe different configurations.

That closes the same-provider staleness hole for: JWT issuer, JWKS URL, discovery settings, audience, every claim mapping (user/email/name/roles/scopes/app/chat/tenant/workspace), scope format, algorithms, clock skew, and JWKS/discovery cache TTLs; Keycloak client id and app/tenant/workspace claim mappings; the Supabase secret; and the no-auth anonymous persona (`AUTH_ANON_USER_ID/EMAIL/ROLES/SCOPES`).

**Custom providers** get a truthful bounded contract: `register_adapter(..., config_identity=...)` (string or callable) participates in cache identity, and an adapter registered *without* one is never cached — rebuilt on every resolution — so changed custom configuration can never reuse an adapter validated under an older one. Re-registration also invalidates. The cache is a single immutable record (fingerprint + provider + adapter) published in one assignment, so a request can never observe a mismatched combination.

All 16 mandatory D5 probes and the full D2 attack matrix pass with **no cache-reset helper** involved in any pass.

### Also in this round

A latent defect found while wiring the snapshot (absent variables stored as `""` shadowed adapter defaults) was fixed by making absent and empty equivalent, matching how the rest of the auth configuration treats blank variables. Two suites referencing the removed `_adapter_instance` global and several fixtures that declared one environment variable while a developer `.env` supplied a conflicting other were migrated.

Full suite on the corrected tree: **15,974 passed / 93 skipped / 0 failed**.



---

## Correction round 3 (restacked head `919e3431`, base `c0188f08`) — Astra D5-A/B/C closed

Astra's review of `f25ce6f6` closed **D1, D2, D3 and D4**, leaving two material defects inside D5. Both are corrected; the branch is restacked onto current `origin/main` (`c0188f08`, #496 — no auth/dispatch overlap; the only shared file is `CHANGELOG.md`, where both entries are preserved).

### D5-A — the lazy dependency chain is now snapshot-bound

Census of every lazy object reachable from an adapter found four escapes, not the two reported:

1. `OIDCDiscoveryClient` gave `MOZAIKS_OIDC_DISCOVERY_URL` **higher priority than the explicit constructor URL**
2. it re-read `AUTH_DISCOVERY_CACHE_TTL` from live environment
3. `JWKSClient` read global `AuthConfig` for both the JWKS URL override and the cache TTL
4. `JWKSClient` resolved `jwks_uri` through the **process-wide discovery singleton**, not the adapter's own client

`JWTAdapterConfig` now carries both cache TTLs, and the adapter constructs its discovery and JWKS clients from that config with `consult_environment=False`, injecting its own discovery client. Both client constructors treat explicit caller input as authoritative and never let live environment or global `AuthConfig` override it; the pre-existing test asserting env-precedence-over-constructor-input is updated to this contract, as the review directed. Keycloak and Supabase already derived their lazy `PyJWKClient` from constructor state and are covered by regression tests.

The mandatory race proof passes: an adapter built under discovery URL A / JWKS A / TTL 31, whose lazy clients are instantiated for the **first time** after the live environment moved to B / TTL 47, still uses A and 31 — and a subsequent resolution builds a separate adapter on B / 47 while the old one stays internally consistent. No cache reset is involved.

### D5-A — TTL validation

`AUTH_JWKS_CACHE_TTL` and `AUTH_DISCOVERY_CACHE_TTL` are parsed by a shared validator during canonical configuration resolution. Valid domain, per the cache semantics (`now > fetched_at + ttl`): a base-10 integer, zero or greater, where `0` means always refetch. Non-integer and negative values are rejected, not coerced, so malformed TTLs fail startup in **both** check modes instead of surfacing during lazy client construction on a request path. `AuthConfig` uses the same validator.

### D5-B — constructor contract

Settings-argument support is now determined by signature inspection **at registration** and recorded on the registration record. The `try settings / catch TypeError / retry without settings` path is deleted outright: any exception raised inside a constructor body — `TypeError` included — propagates as `AuthError`. A defective adapter can no longer be silently rebuilt without its canonical configuration and reported as a successful startup. Tests cover settings-aware, legacy no-settings, body-`TypeError`, body-`ValueError`, malformed-signature, `**kwargs`, and all four built-ins.

### D5-C — custom identity contract

`config_identity` is validated strictly instead of string-coerced. Literals are checked at registration; callable results at each resolution. Non-string values, empty or whitespace-only strings, and callables that raise all fail closed with `AuthError` — none of them truthfully identifies a configured revision. Providers can still opt out of caching by supplying no identity, which keeps the previous safe policy.

### Snapshot-consumption census

Proved for every built-in that captured values are the values consumed downstream: JWT/OIDC (URLs, audience, all claim mappings, clock skew, both TTLs), Keycloak (URL, realm, client id, all three claim mappings, derived issuer/JWKS URLs — programmatic, no admin console), Supabase (URL, secret, derived issuer), and no-auth (all four anonymous-persona settings). Each also asserts that mutating the environment afterwards does not mutate the existing adapter.

### D1–D4 regression

Reproved without touching their architecture: undeclared-action rejection never touches handler attributes/descriptors/`__getattr__`; the finite local-environment allowlist still rejects deployed and unknown environments in both startup modes; only validated bearer-token provenance qualifies as authenticated authority; the canonical auth state can never be both enabled and explicitly disabled. Fulfillment matrix verified per-process: correct key 200, wrong key 401, authenticated admin/scope 200, authenticated unprivileged 403, anonymous-with-admin-roles 403, dev persona 403, and no-auth fulfillment impossible in staging/production/unknown environments.

Full suite on the restacked tree: **16,063 passed / 93 skipped / 0 failed**. CI mypy over `mozaiksai/` + `factory_app/`: clean (602 files).



---

## Correction round 4 (head `6274f0f2`, base `c0188f08`) — Astra D5-1/2/3 closed

Astra's review of `919e3431` closed D1–D4 and independently confirmed the lazy discovery/JWKS snapshot correction, Keycloak binding, and `config_identity` type validation. Three bounded items remained; all are corrected. Main is unchanged at `c0188f08`, and the branch already sits on it — no restack was needed.

### D5-1 — constructor compatibility is now positively established

Registration classifies every constructor into an explicit mode rather than answering a boolean:

| Constructor shape | Classification |
|---|---|
| `settings` as normal/keyword-only parameter | `settings_keyword` → snapshot supplied |
| `**kwargs` | `settings_keyword` → snapshot supplied |
| no `settings`, all other parameters optional | `no_settings` → built with no arguments |
| `settings` **positional-only** | **rejected at registration** |
| required parameter the runtime cannot supply | **rejected at registration** |
| signature cannot be inspected | **rejected at registration** |

Neither "could not inspect" nor "no `settings` keyword found" can any longer produce a construction without the canonical snapshot. For constructors that genuinely cannot be inspected, `register_adapter(..., constructor_mode="settings_keyword"|"no_settings")` lets the registrant state the contract explicitly instead of the registry guessing. Construction still never infers anything from a caught exception, so a body-raised `TypeError` or `ValueError` fails closed after exactly one invocation.

### D5-2 — TTL arithmetic is valid for every accepted TTL

Confirmed the defect first: the parser accepted `10**400`, startup succeeded, and `fetched_at + ttl` then raised `OverflowError: int too large to convert to float` during real cache use. Both caches now compare **elapsed** time against the TTL through a shared helper, preserving the exact boundary semantics (`now > fetched_at + ttl` ⇔ `now - fetched_at > ttl`) while never converting the TTL through a float. Proven for 0, 1, 31, 3600, 86400, 2⁶³, 10³⁰, 10⁴⁰⁰ and 10¹⁰⁰⁰ — accepted at startup *and* exercised in both cache entry types — with a regression witness pinning that the old formulation overflowed on a value the parser accepts.

### D5-3 — blank values normalize once, consistently

Confirmed the defect: whitespace-only TTL passed canonical resolution (defaulted) but `JWTAdapterConfig` rejected it. A single canonical resolver in `mozaiksai/core/auth/cache_ttl.py` now owns the defaults and is used by canonical resolution, `JWTAdapterConfig`, and `AuthConfig`, so absent / empty / whitespace-only all mean the same thing everywhere. **Defaults kept as the repository establishes them — JWKS 3600 (keys rotate), discovery 86400 (documents rarely change)** — which is the inverse of the pair quoted in the review request; the review allowed for this ("unless repository source establishes different defaults"), and the clients' own documentation and prior constants are the source. `0` stays `0` at every layer and is never coerced by truthiness.

### Newly found (pre-existing) defect

Probing surfaced a latent registration bug: built-in adapter registration was gated on the *whole registry* being empty, so a custom adapter registered before the first auth resolution suppressed every built-in provider (`Unknown auth provider: jwt`). Present at this PR's original base `8420fe62`, so it predates the branch. Registration is now per-provider and idempotent, and an intentional override of a built-in name is preserved. Two regression tests added.

A source-hygiene gate also flagged the word "legacy" in the new constructor vocabulary (the repo's pre-production policy forbids it); the mode is named `no_settings` and the wording adjusted.

### Reproved

Lazy snapshot ownership (A/31 preserved on the old adapter after the environment moves to B/47; new resolution gets B/47), Keycloak captured values surviving mutation including the derived issuer and lazily-built JWKS URI, `config_identity` strictness across invalid types/blank/raising-callable/absent, and D1–D4 in full.

Full suite: **16,159 passed / 93 skipped / 0 failed**. CI-equivalent mypy: clean (602 files).



---

## Correction round 5 (head `ce1b09fd`, base `c0188f08`) — constructor signature binding

Codex's review of `6274f0f2` passed the entire acceptance boundary except one bounded defect, corrected here. Main is unchanged at `c0188f08`, so the branch was not restacked.

**The defect.** The classifier recognized a usable `settings=` parameter (or `**kwargs`) and returned `settings_keyword` immediately, so constructors the runtime cannot actually invoke could still register:

```python
def adapter(settings, required): ...
def adapter(settings, *, required): ...
def adapter(required, **kwargs): ...
def adapter(settings, one, two): ...
```

Startup rejected them later, before any body ran — fail-closed, but registration had not positively established the complete invocation contract.

**The fix.** Registration now asks Python's own binding machinery whether the exact call the runtime performs would succeed against the *complete* signature: `signature.bind(settings=<probe>)` for `settings_keyword`, `signature.bind()` for `no_settings`. Recognizing a `settings` parameter only selects *which* invocation to verify; only a successful bind accepts the mode. The registry no longer reasons about parameter kinds to decide invocability, so there is a single source of truth.

| Constructor | Result |
|---|---|
| `(settings)`, `(*, settings)`, `(settings=None, optional=None)`, `(**kwargs)` | accepted → `settings_keyword` |
| `()`, all-optional, `(*args)` | accepted → `no_settings` |
| `(settings, required)`, `(settings, *, required)`, `(required, **kwargs)`, `(settings, one, two)` | **rejected at registration** |
| positional-only `settings` | **rejected** (preserved) |
| uninspectable without declaration | **rejected** (preserved) |

**Explicit mode.** Still the escape hatch for genuinely uninspectable callables — but when the signature *is* inspectable, the declaration is verified against it, so explicit metadata cannot claim an invocation that provably would not bind.

**Preserved unchanged:** constructor-body `TypeError`/`ValueError` → exactly one invocation → `AuthError`, never a settings-free retry, and no inference of mode from a caught exception.

Adds the exact demonstrated cases as regression tests plus a binding truth table over thirteen signature shapes, and reproves that all four built-in providers classify, bind, and resolve.

Focused: 820 passed (registry/adapters/JWT/Keycloak/Supabase/no-auth/TTL/startup/fulfillment/hygiene) and 215 passed (D1–D4 dispatch/authority/route-auth). Full suite: **16,198 passed / 93 skipped / 0 failed**. `ruff`, `git diff --check`, and CI-equivalent mypy (602 files) all clean.
