### PR TITLE
feat(billing): fence stale entitlement revisions at fulfillment commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,63 @@ This project follows a practical pre-1.0 changelog format:
   environments reject outright). Auth being merely unconfigured no longer
   makes the ingress callable without authentication.
 
+### Added
+
+- **Billing fulfillment revision fencing**: `BillingFulfillmentCommand` accepts
+  an optional `subject_revision` — a provider-neutral, monotonically increasing
+  ordinal that the upstream billing source allocates per entitlement subject
+  when it commits a canonical revision. Subscription effects now commit only
+  when the incoming revision is strictly newer than the one already stored for
+  that subject, compared atomically on the assignment document at write time.
+  An out-of-order command (an older HTTP request that completes after a newer
+  one has already been applied) is suppressed rather than regressing
+  entitlement state: its assignment and plan-allowance effects are `skipped`
+  with reason `stale_revision`, and the result carries the new terminal status
+  `superseded` so the sender can settle it without retrying. The last committed
+  revision is stored in the assignment document under the new
+  `assignment_store.revision_field` (`billing_revision`, or null to opt out —
+  the field is a fixed authority name, not a customization point). Plan token
+  allowances are fenced at their own commit too: the ledger accepts an opaque
+  `subject_key`/`subject_revision` pair and folds the ordering predicate into
+  the same single-document update that changes the balance, so a stale command
+  cannot mint tokens even if it was already mid-flight when a newer revision
+  committed, and the wallet-side ordering head advances for every accepted
+  revision — including cancellations, zero-allowance plans, and revisions that
+  reuse an existing period allocation — so "latest accepted revision" is what
+  fences a delayed older allowance, not "revision that last minted tokens".
+  That ordering authority is claimed on every applicable wallet *before* the
+  assignment commits: a revision only becomes the newly authoritative one once
+  no wallet its subject can reach still admits an older revision, and a wallet
+  that reports a newer revision means the command was overtaken, so nothing
+  applies. A head write that *fails* is not a decline: it propagates, nothing
+  applies, and — because that failure provably precedes every effect — the
+  durable command reservation is released so the identical command can be
+  retried instead of being refused as permanently pending. Wallet heads already
+  claimed are never reversed; the retry finds them equal and proceeds.
+  A wallet balance only ever moves under a reservation the invocation has
+  positively acquired: a pending reservation is taken by compare-and-swap on
+  exactly the reservation fields the stored document actually carries —
+  including their absence, so an entry written before reservations were
+  tracked is still adoptable and a movement that already committed stays
+  recoverable — and a lost swap means re-reading and reacquiring rather than
+  writing anyway. A newer, entitled revision may adopt
+  a reservation a stale attempt left behind, and rollback then only ever
+  deletes a reservation the rolling-back attempt still owns.
+  Fencing is one decision for the whole command: an app that sets
+  `revision_field: null` gets prior behavior from both the assignment and the
+  wallet. Enabling fencing requires one assignment row per entitlement subject,
+  enforced by a unique index over the configured subject paths — a store that
+  already carries an equivalent unique index provides that guarantee under
+  whatever name it uses and is accepted as is; pre-existing duplicate subjects
+  fail closed with an actionable error rather than being silently resolved. `billing_revision` is reserved — no other assignment
+  mapping may target it — and a command whose remaining effects are invalidated
+  by a newer revision reports `superseded` even when an earlier effect applied.
+  A replayed command reports `original_status`, preserving whether it
+  originally applied, was rejected, or was superseded. Commands that
+  omit `subject_revision` are applied unfenced exactly as before and keep their
+  pre-existing durable command identity, so upgrading cannot turn a previously
+  completed command into a content conflict.
+
 ### Fixed
 
 - Live workflow smoke checks now read canonical AG2 run events and wait for

--- a/docs/architecture/mozaiksai/cash-to-token-loop-0-1-10.md
+++ b/docs/architecture/mozaiksai/cash-to-token-loop-0-1-10.md
@@ -176,6 +176,7 @@ class BillingFulfillmentCommand(BaseModel):
     ]
     plan_id: str | None = None
     status: str | None = None
+    subject_revision: int | None = None  # monotonic per entitlement subject
     token_wallet_id: str = "ai_tokens"
     token_amount: int | None = None
     occurred_at: datetime | None = None
@@ -186,6 +187,9 @@ class BillingFulfillmentCommand(BaseModel):
 Rules:
 
 - `command_id` is the idempotency key across all fulfillment effects.
+- `subject_revision` is the optional *ordering* authority, and is orthogonal to
+  `command_id`: idempotency answers "have I already applied this command?",
+  ordering answers "is this command still the newest truth for this subject?".
 - Metadata must use the existing token wallet safe-metadata policy: no secrets,
   raw credentials, API keys, bearer tokens, private keys, customer payment
   identifiers, or checkout session secrets.
@@ -217,6 +221,169 @@ For `subscription_cancelled`:
 - Do not delete the record.
 - Effective entitlement behavior falls back through
   `ConfiguredEntitlementAdapter.current_plan_id()` to the default plan.
+
+### Revision Fencing
+
+Fulfillment is delivered over a network, so an older command can complete at
+the receiver *after* a newer one — a local timeout at the sender does not stop
+the request that caused it. Idempotency alone cannot prevent that: the two
+commands have different `command_id`s, so both are "new".
+
+`subject_revision` closes it. The upstream billing source allocates a
+monotonically increasing integer per entitlement subject each time it commits a
+canonical entitlement revision, and carries it on the command. At write time
+the receiver compares it against `assignment_store.revision_field` on the
+subject's own assignment document, in the same atomic operation that performs
+the update:
+
+- **newer** (strictly greater than the stored value, or the subject has no
+  stored revision yet) — the assignment commits and the new revision is
+  stamped.
+- **stale or equal** — nothing commits. The assignment and plan-allowance
+  effects come back `skipped` with reason `stale_revision`, and the result
+  status is `superseded`. Allowances are suppressed with the assignment because
+  their idempotency key is plan-and-period scoped, so a stale command naming a
+  different plan would otherwise mint tokens behind a fenced assignment.
+- **absent** (`subject_revision` omitted) — the command applies unfenced, for
+  callers that have no ordering authority.
+
+`superseded` is a success outcome, not an error: the command was understood and
+safely ignored. A sender should settle it and stop retrying. Equal revisions are
+suppressed because equality carries no ordering information — the upstream
+source must allocate a fresh ordinal for every meaning-bearing revision.
+
+The entitlement subject is the assignment query itself
+(`app_id` plus whichever of tenant/workspace/user the store declares), which is
+already the assignment document's identity — so fencing needs no new
+collection and no transaction.
+
+Creation and update share one predicate. The fenced write is a single
+revision-filtered upsert carrying the deterministic subject id, so a subject
+that does not exist yet is created under the same comparison that guards an
+existing one. There is deliberately no unfenced fallback write: two concurrent
+first-revisions would both observe absence, and the loser's unfenced upsert
+would then overwrite the winner.
+
+Because that subject id is derived by string-formatting scope values, a null
+scope and the literal string `"None"` produce the same id. A duplicate-key
+collision is therefore not by itself proof that a row belongs to the incoming
+subject: the persisted scope fields are compared with typed equality first, and
+a mismatch is rejected as `subject_identity_collision` rather than being read
+as evidence of supersession.
+
+**Fencing needs one row per subject.** The deterministic assignment id cannot
+supply that on its own: an assignment created before this contract carries an
+ObjectId, so a stale revision-filtered upsert would insert a second,
+deterministic row for the same subject and report itself applied. Enabling
+fencing therefore requires a unique index over the exact configured subject
+paths, which follows a store that maps them to dotted or renamed fields. What
+matters is the guarantee, not the name: a store that already carries an index
+with the same ordered key fields, the same directions, and `unique: true`
+already provides it and is accepted as is. An index that narrows its coverage
+(`sparse`, a `partialFilterExpression`) or changes which values compare equal
+(a non-simple collation) is a different promise and does not count; when none
+qualifies, `mozaiks_billing_subject_unique` is created. Pre-existing duplicate
+subjects make that index
+impossible; that is a data-migration decision for an operator, so it fails
+closed with an actionable error rather than picking a winner or deleting rows.
+`billing_revision` is reserved while fencing is on — no other assignment
+mapping may equal it or nest under it — and configured paths resolve the same
+way for the Mongo query, the write, and the typed subject comparison.
+
+**One decision governs the whole command.** Fencing is on only when the command
+carries a revision AND the store declares the revision field. Deciding per
+effect produced a half-fenced system: an app that opted out still had its
+wallet allowances refused as stale while its assignment happily took the older
+revision.
+
+**Every effect carries the fence.** Assignment success observed before an
+`await` is not authority afterwards, so plan allowances are fenced at their own
+commit: `TokenWalletLedger.record_entry` accepts an opaque
+`subject_key`/`subject_revision` pair and folds the ordering predicate into the
+same single-document update that moves the balance. A stale revision that was
+already mid-flight when a newer one committed is refused there, with the entry
+marked `stale_subject_revision`. Wallet top-ups and refunds are keyed by
+`command_id` and carry no subject ordering, so they are unaffected.
+
+The wallet-side head advances for **every** accepted revision, not only ones
+that mint. A cancellation, a plan with no allowance, and a return to a plan
+whose period allocation already exists all supersede everything older; if the
+head only moved when tokens were credited it would mean "last revision that
+minted" and a delayed older allowance would sail past it. A stale movement is
+also refused without persisting anything under the identity a *successful*
+allocation owns — that identity is plan- and period-scoped, so recording a
+rejection there would permanently deny the allocation a later valid revision of
+the same plan and period is entitled to make.
+
+**Authority is claimed before the assignment commits.** The head cannot be
+advanced *after* the assignment lands: that ordering leaves a window in which
+the subject is already at revision 2 while every wallet still admits revision
+1, and if the head write then fails there is nothing to repair — an older
+allowance may already be in flight. So the fenced path claims the head on every
+wallet the subject can reach first, and only then writes the assignment. A
+wallet that declines — it already holds a strictly newer revision — means the
+command was overtaken, so nothing applies and the result is `superseded`; that
+decline is the only thing that catches a subject whose assignment row is
+missing, where the assignment-side comparison has nothing to compare against. A
+head write that *fails* is not a decline: it propagates, the command applies
+nothing, and the retry succeeds because equal revisions are accepted.
+
+**A pre-effect failure releases the durable reservation.** `apply_durable`
+marks the command `pending` before effects run, so a propagating ordering
+failure would otherwise refuse every identical retry forever. Failures raised
+inside the ordering prerequisite are a distinct kind — `BillingFulfillmentPreEffectError`
+— because the caller knows with certainty that no assignment, allowance, or
+wallet movement was written. Only those release the reservation, by
+compare-and-delete on the exact command id, the still-pending status, and the
+exact command hash, and only while unwinding the invocation that owns it. A
+concurrent identical caller that arrives before the release still sees
+`pending`: exclusivity is unchanged, and only a later retry can start. A
+failure after any effect has committed stays pending, as it must. This is not
+general crash recovery for the command store — that remains a separate,
+unsolved follow-up.
+
+Heads claimed by a partially-successful attempt are **not** reversed. If
+wallet A advanced and wallet B failed, the retry finds A equal (which
+succeeds), advances B, and commits. Reversing A would reopen exactly the window
+an older revision could credit in; forward authority is the safe direction.
+
+**Pending allowance reservations are owned.** A movement reserves its ledger
+entry before committing the balance, and a stale movement rolls that
+reservation back. Because the reservation identity is plan- and period-scoped,
+a newer revision legitimately entitled to the same allocation may adopt that
+same reservation — so adoption transfers ownership atomically, and rollback
+only ever deletes a reservation the rolling-back attempt still owns. The
+crash-recovery case is unaffected: an entry already counted in the balance but
+never marked is finished, not rolled back.
+
+**No balance moves without an acquired reservation.** Observing a reservation
+is not holding one: between the read and the write it may be deleted by the
+attempt that made it, adopted by a newer revision, or finalized. Acquisition is
+therefore a compare-and-swap on exactly the reservation fields the stored
+document carries — a field that is *absent* is compared as absent, never read
+as a Python `None` or `0` and then queried for that value, because Mongo would
+never match the very record the swap is trying to take over and a movement
+whose balance already committed would become unrecoverable. A lost swap is not
+permission to continue — it means the world moved, so the
+ledger re-reads and answers the new state: reserve afresh if the reservation is
+gone, return the idempotent outcome if it settled, retry if someone else now
+holds it. Attempts are bounded; unresolvable contention is reported as an
+operational refusal rather than resolved by writing anyway. The postcondition
+is that a balance counting an entry always has that entry, applied, with its
+wallet and amount intact.
+
+Terminal status follows one precedence: `partial` (something rejected and
+something landed) outranks `rejected` (everything rejected), which outranks
+`superseded` (nothing rejected and at least one revision-scoped effect stood
+down for a newer revision), which outranks `applied`. A command whose earlier
+effect applied and whose remaining effects were then invalidated is
+`superseded` — individual effect history stays truthful, but the command as a
+whole was overtaken.
+
+Replay preserves meaning: a replayed result reports `status: "replayed"` and
+`original_status` — whether the original application was `applied`, `rejected`,
+`partial`, or `superseded` — so a caller never has to infer prior semantics
+from counters.
 
 ### Token Credits
 

--- a/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
+++ b/factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml
@@ -3,6 +3,10 @@ registry:
   ContractDesignerAgent: SubscriptionContractOutput
 
 models:
+  BillingRevisionField:
+    type: literal
+    values: [billing_revision]
+
   AssignmentStore:
     type: model
     fields:
@@ -46,6 +50,15 @@ models:
         type: union
         variants: [str, 'null']
         description: Field carrying the plan snapshot, or null.
+      revision_field:
+        type: union
+        variants: [BillingRevisionField, 'null']
+        description: >
+          Field storing the last committed entitlement revision, which fences
+          out-of-order fulfillment commands. Use "billing_revision" to enable
+          fencing (the default) or null to opt out. The runtime accepts only
+          those two values, so no other string may be generated. Explicit null
+          is meaning-bearing and is preserved end to end.
       active_statuses:
         type: list
         items: str

--- a/factory_app/workflows/SubscriptionContractDesigner/tools/save_subscription_contract.py
+++ b/factory_app/workflows/SubscriptionContractDesigner/tools/save_subscription_contract.py
@@ -80,6 +80,24 @@ def _contains_proprietary_term(value: Any) -> str | None:
     return None
 
 
