### PR TITLE
fix(studio): enforce app registry ownership in persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Security
 
+- Studio App Registry reads, updates, promotions, and deletes now carry the
+  caller's owner scope into Mongo filters. Reopening an app ID cannot transfer
+  ownership; concurrent same-owner creation is idempotent. Directory deletion
+  no longer erases app-wide usage facts. Module creation without a target ID
+  allocates a new app instead of reusing the Studio host's identity.
+
 - App secret declarations now use one typed names-only contract in generation,
   validation, and runtime. Invalid or explicitly missing policies fail closed;
   selecting an app never borrows another workspace's manifest. Environment-only

--- a/docs/architecture/builder/studio-product-model.md
+++ b/docs/architecture/builder/studio-product-model.md
@@ -1,6 +1,6 @@
 # Studio Product Model
 
-This note defines the current production-ready product model for the first-party
+This note defines the current pre-launch product model for the first-party
 Mozaiks management UX.
 
 ## Customer-Facing Terminology
@@ -55,6 +55,30 @@ product workflows for app creation, artifact review, promotion, run history, or
 build lifecycle management.
 
 ## Route Model
+
+### App Registry Ownership
+
+Studio directory records have one immutable `owner_user_id`. HTTP routes derive
+it from the authenticated principal, module actions from `ModuleContext`, and
+local build lifecycle updates from the resolved session owner. It is not an
+editable request field, and knowing an app or registry ID grants no access.
+
+The App Registry repo includes ownership in every record read, lifecycle write,
+and deletion filter. Reopening an app ID never transfers ownership. Concurrent
+creation claims one record through the existing unique app-ID index; an
+interrupted metadata write leaves an owned draft that the same owner can retry.
+Missing owners fail validation. Other-owner and missing records are both absent
+to reads and return `404` from Studio update/delete routes.
+
+Removing a directory record does not purge runtime usage facts. A user-chosen
+registry app ID is not authority to erase app-wide accounting. Account data
+management and runtime retention remain separate owners.
+
+Module creation without an explicit target app ID allocates a fresh app ID;
+it must not reuse the host app ID from `ModuleContext`. This is shared Studio
+behavior inherited by hosted products, not hosted commercial policy.
+
+### Navigation
 
 Workspace-level routes:
 

--- a/factory_app/app/modules/app_registry/backend/handler.py
+++ b/factory_app/app/modules/app_registry/backend/handler.py
@@ -25,11 +25,11 @@ class AppRegistryModule:
         current_build_run: dict[str, object] | None = None,
     ) -> dict:
         result = await self.service.create_app_record(
-            owner_user_id=ctx.user_id or "anonymous",
+            owner_user_id=ctx.user_id or "",
             name=name,
             description=description,
             status=status,
-            app_id=app_id or ctx.app_id,
+            app_id=app_id,
             chat_app_id=chat_app_id,
             active_chat_id=active_chat_id,
             active_workflow_id=active_workflow_id,
@@ -64,6 +64,7 @@ class AppRegistryModule:
         current_build_run: dict[str, object] | None = None,
     ) -> dict:
         result = await self.service.update_build_status(
+            owner_user_id=ctx.user_id or "",
             build_registry_id=build_registry_id,
             status=status,
             bundle_path=bundle_path,
@@ -87,7 +88,7 @@ class AppRegistryModule:
         return result
 
     async def list_apps(self, ctx: ModuleContext) -> dict:
-        return await self.service.list_apps(owner_user_id=ctx.user_id or "anonymous")
+        return await self.service.list_apps(owner_user_id=ctx.user_id or "")
 
     async def get_app_record(
         self,
@@ -97,6 +98,7 @@ class AppRegistryModule:
         build_registry_id: str | None = None,
     ) -> dict:
         return await self.service.get_app_record(
+            owner_user_id=ctx.user_id or "",
             app_id=app_id or ctx.app_id,
             build_registry_id=build_registry_id,
         )
@@ -107,7 +109,7 @@ class AppRegistryModule:
         *,
         build_registry_id: str,
     ) -> dict:
-        result = await self.service.delete_app(build_registry_id=build_registry_id)
+        result = await self.service.delete_app(build_registry_id=build_registry_id, owner_user_id=ctx.user_id or "")
         if result.get("success"):
             await ctx.emit(
                 "domain.app_registry.app_deleted",
@@ -123,7 +125,7 @@ class AppRegistryModule:
     ) -> dict:
         result = await self.service.promote_build(
             build_registry_id=build_registry_id,
-            promoted_by=ctx.user_id or "anonymous",
+            promoted_by=ctx.user_id or "",
         )
         app = result.get("app") or {}
         if app:

