### PR TITLE
Bind the shared shell to its active app identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,9 @@ This project follows a practical pre-1.0 changelog format:
 - Workflow entrypoints, transition choices, and refinement launches now forward
   the configured auth adapter's access token through the shared API helper.
   Authenticated builds no longer fail at these steps with a missing-token error.
+- The shared app shell now binds chat and workflow defaults to the active
+  host's app identity, waits for shell configuration, and no longer launches
+  under an implicit `demo-app` scope.
 - Live workflow smoke checks now read canonical AG2 run events and wait for
   resumed user turns. Reconnect replay emits versioned event envelopes, and
   runtime-seeded chat/user identity remains available to usage accounting even

--- a/chat-ui/src/app/MozaiksApp.jsx
+++ b/chat-ui/src/app/MozaiksApp.jsx
@@ -39,7 +39,7 @@ function AppShell({ onAuthRequired }) {
  */
 export default function MozaiksApp({
   appName = 'My App',
-  defaultAppId = 'demo-app',
+  defaultAppId = null,
   apiAdapter,
   authAdapter,
   uiConfig: uiConfigProp,

--- a/chat-ui/src/context/ChatUIContext.jsx
+++ b/chat-ui/src/context/ChatUIContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { createInitialSurfaceState, mapSurfaceEventToAction, uiSurfaceReducer } from '../state/uiSurfaceReducer';
 import platform from '../platform/index.js';
+import { NavigationContext } from '../providers/NavigationProvider';
 import { logChatPersistence } from '../session/chatSessionStorage';
 import {
   getStoredActiveChatId,
@@ -33,6 +34,7 @@ export const ChatUIProvider = ({
   onReady = () => {},
   agents = []
 }) => {
+  const navigation = useContext(NavigationContext);
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -264,9 +266,15 @@ export const ChatUIProvider = ({
   }, [agents]);
 
   const resolvedConfig = useMemo(() => {
-    if (uiConfig && typeof uiConfig === 'object') return uiConfig;
-    return {};
-  }, [uiConfig]);
+    const base = uiConfig && typeof uiConfig === 'object' ? uiConfig : {};
+    if (!navigation?.appId) return base;
+    // The active host owns the default app scope, not a shell/demo placeholder.
+    return {
+      ...base,
+      appName: navigation.appName || base.appName,
+      chat: { ...base.chat, defaultAppId: navigation.appId },
+    };
+  }, [uiConfig, navigation?.appId, navigation?.appName]);
 
   const contextValue = {
     // User state
@@ -352,7 +360,7 @@ export const ChatUIProvider = ({
     },
   };
 
-  if (loading) {
+  if (loading || navigation?.loading) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-gray-900 to-blue-900">
         <div className="text-white text-center">
@@ -361,6 +369,10 @@ export const ChatUIProvider = ({
         </div>
       </div>
     );
+  }
+
+  if (navigation && !resolvedConfig.chat?.defaultAppId) {
+    return <div role="alert">App configuration could not be loaded.</div>;
   }
 
   return (

--- a/docs/architecture/app/platform-authoring.md
+++ b/docs/architecture/app/platform-authoring.md
@@ -123,6 +123,15 @@ The generator should not author low-level runtime plumbing here unless the user 
 
 `app/app.json` is for app identity, startup route, and product auth intent.
 
+The shared shell takes its default app scope from the active host's
+`/api/shell-config` response through `NavigationProvider`. `ChatUIProvider`
+waits for that response and uses its `appId` for chat, workflow launches, and
+usage scope. It must not invent a `demo-app` identity. Standalone embedders
+without a navigation provider may supply their own `uiConfig`; a missing
+identity in the app shell is a configuration error, not permission to launch
+under a placeholder. Server-side authentication and scope checks remain
+authoritative.
+
 It is not the place for shell colors, login theme files, footer links, or header chrome.
 
 It is also not the place for local development shortcuts such as auto-login.

--- a/tests/test_shell_app_identity.py
+++ b/tests/test_shell_app_identity.py
@@ -1,0 +1,45 @@
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_chat_config_uses_active_host_identity_without_mutating_embedder_config() -> None:
+    source = (ROOT / "chat-ui/src/context/ChatUIContext.jsx").read_text(encoding="utf-8")
+    callback = re.search(r"const resolvedConfig = useMemo\(\(\) => \{(.*?)\n  \}, \[", source, re.S)
+    assert callback is not None
+    # Execute the production memo callback without importing JSX or Vite modules.
+    script = "import assert from 'node:assert/strict';\n"
+    script += "function resolve(uiConfig, navigation) {" + callback.group(1) + "}\n"
+    script += """
+const base = { appName: 'Embedder', chat: { defaultAppId: 'placeholder', sound: false }, extra: 42 };
+const original = JSON.stringify(base);
+const host = resolve(base, { appId: 'customer-app', appName: 'Customer App' });
+assert.equal(host.chat.defaultAppId, 'customer-app');
+assert.equal(host.appName, 'Customer App');
+assert.equal(host.chat.sound, false);
+assert.equal(host.extra, 42);
+assert.equal(JSON.stringify(base), original);
+assert.equal(resolve(base, { appId: 'second-app' }).chat.defaultAppId, 'second-app');
+assert.equal(resolve(base, null), base);
+assert.deepEqual(resolve(null, null), {});
+assert.equal(resolve(null, { appId: 'customer-app' }).chat.defaultAppId, 'customer-app');
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT, text=True, capture_output=True, check=False, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_shell_waits_for_identity_and_does_not_invent_a_demo_app() -> None:
+    provider = (ROOT / "chat-ui/src/context/ChatUIContext.jsx").read_text(encoding="utf-8")
+    shell = (ROOT / "chat-ui/src/app/MozaiksApp.jsx").read_text(encoding="utf-8")
+    assert "const navigation = useContext(NavigationContext);" in provider
+    assert "[uiConfig, navigation?.appId, navigation?.appName]" in provider
+    assert "if (loading || navigation?.loading)" in provider
+    assert "if (navigation && !resolvedConfig.chat?.defaultAppId)" in provider
+    assert 'role="alert"' in provider
+    assert "defaultAppId = null" in shell
+    assert "demo-app" not in shell

--- a/web_shell/playwright/apps.responsive.smoke.spec.js
+++ b/web_shell/playwright/apps.responsive.smoke.spec.js
@@ -6,6 +6,9 @@ import { expect, test } from '@playwright/test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
+const appConfig = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'factory_app', 'app', 'app.json'), 'utf8'),
+);
 const themeConfig = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'factory_app', 'app', 'brand', 'theme_config.json'), 'utf8'),
 );
@@ -33,6 +36,8 @@ const transitionRoutes = (extensionRegistry.entrypoints || []).map((entrypoint) 
 }));
 const composedShellConfig = {
   ...shellConfig,
+  appId: appConfig.appId,
+  appName: appConfig.appName,
   pages: [...(routeManifest.pages || []), ...transitionRoutes],
 };
 const dashboardPayload = {

--- a/web_shell/playwright/visual-regression.spec.js
+++ b/web_shell/playwright/visual-regression.spec.js
@@ -26,6 +26,9 @@ import { expect, test } from '@playwright/test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
+const appConfig = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'factory_app', 'app', 'app.json'), 'utf8'),
+);
 const themeConfig = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'factory_app', 'app', 'brand', 'theme_config.json'), 'utf8'),
 );
@@ -37,6 +40,8 @@ const routeManifest = JSON.parse(
 );
 const composedShellConfig = {
   ...shellConfig,
+  appId: appConfig.appId,
+  appName: appConfig.appName,
   pages: routeManifest.pages || [],
 };
 const appsPayload = {
@@ -176,6 +181,41 @@ function dynamicMasks(page) {
 test.describe('App shell visual regression', () => {
   test.beforeEach(async ({ page }) => {
     await mockStudioApis(page);
+  });
+
+  test('app identity is loaded before a workflow uses the host scope', async ({ page }) => {
+    const starts = [];
+    let releaseShell;
+    const shellReady = new Promise((resolve) => { releaseShell = resolve; });
+    await page.route('**/api/shell-config', async (route) => {
+      await shellReady;
+      await route.fulfill({ status: 200, json: composedShellConfig });
+    });
+    await page.route('**/api/workflows', (route) => route.fulfill({
+      status: 200, json: [{ workflow_name: 'RuntimeSmoke' }],
+    }));
+    await page.route('**/api/chats/*/*/start', (route) => {
+      starts.push(new URL(route.request().url()).pathname);
+      return route.fulfill({ status: 409, json: { detail: 'Admission stopped by browser test' } });
+    });
+    try {
+      await page.goto('/chat?workflow=RuntimeSmoke&mode=workflow&new=1');
+      await expect(page.getByText('Initializing ChatUI...')).toBeVisible();
+      expect(starts).toEqual([]);
+      releaseShell();
+      await expect.poll(() => starts.length).toBeGreaterThan(0);
+      expect(starts.every((entry) => entry === `/api/chats/${appConfig.appId}/RuntimeSmoke/start`)).toBe(true);
+    } finally {
+      releaseShell();
+    }
+  });
+
+  test('missing app identity stops the shell instead of creating a demo scope', async ({ page }) => {
+    await page.route('**/api/shell-config', (route) => route.fulfill({
+      status: 200, json: { ...composedShellConfig, appId: null },
+    }));
+    await page.goto('/apps');
+    await expect(page.getByRole('alert')).toHaveText('App configuration could not be loaded.');
   });
 
   test('landing / login screen matches baseline', async ({ page }) => {


### PR DESCRIPTION
## Summary
Use the active host appId from NavigationProvider in ChatUIProvider, wait for shell configuration before mounting chat, and stop an unconfigured shell instead of inventing demo-app. Preserve explicit standalone ChatUIProvider embedding without a navigation context.

Live App Zero testing exposed this after PR #499 fixed bearer forwarding: Create App resolved successfully but created ValueEngine in demo-app, where the funded customer's actual allowance did not exist. This fix belongs in shared UI, not a hosted billing alias or another allowance grant.

## Tests
- Full local Python suite with isolated MongoDB: 16,408 passed, 96 skipped.
- Rebased onto merged PR #499; combined identity/auth/launch/config focused suite: 40 passed.
- Ruff check passed.
- Full desktop/mobile visual suite: 14 passed, no snapshot baseline updates.
- Generated-app fixture browser suite: 26 passed, 2 expected external-app skips.
- Browser tests assert actual chat request app scope and missing-identity rejection. Studio fixtures now include identity from app.json, matching the real API projection.

## OSS Change Impact
Layer: shared shell/context. Workflows and chat inherit the actual host app scope; Python runtime, AG2 execution, authorization, schemas, and product policy are unchanged. Every app consumes this through the package. Docs and changelog updated. Compatibility: implicit demo-app fallback removed; shell configuration must provide identity or an embedder must explicitly configure its standalone ChatUIProvider. No generated artifact shape changes.