+# assignment_store fields whose explicit null is meaning-bearing rather than
+# merely absent. `exclude_none=True` keeps the normalized contract compact,
+# but for these it would turn a deliberate opt-out into a silent opt-in on the
+# next reload, because an absent key falls back to the model default.
+_NULL_MEANING_ASSIGNMENT_FIELDS = ("revision_field",)
+
+
+def _restore_explicit_nulls(validated: Any, normalized: dict[str, Any]) -> None:
+    """Re-add assignment-store nulls the caller set on purpose."""
+    store = getattr(validated, "assignment_store", None)
+    if store is None or not isinstance(normalized.get("assignment_store"), dict):
+        return
+    explicitly_set: set[str] = getattr(store, "model_fields_set", set())
+    for field in _NULL_MEANING_ASSIGNMENT_FIELDS:
+        if field in explicitly_set and getattr(store, field, None) is None:
+            normalized["assignment_store"][field] = None
+
+
 def _normalize_subscription_config(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ValueError("subscription_config_file must be an object when contract_required=true")
@@ -91,6 +109,7 @@ def _normalize_subscription_config(raw: Any) -> dict[str, Any]:
     config.setdefault("plans", [])
     validated = SubscriptionsConfig.model_validate(config)
     normalized = validated.model_dump(mode="python", exclude_none=True)
+    _restore_explicit_nulls(validated, normalized)
     for key in ("token_wallets", "top_up_products", "add_on_products", "usage_charge_policies"):
         if normalized.get(key) == []:
             normalized.pop(key, None)

--- a/mozaiksai/core/billing/fulfillment.py
+++ b/mozaiksai/core/billing/fulfillment.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import json
 import os
 import re
 from collections.abc import Awaitable, Callable, Mapping
@@ -19,8 +20,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pymongo import ReturnDocument
-from pymongo.errors import DuplicateKeyError
+from pymongo.errors import DuplicateKeyError, OperationFailure
 
+from logs.logging_config import get_core_logger
 from mozaiksai.core.core_config import get_mongo_client
 from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE, RuntimeCollections
 from mozaiksai.core.runtime.app.subscriptions_loader import (
@@ -31,7 +33,11 @@ from mozaiksai.core.runtime.app.subscriptions_loader import (
 )
 from mozaiksai.core.runtime.persistence.app_data import collection_name_for_alias
 from mozaiksai.core.runtime.persistence.mongo import DEFAULT_APP_DATABASE_NAME
-from mozaiksai.core.tokens.wallet import TokenWalletLedger, get_token_wallet_ledger
+from mozaiksai.core.tokens.wallet import (
+    STALE_SUBJECT_REVISION_REASON,
+    TokenWalletLedger,
+    get_token_wallet_ledger,
+)
 
 BillingFulfillmentEventType = Literal[
     "subscription_activated",
@@ -51,12 +57,46 @@ BillingFulfillmentEffect = Literal[
     "wallet_debit",
 ]
 BillingFulfillmentEffectStatus = Literal["applied", "skipped", "rejected"]
-BillingFulfillmentStatus = Literal["applied", "replayed", "rejected", "partial"]
+BillingFulfillmentStatus = Literal[
+    "applied", "replayed", "rejected", "partial", "superseded"
+]
 BillingFulfillmentStartState = Literal["started", "replay", "conflict", "pending"]
 
 CollectionResolver = Callable[[str], Any]
 FulfillmentEventSink = Callable[[dict[str, Any]], Awaitable[None] | None]
 COMMANDS_COLLECTION = RuntimeCollections.RUNTIME_BILLING_FULFILLMENT_COMMANDS
+
+logger = get_core_logger(__name__)
+
+# Effect reason emitted when a command is suppressed because the entitlement
+# subject already carries a newer (or equal) revision.
+STALE_REVISION_REASON = "stale_revision"
+
+# Effect reason emitted when the deterministic assignment id collides with a
+# row whose subject fields differ from the incoming command's. Historic
+# assignment ids are built by string-formatting scope values, so `None` and
+# the literal string "None" hash alike; treating that as the same subject
+# would let one subject suppress another. Fail closed instead.
+SUBJECT_IDENTITY_COLLISION_REASON = "subject_identity_collision"
+
+# Largest value BSON can store in an int64 field.
+MAX_SUBJECT_REVISION = 9223372036854775807
+
+# Bounded retries of the fenced assignment upsert. Each duplicate-key retry
+# observes a strictly newer persisted state, so two attempts suffice: one to
+# lose an insert race, one to apply against (or be refused by) the winner.
+_ASSIGNMENT_FENCE_ATTEMPTS = 2
+
+# Deterministic name for the unique subject index revision fencing requires.
+# Stable across processes so a restart verifies the existing index instead of
+# creating a second one, and so an incompatible pre-existing index of the same
+# name surfaces as a clear conflict.
+SUBJECT_UNIQUE_INDEX_NAME = "mozaiks_billing_subject_unique"
+
+# Mongo failures that mean "this collection cannot satisfy subject uniqueness":
+# duplicate data (11000), and an index of this name already existing with
+# different keys or options (85/86).
+_SUBJECT_INDEX_BLOCKING_CODES = frozenset({11000, 85, 86})
 
 _SUBSCRIPTION_PLAN_EVENTS = {"subscription_activated", "subscription_updated"}
 _SUBSCRIPTION_EVENTS = _SUBSCRIPTION_PLAN_EVENTS | {"subscription_cancelled"}
@@ -171,11 +211,39 @@ def _json_hash(value: Any) -> str:
 
 
 def _command_document(command: BillingFulfillmentCommand) -> dict[str, Any]:
-    return command.model_dump(mode="json")
+    """Canonical durable document for a command.
+
+    ``subject_revision`` is omitted entirely when absent so a command that
+    does not opt into revision fencing keeps byte-identical canonical content
+    — and therefore an identical command hash — across the upgrade that
+    introduced the field. Serializing an explicit ``null`` would turn every
+    pre-upgrade command into a content conflict on its first replay.
+    """
+    document = command.model_dump(mode="json")
+    if command.subject_revision is None:
+        document.pop("subject_revision", None)
+    return document
 
 
 def _command_hash(command: BillingFulfillmentCommand) -> str:
     return _json_hash(_command_document(command))
+
+
+#: Terminal-status precedence for a fulfillment command, highest first:
+#:
+#: 1. ``partial``    — something was rejected AND something landed. A hard
+#:                     failure is present, so it outranks ordering.
+#: 2. ``rejected``   — everything was rejected.
+#: 3. ``superseded`` — nothing was rejected, and at least one revision-scoped
+#:                     effect stood down because a newer authoritative revision
+#:                     won. This holds even when an earlier effect of the same
+#:                     command already applied: the command as a whole was
+#:                     overtaken, and its remaining effects were invalidated.
+#: 4. ``applied``    — everything that ran, ran.
+#:
+#: Individual effect history stays truthful in every case: an effect that did
+#: apply still reports ``applied`` and still counts toward ``applied``.
+_STALE_EFFECT_REASONS = frozenset({STALE_REVISION_REASON, STALE_SUBJECT_REVISION_REASON})
 
 
 def _status_from_effects(effects: list[BillingFulfillmentEffectResult]) -> BillingFulfillmentStatus:
@@ -185,6 +253,8 @@ def _status_from_effects(effects: list[BillingFulfillmentEffectResult]) -> Billi
         return "partial"
     if rejected:
         return "rejected"
+    if any(effect.reason in _STALE_EFFECT_REASONS for effect in effects):
+        return "superseded"
     return "applied"
 
 
@@ -194,6 +264,38 @@ def _assignment_id(app_id: str, query: Mapping[str, Any]) -> str:
         parts.append(f"{key}={query[key]}")
     digest = hashlib.sha256("|".join(parts).encode()).hexdigest()
     return f"subscription_assignment:{digest}"
+
+
+def _resolve_document_path(document: Mapping[str, Any], path: str) -> Any:
+    """Read a possibly-dotted configured field path out of a document.
+
+    Mirrors Mongo's own dotted-path semantics so query, write, and typed
+    comparison all agree about what a configured mapping refers to.
+    """
+    current: Any = document
+    for segment in path.split("."):
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(segment)
+    return current
+
+
+def _subject_identity(app_id: str, query: Mapping[str, Any]) -> str:
+    """Type-preserving digest of an entitlement subject.
+
+    The assignment `_id` string-formats scope values, so a null scope and the
+    literal string "None" collapse into the same identity. That is tolerable
+    there — a typed comparison of the persisted subject fields runs before any
+    stale classification — but ordering authority is claimed on wallets that
+    hold no subject fields to compare, so it must never conflate two subjects
+    in the first place. This digest carries each value's type alongside it.
+    """
+    parts = [["app_id", type(app_id).__name__, app_id]]
+    for key in sorted(query):
+        value = query[key]
+        parts.append([str(key), type(value).__name__, value])
+    payload = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def _capability_entries(capability_ids: list[str]) -> list[dict[str, str]]:
@@ -236,6 +338,22 @@ class BillingFulfillmentCommand(BaseModel):
     plan_id: str | None = None
     plan_label: str | None = None
     status: str | None = None
+    # Provider-neutral ordering authority for this entitlement subject.
+    # The upstream billing source allocates a monotonically increasing integer
+    # per subject each time it commits a canonical entitlement revision; the
+    # receiver applies subscription effects only when the incoming revision is
+    # strictly greater than the last one committed for that subject. Omit
+    # (None) for callers with no ordering authority — those commands are
+    # applied unfenced, exactly as before.
+    #
+    # Strict: no coercion from bool, float, str, or Decimal, because a
+    # silently coerced ordering value is worse than a rejected one. Bounded to
+    # BSON int64 so a persisted revision can always round-trip through Mongo
+    # instead of raising OverflowError at write time. Values loaded back as
+    # bson.int64.Int64 (an int subclass) remain acceptable.
+    subject_revision: int | None = Field(
+        default=None, ge=0, le=MAX_SUBJECT_REVISION, strict=True
+    )
     wallet_id: str = "ai_tokens"
     token_amount: int | None = Field(default=None, ge=0)
     granted_capabilities: list[str] = Field(default_factory=list)
@@ -340,6 +458,10 @@ class BillingFulfillmentResult(BaseModel):
     replayed: bool = False
     replay_count: int = 0
     command_log_id: str | None = None
+    # Set only on a replay: the terminal disposition the original application
+    # reached. `status` reports that THIS response is a replay; this reports
+    # what is being replayed.
+    original_status: BillingFulfillmentStatus | None = None
     effects: list[BillingFulfillmentEffectResult]
     applied: int = 0
     skipped: int = 0
@@ -372,6 +494,56 @@ class _ResolvedPlan(BaseModel):
     capabilities: list[str] = Field(default_factory=list)
     token_allowances: list[TokenAllowanceDef] = Field(default_factory=list)
     usage_limits: list[UsageLimitDef] = Field(default_factory=list)
+
+
+class BillingFulfillmentPreEffectError(RuntimeError):
+    """A fenced command failed before any fulfillment effect could commit.
+
+    The distinction is durable-retry safety, not severity. Every failure of
+    this kind happens inside the ordering prerequisite that runs before the
+    assignment mutation, so the caller knows with certainty that nothing was
+    written: no assignment, no allowance, no wallet movement. That is exactly
+    the condition under which the durable command reservation may be released
+    so an identical retry can start, and it is the ONLY condition under which
+    it may be — a failure after an effect has committed must stay pending.
+    """
+
+
+class BillingFulfillmentOrderingUnavailable(BillingFulfillmentPreEffectError):
+    """A wallet ordering head could not be written.
+
+    This is an operational failure, not a decline. A wallet reporting that a
+    strictly newer revision already owns it is `superseded` and terminal; this
+    is "the write did not happen", which says nothing about who won and must
+    be retried rather than acknowledged.
+    """
+
+    def __init__(self, *, wallet_id: str, cause: BaseException) -> None:
+        self.wallet_id = wallet_id
+        super().__init__(
+            "billing revision ordering could not be established for wallet "
+            f"{wallet_id!r}: {cause}"
+        )
+
+
+class BillingFulfillmentSubjectIndexError(BillingFulfillmentPreEffectError):
+    """Subject uniqueness could not be established for a fenced store.
+
+    Either the collection already holds more than one assignment for the same
+    entitlement subject, or an index of the reserved name exists with different
+    keys. Both need an operator decision — which row survives, or which index
+    is correct — so fencing refuses to run rather than guessing.
+    """
+
+    def __init__(self, data_alias: str, fields: list[str]) -> None:
+        self.data_alias = data_alias
+        self.fields = list(fields)
+        super().__init__(
+            "billing revision fencing requires one assignment per entitlement "
+            f"subject in {data_alias!r} (unique over {', '.join(fields)}); "
+            "resolve duplicate subjects or the conflicting "
+            f"{SUBJECT_UNIQUE_INDEX_NAME!r} index before enabling it"
+        )
 
 
 class BillingFulfillmentConflictError(ValueError):
@@ -491,6 +663,41 @@ class BillingFulfillmentCommandStore:
         )
         return BillingFulfillmentStartResult(state="replay", record=updated or existing)
 
+    async def release_pre_effect_failure(
+        self, command: BillingFulfillmentCommand
+    ) -> bool:
+        """Give up a reservation whose invocation committed no effect.
+
+        Only the invocation that obtained `started` and then failed inside the
+        fenced ordering prerequisite may call this, and only while unwinding —
+        by then no further effect can run. The compare-and-delete pins the
+        exact command id, the still-pending status, and the exact command hash,
+        so it can never reclaim a record that some other invocation owns or
+        that has since reached a terminal state.
+
+        Deleting rather than marking is deliberate: the command produced no
+        durable meaning, so there is nothing about this attempt worth keeping,
+        and the retry then takes the ordinary `start` path with no second
+        reacquisition rule to get wrong. A concurrent identical caller that
+        arrived before the delete still sees `pending` and is still refused —
+        exclusivity is unchanged. Only a later retry can start.
+        """
+        collection = await self._collection()
+        result = await collection.delete_one(
+            {
+                "_id": command.command_id,
+                "status": "pending",
+                "command_hash": _command_hash(command),
+            }
+        )
+        released = bool(getattr(result, "deleted_count", 0))
+        if released:
+            logger.info(
+                "BILLING_FULFILLMENT_COMMAND_RELEASED: command_id=%s reason=pre_effect_failure",
+                command.command_id,
+            )
+        return released
+
     async def finish(
         self,
         command: BillingFulfillmentCommand,
@@ -520,9 +727,16 @@ class BillingFulfillmentCommandStore:
         if not isinstance(raw_result, Mapping):
             raise BillingFulfillmentPendingError(command_id=str(record.get("command_id") or ""))
         replay_count = int(record.get("replay_count") or 0)
-        return BillingFulfillmentResult.model_validate(raw_result).model_copy(
+        original = BillingFulfillmentResult.model_validate(raw_result)
+        # `status` stays "replayed" so existing callers are unaffected, but the
+        # original disposition is preserved explicitly: a replayed command that
+        # was superseded (or rejected, or partial) must stay recognizably so.
+        # Inferring it from counters is not sound — an applied command and a
+        # superseded one can both report success with zero rejected effects.
+        return original.model_copy(
             update={
                 "status": "replayed",
+                "original_status": original.original_status or original.status,
                 "replayed": True,
                 "replay_count": replay_count,
                 "command_log_id": str(record.get("command_id") or ""),
@@ -568,6 +782,8 @@ class BillingFulfillmentService:
         self._collection_resolver = collection_resolver
         self._event_sink = event_sink
         self._command_store = command_store
+        # Collections whose subject-uniqueness prerequisite has been verified.
+        self._subject_index_ready: set[tuple[int, str]] = set()
 
     async def apply(self, command: BillingFulfillmentCommand | Mapping[str, Any]) -> BillingFulfillmentResult:
         resolved = (
@@ -599,7 +815,15 @@ class BillingFulfillmentService:
             await self._emit_result(replayed)
             return replayed
 
-        result = await self._apply_effects(resolved)
+        try:
+            result = await self._apply_effects(resolved)
+        except BillingFulfillmentPreEffectError:
+            # The failure is positively before any effect committed, so the
+            # durable reservation describes work that never happened. Leaving
+            # it pending would refuse every identical retry forever; releasing
+            # it here — and only here — lets the same command finish later.
+            await store.release_pre_effect_failure(resolved)
+            raise
         result = await store.finish(resolved, result)
         await self._emit_result(result)
         return result
@@ -657,7 +881,63 @@ class BillingFulfillmentService:
             )
             return effects
 
-        effects.append(await self._apply_assignment(command, plan=plan))
+        if self._fencing_enabled(command):
+            # Ordering authority is established BEFORE the assignment commits.
+            # Doing it afterwards leaves a window in which the assignment is
+            # already the authoritative revision while some wallet still
+            # permits an older revision to credit — and that window cannot be
+            # repaired retroactively, because the older allowance may already
+            # be in flight. Claiming first makes the transition atomic in the
+            # only sense that matters: either this revision owns every
+            # applicable wallet head and may commit, or it does not commit.
+            await self._ensure_fenced_subject_prerequisites()
+            if not await self._claim_wallet_subject_revision(command):
+                # A newer revision already owns a wallet head, so this command
+                # has been overtaken. Its assignment must not apply.
+                return [
+                    BillingFulfillmentEffectResult(
+                        effect=(
+                            "assignment_cancel"
+                            if command.event_type == "subscription_cancelled"
+                            else "assignment_upsert"
+                        ),
+                        status="skipped",
+                        reason=STALE_REVISION_REASON,
+                        details={"subject_revision": command.subject_revision},
+                    ),
+                    BillingFulfillmentEffectResult(
+                        effect="plan_allowances",
+                        status="skipped",
+                        reason=STALE_REVISION_REASON,
+                    ),
+                ]
+
+        assignment = await self._apply_assignment(command, plan=plan)
+        effects.append(assignment)
+        if assignment.reason == SUBJECT_IDENTITY_COLLISION_REASON:
+            # The assignment could not prove which subject it belongs to, so
+            # nothing downstream may act on it either.
+            effects.append(
+                BillingFulfillmentEffectResult(
+                    effect="plan_allowances",
+                    status="skipped",
+                    reason=SUBJECT_IDENTITY_COLLISION_REASON,
+                )
+            )
+            return effects
+        if assignment.reason == STALE_REVISION_REASON:
+            # A newer revision already governs this subject. Allowances must be
+            # suppressed too: their idempotency key is plan-and-period scoped,
+            # so a stale command naming a different plan would otherwise mint
+            # real tokens behind a fenced assignment.
+            effects.append(
+                BillingFulfillmentEffectResult(
+                    effect="plan_allowances",
+                    status="skipped",
+                    reason=STALE_REVISION_REASON,
+                )
+            )
+            return effects
         if command.event_type == "subscription_cancelled":
             effects.append(
                 BillingFulfillmentEffectResult(
@@ -708,6 +988,93 @@ class BillingFulfillmentService:
         collection_name = collection_name_for_alias(store.data_alias)
         client = get_mongo_client()
         return client[_default_database_name()][collection_name]
+
+    async def _ensure_fenced_subject_prerequisites(self) -> None:
+        """Validate subject uniqueness before any authority is claimed."""
+        if self._config is None or self._config.assignment_store is None:
+            return
+        collection = await self._collection()
+        if collection is None:
+            return
+        await self._ensure_subject_uniqueness(collection, self._config.assignment_store)
+
+    async def _claim_wallet_subject_revision(
+        self, command: BillingFulfillmentCommand
+    ) -> bool:
+        """Claim the ordering head on every wallet this subject could touch.
+
+        Each wallet keeps its own head, so the claim covers all wallets the
+        config declares for a compatible scope — otherwise a later allowance on
+        an unclaimed wallet would accept a stale revision.
+
+        Returns False when a wallet reports that a strictly newer revision
+        already owns it: that is a meaning-bearing decline and the command has
+        been overtaken. Operational failures are NOT swallowed — they propagate
+        so the command can be retried, because acknowledging a revision whose
+        ordering was never established is exactly how a stale credit slips
+        through. Retry is safe: equal revisions succeed, so heads already
+        claimed do not block a second attempt.
+        """
+        subject_key = self._subject_key(command)
+        if subject_key is None or self._config is None or command.subject_revision is None:
+            return True
+        for wallet in self._config.token_wallets or []:
+            scope = getattr(wallet, "scope", None)
+            if scope == "tenant" and not command.tenant_id:
+                continue
+            if scope == "user" and not command.user_id:
+                continue
+            try:
+                claimed = await self._ledger.advance_subject_revision(
+                    app_id=command.app_id,
+                    wallet_id=wallet.wallet_id,
+                    user_id=command.user_id,
+                    tenant_id=command.tenant_id,
+                    preferred_scope=scope if scope in {"user", "tenant"} else None,
+                    subject_key=subject_key,
+                    subject_revision=command.subject_revision,
+                )
+            except Exception as exc:
+                raise BillingFulfillmentOrderingUnavailable(
+                    wallet_id=wallet.wallet_id, cause=exc
+                ) from exc
+            if not claimed:
+                logger.info(
+                    "BILLING_SUBJECT_REVISION_SUPERSEDED: app_id=%s wallet_id=%s revision=%s",
+                    command.app_id,
+                    wallet.wallet_id,
+                    command.subject_revision,
+                )
+                return False
+        return True
+
+    def _fencing_enabled(self, command: BillingFulfillmentCommand) -> bool:
+        """One decision governs the whole command.
+
+        Fencing is on only when the caller supplies ordering authority AND the
+        app's assignment store declares the revision field. Deciding per effect
+        produced a half-fenced system: an app that opted out still had its
+        wallet allowances refused as stale while its assignment happily took
+        the older revision.
+        """
+        if command.subject_revision is None:
+            return False
+        store = self._config.assignment_store if self._config is not None else None
+        return store is not None and store.revision_field is not None
+
+    def _subject_key(self, command: BillingFulfillmentCommand) -> str | None:
+        """Opaque entitlement-subject identity shared by every fenced effect.
+
+        Derived from the same assignment query the assignment fence uses, so
+        the two commit boundaries order against exactly the same subject even
+        though a wallet balance is scoped more coarsely (it drops workspace).
+        """
+        if not self._fencing_enabled(command):
+            return None
+        query = self._assignment_query(command)
+        if not query:
+            return None
+        return _subject_identity(command.app_id, query)
 
     def _assignment_query(self, command: BillingFulfillmentCommand) -> dict[str, Any]:
         if self._config is None or self._config.assignment_store is None:
@@ -793,26 +1160,262 @@ class BillingFulfillmentService:
                 captured_at=now,
             )
 
-        await collection.update_one(
-            query,
-            {
-                "$set": updates,
-                "$setOnInsert": {
-                    "_id": assignment_id,
-                    "created_at": now,
-                },
-            },
-            upsert=True,
+        effect: BillingFulfillmentEffect = (
+            "assignment_cancel"
+            if command.event_type == "subscription_cancelled"
+            else "assignment_upsert"
         )
+        revision = command.subject_revision
+        revision_field = store.revision_field
+        insert_only = {"_id": assignment_id, "created_at": now}
+
+        if revision_field is None or revision is None:
+            # Unfenced caller: unchanged pre-fence behavior.
+            await collection.update_one(
+                query, {"$set": updates, "$setOnInsert": insert_only}, upsert=True
+            )
+            return self._assignment_applied(
+                effect,
+                assignment_id=assignment_id,
+                store=store,
+                plan_id=plan_id,
+                status=status,
+                revision=None,
+            )
+
+        # Fencing is only sound when the SUBJECT has exactly one row. The
+        # deterministic `_id` cannot supply that on its own: an assignment
+        # created before this contract carries an ObjectId, so a stale
+        # revision-filtered upsert would happily insert a second, deterministic
+        # row for the same subject and report itself applied. A unique index
+        # over the configured subject paths is what makes "one subject, one
+        # row" true regardless of how a row was originally created.
+        await self._ensure_subject_uniqueness(collection, store)
+
+        updates[revision_field] = revision
+        # ONE atomic operation covers creation and update alike. The filter
+        # carries the revision predicate, so there is never an unfenced write:
+        #
+        #   - subject absent            -> insert, stamped with this revision
+        #   - subject older             -> filter matches, update applies
+        #   - subject newer or equal    -> filter misses, the upsert attempts an
+        #                                  insert and the unique subject index
+        #                                  refuses it
+        #
+        # A separate "does it exist yet?" read followed by an unfenced upsert
+        # would lose the creation race outright: two concurrent new-subject
+        # revisions both observe absence, and the loser's unfenced write then
+        # overwrites the winner.
+        fence_query = {
+            **query,
+            "$or": [
+                {revision_field: {"$exists": False}},
+                {revision_field: None},
+                {revision_field: {"$lt": revision}},
+            ],
+        }
+        write = {"$set": updates, "$setOnInsert": insert_only}
+
+        # A DuplicateKeyError proves a row exists but did not match the fence.
+        # That is either a genuinely newer revision (stale — terminal) or a row
+        # inserted by a concurrent writer whose revision is still older than
+        # ours (retry: the same fenced upsert now matches it). Each iteration
+        # therefore either applies, proves staleness, or observes a strictly
+        # newer state, so the loop cannot spin.
+        for _ in range(_ASSIGNMENT_FENCE_ATTEMPTS):
+            try:
+                await collection.update_one(fence_query, write, upsert=True)
+            except DuplicateKeyError:
+                # Resolve the row through the canonical SUBJECT selector, not
+                # through the deterministic id: the blocking row may predate
+                # this contract and carry an ObjectId.
+                existing = await collection.find_one(dict(query))
+                if existing is None:
+                    existing = await collection.find_one({"_id": assignment_id})
+                collision = self._assignment_subject_mismatch(existing, query=query)
+                if collision is not None:
+                    return BillingFulfillmentEffectResult(
+                        effect=effect,
+                        status="rejected",
+                        reason=SUBJECT_IDENTITY_COLLISION_REASON,
+                        details={
+                            "assignment_id": assignment_id,
+                            "data_alias": store.data_alias,
+                            "conflicting_field": collision,
+                        },
+                    )
+                continue
+            return self._assignment_applied(
+                effect,
+                assignment_id=assignment_id,
+                store=store,
+                plan_id=plan_id,
+                status=status,
+                revision=revision,
+            )
+
         return BillingFulfillmentEffectResult(
-            effect="assignment_cancel" if command.event_type == "subscription_cancelled" else "assignment_upsert",
-            status="applied",
+            effect=effect,
+            status="skipped",
+            reason=STALE_REVISION_REASON,
             details={
                 "assignment_id": assignment_id,
                 "data_alias": store.data_alias,
-                "plan_id": plan_id,
-                "status": status,
+                "subject_revision": revision,
             },
+        )
+
+    async def _ensure_subject_uniqueness(self, collection: Any, store: Any) -> None:
+        """Guarantee one assignment row per entitlement subject, once.
+
+        Revision fencing is a correctness prerequisite, not a convenience: with
+        two rows for one subject, a stale command can create the second and
+        report itself applied. The index is built over the exact configured
+        subject paths, so it follows a store that maps them to dotted or
+        renamed fields — unless the collection already carries an index that
+        makes the same promise, in which case that one is accepted as is. What
+        fencing needs is the guarantee, not ownership of a particular name.
+
+        Pre-existing duplicate subjects make the index impossible. That is a
+        data-migration problem the operator must resolve, so it fails closed
+        with an actionable error rather than silently picking a winner or
+        deleting rows.
+        """
+        alias = str(getattr(store, "data_alias", "") or "")
+        cache_key = (id(collection), alias)
+        if cache_key in self._subject_index_ready:
+            return
+        fields = self._subject_field_paths(store)
+        if not fields:
+            self._subject_index_ready.add(cache_key)
+            return
+        required = [(field, 1) for field in fields]
+        if await self._subject_uniqueness_already_guaranteed(collection, required):
+            # Fencing needs the guarantee, not ownership of a particular index
+            # name. A collection that already carries an equivalent unique index
+            # is fine, and demanding a second one would reject a valid
+            # configuration outright.
+            self._subject_index_ready.add(cache_key)
+            return
+        try:
+            await collection.create_index(
+                required,
+                unique=True,
+                name=SUBJECT_UNIQUE_INDEX_NAME,
+            )
+        except DuplicateKeyError as exc:
+            raise BillingFulfillmentSubjectIndexError(alias, fields) from exc
+        except OperationFailure as exc:
+            code = getattr(exc, "code", None)
+            if code in _SUBJECT_INDEX_BLOCKING_CODES:
+                raise BillingFulfillmentSubjectIndexError(alias, fields) from exc
+            raise
+        self._subject_index_ready.add(cache_key)
+
+    @staticmethod
+    async def _subject_uniqueness_already_guaranteed(
+        collection: Any, required: list[tuple[str, int]]
+    ) -> bool:
+        """Does an existing index already guarantee subject uniqueness?
+
+        Equivalence is judged on what the index actually promises, not on its
+        name: the same ordered keys and directions, and `unique: true`. Options
+        that narrow which documents the constraint covers — `sparse`, a
+        `partialFilterExpression` — disqualify it, because subjects outside the
+        covered set would be free to duplicate. A non-simple `collation` is
+        also refused: it changes which values count as equal, which is a
+        different guarantee than the one fencing reasons about.
+        """
+        information = getattr(collection, "index_information", None)
+        if information is None:
+            return False
+        try:
+            existing = await information()
+        except Exception:
+            return False
+        if not isinstance(existing, Mapping):
+            return False
+        for definition in existing.values():
+            if not isinstance(definition, Mapping):
+                continue
+            if not definition.get("unique"):
+                continue
+            if definition.get("sparse") or definition.get("partialFilterExpression"):
+                continue
+            collation = definition.get("collation")
+            if collation and str(collation.get("locale", "")) != "simple":
+                continue
+            keys = [
+                (str(field), int(direction))
+                for field, direction in (definition.get("key") or [])
+            ]
+            if keys == required:
+                return True
+        return False
+
+    @staticmethod
+    def _subject_field_paths(store: Any) -> list[str]:
+        """Configured paths that together identify one entitlement subject."""
+        names = ("app_id_field", "tenant_id_field", "workspace_id_field", "user_id_field")
+        paths: list[str] = []
+        for name in names:
+            value = str(getattr(store, name, "") or "").strip()
+            if value and value not in paths:
+                paths.append(value)
+        return paths
+
+    @staticmethod
+    def _assignment_subject_mismatch(
+        existing: Mapping[str, Any] | None,
+        *,
+        query: Mapping[str, Any],
+    ) -> str | None:
+        """Name of a subject field whose persisted value differs, if any.
+
+        A duplicate-key collision is not by itself proof that a row belongs to
+        this entitlement subject — the deterministic assignment id is built by
+        string-formatting scope values, so a null scope and the literal string
+        "None" produce the same id — and treating it as proof would let one
+        subject silently suppress another. Compare the persisted scope fields
+        with typed equality first.
+
+        Configured mappings may be dotted paths, so the comparison resolves
+        them exactly as the Mongo query and the `$set` write do. Reading
+        `document["scope.user"]` instead of walking into `scope.user` would
+        report a mismatch for a row that genuinely is the same subject.
+        """
+        if existing is None:
+            # The row vanished between the failed upsert and this read; the
+            # caller retries the fenced upsert.
+            return None
+        for field, expected in query.items():
+            actual = _resolve_document_path(existing, str(field))
+            if actual != expected or type(actual) is not type(expected):
+                return str(field)
+        return None
+
+    @staticmethod
+    def _assignment_applied(
+        effect: BillingFulfillmentEffect,
+        *,
+        assignment_id: str,
+        store: Any,
+        plan_id: str,
+        status: str,
+        revision: int | None,
+    ) -> BillingFulfillmentEffectResult:
+        details: dict[str, Any] = {
+            "assignment_id": assignment_id,
+            "data_alias": store.data_alias,
+            "plan_id": plan_id,
+            "status": status,
+        }
+        if revision is not None:
+            details["subject_revision"] = revision
+        return BillingFulfillmentEffectResult(
+            effect=effect,
+            status="applied",
+            details=details,
         )
 
     async def _apply_plan_allowances(
@@ -853,12 +1456,32 @@ class BillingFulfillmentService:
                 user_id=command.user_id,
                 tenant_id=command.tenant_id,
                 period_start=command.occurred_at or command.starts_at or _now(),
+                # Same entitlement subject the assignment fence uses, so both
+                # effects order identically. The ledger fences its own commit:
+                # the assignment having been applied earlier in this call is
+                # not authority any more once we have awaited.
+                subject_key=self._subject_key(command),
+                subject_revision=command.subject_revision,
             )
         except Exception as exc:
             return BillingFulfillmentEffectResult(
                 effect="plan_allowances",
                 status="rejected",
                 reason=str(exc),
+            )
+
+        if results and all(
+            result.entry.get("rejection_reason") == STALE_SUBJECT_REVISION_REASON
+            for result in results
+            if result.status == "rejected"
+        ) and any(result.status == "rejected" for result in results):
+            # The ledger refused at its own commit boundary because a newer
+            # revision of this subject already landed. That is ordering, not
+            # failure.
+            return BillingFulfillmentEffectResult(
+                effect="plan_allowances",
+                status="skipped",
+                reason=STALE_REVISION_REASON,
             )
 
         statuses = [result.status for result in results]

--- a/mozaiksai/core/runtime/app/subscriptions_loader.py
+++ b/mozaiksai/core/runtime/app/subscriptions_loader.py
@@ -20,6 +20,9 @@ Example::
     default_plan_id: free
     assignment_store:
       data_alias: billing.subscriptions
+      # Stores the last committed entitlement revision for a subject so an
+      # out-of-order fulfillment command cannot regress it. Null to opt out.
+      revision_field: billing_revision
     plans:
       - plan_id: free
         label: Free
@@ -108,6 +111,36 @@ _METER_ID_RE = re.compile(r"^[a-z0-9_.-]+$")
 _WALLET_ID_RE = re.compile(r"^[a-z0-9_.-]+$")
 _DATA_ALIAS_RE = re.compile(r"^[a-z0-9_.-]+$")
 _FIELD_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
+
+# Every configurable assignment mapping that carries identity or business
+# state. When revision fencing is on, none of them may target the reserved
+# ordering-authority field.
+_SUBJECT_AND_BUSINESS_FIELDS = (
+    "app_id_field",
+    "tenant_id_field",
+    "workspace_id_field",
+    "user_id_field",
+    "plan_id_field",
+    "status_field",
+    "starts_at_field",
+    "expires_at_field",
+    "capabilities_field",
+    "plan_snapshot_field",
+)
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    """Would writing one of these Mongo paths disturb the other?
+
+    True when the paths are equal or one is an ancestor of the other, since
+    setting `a` replaces `a.b` and setting `a.b` mutates the document `a`.
+    """
+    left, right = left.strip(), right.strip()
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+    return left.startswith(f"{right}.") or right.startswith(f"{left}.")
 _CATALOG_ID_RE = re.compile(r"^[a-z0-9_-]+$")
 _CAPABILITY_GROUP_RE = re.compile(r"^[a-z0-9_.-]+$")
 _ROUTE_RE = re.compile(r"^/[A-Za-z0-9._~!$&'()*+,;=:@/%-]*(?:\?[A-Za-z0-9._~!$&'()*+,;=:@/?%-]*)?$")
@@ -729,6 +762,18 @@ class SubscriptionAssignmentStoreDef(BaseModel):
     expires_at_field: str | None = "expires_at"
     capabilities_field: str | None = "granted_capabilities"
     plan_snapshot_field: str | None = "plan_snapshot"
+    # Stores the last committed entitlement revision for a subject. Fulfillment
+    # commands carrying `subject_revision` are applied only when strictly newer
+    # than this value, so an out-of-order command cannot regress the subject.
+    #
+    # Deliberately NOT a free-form field name. This is an authority field that
+    # the fence reads and writes inside the same update as the assignment
+    # itself, so an arbitrary name could shadow identity/plan/status/timestamp
+    # fields, collide with keys written by the same update, or introduce dotted
+    # paths and `$` operators. The only meaningful choice is whether fencing is
+    # on, so the contract offers exactly that: the canonical field name, or
+    # null to opt out.
+    revision_field: Literal["billing_revision"] | None = "billing_revision"
     active_statuses: list[str] = Field(default_factory=lambda: ["active", "pending", "trialing"])
 
     @field_validator("data_alias")
@@ -765,6 +810,30 @@ class SubscriptionAssignmentStoreDef(BaseModel):
                 f"field names must match [A-Za-z_][A-Za-z0-9_.]*, got {value!r}"
             )
         return value
+
+    @model_validator(mode="after")
+    def _reserve_revision_field(self) -> SubscriptionAssignmentStoreDef:
+        """No other mapping may target the ordering-authority field.
+
+        The fence reads and writes `revision_field` inside the same update
+        that writes the assignment, so a business or identity mapping aimed at
+        the same path would let ordinary writes clobber the ordering value —
+        and the collision would only show up as a mysterious lost fence at
+        runtime. Reject it at load time instead.
+        """
+        reserved = self.revision_field
+        if reserved is None:
+            return self
+        for name in _SUBJECT_AND_BUSINESS_FIELDS:
+            value = getattr(self, name, None)
+            if value is None:
+                continue
+            if _paths_overlap(str(value), reserved):
+                raise ValueError(
+                    f"{name} must not target the reserved revision field "
+                    f"{reserved!r}; it is the fence's ordering authority"
+                )
+        return self
 
     @field_validator("active_statuses", mode="before")
     @classmethod

--- a/mozaiksai/core/tokens/wallet.py
+++ b/mozaiksai/core/tokens/wallet.py
@@ -9,9 +9,11 @@ their own business checks succeed.
 """
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
+from uuid import uuid4
 
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
@@ -44,6 +46,68 @@ TokenWalletStatus = Literal["pending", "applied", "rejected"]
 
 _CREDIT_OPERATIONS = {"allocation", "credit", "refund", "adjustment_credit"}
 _DEBIT_OPERATIONS = {"usage_debit", "debit", "adjustment_debit"}
+
+# Bounded attempts to take ownership of a movement's reservation. Every losing
+# attempt observes a strictly changed reservation — inserted, adopted, or
+# finalized — so contention resolves in a couple of rounds or is not
+# contention at all.
+_RESERVATION_ATTEMPTS = 5
+
+
+class TokenWalletReservationUnavailable(RuntimeError):
+    """The durable reservation for a movement could not be acquired.
+
+    Reported instead of moving the balance. A credit recorded without the
+    entry that explains it is worse than a credit that has to be retried.
+    """
+
+    def __init__(self, *, entry_id: str) -> None:
+        self.entry_id = entry_id
+        super().__init__(
+            f"token wallet reservation could not be acquired for entry {entry_id!r}"
+        )
+
+
+# Rejection reason for a movement refused because a newer revision of the same
+# entitlement subject has already committed.
+STALE_SUBJECT_REVISION_REASON = "stale_subject_revision"
+
+# Sub-document on the balance holding the highest revision committed per
+# entitlement subject. Nested under one key so the balance keeps exactly one
+# ordering surface no matter how many subjects share a wallet scope.
+_SUBJECT_REVISIONS_FIELD = "subject_revisions"
+
+
+def _subject_revision_path(subject_key: str | None) -> str | None:
+    """Dotted path holding one subject's committed revision, or None.
+
+    The key is sanitized to hex-safe characters because it becomes a Mongo
+    field name: a dot would silently create nesting and a `$` would be
+    rejected, so an opaque caller identity must never reach the path raw.
+    """
+    key = str(subject_key or "").strip()
+    if not key:
+        return None
+    safe = "".join(char for char in key if char.isalnum() or char in "_-")
+    if not safe:
+        return None
+    return f"{_SUBJECT_REVISIONS_FIELD}.{safe}"
+
+
+def _subject_revision_is_stale(
+    balance: dict[str, Any] | None,
+    revision_path: str | None,
+    subject_revision: int | None,
+) -> bool:
+    """Did this balance already commit a strictly newer revision?"""
+    if balance is None or revision_path is None or subject_revision is None:
+        return False
+    committed = (balance.get(_SUBJECT_REVISIONS_FIELD) or {}).get(
+        revision_path.split(".", 1)[-1]
+    )
+    return isinstance(committed, int) and committed > subject_revision
+
+
 _FORBIDDEN_METADATA_KEY_FRAGMENTS = (
     "secret",
     "password",
@@ -210,6 +274,24 @@ def _entry_id(scope: TokenWalletScope, idempotency_key: str) -> str:
     return f"token_wallet_entry:{digest}"
 
 
+def _observed_reservation_predicate(existing: Mapping[str, Any]) -> dict[str, Any]:
+    """Compare-and-swap against exactly what was observed, absence included.
+
+    An entry written before reservations were tracked carries neither field.
+    Reading a missing field as Python `None` or `0` and then querying for that
+    value is not the same question: Mongo matches `{"field": 0}` only against a
+    stored zero, so the swap would never match the very record it is trying to
+    take over — and a movement whose balance already committed would become
+    unrecoverable. Absence is a state, so it is compared as one.
+    """
+    predicate: dict[str, Any] = {}
+    for field in ("reservation_owner", "reservation_generation"):
+        predicate[field] = (
+            existing[field] if field in existing else {"$exists": False}
+        )
+    return predicate
+
+
 def _idempotency_conflict(existing: dict[str, Any], requested: dict[str, Any]) -> bool:
     for key in ("balance_id", "operation", "direction", "amount", "signed_amount"):
         if existing.get(key) != requested.get(key):
@@ -240,6 +322,8 @@ def _empty_balance(scope: TokenWalletScope) -> dict[str, Any]:
 def public_balance(balance: dict[str, Any] | None, scope: TokenWalletScope | None = None) -> dict[str, Any]:
     data = dict(balance or (_empty_balance(scope) if scope else {}))
     data.pop("applied_entry_ids", None)
+    # Internal ordering state, never part of the public balance surface.
+    data.pop(_SUBJECT_REVISIONS_FIELD, None)
     for key in ("balance", "total_allocated", "total_credited", "total_spent", "total_refunded", "entry_count"):
         data[key] = _positive_int(data.get(key))
     if "_id" in data:
@@ -252,6 +336,9 @@ def public_balance(balance: dict[str, Any] | None, scope: TokenWalletScope | Non
 
 def public_entry(entry: dict[str, Any]) -> dict[str, Any]:
     data = dict(entry or {})
+    # Internal reservation bookkeeping, never part of the public entry surface.
+    data.pop("reservation_owner", None)
+    data.pop("reservation_generation", None)
     if "_id" in data:
         data["entry_id"] = data.pop("_id")
     for key in ("created_at", "updated_at", "applied_at", "rejected_at"):
@@ -293,6 +380,77 @@ class TokenWalletLedger:
             self._indexes_ready = True
         return balances, entries
 
+    async def _acquire_entry_reservation(
+        self,
+        entries: Any,
+        *,
+        entry_id: str,
+        entry: dict[str, Any],
+        reservation_owner: str,
+        now: datetime,
+    ) -> dict[str, Any] | None:
+        """Take positive ownership of this movement's durable reservation.
+
+        Returns None once this invocation owns a pending reservation, or the
+        existing terminal entry when the movement already settled. It never
+        returns "nothing happened": the caller may only touch the balance after
+        a None, so there is no path where a balance moves under a reservation
+        somebody else holds — or under none at all.
+
+        Each attempt re-reads before acting, because every observation here can
+        be invalidated the instant after it is made. A pending reservation may
+        be deleted by the attempt that made it, adopted by a newer entitled
+        revision, or finalized. So adoption is a compare-and-swap on the exact
+        observed owner AND generation, and a lost swap is not a failure — it
+        means the world moved, so look again and answer the new state. The
+        generation is what makes an owner that is handed back and forth still
+        distinguishable.
+
+        Attempts are bounded. Contention that will not settle is an operational
+        outcome, not a licence to write anyway.
+        """
+        for _attempt in range(_RESERVATION_ATTEMPTS):
+            existing = await entries.find_one({"_id": entry_id})
+            if existing is None:
+                try:
+                    await entries.insert_one(entry)
+                    return None
+                except DuplicateKeyError:
+                    # Someone reserved between the read and the insert.
+                    continue
+
+            if _idempotency_conflict(existing, entry):
+                raise ValueError(
+                    "idempotency_key was reused with different token wallet entry data"
+                )
+
+            status = existing.get("status")
+            if status in {"applied", "rejected"}:
+                return dict(existing)
+
+            if status != "pending":
+                continue
+
+            adopted = await entries.find_one_and_update(
+                {
+                    "_id": entry_id,
+                    "status": "pending",
+                    **_observed_reservation_predicate(existing),
+                },
+                {
+                    "$set": {
+                        "reservation_owner": reservation_owner,
+                        "updated_at": now,
+                    },
+                    "$inc": {"reservation_generation": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            if adopted is not None:
+                return None
+
+        raise TokenWalletReservationUnavailable(entry_id=entry_id)
+
     async def record_entry(
         self,
         *,
@@ -309,7 +467,21 @@ class TokenWalletLedger:
         metadata: dict[str, Any] | None = None,
         allow_negative_balance: bool = False,
         usage_event_id: str | None = None,
+        subject_key: str | None = None,
+        subject_revision: int | None = None,
     ) -> TokenWalletEntryResult:
+        """Record one idempotent wallet movement.
+
+        ``subject_key`` / ``subject_revision`` are an optional ordering fence.
+        When both are supplied, the movement commits only while this revision
+        is the newest one seen for that subject, and the check happens inside
+        the same single-document update that changes the balance — so a
+        revision that lost the race cannot mint anything, even if it was
+        already mid-flight when the newer one committed. The ledger never
+        interprets ``subject_key``; it is an opaque identity owned by whatever
+        ordering authority the caller uses. Omit both for unordered movements
+        (the default), which behave exactly as before.
+        """
         if operation not in _CREDIT_OPERATIONS and operation not in _DEBIT_OPERATIONS:
             raise ValueError(f"unsupported token wallet operation: {operation}")
         resolved_amount = _positive_int(amount)
@@ -329,6 +501,7 @@ class TokenWalletLedger:
             preferred_scope=preferred_scope,
         )
         entry_id = _entry_id(scope, idempotency_value)
+        reservation_owner = f"rsv_{uuid4().hex}"
         now = _now()
         balance_seed = {
             "_id": scope.balance_id,
@@ -356,6 +529,12 @@ class TokenWalletLedger:
             "amount": resolved_amount,
             "signed_amount": signed_amount,
             "status": "pending",
+            # Who currently owns this reservation. A stale attempt may only
+            # clean up a reservation it still owns; if a newer valid revision
+            # has adopted it, ownership has moved and the stale cleanup must
+            # not touch it.
+            "reservation_owner": reservation_owner,
+            "reservation_generation": 0,
             "source": _text(source) or "runtime",
             "reason": _text(reason) or None,
             "metadata": _safe_metadata(metadata),
@@ -365,30 +544,24 @@ class TokenWalletLedger:
         }
 
         balances, entries = await self._collections()
-        existing = await entries.find_one({"_id": entry_id}, {"_id": 0})
-        if existing and _idempotency_conflict(existing, entry):
-            raise ValueError("idempotency_key was reused with different token wallet entry data")
-        if existing and existing.get("status") in {"applied", "rejected"}:
+        # No balance may move without this invocation positively owning the
+        # durable reservation that represents the movement. "I looked and
+        # something was there" is not ownership: the reservation may be
+        # deleted, adopted, or finalized between the read and the write.
+        acquired = await self._acquire_entry_reservation(
+            entries,
+            entry_id=entry_id,
+            entry=entry,
+            reservation_owner=reservation_owner,
+            now=now,
+        )
+        if acquired is not None:
             balance_doc = await balances.find_one({"_id": scope.balance_id})
             return TokenWalletEntryResult(
-                status=str(existing.get("status") or "applied"),  # type: ignore[arg-type]
-                entry=public_entry(existing),
+                status=str(acquired.get("status") or "applied"),  # type: ignore[arg-type]
+                entry=public_entry(acquired),
                 balance=public_balance(balance_doc, scope),
             )
-        if existing is None:
-            try:
-                await entries.insert_one(entry)
-            except DuplicateKeyError:
-                existing = await entries.find_one({"_id": entry_id})
-                if existing and _idempotency_conflict(existing, entry):
-                    raise ValueError("idempotency_key was reused with different token wallet entry data") from None
-                if existing and existing.get("status") in {"applied", "rejected"}:
-                    balance_doc = await balances.find_one({"_id": scope.balance_id})
-                    return TokenWalletEntryResult(
-                        status=str(existing.get("status") or "applied"),  # type: ignore[arg-type]
-                        entry=public_entry(existing),
-                        balance=public_balance(balance_doc, scope),
-                    )
 
         update_filter: dict[str, Any] = {
             "_id": scope.balance_id,
@@ -396,6 +569,20 @@ class TokenWalletLedger:
         }
         if direction == "debit" and not allow_negative_balance:
             update_filter["balance"] = {"$gte": resolved_amount}
+
+        revision_path = _subject_revision_path(subject_key)
+        fenced = revision_path is not None and subject_revision is not None
+        if revision_path is not None and subject_revision is not None:
+            # The ordering predicate rides in the SAME filter as the balance
+            # mutation, so "am I still current?" and "apply the movement" are
+            # one atomic act. Checking the subject's revision separately and
+            # then writing would leave a window for a newer revision to commit
+            # in between — which is exactly the stale-allowance race.
+            update_filter["$or"] = [
+                {revision_path: {"$exists": False}},
+                {revision_path: None},
+                {revision_path: {"$lte": subject_revision}},
+            ]
 
         inc: dict[str, int] = {
             "balance": signed_amount,
@@ -410,27 +597,66 @@ class TokenWalletLedger:
         else:
             inc["total_spent"] = resolved_amount
 
-        balance_doc = await balances.find_one_and_update(
-            update_filter,
-            {
-                "$setOnInsert": balance_seed,
-                "$set": {
-                    "updated_at": now,
-                },
-                "$inc": inc,
-                "$addToSet": {"applied_entry_ids": entry_id},
+        update_document: dict[str, Any] = {
+            "$setOnInsert": balance_seed,
+            "$set": {
+                "updated_at": now,
             },
-            upsert=direction == "credit",
-            return_document=ReturnDocument.AFTER,
-        )
+            "$inc": inc,
+            "$addToSet": {"applied_entry_ids": entry_id},
+        }
+        if fenced:
+            update_document["$max"] = {revision_path: subject_revision}
+
+        try:
+            balance_doc = await balances.find_one_and_update(
+                update_filter,
+                update_document,
+                upsert=direction == "credit",
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            # An upserting credit whose filter missed because the balance
+            # already exists: the deterministic _id collides. Treat it as a
+            # miss and classify below.
+            balance_doc = None
 
         if balance_doc is None:
             current_balance = await balances.find_one({"_id": scope.balance_id})
             if current_balance and entry_id in set(current_balance.get("applied_entry_ids") or []):
-                applied_entry = await self._mark_entry_applied(entries, entry_id, current_balance)
+                applied_entry = await self._mark_entry_applied(
+                    entries, entry_id, current_balance, entry=entry
+                )
                 return TokenWalletEntryResult(
                     status="applied",
                     entry=public_entry(applied_entry),
+                    balance=public_balance(current_balance, scope),
+                )
+            if fenced and _subject_revision_is_stale(
+                current_balance, revision_path, subject_revision
+            ):
+                # A stale movement must leave no trace under the identity that
+                # a SUCCESSFUL allocation owns. That identity is plan- and
+                # period-scoped, so persisting a rejection here would block the
+                # allocation a later valid revision of the same plan and period
+                # is entitled to make — the stale attempt would permanently
+                # deny a legitimate one. Roll back the reservation we made and
+                # report the refusal without recording it.
+                await entries.delete_one(
+                    {
+                        "_id": entry_id,
+                        "status": "pending",
+                        "reservation_owner": reservation_owner,
+                    }
+                )
+                stale_entry = {
+                    **entry,
+                    "status": "rejected",
+                    "rejection_reason": STALE_SUBJECT_REVISION_REASON,
+                }
+                return TokenWalletEntryResult(
+                    status="rejected",
+                    entry=public_entry(stale_entry),
                     balance=public_balance(current_balance, scope),
                 )
             rejected_entry = await self._mark_entry_rejected(
@@ -445,15 +671,37 @@ class TokenWalletLedger:
                 balance=public_balance(current_balance, scope),
             )
 
-        applied_entry = await self._mark_entry_applied(entries, entry_id, balance_doc)
+        applied_entry = await self._mark_entry_applied(
+            entries, entry_id, balance_doc, entry=entry
+        )
         return TokenWalletEntryResult(
             status="applied",
             entry=public_entry(applied_entry),
             balance=public_balance(balance_doc, scope),
         )
 
-    async def _mark_entry_applied(self, entries: Any, entry_id: str, balance: dict[str, Any]) -> dict[str, Any]:
+    async def _mark_entry_applied(
+        self,
+        entries: Any,
+        entry_id: str,
+        balance: dict[str, Any],
+        *,
+        entry: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Finalize the entry that explains a balance the wallet already moved.
+
+        The write is an upsert on the movement's own facts. Reaching here means
+        the balance counts this entry, so the entry must exist and must say so
+        — an `applied` result whose entry document is absent would report a
+        credit with no wallet or amount behind it. The reservation this
+        invocation owns cannot ordinarily be removed underneath it, but the
+        postcondition does not depend on that being true: if the document is
+        gone, it is restored rather than papered over with an empty lookup.
+        """
         now = _now()
+        seed = {key: value for key, value in entry.items() if key != "_id"}
+        for key in ("status", "updated_at"):
+            seed.pop(key, None)
         await entries.update_one(
             {"_id": entry_id},
             {
@@ -462,10 +710,15 @@ class TokenWalletLedger:
                     "balance_after": int(balance.get("balance") or 0),
                     "applied_at": now,
                     "updated_at": now,
-                }
+                },
+                "$setOnInsert": seed,
             },
+            upsert=True,
         )
-        return await entries.find_one({"_id": entry_id}, {"_id": 0}) or {}
+        applied = await entries.find_one({"_id": entry_id}, {"_id": 0})
+        if not applied:
+            raise TokenWalletReservationUnavailable(entry_id=entry_id)
+        return dict(applied)
 
     async def _mark_entry_rejected(
         self,
@@ -592,6 +845,79 @@ class TokenWalletLedger:
         docs = await cursor.to_list(length=bounded_limit)
         return [public_entry(doc) for doc in docs]
 
+    async def advance_subject_revision(
+        self,
+        *,
+        app_id: str,
+        wallet_id: str = "ai_tokens",
+        user_id: str | None = None,
+        tenant_id: str | None = None,
+        preferred_scope: Literal["user", "tenant"] | None = None,
+        subject_key: str,
+        subject_revision: int,
+    ) -> bool:
+        """Advance this subject's ordering head, moving no balance.
+
+        A revision that legitimately credits nothing — a cancellation, a plan
+        with no allowance, a return to a plan whose period allocation already
+        exists — still supersedes everything older. If the head only moved when
+        tokens were minted it would mean "last revision that minted", not
+        "latest accepted revision", and a delayed older allowance would sail
+        past it.
+
+        Returns False when a strictly newer revision already holds the head, in
+        which case nothing is written — a meaning-bearing decline, not a
+        successful no-op. Equal revisions succeed so that a retry, or the
+        allowance belonging to the very revision that advanced the head, is not
+        fenced out by its own claim. Operational failures propagate: a caller
+        must be able to tell "someone newer won" from "the write did not
+        happen", because only the first means the command was overtaken.
+        """
+        revision_path = _subject_revision_path(subject_key)
+        if revision_path is None:
+            return False
+        scope = _scope_for(
+            app_id=app_id,
+            wallet_id=wallet_id,
+            user_id=user_id,
+            tenant_id=tenant_id,
+            preferred_scope=preferred_scope,
+        )
+        balances, _entries = await self._collections()
+        now = _now()
+        try:
+            updated = await balances.find_one_and_update(
+                {
+                    "_id": scope.balance_id,
+                    "$or": [
+                        {revision_path: {"$exists": False}},
+                        {revision_path: None},
+                        {revision_path: {"$lte": subject_revision}},
+                    ],
+                },
+                {
+                    "$setOnInsert": {
+                        "_id": scope.balance_id,
+                        "app_id": scope.app_id,
+                        "wallet_id": scope.wallet_id,
+                        "scope_type": scope.scope_type,
+                        "scope_id": scope.scope_id,
+                        "user_id": scope.user_id,
+                        "tenant_id": scope.tenant_id,
+                        "created_at": now,
+                    },
+                    "$set": {"updated_at": now},
+                    "$max": {revision_path: subject_revision},
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            # The balance exists but a newer revision holds the head, so the
+            # filtered upsert collided on the deterministic balance id.
+            return False
+        return updated is not None
+
     async def ensure_plan_allowances(
         self,
         *,
@@ -603,6 +929,8 @@ class TokenWalletLedger:
         user_id: str | None = None,
         tenant_id: str | None = None,
         period_start: datetime | None = None,
+        subject_key: str | None = None,
+        subject_revision: int | None = None,
     ) -> list[TokenWalletEntryResult]:
         plan = None
         resolved_plan_id = _text(plan_id)
@@ -670,6 +998,8 @@ class TokenWalletLedger:
                         "cadence": allowance.cadence,
                         "period_key": period_key,
                     },
+                    subject_key=subject_key,
+                    subject_revision=subject_revision,
                 )
             )
         return results

--- a/tests/test_billing_fulfillment.py
+++ b/tests/test_billing_fulfillment.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 from pymongo.errors import DuplicateKeyError
 
 from mozaiksai.core.billing.fulfillment import (
+    MAX_SUBJECT_REVISION,
     BillingFulfillmentCommand,
     BillingFulfillmentCommandStore,
     BillingFulfillmentConflictError,
     BillingFulfillmentService,
+    _json_hash,
 )
 from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
 from mozaiksai.core.tokens.guard import TokenUsageGuard
@@ -49,17 +54,30 @@ class _Collection:
 
     def _matches(self, doc: dict[str, Any], query: dict[str, Any]) -> bool:
         for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(doc, clause) for clause in expected):
+                    return False
+                continue
             actual = doc.get(key)
             if isinstance(expected, dict):
-                if "$ne" in expected:
-                    denied = expected["$ne"]
-                    if isinstance(actual, list):
-                        if denied in actual:
+                for operator, operand in expected.items():
+                    if operator == "$ne":
+                        if isinstance(actual, list):
+                            if operand in actual:
+                                return False
+                        elif actual == operand:
                             return False
-                    elif actual == denied:
-                        return False
-                if "$gte" in expected and not (actual is not None and actual >= expected["$gte"]):
-                    return False
+                    elif operator == "$gte":
+                        if actual is None or not actual >= operand:
+                            return False
+                    elif operator == "$lt":
+                        if actual is None or not actual < operand:
+                            return False
+                    elif operator == "$exists":
+                        if (key in doc) is not bool(operand):
+                            return False
+                    else:  # pragma: no cover - guards against silent test lies
+                        raise NotImplementedError(f"fake mongo operator {operator}")
                 continue
             if actual != expected:
                 return False
@@ -104,13 +122,18 @@ class _Collection:
         for doc in self.docs.values():
             if self._matches(doc, query):
                 self._apply_update(doc, update)
-                return None
+                return SimpleNamespace(matched_count=1, modified_count=1, upserted_id=None)
         if upsert:
             key = (update.get("$setOnInsert") or {}).get("_id") or query.get("_id") or f"doc:{len(self.docs)}"
+            if key in self.docs:
+                # A filtered upsert whose predicate excluded an existing
+                # document collides on the unique _id, exactly as Mongo does.
+                raise DuplicateKeyError("duplicate")
             doc = {"_id": key}
             self._apply_update(doc, update, inserted=True)
             self.docs[key] = doc
-        return None
+            return SimpleNamespace(matched_count=0, modified_count=0, upserted_id=key)
+        return SimpleNamespace(matched_count=0, modified_count=0, upserted_id=None)
 
     async def find_one_and_update(
         self,
@@ -901,3 +924,781 @@ def test_fulfillment_fails_closed_in_protected_env_even_if_startup_bypassed(
         assert resp.status_code == 500  # AuthError surfaces; never 200
     finally:
         reset_auth_adapter()
+
+
+# ── subject revision fencing ─────────────────────────────────────────────────
+#
+# Commands may carry `subject_revision`: a provider-neutral, monotonically
+# increasing ordinal allocated by the upstream billing source per entitlement
+# subject. Subscription effects commit only when the incoming revision is
+# strictly newer than the one already stored for that subject, so an
+# out-of-order command can never regress entitlement state.
+
+
+def _subscription_command(
+    command_id: str,
+    *,
+    plan_id: str,
+    subject_revision: int | None = None,
+    event_type: str = "subscription_updated",
+    user_id: str = "user_1",
+) -> BillingFulfillmentCommand:
+    return BillingFulfillmentCommand(
+        command_id=command_id,
+        event_type=event_type,
+        source="test",
+        app_id="app_1",
+        user_id=user_id,
+        plan_id=plan_id,
+        subject_revision=subject_revision,
+        occurred_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+
+async def _assignment(assignments: _Collection, *, user_id: str = "user_1"):
+    return await assignments.find_one(
+        {"app_id": "app_1", "tenant_id": None, "user_id": user_id}
+    )
+
+
+@pytest.mark.asyncio
+async def test_newer_revision_applies_and_stamps_the_subject() -> None:
+    service, _ledger, assignments = _service()
+
+    result = await service.apply(
+        _subscription_command("cmd_rev_1", plan_id="pro", subject_revision=7)
+    )
+
+    assert result.status == "applied"
+    assert result.success is True
+    assignment = await _assignment(assignments)
+    assert assignment["plan_id"] == "pro"
+    assert assignment["billing_revision"] == 7
+    assert result.effects[0].details["subject_revision"] == 7
+
+
+@pytest.mark.asyncio
+async def test_stale_revision_cannot_regress_a_newer_subject() -> None:
+    """The core race: an older command completes remotely after a newer one."""
+    service, ledger, assignments = _service()
+
+    await service.apply(
+        _subscription_command("cmd_new", plan_id="pro", subject_revision=9)
+    )
+    stale = await service.apply(
+        _subscription_command("cmd_old", plan_id="free", subject_revision=4)
+    )
+
+    assert stale.status == "superseded"
+    assert stale.success is True, "a correctly suppressed command is not an error"
+    assert stale.applied == 0
+    assert {effect.effect for effect in stale.effects} == {
+        "assignment_upsert", "plan_allowances",
+    }
+    assert all(effect.reason == "stale_revision" for effect in stale.effects)
+
+    assignment = await _assignment(assignments)
+    assert assignment["plan_id"] == "pro", "the newer revision must still govern"
+    assert assignment["billing_revision"] == 9
+    # The stale command must not mint allowances behind the fenced assignment.
+    balance = await ledger.query_balance(app_id="app_1", user_id="user_1")
+    assert balance["balance"] == 1000, "a fenced command must not mint allowances"
+
+
+@pytest.mark.asyncio
+async def test_equal_revision_is_suppressed() -> None:
+    """Equal revisions carry no ordering information, so the first commit wins
+    and a second distinct command for the same revision is suppressed."""
+    service, _ledger, assignments = _service()
+
+    await service.apply(
+        _subscription_command("cmd_a", plan_id="pro", subject_revision=5)
+    )
+    duplicate = await service.apply(
+        _subscription_command("cmd_b", plan_id="free", subject_revision=5)
+    )
+
+    assert duplicate.status == "superseded"
+    assignment = await _assignment(assignments)
+    assert assignment["plan_id"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_revision_sequence_applies_in_order() -> None:
+    service, _ledger, assignments = _service()
+
+    for index, plan_id in enumerate(["free", "pro", "free"], start=1):
+        result = await service.apply(
+            _subscription_command(f"cmd_seq_{index}", plan_id=plan_id, subject_revision=index)
+        )
+        assert result.status == "applied"
+
+    assignment = await _assignment(assignments)
+    assert assignment["plan_id"] == "free"
+    assert assignment["billing_revision"] == 3
+
+
+@pytest.mark.asyncio
+async def test_first_fenced_write_creates_the_subject() -> None:
+    """A fenced command for a subject that does not exist yet must insert it."""
+    service, _ledger, assignments = _service()
+
+    result = await service.apply(
+        _subscription_command(
+            "cmd_first", plan_id="pro", subject_revision=1,
+            event_type="subscription_activated",
+        )
+    )
+
+    assert result.status == "applied"
+    assert (await _assignment(assignments))["billing_revision"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unfenced_command_keeps_prior_behavior() -> None:
+    """Commands without `subject_revision` apply unfenced, exactly as before —
+    callers with no ordering authority are unaffected."""
+    service, _ledger, assignments = _service()
+
+    await service.apply(_subscription_command("cmd_x", plan_id="pro", subject_revision=9))
+    unfenced = await service.apply(_subscription_command("cmd_y", plan_id="free"))
+
+    assert unfenced.status == "applied"
+    assignment = await _assignment(assignments)
+    assert assignment["plan_id"] == "free"
+    assert assignment["billing_revision"] == 9, "an unfenced write leaves the stamp"
+
+
+@pytest.mark.asyncio
+async def test_fence_is_scoped_to_one_entitlement_subject() -> None:
+    """Revisions are compared per subject; one customer's newer revision must
+    not suppress another customer's older one."""
+    service, _ledger, assignments = _service()
+
+    await service.apply(
+        _subscription_command("cmd_u1", plan_id="pro", subject_revision=9, user_id="user_1")
+    )
+    other = await service.apply(
+        _subscription_command("cmd_u2", plan_id="pro", subject_revision=2, user_id="user_2")
+    )
+
+    assert other.status == "applied"
+    assert (await _assignment(assignments, user_id="user_2"))["billing_revision"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_cancellation_cannot_revoke_a_newer_activation() -> None:
+    service, _ledger, assignments = _service()
+
+    await service.apply(
+        _subscription_command(
+            "cmd_reactivate", plan_id="pro", subject_revision=12,
+            event_type="subscription_activated",
+        )
+    )
+    stale_cancel = await service.apply(
+        _subscription_command(
+            "cmd_cancel_old", plan_id="pro", subject_revision=8,
+            event_type="subscription_cancelled",
+        )
+    )
+
+    assert stale_cancel.status == "superseded"
+    assignment = await _assignment(assignments)
+    assert assignment["status"] == "active", "a stale cancel must not revoke access"
+
+
+@pytest.mark.asyncio
+async def test_durable_stale_revision_is_replayable_and_stable() -> None:
+    """Replay of a stale command returns the preserved superseded result rather
+    than re-evaluating the fence."""
+    database = _Database()
+    store = BillingFulfillmentCommandStore(database=database)
+    assignments = _Collection()
+    ledger = TokenWalletLedger(database=database)
+    service = BillingFulfillmentService(
+        config=_subscriptions_config(),
+        ledger=ledger,
+        collection_resolver=lambda _alias: assignments,
+        command_store=store,
+    )
+
+    await service.apply_durable(
+        _subscription_command("cmd_head", plan_id="pro", subject_revision=20)
+    )
+    stale_command = _subscription_command("cmd_stale", plan_id="free", subject_revision=3)
+    first = await service.apply_durable(stale_command)
+    replayed = await service.apply_durable(stale_command)
+
+    assert first.status == "superseded"
+    assert replayed.status == "replayed"
+    assert replayed.replayed is True
+    assert replayed.success is True
+    assert replayed.applied == 0
+
+
+@pytest.mark.asyncio
+async def test_revision_field_can_be_disabled_per_app() -> None:
+    """Setting `revision_field: null` opts an app out of fencing entirely."""
+    config = SubscriptionsConfig.model_validate(
+        {
+            **_subscriptions_config().model_dump(mode="json"),
+            "assignment_store": {
+                "data_alias": "billing.subscriptions",
+                "user_id_field": "user_id",
+                "revision_field": None,
+            },
+        }
+    )
+    database = _Database()
+    ledger = TokenWalletLedger(database=database)
+    assignments = _Collection()
+    service = BillingFulfillmentService(
+        config=config,
+        ledger=ledger,
+        collection_resolver=lambda _alias: assignments,
+    )
+
+    await service.apply(_subscription_command("cmd_p", plan_id="pro", subject_revision=9))
+    older = await service.apply(_subscription_command("cmd_q", plan_id="free", subject_revision=1))
+
+    assert older.status == "applied"
+    assignment = await assignments.find_one(
+        {"app_id": "app_1", "tenant_id": None, "user_id": "user_1"}
+    )
+    assert assignment["plan_id"] == "free"
+    assert "billing_revision" not in assignment
+
+
+# ── subject_revision is strict and BSON-safe ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 1.0, 0.0, "1", "1.0", "", [1], {"v": 1}, Decimal("1")],
+)
+def test_subject_revision_rejects_coercible_values(value) -> None:
+    """A silently coerced ordering value is worse than a rejected one."""
+    with pytest.raises(ValidationError):
+        _subscription_command("cmd_strict", plan_id="pro", subject_revision=value)
+
+
+@pytest.mark.parametrize("value", [-1, MAX_SUBJECT_REVISION + 1, 2**70])
+def test_subject_revision_rejects_out_of_range(value) -> None:
+    """Bounded to BSON int64 so a revision can always be persisted."""
+    with pytest.raises(ValidationError):
+        _subscription_command("cmd_range", plan_id="pro", subject_revision=value)
+
+
+@pytest.mark.parametrize("value", [0, 1, MAX_SUBJECT_REVISION])
+def test_subject_revision_accepts_valid_bounds(value) -> None:
+    command = _subscription_command("cmd_ok", plan_id="pro", subject_revision=value)
+    assert command.subject_revision == value
+
+
+def test_subject_revision_accepts_bson_int64() -> None:
+    """Values read back from Mongo arrive as Int64, an int subclass."""
+    from bson.int64 import Int64
+
+    command = _subscription_command("cmd_i64", plan_id="pro", subject_revision=Int64(9))
+    assert command.subject_revision == 9
+
+
+# ── revision_field is a fixed authority field, not a customization point ─────
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["app_id", "user_id", "plan_id", "status", "updated_at", "billing_fulfillment",
+     "_id", "  ", "a.b", "$set", "billing_revision "],
+)
+def test_revision_field_rejects_anything_but_the_canonical_name(value) -> None:
+    """This field is read and written inside the same update as the assignment
+    itself, so an arbitrary name could shadow identity/plan/status fields or
+    introduce dotted paths. The only meaningful choice is on or off."""
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    with pytest.raises(ValidationError):
+        SubscriptionAssignmentStoreDef.model_validate(
+            {"data_alias": "billing.subscriptions", "revision_field": value}
+        )
+
+
+@pytest.mark.parametrize("value", ["billing_revision", None])
+def test_revision_field_accepts_on_and_off(value) -> None:
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    store = SubscriptionAssignmentStoreDef.model_validate(
+        {"data_alias": "billing.subscriptions", "revision_field": value}
+    )
+    assert store.revision_field == value
+
+
+def test_revision_field_defaults_on_when_absent() -> None:
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    store = SubscriptionAssignmentStoreDef.model_validate(
+        {"data_alias": "billing.subscriptions"}
+    )
+    assert store.revision_field == "billing_revision"
+
+
+# ── pre-fence command identity survives the upgrade ──────────────────────────
+
+
+def test_unfenced_command_document_omits_the_revision_field() -> None:
+    """The canonical document — and therefore the durable command hash — must
+    be byte-identical to its pre-fence form for a command that never opted in.
+    Serializing an explicit null would turn every pre-upgrade command into a
+    content conflict on its first replay."""
+    from mozaiksai.core.billing.fulfillment import _command_document, _command_hash
+
+    unfenced = _subscription_command("cmd_unfenced", plan_id="pro")
+    document = _command_document(unfenced)
+    assert "subject_revision" not in document
+
+    # The hash a pre-#497 build would have produced, reconstructed from the
+    # same canonical rules without the field existing at all.
+    baseline = dict(document)
+    assert _command_hash(unfenced) == _json_hash(baseline)
+
+
+def test_fenced_command_document_carries_the_revision() -> None:
+    from mozaiksai.core.billing.fulfillment import _command_document
+
+    fenced = _subscription_command("cmd_fenced", plan_id="pro", subject_revision=4)
+    assert _command_document(fenced)["subject_revision"] == 4
+
+
+@pytest.mark.asyncio
+async def test_wallet_command_hash_is_unchanged_by_the_upgrade() -> None:
+    """Wallet commands never carry a revision, so their identity must be
+    untouched too."""
+    from mozaiksai.core.billing.fulfillment import _command_document, _command_hash
+
+    top_up = BillingFulfillmentCommand(
+        command_id="cmd_topup_unfenced",
+        event_type="token_top_up_paid",
+        source="test",
+        app_id="app_1",
+        user_id="user_1",
+        token_amount=500,
+    )
+    document = _command_document(top_up)
+    assert "subject_revision" not in document
+    assert _command_hash(top_up) == _json_hash(document)
+
+
+# ── replay preserves the original disposition ────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("plan_id", "revision", "expected_status"),
+    [("pro", 5, "applied"), ("free", 1, "superseded")],
+)
+async def test_replay_preserves_the_original_status(
+    plan_id, revision, expected_status
+) -> None:
+    """`status` says THIS response is a replay; `original_status` says what is
+    being replayed. Inferring the latter from counters is unsound — an applied
+    command and a superseded one both report success with zero rejections."""
+    database = _Database()
+    store = BillingFulfillmentCommandStore(database=database)
+    assignments = _Collection()
+    ledger = TokenWalletLedger(database=database)
+    service = BillingFulfillmentService(
+        config=_subscriptions_config(),
+        ledger=ledger,
+        collection_resolver=lambda _alias: assignments,
+        command_store=store,
+    )
+
+    await service.apply_durable(
+        _subscription_command("cmd_head", plan_id="pro", subject_revision=4)
+    )
+    command = _subscription_command(
+        f"cmd_{expected_status}", plan_id=plan_id, subject_revision=revision
+    )
+    first = await service.apply_durable(command)
+    replay = await service.apply_durable(command)
+
+    assert first.status == expected_status
+    assert first.original_status is None, "a fresh application is not a replay"
+    assert replay.status == "replayed"
+    assert replay.replayed is True
+    assert replay.original_status == expected_status
+    assert replay.success is first.success
+
+
+@pytest.mark.asyncio
+async def test_replay_of_a_rejected_command_stays_rejected() -> None:
+    database = _Database()
+    store = BillingFulfillmentCommandStore(database=database)
+    assignments = _Collection()
+    service = BillingFulfillmentService(
+        config=_subscriptions_config(),
+        ledger=TokenWalletLedger(database=database),
+        collection_resolver=lambda _alias: assignments,
+        command_store=store,
+    )
+    unknown_plan = BillingFulfillmentCommand(
+        command_id="cmd_unknown_plan",
+        event_type="subscription_activated",
+        source="test",
+        app_id="app_1",
+        user_id="user_1",
+        plan_id="does_not_exist",
+    )
+
+    first = await service.apply_durable(unknown_plan)
+    replay = await service.apply_durable(unknown_plan)
+
+    assert first.status in {"rejected", "partial"}
+    assert replay.status == "replayed"
+    assert replay.original_status == first.status
+    assert replay.success is False
+
+
+# ── allowance fence is generic and opt-in ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ledger_movement_without_a_subject_is_unfenced() -> None:
+    """Callers with no ordering authority behave exactly as before."""
+    database = _Database()
+    ledger = TokenWalletLedger(database=database)
+
+    first = await ledger.credit(
+        app_id="app_1", user_id="user_1", amount=50, idempotency_key="k1"
+    )
+    second = await ledger.credit(
+        app_id="app_1", user_id="user_1", amount=50, idempotency_key="k2"
+    )
+
+    assert first.status == "applied" and second.status == "applied"
+    balance = await ledger.query_balance(app_id="app_1", user_id="user_1")
+    assert balance["balance"] == 100
+    assert "subject_revisions" not in balance, (
+        "ordering state must never reach the public balance surface"
+    )
+
+
+# ── the revision field is reserved against every other mapping ───────────────
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        "app_id_field", "tenant_id_field", "workspace_id_field", "user_id_field",
+        "plan_id_field", "status_field", "starts_at_field", "expires_at_field",
+        "capabilities_field", "plan_snapshot_field",
+    ],
+)
+def test_no_mapping_may_target_the_reserved_revision_field(mapping) -> None:
+    """An identity or business mapping aimed at the ordering field would let
+    ordinary writes clobber the fence — caught at load, not at runtime."""
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    with pytest.raises(ValidationError, match="reserved revision field"):
+        SubscriptionAssignmentStoreDef.model_validate(
+            {"data_alias": "billing.subscriptions", mapping: "billing_revision"}
+        )
+
+
+@pytest.mark.parametrize("value", ["billing_revision.inner", "billing_revision.a.b"])
+def test_mappings_nested_under_the_reserved_field_are_rejected(value) -> None:
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    with pytest.raises(ValidationError, match="reserved revision field"):
+        SubscriptionAssignmentStoreDef.model_validate(
+            {"data_alias": "billing.subscriptions", "plan_id_field": value}
+        )
+
+
+def test_reserved_field_check_is_skipped_when_fencing_is_off() -> None:
+    """With fencing off there is no ordering authority to protect."""
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    store = SubscriptionAssignmentStoreDef.model_validate(
+        {
+            "data_alias": "billing.subscriptions",
+            "revision_field": None,
+            "plan_id_field": "billing_revision",
+        }
+    )
+    assert store.plan_id_field == "billing_revision"
+
+
+def test_unrelated_mappings_remain_valid_with_fencing_on() -> None:
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    store = SubscriptionAssignmentStoreDef.model_validate(
+        {
+            "data_alias": "billing.subscriptions",
+            "user_id_field": "scope.user",
+            "plan_id_field": "billing_plan",
+        }
+    )
+    assert store.revision_field == "billing_revision"
+    assert store.user_id_field == "scope.user"
+
+
+# ── configured dotted paths resolve the same way everywhere ──────────────────
+
+
+def test_dotted_subject_paths_resolve_for_typed_comparison() -> None:
+    """Reading `document["scope.user"]` instead of walking into `scope.user`
+    reports a mismatch for a row that genuinely is the same subject."""
+    from mozaiksai.core.billing.fulfillment import _resolve_document_path
+
+    document = {"app_id": "app_1", "scope": {"user": "u-123", "tenant": None}}
+    assert _resolve_document_path(document, "scope.user") == "u-123"
+    assert _resolve_document_path(document, "scope.tenant") is None
+    assert _resolve_document_path(document, "app_id") == "app_1"
+    assert _resolve_document_path(document, "scope.missing") is None
+    assert _resolve_document_path(document, "app_id.nested") is None
+
+
+def test_same_subject_under_dotted_mapping_is_not_a_collision() -> None:
+    from mozaiksai.core.billing.fulfillment import BillingFulfillmentService
+
+    existing = {"app_id": "app_1", "scope": {"user": "u-123"}}
+    query = {"app_id": "app_1", "scope.user": "u-123"}
+    assert BillingFulfillmentService._assignment_subject_mismatch(
+        existing, query=query
+    ) is None
+
+
+def test_different_subject_under_dotted_mapping_is_a_collision() -> None:
+    from mozaiksai.core.billing.fulfillment import BillingFulfillmentService
+
+    existing = {"app_id": "app_1", "scope": {"user": None}}
+    query = {"app_id": "app_1", "scope.user": "None"}
+    assert BillingFulfillmentService._assignment_subject_mismatch(
+        existing, query=query
+    ) == "scope.user"
+
+
+# ── terminal-status aggregation precedence ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("effects", "expected"),
+    [
+        ([("applied", None), ("applied", None)], "applied"),
+        ([("applied", None), ("skipped", "no_token_allowances")], "applied"),
+        ([("rejected", "boom"), ("applied", None)], "partial"),
+        ([("rejected", "boom"), ("rejected", "boom")], "rejected"),
+        ([("skipped", "stale_revision"), ("skipped", "stale_revision")], "superseded"),
+        # An earlier effect really did apply, but a newer revision invalidated
+        # the rest of the command: the command as a whole was overtaken.
+        ([("applied", None), ("rejected", "stale_subject_revision")], "partial"),
+        ([("applied", None), ("skipped", "stale_subject_revision")], "superseded"),
+        ([("applied", None), ("skipped", "stale_revision")], "superseded"),
+    ],
+)
+def test_status_aggregation_precedence(effects, expected) -> None:
+    from mozaiksai.core.billing.fulfillment import (
+        BillingFulfillmentEffectResult,
+        _status_from_effects,
+    )
+
+    results = [
+        BillingFulfillmentEffectResult(effect="plan_allowances", status=status, reason=reason)
+        for status, reason in effects
+    ]
+    assert _status_from_effects(results) == expected
+
+
+# ── one effective fencing decision ───────────────────────────────────────────
+
+
+def test_fencing_requires_both_command_and_store_authority() -> None:
+    """Deciding per effect produced a half-fenced system: an app that opted out
+    still had wallet allowances refused as stale while its assignment took the
+    older revision."""
+    from mozaiksai.core.billing.fulfillment import BillingFulfillmentService
+    from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
+
+    def _service_with(revision_field):
+        config = SubscriptionsConfig.model_validate(
+            {
+                **_subscriptions_config().model_dump(mode="json"),
+                "assignment_store": {
+                    "data_alias": "billing.subscriptions",
+                    "user_id_field": "user_id",
+                    "revision_field": revision_field,
+                },
+            }
+        )
+        return BillingFulfillmentService(config=config, ledger=None)
+
+    fenced = _subscription_command("cmd_f", plan_id="pro", subject_revision=3)
+    unfenced = _subscription_command("cmd_u", plan_id="pro")
+
+    on = _service_with("billing_revision")
+    off = _service_with(None)
+
+    assert on._fencing_enabled(fenced) is True
+    assert on._fencing_enabled(unfenced) is False
+    assert off._fencing_enabled(fenced) is False, "store opt-out disables everything"
+    assert off._subject_key(fenced) is None, "no wallet authority when opted out"
+    assert on._subject_key(fenced) is not None
+
+
+# ── designer literal matches the runtime contract exactly ────────────────────
+
+
+def test_designer_revision_field_compiles_to_the_runtime_literal() -> None:
+    """A `str | null` schema could generate a value the runtime rejects, so the
+    designer declares the same finite literal — and it must actually COMPILE
+    through the canonical structured-output builder, not merely parse as YAML."""
+    from pathlib import Path
+
+    import yaml as _yaml
+
+    from mozaiksai.core.workflow.outputs.structured import build_models_from_config
+
+    schema = _yaml.safe_load(
+        (
+            Path(__file__).resolve().parents[1]
+            / "factory_app/workflows/SubscriptionContractDesigner/structured_outputs.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    field = schema["models"]["AssignmentStore"]["fields"]["revision_field"]
+    assert field["type"] == "union"
+    assert field["variants"] == ["BillingRevisionField", "null"]
+    assert schema["models"]["BillingRevisionField"] == {
+        "type": "literal",
+        "values": ["billing_revision"],
+    }
+
+    models = build_models_from_config(schema["models"])
+    store = models["AssignmentStore"]
+    base = {
+        "data_alias": "billing.subscriptions",
+        "app_id_field": "app_id",
+        "plan_id_field": "plan_id",
+        "status_field": "status",
+        "active_statuses": ["active"],
+    }
+    assert store(**base, revision_field="billing_revision").revision_field is not None
+    assert store(**base, revision_field=None).revision_field is None
+    with pytest.raises(ValidationError):
+        store(**base, revision_field="other_field")
+
+
+@pytest.mark.parametrize("value", ["other_field", "billing_revisions", "", "  "])
+def test_runtime_rejects_any_other_revision_field_value(value) -> None:
+    from mozaiksai.core.runtime.app.subscriptions_loader import (
+        SubscriptionAssignmentStoreDef,
+    )
+
+    with pytest.raises(ValidationError):
+        SubscriptionAssignmentStoreDef.model_validate(
+            {"data_alias": "billing.subscriptions", "revision_field": value}
+        )
+
+
+# ── an existing index that already provides the guarantee is accepted ────────
+
+
+class _IndexInformation:
+    def __init__(self, information: dict[str, dict]) -> None:
+        self._information = information
+
+    async def index_information(self) -> dict[str, dict]:
+        return self._information
+
+
+_REQUIRED_SUBJECT_KEYS = [("app_id", 1), ("tenant_id", 1), ("user_id", 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("definition", "accepted"),
+    [
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True}, True),
+        # Same guarantee, different name — the name is not the contract.
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True, "v": 2}, True),
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True,
+          "collation": {"locale": "simple"}}, True),
+        # Not unique at all.
+        ({"key": _REQUIRED_SUBJECT_KEYS}, False),
+        # A different subject definition.
+        ({"key": [("app_id", 1), ("user_id", 1)], "unique": True}, False),
+        # Right fields, wrong order — a compound index is ordered.
+        ({"key": [("user_id", 1), ("tenant_id", 1), ("app_id", 1)], "unique": True}, False),
+        # Descending is a different index.
+        ({"key": [("app_id", 1), ("tenant_id", 1), ("user_id", -1)], "unique": True}, False),
+        # Narrowed coverage: subjects outside the filter may still duplicate.
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True, "sparse": True}, False),
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True,
+          "partialFilterExpression": {"status": "active"}}, False),
+        # A collation changes which values compare equal.
+        ({"key": _REQUIRED_SUBJECT_KEYS, "unique": True,
+          "collation": {"locale": "en", "strength": 2}}, False),
+    ],
+)
+async def test_existing_index_equivalence(definition, accepted) -> None:
+    from mozaiksai.core.billing.fulfillment import BillingFulfillmentService
+
+    collection = _IndexInformation({"_id_": {"key": [("_id", 1)]}, "candidate": definition})
+    assert (
+        await BillingFulfillmentService._subject_uniqueness_already_guaranteed(
+            collection, _REQUIRED_SUBJECT_KEYS
+        )
+        is accepted
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_collection_that_cannot_report_indexes_is_not_assumed_guaranteed() -> None:
+    from mozaiksai.core.billing.fulfillment import BillingFulfillmentService
+
+    class _Silent:
+        pass
+
+    assert (
+        await BillingFulfillmentService._subject_uniqueness_already_guaranteed(
+            _Silent(), _REQUIRED_SUBJECT_KEYS
+        )
+        is False
+    )
+
+
+# ── the ordering key distinguishes subjects the assignment id conflates ──────
+
+
+def test_subject_identity_preserves_value_types() -> None:
+    """`_assignment_id` string-formats scope values, so a null tenant and the
+    literal string "None" produce the same id. Ordering authority keyed that
+    way would let one subject fence the other out."""
+    from mozaiksai.core.billing.fulfillment import _assignment_id, _subject_identity
+
+    null_scope = {"app_id": "app_1", "tenant_id": None, "user_id": "u1"}
+    forged_scope = {"app_id": "app_1", "tenant_id": "None", "user_id": "u1"}
+
+    assert _assignment_id("app_1", null_scope) == _assignment_id("app_1", forged_scope)
+    assert _subject_identity("app_1", null_scope) != _subject_identity(
+        "app_1", forged_scope
+    )
+    # And it stays stable for the same subject regardless of key order.
+    assert _subject_identity("app_1", null_scope) == _subject_identity(
+        "app_1", {"user_id": "u1", "app_id": "app_1", "tenant_id": None}
+    )

--- a/tests/test_billing_fulfillment_revision_fence_real_mongo.py
+++ b/tests/test_billing_fulfillment_revision_fence_real_mongo.py
@@ -1,0 +1,1774 @@
+"""Real-MongoDB proofs for billing fulfillment revision fencing.
+
+The in-memory double in ``test_billing_fulfillment.py`` models Mongo's
+document-level atomicity, but only a real server can prove the things this
+fence depends on: that a filtered upsert collides on the deterministic
+assignment id rather than inserting a second row, that concurrent creations of
+the same subject resolve to the highest revision, and that a stale allowance
+loses its race inside the balance update itself.
+
+These are gated on MongoDB *reachability*, matching
+``test_chat_execution_lease_real_mongo.py``. The authoritative CI shard lane
+exports ``MONGO_URI`` against a live ``mongo:7`` service, so these execute on
+every PR instead of silently skipping the way an opt-in env flag would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from mozaiksai.core.billing.fulfillment import (
+    MAX_SUBJECT_REVISION,
+    SUBJECT_UNIQUE_INDEX_NAME,
+    BillingFulfillmentCommand,
+    BillingFulfillmentCommandStore,
+    BillingFulfillmentOrderingUnavailable,
+    BillingFulfillmentPendingError,
+    BillingFulfillmentService,
+    BillingFulfillmentSubjectIndexError,
+)
+from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
+from mozaiksai.core.tokens.wallet import TokenWalletLedger, _entry_id, _scope_for
+
+
+def _mongo_uri() -> str | None:
+    for name in ("MONGO_URI", "MONGODB_URI", "MONGO_URL"):
+        value = (os.getenv(name) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _mongo_reachable() -> bool:
+    uri = _mongo_uri()
+    if not uri:
+        return False
+    try:
+        from pymongo import MongoClient
+
+        MongoClient(uri, serverSelectionTimeoutMS=2000).admin.command("ping")
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _mongo_reachable(),
+    reason="requires a reachable MongoDB via MONGO_URI (provided by the CI mongo service)",
+)
+
+
+def _config(*, revision_field: str | None = "billing_revision") -> SubscriptionsConfig:
+    return SubscriptionsConfig.model_validate(
+        {
+            "schema_version": "mozaiks.subscriptions.v1",
+            "label": "Fence proof",
+            "default_plan_id": "free",
+            "assignment_store": {
+                "data_alias": "billing.subscriptions",
+                "user_id_field": "user_id",
+                "revision_field": revision_field,
+            },
+            "token_wallets": [
+                {
+                    "wallet_id": "ai_tokens",
+                    "label": "AI tokens",
+                    "unit": "tokens",
+                    "usage_meter_id": "ai_tokens",
+                    "scope": "user",
+                }
+            ],
+            "plans": [
+                {"plan_id": "free", "label": "Free", "capabilities": []},
+                {
+                    "plan_id": "pro",
+                    "label": "Pro",
+                    "capabilities": ["reports.export"],
+                    "token_allowances": [
+                        {"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}
+                    ],
+                },
+                {
+                    "plan_id": "enterprise",
+                    "label": "Enterprise",
+                    "capabilities": ["reports.export", "reports.admin"],
+                    "token_allowances": [
+                        {"wallet_id": "ai_tokens", "amount": 200, "cadence": "monthly"}
+                    ],
+                },
+            ],
+        }
+    )
+
+
+class _Harness:
+    def __init__(self, database: Any, suffix: str) -> None:
+        self.database = database
+        self.assignments = database[f"fence_assignments_{suffix}"]
+        self.app_id = f"app_{suffix}"
+        self.ledger = TokenWalletLedger(database=database)
+        self.store = BillingFulfillmentCommandStore(database=database)
+
+    def service(self, *, revision_field: str | None = "billing_revision", durable: bool = False):
+        return BillingFulfillmentService(
+            config=_config(revision_field=revision_field),
+            ledger=self.ledger,
+            collection_resolver=lambda _alias: self.assignments,
+            command_store=self.store if durable else None,
+        )
+
+    def command(
+        self,
+        command_id: str,
+        *,
+        plan_id: str = "pro",
+        subject_revision: int | None = None,
+        event_type: str = "subscription_updated",
+        user_id: str = "user_1",
+    ) -> BillingFulfillmentCommand:
+        return BillingFulfillmentCommand(
+            command_id=f"{command_id}_{self.app_id}",
+            event_type=event_type,
+            source="test",
+            app_id=self.app_id,
+            user_id=user_id,
+            plan_id=plan_id,
+            subject_revision=subject_revision,
+            occurred_at=datetime(2026, 7, 1, tzinfo=UTC),
+        )
+
+    async def assignment(self, *, user_id: str = "user_1") -> dict[str, Any] | None:
+        return await self.assignments.find_one(
+            {"app_id": self.app_id, "tenant_id": None, "user_id": user_id}
+        )
+
+    async def balance(self, *, user_id: str = "user_1") -> int:
+        result = await self.ledger.query_balance(app_id=self.app_id, user_id=user_id)
+        return int(result["balance"])
+
+
+@pytest.fixture()
+async def harness():
+    from mozaiksai.core.core_config import close_mongo_client, get_mongo_client
+
+    close_mongo_client()
+    client = get_mongo_client()
+    database = client["mozaiks_billing_fence_proof"]
+    suffix = uuid.uuid4().hex[:12]
+    subject = _Harness(database, suffix)
+    yield subject
+    await subject.assignments.drop()
+    close_mongo_client()
+
+
+# ── Defect A: strict, BSON-safe revision ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value", [True, False, 1.0, "1", "1.0", -1, MAX_SUBJECT_REVISION + 1]
+)
+async def test_invalid_subject_revision_is_rejected(harness, value) -> None:
+    """No coercion, no out-of-range value that Mongo could not store."""
+    with pytest.raises(ValueError):
+        harness.command("cmd_bad", subject_revision=value)
+
+
+@pytest.mark.asyncio
+async def test_max_int64_revision_round_trips_through_mongo(harness) -> None:
+    """The upper bound must actually persist rather than raise OverflowError."""
+    from bson.int64 import Int64
+
+    service = harness.service()
+    result = await service.apply(
+        harness.command("cmd_max", subject_revision=MAX_SUBJECT_REVISION)
+    )
+    assert result.status == "applied"
+    stored = await harness.assignment()
+    assert int(stored["billing_revision"]) == MAX_SUBJECT_REVISION
+    # And a value read back as BSON Int64 is still an acceptable command value.
+    assert (
+        harness.command("cmd_i64", subject_revision=Int64(5)).subject_revision == 5
+    )
+
+
+# ── Defects C/D: atomic creation and subject identity ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_fenced_write_creates_and_stamps(harness) -> None:
+    service = harness.service()
+    result = await service.apply(harness.command("cmd_first", subject_revision=3))
+    assert result.status == "applied"
+    assert (await harness.assignment())["billing_revision"] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("first", "second"), [(2, 9), (9, 2)])
+async def test_two_concurrent_creations_keep_the_highest(harness, first, second) -> None:
+    """Both revisions observe an absent subject at the same moment.
+
+    A read-then-unfenced-upsert loses this outright: whichever writer inserts
+    second overwrites the winner and the subject ends at the lower revision.
+    """
+    service = harness.service()
+    results = await asyncio.gather(
+        service.apply(
+            harness.command(f"cmd_a_{first}", plan_id="pro", subject_revision=first)
+        ),
+        service.apply(
+            harness.command(
+                f"cmd_b_{second}", plan_id="enterprise", subject_revision=second
+            )
+        ),
+    )
+    stored = await harness.assignment()
+    assert stored["billing_revision"] == max(first, second)
+    assert stored["plan_id"] == ("pro" if first > second else "enterprise")
+    # Whether the two interleave or serialize, the invariant is the same: the
+    # subject ends at the highest revision and no command reports a stale
+    # application. (Serialized execution legitimately applies both in order.)
+    assert all(r.status in {"applied", "superseded"} for r in results)
+    assert await harness.assignments.count_documents({}) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("order", ["ascending", "descending"])
+async def test_ten_concurrent_creations_settle_on_the_highest(harness, order) -> None:
+    service = harness.service()
+    revisions = list(range(1, 11))
+    if order == "descending":
+        revisions.reverse()
+    results = await asyncio.gather(
+        *[
+            service.apply(harness.command(f"cmd_{r}", subject_revision=r))
+            for r in revisions
+        ]
+    )
+    stored = await harness.assignment()
+    assert stored["billing_revision"] == 10, "the highest revision must govern"
+    assert await harness.assignments.count_documents({}) == 1, "one subject, one row"
+    # No stale command may claim it applied.
+    for revision, result in zip(revisions, results, strict=True):
+        if result.status == "applied":
+            assert result.effects[0].details["subject_revision"] == revision
+
+
+@pytest.mark.asyncio
+async def test_stale_and_equal_revisions_are_superseded(harness) -> None:
+    service = harness.service()
+    await service.apply(harness.command("cmd_head", plan_id="pro", subject_revision=5))
+    stale = await service.apply(
+        harness.command("cmd_stale", plan_id="free", subject_revision=2)
+    )
+    equal = await service.apply(
+        harness.command("cmd_equal", plan_id="free", subject_revision=5)
+    )
+    assert stale.status == "superseded" and equal.status == "superseded"
+    assert stale.applied == 0 and equal.applied == 0
+    assert (await harness.assignment())["plan_id"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_subject_identity_collision_fails_closed(harness) -> None:
+    """A null scope and the literal string "None" hash to the same assignment
+    id. That collision must never be read as evidence of the same subject."""
+    service = harness.service()
+    await service.apply(
+        harness.command("cmd_null_user", subject_revision=4, user_id="user_x")
+    )
+    row = await harness.assignments.find_one({"user_id": "user_x"})
+    # Force the historic ambiguity: same deterministic _id, different subject.
+    await harness.assignments.update_one(
+        {"_id": row["_id"]}, {"$set": {"user_id": None}}
+    )
+
+    collided = await service.apply(
+        harness.command("cmd_string_none", subject_revision=99, user_id="user_x")
+    )
+    assert collided.success is False
+    assignment_effect = collided.effects[0]
+    assert assignment_effect.status == "rejected"
+    assert assignment_effect.reason == "subject_identity_collision"
+    assert assignment_effect.details["conflicting_field"] == "user_id"
+    # Nothing downstream may act on an unprovable subject either.
+    assert collided.effects[1].reason == "subject_identity_collision"
+    # Only the first, legitimate command minted; the collided one added nothing.
+    assert await harness.balance(user_id="user_x") == 100
+    # Nothing was suppressed as if it were the same subject, and nothing was
+    # written over the colliding row.
+    assert (await harness.assignments.find_one({"_id": row["_id"]}))["user_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_distinct_subjects_stay_isolated(harness) -> None:
+    service = harness.service()
+    await service.apply(
+        harness.command("cmd_u1", subject_revision=9, user_id="user_1")
+    )
+    other = await service.apply(
+        harness.command("cmd_u2", subject_revision=2, user_id="user_2")
+    )
+    assert other.status == "applied", "one subject's revision must not fence another"
+    assert (await harness.assignment(user_id="user_2"))["billing_revision"] == 2
+
+
+# ── Defect E: allowance fenced at its own commit ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_allowance_cannot_mint_after_a_newer_revision(harness) -> None:
+    """The motivating race: revision 1 pauses right before its allowance
+    commit, revision 2 fully applies, then revision 1 resumes."""
+    service = harness.service()
+
+    # Revision 2 applies fully first (assignment + 200 tokens).
+    newer = await service.apply(
+        harness.command("cmd_rev2", plan_id="enterprise", subject_revision=2)
+    )
+    assert newer.status == "applied"
+    assert await harness.balance() == 200
+
+    # Revision 1 resumes and attempts ONLY its allowance commit, exactly as a
+    # paused in-flight command would.
+    stale_entries = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="pro",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(
+            harness.command("cmd_rev1", plan_id="pro", subject_revision=1)
+        ),
+        subject_revision=1,
+    )
+
+    assert [entry.status for entry in stale_entries] == ["rejected"]
+    assert stale_entries[0].entry["rejection_reason"] == "stale_subject_revision"
+    assert await harness.balance() == 200, "a stale revision must not mint tokens"
+
+
+@pytest.mark.asyncio
+async def test_allowance_fence_permits_the_newest_revision(harness) -> None:
+    service = harness.service()
+    first = await service.apply(
+        harness.command("cmd_p1", plan_id="pro", subject_revision=1)
+    )
+    assert first.status == "applied"
+    assert await harness.balance() == 100
+
+    second = await service.apply(
+        harness.command("cmd_p2", plan_id="enterprise", subject_revision=2)
+    )
+    assert second.status == "applied"
+    assert await harness.balance() == 300, "the newer plan's allowance is additive"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_allowances_leave_no_stale_credit(harness) -> None:
+    service = harness.service()
+    results = await asyncio.gather(
+        *[
+            service.apply(
+                harness.command(
+                    f"cmd_c{r}",
+                    plan_id="pro" if r % 2 else "enterprise",
+                    subject_revision=r,
+                )
+            )
+            for r in range(1, 6)
+        ]
+    )
+    stored = await harness.assignment()
+    assert stored["billing_revision"] == 5
+    applied = [r for r in results if r.status == "applied"]
+    # Allowance idempotency is plan-and-period scoped, so repeated applications
+    # of the same plan within the period credit once. Every applied revision
+    # contributed its own plan's allowance and no superseded revision
+    # contributed anything.
+    plans = {
+        "pro" if int(r.effects[0].details["subject_revision"]) % 2 else "enterprise"
+        for r in applied
+    }
+    expected = sum(100 if plan == "pro" else 200 for plan in plans)
+    assert await harness.balance() == expected
+
+
+# ── Cancellation / reactivation ordering ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delayed_activation_cannot_revive_a_newer_cancellation(harness) -> None:
+    service = harness.service()
+    await service.apply(
+        harness.command(
+            "cmd_act1", subject_revision=1, event_type="subscription_activated"
+        )
+    )
+    await service.apply(
+        harness.command(
+            "cmd_cancel2", subject_revision=2, event_type="subscription_cancelled"
+        )
+    )
+    late = await service.apply(
+        harness.command(
+            "cmd_act1_late", subject_revision=1, event_type="subscription_activated"
+        )
+    )
+    assert late.status == "superseded"
+    assert (await harness.assignment())["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_delayed_cancellation_cannot_revoke_a_newer_activation(harness) -> None:
+    service = harness.service()
+    await service.apply(
+        harness.command(
+            "cmd_cancel2", subject_revision=2, event_type="subscription_cancelled"
+        )
+    )
+    await service.apply(
+        harness.command(
+            "cmd_act3", subject_revision=3, event_type="subscription_activated"
+        )
+    )
+    late = await service.apply(
+        harness.command(
+            "cmd_cancel2_late", subject_revision=2, event_type="subscription_cancelled"
+        )
+    )
+    assert late.status == "superseded"
+    assert (await harness.assignment())["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_a_b_a_sequence_ends_at_the_third_revision(harness) -> None:
+    service = harness.service()
+    for index, plan in enumerate(["pro", "enterprise", "pro"], start=1):
+        result = await service.apply(
+            harness.command(f"cmd_seq{index}", plan_id=plan, subject_revision=index)
+        )
+        assert result.status == "applied"
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "pro"
+    assert stored["billing_revision"] == 3
+
+
+# ── Defects F/G: durable command identity and replay ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pre_fence_command_hash_survives_the_upgrade(harness) -> None:
+    """A command completed before this change must replay, not conflict.
+
+    The pre-change canonical document is reproduced by simply omitting
+    `subject_revision`, which is exactly what an unfenced command serializes
+    to now — so a hash computed then still matches one computed today.
+    """
+    service = harness.service(durable=True)
+    unfenced = harness.command("cmd_unfenced", subject_revision=None)
+
+    first = await service.apply_durable(unfenced)
+    assert first.status == "applied"
+
+    records = await harness.store.list_records(command_id=unfenced.command_id)
+    assert len(records) == 1
+    assert "subject_revision" not in records[0]["command"], (
+        "an unfenced command must not persist the new field at all"
+    )
+
+    replay = await service.apply_durable(unfenced)
+    assert replay.status == "replayed"
+    assert replay.original_status == "applied"
+    assert replay.success is True
+
+
+@pytest.mark.asyncio
+async def test_superseded_replay_keeps_its_disposition(harness) -> None:
+    service = harness.service(durable=True)
+    await service.apply_durable(harness.command("cmd_head", subject_revision=9))
+    stale = harness.command("cmd_stale", plan_id="free", subject_revision=1)
+
+    first = await service.apply_durable(stale)
+    replay = await service.apply_durable(stale)
+
+    assert first.status == "superseded"
+    assert replay.status == "replayed"
+    assert replay.original_status == "superseded", (
+        "a replayed supersession must stay recognizably superseded"
+    )
+    assert replay.success is True and replay.applied == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_remote_outcome_acceptance_theorem(harness) -> None:
+    """#497's acceptance theorem, end to end.
+
+    An old revision's request is in flight when the sender loses the response;
+    a newer revision applies; the old request finally reaches the receiver.
+    Both the assignment AND the allowance authority must stay at the newer
+    revision, and retrying the old command must replay a stable supersession.
+    """
+    service = harness.service(durable=True)
+    old_command = harness.command("cmd_old", plan_id="pro", subject_revision=4)
+
+    newer = await service.apply_durable(
+        harness.command("cmd_new", plan_id="enterprise", subject_revision=8)
+    )
+    assert newer.status == "applied"
+    assert await harness.balance() == 200
+
+    late = await service.apply_durable(old_command)
+    assert late.status == "superseded"
+    assert (await harness.assignment())["billing_revision"] == 8
+    assert (await harness.assignment())["plan_id"] == "enterprise"
+    assert await harness.balance() == 200, "the allowance authority did not regress"
+
+    retry = await service.apply_durable(old_command)
+    assert retry.status == "replayed"
+    assert retry.original_status == "superseded"
+
+
+# ── commands that never opted into fencing ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_commands_without_revisions_are_untouched(harness) -> None:
+    """Merely upgrading must not stamp revisions on commands that never opted in."""
+    service = harness.service()
+    await service.apply(harness.command("cmd_unfenced1", plan_id="pro"))
+    stored = await harness.assignment()
+    assert "billing_revision" not in stored
+    assert stored["plan_id"] == "pro"
+
+    await service.apply(harness.command("cmd_unfenced2", plan_id="enterprise"))
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "enterprise", "unfenced writes stay last-writer-wins"
+    assert "billing_revision" not in stored
+    assert await harness.balance() == 300
+
+
+@pytest.mark.asyncio
+async def test_revision_field_null_disables_fencing_end_to_end(harness) -> None:
+    service = harness.service(revision_field=None)
+    await service.apply(harness.command("cmd_n1", plan_id="pro", subject_revision=9))
+    older = await service.apply(
+        harness.command("cmd_n2", plan_id="free", subject_revision=1)
+    )
+    assert older.status == "applied", "opted-out stores keep prior behavior"
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "free"
+    assert "billing_revision" not in stored
+
+
+# ══ correction round: subject uniqueness, wallet head, aggregation ══════════
+
+
+@pytest.mark.asyncio
+async def test_existing_objectid_row_cannot_be_duplicated_by_a_stale_revision(
+    harness,
+) -> None:
+    """The defect this round closes.
+
+    An assignment created before this contract carries an ObjectId. A stale
+    revision-filtered upsert used to insert a SECOND, deterministic-id row for
+    the same subject and report itself applied — leaving one subject with two
+    assignments. Deterministic-id uniqueness cannot prevent that; subject
+    uniqueness can.
+    """
+    service = harness.service()
+    # A pre-contract row: ObjectId _id, no revision stamp.
+    await harness.assignments.insert_one(
+        {
+            "app_id": harness.app_id,
+            "tenant_id": None,
+            "user_id": "user_1",
+            "plan_id": "free",
+            "status": "active",
+        }
+    )
+
+    newer = await service.apply(
+        harness.command("cmd_new", plan_id="enterprise", subject_revision=6)
+    )
+    assert newer.status == "applied"
+    stale = await service.apply(
+        harness.command("cmd_stale", plan_id="pro", subject_revision=2)
+    )
+
+    assert stale.status == "superseded"
+    assert await harness.assignments.count_documents({}) == 1, (
+        "one entitlement subject must never hold two assignment rows"
+    )
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "enterprise"
+    assert stored["billing_revision"] == 6
+    assert not isinstance(stored["_id"], str), "the historical row must be updated in place"
+
+
+@pytest.mark.asyncio
+async def test_fenced_mode_establishes_the_subject_unique_index(harness) -> None:
+    service = harness.service()
+    await service.apply(harness.command("cmd_idx", subject_revision=1))
+
+    names = await harness.assignments.index_information()
+    assert SUBJECT_UNIQUE_INDEX_NAME in names
+    index = names[SUBJECT_UNIQUE_INDEX_NAME]
+    assert index.get("unique") is True
+    assert [key for key, _direction in index["key"]] == ["app_id", "tenant_id", "user_id"]
+
+
+@pytest.mark.asyncio
+async def test_pre_existing_duplicate_subjects_fail_initialization(harness) -> None:
+    """A data-migration problem the operator must resolve — never a silent
+    winner and never a deletion."""
+    for plan in ("free", "pro"):
+        await harness.assignments.insert_one(
+            {
+                "app_id": harness.app_id,
+                "tenant_id": None,
+                "user_id": "user_1",
+                "plan_id": plan,
+                "status": "active",
+            }
+        )
+
+    service = harness.service()
+    with pytest.raises(BillingFulfillmentSubjectIndexError) as excinfo:
+        await service.apply(harness.command("cmd_dupes", subject_revision=1))
+
+    assert "one assignment per entitlement subject" in str(excinfo.value)
+    assert await harness.assignments.count_documents({}) == 2, "no row may be removed"
+
+
+@pytest.mark.asyncio
+async def test_dotted_subject_mapping_classifies_the_same_subject_correctly(
+    harness,
+) -> None:
+    """A configured `scope.user` mapping must resolve nested, or a legitimate
+    stale request for the SAME subject reads as an identity collision."""
+    config = SubscriptionsConfig.model_validate(
+        {
+            **_config().model_dump(mode="json"),
+            "assignment_store": {
+                "data_alias": "billing.subscriptions",
+                "user_id_field": "scope.user",
+                "tenant_id_field": None,
+                "revision_field": "billing_revision",
+            },
+        }
+    )
+    service = BillingFulfillmentService(
+        config=config,
+        ledger=harness.ledger,
+        collection_resolver=lambda _alias: harness.assignments,
+    )
+
+    newer = await service.apply(harness.command("cmd_dot_new", subject_revision=5))
+    assert newer.status == "applied"
+    stored = await harness.assignments.find_one({"app_id": harness.app_id})
+    assert stored["scope"]["user"] == "user_1", "the dotted path is written nested"
+
+    stale = await service.apply(
+        harness.command("cmd_dot_stale", plan_id="free", subject_revision=2)
+    )
+    assert stale.status == "superseded", "same subject, just older"
+    assert stale.effects[0].reason == "stale_revision"
+    assert await harness.assignments.count_documents({}) == 1
+
+
+# ── wallet ordering authority advances for every accepted revision ───────────
+
+
+@pytest.mark.asyncio
+async def test_cancellation_advances_wallet_authority(harness) -> None:
+    """A1's allowance is delayed; a cancellation carrying no allowance
+    completes; A1 resumes and must not credit."""
+    service = harness.service()
+    accepted = await service.apply(
+        harness.command("cmd_a1", plan_id="pro", subject_revision=1)
+    )
+    assert accepted.status == "applied"
+    await harness.assignments.update_one({}, {"$set": {"billing_revision": 0}})
+    await harness.ledger._collections()
+    balances, _entries = await harness.ledger._collections()
+    await balances.delete_many({})
+
+    cancelled = await service.apply(
+        harness.command(
+            "cmd_cancel2", plan_id="pro", subject_revision=2,
+            event_type="subscription_cancelled",
+        )
+    )
+    assert cancelled.status == "applied"
+
+    # A1's delayed allowance now arrives.
+    stale = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="pro",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(
+            harness.command("cmd_a1", plan_id="pro", subject_revision=1)
+        ),
+        subject_revision=1,
+    )
+    assert [entry.status for entry in stale] == ["rejected"]
+    assert stale[0].entry["rejection_reason"] == "stale_subject_revision"
+    assert await harness.balance() == 0, "a cancellation must stop an older allowance"
+
+
+@pytest.mark.asyncio
+async def test_zero_allowance_plan_advances_wallet_authority(harness) -> None:
+    service = harness.service()
+    # Revision 2 selects a valid plan that credits nothing.
+    accepted = await service.apply(
+        harness.command("cmd_free2", plan_id="free", subject_revision=2)
+    )
+    assert accepted.status == "applied"
+    assert await harness.balance() == 0
+
+    stale = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="pro",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(
+            harness.command("cmd_pro1", plan_id="pro", subject_revision=1)
+        ),
+        subject_revision=1,
+    )
+    assert stale[0].status == "rejected"
+    assert await harness.balance() == 0, "a zero-credit revision still supersedes"
+
+
+@pytest.mark.asyncio
+async def test_idempotent_allowance_reuse_still_advances_authority(harness) -> None:
+    """A1 allocates plan A for period P. B2's allowance is delayed. A3 returns
+    to plan A in the same period: it must NOT mint again, but it must still
+    advance the head so the delayed B2 is refused."""
+    service = harness.service()
+
+    first = await service.apply(
+        harness.command("cmd_a1", plan_id="pro", subject_revision=1)
+    )
+    assert first.status == "applied"
+    assert await harness.balance() == 100
+
+    third = await service.apply(
+        harness.command("cmd_a3", plan_id="pro", subject_revision=3)
+    )
+    assert third.status == "applied"
+    assert await harness.balance() == 100, "same plan and period must not double mint"
+
+    delayed_b2 = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="enterprise",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 200, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(
+            harness.command("cmd_b2", plan_id="enterprise", subject_revision=2)
+        ),
+        subject_revision=2,
+    )
+    assert delayed_b2[0].status == "rejected"
+    assert delayed_b2[0].entry["rejection_reason"] == "stale_subject_revision"
+    assert await harness.balance() == 100
+
+
+@pytest.mark.asyncio
+async def test_stale_rejection_does_not_consume_the_allowance_identity(harness) -> None:
+    """A stale attempt must leave no record under the identity a SUCCESSFUL
+    allocation owns, or a later valid revision of the same plan and period is
+    permanently denied the allocation it is entitled to."""
+    service = harness.service()
+
+    # B2 wins the subject first; plan A never allocated for this period.
+    winner = await service.apply(
+        harness.command("cmd_b2", plan_id="free", subject_revision=2)
+    )
+    assert winner.status == "applied"
+
+    stale_a1 = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="pro",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(
+            harness.command("cmd_a1", plan_id="pro", subject_revision=1)
+        ),
+        subject_revision=1,
+    )
+    assert stale_a1[0].status == "rejected"
+    assert await harness.balance() == 0
+
+    # A3 legitimately returns to plan A in the same period.
+    valid_a3 = await service.apply(
+        harness.command("cmd_a3", plan_id="pro", subject_revision=3)
+    )
+    assert valid_a3.status == "applied"
+    assert await harness.balance() == 100, (
+        "the stale attempt must not have consumed plan A's period allocation"
+    )
+
+
+# ── a partially applied command overtaken mid-flight ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_partially_applied_command_reports_superseded(harness) -> None:
+    """The assignment landed, then a newer revision won, so the command's
+    remaining effects were invalidated. Its terminal meaning is superseded even
+    though one effect truthfully applied."""
+    service = harness.service(durable=True)
+    old_command = harness.command("cmd_old", plan_id="pro", subject_revision=5)
+
+    # Interleave for real: the old command claims the head and commits its
+    # assignment, and only then does a newer revision take the head — so the
+    # allowance that is still to come is the effect that gets invalidated.
+    original_apply = service._apply_assignment
+
+    async def _apply_then_lose(command, *, plan):
+        effect = await original_apply(command, plan=plan)
+        if command.command_id == old_command.command_id:
+            await harness.ledger.advance_subject_revision(
+                app_id=harness.app_id,
+                wallet_id="ai_tokens",
+                user_id="user_1",
+                preferred_scope="user",
+                subject_key=service._subject_key(old_command),
+                subject_revision=9,
+            )
+        return effect
+
+    service._apply_assignment = _apply_then_lose
+
+    result = await service.apply_durable(old_command)
+
+    assignment_effect = next(e for e in result.effects if e.effect == "assignment_upsert")
+    allowance_effect = next(e for e in result.effects if e.effect == "plan_allowances")
+    assert assignment_effect.status == "applied", "effect history stays truthful"
+    assert allowance_effect.reason in {"stale_revision", "stale_subject_revision"}
+    assert result.applied >= 1, "the applied effect is still counted"
+    assert result.status == "superseded", (
+        "a command whose remaining effects were invalidated was overtaken"
+    )
+    assert result.success is True
+    service._apply_assignment = original_apply
+
+    replay = await service.apply_durable(old_command)
+    assert replay.status == "replayed"
+    assert replay.original_status == "superseded", (
+        "the durable replay must preserve the real terminal disposition"
+    )
+
+
+# ── the opt-out disables BOTH fences ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_revision_field_null_disables_assignment_and_wallet_fences(
+    harness,
+) -> None:
+    """Half-fenced is the bug: assignment took the older revision while the
+    wallet refused its allowance as stale."""
+    service = harness.service(revision_field=None)
+
+    newer = await service.apply(
+        harness.command("cmd_b9", plan_id="enterprise", subject_revision=9)
+    )
+    assert newer.status == "applied"
+    assert await harness.balance() == 200
+
+    older = await service.apply(
+        harness.command("cmd_a1", plan_id="pro", subject_revision=1)
+    )
+    assert older.status == "applied", "opted-out stores keep last-writer-wins"
+    index_names = await harness.assignments.index_information()
+    assert SUBJECT_UNIQUE_INDEX_NAME not in index_names, (
+        "an opted-out config must not acquire fenced-mode index requirements"
+    )
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "pro"
+    assert "billing_revision" not in stored
+    assert await harness.balance() == 300, (
+        "the wallet must not fence when the store opted out"
+    )
+    balances, _entries = await harness.ledger._collections()
+    balance_doc = await balances.find_one({"app_id": harness.app_id})
+    assert balance_doc is not None
+    assert "subject_revisions" not in balance_doc, "no ordering head when opted out"
+
+
+# ── R3-A: the guarantee matters, not which index provides it ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_equivalent_unique_index_under_another_name_is_accepted(
+    harness,
+) -> None:
+    """A store that already enforces one row per subject is correctly
+    configured. Requiring our own index name on top of it would reject a valid
+    deployment outright, so equivalence is judged on the ordered key fields,
+    their directions, and uniqueness."""
+    await harness.assignments.create_index(
+        [("app_id", 1), ("tenant_id", 1), ("user_id", 1)],
+        unique=True,
+        name="subscriptions_by_app_user",
+    )
+
+    service = harness.service()
+    newer = await service.apply(
+        harness.command("cmd_new", plan_id="enterprise", subject_revision=6)
+    )
+    assert newer.status == "applied"
+
+    names = await harness.assignments.index_information()
+    assert SUBJECT_UNIQUE_INDEX_NAME not in names, (
+        "an equivalent guarantee must be accepted, not duplicated"
+    )
+    assert "subscriptions_by_app_user" in names
+
+    stale = await service.apply(
+        harness.command("cmd_stale", plan_id="pro", subject_revision=2)
+    )
+    assert stale.status == "superseded", "fencing still works through the existing index"
+    assert await harness.assignments.count_documents({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_narrowed_unique_index_does_not_satisfy_the_requirement(
+    harness,
+) -> None:
+    """A partial index only constrains the documents it covers, so subjects
+    outside that filter could still duplicate. It is not the same guarantee."""
+    await harness.assignments.create_index(
+        [("app_id", 1), ("tenant_id", 1), ("user_id", 1)],
+        unique=True,
+        name="only_active_subjects",
+        partialFilterExpression={"status": "active"},
+    )
+
+    service = harness.service()
+    assert (
+        await service.apply(harness.command("cmd_partial", subject_revision=1))
+    ).status == "applied"
+
+    names = await harness.assignments.index_information()
+    assert SUBJECT_UNIQUE_INDEX_NAME in names, (
+        "a narrowed index must not stand in for the full constraint"
+    )
+
+
+# ── R3-B: ordering authority is established before the assignment commits ────
+
+
+@pytest.mark.asyncio
+async def test_a_failed_head_claim_aborts_before_the_assignment_commits(
+    harness,
+) -> None:
+    """The window this closes: the assignment used to commit first and claim
+    wallet ordering afterwards, so a failed head write left the subject at
+    revision 5 while every wallet still admitted revision 1. Claiming first
+    means the failure costs nothing — no assignment, no credit, and a retry
+    that completes normally."""
+    service = harness.service()
+    command = harness.command("cmd_claim_fails", plan_id="pro", subject_revision=5)
+
+    working = harness.ledger.advance_subject_revision
+
+    async def _fail(**_kwargs):
+        raise RuntimeError("wallet head write failed")
+
+    harness.ledger.advance_subject_revision = _fail
+    with pytest.raises(RuntimeError, match="wallet head write failed"):
+        await service.apply(command)
+    harness.ledger.advance_subject_revision = working
+
+    assert await harness.assignment() is None, (
+        "no assignment may exist without the ordering authority behind it"
+    )
+    assert await harness.balance() == 0
+    balances, _entries = await harness.ledger._collections()
+    assert await balances.count_documents({"app_id": harness.app_id}) == 0, (
+        "no head was claimed either"
+    )
+
+    # The retry is the same command and completes normally.
+    retried = await service.apply(command)
+    assert retried.status == "applied"
+    stored = await harness.assignment()
+    assert stored["plan_id"] == "pro"
+    assert int(stored["billing_revision"]) == 5
+    assert await harness.balance() == 100
+
+
+@pytest.mark.asyncio
+async def test_null_and_the_string_none_are_different_subjects(harness) -> None:
+    """Ordering authority is keyed per subject, so two subjects that differ
+    only by type must never share a head — otherwise one silently fences the
+    other out."""
+    service = harness.service()
+    typed = service._subject_key(harness.command("cmd_typed", subject_revision=1))
+    forged = service._subject_key(
+        harness.command("cmd_forged", subject_revision=1, user_id="None")
+    )
+    assert typed is not None and forged is not None
+    assert typed != forged
+
+
+# ── R3-C: a declined head claim means the command was overtaken ──────────────
+
+
+@pytest.mark.asyncio
+async def test_cancellation_resuming_behind_a_newer_revision_is_superseded(
+    harness,
+) -> None:
+    """A revision-2 cancellation that resumes after revision 3 has already
+    taken the subject must not cancel anything. Declining the head claim is
+    meaning-bearing: the command lost, so its assignment never applies."""
+    service = harness.service()
+    assert (
+        await service.apply(harness.command("cmd_r3", plan_id="pro", subject_revision=3))
+    ).status == "applied"
+
+    late_cancel = await service.apply(
+        harness.command(
+            "cmd_cancel_r2",
+            plan_id="pro",
+            subject_revision=2,
+            event_type="subscription_cancelled",
+        )
+    )
+
+    assert late_cancel.status == "superseded"
+    assert {effect.reason for effect in late_cancel.effects} == {"stale_revision"}
+    assert [effect.status for effect in late_cancel.effects] == ["skipped", "skipped"]
+    stored = await harness.assignment()
+    assert stored["status"] == "active", "the cancellation must not have applied"
+    assert stored["plan_id"] == "pro"
+    assert int(stored["billing_revision"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_declined_head_blocks_a_subject_the_assignment_store_forgot(
+    harness,
+) -> None:
+    """The case only the wallet head can catch. If the assignment row is gone —
+    a restored store, a migration, an assignment that never landed — the
+    assignment-side comparison has nothing to compare against and would happily
+    create revision 2 as if it were the first. The wallet still remembers
+    revision 3, so the claim declines and nothing is written."""
+    service = harness.service()
+    assert (
+        await service.apply(harness.command("cmd_r3", plan_id="pro", subject_revision=3))
+    ).status == "applied"
+    await harness.assignments.delete_many({})
+
+    late = await service.apply(
+        harness.command("cmd_r2", plan_id="free", subject_revision=2)
+    )
+
+    assert late.status == "superseded"
+    assert await harness.assignments.count_documents({}) == 0, (
+        "an overtaken revision must not resurrect the subject at an older plan"
+    )
+
+
+# ── R3-D: reservations are owned, so a stale attempt cannot steal one ────────
+
+
+@pytest.mark.asyncio
+async def test_a_stale_attempt_cannot_delete_a_reservation_a_newer_revision_adopted(
+    harness,
+) -> None:
+    """A1 reserves the allowance identity, then goes stale. A3 — legitimately
+    entitled to that same plan-and-period identity — adopts the reservation.
+    A1's rollback must not delete it out from under A3, or A3 commits a balance
+    movement whose ledger entry no longer exists."""
+    service = harness.service()
+    subject_key = service._subject_key(harness.command("cmd_k", subject_revision=1))
+    _balances, entries = await harness.ledger._collections()
+
+    state: dict[str, Any] = {"armed": True, "adopted_owner": "rsv_a3_simulated"}
+
+    async def _overtake() -> None:
+        if state["armed"]:
+            state["armed"] = False
+            # A3 wins the subject and adopts A1's pending reservation, but has
+            # not committed its balance movement yet.
+            await harness.ledger.advance_subject_revision(
+                app_id=harness.app_id,
+                wallet_id="ai_tokens",
+                user_id="user_1",
+                preferred_scope="user",
+                subject_key=subject_key,
+                subject_revision=3,
+            )
+            pending = await entries.find_one(
+                {"app_id": harness.app_id, "status": "pending"}
+            )
+            assert pending is not None, "A1 must have reserved before committing"
+            state["entry_id"] = pending["_id"]
+            await entries.update_one(
+                {"_id": pending["_id"]},
+                {
+                    "$set": {"reservation_owner": state["adopted_owner"]},
+                    "$inc": {"reservation_generation": 1},
+                },
+            )
+
+    class _BalancesThatLoseTheRace:
+        """Fires the overtake at the exact instant A1 commits its balance."""
+
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        async def find_one_and_update(self, *args: Any, **kwargs: Any) -> Any:
+            await _overtake()
+            return await self._inner.find_one_and_update(*args, **kwargs)
+
+    original_collections = harness.ledger._collections
+
+    async def _hooked_collections() -> tuple[Any, Any]:
+        inner_balances, inner_entries = await original_collections()
+        return _BalancesThatLoseTheRace(inner_balances), inner_entries
+
+    harness.ledger._collections = _hooked_collections
+    try:
+        stale = await harness.ledger.record_entry(
+            app_id=harness.app_id,
+            wallet_id="ai_tokens",
+            amount=100,
+            operation="allocation",
+            idempotency_key="proof_alloc",
+            user_id="user_1",
+            preferred_scope="user",
+            subject_key=subject_key,
+            subject_revision=1,
+        )
+    finally:
+        harness.ledger._collections = original_collections
+
+    assert stale.status == "rejected"
+    assert stale.entry["rejection_reason"] == "stale_subject_revision"
+    survivor = await entries.find_one({"_id": state["entry_id"]})
+    assert survivor is not None, (
+        "the stale attempt deleted a reservation it no longer owned"
+    )
+    assert survivor["reservation_owner"] == state["adopted_owner"]
+
+    # A3 now completes against the reservation it owns.
+    committed = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="proof_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+        subject_key=subject_key,
+        subject_revision=3,
+    )
+    assert committed.status == "applied"
+    assert await harness.balance() == 100
+    final = await entries.find_one({"_id": state["entry_id"]})
+    assert final["status"] == "applied"
+
+
+@pytest.mark.asyncio
+async def test_a_pending_entry_already_counted_in_the_balance_is_recovered(
+    harness,
+) -> None:
+    """Crash recovery: the balance moved but the entry never got marked. The
+    retry must finish the entry, not treat the reservation as rollback-able."""
+    service = harness.service()
+    subject_key = service._subject_key(harness.command("cmd_k", subject_revision=1))
+    _balances, entries = await harness.ledger._collections()
+
+    first = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="recover_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+        subject_key=subject_key,
+        subject_revision=2,
+    )
+    assert first.status == "applied"
+    entry_id = first.entry["entry_id"]
+    # Rewind only the entry, as a crash between the two writes would.
+    await entries.update_one({"_id": entry_id}, {"$set": {"status": "pending"}})
+
+    recovered = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="recover_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+        subject_key=subject_key,
+        subject_revision=2,
+    )
+    assert recovered.status == "applied"
+    assert await entries.count_documents({"_id": entry_id}) == 1
+    assert await harness.balance() == 100, "recovery must not double credit"
+
+
+# ── R4-A: a pre-effect ordering failure must not wedge the command ───────────
+
+
+def _two_wallet_config() -> SubscriptionsConfig:
+    """Same contract, two user-scoped wallets, so one head can fail alone."""
+    base = _config().model_dump(mode="json")
+    base["token_wallets"] = [
+        {
+            "wallet_id": "ai_tokens",
+            "label": "AI tokens",
+            "unit": "tokens",
+            "usage_meter_id": "ai_tokens",
+            "scope": "user",
+        },
+        {
+            "wallet_id": "build_tokens",
+            "label": "Build tokens",
+            "unit": "tokens",
+            "usage_meter_id": "build_tokens",
+            "scope": "user",
+        },
+    ]
+    return SubscriptionsConfig.model_validate(base)
+
+
+async def _subject_heads(harness) -> dict[str, dict[str, int]]:
+    balances, _entries = await harness.ledger._collections()
+    heads: dict[str, dict[str, int]] = {}
+    async for document in balances.find({"app_id": harness.app_id}):
+        revisions = document.get("subject_revisions") or {}
+        if revisions:
+            heads[str(document.get("wallet_id"))] = {
+                key: int(value) for key, value in revisions.items()
+            }
+    return heads
+
+
+@pytest.mark.asyncio
+async def test_a_durable_command_survives_a_pre_assignment_ordering_failure(
+    harness,
+) -> None:
+    """The wedge this closes.
+
+    `apply_durable` reserves the command as pending before running effects.
+    Round 3 correctly made a failed wallet-head write propagate — but the
+    reservation then stayed pending forever, so every identical retry was
+    refused with `BillingFulfillmentPendingError` even though nothing had been
+    written. A failure that provably precedes every effect must leave the exact
+    command retryable.
+    """
+    service = harness.service(durable=True)
+    activation = harness.command("cmd_r1", plan_id="pro", subject_revision=1)
+    assert (await service.apply_durable(activation)).status == "applied"
+
+    # Revision 1's allowance is delayed: nothing has been credited yet.
+    balances, entries = await harness.ledger._collections()
+    await balances.delete_many({"app_id": harness.app_id})
+    await entries.delete_many({"app_id": harness.app_id})
+
+    cancellation = harness.command(
+        "cmd_r2_cancel",
+        plan_id="pro",
+        subject_revision=2,
+        event_type="subscription_cancelled",
+    )
+    working = harness.ledger.advance_subject_revision
+
+    async def _fail(**_kwargs):
+        raise RuntimeError("wallet head write failed")
+
+    harness.ledger.advance_subject_revision = _fail
+    with pytest.raises(BillingFulfillmentOrderingUnavailable):
+        await service.apply_durable(cancellation)
+    harness.ledger.advance_subject_revision = working
+
+    stored = await harness.assignment()
+    assert stored["status"] == "active", "no effect may have committed"
+    assert int(stored["billing_revision"]) == 1
+
+    # The identical command retries and completes.
+    retried = await service.apply_durable(cancellation)
+    assert retried.status == "applied"
+    stored = await harness.assignment()
+    assert stored["status"] == "cancelled"
+    assert int(stored["billing_revision"]) == 2
+
+    # And the delayed revision-1 allowance still cannot credit behind it.
+    delayed = await harness.ledger.ensure_plan_allowances(
+        config=_config(),
+        app_id=harness.app_id,
+        plan_id="pro",
+        token_allowances=[{"wallet_id": "ai_tokens", "amount": 100, "cadence": "monthly"}],
+        user_id="user_1",
+        subject_key=service._subject_key(activation),
+        subject_revision=1,
+    )
+    assert delayed[0].status == "rejected"
+    assert delayed[0].entry["rejection_reason"] == "stale_subject_revision"
+    assert await harness.balance() == 0
+
+    # The durable command is terminal, and replays as one.
+    replay = await service.apply_durable(cancellation)
+    assert replay.status == "replayed"
+    assert replay.original_status == "applied"
+
+
+@pytest.mark.asyncio
+async def test_a_partial_multi_wallet_head_failure_converges_on_retry(
+    harness,
+) -> None:
+    """Wallet A's head advances, wallet B's write fails, the assignment never
+    commits. The retry finds A already equal, advances B, and completes. A is
+    never reversed — conservative forward authority is safe, and
+    reversing it would reopen the window an older revision could credit in."""
+    service = BillingFulfillmentService(
+        config=_two_wallet_config(),
+        ledger=harness.ledger,
+        collection_resolver=lambda _alias: harness.assignments,
+        command_store=harness.store,
+    )
+    command = harness.command("cmd_multi", plan_id="pro", subject_revision=3)
+    working = harness.ledger.advance_subject_revision
+    state = {"fail_second_wallet": True}
+
+    async def _fail_one_wallet(**kwargs):
+        if state["fail_second_wallet"] and kwargs.get("wallet_id") == "build_tokens":
+            raise RuntimeError("wallet head write failed")
+        return await working(**kwargs)
+
+    harness.ledger.advance_subject_revision = _fail_one_wallet
+    with pytest.raises(BillingFulfillmentOrderingUnavailable):
+        await service.apply_durable(command)
+
+    assert await harness.assignment() is None, "the assignment never committed"
+    heads = await _subject_heads(harness)
+    assert "ai_tokens" in heads, "the wallet that succeeded keeps its claim"
+    assert "build_tokens" not in heads
+
+    state["fail_second_wallet"] = False
+    retried = await service.apply_durable(command)
+    harness.ledger.advance_subject_revision = working
+
+    assert retried.status == "applied"
+    stored = await harness.assignment()
+    assert int(stored["billing_revision"]) == 3
+    heads = await _subject_heads(harness)
+    assert set(heads) == {"ai_tokens", "build_tokens"}
+    assert {tuple(sorted(value.values())) for value in heads.values()} == {(3,)}
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_duplicate_stays_excluded_until_the_release(
+    harness,
+) -> None:
+    """Releasing a pending reservation must not weaken exclusivity. While the
+    failing invocation is still running, an identical caller is still refused;
+    only a retry after the release can start."""
+    service = harness.service(durable=True)
+    command = harness.command("cmd_exclusive", plan_id="pro", subject_revision=4)
+    working = harness.ledger.advance_subject_revision
+    state = {"armed": True, "probed": False}
+
+    async def _probe_then_fail(**_kwargs):
+        if state["armed"]:
+            state["armed"] = False
+            with pytest.raises(BillingFulfillmentPendingError):
+                await service.apply_durable(command)
+            state["probed"] = True
+        raise RuntimeError("wallet head write failed")
+
+    harness.ledger.advance_subject_revision = _probe_then_fail
+    with pytest.raises(BillingFulfillmentOrderingUnavailable):
+        await service.apply_durable(command)
+    harness.ledger.advance_subject_revision = working
+
+    assert state["probed"], "the concurrent duplicate must have been refused"
+    assert (await service.apply_durable(command)).status == "applied"
+
+
+@pytest.mark.asyncio
+async def test_only_a_pre_effect_failure_releases_the_command(harness) -> None:
+    """A failure after an effect has committed must stay pending. The release
+    is not general crash recovery — it is only sound because the ordering
+    prerequisite provably precedes every mutation."""
+    service = harness.service(durable=True)
+    command = harness.command("cmd_post_effect", plan_id="pro", subject_revision=1)
+    original_allowances = service._apply_plan_allowances
+
+    async def _explode(_command, *, plan):
+        raise RuntimeError("something failed after the assignment committed")
+
+    service._apply_plan_allowances = _explode
+    with pytest.raises(RuntimeError, match="after the assignment committed"):
+        await service.apply_durable(command)
+    service._apply_plan_allowances = original_allowances
+
+    with pytest.raises(BillingFulfillmentPendingError):
+        await service.apply_durable(command)
+
+
+# ── R4-B: a balance may not move without an owned reservation ────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_lost_adoption_reacquires_before_touching_the_balance(
+    harness,
+) -> None:
+    """The exact interleave Codex found.
+
+    A3 reads A1's pending reservation, A1 deletes its own reservation before
+    A3's compare-and-swap runs, and the swap therefore matches nothing. The old
+    code read that as "carry on", crediting the balance with no ledger entry
+    behind it: +100, an applied_entry_id on the balance, and zero entries. A
+    lost swap means the world moved, so A3 must look again and establish a
+    reservation it actually owns before any balance write.
+    """
+    service = harness.service()
+    subject_key = service._subject_key(harness.command("cmd_k", subject_revision=1))
+    balances, entries = await harness.ledger._collections()
+
+    scope = _scope_for(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        user_id="user_1",
+        preferred_scope="user",
+    )
+    entry_id = _entry_id(scope, "proof_alloc")
+    await entries.insert_one(
+        {
+            "_id": entry_id,
+            "entry_id": entry_id,
+            "idempotency_key": "proof_alloc",
+            "balance_id": scope.balance_id,
+            "app_id": harness.app_id,
+            "wallet_id": "ai_tokens",
+            "scope_type": "user",
+            "scope_id": "user_1",
+            "user_id": "user_1",
+            "tenant_id": None,
+            "operation": "allocation",
+            "direction": "credit",
+            "amount": 100,
+            "signed_amount": 100,
+            "status": "pending",
+            "reservation_owner": "rsv_a1",
+            "reservation_generation": 0,
+        }
+    )
+
+    state: dict[str, Any] = {"armed": True, "reservation_at_balance_write": "unset"}
+
+    class _EntriesThatLoseTheSwap:
+        """A1 deletes its own reservation the instant before A3's swap."""
+
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        async def find_one_and_update(self, *args: Any, **kwargs: Any) -> Any:
+            if state["armed"]:
+                state["armed"] = False
+                await self._inner.delete_one(
+                    {"_id": entry_id, "status": "pending", "reservation_owner": "rsv_a1"}
+                )
+            return await self._inner.find_one_and_update(*args, **kwargs)
+
+    class _BalancesThatWitnessTheReservation:
+        """Captures what the ledger owned at the instant the balance moved."""
+
+        def __init__(self, inner: Any, inner_entries: Any) -> None:
+            self._inner = inner
+            self._entries = inner_entries
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        async def find_one_and_update(self, *args: Any, **kwargs: Any) -> Any:
+            state["reservation_at_balance_write"] = await self._entries.find_one(
+                {"_id": entry_id}
+            )
+            return await self._inner.find_one_and_update(*args, **kwargs)
+
+    original_collections = harness.ledger._collections
+
+    async def _hooked_collections() -> tuple[Any, Any]:
+        inner_balances, inner_entries = await original_collections()
+        return (
+            _BalancesThatWitnessTheReservation(inner_balances, inner_entries),
+            _EntriesThatLoseTheSwap(inner_entries),
+        )
+
+    harness.ledger._collections = _hooked_collections
+    try:
+        result = await harness.ledger.record_entry(
+            app_id=harness.app_id,
+            wallet_id="ai_tokens",
+            amount=100,
+            operation="allocation",
+            idempotency_key="proof_alloc",
+            user_id="user_1",
+            preferred_scope="user",
+            subject_key=subject_key,
+            subject_revision=3,
+        )
+    finally:
+        harness.ledger._collections = original_collections
+
+    assert state["armed"] is False, "the swap must actually have been raced"
+
+    # The invariant itself: at the instant the balance moved, this invocation
+    # held a durable pending reservation that was no longer A1's.
+    witnessed = state["reservation_at_balance_write"]
+    assert witnessed is not None, (
+        "the balance was mutated with no durable reservation behind it"
+    )
+    assert witnessed["status"] == "pending"
+    assert witnessed["reservation_owner"] != "rsv_a1"
+
+    assert result.status == "applied"
+    assert result.entry["wallet_id"] == "ai_tokens"
+    assert result.entry["amount"] == 100
+    assert await harness.balance() == 100
+
+    stored = await entries.find_one({"_id": entry_id})
+    assert stored is not None, "a moved balance must have the entry that explains it"
+    assert stored["status"] == "applied"
+    assert stored["wallet_id"] == "ai_tokens"
+    assert stored["amount"] == 100
+    assert stored["reservation_owner"] != "rsv_a1", "ownership must have been retaken"
+    assert await entries.count_documents({"app_id": harness.app_id}) == 1
+
+    balance_doc = await balances.find_one({"_id": scope.balance_id})
+    assert entry_id in set(balance_doc.get("applied_entry_ids") or [])
+
+    # And the allocation is not mintable twice.
+    again = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="proof_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+        subject_key=subject_key,
+        subject_revision=3,
+    )
+    assert again.status == "applied"
+    assert await harness.balance() == 100, "no duplicate mint"
+
+
+@pytest.mark.asyncio
+async def test_the_release_cannot_reclaim_a_record_it_does_not_own(harness) -> None:
+    """The compare-and-delete pins command id, pending status, and command
+    hash together. Anything else — a settled command, or the same id carrying
+    different data — is somebody else's record and stays put."""
+    service = harness.service(durable=True)
+    settled = harness.command("cmd_settled", plan_id="pro", subject_revision=1)
+    assert (await service.apply_durable(settled)).status == "applied"
+
+    assert await harness.store.release_pre_effect_failure(settled) is False, (
+        "a completed command must never be reclaimed"
+    )
+    record = await harness.store._collection()
+    assert await record.count_documents({"_id": settled.command_id}) == 1
+
+    # A pending record is only releasable by the exact same command.
+    pending = harness.command("cmd_pending", plan_id="pro", subject_revision=2)
+    assert (await harness.store.start(pending)).state == "started"
+    impostor = harness.command("cmd_pending", plan_id="enterprise", subject_revision=2)
+    assert await harness.store.release_pre_effect_failure(impostor) is False, (
+        "a different command body must not release this reservation"
+    )
+    assert await harness.store.release_pre_effect_failure(pending) is True
+    assert await record.count_documents({"_id": pending.command_id}) == 0
+
+
+# ── a reservation written before reservations were tracked ───────────────────
+
+
+def _pre_reservation_entry(
+    scope: Any, entry_id: str, *, idempotency_key: str
+) -> dict[str, Any]:
+    """The exact document `record_entry` wrote before this PR.
+
+    Copied field for field from `mozaiksai/core/tokens/wallet.py` as it stands
+    on the base commit: no `reservation_owner`, no `reservation_generation`,
+    because neither existed yet. Approximating this shape would prove nothing —
+    the whole question is what a real historical row looks like.
+    """
+    return {
+        "_id": entry_id,
+        "entry_id": entry_id,
+        "idempotency_key": idempotency_key,
+        "balance_id": scope.balance_id,
+        "app_id": scope.app_id,
+        "wallet_id": scope.wallet_id,
+        "scope_type": scope.scope_type,
+        "scope_id": scope.scope_id,
+        "user_id": scope.user_id,
+        "tenant_id": scope.tenant_id,
+        "operation": "allocation",
+        "direction": "credit",
+        "amount": 100,
+        "signed_amount": 100,
+        "status": "pending",
+        "source": "runtime",
+        "reason": None,
+        "metadata": {},
+        "usage_event_id": None,
+        "created_at": datetime(2026, 6, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 6, 1, tzinfo=UTC),
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_pre_reservation_pending_entry_still_recovers(harness) -> None:
+    """The regression this closes.
+
+    A crash between the balance write and the entry finalization leaves a
+    pending entry whose movement already committed. When that entry predates
+    reservation tracking it carries neither reservation field, and asking Mongo
+    for `reservation_generation: 0` never matches it — so acquisition exhausted
+    its attempts and raised, permanently stranding a movement the wallet had
+    already made.
+    """
+    balances, entries = await harness.ledger._collections()
+    scope = _scope_for(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        user_id="user_1",
+        preferred_scope="user",
+    )
+    entry_id = _entry_id(scope, "historical_alloc")
+    historical = _pre_reservation_entry(
+        scope, entry_id, idempotency_key="historical_alloc"
+    )
+    assert "reservation_owner" not in historical
+    assert "reservation_generation" not in historical
+    await entries.insert_one(historical)
+    await balances.insert_one(
+        {
+            "_id": scope.balance_id,
+            "app_id": harness.app_id,
+            "wallet_id": "ai_tokens",
+            "scope_type": "user",
+            "scope_id": "user_1",
+            "user_id": "user_1",
+            "tenant_id": None,
+            "balance": 100,
+            "total_allocated": 100,
+            "total_credited": 0,
+            "total_spent": 0,
+            "total_refunded": 0,
+            "entry_count": 1,
+            "applied_entry_ids": [entry_id],
+            "created_at": datetime(2026, 6, 1, tzinfo=UTC),
+            "updated_at": datetime(2026, 6, 1, tzinfo=UTC),
+        }
+    )
+
+    recovered = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="historical_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+    )
+
+    assert recovered.status == "applied"
+    assert recovered.entry["wallet_id"] == "ai_tokens"
+    assert recovered.entry["amount"] == 100
+    assert await harness.balance() == 100, "the movement must not happen twice"
+
+    stored = await entries.find_one({"_id": entry_id})
+    assert stored["status"] == "applied"
+    assert stored["amount"] == 100
+    assert stored["wallet_id"] == "ai_tokens"
+    assert await entries.count_documents({"app_id": harness.app_id}) == 1
+
+    # And the idempotent repeat is still idempotent.
+    again = await harness.ledger.record_entry(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        amount=100,
+        operation="allocation",
+        idempotency_key="historical_alloc",
+        user_id="user_1",
+        preferred_scope="user",
+    )
+    assert again.status == "applied"
+    assert await harness.balance() == 100, "no second mint"
+    assert await entries.count_documents({"app_id": harness.app_id}) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reservation_fields", "label"),
+    [
+        ({}, "absent"),
+        ({"reservation_owner": "rsv_prior", "reservation_generation": 0}, "zero"),
+        ({"reservation_owner": "rsv_prior", "reservation_generation": 7}, "nonzero"),
+    ],
+)
+async def test_adoption_matches_every_persisted_reservation_state(
+    harness, reservation_fields, label
+) -> None:
+    """Absent, zero, and non-zero are three different persisted states, and the
+    compare-and-swap must take over all three. Collapsing absence into zero is
+    what broke recovery."""
+    _balances, entries = await harness.ledger._collections()
+    scope = _scope_for(
+        app_id=harness.app_id,
+        wallet_id="ai_tokens",
+        user_id="user_1",
+        preferred_scope="user",
+    )
+    key = f"state_{label}"
+    entry_id = _entry_id(scope, key)
+    await entries.insert_one(
+        {**_pre_reservation_entry(scope, entry_id, idempotency_key=key), **reservation_fields}
+    )
+
+    acquired = await harness.ledger._acquire_entry_reservation(
+        entries,
+        entry_id=entry_id,
+        entry=_pre_reservation_entry(scope, entry_id, idempotency_key=key),
+        reservation_owner="rsv_mine",
+        now=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+    assert acquired is None, "ownership must have been taken, not refused"
+    owned = await entries.find_one({"_id": entry_id})
+    assert owned["reservation_owner"] == "rsv_mine"
+    expected = int(reservation_fields.get("reservation_generation", 0)) + 1
+    assert owned["reservation_generation"] == expected, (
+        "the generation advances from whatever was actually stored"
+    )

--- a/tests/test_subscription_contract_designer.py
+++ b/tests/test_subscription_contract_designer.py
@@ -779,3 +779,84 @@ def test_subscription_contract_rejects_token_wallets_without_usage_credit_or_quo
 
     with pytest.raises(ValueError, match="token_wallets are only valid"):
         normalize_subscription_contract(contract)
+
+
+def _normalize(config: dict) -> dict:
+    from factory_app.workflows.SubscriptionContractDesigner.tools.save_subscription_contract import (  # noqa: E501
+        _normalize_subscription_config,
+    )
+
+    return _normalize_subscription_config(config)
+
+
+def test_assignment_store_schema_declares_the_revision_field() -> None:
+    """The designer must be able to express the fence opt-out at all.
+
+    Structured outputs are exact: an agent emitting an undeclared nested field
+    is rejected before normalization, so an undeclared `revision_field` means
+    the opt-out has no way into the pipeline.
+    """
+    structured_outputs = _read_yaml(SUBSCRIPTION_WORKFLOW / "structured_outputs.yaml")
+    schema = structured_outputs["models"]["AssignmentStore"]["fields"]
+    assert "revision_field" in schema
+    # The finite literal the runtime accepts, not an open string — a `str`
+    # variant could generate a value the runtime would reject at load. The
+    # compiler resolves union variants by name, so the literal is declared as
+    # its own alias and referenced; an inline `values` list beside `variants`
+    # is not a shape it compiles.
+    assert schema["revision_field"]["variants"] == ["BillingRevisionField", "null"]
+    assert structured_outputs["models"]["BillingRevisionField"] == {
+        "type": "literal",
+        "values": ["billing_revision"],
+    }
+
+
+def test_explicit_null_revision_field_survives_normalization() -> None:
+    """`revision_field: null` is meaning-bearing: it opts a store out of
+    revision fencing. Dropping it as "just a null" would silently restore the
+    default on the next reload, turning an opt-out into an opt-in."""
+    contract = _sample_contract()
+    contract["subscription_config_file"]["assignment_store"]["revision_field"] = None
+
+    normalized = _normalize(contract["subscription_config_file"])
+
+    assert "revision_field" in normalized["assignment_store"]
+    assert normalized["assignment_store"]["revision_field"] is None
+
+
+def test_absent_revision_field_normalizes_to_the_explicit_default() -> None:
+    """Absence means "use the default", so the normalized contract states it
+    explicitly. That is the same semantics, just no longer implicit — and it
+    stays clearly distinguishable from the explicit null opt-out."""
+    contract = _sample_contract()
+    contract["subscription_config_file"]["assignment_store"].pop("revision_field", None)
+
+    normalized = _normalize(contract["subscription_config_file"])
+
+    assert normalized["assignment_store"]["revision_field"] == "billing_revision"
+
+
+def test_null_revision_field_survives_the_full_generator_roundtrip() -> None:
+    """design -> normalize -> materialize -> reload, with no default sneaking
+    back in at any hop."""
+    import yaml
+
+    from factory_app.workflows.AppGenerator.tools.materialize_app_config_contracts import (
+        _materialize_subscriptions_yaml,
+    )
+    from mozaiksai.core.runtime.app.subscriptions_loader import SubscriptionsConfig
+
+    contract = _sample_contract()
+    contract["subscription_config_file"]["assignment_store"]["revision_field"] = None
+    normalized = _normalize(contract["subscription_config_file"])
+
+    rendered = _materialize_subscriptions_yaml(
+        context_variables={"subscription_contract": {"subscription_config_file": normalized}}
+    )
+    assert "revision_field: null" in rendered
+
+    reloaded = SubscriptionsConfig.model_validate(yaml.safe_load(rendered))
+    assert reloaded.assignment_store is not None
+    assert reloaded.assignment_store.revision_field is None, (
+        "the opt-out must survive the roundtrip"
+    )

--- a/tests/test_token_wallet_ledger.py
+++ b/tests/test_token_wallet_ledger.py
@@ -416,3 +416,139 @@ async def test_list_entries_returns_public_entries() -> None:
 def test_runtime_collections_include_token_wallet_collections() -> None:
     assert RuntimeCollections.RUNTIME_TOKEN_WALLET_BALANCES == "RuntimeTokenWalletBalances"
     assert RuntimeCollections.RUNTIME_TOKEN_WALLET_ENTRIES == "RuntimeTokenWalletEntries"
+
+
+# ── reservation acquisition never yields without ownership ───────────────────
+
+
+def _reservation_entry(entry_id: str) -> dict:
+    return {
+        "_id": entry_id,
+        "entry_id": entry_id,
+        "balance_id": "app:ai_tokens:user:u1",
+        "operation": "allocation",
+        "direction": "credit",
+        "amount": 100,
+        "signed_amount": 100,
+        "status": "pending",
+        "reservation_owner": "rsv_original",
+        "reservation_generation": 0,
+    }
+
+
+class _ContendedEntries:
+    """Every compare-and-swap loses to a competitor that never settles."""
+
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.generation = 0
+        self.swaps = 0
+
+    async def find_one(self, _filter, _projection=None):
+        document = _reservation_entry(self.entry_id)
+        document["reservation_generation"] = self.generation
+        return document
+
+    async def find_one_and_update(self, *_args, **_kwargs):
+        self.swaps += 1
+        self.generation += 1
+        return None
+
+    async def insert_one(self, _document):  # pragma: no cover - not reached
+        raise AssertionError("a pending reservation exists; insert must not run")
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_contention_refuses_instead_of_writing() -> None:
+    """Bounded attempts, then an operational refusal. Spinning forever is not
+    an option and neither is moving the balance without the reservation that
+    explains the movement."""
+    from mozaiksai.core.tokens.wallet import (
+        TokenWalletLedger,
+        TokenWalletReservationUnavailable,
+        _now,
+    )
+
+    entry_id = "token_wallet_entry:contended"
+    entries = _ContendedEntries(entry_id)
+    ledger = TokenWalletLedger(database=object())
+
+    with pytest.raises(TokenWalletReservationUnavailable):
+        await ledger._acquire_entry_reservation(
+            entries,
+            entry_id=entry_id,
+            entry=_reservation_entry(entry_id),
+            reservation_owner="rsv_mine",
+            now=_now(),
+        )
+    assert entries.swaps > 1, "the attempt must be retried, not abandoned at once"
+
+
+class _VanishingEntries:
+    """The observed reservation is deleted before the swap can take it."""
+
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.present = True
+        self.inserted: dict | None = None
+
+    async def find_one(self, _filter, _projection=None):
+        if not self.present:
+            return None
+        return _reservation_entry(self.entry_id)
+
+    async def find_one_and_update(self, *_args, **_kwargs):
+        self.present = False
+        return None
+
+    async def insert_one(self, document):
+        self.inserted = dict(document)
+
+
+@pytest.mark.asyncio
+async def test_a_lost_swap_is_followed_by_a_fresh_reservation() -> None:
+    """A swap that matches nothing means the world moved. The next attempt
+    re-reads, finds the reservation gone, and makes one it owns."""
+    from mozaiksai.core.tokens.wallet import TokenWalletLedger, _now
+
+    entry_id = "token_wallet_entry:vanishing"
+    entries = _VanishingEntries(entry_id)
+    ledger = TokenWalletLedger(database=object())
+
+    acquired = await ledger._acquire_entry_reservation(
+        entries,
+        entry_id=entry_id,
+        entry=_reservation_entry(entry_id) | {"reservation_owner": "rsv_mine"},
+        reservation_owner="rsv_mine",
+        now=_now(),
+    )
+
+    assert acquired is None, "ownership, not a terminal outcome"
+    assert entries.inserted is not None
+    assert entries.inserted["reservation_owner"] == "rsv_mine"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["applied", "rejected"])
+async def test_a_settled_entry_is_returned_rather_than_reserved(status) -> None:
+    from mozaiksai.core.tokens.wallet import TokenWalletLedger, _now
+
+    entry_id = "token_wallet_entry:settled"
+
+    class _Settled:
+        async def find_one(self, _filter, _projection=None):
+            return _reservation_entry(entry_id) | {"status": status}
+
+        async def insert_one(self, _document):  # pragma: no cover
+            raise AssertionError("a settled entry must not be re-reserved")
+
+    ledger = TokenWalletLedger(database=object())
+    acquired = await ledger._acquire_entry_reservation(
+        _Settled(),
+        entry_id=entry_id,
+        entry=_reservation_entry(entry_id),
+        reservation_owner="rsv_mine",
+        now=_now(),
+    )
+    assert acquired is not None
+    assert acquired["status"] == status


