### PR TITLE
fix(security): authenticate browser WebSockets without URL tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -271,8 +271,11 @@ KEYCLOAK_REALM=
 KEYCLOAK_CLIENT_ID=
 
 # Accept JWT via WebSocket query-param on connect.
-# SECURITY: Keep false in production — query-param tokens appear in server logs and browser history.
-# Set to true only for local development or when WebSocket header auth is unavailable.
+# Not needed by browsers: the shared browser client sends the token in the
+# `Sec-WebSocket-Protocol` handshake header, which works in production with no opt-in.
+# SECURITY: Keep false in production — query-param tokens appear in server logs,
+# browser history, and shared links. Set to true only for local development or for
+# non-browser clients that cannot use the subprotocol path.
 MOZAIKS_WS_ALLOW_QUERY_TOKEN=false
 
 
@@ -618,7 +621,7 @@ MOZAIKS_TELEMETRY_SECRET=
 # 3. AUTHENTICATION
 #    [ ] AUTH_ENABLED=true
 #    [ ] MOZAIKS_OIDC_AUTHORITY or MOZAIKS_OIDC_DISCOVERY_URL points to the production OIDC provider or broker
-#    [ ] MOZAIKS_WS_ALLOW_QUERY_TOKEN=false (use header auth)
+#    [ ] MOZAIKS_WS_ALLOW_QUERY_TOKEN=false (browsers use the handshake subprotocol)
 #
 # 4. NETWORK
 #    [ ] FRONTEND_URL is set to your production domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,20 @@ This project follows a practical pre-1.0 changelog format:
 - Account export and deletion now bind the authenticated principal and the
   canonical app-data database before invoking module lifecycle handlers.
   Signed-token Mongo tests cover ownership, app isolation, and repeated deletion.
-
+- **Production-safe browser WebSocket authentication**: the shared browser client
+  no longer puts the access token in the WebSocket URL
+  (`?access_token=<jwt>`), where it leaked into server access logs, browser
+  history, `Referer` headers, and shared links. The credential now travels in
+  the `Sec-WebSocket-Protocol` handshake header — the one request header the
+  browser WebSocket API lets a client set — as
+  `["mozaiks.bearer.v1", base64url(token)]`. The runtime decodes it, validates
+  it through the same configured auth adapter as HTTP routes, binds the same
+  `WebSocketUser`, and echoes back only the marker, never the credential.
+  Authenticated browser connections therefore work in production and staging
+  **without** setting `MOZAIKS_WS_ALLOW_QUERY_TOKEN=true`. Query-string tokens
+  remain rejected by default and stay available only as an explicit
+  local-development opt-in for non-browser clients. Auth-disabled local
+  development is unchanged.
 - **Fail-closed module action dispatch**: `ModuleExecutor` no longer falls
   back from an undeclared action id to a same-named Python handler method.
   Only action ids declared in the module's contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,11 @@ This project follows a practical pre-1.0 changelog format:
   **without** setting `MOZAIKS_WS_ALLOW_QUERY_TOKEN=true`. Query-string tokens
   remain rejected by default and stay available only as an explicit
   local-development opt-in for non-browser clients. Auth-disabled local
-  development is unchanged.
+  development is unchanged. The credential component must be canonical unpadded
+  base64url: illegal characters, whitespace, padding, trailing garbage,
+  impossible lengths, invalid UTF-8, and non-canonical encodings are refused
+  before the auth adapter runs, with their own bounded close reason, and are
+  never sanitized into a usable credential.
 - **Fail-closed module action dispatch**: `ModuleExecutor` no longer falls
   back from an undeclared action id to a same-named Python handler method.
   Only action ids declared in the module's contract

--- a/chat-ui/src/adapters/api.js
+++ b/chat-ui/src/adapters/api.js
@@ -3,6 +3,7 @@ import workflowConfig from '../config/workflowConfig';
 import resolveWorkflow from '../utils/resolveWorkflow';
 import config from '../config';
 import platform from '../platform/index.js';