--- a/factory_app/app/modules/app_registry/backend/policy.py
+++ b/factory_app/app/modules/app_registry/backend/policy.py
@@ -17,6 +17,13 @@ APP_NAME_SOURCE_SET = set(APP_NAME_SOURCES)
 GENERIC_APP_NAMES = {"new app", "untitled app", "untitled", "app", "my app"}
 
 
+def owner_filter(owner_user_id: str) -> dict[str, str]:
+    owner = normalize_optional_text(owner_user_id)
+    if not owner:
+        raise ValueError("owner_user_id is required")
+    return {"owner_user_id": owner}
+
+
 def validate_lifecycle_state(value: str) -> str:
     normalized = str(value or "").strip().lower()
     if normalized not in APP_LIFECYCLE_STATE_SET:

--- a/factory_app/app/modules/app_registry/backend/repo.py
+++ b/factory_app/app/modules/app_registry/backend/repo.py
@@ -5,9 +5,14 @@ from datetime import UTC, datetime
 from typing import Any, cast
 from uuid import uuid4
 
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
 from mozaiksai.core.data.persistence.namespaces import SYSTEM_DATABASE, RuntimeCollections
 from mozaiksai.core.data.persistence.persistence_manager import AG2PersistenceManager
 from mozaiksai.core.multitenant import build_app_scope_filter
+
+from .policy import owner_filter
 
 IndexSpec = tuple[Sequence[tuple[str, int]], dict[str, Any]]
 APP_REGISTRY_COLLECTION = "AppRegistryRecords"
@@ -66,16 +71,33 @@ class AppRegistryRepo:
         build_context_profile: dict[str, Any] | None = None,
         current_build_run: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        query = {"app_id": app_id, **owner_filter(owner_user_id)}
         await self.ensure_indexes()
         coll = await self._collection()
         now = datetime.now(UTC)