### PR DESCRIPTION
**Draft — prerequisite for mozaiks-app PR #262. Do not merge without independent review.**

## The defect

Fulfillment is delivered over a network, so an older command can complete at the receiver **after** a newer one has already been applied — a local timeout at the sender does not stop the request that caused it.

Idempotency cannot prevent this. The two commands carry different `command_id`s, so both are new to the durable command store, and `_apply_assignment` committed an unconditional last-writer-wins upsert:

```python
await collection.update_one(query, {"$set": updates, "$setOnInsert": {...}}, upsert=True)
```

Nothing in the assignment document, the command store, or the effect path recorded or compared the *order* of applied commands. An out-of-order command therefore silently regressed a subject's entitlement state — e.g. a stale `free` command landing after a legitimate upgrade to `pro`, or a stale cancellation revoking a newer reactivation.

## The fix

`BillingFulfillmentCommand` accepts an optional `subject_revision`: a **provider-neutral**, monotonically increasing ordinal that the upstream billing source allocates per entitlement subject when it commits a canonical revision. The receiver never learns anything about a provider — it just compares integers.

At write time the comparison happens in the same atomic operation that performs the update, on the subject's own assignment document:

| incoming | outcome |
|---|---|
| strictly newer, or subject has no stored revision | applies, stamps the new revision |
| stale or equal | commits nothing — effects `skipped` / `stale_revision`, result status `superseded` |
| absent (`None`) | applies unfenced, exactly as before |

