### PR TITLE
Fix authentication on browser workflow launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Workflow entrypoints, transition choices, and refinement launches now forward
+  the configured auth adapter's access token through the shared API helper.
+  Authenticated builds no longer fail at these steps with a missing-token error.
 - Live workflow smoke checks now read canonical AG2 run events and wait for
   resumed user turns. Reconnect replay emits versioned event envelopes, and
   runtime-seeded chat/user identity remains available to usage accounting even

--- a/chat-ui/src/adapters/api.js
+++ b/chat-ui/src/adapters/api.js
@@ -57,7 +57,7 @@ function buildAuthHeaders(contentType = 'application/json', adapterConfig = null
 /**
  * Wrapper for fetch with automatic auth header injection.
  */
-async function authFetch(url, options = {}, adapterConfig = null) {
+export async function authFetch(url, options = {}, adapterConfig = null) {
   const token = getAccessToken(adapterConfig);
   
   const headers = {

--- a/chat-ui/src/components/RouteRenderer.jsx
+++ b/chat-ui/src/components/RouteRenderer.jsx
@@ -16,6 +16,7 @@ import { useNavigation } from '../providers/NavigationProvider';
 import { getComponent, hasComponent } from '../registry/componentRegistry';
 import { TransitionScreen } from '../ui/screens/TransitionScreen';
 import { useChatUI } from '../context/ChatUIContext';
+import { authFetch } from '../adapters/api';
 import Header from './layout/Header';
 import Footer from './layout/Footer';
 import MobileBottomBar from './layout/MobileBottomBar';
@@ -205,7 +206,7 @@ const ComponentNotFound = ({ componentName }) => (
  */
 function TransitionRoute({ route }) {
   const navigate = useNavigate();
-  const { user, config } = useChatUI();
+  const { user, config, auth } = useChatUI();
   const [currentTransitionId, setCurrentTransitionId] = useState(null);
   const [currentJourneyId, setCurrentJourneyId] = useState(route.sequence || null);
   const [accumulatedContext, setAccumulatedContext] = useState({});
@@ -224,7 +225,7 @@ function TransitionRoute({ route }) {
       const mergedContext = { ...accumulatedContext, ...contextVariables };
 
       try {
-        const res = await fetch('/api/transitions/resolve', {
+        const res = await authFetch('/api/transitions/resolve', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -235,7 +236,7 @@ function TransitionRoute({ route }) {
             app_id: resolvedAppId,
             user_id: resolvedUserId,
           }),
-        });
+        }, { auth });
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({ detail: res.statusText }));
@@ -264,7 +265,7 @@ function TransitionRoute({ route }) {
         return false;
       }
     },
-    [accumulatedContext, currentJourneyId, currentTransitionId, navigate, resolvedAppId, resolvedUserId]
+    [accumulatedContext, auth, currentJourneyId, currentTransitionId, navigate, resolvedAppId, resolvedUserId]
   );
 
   if (!currentTransitionId) return null;
@@ -274,7 +275,7 @@ function TransitionRoute({ route }) {
 
 function WorkflowEntryRoute({ route }) {
   const navigate = useNavigate();
-  const { user, config } = useChatUI();
+  const { user, config, auth } = useChatUI();
   const [error, setError] = useState(null);
   const workflowId = route.workflow || null;
   const resolvedAppId = resolveRouteAppId(config, user);
@@ -286,7 +287,7 @@ function WorkflowEntryRoute({ route }) {
 
     async function startWorkflow() {
       try {
-        const res = await fetch('/api/workflows/trigger', {
+        const res = await authFetch('/api/workflows/trigger', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -297,7 +298,7 @@ function WorkflowEntryRoute({ route }) {
             app_id: resolvedAppId,
             user_id: resolvedUserId,
           }),
-        });
+        }, { auth });
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({ detail: res.statusText }));
@@ -317,7 +318,7 @@ function WorkflowEntryRoute({ route }) {
     return () => {
       cancelled = true;
     };
-  }, [workflowId, route, navigate, resolvedAppId, resolvedUserId]);
+  }, [auth, workflowId, route, navigate, resolvedAppId, resolvedUserId]);
 
   if (error) {
     return <ComponentNotFound componentName={`Workflow route ${workflowId}: ${error.message}`} />;

--- a/chat-ui/src/hooks/useWorkflowStart.js
+++ b/chat-ui/src/hooks/useWorkflowStart.js
@@ -26,6 +26,7 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useChatUI } from '../context/ChatUIContext';
+import { authFetch } from '../adapters/api';
 
 const CHAT_TRIGGER_SOURCE = 'chat';
 
@@ -66,7 +67,7 @@ const resolveWorkflowUserId = (user, overrideUserId) => {
 
 export function useWorkflowStart() {
   const navigate = useNavigate();
-  const { user, config } = useChatUI();
+  const { user, config, auth } = useChatUI();
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState(null);
 
@@ -108,11 +109,11 @@ export function useWorkflowStart() {
           ...(trigger_payload && Object.keys(trigger_payload).length > 0 ? { trigger_payload } : {}),
         };
 
-        const res = await fetch('/api/workflows/trigger', {
+        const res = await authFetch('/api/workflows/trigger', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
-        });
+        }, { auth });
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({ detail: res.statusText }));
@@ -133,7 +134,7 @@ export function useWorkflowStart() {
         setStarting(false);
       }
     },
-    [config, navigate, user]
+    [auth, config, navigate, user]
   );
 
   return { startWorkflow, starting, error };