-        existing = await coll.find_one({"app_id": app_id})
-        build_registry_id = str((existing or {}).get("_id") or f"appreg_{uuid4().hex}")
+        # Claim immutable ownership before merging lifecycle metadata. A failed
+        # merge leaves an owned draft that the same owner can safely reopen.
+        try:
+            existing = await coll.find_one_and_update(
+                query,
+                {"$setOnInsert": {
+                    "_id": f"appreg_{uuid4().hex}", "created_at": now,
+                    "updated_at": now, "lifecycle_state": "draft",
+                    "bundle_path": None, "description": None,
+                }},
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError as exc:
+            existing = await coll.find_one(query)
+            if existing is None:
+                raise ValueError("App id is not available") from exc
+        if existing is None:
+            raise RuntimeError("App record ownership could not be established")
+        build_registry_id = str(existing["_id"])
         existing_name_status = str((existing or {}).get("name_status") or "").strip()
         incoming_named = name_status == "named" and bool(name)
         set_fields: dict[str, Any] = {
-            "app_id": app_id,
-            "owner_user_id": owner_user_id,
             "lifecycle_state": lifecycle_state,
             "updated_at": now,
             "last_status_changed_at": now,
@@ -127,21 +149,11 @@ class AppRegistryRepo:
                 (existing or {}).get("build_runs"),
                 build_run,
             )
-        set_on_insert: dict[str, Any] = {
-            "created_at": now,
-            "bundle_path": None,
-        }
-        if "description" not in set_fields:
-            set_on_insert["description"] = description
-        await coll.update_one(
-            {"_id": build_registry_id},
-            {
-                "$set": set_fields,
-                "$setOnInsert": set_on_insert,
-            },
-            upsert=True,
+        doc = await coll.find_one_and_update(
+            {"_id": build_registry_id, **owner_filter(owner_user_id)},
+            {"$set": set_fields},
+            return_document=ReturnDocument.AFTER,
         )
-        doc = await coll.find_one({"_id": build_registry_id})
         normalized = self._normalize_doc(doc)
         if normalized is None:
             raise RuntimeError("App record could not be loaded after upsert")
@@ -151,6 +163,7 @@ class AppRegistryRepo:
         self,
         *,
         build_registry_id: str,
+        owner_user_id: str,
         lifecycle_state: str,
         bundle_path: str | None = None,
         artifact_version_id: str | None = None,
@@ -159,9 +172,10 @@ class AppRegistryRepo:
         active_workflow_id: str | None = None,
         current_build_run: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
+        query = {"_id": build_registry_id, **owner_filter(owner_user_id)}
         await self.ensure_indexes()
         coll = await self._collection()
-        existing = await coll.find_one({"_id": build_registry_id})
+        existing = await coll.find_one(query)
         if not existing:
             return None
         now = datetime.now(UTC)
@@ -201,31 +215,35 @@ class AppRegistryRepo:
             )
             update_fields["current_build_run"] = build_run
             update_fields["build_runs"] = self._upsert_build_run(existing.get("build_runs"), build_run)
-        await coll.update_one({"_id": build_registry_id}, {"$set": update_fields}, upsert=False)
-        return await self.get_by_build_registry_id(build_registry_id=build_registry_id)
+        doc = await coll.find_one_and_update(query, {"$set": update_fields}, return_document=ReturnDocument.AFTER)
+        return self._normalize_doc(doc)
 
     async def list_apps_for_user(self, *, owner_user_id: str) -> list[dict[str, Any]]:
+        query = owner_filter(owner_user_id)
         await self.ensure_indexes()
         coll = await self._collection()
-        docs = await coll.find({"owner_user_id": owner_user_id}).sort("updated_at", -1).to_list(length=500)
+        docs = await coll.find(query).sort("updated_at", -1).to_list(length=500)
         records = [normalized for doc in docs if (normalized := self._normalize_doc(doc))]
         return [await self._with_active_chat_fallback(record, owner_user_id=owner_user_id) for record in records]
 
-    async def get_by_app_id(self, *, app_id: str) -> dict[str, Any] | None:
+    async def get_by_app_id(self, *, app_id: str, owner_user_id: str) -> dict[str, Any] | None:
+        query = {"app_id": app_id, **owner_filter(owner_user_id)}
         await self.ensure_indexes()
         coll = await self._collection()
-        doc = await coll.find_one({"app_id": app_id})
+        doc = await coll.find_one(query)
         return self._normalize_doc(doc)
 
-    async def get_by_build_registry_id(self, *, build_registry_id: str) -> dict[str, Any] | None:
+    async def get_by_build_registry_id(self, *, build_registry_id: str, owner_user_id: str) -> dict[str, Any] | None:
+        query = {"_id": build_registry_id, **owner_filter(owner_user_id)}
         await self.ensure_indexes()
         coll = await self._collection()
-        doc = await coll.find_one({"_id": build_registry_id})
+        doc = await coll.find_one(query)
         return self._normalize_doc(doc)
 
-    async def delete_app(self, *, build_registry_id: str) -> bool:
+    async def delete_app(self, *, build_registry_id: str, owner_user_id: str) -> bool:
+        query = {"_id": build_registry_id, **owner_filter(owner_user_id)}
         coll = await self._collection()
-        result = await coll.delete_one({"_id": build_registry_id})
+        result = await coll.delete_one(query)
         return int(getattr(result, "deleted_count", 0) or 0) > 0
 
     async def _with_active_chat_fallback(

--- a/factory_app/app/modules/app_registry/backend/service.py
+++ b/factory_app/app/modules/app_registry/backend/service.py
@@ -76,6 +76,7 @@ class AppRegistryService:
         self,
         *,
         build_registry_id: str,
+        owner_user_id: str,
         status: str,
         bundle_path: str | None = None,
         artifact_version_id: str | None = None,
@@ -95,6 +96,7 @@ class AppRegistryService:
             current_build_run=current_build_run,
         )
         app = await self.repo.update_lifecycle_state(
+            owner_user_id=owner_user_id,
             build_registry_id=payload["build_registry_id"],
             lifecycle_state=payload["status"],
             bundle_path=payload["bundle_path"],
@@ -113,6 +115,7 @@ class AppRegistryService:
     async def get_app_record(
         self,
         *,
+        owner_user_id: str,
         app_id: str | None = None,
         build_registry_id: str | None = None,
     ) -> dict[str, Any]:
@@ -120,9 +123,9 @@ class AppRegistryService:
         normalized_record_id = normalize_optional_text(build_registry_id)
         app = None
         if normalized_record_id:
-            app = await self.repo.get_by_build_registry_id(build_registry_id=normalized_record_id)
+            app = await self.repo.get_by_build_registry_id(build_registry_id=normalized_record_id, owner_user_id=owner_user_id)
         elif normalized_app_id:
-            app = await self.repo.get_by_app_id(app_id=normalized_app_id)
+            app = await self.repo.get_by_app_id(app_id=normalized_app_id, owner_user_id=owner_user_id)
         return {"app": app}
 
     async def promote_build(
@@ -134,7 +137,7 @@ class AppRegistryService:
         normalized_record_id = normalize_optional_text(build_registry_id)
         if not normalized_record_id:
             raise ValueError("build_registry_id is required")
-        record = await self.repo.get_by_build_registry_id(build_registry_id=normalized_record_id)
+        record = await self.repo.get_by_build_registry_id(build_registry_id=normalized_record_id, owner_user_id=promoted_by)
         if not record:
             raise ValueError(f"App record not found: {normalized_record_id}")
         current_state = record.get("lifecycle_state", "")
@@ -143,27 +146,19 @@ class AppRegistryService:
                 f"Cannot promote app from '{current_state}' state. App must be in 'review' to promote."
             )
         app = await self.repo.update_lifecycle_state(
+            owner_user_id=promoted_by,
             build_registry_id=normalized_record_id,
             lifecycle_state="active",
             bundle_path=record.get("bundle_path"),
         )
         return {"success": app is not None, "app": app}
 
-    async def delete_app(self, *, build_registry_id: str) -> dict[str, Any]:
+    async def delete_app(self, *, build_registry_id: str, owner_user_id: str) -> dict[str, Any]:
         normalized_record_id = normalize_optional_text(build_registry_id)
         if not normalized_record_id:
             raise ValueError("build_registry_id is required")
-        # Resolve app_id before deleting so we can cascade-purge usage events
-        existing = await self.repo.get_by_build_registry_id(build_registry_id=normalized_record_id)
-        deleted = await self.repo.delete_app(build_registry_id=normalized_record_id)
-        if deleted and existing:
-            app_id = existing.get("app_id")
-            if app_id:
-                try:
-                    from mozaiksai.core.usage import get_runtime_usage_ledger
-                    await get_runtime_usage_ledger().purge_usage_for_app(app_id=app_id)
-                except Exception:
-                    pass  # usage purge is best-effort; don't fail the delete
+        # A directory record does not authorize deleting app-wide usage facts.
+        deleted = await self.repo.delete_app(build_registry_id=normalized_record_id, owner_user_id=owner_user_id)
         return {"success": deleted}
 
     async def ensure_status_for_app(
@@ -174,10 +169,11 @@ class AppRegistryService:
         status: str,
         default_name: str | None = None,
     ) -> dict[str, Any]:
-        existing = await self.repo.get_by_app_id(app_id=app_id)
+        existing = await self.repo.get_by_app_id(app_id=app_id, owner_user_id=owner_user_id)
         validated_status = validate_lifecycle_state(status)
         if existing:
             app = await self.repo.update_lifecycle_state(
+                owner_user_id=owner_user_id,
                 build_registry_id=existing["build_registry_id"],
                 lifecycle_state=validated_status,
             )

--- a/factory_app/app/modules/app_registry/module.yaml
+++ b/factory_app/app/modules/app_registry/module.yaml
@@ -14,7 +14,7 @@ permissions:
     description: Create app records and update lifecycle state.
 actions:
   - id: create_app_record
-    description: Create or reopen an app lifecycle record.
+    description: Create or reopen an app lifecycle record owned by the current user. Omitted app_id allocates a new app.
     handler_method: create_app_record
     input_schema:
       type: object
@@ -80,7 +80,7 @@ actions:
     emits:
       - domain.app_registry.app_created
   - id: update_build_status
-    description: Update the lifecycle state for an existing app record.
+    description: Update the lifecycle state for an existing app record owned by the current user.
     handler_method: update_build_status
     input_schema:
       type: object
@@ -139,7 +139,7 @@ actions:
     permissions:
       - app_registry.read
   - id: get_app_record
-    description: Fetch one app lifecycle record by app id or build registry id.
+    description: Fetch an owned app lifecycle record by app id or build registry id.
     handler_method: get_app_record
     input_schema:
       type: object

--- a/factory_app/workflows/_shared/platform/build_lifecycle.py
+++ b/factory_app/workflows/_shared/platform/build_lifecycle.py
@@ -612,11 +612,14 @@ async def _materialize_local_app_registry_event(
         build_registry_id = _normalize_text(context.get("build_registry_id"))
         existing = None
         if build_registry_id and context.get("build_registry_id_source") != "build_id_fallback":
-            existing_response = await service.get_app_record(build_registry_id=build_registry_id)
+            existing_response = await service.get_app_record(
+                build_registry_id=build_registry_id, owner_user_id=registry_payload["owner_user_id"],
+            )
             existing = existing_response.get("app") if isinstance(existing_response, dict) else None
 
         if isinstance(existing, dict) and existing.get("build_registry_id"):
             await service.update_build_status(
+                owner_user_id=registry_payload["owner_user_id"],
                 build_registry_id=str(existing["build_registry_id"]),
                 status=lifecycle_state,
                 workflow_sequence=registry_payload["current_build_run"].get("workflow_sequence"),

--- a/mozaiksai/hosts/studio.py
+++ b/mozaiksai/hosts/studio.py
@@ -660,7 +660,7 @@ async def get_app_overview(
     app_id: str | None = None,
     principal: UserPrincipal = Depends(require_user_scope),
 ):
-    resolved_app_id, _ = _resolve_studio_scope(principal, app_id=app_id)
+    resolved_app_id, user_id = _resolve_studio_scope(principal, app_id=app_id)
     app_root = resolve_app_root()
     missing_surfaces = get_missing_studio_surfaces(app_root)
     if missing_surfaces:
@@ -670,7 +670,7 @@ async def get_app_overview(
         )
 
     try:
-        record = (await _get_app_registry_service().get_app_record(app_id=resolved_app_id)).get("app")
+        record = (await _get_app_registry_service().get_app_record(app_id=resolved_app_id, owner_user_id=user_id)).get("app")
         if not isinstance(record, dict):
             raise HTTPException(status_code=404, detail=f"App record not found: {resolved_app_id}")
         return build_app_overview_summary(
@@ -769,9 +769,10 @@ async def update_workspace_app_status(
     body: UpdateWorkspaceAppStatusRequest,
     principal: UserPrincipal = Depends(require_user_scope),
 ):
-    _, _user_id = _resolve_studio_scope(principal)
+    _, user_id = _resolve_studio_scope(principal)
     try:
-        return await _get_app_registry_service().update_build_status(
+        result = await _get_app_registry_service().update_build_status(
+            owner_user_id=user_id,
             build_registry_id=build_registry_id,
             status=body.status,
             bundle_path=body.bundle_path,
@@ -781,6 +782,11 @@ async def update_workspace_app_status(
             active_workflow_id=body.active_workflow_id,
             current_build_run=body.current_build_run,
         )
+        if not result.get("success"):
+            raise HTTPException(status_code=404, detail="App registry record not found")
+        return result
+    except HTTPException:
+        raise
     except ValueError as exc:
         logger.warning("update_app_status validation error: %s", exc)
         raise HTTPException(status_code=400, detail="Invalid app status parameters.") from exc
@@ -794,9 +800,14 @@ async def delete_workspace_app(
     build_registry_id: str,
     principal: UserPrincipal = Depends(require_user_scope),
 ):
-    _, _user_id = _resolve_studio_scope(principal)
+    _, user_id = _resolve_studio_scope(principal)
     try:
-        return await _get_app_registry_service().delete_app(build_registry_id=build_registry_id)
+        result = await _get_app_registry_service().delete_app(build_registry_id=build_registry_id, owner_user_id=user_id)
+        if not result.get("success"):
+            raise HTTPException(status_code=404, detail="App registry record not found")
+        return result
+    except HTTPException:
+        raise
     except ValueError as exc:
         logger.warning("delete_app validation error: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1895,7 +1906,7 @@ async def promote_build_artifact_version(
     if promotion_build_registry_id:
         app_registry_service = _get_app_registry_service()
         registry_record = (
-            await app_registry_service.get_app_record(build_registry_id=promotion_build_registry_id)
+            await app_registry_service.get_app_record(build_registry_id=promotion_build_registry_id, owner_user_id=user_id)
         ).get("app")
         if not registry_record:
             raise HTTPException(
@@ -2072,7 +2083,7 @@ async def get_build_surface(
     app_id: str | None = None,
     principal: UserPrincipal = Depends(require_user_scope),
 ):
-    app_id, _ = _resolve_studio_scope(principal, app_id=app_id)
+    app_id, user_id = _resolve_studio_scope(principal, app_id=app_id)
     app_root = resolve_app_root()
     missing_surfaces = get_missing_studio_surfaces(app_root)
     if missing_surfaces:
@@ -2082,7 +2093,7 @@ async def get_build_surface(
         )
 
     try:
-        record = (await _get_app_registry_service().get_app_record(app_id=app_id)).get("app")
+        record = (await _get_app_registry_service().get_app_record(app_id=app_id, owner_user_id=user_id)).get("app")
         if not isinstance(record, dict):
             raise HTTPException(status_code=404, detail=f"App record not found: {app_id}")
         build_state = await load_build_state_from_db(app_id)

--- a/tests/test_app_registry_module.py
+++ b/tests/test_app_registry_module.py
@@ -79,13 +79,13 @@ class _FakeRepo:
             return [self.record]
         return []
 
-    async def get_by_app_id(self, *, app_id: str):
-        if self.record and self.record["app_id"] == app_id:
+    async def get_by_app_id(self, *, app_id: str, owner_user_id: str):
+        if self.record and self.record["app_id"] == app_id and self.record["owner_user_id"] == owner_user_id:
             return self.record
         return None
 
-    async def get_by_build_registry_id(self, *, build_registry_id: str):
-        if self.record and self.record["build_registry_id"] == build_registry_id:
+    async def get_by_build_registry_id(self, *, build_registry_id: str, owner_user_id: str):
+        if self.record and self.record["build_registry_id"] == build_registry_id and self.record["owner_user_id"] == owner_user_id:
             return self.record
         return None
 
@@ -108,6 +108,7 @@ async def test_app_registry_service_creates_and_updates_lifecycle_records() -> N
     assert app["name_source"] == "manual"
 
     updated = await service.update_build_status(
+        owner_user_id="user_1",
         build_registry_id="appreg_1",
         status="review",
         bundle_path="generated/apps/app_1/build_1/app",
@@ -167,6 +168,7 @@ async def test_app_registry_service_persists_build_context_and_current_run() -> 
     assert app["current_build_run"]["active_chat_id"] == "chat_1"
 
     updated = await service.update_build_status(
+        owner_user_id="user_1",
         build_registry_id="appreg_1",
         status="review",
         bundle_path="generated/apps/app_1/build_1/app",

--- a/tests/test_build_lifecycle_hooks.py
+++ b/tests/test_build_lifecycle_hooks.py
@@ -375,6 +375,7 @@ async def test_emit_build_completed_updates_existing_local_registry_record(monke
     assert registry.create_calls == []
     assert registry.update_calls == [
         {
+            "owner_user_id": "user_1",
             "build_registry_id": "build_reg_1",
             "status": "review",
             "workflow_sequence": "build",

--- a/tests/test_studio_app_registry_ownership_mongo.py
+++ b/tests/test_studio_app_registry_ownership_mongo.py
@@ -1,0 +1,232 @@
+"""Signed-user Studio requests exercise real registry persistence boundaries."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import jwt
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from factory_app.app.modules.app_registry.backend.handler import AppRegistryModule
+from factory_app.app.modules.app_registry.backend.repo import AppRegistryRepo
+from factory_app.app.modules.app_registry.backend.service import AppRegistryService
+from mozaiksai.core.auth import reset_auth_adapter
+
+
+@pytest_asyncio.fixture
+async def registry_host(monkeypatch):
+    database_name = f"registry_ownership_{uuid4().hex}"
+    mongo = AsyncIOMotorClient(os.getenv("MONGO_URI", "mongodb://127.0.0.1:27017"), serverSelectionTimeoutMS=1500)
+    try:
+        await mongo.admin.command("ping")
+    except Exception:
+        mongo.close()
+        if os.getenv("MOZAIKS_REQUIRE_REAL_MONGO"):
+            pytest.fail("Real Mongo is required for app registry ownership acceptance")
+        pytest.skip("Mongo is unavailable")
+    collection = mongo[database_name]["AppRegistryRecords"]
+    repo = AppRegistryRepo.__new__(AppRegistryRepo)
+
+    async def get_collection():
+        return collection
+
+    monkeypatch.setattr(repo, "_collection", get_collection)
+    service = AppRegistryService(repo=repo)
+    monkeypatch.setenv("PLATFORM_PATH", str(Path(__file__).resolve().parents[1] / "factory_app" / "app"))
+    monkeypatch.setenv("ENV", "test")
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+    monkeypatch.setenv("SUPABASE_URL", "http://127.0.0.1")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    signing_key = uuid4().hex + uuid4().hex
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", signing_key)
+    reset_auth_adapter()
+    import mozaiksai.core.usage as usage
+    from mozaiksai.hosts import studio
+
+    purged = []
+
+    async def purge(*, app_id):
+        purged.append(app_id)
+
+    monkeypatch.setattr(usage, "get_runtime_usage_ledger", lambda: SimpleNamespace(purge_usage_for_app=purge))
+    monkeypatch.setattr(studio, "_get_app_registry_service", lambda: service)
+
+    def headers(user):
+        now = datetime.now(UTC)
+        token = jwt.encode(
+            {"sub": user, "aud": "authenticated", "role": "authenticated", "iat": now,
+             "exp": now + timedelta(minutes=5)},
+            signing_key, algorithm="HS256",
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    try:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=studio.app), base_url="http://test") as http:
+            yield SimpleNamespace(http=http, service=service, collection=collection, headers=headers, purged=purged)
+    finally:
+        reset_auth_adapter()
+        assert database_name.startswith("registry_ownership_")
+        await mongo.drop_database(database_name)
+        mongo.close()
+
+
+async def _create(host, *, owner="alice", app_id="owned-app", status="review"):
+    response = await host.http.post(
+        "/api/studio/apps", headers=host.headers(owner),
+        json={"app_id": app_id, "name": "Owner's app", "status": status},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["app"]
+
+
+async def test_another_user_cannot_take_over_existing_app_id(registry_host):
+    host = registry_host
+    record = await _create(host)
+    before = await host.collection.find_one({"_id": record["build_registry_id"]})
+    response = await host.http.post(
+        "/api/studio/apps", headers=host.headers("bob"),
+        json={"app_id": "owned-app", "name": "Replacement", "owner_user_id": "alice"},
+    )
+    assert response.status_code == 400
+    assert await host.collection.find_one({"_id": record["build_registry_id"]}) == before
+
+
+@pytest.mark.parametrize("path", ["/api/studio/overview", "/api/studio/build"])
+async def test_studio_reads_hide_other_owners_record(registry_host, path):
+    host = registry_host
+    await _create(host)
+    response = await host.http.get(path + "?app_id=owned-app", headers=host.headers("bob"))
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.parametrize("method", ["PUT", "DELETE"])
+async def test_other_owner_and_anonymous_cannot_mutate_or_purge(registry_host, method):
+    host = registry_host
+    record = await _create(host)
+    before = await host.collection.find_one({"_id": record["build_registry_id"]})
+    path = f"/api/studio/apps/{record['build_registry_id']}" + ("/status" if method == "PUT" else "")
+    payload = {"status": "active"} if method == "PUT" else None
+    assert (await host.http.request(method, path, json=payload)).status_code == 401
+    response = await host.http.request(method, path, json=payload, headers=host.headers("bob"))
+    assert response.status_code == 404
+    assert await host.collection.find_one({"_id": record["build_registry_id"]}) == before
+    assert host.purged == []
+
+
+async def test_owner_can_reopen_update_and_delete_record(registry_host):
+    host = registry_host
+    original = await _create(host)
+    reopened = await _create(host)
+    assert original["build_registry_id"] == reopened["build_registry_id"]
+    path = f"/api/studio/apps/{original['build_registry_id']}"
+    updated = await host.http.put(path + "/status", headers=host.headers("alice"), json={"status": "active"})
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["app"]["lifecycle_state"] == "active"
+    deleted = await host.http.delete(path, headers=host.headers("alice"))
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json()["success"] is True
+    assert await host.collection.count_documents({}) == 0
+    assert host.purged == []
+
+
+async def test_concurrent_same_owner_creation_is_idempotent(registry_host):
+    host = registry_host
+    results = await asyncio.gather(*[_create(host) for _ in range(12)])
+    assert len({item["build_registry_id"] for item in results}) == 1
+    assert await host.collection.count_documents({}) == 1
+
+
+async def test_service_reads_and_promotions_require_owner(registry_host):
+    host = registry_host
+    record = await _create(host)
+    for reference in ({"app_id": "owned-app"}, {"build_registry_id": record["build_registry_id"]}):
+        assert (await host.service.get_app_record(owner_user_id="bob", **reference))["app"] is None
+        assert (await host.service.get_app_record(owner_user_id="alice", **reference))["app"]["app_id"] == "owned-app"
+    with pytest.raises(ValueError, match="not found"):
+        await host.service.promote_build(build_registry_id=record["build_registry_id"], promoted_by="bob")
+    assert (await host.collection.find_one({"app_id": "owned-app"}))["lifecycle_state"] == "review"
+    result = await host.service.promote_build(build_registry_id=record["build_registry_id"], promoted_by="alice")
+    assert result["app"]["lifecycle_state"] == "active"
+
+
+async def test_ensure_status_cannot_reopen_someone_elses_record(registry_host):
+    host = registry_host
+    await _create(host)
+    before = await host.collection.find_one({"app_id": "owned-app"})
+    with pytest.raises(ValueError):
+        await host.service.ensure_status_for_app(app_id="owned-app", owner_user_id="bob", status="draft")
+    assert await host.collection.find_one({"app_id": "owned-app"}) == before
+
+
+@pytest.mark.parametrize("owner", [None, "", " "])
+async def test_missing_owner_cannot_create_a_record(registry_host, owner):
+    with pytest.raises(ValueError, match="owner_user_id"):
+        await registry_host.service.create_app_record(owner_user_id=owner, app_id="new-app")
+    assert await registry_host.collection.count_documents({}) == 0
+
+
+async def test_concurrent_different_owners_cannot_share_an_app_id(registry_host):
+    host = registry_host
+    owners = ["alice", "bob"] * 6
+    responses = await asyncio.gather(*[
+        host.http.post("/api/studio/apps", headers=host.headers(owner), json={"app_id": "shared-target"})
+        for owner in owners
+    ])
+    record = await host.collection.find_one({"app_id": "shared-target"})
+    assert await host.collection.count_documents({}) == 1
+    for owner, response in zip(owners, responses, strict=True):
+        assert response.status_code == (200 if owner == record["owner_user_id"] else 400)
+
+
+async def test_interrupted_creation_keeps_ownership_and_allows_owner_retry(registry_host, monkeypatch):
+    host = registry_host
+    original = host.collection.find_one_and_update
+
+    async def interrupted(query, update, **kwargs):
+        if "$set" in update:
+            raise RuntimeError("interrupted metadata write")
+        return await original(query, update, **kwargs)
+
+    monkeypatch.setattr(host.collection, "find_one_and_update", interrupted)
+    with pytest.raises(RuntimeError, match="interrupted metadata"):
+        await host.service.create_app_record(owner_user_id="alice", app_id="owned-app")
+    draft = await host.collection.find_one({"app_id": "owned-app"})
+    assert draft["owner_user_id"] == "alice"
+    assert draft["lifecycle_state"] == "draft"
+    monkeypatch.setattr(host.collection, "find_one_and_update", original)
+    with pytest.raises(ValueError, match="not available"):
+        await host.service.create_app_record(owner_user_id="bob", app_id="owned-app")
+    reopened = await _create(host)
+    assert reopened["build_registry_id"] == draft["_id"]
+
+
+async def test_module_actions_use_context_owner_and_do_not_emit_on_denial(registry_host):
+    host = registry_host
+    record = await _create(host)
+    events = []
+
+    async def emit(*args):
+        events.append(args)
+
+    module = AppRegistryModule(service=host.service)
+    context = SimpleNamespace(user_id="bob", app_id="studio-host", emit=emit)
+    reference = {"build_registry_id": record["build_registry_id"]}
+    assert (await module.get_app_record(context, **reference))["app"] is None
+    assert (await module.update_build_status(context, status="active", **reference))["success"] is False
+    assert (await module.delete_app(context, **reference))["success"] is False
+    with pytest.raises(ValueError, match="not found"):
+        await module.promote_build(context, **reference)
+    assert events == []
+    created = await module.create_app_record(context, name="Independent app")
+    assert created["app"]["app_id"] != "studio-host"
+    assert created["app"]["owner_user_id"] == "bob"

--- a/tests/test_studio_artifact_restore.py
+++ b/tests/test_studio_artifact_restore.py
@@ -148,7 +148,8 @@ class _AppRegistryServiceDouble:
         }
         self.promote_calls: list[dict[str, str | None]] = []
 
-    async def get_app_record(self, *, app_id: str | None = None, build_registry_id: str | None = None):
+    async def get_app_record(self, *, owner_user_id: str, app_id: str | None = None, build_registry_id: str | None = None):
+        assert owner_user_id == "demo-user"
         if build_registry_id == self.app["build_registry_id"] or app_id == self.app["app_id"]:
             return {"app": dict(self.app)}
         return {"app": None}


### PR DESCRIPTION
## Summary
- Carry authenticated owner scope through Studio routes, app registry module/service/repo, and local factory lifecycle consumers; scope the actual Mongo read/write/delete filters.
- Claim immutable registry ownership using the existing unique app-ID index. Same-owner concurrent creation reuses one record; interrupted creation leaves an owned draft recoverable by its owner.
- Remove directory-delete usage purging: a registry record cannot authorize erasing app-wide accounting. Module creation without a target allocates a fresh app ID instead of using the Studio host identity.

## Evidence
Before the fix, real authenticated HTTP/Mongo tests reproduced cross-owner modification, deletion, takeover, and concurrent-creation failures (9 failed, 1 passed).
After the fix:
- Full suite: 16468 passed, 96 skipped, 4 warnings (real disposable Mongo, no paid provider calls).
- Focused Studio/registry/lifecycle acceptance: 63 passed, 2 skipped; final owner/module recheck: 20 passed.
- ruff check ., git diff --check, governance_guardrails --all --errors-only: passed.
- Full mypy: 604 source files passed.

## OSS Change Impact
- Layer: shared Studio management capability, not hosted commercial policy or agent scheduling.
- Build workflow: existing lifecycle registry calls now carry their resolved session owner. No transitions, entrypoints, agent prompts, generation schemas, or AG2 execution mechanics changed.
- Runtime/platform: authenticated Studio record access is owner-scoped; non-owner update/delete returns 404.
- App workspace: first-party app_registry handlers and manifest descriptions aligned; module loader and generated module shapes unchanged.
- Docs: Studio ownership contract and unreleased changelog updated.
- Compatibility: pre-1.0 replacement. Internal registry service/repo callers must supply owner_user_id; no unscoped compatibility fallback. Existing hosted product does not call these Python methods directly, but inherits Studio HTTP behavior when its OSS pin advances.

## Limits
This fixes ownership of existing Studio directory records; it is not a complete tenant/security audit, authoritative generated-app identity redesign, or paid-build budget reservation. No public release, infrastructure provisioning, or cloud deployment.