### PR TITLE
Bound declarative workflow tools and fail continuation deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,11 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Declarative workflow agents no longer receive undeclared AG2 network
+  delegation/discovery tools automatically. Declared tools and AG2 graph
+  execution remain available. Continuation timeouts now return failed results
+  and close live-run clients instead of escaping as an exception or pretending
+  to await human input.
 - Workflow entrypoints, transition choices, and refinement launches now forward
   the configured auth adapter's access token through the shared API helper.
   Authenticated builds no longer fail at these steps with a missing-token error.

--- a/docs/architecture/workflows/ag2-ownership-boundary.md
+++ b/docs/architecture/workflows/ag2-ownership-boundary.md
@@ -43,8 +43,9 @@ must not assume an implicit network-tool grant.
 This uses AG2's supported
 [network-tool opt-out](https://docs.ag2.ai/docs/user-guide/network/network_assigned_tools/),
 not a replacement scheduler or network implementation. The installed AG2
-1.0.3 source and real-provider-request tests verify that the default handler
-still runs without the plugin. Recheck this boundary when upgrading AG2.
+1.0.3 source and real AG2 tests with provider HTTP replaced verify that the
+default handler still runs without the plugin. Recheck this boundary when
+upgrading AG2.
 
 A continuation settlement timeout is a failed run, not a human-input pause.
 The adapter returns a failed result and closes its live clients; transport

--- a/docs/architecture/workflows/ag2-ownership-boundary.md
+++ b/docs/architecture/workflows/ag2-ownership-boundary.md
@@ -31,6 +31,26 @@ Mozaiks owns deterministic product and runtime contracts around AG2:
 
 ## Runtime Handoff
 
+Declarative workflow participants attach through AG2's public
+`attach_plugin=False` option. They keep AG2's default envelope handler,
+channel adapter, graph execution, and declared workflow tools, but do not
+automatically receive the optional `NetworkPlugin` tools (`delegate`, `peers`,
+`channels`, `tasks`, `context`). Those tools allow model-selected network work
+outside the declared workflow topology. Delegation inside a generated workflow
+must use its declared graph, task batches, or explicitly bound tools; prompts
+must not assume an implicit network-tool grant.
+
+This uses AG2's supported
+[network-tool opt-out](https://docs.ag2.ai/docs/user-guide/network/network_assigned_tools/),
+not a replacement scheduler or network implementation. The installed AG2
+1.0.3 source and real-provider-request tests verify that the default handler
+still runs without the plugin. Recheck this boundary when upgrading AG2.
+
+A continuation settlement timeout is a failed run, not a human-input pause.
+The adapter returns a failed result and closes its live clients; transport
+then uses the existing failure event path. A timeout must not leave a reusable
+live-run handle or claim that the workflow is waiting for the user.
+
 AG2 network packets are the source trace for agent execution, not automatically
 user-visible chat copy. Mozaiks owns the projection from AG2 packet history into
 transport events and replayed chat history because that projection enforces

--- a/docs/architecture/workflows/ag2-update-watchpoints.md
+++ b/docs/architecture/workflows/ag2-update-watchpoints.md
@@ -80,6 +80,15 @@ Classify each AG2 update with exactly one primary outcome:
 
 ## Active Watchpoint Ledger
 
+For `AG2-WP-001` and `AG2-WP-002`, also verify the workflow tool boundary and
+continuation deadlines. The runner uses `attach_plugin=False` without replacing
+AG2's handler; only declared tools and adapter-owned protocol tools reach the
+model. A deadline reached before polling or inside `wait_for_channel_event`
+must return `FAILED` and close the live run, never `PAUSED` or an uncaught
+`TimeoutError`. The HTTP-provider fixture in
+`test_ag2_network_tool_routing.py` and both deadline cases in
+`test_ag2_network_execution_alignment.py` cover these contracts.
+
 The YAML index repeats only the fields used by automation. The reason and test
 intent below remain authoritative for maintainers.
 

--- a/mozaiksai/core/adapters/ag2_network_runner.py
+++ b/mozaiksai/core/adapters/ag2_network_runner.py
@@ -214,7 +214,6 @@ class AG2NetworkRunnerRequest:
     structured_registry: Mapping[str, Any] = field(default_factory=dict)
     max_turns: int | None = None
     close_timeout_seconds: float = 120.0
-    attach_network_plugin: bool = True
     agent_text_context_deriver: Callable[[str, str], Mapping[str, Any]] | None = None
     agent_output_handler: Callable[[str, Any], Awaitable[None]] | None = None
     context_authority_policy: ContextAuthorityPolicy | None = None
@@ -354,7 +353,9 @@ class AG2NetworkRunner:
                     name,
                     passport=Passport(name=name),
                     resume=Resume(claimed_capabilities=[name]),
-                    attach_plugin=request.attach_network_plugin,
+                    # Workflow tools and topology are contract-owned. AG2's
+                    # optional plugin adds undeclared channel/delegation tools.
+                    attach_plugin=False,
                 )
                 _install_context_update_handler(
                     agent=agent,
@@ -788,16 +789,7 @@ class _AG2LiveWorkflowRun:
             while True:
                 remaining = deadline - loop.time()
                 if remaining <= 0:
-                    result = await self._snapshot_result(
-                        status=RunStatus.PAUSED,
-                        close_reason="awaiting_user_input",
-                        error=(
-                            "workflow channel did not settle within "
-                            f"{self._close_timeout_seconds} seconds"
-                        ),
-                    )
-                    result.live_run = self
-                    return result
+                    break
 
                 event_task = asyncio.create_task(
                     self._initiator.wait_for_channel_event(
@@ -829,6 +821,8 @@ class _AG2LiveWorkflowRun:
 
                 try:
                     event_env = event_task.result()
+                except TimeoutError:
+                    break
                 finally:
                     for task in pending:
                         task.cancel()
@@ -853,6 +847,11 @@ class _AG2LiveWorkflowRun:
         finally:
             failure_task.cancel()
             await asyncio.gather(failure_task, return_exceptions=True)
+
+        return await self._snapshot_result(
+            status=RunStatus.FAILED,
+            error=f"workflow channel did not settle within {self._close_timeout_seconds} seconds",
+        )
 
     def _next_agent_audience_for_user_text(self, message: str) -> list[str] | None:
         state = self._hub.adapter_state(self.channel_id)

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from time import perf_counter
@@ -696,6 +697,48 @@ async def test_ag2_network_runner_continues_paused_channel_with_user_message() -
     assert EV_TEXT in continued_event_types
     assert EV_CHANNEL_CLOSED in continued_event_types
     assert EV_PACKET not in continued_event_types
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("timeout", [0.0, 0.05])
+async def test_continuation_timeout_fails_and_closes_live_run(timeout: float) -> None:
+    class WaitingAgent(_DeterministicAgent):
+        async def ask(self, *msg: Any, **kwargs: Any) -> _Reply:
+            if self.ask_calls:
+                await asyncio.Event().wait()
+            return await super().ask(*msg, **kwargs)
+
+    agent = WaitingAgent("Interviewer", "What should I build?")
+    result = await AG2NetworkRunner().run(
+        AG2NetworkRunnerRequest(
+            workflow_name="ContinuationTimeout",
+            chat_id="timeout-chat",
+            app_id="timeout-app",
+            agents={"Interviewer": agent},
+            transition_rules=[
+                {"source_agent": "Interviewer", "target_agent": "user", "transition_type": "after_turn"},
+                {"source_agent": "user", "target_agent": "Interviewer", "transition_type": "after_turn"},
+            ],
+            initial_agent_name="Interviewer",
+            initial_message="Begin.",
+            close_timeout_seconds=2.0,
+        )
+    )
+    assert result.status is RunStatus.PAUSED
+    live_run = result.live_run
+    assert live_run is not None
+    live_run._close_timeout_seconds = timeout
+    try:
+        continued = await asyncio.wait_for(live_run.continue_with_user_message("A tracker."), timeout=3.0)
+        assert continued.status is RunStatus.FAILED
+        assert "did not settle" in continued.error
+        assert continued.close_reason != "awaiting_user_input"
+        assert continued.live_run is None
+        assert live_run._closed
+        rejected = await live_run.continue_with_user_message("Try again.")
+        assert rejected.error == "live_ag2_channel_closed"
+    finally:
+        await live_run.close()
 
 
 @pytest.mark.anyio

--- a/tests/test_ag2_network_execution_alignment.py
+++ b/tests/test_ag2_network_execution_alignment.py
@@ -702,10 +702,17 @@ async def test_ag2_network_runner_continues_paused_channel_with_user_message() -
 @pytest.mark.anyio
 @pytest.mark.parametrize("timeout", [0.0, 0.05])
 async def test_continuation_timeout_fails_and_closes_live_run(timeout: float) -> None:
+    waiting = asyncio.Event()
+    cancelled = asyncio.Event()
+
     class WaitingAgent(_DeterministicAgent):
         async def ask(self, *msg: Any, **kwargs: Any) -> _Reply:
             if self.ask_calls:
-                await asyncio.Event().wait()
+                waiting.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
             return await super().ask(*msg, **kwargs)
 
     agent = WaitingAgent("Interviewer", "What should I build?")
@@ -735,6 +742,9 @@ async def test_continuation_timeout_fails_and_closes_live_run(timeout: float) ->
         assert continued.close_reason != "awaiting_user_input"
         assert continued.live_run is None
         assert live_run._closed
+        if timeout:
+            assert waiting.is_set()
+            await asyncio.wait_for(cancelled.wait(), timeout=1.0)
         rejected = await live_run.continue_with_user_message("Try again.")
         assert rejected.error == "live_ag2_channel_closed"
     finally:

--- a/tests/test_ag2_network_tool_routing.py
+++ b/tests/test_ag2_network_tool_routing.py
@@ -279,6 +279,20 @@ def _assert_real_tool_events(scenario: _SDKScenario, names: tuple[str, ...]) -> 
 
 
 @pytest.mark.asyncio
+async def test_workflow_agents_receive_only_declared_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _SDKScenario()
+    result = await _run(monkeypatch, scenario, _rules())
+    assert result.status is RunStatus.COMPLETED, result.error
+    assert scenario.requests == {"AgentA": 2, "AgentB": 1}
+    for payload in scenario.request_bodies:
+        names = {tool["function"]["name"] for tool in payload.get("tools", [])}
+        expected = {"complete_intake", "other_tool"} if payload["model"] == "AgentA" else set()
+        assert names == expected
+
+
+@pytest.mark.asyncio
 async def test_factory_tool_authority_reaches_network_context_equals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Keep AG2 graph/agent execution and declared tools, but do not inject the optional network plugin's undeclared delegation and channel tools.
- Return a failed continuation result and close live clients for both deadline paths; never mislabel a timeout as awaiting human input.
- Add real AG2/SDK regression tests for the model-visible tool set and cancellation of a waiting agent turn. Document the supported AG2 opt-out and upgrade checks.

## Evidence
A real local ValueEngine run opened consulting channels and kept calling the model after a continuation timeout. With this correction, a fresh run stayed in one workflow channel and produced schema-accepted concept output. Concept approval/next-stage routing and full app generation are still separate unresolved acceptance gates; this PR does not claim a completed build or enforceable monetary budget.

## Tests
- Full OSS pytest -q --no-cov with disposable local MongoDB: 16,415 passed, 96 skipped.
- Final focused AG2/tool-outcome/pattern suite: 89 passed, 1 skipped, including strengthened cancellation coverage.
- ruff check . and git diff --check passed.

## OSS Change Impact
Runtime ExecutionEngine/Run boundary only; no hosted pricing, provider policy, YAML shape, new scheduler, or parallel network implementation. Declared graph routing and tool customization remain supported. The unused internal attach_network_plugin request switch is removed.