### PR TITLE
fix(runtime): preserve AG2 model output and retry limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project follows a practical pre-1.0 changelog format:
 
 ## Unreleased
 
+### Fixed
+
+- Preserve explicit provider-native output token limits and SDK retry counts
+  when converting runtime LLM configuration to AG2. Invalid, conflicting, or
+  unsupported limits now fail before a provider request instead of disappearing.
+  This does not introduce a wallet reservation or a total-spend guarantee.
+
 ### App workspace alignment
 
 - Expose the existing reference bundle evaluator through `factory_app.eval` so

--- a/docs/architecture/mozaiksai/token-management.md
+++ b/docs/architecture/mozaiksai/token-management.md
@@ -76,6 +76,42 @@ workflows can tighten this by setting one of these context variables:
 
 The process-wide fallback is `MOZAIKS_TOKEN_PREFLIGHT_REQUIRED_TOKENS`.
 
+### Provider Request Limits
+
+`mozaiksai.core.adapters.llm_fallback.llm_config_to_ag2_config` forwards explicit
+limits into AG2's native model configuration. These are runtime LLM options,
+not new fields in generated workflow or subscription YAML.
+
+| Selected AG2 configuration | Output limit | SDK retry control |
+| --- | --- | --- |
+| OpenAI Chat Completions | `max_completion_tokens` or `max_tokens`, never both | `max_retries` |
+| OpenAI Responses | `max_output_tokens` | `max_retries` |
+| Anthropic | `max_tokens` | `max_retries` |
+| Gemini | `max_output_tokens` | Not exposed by the AG2 config |
+| Ollama | `max_tokens` | Not exposed by the AG2 config |
+
+The selected `config_list` entry overrides the same option at the shared
+`llm_config` level. Explicit output limits must be positive integers; retry
+counts must be nonnegative integers, including zero to disable SDK retries.
+Omit a field to keep AG2's default. Unsupported fields, nulls, booleans,
+non-integer values, and multiple output limit fields are rejected before client
+creation. Provider-native field names are not interchangeable aliases.
+
+For OpenAI, prefer `max_completion_tokens` for Chat Completions; it includes
+reasoning tokens. Responses uses `max_output_tokens` for visible and reasoning
+output. See the official [Chat Completions API](https://developers.openai.com/api/reference/python/resources/chat/subresources/completions/methods/create)
+and [Responses API](https://developers.openai.com/api/reference/python/resources/responses/methods/create).
+
+**These controls are not a hard spending cap.** They bound configured request
+output or SDK retry behavior, not cumulative input, workflow turns, AG2 retry
+middleware, parallel calls, provider tool charges, or USD spending. The current
+wallet preflight is a balance check, not an atomic reservation. Post-response
+debit rejection cannot undo a provider call. Sponsored builds must not be opened
+to unsupervised public use on the assumption that the existing balance check or
+watchdog prevents overspend. Durable pre-call reservation and settlement remain
+required for that guarantee; measurement stays in `TokenManager`, not billing
+or admission policy.
+
 ### AG2 Token Watchdog
 
 `mozaiksai/core/usage/watchdog.py` attaches AG2's built-in `TokenMonitor` to

--- a/mozaiksai/core/adapters/llm_fallback.py
+++ b/mozaiksai/core/adapters/llm_fallback.py
@@ -271,22 +271,24 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
         return GeminiConfig(**kwargs)
     if api_type == "anthropic":
         from ag2.config import AnthropicConfig  # type: ignore[attr-defined]
-        return AnthropicConfig(
-            model=model,
-            api_key=api_key,
-            temperature=temperature,
-            streaming=streaming,
+        kwargs = {
+            "model": model,
+            "api_key": api_key,
+            "temperature": temperature,
+            "streaming": streaming,
             **_model_call_limits(llm_config, entry, ("max_tokens", "max_retries")),
-        )
+        }
+        return AnthropicConfig(**kwargs)
     if api_type == "ollama":
         from ag2.config import OllamaConfig  # type: ignore[attr-defined]
-        return OllamaConfig(
-            model=model,
-            host=base_url or "http://localhost:11434",
-            temperature=temperature,
-            streaming=streaming,
+        kwargs = {
+            "model": model,
+            "host": base_url or "http://localhost:11434",
+            "temperature": temperature,
+            "streaming": streaming,
             **_model_call_limits(llm_config, entry, ("max_tokens",)),
-        )
+        }
+        return OllamaConfig(**kwargs)
     # openai / azure / default
     if api_type == "openai" and bool(llm_config.get("use_responses_api") or llm_config.get("responses_api")):
         from ag2.config import OpenAIResponsesConfig

--- a/mozaiksai/core/adapters/llm_fallback.py
+++ b/mozaiksai/core/adapters/llm_fallback.py
@@ -203,6 +203,28 @@ def build_fallback_llm_config(
 # AG2 typed config factory
 # ---------------------------------------------------------------------------
 
+def _model_call_limits(
+    llm_config: dict[str, Any],
+    entry: dict[str, Any],
+    supported: tuple[str, ...],
+) -> dict[str, int]:
+    """Keep explicit safety controls; never silently ignore an unsupported one."""
+    limits: dict[str, int] = {}
+    for key in ("max_tokens", "max_completion_tokens", "max_output_tokens", "max_retries"):
+        if key not in entry and key not in llm_config:
+            continue
+        if key not in supported:
+            raise ValueError(f"{key} is not supported by the selected AG2 model configuration")
+        value = entry[key] if key in entry else llm_config[key]
+        minimum = 0 if key == "max_retries" else 1
+        if type(value) is not int or value < minimum:
+            raise ValueError(f"{key} must be an integer >= {minimum}; omit it to use the provider default")
+        limits[key] = value
+    if len(limits.keys() - {"max_retries"}) > 1:
+        raise ValueError("Configure only one output token limit for the selected provider")
+    return limits
+
+
 def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
     """Convert an AG2 ``llm_config`` dict to a typed AG2 ``ModelConfig`` instance.
 
@@ -215,6 +237,10 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
     - ``"ollama"``           → ``OllamaConfig``  (local inference)
 
     Any unrecognised api_type falls through to ``OpenAIConfig``.
+
+    Explicit output/retry limits use the provider's native AG2 field names.
+    Provider-entry values override shared defaults. Unsupported, ambiguous,
+    or invalid limit declarations fail before constructing a provider client.
     """
     config_list = llm_config.get("config_list") or []
     if not config_list:
@@ -236,6 +262,7 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
             "api_key": api_key,
             "temperature": temperature,
             "streaming": streaming,
+            **_model_call_limits(llm_config, entry, ("max_output_tokens",)),
         }
         if llm_config.get("response_modalities"):
             kwargs["response_modalities"] = llm_config["response_modalities"]
@@ -244,7 +271,13 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
         return GeminiConfig(**kwargs)
     if api_type == "anthropic":
         from ag2.config import AnthropicConfig  # type: ignore[attr-defined]
-        return AnthropicConfig(model=model, api_key=api_key, temperature=temperature, streaming=streaming)
+        return AnthropicConfig(
+            model=model,
+            api_key=api_key,
+            temperature=temperature,
+            streaming=streaming,
+            **_model_call_limits(llm_config, entry, ("max_tokens", "max_retries")),
+        )
     if api_type == "ollama":
         from ag2.config import OllamaConfig  # type: ignore[attr-defined]
         return OllamaConfig(
@@ -252,6 +285,7 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
             host=base_url or "http://localhost:11434",
             temperature=temperature,
             streaming=streaming,
+            **_model_call_limits(llm_config, entry, ("max_tokens",)),
         )
     # openai / azure / default
     if api_type == "openai" and bool(llm_config.get("use_responses_api") or llm_config.get("responses_api")):
@@ -263,10 +297,11 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
             "base_url": base_url,
             "temperature": temperature,
             "streaming": streaming,
+            **_model_call_limits(llm_config, entry, ("max_output_tokens", "max_retries")),
         }
         if timeout is not None:
             response_kwargs["timeout"] = timeout
-        for key in ("max_output_tokens", "max_tool_calls", "parallel_tool_calls", "store"):
+        for key in ("max_tool_calls", "parallel_tool_calls", "store"):
             if key in llm_config:
                 response_kwargs[key] = llm_config[key]
         return OpenAIResponsesConfig(**response_kwargs)
@@ -278,6 +313,7 @@ def llm_config_to_ag2_config(llm_config: dict[str, Any]) -> Any:
         "base_url": base_url,
         "temperature": temperature,
         "streaming": streaming,
+        **_model_call_limits(llm_config, entry, ("max_tokens", "max_completion_tokens", "max_retries")),
     }
     if timeout is not None:
         kwargs["timeout"] = timeout