`superseded` is a new terminal `BillingFulfillmentStatus`. It is a **success** outcome (`success: true`, `applied: 0`): the command was understood and safely ignored, so a sender settles it rather than retrying. Equal revisions are suppressed because equality carries no ordering information.

Plan allowances are suppressed alongside a fenced assignment. This is load-bearing, not tidiness: the allowance idempotency key is plan-and-period scoped, so a stale command naming a *different* plan would otherwise mint real tokens behind a fenced assignment.

## Why this shape

- **The subject key already exists.** The entitlement subject is the assignment query (`app_id` plus whichever of tenant/workspace/user the store declares), which is already the assignment document's deterministic identity. No new collection, no new index, no transaction — correctness holds on standalone Mongo.
- **Idempotency and ordering stay orthogonal.** `command_id` answers "have I already applied this command?"; `subject_revision` answers "is this still the newest truth for this subject?". The command store is untouched.
- **Backwards compatible by construction.** Commands without `subject_revision` behave exactly as before, which is why every existing test passes unchanged.
- **No provider vocabulary.** Not a Stripe version, not an event id, not a timestamp — timestamps are not a reliable strict ordering primitive and equal ones would discard legitimate revisions.

## Contract surface

- `BillingFulfillmentCommand.subject_revision: int | None` (`ge=0`)
- `BillingFulfillmentStatus` gains `"superseded"`
- `SubscriptionAssignmentStoreDef.revision_field: str | None = "billing_revision"` (null opts out per app)
- effect reason `stale_revision` (exported as `STALE_REVISION_REASON`)