+import { openAuthenticatedWebSocket } from './websocketAuth.js';
 
 function _firstString(...values) {
   for (const value of values) {
@@ -440,17 +441,14 @@ export class WebSocketApiAdapter extends ApiAdapter {
       } catch (_) {}
     }
     
-    // Build WebSocket URL with access_token query param for authentication
+    // Build the WebSocket URL. The credential never goes in the URL — it travels in
+    // the handshake subprotocol header. See adapters/websocketAuth.js.
     const wsUrl = new URL(`/ws/${actualworkflowname}/${appId}/${chatId}/${userId}`, wsBase);
-    const token = getAccessToken(this.config);
-    if (token) {
-      wsUrl.searchParams.set('access_token', token);
-    }
     if (options?.suppressHistoryReplay) {
       wsUrl.searchParams.set('suppress_history_replay', '1');
     }
-    
-    const socket = new WebSocket(wsUrl.toString());
+
+    const socket = openAuthenticatedWebSocket(wsUrl.toString(), getAccessToken(this.config));
     let closedByClient = false;
     let hasOpened = false;
     

--- a/chat-ui/src/adapters/websocketAuth.js
+++ b/chat-ui/src/adapters/websocketAuth.js
@@ -1,0 +1,62 @@
+/**
+ * Browser WebSocket credential transport.
+ *
+ * The browser WebSocket API cannot set request headers, so a browser cannot send
+ * `Authorization: Bearer ...` on a WebSocket handshake. Putting the token in the URL
+ * query string instead leaks it into access logs, browser history, `Referer`, and any
+ * shared/bookmarked link — which is why the runtime rejects query-string tokens unless
+ * `MOZAIKS_WS_ALLOW_QUERY_TOKEN` is explicitly enabled for local development.
+ *
+ * The credential is therefore carried in the `Sec-WebSocket-Protocol` handshake header,
+ * the one request header `new WebSocket(url, protocols)` lets a browser populate. The
+ * runtime reads the token from there, validates it through the configured auth adapter,
+ * and echoes back only the marker value.
+ *
+ * Wire shape: [WS_BEARER_SUBPROTOCOL, base64url(access_token)]
+ */
+
+export const WS_BEARER_SUBPROTOCOL = 'mozaiks.bearer.v1';
+
+/**
+ * Encode a credential as unpadded base64url so any token shape stays a legal
+ * handshake header token (RFC 7230), which raw credentials are not guaranteed to be.
+ */
+function encodeBearerCredential(token) {
+  const bytes = new TextEncoder().encode(token);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Build the WebSocket subprotocol list carrying the access token.
+ *
+ * @param {string|null|undefined} token - Access token from the configured auth adapter.
+ * @returns {string[]} Subprotocols to pass to `new WebSocket(url, protocols)`. Empty
+ *   when there is no token, so unauthenticated local development still connects.
+ */
+export function buildWebSocketAuthProtocols(token) {
+  if (typeof token !== 'string' || !token) {
+    return [];
+  }
+  try {
+    return [WS_BEARER_SUBPROTOCOL, encodeBearerCredential(token)];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Open a WebSocket that carries the credential in the handshake header rather than
+ * the URL. Never appends the token to `url`.
+ *
+ * @param {string} url - WebSocket URL, free of credentials.
+ * @param {string|null|undefined} token - Access token, or null when auth is disabled.
+ * @returns {WebSocket}
+ */
+export function openAuthenticatedWebSocket(url, token) {
+  const protocols = buildWebSocketAuthProtocols(token);
+  return protocols.length > 0 ? new WebSocket(url, protocols) : new WebSocket(url);
+}

--- a/chat-ui/src/runtimeBridge.js
+++ b/chat-ui/src/runtimeBridge.js
@@ -9,25 +9,28 @@
  */
 
 import platform from './platform/index.js';
+import { buildWebSocketAuthProtocols } from './adapters/websocketAuth.js';
 
 /**
  * Build WebSocket URL for AI runtime chat
- * 
+ *
+ * The URL carries no credential. Pass the access token to
+ * `buildWebSocketAuthProtocols` and hand the result to `new WebSocket(url, protocols)`,
+ * or use `openAuthenticatedWebSocket` — see adapters/websocketAuth.js.
+ *
  * @param {Object} config - Configuration object
  * @param {string} config.workflowName - The workflow to connect to
  * @param {string} config.appId - The app context
  * @param {string} config.chatId - The chat session ID
  * @param {string} config.userId - The authenticated user ID
- * @param {string} config.token - JWT access token
  * @param {string} [config.runtimeUrl] - Optional runtime base URL
- * @returns {string} WebSocket URL with auth
+ * @returns {string} Credential-free WebSocket URL
  */
 export function buildRuntimeWebSocketUrl({
   workflowName,
   appId,
   chatId,
   userId,
-  token,
   runtimeUrl = null,
 }) {
   // Determine base URL
@@ -48,14 +51,8 @@ export function buildRuntimeWebSocketUrl({
   // Build the runtime WebSocket path
   // Format: /ws/{workflow_name}/{app_id}/{chat_id}/{user_id}
   const path = `/ws/${workflowName}/${appId}/${chatId}/${userId}`;
-  
-  // Add token as query param
-  const url = new URL(path, baseWsUrl);
-  if (token) {
-    url.searchParams.set('access_token', token);
-  }
-  
-  return url.toString();
+
+  return new URL(path, baseWsUrl).toString();
 }
 
 /**
@@ -135,8 +132,11 @@ export class CoreAuthAdapter {
   }
 }
 
+export { buildWebSocketAuthProtocols };
+
 export default {
   buildRuntimeWebSocketUrl,
+  buildWebSocketAuthProtocols,
   buildRuntimeApiUrl,
   isAIEnabled,
   getRuntimeAuthHeaders,

--- a/docs/architecture/mobile-client-contract.md
+++ b/docs/architecture/mobile-client-contract.md
@@ -28,8 +28,17 @@ HTTP:
 - Send `Authorization: Bearer <token>` on protected routes.
 
 WebSocket:
-- Connect with `access_token` query parameter:
-  - `ws://<host>/ws/{workflow_name}/{app_id}/{chat_id}/{user_id}?access_token=<jwt>`
+- Carry the token in the `Sec-WebSocket-Protocol` handshake header, offering the marker
+  followed by the base64url-encoded (unpadded) token:
+  - endpoint: `wss://<host>/ws/{workflow_name}/{app_id}/{chat_id}/{user_id}`
+  - subprotocols: `["mozaiks.bearer.v1", "<base64url(jwt)>"]`
+- The server validates the token through the same auth adapter as HTTP routes and
+  selects `mozaiks.bearer.v1` on accept. Missing or invalid credentials close with 1008.
+- Native clients that can set request headers may instead pass the token however their
+  WebSocket stack allows, as long as it does not go in the URL.
+- The `?access_token=<jwt>` query form is rejected unless
+  `MOZAIKS_WS_ALLOW_QUERY_TOKEN=true`, which is a local-development opt-in only —
+  URL-borne tokens leak into logs, history, and shared links.
 
 Auth-disabled local mode (`AUTH_ENABLED=false`) is supported for local development, but production clients should always run with auth enabled.
 

--- a/docs/architecture/verified/auth-setup.md
+++ b/docs/architecture/verified/auth-setup.md
@@ -326,15 +326,44 @@ MY_AUTH_SECRET=...
 
 ## WebSocket Auth
 
-WebSocket connections extract tokens from query params by default:
+Browsers cannot set request headers on a WebSocket handshake, so the access token is
+carried in the `Sec-WebSocket-Protocol` header — the one handshake header the browser
+WebSocket API exposes. This is the normal production path and requires no opt-in.
 
-```
-ws://localhost:8000/ai/ws/workflow?access_token=eyJ...
+Clients offer two subprotocol values, the marker followed by the base64url-encoded
+(unpadded) token:
+
+```js
+new WebSocket(url, ['mozaiks.bearer.v1', base64url(accessToken)]);
 ```
 
-To disable (in production behind reverse proxy):
+The shared browser adapter does this for you:
+
+```js
+import { openAuthenticatedWebSocket } from '@mozaiks/chat-ui/adapters/websocketAuth.js';
+
+const socket = openAuthenticatedWebSocket(wsUrl, accessToken);
+```
+
+The runtime decodes the token, validates it through the configured auth adapter — the
+same adapter and the same validation as HTTP routes — binds the resulting
+`WebSocketUser`, and selects only `mozaiks.bearer.v1` on accept. The credential is never
+echoed back and never appears in the URL.
+
+Missing or invalid credentials close the connection with code 1008 before accept.
+
+### Query-param tokens (local development only)
+
+A query-string token (`?access_token=...`) is rejected by default. Tokens in URLs land in
+server access logs, browser history, `Referer` headers, and shared links. It remains
+available as an explicit opt-in for local development and for non-browser clients that
+cannot use the subprotocol path:
+
 ```bash
-MOZAIKS_WS_ALLOW_QUERY_TOKEN=false
+MOZAIKS_WS_ALLOW_QUERY_TOKEN=true   # never set this in production or staging
 ```
+
+Leave it `false` (the default) everywhere else. Production browser clients do not need
+it.
 
 ---

--- a/factory_app/workflows/AppGenerator/ui/useSandbox.js
+++ b/factory_app/workflows/AppGenerator/ui/useSandbox.js
@@ -8,6 +8,7 @@
 // ==============================================================================
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { openAuthenticatedWebSocket } from '@mozaiks/chat-ui/adapters/websocketAuth.js';
 import { getStudioAccessToken, studioFetch } from '../../../app/admin/pages/studioApi.js';
 
 export function useSandbox(artifactId) {
@@ -24,9 +25,7 @@ export function useSandbox(artifactId) {
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = new URL(`${protocol}//${window.location.host}/ws/sandbox/${encodeURIComponent(sandboxId)}`);
-    const token = getStudioAccessToken();
-    if (token) wsUrl.searchParams.set('access_token', token);
-    const ws = new WebSocket(wsUrl.toString());
+    const ws = openAuthenticatedWebSocket(wsUrl.toString(), getStudioAccessToken());
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/mozaiksai/core/auth/__init__.py
+++ b/mozaiksai/core/auth/__init__.py
@@ -22,7 +22,7 @@ Quick Start:
         return {"user_id": user.user_id, "email": user.email}
 
     # WebSocket authentication
-    from mozaiksai.core.auth import authenticate_websocket
+    from mozaiksai.core.auth import accept_websocket, authenticate_websocket
 
     @app.websocket("/ws/chat")
     async def chat_ws(websocket: WebSocket):
@@ -30,7 +30,7 @@ Quick Start:
         if not user:
             return  # Connection closed
 
-        await websocket.accept()
+        await accept_websocket(websocket)
         # websocket.state.user_id is now set
 
 Configuration (environment variables):
@@ -112,14 +112,18 @@ from mozaiksai.core.auth.dependencies import (
 
 # WebSocket authentication
 from mozaiksai.core.auth.websocket_auth import (
+    WS_BEARER_SUBPROTOCOL,
     WS_CLOSE_ACCESS_DENIED,
     WS_CLOSE_AUTH_INVALID,
     WS_CLOSE_AUTH_REQUIRED,
     WS_CLOSE_POLICY_VIOLATION,
     WebSocketUser,
+    accept_websocket,
     authenticate_websocket,
     authenticate_websocket_with_path_binding,
     authenticate_websocket_with_path_user,
+    extract_subprotocol_bearer_token,
+    negotiated_subprotocol,
     require_resource_ownership,
     verify_user_owns_resource,
 )
@@ -151,6 +155,7 @@ __all__ = [
     "validate_user_id_against_principal",
     # WebSocket
     "WebSocketUser",
+    "accept_websocket",
     "authenticate_websocket",
     "authenticate_websocket_with_path_user",
     "authenticate_websocket_with_path_binding",
@@ -160,6 +165,9 @@ __all__ = [
     "WS_CLOSE_AUTH_REQUIRED",
     "WS_CLOSE_AUTH_INVALID",
     "WS_CLOSE_ACCESS_DENIED",
+    "WS_BEARER_SUBPROTOCOL",
+    "extract_subprotocol_bearer_token",
+    "negotiated_subprotocol",
     # Auth config exports
     "AuthConfig",
     "get_auth_config",

--- a/mozaiksai/core/auth/websocket_auth.py
+++ b/mozaiksai/core/auth/websocket_auth.py
@@ -22,10 +22,12 @@ Usage:
             await websocket.close(code=1008, reason="Access denied")
             return
 
-        await websocket.accept()
+        await accept_websocket(websocket)
         ...
 """
 
+import base64
+import binascii
 import os
 from dataclasses import dataclass
 
@@ -46,6 +48,86 @@ WS_CLOSE_POLICY_VIOLATION = 1008
 WS_CLOSE_AUTH_REQUIRED = 1008
 WS_CLOSE_AUTH_INVALID = 1008
 WS_CLOSE_ACCESS_DENIED = 1008
+
+
+# The browser WebSocket API cannot set request headers, so a browser client cannot
+# send `Authorization: Bearer ...` on the handshake. The only header a browser can
+# influence is `Sec-WebSocket-Protocol`, via `new WebSocket(url, protocols)`.
+#
+# Clients therefore offer two subprotocol values:
+#
+#     [WS_BEARER_SUBPROTOCOL, base64url(access_token)]
+#
+# The credential travels in a handshake header rather than the URL, so it stays out
+# of access logs, browser history, `Referer`, and bookmark/share surfaces — the
+# reasons query-param tokens are rejected by default. The token is base64url-encoded
+# (no padding) so that any credential shape remains a legal RFC 7230 header token.
+#
+# The server selects only WS_BEARER_SUBPROTOCOL on accept; the encoded credential is
+# never echoed back in the handshake response.
+WS_BEARER_SUBPROTOCOL = "mozaiks.bearer.v1"
+
+
+def _offered_subprotocols(websocket: WebSocket) -> list[str]:
+    """Return the subprotocols the client offered on the handshake."""
+    scope = getattr(websocket, "scope", None) or {}
+    offered = scope.get("subprotocols") or []
+    return [str(value).strip() for value in offered if str(value).strip()]
+
+
+def _decode_bearer_subprotocol(value: str) -> str | None:
+    """Decode a base64url (unpadded) subprotocol credential, or None if malformed."""
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode(value + padding).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+
+
+def extract_subprotocol_bearer_token(websocket: WebSocket) -> str | None:
+    """
+    Extract the bearer token a browser client carried in `Sec-WebSocket-Protocol`.
+
+    Returns None when the client did not offer the Mozaiks bearer subprotocol or the
+    credential value is missing/malformed. Never logs the credential.
+    """
+    offered = _offered_subprotocols(websocket)
+    try:
+        marker_index = offered.index(WS_BEARER_SUBPROTOCOL)
+    except ValueError:
+        return None
+
+    credential_index = marker_index + 1
+    if credential_index >= len(offered):
+        logger.warning("WebSocket bearer subprotocol offered without a credential value")
+        return None
+
+    token = _decode_bearer_subprotocol(offered[credential_index])
+    if not token:
+        logger.warning("WebSocket bearer subprotocol credential was not valid base64url")
+        return None
+    return token
+
+
+def negotiated_subprotocol(websocket: WebSocket) -> str | None:
+    """Return the subprotocol to echo on accept, or None when the client offered none."""
+    if WS_BEARER_SUBPROTOCOL in _offered_subprotocols(websocket):
+        return WS_BEARER_SUBPROTOCOL
+    return None
+
+
+async def accept_websocket(websocket: WebSocket) -> None:
+    """
+    Accept a WebSocket, completing subprotocol negotiation when the client used one.
+
+    RFC 6455 requires the server to select a subprotocol the client offered, so only
+    the marker is echoed — never the credential value beside it.
+    """
+    subprotocol = negotiated_subprotocol(websocket)
+    if subprotocol:
+        await websocket.accept(subprotocol=subprotocol)
+        return
+    await websocket.accept()
 
 
 @dataclass
@@ -122,7 +204,8 @@ async def authenticate_websocket(
 
     Token is extracted from:
     1. `access_token` parameter passed directly
-    2. `access_token` query parameter (if MOZAIKS_WS_ALLOW_QUERY_TOKEN=true)
+    2. the `Sec-WebSocket-Protocol` bearer subprotocol (the browser path)
+    3. `access_token` query parameter (if MOZAIKS_WS_ALLOW_QUERY_TOKEN=true)
 
     Args:
         websocket: The WebSocket connection to authenticate
@@ -143,7 +226,7 @@ async def authenticate_websocket(
             if user is None:
                 return  # Already closed
 
-            await websocket.accept()
+            await accept_websocket(websocket)
             # Use websocket.state.user_id
     """
     # Get the configured auth adapter
@@ -174,6 +257,11 @@ async def authenticate_websocket(
 
     # Extract token
     token = access_token
+
+    # Browser clients carry the credential in the `Sec-WebSocket-Protocol` handshake
+    # header. This is the normal production browser path and needs no opt-in.
+    if not token:
+        token = extract_subprotocol_bearer_token(websocket)
 
     # Query-param token extraction is disabled by default.
     # Tokens in query params appear in server logs, browser history, and proxy logs.
@@ -268,7 +356,7 @@ async def require_resource_ownership(
         if not await require_resource_ownership(websocket, chat.user_id):
             return  # Already closed with 1008
 
-        await websocket.accept()
+        await accept_websocket(websocket)
     """
     token_user_id = getattr(websocket.state, "user_id", None)
 

--- a/mozaiksai/core/auth/websocket_auth.py
+++ b/mozaiksai/core/auth/websocket_auth.py
@@ -29,6 +29,7 @@ Usage:
 import base64
 import binascii
 import os
+import re
 from dataclasses import dataclass
 
 from fastapi import WebSocket
@@ -48,6 +49,11 @@ WS_CLOSE_POLICY_VIOLATION = 1008
 WS_CLOSE_AUTH_REQUIRED = 1008
 WS_CLOSE_AUTH_INVALID = 1008
 WS_CLOSE_ACCESS_DENIED = 1008
+
+# Bounded refusal reason for a credential whose *encoding* is malformed. Kept distinct
+# from "Missing access_token" so an invalid wire representation is never reported — or
+# diagnosed — as an absent credential. It names no credential material.
+WS_REASON_MALFORMED_CREDENTIAL = "Malformed bearer credential encoding"
 
 
 # The browser WebSocket API cannot set request headers, so a browser client cannot
@@ -69,18 +75,70 @@ WS_BEARER_SUBPROTOCOL = "mozaiks.bearer.v1"
 
 
 def _offered_subprotocols(websocket: WebSocket) -> list[str]:
-    """Return the subprotocols the client offered on the handshake."""
+    """
+    Return the subprotocols the client offered, exactly as received.
+
+    Values are deliberately not stripped or filtered. ASGI servers already split and
+    trim the `Sec-WebSocket-Protocol` header, so trimming again here would only serve
+    to silently normalize a malformed credential (for example one carrying embedded
+    whitespace) into an acceptable one, and dropping empty entries would shift the
+    credential's position relative to its marker.
+    """
     scope = getattr(websocket, "scope", None) or {}
     offered = scope.get("subprotocols") or []
-    return [str(value).strip() for value in offered if str(value).strip()]
+    return [str(value) for value in offered]
+
+
+class MalformedBearerCredential(Exception):
+    """The bearer subprotocol was offered with a credential that is not canonical base64url."""
+
+
+# The credential component must be canonical, unpadded base64url and nothing else.
+# `=` and whitespace are deliberately absent: padding is a wire-format violation and
+# whitespace can never appear inside a handshake subprotocol token.
+_BEARER_CREDENTIAL_ALPHABET = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def _decode_bearer_subprotocol(value: str) -> str | None:
-    """Decode a base64url (unpadded) subprotocol credential, or None if malformed."""
-    padding = "=" * (-len(value) % 4)
+    """
+    Strictly decode a canonical unpadded base64url credential.
+
+    Returns the decoded token only when `value` is *exactly* the canonical unpadded
+    base64url encoding of a UTF-8 string. Malformed input is refused, never repaired:
+    illegal characters, whitespace, `=` padding, trailing garbage, impossible lengths,
+    invalid UTF-8, and non-canonical encodings that set unused trailing bits all return
+    None. Nothing is stripped, normalized, or partially decoded, so a malformed
+    representation can never be silently turned back into a usable credential.
+    """
+    if not _BEARER_CREDENTIAL_ALPHABET.fullmatch(value):
+        return None
+
+    # A base64 quantum is four characters; a remainder of one cannot encode any byte.
+    if len(value) % 4 == 1:
+        return None
+
+    # Padding is reconstructed only to satisfy the strict decoder; the wire
+    # representation itself stays unpadded. `validate=True` makes base64 reject stray
+    # characters instead of discarding them (the default silently drops them, which is
+    # exactly how trailing garbage used to slip through). The alphabet check above is
+    # still required: with altchars, `validate` would accept standard-base64 `+` and
+    # `/`, which are not legal in a base64url representation.
     try:
-        return base64.urlsafe_b64decode(value + padding).decode("utf-8")
-    except (binascii.Error, UnicodeDecodeError, ValueError):
+        raw = base64.b64decode(
+            value + "=" * (-len(value) % 4), altchars=b"-_", validate=True
+        )
+    except (binascii.Error, ValueError):
+        return None
+
+    # Canonicality: re-encoding must reproduce the supplied representation exactly.
+    # This is what rejects non-canonical encodings such as "QR", which decodes to the
+    # same byte as the canonical "QQ" only because the unused trailing bits are ignored.
+    if base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=") != value:
+        return None
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
         return None
 
 
@@ -88,8 +146,13 @@ def extract_subprotocol_bearer_token(websocket: WebSocket) -> str | None:
     """
     Extract the bearer token a browser client carried in `Sec-WebSocket-Protocol`.
 
-    Returns None when the client did not offer the Mozaiks bearer subprotocol or the
-    credential value is missing/malformed. Never logs the credential.
+    Returns None when the client did not offer the Mozaiks bearer subprotocol, or
+    offered the marker with no credential beside it at all.
+
+    Raises MalformedBearerCredential when a credential *is* present but is not a
+    canonical unpadded base64url representation, so that a malformed encoding is
+    refused outright rather than falling through to another transport. Never logs
+    the credential.
     """
     offered = _offered_subprotocols(websocket)
     try:
@@ -103,9 +166,11 @@ def extract_subprotocol_bearer_token(websocket: WebSocket) -> str | None:
         return None
 
     token = _decode_bearer_subprotocol(offered[credential_index])
-    if not token:
-        logger.warning("WebSocket bearer subprotocol credential was not valid base64url")
-        return None
+    if token is None:
+        # Refuse the connection outright rather than falling through to another
+        # transport: the client explicitly claimed this credential channel.
+        logger.warning("WebSocket bearer subprotocol credential was not canonical base64url")
+        raise MalformedBearerCredential
     return token
 
 
@@ -207,6 +272,11 @@ async def authenticate_websocket(
     2. the `Sec-WebSocket-Protocol` bearer subprotocol (the browser path)
     3. `access_token` query parameter (if MOZAIKS_WS_ALLOW_QUERY_TOKEN=true)
 
+    A bearer subprotocol credential must be canonical unpadded base64url. A malformed
+    representation closes the connection with WS_REASON_MALFORMED_CREDENTIAL before the
+    auth adapter is consulted; it is never repaired, normalized, or retried on another
+    transport.
+
     Args:
         websocket: The WebSocket connection to authenticate
         access_token: Token passed directly (e.g., from header extraction)
@@ -261,7 +331,17 @@ async def authenticate_websocket(
     # Browser clients carry the credential in the `Sec-WebSocket-Protocol` handshake
     # header. This is the normal production browser path and needs no opt-in.
     if not token:
-        token = extract_subprotocol_bearer_token(websocket)
+        try:
+            token = extract_subprotocol_bearer_token(websocket)
+        except MalformedBearerCredential:
+            # Fail closed on the claimed channel: do not fall through to the query
+            # param, and do not hand the adapter a token recovered from a malformed
+            # representation.
+            await websocket.close(
+                code=WS_CLOSE_POLICY_VIOLATION,
+                reason=WS_REASON_MALFORMED_CREDENTIAL,
+            )
+            return None
 
     # Query-param token extraction is disabled by default.
     # Tokens in query params appear in server logs, browser history, and proxy logs.

--- a/mozaiksai/core/transport/simple_transport.py
+++ b/mozaiksai/core/transport/simple_transport.py
@@ -20,6 +20,7 @@ from websockets.exceptions import ConnectionClosed
 
 # Enhanced logging setup
 from logs.logging_config import get_core_logger
+from mozaiksai.core.auth.websocket_auth import accept_websocket
 from mozaiksai.core.events.runtime_events import RUNTIME_PROCESS_COMPLETED
 
 # Extracted mixins for separation of concerns
@@ -1591,7 +1592,7 @@ class SimpleTransport(WebSocketProtocolMixin, WorkflowBridgeMixin, GeneralModeMi
                 await websocket.close(code=1008, reason="User connection limit reached")
                 return
 
-        await websocket.accept()
+        await accept_websocket(websocket)
 
         # Store ws_id for session registry lookups
         if ws_id is None:

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -25,6 +25,7 @@ from mozaiksai.core.admin.registry import build_admin_shell_routes, load_admin_r
 from mozaiksai.core.auth import (
     WS_CLOSE_POLICY_VIOLATION,
     UserPrincipal,
+    accept_websocket,
     authenticate_websocket_with_path_binding,
     require_any_auth,
     require_user_scope,
@@ -3512,7 +3513,7 @@ async def websocket_endpoint(
         )
         if not is_valid:
             try:
-                await websocket.accept()
+                await accept_websocket(websocket)
                 await send_event_envelope(websocket, {
                     "schema_version": "mozaiks.ui.event.v1",
                     "type": "chat.error",
@@ -3531,7 +3532,7 @@ async def websocket_endpoint(
     except Exception as dep_err:
         logger.error("WS_PREREQ_VALIDATION_FAILED: %s", dep_err, exc_info=True)
         try:
-            await websocket.accept()
+            await accept_websocket(websocket)
             await send_event_envelope(websocket, {
                 "schema_version": "mozaiks.ui.event.v1",
                 "type": "chat.error",

--- a/mozaiksai/hosts/routers/sandbox.py
+++ b/mozaiksai/hosts/routers/sandbox.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from mozaiksai.core.auth import (
     WS_CLOSE_POLICY_VIOLATION,
+    accept_websocket,
     authenticate_websocket,
     require_user_scope,
 )
@@ -175,7 +176,7 @@ async def ws_sandbox_stream(websocket: WebSocket, sandboxId: str):
         return  # Connection already closed with 1008
 
     mgr = get_artifact_preview_sessions()
-    await websocket.accept()
+    await accept_websocket(websocket)
     await mgr.register_ws(sandboxId, websocket)
     try:
         while True:

--- a/mozaiksai/hosts/runtime.py
+++ b/mozaiksai/hosts/runtime.py
@@ -33,6 +33,7 @@ from logs.logging_config import (
 from mozaiksai.core.auth import (
     WS_CLOSE_POLICY_VIOLATION,
     UserPrincipal,
+    accept_websocket,
     authenticate_websocket_with_path_binding,
     require_any_auth,
     require_user_scope,
@@ -945,7 +946,7 @@ async def websocket_endpoint(
             )
         except Exception as prereq_exc:
             logger.error("WS_PREREQ_VALIDATION_FAILED workflow=%s chat=%s: %s", resolved_workflow_name, chat_id, prereq_exc, exc_info=True)
-            await websocket.accept()
+            await accept_websocket(websocket)
             await send_event_envelope(websocket,
                 {
                     "schema_version": "mozaiks.ui.event.v1",
@@ -963,7 +964,7 @@ async def websocket_endpoint(
             return
 
         if not prereqs_ok:
-            await websocket.accept()
+            await accept_websocket(websocket)
             await send_event_envelope(websocket,
                 {
                     "schema_version": "mozaiks.ui.event.v1",

--- a/tests/test_websocket_subprotocol_auth.py
+++ b/tests/test_websocket_subprotocol_auth.py
@@ -11,9 +11,18 @@ Covers:
   Transport extraction:
     - base64url credential in the bearer subprotocol is decoded
     - marker without a credential value is rejected
-    - malformed base64url is rejected
+    - malformed base64url is refused, not repaired
     - unrelated subprotocols are ignored
     - credential is never echoed as the selected subprotocol
+
+  Strict credential encoding (the credential must be canonical unpadded base64url):
+    - trailing garbage, illegal characters, whitespace, `=` padding, impossible
+      lengths, standard-base64 `+`/`/`, empty values, invalid UTF-8, and
+      non-canonical trailing bits are all refused before the auth adapter runs
+    - refusal carries its own bounded reason, distinct from a missing credential
+    - a malformed subprotocol never falls through to the query-token path
+    - the same matrix is re-proven over a real FastAPI/Starlette handshake, with
+      the adapter asserted never to have authenticated a recovered bearer
 
   Authentication through the configured adapter:
     - subprotocol token validates through get_auth_adapter() and binds WebSocketUser
@@ -58,6 +67,8 @@ from mozaiksai.core.auth.adapters.registry import (
 from mozaiksai.core.auth.websocket_auth import (
     WS_BEARER_SUBPROTOCOL,
     WS_CLOSE_POLICY_VIOLATION,
+    WS_REASON_MALFORMED_CREDENTIAL,
+    MalformedBearerCredential,
     accept_websocket,
     authenticate_websocket,
     authenticate_websocket_with_path_binding,
@@ -177,9 +188,11 @@ class TestSubprotocolExtraction:
         socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL])
         assert extract_subprotocol_bearer_token(socket) is None
 
-    def test_malformed_base64url_is_rejected(self):
+    def test_malformed_base64url_raises_rather_than_returning_none(self):
+        """Malformed encoding is a hard refusal, not an absent credential."""
         socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "!!!not-base64!!!"])
-        assert extract_subprotocol_bearer_token(socket) is None
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(socket)
 
     def test_unrelated_subprotocols_are_ignored(self):
         socket = _FakeWebSocket(subprotocols=["graphql-ws", "json"])
@@ -247,10 +260,13 @@ class TestAuthenticateThroughAdapter:
         assert socket.closed[0][0] == WS_CLOSE_POLICY_VIOLATION
 
     @pytest.mark.asyncio
-    async def test_malformed_credential_is_rejected_as_missing(self, auth_enabled):
+    async def test_malformed_credential_is_refused_with_its_own_reason(self, auth_enabled):
         socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "!!!"])
         assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
         assert socket.accepted is False
+        assert socket.closed == [
+            (WS_CLOSE_POLICY_VIOLATION, WS_REASON_MALFORMED_CREDENTIAL)
+        ]
 
     @pytest.mark.asyncio
     async def test_explicit_access_token_argument_still_wins(self, auth_enabled):
@@ -591,3 +607,243 @@ class TestRealAsgiHandshake:
                 websocket.receive_json()
         assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
         assert excinfo.value.reason == "Missing access_token"
+
+
+# ---------------------------------------------------------------------------
+# 7. Strict credential encoding
+# ---------------------------------------------------------------------------
+
+# Malformed representations that must never reach the auth adapter. Each pairs a
+# label with a factory turning a canonical encoding into the malformed form.
+MALFORMED_CREDENTIALS = [
+    ("trailing garbage", lambda c: c + "!!!!"),
+    ("single illegal character", lambda c: c + "!"),
+    ("leading illegal character", lambda c: "!" + c),
+    ("embedded space", lambda c: c[:4] + " " + c[4:]),
+    ("surrounding whitespace", lambda c: "  " + c + "  "),
+    ("embedded tab", lambda c: c[:4] + "\t" + c[4:]),
+    ("trailing newline", lambda c: c + "\n"),
+    ("explicit padding", lambda c: c + "="),
+    ("impossible length", lambda c: c + "A"),
+    ("standard-base64 plus", lambda c: c[:4] + "+" + c[5:]),
+    ("standard-base64 slash", lambda c: c[:4] + "/" + c[5:]),
+    ("empty credential", lambda c: ""),
+]
+
+MALFORMED_IDS = [label for label, _ in MALFORMED_CREDENTIALS]
+
+# HTTP list framing (RFC 7230) strips optional whitespace *around* each element of
+# `Sec-WebSocket-Protocol`, so these two forms are unrepresentable on a real wire: the
+# value the client actually transmits is already the canonical one. They are still
+# refused at our boundary, which is what the _FakeWebSocket matrix above proves.
+WIRE_UNREPRESENTABLE = {"surrounding whitespace", "trailing newline"}
+
+ON_WIRE_MALFORMED = [
+    (label, mangle)
+    for label, mangle in MALFORMED_CREDENTIALS
+    if label not in WIRE_UNREPRESENTABLE
+]
+ON_WIRE_MALFORMED_IDS = [label for label, _ in ON_WIRE_MALFORMED]
+
+
+class TestStrictCredentialEncoding:
+    """
+    The credential after `mozaiks.bearer.v1` must be canonical unpadded base64url.
+
+    Python's base64 silently *discards* characters outside the alphabet by default, so
+    a lenient decoder turns base64url(token) + trailing garbage back into a usable
+    token. That is a transport defect even though the recovered bearer still had to be
+    valid: the transport must refuse a malformed representation, never repair one.
+    """
+
+    @pytest.mark.parametrize("label,mangle", MALFORMED_CREDENTIALS, ids=MALFORMED_IDS)
+    def test_malformed_representation_is_refused(self, label: str, mangle) -> None:
+        mangled = mangle(encode_credential(VALID_TOKEN))
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, mangled])
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(socket)
+
+    def test_noncanonical_trailing_bits_are_refused(self) -> None:
+        # "QR" decodes to the same byte as canonical "QQ" only because the unused
+        # trailing bits are ignored, so only the canonical form may be accepted.
+        assert extract_subprotocol_bearer_token(
+            _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "QQ"])
+        ) == "A"
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(
+                _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "QR"])
+            )
+
+    def test_invalid_utf8_after_decoding_is_refused(self) -> None:
+        undecodable = base64.urlsafe_b64encode(b"\xff\xfe\xfd").decode("ascii").rstrip("=")
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(
+                _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, undecodable])
+            )
+
+    def test_canonical_encoding_round_trips_including_multibyte(self) -> None:
+        for token in (VALID_TOKEN, "a+b/c=d?e&f", "tok-é中\U0001f600", "A"):
+            socket = _FakeWebSocket(
+                subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(token)]
+            )
+            assert extract_subprotocol_bearer_token(socket) == token
+
+    @pytest.mark.asyncio
+    async def test_malformed_never_falls_through_to_the_query_token(
+        self, auth_enabled, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even with the dev opt-in on, a malformed subprotocol refuses outright."""
+        monkeypatch.setenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", "true")
+        socket = _FakeWebSocket(
+            subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(VALID_TOKEN) + "!!!!"],
+            query_params={"access_token": VALID_TOKEN},
+        )
+        assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
+        assert socket.accepted is False
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, WS_REASON_MALFORMED_CREDENTIAL)]
+
+    def test_no_credential_material_in_logs_on_malformed_refusal(
+        self, auth_enabled, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        secret = "super.secret.jwt"
+        encoded = encode_credential(secret)
+        caplog.set_level(logging.DEBUG)
+
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, encoded + "!!!!"])
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(socket)
+
+        assert caplog.records, "expected a refusal to be logged"
+        emitted = "\n".join(record.getMessage() for record in caplog.records)
+        assert secret not in emitted
+        assert encoded not in emitted
+
+
+class TestStrictEncodingOverRealHandshake:
+    """The same matrix over a real FastAPI/Starlette handshake, not a double."""
+
+    @staticmethod
+    def _app(seen: list[str]):
+        app = FastAPI()
+
+        @app.websocket("/ws/{app_id}/{chat_id}/{user_id}")
+        async def endpoint(websocket: WebSocket, app_id: str, chat_id: str, user_id: str):
+            user = await authenticate_websocket_with_path_binding(
+                websocket,
+                path_user_id=user_id,
+                path_app_id=app_id,
+                path_chat_id=chat_id,
+            )
+            if user is None:
+                return
+            seen.append(user.user_id)
+            await accept_websocket(websocket)
+            await websocket.send_json({"user_id": user.user_id})
+            await websocket.close()
+
+        return app
+
+    def _connect(self, subprotocols, seen):
+        from starlette.testclient import TestClient
+
+        client = TestClient(self._app(seen))
+        return client.websocket_connect("/ws/app-1/chat-1/user-1", subprotocols=subprotocols)
+
+    def test_canonical_credential_is_accepted(self, auth_enabled) -> None:
+        """Positive control: the canonical encoding still authenticates end to end."""
+        seen: list[str] = []
+        with self._connect([WS_BEARER_SUBPROTOCOL, encode_credential(VALID_TOKEN)], seen) as ws:
+            assert ws.accepted_subprotocol == WS_BEARER_SUBPROTOCOL
+            assert ws.receive_json() == {"user_id": "user-1"}
+        assert seen == ["user-1"]
+
+    def test_canonical_plus_trailing_garbage_is_refused(self, auth_enabled) -> None:
+        """The exact reproduction: canonical encoding followed by trailing garbage."""
+        from starlette.websockets import WebSocketDisconnect
+
+        seen: list[str] = []
+        mangled = encode_credential(VALID_TOKEN) + "!!!!"
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with self._connect([WS_BEARER_SUBPROTOCOL, mangled], seen) as ws:
+                ws.receive_json()
+
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == WS_REASON_MALFORMED_CREDENTIAL
+        # The adapter must never have authenticated the recovered underlying bearer.
+        assert seen == []
+
+    @pytest.mark.parametrize("label,mangle", ON_WIRE_MALFORMED, ids=ON_WIRE_MALFORMED_IDS)
+    def test_malformed_matrix_is_refused_over_the_wire(
+        self, auth_enabled, label: str, mangle
+    ) -> None:
+        from starlette.websockets import WebSocketDisconnect
+
+        seen: list[str] = []
+        mangled = mangle(encode_credential(VALID_TOKEN))
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with self._connect([WS_BEARER_SUBPROTOCOL, mangled], seen) as ws:
+                ws.receive_json()
+
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert seen == [], label + " authenticated a recovered bearer"
+
+    def test_invalid_utf8_is_refused_over_the_wire(self, auth_enabled) -> None:
+        from starlette.websockets import WebSocketDisconnect
+
+        seen: list[str] = []
+        undecodable = base64.urlsafe_b64encode(b"\xff\xfe\xfd").decode("ascii").rstrip("=")
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with self._connect([WS_BEARER_SUBPROTOCOL, undecodable], seen) as ws:
+                ws.receive_json()
+
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == WS_REASON_MALFORMED_CREDENTIAL
+        assert seen == []
+
+    @pytest.mark.parametrize("label", sorted(WIRE_UNREPRESENTABLE))
+    def test_surrounding_whitespace_is_http_framing_not_a_credential(
+        self, auth_enabled, label: str
+    ) -> None:
+        """
+        OWS around a list element is removed by HTTP before our boundary sees it.
+
+        The client therefore transmitted a canonical credential and is accepted. This
+        is correct RFC 7230 framing, not the transport normalizing a malformed value —
+        our boundary still refuses whitespace when it is presented directly, which
+        TestStrictCredentialEncoding asserts.
+        """
+        mangle = dict(MALFORMED_CREDENTIALS)[label]
+        canonical = encode_credential(VALID_TOKEN)
+        seen: list[str] = []
+
+        with self._connect([WS_BEARER_SUBPROTOCOL, mangle(canonical)], seen) as ws:
+            assert ws.receive_json() == {"user_id": "user-1"}
+        assert seen == ["user-1"]
+
+        # Presented directly to the boundary, the same value is refused.
+        with pytest.raises(MalformedBearerCredential):
+            extract_subprotocol_bearer_token(
+                _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, mangle(canonical)])
+            )
+
+    def test_query_token_development_compatibility_is_unchanged(
+        self, auth_enabled, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The dev opt-in still works over a real handshake, and stays off by default."""
+        from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        seen: list[str] = []
+        client = TestClient(self._app(seen))
+        url = "/ws/app-1/chat-1/user-1?access_token=" + VALID_TOKEN
+
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with client.websocket_connect(url) as ws:
+                ws.receive_json()
+        assert excinfo.value.reason == "Missing access_token"
+        assert seen == []
+
+        monkeypatch.setenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", "true")
+        with client.websocket_connect(url) as ws:
+            assert ws.receive_json() == {"user_id": "user-1"}
+        assert seen == ["user-1"]

--- a/tests/test_websocket_subprotocol_auth.py
+++ b/tests/test_websocket_subprotocol_auth.py
@@ -1,0 +1,593 @@
+"""
+Production-safe browser WebSocket authentication.
+
+Browsers cannot set request headers on a WebSocket handshake, so the shared browser
+client used to append `?access_token=<jwt>` to the URL — which the runtime rejects by
+default (`MOZAIKS_WS_ALLOW_QUERY_TOKEN=false`) because URL-borne tokens leak into access
+logs, browser history, and shared links. The credential now travels in the
+`Sec-WebSocket-Protocol` handshake header instead.
+
+Covers:
+  Transport extraction:
+    - base64url credential in the bearer subprotocol is decoded
+    - marker without a credential value is rejected
+    - malformed base64url is rejected
+    - unrelated subprotocols are ignored
+    - credential is never echoed as the selected subprotocol
+
+  Authentication through the configured adapter:
+    - subprotocol token validates through get_auth_adapter() and binds WebSocketUser
+    - missing credential closes 1008 before accept
+    - invalid credential closes 1008 before accept
+    - query-string token stays rejected by default
+    - query-string token still honored under the development opt-in
+    - auth-disabled local development still connects
+
+  Scope binding preserved (authenticate_websocket_with_path_binding):
+    - wrong user_id closes 1008
+    - another app's bound identity does not become this app
+    - wrong chat_id closes 1008
+    - matching user/app/chat is accepted
+
+  Log hygiene:
+    - no token material in log records on success or failure
+
+  Browser proof (real chat-ui source executed under Node):
+    - websocketAuth.js encodes the credential the server decodes
+    - api.js builds a WebSocket URL with no bearer token and passes the credential
+      as a subprotocol instead
+    - runtimeBridge.js emits a credential-free URL
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, WebSocket
+
+from mozaiksai.core.auth.adapters import AuthError, UserClaims
+from mozaiksai.core.auth.adapters.base import BaseAuthAdapter
+from mozaiksai.core.auth.adapters.registry import (
+    register_adapter,
+    reset_auth_adapter,
+)
+from mozaiksai.core.auth.websocket_auth import (
+    WS_BEARER_SUBPROTOCOL,
+    WS_CLOSE_POLICY_VIOLATION,
+    accept_websocket,
+    authenticate_websocket,
+    authenticate_websocket_with_path_binding,
+    extract_subprotocol_bearer_token,
+    negotiated_subprotocol,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+VALID_TOKEN = "header.payload.signature"
+OTHER_APP_TOKEN = "other-app-token"
+
+
+def encode_credential(token: str) -> str:
+    """Mirror of the browser encoder: base64url, unpadded."""
+    return base64.urlsafe_b64encode(token.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket double exposing the surface the auth boundary touches."""
+
+    def __init__(self, *, subprotocols: list[str] | None = None, query_params: dict | None = None) -> None:
+        self.scope: dict = {"subprotocols": list(subprotocols or [])}
+        self.query_params: dict = dict(query_params or {})
+        self.state = type("_State", (), {})()
+        self.accepted = False
+        self.accepted_subprotocol: str | None = None
+        self.closed: list[tuple[int | None, str | None]] = []
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        self.accepted = True
+        self.accepted_subprotocol = subprotocol
+
+    async def close(self, code: int | None = None, reason: str | None = None) -> None:
+        self.closed.append((code, reason))
+
+
+def browser_socket(token: str | None = VALID_TOKEN) -> _FakeWebSocket:
+    """A handshake shaped exactly as the shared browser client sends it."""
+    if token is None:
+        return _FakeWebSocket()
+    return _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(token)])
+
+
+class _StubAdapter(BaseAuthAdapter):
+    """Stands in for a configured IdP adapter; only VALID_TOKEN/OTHER_APP_TOKEN verify."""
+
+    name = "test-stub"
+
+    async def validate_token(self, token: str) -> UserClaims:
+        if token == VALID_TOKEN:
+            return UserClaims(
+                user_id="user-1",
+                email="user-1@example.com",
+                name="User One",
+                roles=["member"],
+                scopes=["access_as_user"],
+                raw_claims={"sub": "user-1", "app_id": "app-1", "chat_id": "chat-1", "exp": 4102444800},
+                provider="test-stub",
+                app_id="app-1",
+                chat_id="chat-1",
+            )
+        if token == OTHER_APP_TOKEN:
+            return UserClaims(
+                user_id="user-1",
+                scopes=["access_as_user"],
+                raw_claims={"sub": "user-1", "app_id": "app-2"},
+                provider="test-stub",
+                app_id="app-2",
+                chat_id="chat-1",
+            )
+        raise AuthError("Invalid token", status_code=401, provider="test-stub")
+
+    def validate_token_sync(self, token: str) -> UserClaims:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def is_enabled(self) -> bool:
+        return True
+
+
+@pytest.fixture
+def auth_enabled(monkeypatch: pytest.MonkeyPatch):
+    """Configure the runtime with a real registered adapter under the canonical registry."""
+    register_adapter("test-stub", _StubAdapter, config_identity="test-stub-v1")
+    monkeypatch.setenv("AUTH_PROVIDER", "test-stub")
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.delenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", raising=False)
+    reset_auth_adapter()
+    yield
+    reset_auth_adapter()
+
+
+@pytest.fixture
+def auth_disabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AUTH_PROVIDER", "none")
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.delenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", raising=False)
+    reset_auth_adapter()
+    yield
+    reset_auth_adapter()
+
+
+# ---------------------------------------------------------------------------
+# 1. Transport extraction
+# ---------------------------------------------------------------------------
+
+class TestSubprotocolExtraction:
+    def test_decodes_base64url_credential(self):
+        assert extract_subprotocol_bearer_token(browser_socket()) == VALID_TOKEN
+
+    def test_decodes_credential_containing_url_unsafe_bytes(self):
+        token = "a+b/c=d?e&f"
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(token)])
+        assert extract_subprotocol_bearer_token(socket) == token
+
+    def test_marker_without_credential_is_rejected(self):
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL])
+        assert extract_subprotocol_bearer_token(socket) is None
+
+    def test_malformed_base64url_is_rejected(self):
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "!!!not-base64!!!"])
+        assert extract_subprotocol_bearer_token(socket) is None
+
+    def test_unrelated_subprotocols_are_ignored(self):
+        socket = _FakeWebSocket(subprotocols=["graphql-ws", "json"])
+        assert extract_subprotocol_bearer_token(socket) is None
+        assert negotiated_subprotocol(socket) is None
+
+    def test_no_subprotocols_offered(self):
+        assert extract_subprotocol_bearer_token(_FakeWebSocket()) is None
+
+    def test_websocket_without_scope_attribute_is_tolerated(self):
+        class _Bare:
+            pass
+
+        assert extract_subprotocol_bearer_token(_Bare()) is None  # type: ignore[arg-type]
+
+
+class TestAcceptNegotiation:
+    @pytest.mark.asyncio
+    async def test_accept_echoes_marker_only_never_the_credential(self):
+        socket = browser_socket()
+        await accept_websocket(socket)  # type: ignore[arg-type]
+        assert socket.accepted is True
+        assert socket.accepted_subprotocol == WS_BEARER_SUBPROTOCOL
+        assert encode_credential(VALID_TOKEN) != socket.accepted_subprotocol
+        assert VALID_TOKEN not in str(socket.accepted_subprotocol)
+
+    @pytest.mark.asyncio
+    async def test_accept_selects_nothing_when_client_offered_nothing(self):
+        socket = _FakeWebSocket()
+        await accept_websocket(socket)  # type: ignore[arg-type]
+        assert socket.accepted is True
+        assert socket.accepted_subprotocol is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Authentication through the configured adapter
+# ---------------------------------------------------------------------------
+
+class TestAuthenticateThroughAdapter:
+    @pytest.mark.asyncio
+    async def test_subprotocol_token_authenticates_and_binds_user(self, auth_enabled):
+        socket = browser_socket()
+        user = await authenticate_websocket(socket)  # type: ignore[arg-type]
+
+        assert user is not None
+        assert user.user_id == "user-1"
+        assert user.provider == "test-stub"
+        assert user.app_id == "app-1"
+        assert socket.state.user_id == "user-1"
+        assert socket.state.user is user
+        assert socket.closed == []
+
+    @pytest.mark.asyncio
+    async def test_missing_credential_is_rejected(self, auth_enabled):
+        socket = _FakeWebSocket()
+        assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
+        assert socket.accepted is False
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, "Missing access_token")]
+
+    @pytest.mark.asyncio
+    async def test_invalid_credential_is_rejected(self, auth_enabled):
+        socket = browser_socket("forged-token")
+        assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
+        assert socket.accepted is False
+        assert socket.closed[0][0] == WS_CLOSE_POLICY_VIOLATION
+
+    @pytest.mark.asyncio
+    async def test_malformed_credential_is_rejected_as_missing(self, auth_enabled):
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "!!!"])
+        assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
+        assert socket.accepted is False
+
+    @pytest.mark.asyncio
+    async def test_explicit_access_token_argument_still_wins(self, auth_enabled):
+        socket = _FakeWebSocket()
+        user = await authenticate_websocket(socket, access_token=VALID_TOKEN)  # type: ignore[arg-type]
+        assert user is not None and user.user_id == "user-1"
+
+
+class TestQueryTokenDisposition:
+    @pytest.mark.asyncio
+    async def test_query_token_still_rejected_by_default(self, auth_enabled):
+        socket = _FakeWebSocket(query_params={"access_token": VALID_TOKEN})
+        assert await authenticate_websocket(socket) is None  # type: ignore[arg-type]
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, "Missing access_token")]
+
+    @pytest.mark.asyncio
+    async def test_query_token_honored_under_development_opt_in(
+        self, auth_enabled, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", "true")
+        socket = _FakeWebSocket(query_params={"access_token": VALID_TOKEN})
+        user = await authenticate_websocket(socket)  # type: ignore[arg-type]
+        assert user is not None and user.user_id == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_subprotocol_needs_no_opt_in(self, auth_enabled, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MOZAIKS_WS_ALLOW_QUERY_TOKEN", "false")
+        user = await authenticate_websocket(browser_socket())  # type: ignore[arg-type]
+        assert user is not None and user.user_id == "user-1"
+
+
+class TestAuthDisabledDevelopment:
+    @pytest.mark.asyncio
+    async def test_local_development_without_auth_still_connects(self, auth_disabled):
+        socket = _FakeWebSocket()
+        user = await authenticate_websocket(socket)  # type: ignore[arg-type]
+        assert user is not None
+        assert socket.closed == []
+
+    @pytest.mark.asyncio
+    async def test_path_binding_bypass_intact_when_auth_disabled(self, auth_disabled):
+        socket = _FakeWebSocket()
+        user = await authenticate_websocket_with_path_binding(
+            socket, path_user_id="dev-user", path_app_id="app-1", path_chat_id="chat-1"  # type: ignore[arg-type]
+        )
+        assert user is not None and user.user_id == "dev-user"
+        assert socket.closed == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Scope binding preserved
+# ---------------------------------------------------------------------------
+
+class TestScopeBinding:
+    @pytest.mark.asyncio
+    async def test_matching_user_app_chat_is_accepted(self, auth_enabled):
+        socket = browser_socket()
+        user = await authenticate_websocket_with_path_binding(
+            socket, path_user_id="user-1", path_app_id="app-1", path_chat_id="chat-1"  # type: ignore[arg-type]
+        )
+        assert user is not None and user.user_id == "user-1"
+        assert socket.closed == []
+
+    @pytest.mark.asyncio
+    async def test_wrong_user_is_rejected(self, auth_enabled):
+        socket = browser_socket()
+        user = await authenticate_websocket_with_path_binding(
+            socket, path_user_id="user-2", path_app_id="app-1", path_chat_id="chat-1"  # type: ignore[arg-type]
+        )
+        assert user is None
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, "user_id mismatch")]
+
+    @pytest.mark.asyncio
+    async def test_another_apps_bound_identity_does_not_become_this_app(self, auth_enabled):
+        """A token bound to app-2 cannot open a socket scoped to app-1."""
+        socket = browser_socket(OTHER_APP_TOKEN)
+        user = await authenticate_websocket_with_path_binding(
+            socket, path_user_id="user-1", path_app_id="app-1", path_chat_id="chat-1"  # type: ignore[arg-type]
+        )
+        assert user is None
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, "app_id mismatch")]
+        assert socket.accepted is False
+
+    @pytest.mark.asyncio
+    async def test_wrong_chat_is_rejected(self, auth_enabled):
+        socket = browser_socket()
+        user = await authenticate_websocket_with_path_binding(
+            socket, path_user_id="user-1", path_app_id="app-1", path_chat_id="chat-9"  # type: ignore[arg-type]
+        )
+        assert user is None
+        assert socket.closed == [(WS_CLOSE_POLICY_VIOLATION, "chat_id mismatch")]
+
+
+# ---------------------------------------------------------------------------
+# 4. Log hygiene
+# ---------------------------------------------------------------------------
+
+class TestLogHygiene:
+    @pytest.mark.asyncio
+    async def test_no_token_material_in_logs(self, auth_enabled, caplog: pytest.LogCaptureFixture):
+        secret = "super.secret.jwt"
+        encoded = encode_credential(secret)
+        caplog.set_level(logging.DEBUG)
+
+        await authenticate_websocket(browser_socket(secret))  # type: ignore[arg-type]
+        await authenticate_websocket(_FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, "!!!"]))  # type: ignore[arg-type]
+        await authenticate_websocket(browser_socket())  # type: ignore[arg-type]
+
+        # Guard against a vacuous assertion: the boundary must actually have logged.
+        assert caplog.records, "expected auth logging to be captured"
+
+        emitted = "\n".join(record.getMessage() for record in caplog.records)
+        assert secret not in emitted
+        assert encoded not in emitted
+        assert VALID_TOKEN not in emitted
+
+
+# ---------------------------------------------------------------------------
+# 5. Browser proof — real chat-ui source executed under Node
+# ---------------------------------------------------------------------------
+
+def run_node(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT, text=True, capture_output=True, check=False, timeout=60,
+    )
+
+
+WS_AUTH_MODULE = (ROOT / "chat-ui/src/adapters/websocketAuth.js").as_uri()
+
+
+class TestBrowserTransport:
+    def test_browser_encoder_round_trips_through_the_server_decoder(self):
+        """The real browser module's output is what the server decodes."""
+        script = f"""
+import assert from 'node:assert/strict';
+import {{ buildWebSocketAuthProtocols, WS_BEARER_SUBPROTOCOL }} from '{WS_AUTH_MODULE}';
+
+const protocols = buildWebSocketAuthProtocols('{VALID_TOKEN}');
+assert.equal(protocols.length, 2);
+assert.equal(protocols[0], WS_BEARER_SUBPROTOCOL);
+assert.notEqual(protocols[1], '{VALID_TOKEN}');
+assert.match(protocols[1], /^[A-Za-z0-9_-]+$/, 'credential must be an unpadded base64url header token');
+
+// No token means no protocols, so auth-disabled local dev still connects.
+assert.deepEqual(buildWebSocketAuthProtocols(null), []);
+assert.deepEqual(buildWebSocketAuthProtocols(''), []);
+assert.deepEqual(buildWebSocketAuthProtocols(undefined), []);
+
+console.log(JSON.stringify(protocols));
+"""
+        result = run_node(script)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        marker, credential = json.loads(result.stdout.strip().splitlines()[-1])
+        assert marker == WS_BEARER_SUBPROTOCOL
+
+        socket = _FakeWebSocket(subprotocols=[marker, credential])
+        assert extract_subprotocol_bearer_token(socket) == VALID_TOKEN
+
+    def test_api_adapter_puts_no_bearer_token_in_the_websocket_url(self):
+        """Executes the production URL/socket construction lines from api.js."""
+        source = (ROOT / "chat-ui/src/adapters/api.js").read_text(encoding="utf-8")
+        start = source.index("    const wsBase = this.getWsBaseUrl();")
+        end = source.index("openAuthenticatedWebSocket(wsUrl.toString(), getAccessToken(this.config));")
+        body = source[start:end] + "openAuthenticatedWebSocket(wsUrl.toString(), getAccessToken(this.config));"
+
+        script = f"""
+import assert from 'node:assert/strict';
+import {{ openAuthenticatedWebSocket, WS_BEARER_SUBPROTOCOL }} from '{WS_AUTH_MODULE}';
+
+const opened = [];
+globalThis.WebSocket = class {{
+  constructor(url, protocols) {{ opened.push({{ url, protocols }}); this.readyState = 0; }}
+  static CONNECTING = 0; static OPEN = 1; static CLOSING = 2; static CLOSED = 3;
+}};
+
+const getAccessToken = () => '{VALID_TOKEN}';
+
+function construct(appId, userId, actualworkflowname, chatId, options) {{
+  const self = {{
+    getWsBaseUrl: () => 'wss://app.example.com',
+    _chatConnections: new Map(),
+    config: {{}},
+  }};
+  return (function () {{
+{body}
+    return socket;
+  }}).call(self);
+}}
+
+construct('app-1', 'user-1', 'AppGenerator', 'chat-1', {{ suppressHistoryReplay: true }});
+assert.equal(opened.length, 1);
+const {{ url, protocols }} = opened[0];
+
+// The credential is not in the URL, in any form.
+assert.ok(!url.includes('access_token'), url);
+assert.ok(!url.includes('{VALID_TOKEN}'), url);
+assert.ok(!url.includes(encodeURIComponent('{VALID_TOKEN}')), url);
+assert.equal(new URL(url).searchParams.get('access_token'), null);
+
+// Non-credential query state is preserved.
+assert.equal(new URL(url).searchParams.get('suppress_history_replay'), '1');
+assert.equal(new URL(url).pathname, '/ws/AppGenerator/app-1/chat-1/user-1');
+assert.equal(new URL(url).protocol, 'wss:');
+
+// The credential rides the handshake subprotocol instead.
+assert.equal(protocols[0], WS_BEARER_SUBPROTOCOL);
+assert.equal(protocols.length, 2);
+console.log(JSON.stringify(protocols[1]));
+"""
+        result = run_node(script)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        credential = json.loads(result.stdout.strip().splitlines()[-1])
+        socket = _FakeWebSocket(subprotocols=[WS_BEARER_SUBPROTOCOL, credential])
+        assert extract_subprotocol_bearer_token(socket) == VALID_TOKEN
+
+    def test_runtime_bridge_url_carries_no_credential(self):
+        source = (ROOT / "chat-ui/src/runtimeBridge.js").read_text(encoding="utf-8")
+        assert "access_token" not in source
+        assert "searchParams.set('access_token'" not in source
+
+    def test_no_shared_browser_surface_puts_a_token_in_a_websocket_url(self):
+        """Regression fence: the URL-token transport must not come back."""
+        surfaces = [
+            "chat-ui/src/adapters/api.js",
+            "chat-ui/src/runtimeBridge.js",
+            "chat-ui/src/adapters/websocketAuth.js",
+            "factory_app/workflows/AppGenerator/ui/useSandbox.js",
+        ]
+        for relative in surfaces:
+            source = (ROOT / relative).read_text(encoding="utf-8")
+            assert "searchParams.set('access_token'" not in source, relative
+            assert "access_token=" not in source, relative
+
+    def test_studio_sandbox_import_resolves_through_the_chat_ui_alias(self):
+        """`@mozaiks/chat-ui` aliases to chat-ui/src (web_shell/vite.config.js)."""
+        source = (ROOT / "factory_app/workflows/AppGenerator/ui/useSandbox.js").read_text(encoding="utf-8")
+        assert "from '@mozaiks/chat-ui/adapters/websocketAuth.js'" in source
+        assert (ROOT / "chat-ui/src/adapters/websocketAuth.js").is_file()
+        assert "'@mozaiks/chat-ui': chatUiSrcRoot" in (
+            ROOT / "web_shell/vite.config.js"
+        ).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 6. Real ASGI handshake — proves the scope/accept seam, not a double
+# ---------------------------------------------------------------------------
+
+class TestRealAsgiHandshake:
+    """Runs the boundary against a real FastAPI app over a real WebSocket handshake.
+
+    The doubles above assume `scope["subprotocols"]` carries the offer and that
+    accepting with a subprotocol completes negotiation. This proves both against the
+    actual server stack.
+    """
+
+    @staticmethod
+    def _app():
+        app = FastAPI()
+
+        @app.websocket("/ws/{app_id}/{chat_id}/{user_id}")
+        async def endpoint(websocket: WebSocket, app_id: str, chat_id: str, user_id: str):
+            user = await authenticate_websocket_with_path_binding(
+                websocket,
+                path_user_id=user_id,
+                path_app_id=app_id,
+                path_chat_id=chat_id,
+            )
+            if user is None:
+                return
+            await accept_websocket(websocket)
+            await websocket.send_json({"user_id": user.user_id, "app_id": user.app_id})
+            await websocket.close()
+
+        return app
+
+    def test_browser_handshake_authenticates_and_negotiates(self, auth_enabled):
+        from starlette.testclient import TestClient
+
+        client = TestClient(self._app())
+        with client.websocket_connect(
+            "/ws/app-1/chat-1/user-1",
+            subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(VALID_TOKEN)],
+        ) as websocket:
+            assert websocket.accepted_subprotocol == WS_BEARER_SUBPROTOCOL
+            assert websocket.receive_json() == {"user_id": "user-1", "app_id": "app-1"}
+
+    def test_missing_credential_is_refused_by_the_real_server(self, auth_enabled):
+        from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        client = TestClient(self._app())
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with client.websocket_connect("/ws/app-1/chat-1/user-1") as websocket:
+                websocket.receive_json()
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == "Missing access_token"
+
+    def test_invalid_credential_is_refused_by_the_real_server(self, auth_enabled):
+        from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        client = TestClient(self._app())
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with client.websocket_connect(
+                "/ws/app-1/chat-1/user-1",
+                subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential("forged")],
+            ) as websocket:
+                websocket.receive_json()
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == "Invalid token"
+
+    def test_another_apps_identity_is_refused_by_the_real_server(self, auth_enabled):
+        from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        client = TestClient(self._app())
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with client.websocket_connect(
+                "/ws/app-1/chat-1/user-1",
+                subprotocols=[WS_BEARER_SUBPROTOCOL, encode_credential(OTHER_APP_TOKEN)],
+            ) as websocket:
+                websocket.receive_json()
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == "app_id mismatch"
+
+    def test_query_token_is_refused_by_the_real_server_without_opt_in(self, auth_enabled):
+        from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        client = TestClient(self._app())
+        with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT012
+            with client.websocket_connect(
+                f"/ws/app-1/chat-1/user-1?access_token={VALID_TOKEN}"
+            ) as websocket:
+                websocket.receive_json()
+        assert excinfo.value.code == WS_CLOSE_POLICY_VIOLATION
+        assert excinfo.value.reason == "Missing access_token"


### PR DESCRIPTION
## Problem

The shared browser client put the access token in the WebSocket URL as
`?access_token=<jwt>`. The runtime correctly rejects query-string tokens unless
`MOZAIKS_WS_ALLOW_QUERY_TOKEN=true`, so an authenticated browser connection only
worked by enabling an opt-in that is unsafe in production — URL-borne tokens land
in server access logs, browser history, `Referer` headers, and shared or
bookmarked links.

Identified by controlled-beta staging PR `BlocUnited-LLC/mozaiks-app#274`. This is
the third and last of the shared-shell auth defects, after #499 (launch HTTP
authorization) and #500 (canonical app scope), both already merged and untouched
here.

## Change

Carry the credential in the `Sec-WebSocket-Protocol` handshake header — the one
request header the browser WebSocket API lets a client set. Clients offer:

```js
new WebSocket(url, ['mozaiks.bearer.v1', base64url(accessToken)]);
```

The runtime decodes it, validates it through the **same** configured auth adapter
used by HTTP routes, binds the same `WebSocketUser`, and selects only the marker on
accept so the credential is never echoed back. The token is base64url-encoded
(unpadded) so any credential shape stays a legal RFC 7230 header token.

Token precedence in `authenticate_websocket` is now: explicit `access_token`
argument → bearer subprotocol → query param (still gated on the opt-in).

Requires **no** opt-in in production or staging.

## Scope

Shared WebSocket auth transport only. No second JWT validator, no change to HTTP
JWT validation, no App Zero-specific server logic. App/user/chat/tenant/workspace
binding checks are untouched and still run after authentication. Auth-disabled
local development is unchanged. Query-string tokens remain rejected by default,
retained only as the existing development opt-in for non-browser clients.

The Studio sandbox client (`useSandbox.js`) carried the same URL-token leak and
moves to the same shared transport.

## Proof

`tests/test_websocket_subprotocol_auth.py` (34 tests) covers transport extraction,
adapter authentication, scope binding, log hygiene, the real browser sources, and a
**real FastAPI/Starlette handshake** — not only doubles.

Both negative controls were run against unmodified `main`: the backend tests fail at
import (the boundary does not exist), and the browser proofs fail against `main`'s
`api.js`/`runtimeBridge.js` because they still set `access_token` in the URL.

The browser proofs execute the real `chat-ui` sources under Node, following the
pattern established by the #499 tests — including the actual URL/socket-construction
lines from `api.js`, asserting the URL contains no bearer token in any form while
`suppress_history_replay` and the path are preserved.

## Known limitations (pre-existing, not addressed here)

- `mozaiksai/factory.py`'s `create_mozaiks_app` WebSocket endpoint calls
  `transport.handle_websocket` with **no authentication at all**. That is a missing-auth
  defect rather than a transport defect, and adding auth there would change embedder
  behavior, so it is left for a separate change.
- `mozaiksai/core/auth/dependencies.py::_extract_token` accepts `?access_token=` on
  **HTTP** routes as an ungated fallback, justified in its docstring by "WebSocket
  upgrade" — a rationale this PR makes obsolete. Not changed here, since the brief
  forbids weakening HTTP JWT validation and this PR owns WebSocket transport only.

## Docs

`auth-setup.md` and `mobile-client-contract.md` described query-string tokens as the
normal production browser path; both now document the subprotocol path and mark the
query form a local-development opt-in. `.env.example` guidance updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