--- a/tests/test_ag2_model_call_limits.py
+++ b/tests/test_ag2_model_call_limits.py
@@ -1,0 +1,184 @@
+"""Provider configuration limits must survive the AG2 adapter boundary."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+
+import httpx
+import pytest
+
+from mozaiksai.core.adapters.llm_fallback import llm_config_to_ag2_config
+
+
+@pytest.mark.parametrize(
+    ("provider", "responses", "limit", "dependency"),
+    [
+        ("openai", False, "max_tokens", "openai"),
+        ("openai", False, "max_completion_tokens", "openai"),
+        ("openai", True, "max_output_tokens", "openai"),
+        ("anthropic", False, "max_tokens", "anthropic"),
+        ("google", False, "max_output_tokens", "google.genai"),
+        ("ollama", False, "max_tokens", "ollama"),
+    ],
+)
+@pytest.mark.parametrize("location", ["shared", "provider"])
+def test_output_limit_reaches_real_ag2_config(provider, responses, limit, dependency, location):
+    pytest.importorskip(dependency)
+    source = {
+        "config_list": [{"api_type": provider, "model": "test-model", "api_key": "test"}],
+        "use_responses_api": responses,
+        "streaming": False,
+    }
+    target = source if location == "shared" else source["config_list"][0]
+    target[limit] = 128
+    original = deepcopy(source)
+
+    config = llm_config_to_ag2_config(source)
+
+    assert getattr(config, limit) == 128
+    assert source == original
+
+
+@pytest.mark.parametrize("provider,responses", [("openai", False), ("openai", True), ("anthropic", False)])
+def test_provider_retry_override_preserves_zero(provider, responses):
+    pytest.importorskip(provider)
+    config = llm_config_to_ag2_config({
+        "config_list": [{"api_type": provider, "model": "test", "max_retries": 0}],
+        "use_responses_api": responses,
+        "max_retries": 4,
+    })
+
+    assert config.max_retries == 0
+
+
+def test_provider_limit_overrides_shared_default_without_mutation():
+    source = {
+        "config_list": [{"model": "test", "max_completion_tokens": 128}],
+        "max_completion_tokens": 512,
+    }
+    original = deepcopy(source)
+    assert llm_config_to_ag2_config(source).max_completion_tokens == 128
+    assert source == original
+
+
+@pytest.mark.parametrize(
+    "provider,responses,key",
+    [
+        ("openai", False, "max_output_tokens"),
+        ("openai", True, "max_completion_tokens"),
+        ("openai", True, "max_tokens"),
+        ("anthropic", False, "max_output_tokens"),
+        ("google", False, "max_tokens"),
+        ("google", False, "max_retries"),
+        ("ollama", False, "max_retries"),
+    ],
+)
+def test_unsupported_limit_is_not_silently_discarded(provider, responses, key):
+    with pytest.raises(ValueError, match=key):
+        llm_config_to_ag2_config({
+            "config_list": [{"api_type": provider, "model": "test"}],
+            "use_responses_api": responses,
+            key: 1,
+        })
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, "128", None])
+def test_invalid_output_limit_fails_before_client_creation(value):
+    with pytest.raises(ValueError, match="max_completion_tokens"):
+        llm_config_to_ag2_config({
+            "config_list": [{"model": "test"}],
+            "max_completion_tokens": value,
+        })
+
+
+@pytest.mark.parametrize("value", [-1, True, 1.5, "0", None])
+def test_invalid_retry_limit_fails_before_client_creation(value):
+    with pytest.raises(ValueError, match="max_retries"):
+        llm_config_to_ag2_config({"config_list": [{"model": "test"}], "max_retries": value})
+
+
+def test_conflicting_output_limits_are_rejected():
+    with pytest.raises(ValueError, match="one output token limit"):
+        llm_config_to_ag2_config({
+            "config_list": [{"model": "test", "max_tokens": 128}],
+            "max_completion_tokens": 256,
+        })
+
+
+def test_unconfigured_limits_keep_ag2_defaults():
+    from ag2.config import OpenAIConfig
+
+    actual = llm_config_to_ag2_config({"config_list": [{"model": "test"}]})
+    defaults = OpenAIConfig(model="test")
+    assert actual.max_retries == defaults.max_retries
+    assert actual.max_completion_tokens == defaults.max_completion_tokens
+    assert actual.max_tokens == defaults.max_tokens
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", ["max_tokens", "max_completion_tokens"])
+async def test_limit_reaches_provider_http_through_real_ag2_agent(limit):
+    from ag2 import Agent
+
+    requests = []
+
+    def respond(request):
+        assert request.url.host == "provider.invalid"
+        body = json.loads(request.content)
+        requests.append(body)
+        return httpx.Response(200, json={
+            "id": "bounded-completion",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Complete."},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        config = llm_config_to_ag2_config({
+            "config_list": [{"model": "test-model", "api_key": "test", "base_url": "https://provider.invalid/v1"}],
+            "streaming": False,
+            limit: 128,
+            "max_retries": 0,
+        }).copy(http_client=http)
+        async with Agent("bounded", config=config).run("Complete the task.") as run:
+            await run.result()
+
+    assert len(requests) == 1
+    assert requests[0][limit] == 128
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+async def test_disabled_sdk_retries_make_only_one_attempt(responses):
+    from ag2 import Agent
+    from openai import RateLimitError
+
+    requests = []
+
+    def respond(request):
+        assert request.url.host == "provider.invalid"
+        requests.append(json.loads(request.content))
+        return httpx.Response(429, json={"error": {"message": "Rate limited", "type": "rate_limit_error"}})
+
+    limit = "max_output_tokens" if responses else "max_completion_tokens"
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        config = llm_config_to_ag2_config({
+            "config_list": [{"model": "test-model", "api_key": "test", "base_url": "https://provider.invalid/v1"}],
+            "use_responses_api": responses,
+            "streaming": False,
+            limit: 128,
+            "max_retries": 0,
+        }).copy(http_client=http)
+        with pytest.raises(RateLimitError, match="Rate limited"):
+            async with Agent("bounded", config=config).run("Complete the task.") as run:
+                await run.result()
+
+    assert len(requests) == 1
+    assert requests[0][limit] == 128

--- a/tests/test_ag2_network_tool_routing.py
+++ b/tests/test_ag2_network_tool_routing.py
@@ -187,6 +187,8 @@ async def _agents(
                 }
             ],
             "streaming": False,
+            "max_completion_tokens": 128,
+            "max_retries": 0,
         }
 
     original_converter = factory.llm_config_to_ag2_config
@@ -290,6 +292,7 @@ async def test_workflow_agents_receive_only_declared_tools(
         names = {tool["function"]["name"] for tool in payload.get("tools", [])}
         expected = {"complete_intake", "other_tool"} if payload["model"] == "AgentA" else set()
         assert names == expected
+        assert payload["max_completion_tokens"] == 128
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Forward provider-native output token limits and SDK retry counts into the existing AG2 config adapter; selected provider entries override shared defaults.
- Reject unsupported, ambiguous, or malformed limits before client creation. Omitted limits retain AG2 defaults; zero retries is preserved.
- Verify real AG2 configs for OpenAI, Responses, Anthropic, Gemini, and Ollama, plus real SDK HTTP payloads and a single HTTP attempt on rate limiting with SDK retries disabled. Factory network acceptance also checks output limits.

## Scope and Safety
This is a necessary model-admission foundation, NOT a durable wallet reservation, USD cap, public free-tier enablement, provider retry replacement, or new billing subsystem. Current balance preflight and post-response debit cannot guarantee no overspend; docs state the remaining gap explicitly. No paid calls or infrastructure provisioned.

## OSS Change Impact
- Layer: runtime execution adapter (ExecutionEngine configuration).
- Build workflow: existing factory agents receive the declared controls; no graph, YAML contract, or prompt changes.
- App workspace: generic behavior inherited when upgrading the package; no hosted commercial rules.
- Compatibility: invalid/unsupported explicit limits now fail closed rather than being silently dropped. Native provider field names are not aliases.
- Docs: token management and Unreleased changelog.

## Tests
- Red regression proof: 34 failed / 2 passed before fix.
- Focused adapter/media/config/network: 77 passed.
- Full pytest -q --no-cov with isolated local Mongo: 16493 passed / 96 skipped / 4 warnings (827s).
- Ruff check . and git diff --check passed.
- Public release hold preserved.