## Tests

`tests/test_billing_fulfillment.py` — 10 new cases: newer applies and stamps; **stale cannot regress a newer subject** (and mints no allowances); equal is suppressed; an ordered A→B→A sequence lands in order; first fenced write creates the subject; unfenced commands keep legacy behavior; the fence is scoped per subject (one customer cannot suppress another); a stale cancellation cannot revoke a newer activation; a durable stale command replays as a stable `superseded`; `revision_field: null` opts out.

The in-test Mongo double was extended with `$or` / `$lt` / `$exists`, real `matched_count`, and `_id` collision on filtered upserts — and now raises on unknown operators instead of silently matching everything, which was letting predicates pass vacuously.

Run: `tests/test_billing_fulfillment.py` (20 passed), `tests/test_generated_saas_subscription_runtime_acceptance.py` + `tests/test_generated_app_archetype_matrix.py` + `tests/test_monetization_taxonomy.py` (14 passed), and the full billing/subscription/entitlement/monetization selection (477 passed, 5 skipped). `ruff` clean.

## OSS Change Impact

- **Layer changed**: runtime — `mozaiksai/core/billing/fulfillment.py`, `mozaiksai/core/runtime/app/subscriptions_loader.py`
- **Build workflow impact**: none
- **Runtime/platform impact**: additive optional command field + one additive optional config field; fenced path only activates when a caller supplies `subject_revision`
- **App workspace impact**: `app/config/subscriptions.yaml` may declare `assignment_store.revision_field` (defaulted, opt-out only)
- **Tests run**: listed above
- **Docs updated**: `CHANGELOG.md`, `docs/architecture/mozaiksai/cash-to-token-loop-0-1-10.md` (new "Revision Fencing" section + model listing), `subscriptions_loader.py` canonical example
- **Compatibility risk**: low — no behavior change for commands without `subject_revision`; existing tests pass unchanged