--- a/chat-ui/src/pages/ChatPage.js
+++ b/chat-ui/src/pages/ChatPage.js
@@ -16,6 +16,7 @@ import { getWorkflow } from '../@chat-workflows/index.js';
 import resolveWorkflow from '../utils/resolveWorkflow';
 import { dynamicUIHandler } from '../core/dynamicUIHandler';
 import platform from '../platform/index.js';
+import { authFetch } from '../adapters/api';
 import LoadingSpinner from '../utils/AgentChatLoadingSpinner';
 import useTheme from "../styles/useTheme";
 import {
@@ -3531,7 +3532,7 @@ const ChatPage = () => {
         const triggerPayload = {
           refinement_request: refinementRequest,
         };
-        fetch('/api/workflows/trigger', {
+        authFetch('/api/workflows/trigger', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -3540,7 +3541,7 @@ const ChatPage = () => {
             user_id: resolvedUserId,
             trigger_payload: triggerPayload,
           }),
-        })
+        }, { auth })
           .then(async (res) => {
             if (!res.ok) {
               console.error('❌ [ChatPage] revision trigger failed:', res.status);
@@ -3623,7 +3624,7 @@ const ChatPage = () => {
       default:
         return;
     }
-  }, [activeChatId, activeWorkflowName, currentChatId, currentWorkflowName, rememberWorkflowChatSession, resolveKnownWorkflowName, sanitizeVisibleWorkflowMessages, setMessagesWithLogging, setWorkflowMessages, persistWorkflowTranscriptSnapshot, cacheWorkflowTranscriptMessage, extractAgentName, isSidePanelOpen, showInitSpinner, setLayoutMode, isMobileView, mobileDrawerState, setConversationMode, setActiveGeneralChatId, setGeneralChatSummary, hydrateGeneralTranscript, refreshGeneralSessions, setActiveChatId, setActiveWorkflowName, setCurrentChatId, setCurrentWorkflowName, applyArtifactUpdateForAction, updateArtifactPayload, applySessionStatePendingHarnessDecision, applySessionStatePendingTransition, buildPendingHarnessDecision, cacheServerLastArtifact, handleMissingBackendArtifact, urlWorkflowName]);
+  }, [activeChatId, activeWorkflowName, appId, auth, config, user, currentChatId, currentWorkflowName, rememberWorkflowChatSession, resolveKnownWorkflowName, sanitizeVisibleWorkflowMessages, setMessagesWithLogging, setWorkflowMessages, persistWorkflowTranscriptSnapshot, cacheWorkflowTranscriptMessage, extractAgentName, isSidePanelOpen, showInitSpinner, setLayoutMode, isMobileView, mobileDrawerState, setConversationMode, setActiveGeneralChatId, setGeneralChatSummary, hydrateGeneralTranscript, refreshGeneralSessions, setActiveChatId, setActiveWorkflowName, setCurrentChatId, setCurrentWorkflowName, applyArtifactUpdateForAction, updateArtifactPayload, applySessionStatePendingHarnessDecision, applySessionStatePendingTransition, buildPendingHarnessDecision, cacheServerLastArtifact, handleMissingBackendArtifact, urlWorkflowName]);
   useEffect(() => {
     handleIncomingRef.current = handleIncoming;
   }, [handleIncoming]);