## Managed Capability Boundary Check

- Managed-capability surfaces affected: none
- App-owned facade boundary preserved: yes
- No provider internals in OSS: confirmed — the ordinal is a plain integer with no provider semantics
- Examples remain provider-neutral: yes

## Relationship to other work

- Prerequisite for **mozaiks-app #262** (generated-app fulfillment delivery), which is `BLOCKED_ON_OSS_PR` on this.
- Independent of **#495** (module dispatch / auth config / fulfillment ingress). No overlap: #495 touches ingress authorization, this touches effect commit ordering. Both are required before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Correction round 1 (2026-09-09) — head `e05cafee`, rebased onto `c0188f08`

Astra reviewed `b7b004f8` and returned MATERIAL DEFECT while affirming the architecture (separating command idempotency from subject ordering, and enforcing order receiver-side in OSS). All eight defects are corrected; the architecture is unchanged.

**A — strict, BSON-safe revision.** `subject_revision` was accepting `True`, `1.0`, `"1"`, `"1.0"` through coercion, and values beyond int64 that later raise `OverflowError` in Mongo. Now `strict=True`, `0 <= v <= 9223372036854775807`. BSON `Int64` (an int subclass) still parses. Proven at model, persistence and replay level, including a max-int64 round trip through a real server.

**B — the revision field is no longer configurable.** It was a free-form Mongo path that could shadow `app_id`/`user_id`/`plan_id`/`status`/`updated_at`/`billing_fulfillment`/`_id`, collide with keys written by the same update, traverse dotted paths, or be silently disabled by whitespace. This is an authority field, not a customization feature, so the schema is now exactly `"billing_revision" | null`. That deletes the entire class of defects rather than validating around it.

**C — a duplicate key is no longer read as proof of the same subject.** The deterministic assignment id string-formats scope values, so `None` and `"None"` hash alike. Persisted scope fields are now compared with typed equality before any stale/equal classification, and a mismatch is rejected as `subject_identity_collision` — which also suppresses allowances, since nothing downstream may act on an unprovable subject. The historic id algorithm is deliberately untouched (no migration proof here); failing closed is the bounded correction.

**D — creation and update now share one atomic predicate.** The read-then-unfenced-fallback-upsert was the largest defect: two concurrent first-revisions both observed absence and the loser's unfenced write overwrote the winner. There is now a single revision-filtered upsert carrying the deterministic subject id, with a bounded duplicate-key retry, and **no unfenced write anywhere**. Proven on real Mongo: 2-way both orders, 10-way ascending and descending — final state is always the highest revision, one row, and no stale command reports applied.

**E — allowances are fenced at their own commit.** Assignment success observed before an `await` is not authority afterwards. `TokenWalletLedger.record_entry` now takes an opaque `subject_key`/`subject_revision` pair and folds the ordering predicate into the *same single-document update that moves the balance* — not a preflight read, and not a re-read of the assignment. A stale revision that was mid-flight when a newer one committed is refused there and marked `stale_subject_revision`. The idempotency key stays plan-and-period scoped on purpose: folding the revision into it would double-mint for two legitimate revisions in one period.

**F — pre-fence command identity is preserved.** The canonical document omits `subject_revision` entirely when absent, so a command completed before this change hashes identically and replays instead of becoming a content conflict. Proven for both subscription and wallet command shapes, and end to end through the durable store on a real server.

**G — replay keeps its meaning.** `status` stays `"replayed"` (no caller breakage) and the result now carries an immutable `original_status`, so a replayed supersession stays recognizably superseded instead of being flattened. Proven for applied / rejected / superseded.