@@ -5863,7 +5864,7 @@ const ChatPage = () => {
       const resolvedUserId = user?.id || user?.user_id || user?.email || null;
 
       try {
-        const res = await fetch('/api/transitions/resolve', {
+        const res = await authFetch('/api/transitions/resolve', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -5873,7 +5874,7 @@ const ChatPage = () => {
             app_id: resolvedAppId,
             user_id: resolvedUserId,
           }),
-        });
+        }, { auth });
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({ detail: res.statusText }));
@@ -5960,6 +5961,7 @@ const ChatPage = () => {
     },
     [
       appId,
+      auth,
       config,
       navigate,
       pendingTransitionContext,

--- a/docs/architecture/workflows/workflow-routing-transitions.md
+++ b/docs/architecture/workflows/workflow-routing-transitions.md
@@ -39,6 +39,15 @@ The OSS loader then builds one effective registry:
 Do not copy default factory workflow registry entries into an app repo just to
 make hosted routes work.
 
+## Authenticated Launches
+
+Shell entrypoints, in-chat transitions, and refinement requests use the shared
+API adapter's `authFetch` with the current ChatUI auth adapter. Supplying
+`app_id` and `user_id` in a launch payload does not authenticate the request;
+the runtime validates the bearer token and checks that the requested scope
+matches the authenticated principal. Local no-auth operation remains governed
+by runtime configuration, not by a browser-side bypass.
+
 ## Contract
 
 `extension_registry.json` has three concerns:

--- a/tests/test_transition_scope_contracts.py
+++ b/tests/test_transition_scope_contracts.py
@@ -91,7 +91,7 @@ def test_route_renderer_posts_app_and_user_scope_for_transition_resolution() -> 
     assert "option_id" in source
     assert "route_to" not in source
     assert "setAccumulatedContext(data.context_variables ?? mergedContext)" in source
-    assert "const { user, config } = useChatUI();" in source
+    assert "const { user, config, auth } = useChatUI();" in source
 
 
 @pytest.mark.asyncio
@@ -163,7 +163,7 @@ def test_workflow_start_posts_app_and_user_scope_for_triggered_workflows() -> No
 
     assert "app_id: resolvedAppId" in source
     assert "user_id: resolvedUserId" in source
-    assert "const { user, config } = useChatUI();" in source
+    assert "const { user, config, auth } = useChatUI();" in source
 
 
 def test_chat_page_transition_handoff_persists_workflow_before_reconnect() -> None:

--- a/tests/test_workflow_launch_browser_auth.py
+++ b/tests/test_workflow_launch_browser_auth.py
@@ -1,0 +1,56 @@
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("path,expected_calls", [
+    ("chat-ui/src/components/RouteRenderer.jsx", 2),
+    ("chat-ui/src/pages/ChatPage.js", 2),
+    ("chat-ui/src/hooks/useWorkflowStart.js", 1),
+])
+def test_all_launch_surfaces_use_configured_auth(path: str, expected_calls: int) -> None:
+    source = (ROOT / path).read_text(encoding="utf-8")
+    calls = re.findall(
+        r"authFetch\('/api/(?:transitions/resolve|workflows/trigger)', \{(.*?)\}, \{ auth \}\)",
+        source, re.S,
+    )
+    assert len(calls) == expected_calls
+    assert not re.search(r"\bfetch\('/api/(?:transitions/resolve|workflows/trigger)'", source)
+    assert "import { authFetch } from '../adapters/api';" in source
+
+
+def test_launch_auth_helper_forwards_current_adapter_token_and_preserves_response() -> None:
+    source = (ROOT / "chat-ui/src/adapters/api.js").read_text(encoding="utf-8")
+    # Exercise the actual fetch/token helper definitions without loading browser
+    # configuration modules, which require Vite's build-time environment.
+    helpers = source[source.index("function getAccessToken("):source.index("export class ApiAdapter")]
+    script = """
+import assert from 'node:assert/strict';
+const platform = { getAccessToken: () => { throw new Error('unexpected storage fallback'); } };
+const requests = [];
+const response = { ok: true, status: 200 };
+globalThis.fetch = async (url, options) => { requests.push({ url, ...options }); return response; };
+""" + helpers + """
+let token = 'first-token';
+const auth = { getAccessToken: () => token };
+const options = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' };
+assert.equal(await authFetch('/api/transitions/resolve', options, { auth }), response);
+assert.equal(requests[0].headers.Authorization, 'Bearer first-token');
+token = 'refreshed-token';
+await authFetch('/api/workflows/trigger', options, { auth });
+assert.equal(requests[1].headers.Authorization, 'Bearer refreshed-token');
+token = null;
+await authFetch('/api/transitions/resolve', options, { auth });
+assert.equal(requests[2].headers.Authorization, undefined);
+assert.equal(options.headers.Authorization, undefined);
+assert.ok(requests.every((r) => r.body === '{}' && r.method === 'POST'));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT, text=True, capture_output=True, check=False, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
Forward the configured auth adapter token through the existing shared authFetch helper at all five workflow-trigger and transition-resolve browser call sites. Keep backend authentication, scope validation, schemas, and AG2 execution unchanged.

## Verification
- Focused launch/scope tests: 12 passed.
- Ruff check passed.
- Full local suite: 16,343 passed, 161 skipped, 2 failed when MONGO_URI was unset and dotenv disabled.
- Reproduced both identical database-startup failures on pristine origin/main e44efef4.
- With the same explicit local MongoDB prerequisite used by CI, both failures plus launch/scope tests pass: 14 passed. No test assertions were weakened.

## OSS Change Impact
- Layer: shared browser API and workflow launch callers.
- Build workflow: authenticated entry, transitions, and refinement requests carry the current adapter token.
- Runtime/platform: existing authorization remains authoritative; no Python runtime behavior changes.
- App workspace: inherited by generated apps and App Zero through their framework dependency.
- Docs: workflow routing authentication guidance and changelog updated.
- Compatibility: additive helper export; no schema, registry, pricing, or product policy changes.

Observed through a real local Keycloak login in App Zero: unpatched transition requests fail with Missing authorization token. Full Genesis remains unverified pending consuming this fix.