**H — the null opt-out survives generation.** `AssignmentStore` in the designer's structured output now declares `revision_field` (exact structured outputs reject undeclared fields, so without this the opt-out had no way into the pipeline), and `save_subscription_contract` restores explicitly-set nulls that `exclude_none=True` would erase — targeted to this field rather than changing null policy globally. Roundtrip proven: design → normalize → materialize → reload, still null.

### Note on `tests/fixtures/workflow-document-version-migration.json`

Declaring `revision_field` changes a governed workflow document, and that frozen-corpus guard pins all 30 of them. One row's fingerprints were regenerated using the same rule the fixture encodes (validated against 28 of the 29 untouched documents first); the migration evidence itself is unchanged — `schema_version` is still the only thing #486 added — and the other 29 documents are untouched. Flagging it explicitly because it is someone else's invariant.

### Real Mongo is now mandatory, not opt-in

`tests/test_billing_fulfillment_revision_fence_real_mongo.py` (27 tests) is gated on MongoDB **reachability**, matching `test_chat_execution_lease_real_mongo.py`, so it executes in the authoritative `test-shard` lane instead of silently skipping the way `MOZAIKS_RUN_REAL_MONGO_TESTS` files do. It covers strict bounds, first fenced insert, newer/stale/equal, concurrent creation, 10-way mixed, duplicate-key classification, subject-identity collision, the stale-allowance race, cancellation/reactivation both directions, A→B→A, pre-fence durable replay, superseded replay, and the unknown-remote-outcome acceptance theorem.

### Validation

`tests/test_billing_fulfillment.py` 58 passed; the real-Mongo fence file 27 passed; billing/subscription/entitlement/monetization/wallet/token/designer/materializer/readiness/document-identity selection **1229 passed / 43 skipped** post-rebase; full suite **15761 passed / 93 skipped**. `ruff` clean, `git diff --check` clean, mypy clean in CI.

### Pre-existing follow-ups (not bundled)

- **Medium**: reactivation can retain an old `expires_at` and read as active-but-expired.
- **Medium**: `BillingFulfillmentCommandStore` has no TTL or lease on `pending`, so a crash between `start` and `finish` wedges that `command_id` at 409-pending permanently.
- **Low**: `BillingFulfillmentService._collection()` honors only `config.assignment_store`, ignoring v2 `products[].assignment_store` that `ConfiguredEntitlementAdapter` supports.
- **Low**: `generated_bundle_scanner` gates on `assignment_store` truthiness, so `assignment_store: {}` skips the entitlement-dispatch check.

None is required by the revision-fence theorem and none is touched here.

Still draft, auto-merge off, not merged — ready for another Astra exact-head review.


---

## Correction round 2 (2026-09-09) — head `66d4fadf`, base `c0188f08` (unchanged)

Astra reviewed `c43a948b` and returned MATERIAL DEFECT while affirming the architecture and closing seven items from the prior round. All nine remaining defects are corrected; the architecture is unchanged and the previously closed work is preserved.

**A — `billing_revision` is reserved.** `revision_field` was locked down, but `plan_id_field: billing_revision` (or any other mapping) could still aim ordinary business writes at the fence's ordering authority. A load-time validator now rejects any of the ten configurable identity/business mappings that equals the reserved field or nests under it — caught at config load, not discovered later as a mysteriously lost fence.

**B — dotted paths resolve identically everywhere.** With `user_id_field: scope.user`, subject comparison read `document["scope.user"]` instead of walking into `scope.user`, so a legitimate stale request for the *same* subject was misclassified as `subject_identity_collision`. One helper now gives query, write, and typed comparison the same semantics.

**C — fenced mode requires real subject uniqueness.** The deterministic `_id` could not deliver it: an assignment created before this contract carries an ObjectId, so a stale revision-filtered upsert inserted a *second* deterministic row for the same subject and reported itself applied. Enabling fencing now establishes a unique index (`mozaiks_billing_subject_unique`) over the exact configured subject paths, and duplicate-key handling resolves the blocking row through the canonical **subject** selector rather than the id. Pre-existing duplicate subjects fail closed with `BillingFulfillmentSubjectIndexError` — no silent winner, no deletion. Opted-out configs acquire no index requirement.

**D — one effective fencing decision.** `revision_field: null` disabled the assignment fence but still handed subject authority to the ledger, so an opted-out app's assignment took the older revision while its wallet refused the matching allowance as stale. Fencing is now on only when the command carries a revision **and** the store declares the field, and that single decision governs assignment, allowance, and ordering head.

**E — the wallet head advances for every accepted revision.** It previously moved only when tokens were actually minted, so it meant "last revision that minted" rather than "latest accepted revision". A cancellation, a zero-allowance plan, or a return to a plan whose period allocation already exists all legitimately credit nothing — and a delayed older allowance sailed straight past them. New provider-neutral `TokenWalletLedger.advance_subject_revision` claims the head atomically with no balance movement (newer advances, equal is safe for the revision's own allowance and for retries, older is refused), and the service claims it on every wallet the subject could touch as soon as a fenced assignment is accepted.

**F — a stale attempt no longer consumes the successful allowance identity.** A rejected stale attempt was persisted under the plan-and-period identity that a *successful* allocation owns, permanently denying the allocation a later valid revision of the same plan and period was entitled to make. The reservation is now rolled back and the refusal reported without recording it there.

**G — terminal status reflects being overtaken.** A command whose assignment applied and whose remaining effects were then invalidated still reported `applied`, and its durable replay preserved that wrong disposition. There is now one documented precedence — `partial` > `rejected` > `superseded` > `applied` — so such a command is `superseded` while individual effect history stays truthful (`applied` effects still count). Proven with a genuine interleave: the assignment commits, a newer revision claims the head, the allowance stands down.

**H — designer literal matches runtime exactly.** The structured model declared `str | null` and could therefore generate a value the runtime rejects; it is now the same finite literal, `billing_revision | null`.

**I — historical migration evidence restored.** The previous round regenerated a fingerprint in `tests/fixtures/workflow-document-version-migration.json`, which rewrote a claim about a historical commit. That fixture is now **byte-identical to main** (`git diff c0188f08 -- <fixture>` is empty). The current contract addition is instead accounted for in the comparator, following the pattern main already uses for `AgentGenerator`'s reviewed guidance edits: the reviewed addition is removed before comparing, so the historical capture still proves itself and unapproved drift is still caught.

### Validation

Real-Mongo suite **37 passed** — now including existing-ObjectId row + newer/stale, index establishment and key shape, pre-existing duplicates failing initialization, dotted subject mapping, cancellation and zero-credit ordering, idempotent reuse still advancing the head, stale rejection not consuming the allowance identity, partially-applied → superseded with replay, and the opt-out disabling both fences plus acquiring no index. `tests/test_billing_fulfillment.py` **89 passed**. Broad billing/subscription/entitlement/wallet/designer/materializer/readiness/document-identity/archetype/SaaS selection **1416 passed / 43 skipped**. Full suite **15827 passed / 93 skipped**. `ruff` clean, `git diff --check` clean.

### Subject index governance

Deterministic name, keys derived from the configured subject paths (so the same config always yields the same index), verified once per collection and reused on restart, incompatible name/keys and duplicate data both fail closed with an actionable error, no destructive cleanup, and no cross-app or cross-tenant reach — the index is per assignment collection over app-scoped fields. Documented in `cash-to-token-loop-0-1-10.md` as a correctness prerequisite of enabling fencing.

Still draft, auto-merge off, not merged. mozaiks-app #262 untouched and still `BLOCKED_ON_OSS_PR_497`.


---

## Correction round 3 (2026-09-09) — head `a99d1387`, base `c0188f08` (unchanged)

Astra reviewed `66d4fadf` and returned five bounded blockers while affirming everything else. All five are corrected. The architecture is unchanged, and nothing Astra closed in rounds 1–2 was reopened.

**R3-A — an equivalent existing index is accepted.** Fencing demanded ownership of the name `mozaiks_billing_subject_unique` and would fail closed against a store that *already* enforced one row per subject under its own name (`subscriptions_by_app_user` over `app_id`+`tenant_id`+`user_id`). That rejected a correctly-configured deployment. What fencing needs is the guarantee, not the name: an existing index qualifies when it has the same ordered key fields, the same directions, and `unique: true`. An index that narrows its coverage (`sparse`, a `partialFilterExpression`) or changes which values compare equal (a non-simple collation) is a different promise and does not qualify — in that case the canonical index is still created.

**R3-B — ordering authority is established before the assignment commits.** This was the important one. The previous flow committed the assignment, *then* advanced the wallet head through a helper that swallowed exceptions and ignored the returned Boolean, so a failed head write left the subject at revision 2 while every wallet still admitted revision 1 — and that window cannot be repaired retroactively, because an older allowance may already be in flight. Re-raising after the assignment had committed would not have fixed it either; the ordering itself was wrong. The fenced path now claims the head on every wallet the subject can reach **first**, and only then writes the assignment. A head write that *fails* is not a decline: it propagates, the command applies nothing, and the retry completes normally because equal revisions are accepted. Separately, the ordering key was derived from the assignment `_id`, which string-formats scope values and so gave a null scope and the literal string `"None"` the same head; it is now a type-preserving digest. The historical assignment `_id` is unchanged.

**R3-C — a declined head claim means the command was overtaken.** `advance_subject_revision() == False` is meaning-bearing, not an advisory no-op. When any applicable wallet reports a strictly newer revision, the assignment is not applied, both effects come back `skipped` / `stale_revision`, and the terminal status is `superseded`. This is the only thing that catches a subject whose assignment row is missing — a restored store, a migration, an assignment that never landed — where the assignment-side comparison has nothing to compare against and would otherwise recreate the subject at an older plan.

**R3-D — pending allowance reservations are owned.** A stale attempt rolled back "the pending reservation" unconditionally. Because that reservation identity is plan- and period-scoped, a newer, entitled revision may legitimately adopt it — and the stale rollback then deleted a reservation a newer revision was about to commit against. Adoption now transfers ownership atomically (with a monotonic `reservation_generation`), and rollback deletes only a reservation the rolling-back attempt still owns. The crash-recovery case is preserved: an entry already present in `applied_entry_ids` but still `pending` is finished, not rolled back. Neither field is exposed on the public entry surface.

**R3-E — the designer literal actually compiles.** `variants: [enum, 'null']` with a sibling `values:` list is not a shape the canonical compiler accepts — union variants resolve by name. The schema now declares a named literal alias `BillingRevisionField` and references it, and the test builds the models through `build_models_from_config` rather than parsing YAML: it compiles, accepts `billing_revision` and explicit `null`, and rejects any other string.

### New proofs

Real-Mongo suite is now **45 tests** (was 37); the previous 37 all still pass. Eight added:

- an equivalent unique index under a different name is accepted, no second index is created, and fencing still works through it
- a narrowed (`partialFilterExpression`) unique index does **not** stand in for the full constraint
- a failing head write aborts before the assignment commits — no assignment row, no balance document, no head — and the retry of the same command completes normally
- null and the literal string `"None"` are different subjects
- a revision-2 cancellation resuming behind revision 3 is `superseded` and cancels nothing
- a declined head blocks a subject whose assignment row is gone (the case only the wallet head can catch)
- a stale attempt cannot delete a reservation a newer revision has adopted, and that newer revision then commits against it
- a pending entry already counted in the balance is recovered rather than rolled back

Plus unit coverage: a ten-case index-equivalence matrix (ordering, direction, `sparse`, `partialFilterExpression`, collation, non-unique, a collection that cannot report indexes), and a direct demonstration that `_assignment_id` conflates null with `"None"` while `_subject_identity` does not.

Each of R3-A, R3-B, R3-C and R3-D was mutation-checked: reverting the fix makes the corresponding new proof fail, so these tests bite rather than merely pass.

### Validation

`ruff check .` clean. `git diff --check` clean. `mypy` clean (`--python-version=3.12`, 397 source files; the local default target trips an unrelated numpy stub in `.release-venv`). `tests/test_billing_fulfillment.py` **101 passed**; the real-Mongo fence file **45 passed**; `tests/test_token_wallet_ledger.py`, `tests/test_subscription_contract_designer.py`, `tests/test_workflow_document_identity_migration.py`, `tests/test_production_readiness_gate.py` all green; broad billing/subscription/entitlement/wallet/token/designer/materializer/readiness/document-identity/archetype/SaaS/monetization selection **1127 passed / 42 skipped**. Full suite: **15848 passed / 93 skipped**, zero failures, working tree clean at the pushed head.

### Historical evidence

`tests/fixtures/workflow-document-version-migration.json` remains **byte-identical to main** (`git diff c0188f08 -- <fixture>` is empty). R3-E adds a second element to the same reviewed contract addition (the `BillingRevisionField` alias), so the comparator now removes both before digesting — same pattern main already uses for `AgentGenerator`'s reviewed guidance edits.

### Scope

Nothing outside the five findings was folded in. The documented follow-ups remain follow-ups and are untouched: stale `expires_at` on reactivation, no TTL/lease on `pending` commands, `_collection()` ignoring v2 `products[].assignment_store`, and `generated_bundle_scanner` gating on `assignment_store` truthiness.

Base unchanged at `c0188f08`, which is still `origin/main`, so no restack was needed. Still draft, auto-merge off, not merged. mozaiks-app #262 untouched and still `BLOCKED_ON_OSS_PR_497`.


---

## Correction round 4 (2026-09-10) — head `34c0bfae`, base `c0188f08` (unchanged)

Codex reviewed `a99d1387` and passed every Round-3 acceptance area except two bounded runtime cases. Both are corrected. Nothing else was reopened, and `origin/main` had not moved, so no restack was needed.

**R4-A — a pre-assignment ordering failure no longer wedges the command.** Round 3 correctly moved wallet head establishment ahead of the assignment and correctly stopped swallowing operational failures. But `apply_durable` reserves the command as `pending` *before* effects run, so a propagating head-write failure left that reservation pending with nothing written — and every identical retry was then refused with `BillingFulfillmentPendingError`, permanently.

The release is deliberately narrow. Failures raised inside the ordering prerequisite are now a distinct kind, `BillingFulfillmentPreEffectError` (with `BillingFulfillmentOrderingUnavailable` for a failed head write and the existing `BillingFulfillmentSubjectIndexError` beneath it), because the caller knows with certainty that no assignment, allowance, or wallet movement was written. Only those release the reservation, via `BillingFulfillmentCommandStore.release_pre_effect_failure()` — a compare-and-delete pinning the exact command id, the still-pending status, *and* the exact command hash — and only while unwinding the invocation that obtained `started`. Deleting rather than marking keeps the retry on the ordinary `start` path, with no second reacquisition rule to get wrong.

Exclusivity is unchanged: a concurrent identical caller arriving before the release still sees `pending` and is still refused; only a later retry can start. A failure *after* an effect has committed stays pending, as it must. This is not general command-store crash recovery — that remains the separate, untouched follow-up.

Heads claimed by a partially successful attempt are not reversed. If wallet A advanced and wallet B failed, the retry finds A equal (which succeeds), advances B, and commits. Reversing A would reopen exactly the window an older revision could credit in.

**R4-B — no balance moves without an acquired reservation.** Round 3's ownership fix closed the case where a stale attempt deleted a reservation a newer revision had already adopted. The opposite ordering was still open: revision 3 reads revision 1's pending reservation, revision 1 deletes its own reservation before revision 3's compare-and-swap runs, the swap matches nothing — and the old code carried on, crediting the balance with no ledger entry behind it (+100, an `applied_entry_id` on the balance, zero entries, command reporting `applied`).

Acquisition is now a single bounded helper, `_acquire_entry_reservation()`. It returns either an owned pending reservation or an already-terminal entry, never "nothing happened", and the balance is only touched after the former. Each attempt re-reads before acting, because every observation here can be invalidated the instant after it is made; adoption is a compare-and-swap on the exact observed `reservation_owner` **and** `reservation_generation`, and a lost swap means the world moved, so the ledger answers the new state — reserve afresh if the reservation is gone, return the idempotent outcome if it settled, retry if someone else now holds it. Attempts are bounded; unresolvable contention raises `TokenWalletReservationUnavailable` rather than writing anyway (both wallet effect paths already convert that into a `rejected` effect, so it is terminal and never wedges a command).

`_mark_entry_applied` now finalizes by upsert on the movement's own facts. Reaching it means the balance already counts the entry, so it must be impossible to report `applied` with an absent entry document or null wallet facts from an empty lookup.

### New proofs

Real-Mongo suite is now **51 tests** (was 45); all 45 prior cases still pass. Six added:

- a durable command survives a pre-assignment ordering failure: nothing commits, the identical command retries and completes, a delayed revision-1 allowance still cannot credit behind it, and the command is terminal and replays normally
- a partial multi-wallet head failure converges: wallet A keeps its claim, the assignment never commits, and the retry advances B and commits with both heads at 3
- a concurrent duplicate is still refused while the failing invocation is running, and only the later retry starts
- a failure *after* an effect committed stays pending — the release really is pre-effect only
- the release cannot reclaim a settled command, nor a pending record whose command body differs
- the exact lost-swap interleave, asserting the invariant directly: a hook captures the reservation state at the instant of the balance write and requires a pending reservation no longer owned by A1, plus one applied entry with correct wallet and amount, the `applied_entry_id` on the balance, and no duplicate mint on repeat

Unit coverage adds unresolvable contention refusing rather than writing, a lost swap followed by a fresh reservation, and a settled entry being returned rather than re-reserved.

Both corrections were mutation-checked: removing the pre-effect release fails three of the durable tests, and restoring "proceed after a lost swap" fails the interleave test on the witness assertion. Note the witness is what makes the R4-B proof independent of the `_mark_entry_applied` upsert repair — asserting only the end state would have passed either way.

### Validation

`ruff check .` clean. `git diff --check` clean. `mypy` clean (`--python-version=3.12`, 397 source files). Real-Mongo fence file **51 passed**; `tests/test_billing_fulfillment.py`, `tests/test_token_wallet_ledger.py`, `tests/test_subscription_contract_designer.py`, `tests/test_workflow_document_identity_migration.py`, `tests/test_production_readiness_gate.py`, `tests/test_generated_saas_subscription_runtime_acceptance.py` — **235 passed** together; broad billing/subscription/entitlement/wallet/token/designer/materializer/readiness/document-identity/archetype/SaaS/monetization/replay selection **1183 passed / 43 skipped**. Full suite: **15858 passed / 93 skipped**, zero failures, working tree clean at the pushed head.

### Scope

Only the two findings. No Mongo transactions, no locking service, no generalized pending lease or TTL, no provider logic, no #262 changes. The documented follow-ups remain follow-ups: general command-store pending recovery, stale `expires_at` on reactivation, `_collection()` ignoring v2 `products[].assignment_store`, and `generated_bundle_scanner` gating on `assignment_store` truthiness.

Still draft, auto-merge off, not merged. mozaiks-app #262 untouched and still `BLOCKED_ON_OSS_PR_497`.


---

## Correction round 5 (2026-09-10) — head `90220d1a`, restacked onto `5950c855`

Codex reviewed `34c0bfae` and passed every Round-4 acceptance area except one B3 regression. That is the only change here.

**Restack.** `origin/main` advanced from `c0188f08` to `5950c855` when #495 merged, so #497 was rebased onto it before final validation. Two files overlapped — `CHANGELOG.md` and `tests/test_billing_fulfillment.py` — and both were purely additive on each side (#495 adds a `### Security` entry and a fulfillment-ingress auth test block; this PR adds an `### Added` entry and the fencing test block). Both were kept whole. **No semantic conflict**: no shared symbol, contract, or behavior was touched by both.

**R5 — a pending entry written before reservations existed must still recover.** Round 4's adoption predicate read the stored generation as `existing.get("reservation_generation", 0)`. That is a Python default, not a Mongo query: `{"reservation_generation": 0}` matches only a stored zero, never an absent field. So a pending entry from the pre-reservation format could never be adopted, acquisition burned all five attempts, and `TokenWalletReservationUnavailable` was raised — stranding a movement whose balance had *already* committed. Round 3 (`a99d1387`) recovered the same record, because its predicate used only `reservation_owner`, and Mongo's `{field: None}` happens to match a missing field.

Reproduced first against the exact base-commit document shape, then fixed. The predicate is now built from what was actually observed:

```python
predicate[field] = existing[field] if field in existing else {"$exists": False}
```

applied to both reservation fields. A **source census of the base commit** (`git show c0188f08:mozaiksai/core/tokens/wallet.py`) confirms the historical entry carries *neither* `reservation_owner` nor `reservation_generation` — both fields arrived together in Round 3 — so both absences are preserved rather than only the generation. Nothing is manufactured, no migration is added, and a successful adoption still uses `$inc`, which initializes the field to 1 for a record that never had one.

### Proofs

Real-Mongo suite is now **55 tests** (was 51); all 51 prior cases still pass. Four added:

- `test_a_pre_reservation_pending_entry_still_recovers` — a pending entry built field-for-field from the base commit's writer, its 100-token movement already in the balance and its id already in `applied_entry_ids`. Recovery returns `applied` with correct wallet and amount, the balance stays exactly 100, exactly one durable entry exists and is `applied`, no `TokenWalletReservationUnavailable`, and the repeat invocation is idempotent with no second mint.
- `test_adoption_matches_every_persisted_reservation_state[absent|zero|nonzero]` — three genuinely different persisted states. Each is adopted, and the generation advances from whatever was actually stored (absent → 1, 0 → 1, 7 → 8), so absence cannot collapse into zero unnoticed.

Mutation-checked: restoring `existing.get(field, 0)` fails the historical-recovery test and the `absent` parameter case, while `zero` and `nonzero` still pass — which is exactly the shape of the reported regression.

Also verified ad hoc (not added as tests, since no shipped code writes them): the two mixed shapes — owner present with generation absent, and generation present with owner absent — both recover correctly. The predicate is shape-agnostic because it compares what is there rather than what it expects to be there.

### Validation

`ruff check .` clean. `git diff --check` clean. `mypy` clean (`--python-version=3.12`, 399 source files). Real-Mongo fence file **55 passed**; `tests/test_billing_fulfillment.py`, `tests/test_token_wallet_ledger.py`, `tests/test_subscription_contract_designer.py`, `tests/test_workflow_document_identity_migration.py`, `tests/test_generated_saas_subscription_runtime_acceptance.py` — **243 passed** together with the fence file; `tests/test_production_readiness_gate.py` green. Full suite: **16352 passed / 93 skipped**, zero failures, working tree clean at the pushed head (the count rises from 15858 because the restack brought #495's tests in).

### Scope

One predicate and its proofs. No migration, no schema conversion, no command pending TTL or lease, no provider logic, no new billing functionality, no #262 changes. Every Round-4 behavior is untouched and still green.

Still draft, auto-merge off, not merged. mozaiks-app #262 untouched and still `BLOCKED_ON_OSS_PR_497`.

---

## Restack onto #498 (2026-09-10) — head `69b7f7e8`, base `b132ddf2`

Codex passed the substantive review of `90220d1a` and returned `STALE / RESTACK REQUIRED` only because main advanced. This pass is the restack and nothing else — **no production file changed**.

**Conflict: `tests/test_workflow_document_identity_migration.py`.** #498 deliberately replaced `test_document_version_and_reviewed_guidance_changes_preserve_contract_shape` with `test_current_documents_require_explicit_versions_and_parse_repeatably`, deleting the historical-comparison machinery — including the `AgentGenerator` guidance-edit restoration that this PR had extended with a `SubscriptionContractDesigner` branch for `revision_field` / `BillingRevisionField`.

Resolved by taking main's version whole. The file is now **byte-identical to `b132ddf2`** and no longer appears in this PR's diff at all — `git diff b132ddf2 HEAD -- tests/test_workflow_document_identity_migration.py` is empty. #498's philosophy stands unmodified: current documents require explicit schema versions, parse repeatably, may evolve after the historical migration, and remain invalid unversioned.

No replacement machinery was resurrected and no new assertion was added, because `revision_field` already has direct coverage that does not depend on historical digests:

- `tests/test_subscription_contract_designer.py::test_assignment_store_schema_declares_the_revision_field` — the YAML shape and the `BillingRevisionField` literal alias
- `tests/test_billing_fulfillment.py::test_designer_revision_field_compiles_to_the_runtime_literal` — compiles through `build_models_from_config`, accepts `billing_revision` and explicit null, rejects anything else
- `tests/test_subscription_contract_designer.py::test_explicit_null_revision_field_survives_normalization` — the opt-out roundtrip

`tests/fixtures/workflow-document-version-migration.json` is unchanged from main, as it has been since round 2.

**Restack integrity.** Every production file is byte-identical to the reviewed head — `git diff 90220d1a HEAD` over `fulfillment.py`, `wallet.py`, `subscriptions_loader.py`, and both `SubscriptionContractDesigner` files returns zero lines. All twelve Codex-approved behaviors are carried forward untouched, and the real-Mongo fence suite still runs **55 tests**, all passing.

### Validation

`ruff check .` clean; `git diff --check` clean; `mypy --python-version=3.12` clean over 400 source files. Focused #497 regression selection (document-identity guard, designer, fulfillment, wallet ledger, real-Mongo fence, generated-SaaS acceptance, readiness gate) — **252 passed**. Real-Mongo fence file **55 passed**. Full suite: **16421 passed / 95 skipped**, zero failures, working tree clean at the pushed head.

GitHub reports the PR `MERGEABLE` again. Still draft, auto-merge off, not merged. mozaiks-app #262 untouched and still `BLOCKED_ON_OSS_PR_497`.
