### PR TITLE
fix(factory): require explicit concept review before handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,9 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_GC: "1"
 
+      - name: Concept review interactions
+        run: npm run test:concept-review
+
       - name: Responsive smoke
         run: npm run test:responsive-smoke
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- ValueEngine concept review now waits for a structured approve, request-changes,
+  or cancel action tied to the displayed draft. Stale reviews, failed saves, and
+  invalid responses cannot complete the workflow. The declared review budget is
+  three proposals per run, with retries only after an explicit request for changes;
+  this is an execution guard, not a subscription allowance.
+
 - Preserve explicit provider-native output token limits and SDK retry counts
   when converting runtime LLM configuration to AG2. Invalid, conflicting, or
   unsupported limits now fail before a provider request instead of disappearing.

--- a/docs/architecture/builder/shared-workflow-infrastructure.md
+++ b/docs/architecture/builder/shared-workflow-infrastructure.md
@@ -65,6 +65,45 @@ need the same component, move the reusable implementation to `_shared/ui/` and
 keep only workflow-specific wrappers or registration barrels inside each
 workflow's `ui/` directory.
 
+## ValueEngine Concept Review
+
+`ValueEngine/tools/manifest.py` owns the concept-specific review operation. Its
+`save_value_manifest` tool is response-bearing (`UI_Tool`), auto-invoked after
+structured output, and not separately exposed as an agent-callable tool. One
+`ConceptBlueprint` component displays the draft and collects its review; it
+does not emit a second display-only surface.
+
+The operation persists a draft, then binds the structured response to a fresh
+`review_id`. `BuilderArtifactStore.finish_concept_review` applies the decision
+only to the current pending draft and its reviewer. A unique app index keeps one
+current concept record per app. Duplicate pre-1.0 concept records must be
+resolved before the index can be created; they are not silently chosen between.
+
+The existing `ToolOutcomeSpec` writes `concept_review_outcome`, and the existing
+AG2 transition graph consumes it:
+
+- `approved`: complete ValueEngine so the normal build journey can advance.
+- `changes_requested`: return to the user; the next message resumes
+  GapAnalysisAgent with `concept_review_feedback`.
+- `cancelled` or `blocked`: end unsuccessfully; do not advance downstream.
+
+`tools.yaml` declares three proposals per run and permits another invocation only
+after `changes_requested`. This workflow execution guard is independent of
+subscription entitlements and hosted revision charging. Freeform chat prose and
+model-generated text do not grant approval. An approved scope is populated only
+after the structured decision and required persistence succeed.
+
+This review contract does not resolve the separate factory registration/identity
+boundary: session `app_id` must not be overwritten with a generated target app ID
+to make registration work. A full hosted Genesis proof still requires aligned,
+server-owned build registration, artifact addressing, and usage scope. Component
+tests and isolated runtime smoke tests do not prove that hosted journey.
+
+Run the focused backend checks with `pytest tests/test_value_engine_concept_review.py
+tests/test_concept_review_real_mongo.py --no-cov`; the latter uses an isolated
+database on `MONGO_URI`. Run the browser checks from `web_shell` with
+`npm run test:concept-review` after installing Playwright Chromium.
+
 ## What Must Stay Workflow-Local
 
 Keep code inside `factory_app/workflows/{WorkflowName}/tools/` when any of the

--- a/factory_app/workflows/ValueEngine/agents.yaml
+++ b/factory_app/workflows/ValueEngine/agents.yaml
@@ -335,8 +335,10 @@ agents:
       If the app is mostly CRUD/modules, one known workflow, or fixed transition/sequence routing, do not emit `refinement`; prefer `module` or `workflow`.
       Use `external_integration` when the surface is mainly a third-party system boundary such as payment provider onboarding, hosting providers, ads APIs, or CRM APIs. Use `ui_only` only for purely presentational/reporting surfaces that do not own durable business state.
 
-      Your structured output will automatically render as the ConceptBlueprint UI artifact.
-      After output, the runtime persists the manifest and asks the user for approval.
+      Your structured output is a proposed concept, not an approved contract.
+      The save_value_manifest auto tool persists the draft and waits for an explicit structured user review.
+      Only that review can approve the handoff. Never infer approval from chat prose or emit approval state yourself.
+      If changes were requested, revise the blueprint using concept_review_feedback and the user's next message.
   - id: output_format
     heading: '[OUTPUT FORMAT]'
     content: |-

--- a/factory_app/workflows/ValueEngine/context_variables.yaml
+++ b/factory_app/workflows/ValueEngine/context_variables.yaml
@@ -380,6 +380,26 @@ definitions:
     source:
       type: state
       default: false
+  concept_review_outcome:
+    type: string
+    authority_class: closed_writer_routing_state
+    writer_ids: [deterministic_tool]
+    persisted: true
+    source: {type: state, default: blocked}
+  concept_review_attempts:
+    type: integer
+    authority_class: closed_writer_quality_state
+    writer_ids: [deterministic_tool]
+    persisted: true
+    source: {type: state, default: 0}
+  concept_review_feedback:
+    type: string
+    description: User feedback returned by the structured concept review, never approval authority.
+    source: {type: state, default: ""}
+  value_manifest:
+    type: object
+    description: The persisted concept summary and its review status.
+    source: {type: computed, default: null}
 
 # ============================================================================
 # COMPUTED - Values set by tools/agents
@@ -533,6 +553,7 @@ agents:
     - concept_presented
   GapAnalysisAgent:
     variables:
+    - concept_review_feedback
     - app_type
     - app_name
     - github_repo

--- a/factory_app/workflows/ValueEngine/tools.yaml
+++ b/factory_app/workflows/ValueEngine/tools.yaml
@@ -8,14 +8,72 @@ tools:
 - agent: GapAnalysisAgent
   file: manifest.py
   function: save_value_manifest
-  description: Auto-invoked after GapAnalysisAgent outputs ConceptBlueprint. Persists manifest and emits UI artifact.
-  tool_type: UI_Surface
+  description: Persist the concept draft and collect a structured owner review before downstream generation.
+  tool_type: UI_Tool
   auto_tool_call: true
+  bind_to_agent: false
+  outcome:
+    context_key: concept_review_outcome
+    attempts_key: concept_review_attempts
+    result_field: outcome
+    values: [approved, changes_requested, cancelled, blocked]
+    error_value: blocked
+    max_attempts: 3
+    retry_on: [changes_requested]
   ui:
     component: ConceptBlueprint
     mode: artifact
-    workflow_primitive: document_preview
-    realization: generated_component
+    workflow_primitive: approval_card
+    realization: workflow_wrapper
+  ui_contract:
+    surface_kind: agent_tool
+    payload_schema:
+      type: object
+      required: [review_id, blueprint]
+      properties:
+        review_id: {type: string}
+        blueprint: {type: object}
+      additionalProperties: true
+    actions_schema:
+    - id: approve
+      label: Approve Concept
+      variant: primary
+      approved: true
+      payload_schema:
+        type: object
+        required: [action, approved, review_id]
+        properties:
+          action: {type: string, enum: [approve]}
+          approved: {type: boolean, const: true}
+          review_id: {type: string}
+          rationale: {type: string}
+        additionalProperties: false
+    - id: request_changes
+      label: Request Changes
+      variant: secondary
+      approved: false
+      payload_schema:
+        type: object
+        required: [action, approved, review_id]
+        properties:
+          action: {type: string, enum: [request_changes]}
+          approved: {type: boolean, const: false}
+          review_id: {type: string}
+          rationale: {type: string}
+        additionalProperties: false
+    - id: cancel
+      label: Cancel
+      variant: ghost
+      approved: false
+      payload_schema:
+        type: object
+        required: [action, approved, review_id]
+        properties:
+          action: {type: string, enum: [cancel]}
+          approved: {type: boolean, const: false}
+          review_id: {type: string}
+          rationale: {type: string}
+        additionalProperties: false
 
 - agent: GapAnalysisAgent
   file: manifest.py

--- a/factory_app/workflows/ValueEngine/tools/manifest.py
+++ b/factory_app/workflows/ValueEngine/tools/manifest.py
@@ -1,51 +1,39 @@
-"""
-Value Manifest Tool - Save and update the app's value direction.
-
-Auto-invoked after GapAnalysisAgent outputs ConceptBlueprint structured output.
-Reads the structured output from context and:
-1. Persists the manifest to MongoDB
-2. Emits the ConceptBlueprint UI artifact
-
-Tools are dumb. LLMs reason. This tool just saves and emits.
-"""
+"""Persist ConceptBlueprint drafts and collect explicit, draft-bound reviews."""
 
 import logging
-import os
+from collections.abc import MutableMapping
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
+from uuid import uuid4
 
-_API_BASE = os.getenv("MOZAIKSAI_URL") or os.getenv("VITE_API_URL") or "http://localhost:8000"
+from pydantic import BaseModel, Field, StrictBool, StrictStr, ValidationError
 
 logger = logging.getLogger(__name__)
 
-# Use mozaiks runtime persistence
-try:
-    from mozaiksai.core.data.persistence.artifact_store import BuilderArtifactStore
-    _HAS_PERSISTENCE = True
-except ImportError:
-    _HAS_PERSISTENCE = False
-    BuilderArtifactStore = None  # type: ignore[assignment,misc]
-
 from factory_app.app.modules.app_registry.backend.policy import is_generic_app_name
 from mozaiksai.core.artifacts import persist_summary_artifact
-from mozaiksai.core.workflow.ui_tools import emit_ui_surface
+from mozaiksai.core.data.persistence.artifact_store import BuilderArtifactStore
+from mozaiksai.core.workflow.context.frozen import detach
+from mozaiksai.core.workflow.ui_tools import use_ui_tool
+
+
+class ConceptReviewResponse(BaseModel):
+    action: Literal["approve", "request_changes", "cancel"]
+    approved: StrictBool
+    review_id: StrictStr
+    rationale: StrictStr = Field(default="", max_length=4000)
 
 
 def _set_context_value(context_variables: Any | None, key: str, value: Any) -> None:
-    """Set a context variable across supported container implementations."""
-    if context_variables is None or not isinstance(key, str) or not key:
+    """Preserve runtime authority failures instead of silently dropping writes."""
+    if context_variables is None:
         return
-    try:
-        if hasattr(context_variables, "set"):
-            context_variables.set(key, value)
-            return
-    except Exception:
-        pass
-    try:
-        if hasattr(context_variables, "__setitem__"):
-            context_variables[key] = value
-    except Exception:
-        return
+    if callable(getattr(context_variables, "set", None)):
+        context_variables.set(key, value)
+    elif isinstance(context_variables, MutableMapping):
+        context_variables[key] = value
+    else:
+        raise TypeError("Concept review requires writable runtime context")
 
 
 def _build_concept_record(
@@ -109,21 +97,10 @@ def _concept_record_to_manifest(doc: dict[str, Any], app_id: str) -> dict[str, A
 async def save_value_manifest(
     context_variables: Annotated[Any | None, "Runtime context with structured output"] = None,
 ) -> dict[str, Any]:
-    """
-    Auto-invoked after GapAnalysisAgent outputs ConceptBlueprint.
-
-    Reads the structured output from context_variables and:
-    1. Persists the manifest to MongoDB
-    2. Emits the ConceptBlueprint UI artifact
-
-    Returns:
-        {
-            "success": bool,
-            "manifest_id": str,
-            "app_id": str,
-            "message": str
-        }
-    """
+    """Return a declared tool outcome only after persistence and structured review."""
+    _set_context_value(context_variables, "concept_review_outcome", "blocked")
+    # A prior approval must never carry over to a newly generated proposal.
+    _set_context_value(context_variables, "value_manifest", None)
     # Extract context
     chat_id = None
     app_id = None
@@ -139,22 +116,18 @@ async def save_value_manifest(
         workflow_name = context_variables.get("workflow_name", "ValueEngine")
         build_mode = context_variables.get("build_mode")
         # Structured output from GapAnalysisAgent
-        structured_output = context_variables.get("structured_output")
-        # Also check for direct ConceptBlueprint output
-        if not structured_output:
-            structured_output = context_variables.get("ConceptBlueprint")
-
-    if not structured_output:
-        return {"success": False, "error": "No structured output (ConceptBlueprint) in context"}
-
-    if not app_id:
-        return {"success": False, "error": "app_id required in context"}
+        structured_output = detach(context_variables.get("structured_output"))
+    if not isinstance(structured_output, dict) or not structured_output:
+        return {"success": False, "outcome": "blocked", "error": "ConceptBlueprint structured output is required"}
+    if not all(isinstance(value, str) and value.strip() for value in (app_id, chat_id, user_id)):
+        return {"success": False, "outcome": "blocked", "error": "App, chat, and user identities are required for review"}
 
     # Extract fields from structured output
     app_name = str(structured_output.get("app_name") or "").strip()
     if is_generic_app_name(app_name):
         return {
             "success": False,
+            "outcome": "blocked",
             "error": "ConceptBlueprint.app_name must be a specific product name before the app registry can be named.",
         }
     value_proposition = structured_output.get("value_proposition", "")
@@ -175,6 +148,7 @@ async def save_value_manifest(
 
     manifest_id = f"manifest_{app_id}"
     now = datetime.now(UTC)
+    review_id = f"concept_review_{uuid4().hex}"
 
     # Build manifest for persistence
     manifest = {
@@ -186,7 +160,7 @@ async def save_value_manifest(
         "target_user": target_user,
         "target_users": target_users,
         "core_jobs": core_jobs,
-        "approved_scope": core_features,  # core_features = approved scope
+        "approved_scope": [],
         "deferred_scope": deferred_features,
         "unique_differentiators": unique_differentiators,
         "brand_intent": brand_intent if isinstance(brand_intent, dict) else None,
@@ -198,6 +172,7 @@ async def save_value_manifest(
         "agentic_capabilities": agentic_capabilities,
         "updated_at": now.isoformat(),
         "status": "draft",  # Will be "approved" after user confirms
+        "review_id": review_id,
     }
     concept_record = _build_concept_record(
         app_id=str(app_id),
@@ -212,20 +187,10 @@ async def save_value_manifest(
         now_iso=now.isoformat(),
     )
 
-    # Persist to MongoDB via mozaiks runtime
-    if _HAS_PERSISTENCE and BuilderArtifactStore:  # type: ignore[truthy-function]
-        try:
-            store = BuilderArtifactStore()
-            await store.save_concept(
-                app_id=str(app_id),
-                concept_record=concept_record,
-                created_at=now.isoformat(),
-            )
-            logger.info("[ValueEngine] Concept saved for app_id=%s", app_id)
-        except Exception as e:
-            logger.warning("[ValueEngine] Persistence failed: %s", e)
-
+    concept_record.update(review_id=review_id, review_owner_user_id=user_id)
+    store = BuilderArtifactStore()
     try:
+        await store.save_concept(app_id=str(app_id), concept_record=concept_record, created_at=now.isoformat())
         await persist_summary_artifact(
             app_id=str(app_id),
             artifact_kind="concept",
@@ -237,12 +202,14 @@ async def save_value_manifest(
             revision_mode=str(build_mode or "").strip().lower() == "revision",
         )
     except Exception as exc:
-        logger.warning("[ValueEngine] Generic concept artifact persistence failed: %s", exc)
+        logger.warning("[ValueEngine] Draft persistence failed: %s", exc)
+        return {"success": False, "outcome": "blocked", "error": "Concept draft could not be persisted"}
 
     # Build UI payload matching ConceptBlueprint.js expectations
     ui_payload = {
         "title": f"Concept Blueprint: {app_name}",
         "app_id": str(app_id),
+        "review_id": review_id,
         "concept_overview": concept_overview,
         "blueprint": {
             "app_name": app_name,
@@ -263,18 +230,6 @@ async def save_value_manifest(
         "api_endpoints": api_endpoints,
     }
 
-    # Emit UI artifact through the sanctioned one-way UI helper.
-    try:
-        await emit_ui_surface(
-            "ConceptBlueprint",
-            ui_payload,
-            chat_id=str(chat_id) if chat_id else None,
-            workflow_name=str(workflow_name or "ValueEngine"),
-            agent_name="GapAnalysisAgent",
-        )
-    except Exception as e:
-        logger.debug("[ValueEngine] UI event failed: %s", e)
-
     # Store context values for downstream routing and tools.
     _set_context_value(context_variables, "value_manifest", manifest)
     _set_context_value(context_variables, "concept_blueprint", structured_output)
@@ -283,30 +238,42 @@ async def save_value_manifest(
     _set_context_value(context_variables, "surface_candidate_hints", surface_candidate_hints)
     _set_context_value(context_variables, "concept_presented", True)
 
-    # Update the registry record with the actual app name now that the concept is known.
-    # Uses the unique build app_id set by create_app_record so the upsert finds the right record.
     try:
-        import httpx
-        registry_payload = {
-            "name": app_name,
-            "name_source": "value_engine_concept",
-            "description": concept_overview,
-            "app_id": str(app_id),
-            "status": "building",
-            "active_chat_id": str(chat_id) if chat_id else None,
-            "active_workflow_id": str(workflow_name or "ValueEngine"),
+        response = ConceptReviewResponse.model_validate(await use_ui_tool(
+            "save_value_manifest", ui_payload, chat_id=str(chat_id),
+            workflow_name=str(workflow_name or "ValueEngine"), display="artifact",
+        ))
+        if response.review_id != review_id or response.approved is not (response.action == "approve"):
+            return {"success": False, "outcome": "blocked", "error": "Concept review does not match this draft"}
+        outcome = {"approve": "approved", "request_changes": "changes_requested", "cancel": "cancelled"}[response.action]
+        if not await store.finish_concept_review(
+            app_id=str(app_id), review_id=review_id, status=outcome,
+            reviewed_by=str(user_id), feedback=response.rationale,
+        ):
+            return {"success": False, "outcome": "blocked", "error": "Concept draft is no longer awaiting this review"}
+        reviewed_manifest = {
+            **manifest, "status": outcome, "review_feedback": response.rationale,
+            "approved_scope": core_features if outcome == "approved" else [],
         }
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            await client.post(f"{_API_BASE}/api/studio/apps", json=registry_payload)
-        logger.debug("[ValueEngine] Registry record renamed to '%s'", app_name)
+        await persist_summary_artifact(
+            app_id=str(app_id), artifact_kind="concept", artifact_key="concept", summary_payload=reviewed_manifest,
+            source_workflow=str(workflow_name or "ValueEngine"), source_chat_id=str(chat_id),
+            author_user_id=str(user_id), revision_mode=str(build_mode or "").strip().lower() == "revision",
+        )
+    except ValidationError:
+        return {"success": False, "outcome": "blocked", "error": "Invalid structured concept review"}
     except Exception as exc:
-        logger.debug("[ValueEngine] Registry name update failed (non-fatal): %s", exc)
-
+        logger.warning("[ValueEngine] Concept review failed: %s", exc)
+        return {"success": False, "outcome": "blocked", "error": "Concept review could not be completed"}
+    _set_context_value(context_variables, "value_manifest", reviewed_manifest)
+    _set_context_value(context_variables, "concept_review_feedback", response.rationale)
+    _set_context_value(context_variables, "app_name", app_name)
     return {
-        "success": True,
+        "success": outcome == "approved",
+        "outcome": outcome,
         "manifest_id": manifest_id,
         "app_id": str(app_id),
-        "message": f"ConceptBlueprint saved for {app_name}",
+        "message": f"Concept review: {outcome}",
     }
 
 
@@ -326,16 +293,12 @@ async def get_value_manifest(
             return {"success": True, "manifest": cached}
 
     # Load from MongoDB
-    if _HAS_PERSISTENCE and BuilderArtifactStore:  # type: ignore[truthy-function]
-        try:
-            store = BuilderArtifactStore()
-            concept = await store.get_concept(app_id=str(app_id))
-            if concept:
-                return {
-                    "success": True,
-                    "manifest": _concept_record_to_manifest(concept, str(app_id)),
-                }
-        except Exception as e:
-            logger.warning("[ValueEngine] Load manifest failed: %s", e)
+    try:
+        store = BuilderArtifactStore()
+        concept = await store.get_concept(app_id=str(app_id))
+        if concept:
+            return {"success": True, "manifest": _concept_record_to_manifest(concept, str(app_id))}
+    except Exception as e:
+        logger.warning("[ValueEngine] Load manifest failed: %s", e)
 
     return {"success": False, "error": f"No manifest found for app_id={app_id}"}

--- a/factory_app/workflows/ValueEngine/transition_graph.yaml
+++ b/factory_app/workflows/ValueEngine/transition_graph.yaml
@@ -14,9 +14,45 @@ transition_rules:
   transition_target: AgentTarget
 
 - source_agent: GapAnalysisAgent
-  target_agent: user
+  target_agent: terminate
   transition_type: after_turn
+  transition_target: TerminateTarget
+  termination_reason: workflow_failed
+
+- source_agent: GapAnalysisAgent
+  target_agent: terminate
+  transition_type: condition
+  condition_type: context_equals
+  condition_key: concept_review_outcome
+  condition_value: approved
+  transition_target: TerminateTarget
+  termination_reason: workflow_complete
+
+- source_agent: GapAnalysisAgent
+  target_agent: user
+  transition_type: condition
+  condition_type: context_equals
+  condition_key: concept_review_outcome
+  condition_value: changes_requested
   transition_target: RevertToUserTarget
+
+- source_agent: GapAnalysisAgent
+  target_agent: terminate
+  transition_type: condition
+  condition_type: context_equals
+  condition_key: concept_review_outcome
+  condition_value: blocked
+  transition_target: TerminateTarget
+  termination_reason: workflow_failed
+
+- source_agent: GapAnalysisAgent
+  target_agent: terminate
+  transition_type: condition
+  condition_type: context_equals
+  condition_key: concept_review_outcome
+  condition_value: cancelled
+  transition_target: TerminateTarget
+  termination_reason: workflow_failed
 
 # Conditional rules win over same-source after_turn fallbacks when their context matches.
 - source_agent: ValueInterviewAgent

--- a/factory_app/workflows/ValueEngine/ui/ValueEngine/components/ConceptBlueprint.js
+++ b/factory_app/workflows/ValueEngine/ui/ValueEngine/components/ConceptBlueprint.js
@@ -1,20 +1,23 @@
 // ==============================================================================
-// FILE: ChatUI/src/workflows/ValueEngine/components/ConceptBlueprint.js
-// DESCRIPTION: ValueEngine "Concept Blueprint" artifact (display-only)
+// ValueEngine concept artifact and structured review.
 // ==============================================================================
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Bot,
+  Check,
   Layers3,
   ListChecks,
   MonitorSmartphone,
   Palette,
+  PencilLine,
   Route,
   Sparkles,
   Target,
+  X,
 } from 'lucide-react';
 import { workflowSurfaceStyles } from '@mozaiks/chat-ui/platform/workflowSurfaceStyles.js';
+import { normalizePrimitiveActions } from '@mozaiks/chat-ui/core/ui/workflowPrimitiveUtils.js';
 
 const asText = (value) => (typeof value === 'string' ? value.trim() : '');
 
@@ -34,7 +37,31 @@ const renderList = (items) => {
   );
 };
 
-const ConceptBlueprint = ({ payload = {}, toolCallId, sourceWorkflowName, generatedWorkflowName }) => {
+const ConceptBlueprintContent = ({ payload = {}, onResponse, toolCallId, sourceWorkflowName, generatedWorkflowName }) => {
+  const [feedback, setFeedback] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [reviewError, setReviewError] = useState('');
+  const reviewActions = normalizePrimitiveActions(payload).filter((action) =>
+    ['approve', 'request_changes', 'cancel'].includes(action.id));
+  const submitReview = async (action) => {
+    if (!onResponse || submitting || submitted) return;
+    setSubmitting(true);
+    setReviewError('');
+    try {
+      await onResponse({
+        action: action.id,
+        approved: action.approved,
+        review_id: payload.review_id,
+        rationale: feedback.trim(),
+      });
+      setSubmitted(true);
+    } catch {
+      setReviewError('The review could not be submitted.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
   const blueprint = payload && typeof payload.blueprint === 'object' ? payload.blueprint : null;
   const endpoints = asArray(payload.api_endpoints).filter((x) => x && typeof x === 'object');
 
@@ -86,35 +113,35 @@ const ConceptBlueprint = ({ payload = {}, toolCallId, sourceWorkflowName, genera
 
   return (
     <div className={panelClass}>
-      <div className="px-5 py-4 border-b border-white/10 bg-black/35">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
+      <div className="px-5 py-4 border-b border-border bg-muted/40">
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
+          <div className="min-w-0 flex-1">
             <div className="flex items-center gap-3">
-              <div className="rounded-lg bg-primary/20 p-2.5 ring-2 ring-primary/50">
+              <div className="shrink-0 rounded-lg bg-primary/20 p-2.5 ring-2 ring-primary/50">
                 <Sparkles className="w-5 h-5 text-[var(--color-primary-light)]" />
               </div>
               <div className="min-w-0">
-                <div className="text-xl font-heading font-black text-foreground">{title}</div>
+                <h2 className="text-xl font-heading font-bold text-foreground break-words">{title}</h2>
                 {appName && (
                   <div className="text-sm text-muted-foreground truncate">{appName}</div>
                 )}
               </div>
             </div>
-            <div className="mt-2 text-[11px] text-muted-foreground">
+            <div className="mt-2 text-[11px] text-muted-foreground break-words">
               {generatedWorkflowName || sourceWorkflowName || 'ValueEngine'} • event {toolCallId || 'n/a'}
               {appId ? ` • app_id ${appId}` : null}
             </div>
           </div>
           {valueProp && (
-            <div className="inline-flex items-center gap-2 rounded-lg border-2 border-primary/45 bg-primary/12 text-primary px-4 py-2 text-xs font-sans font-bold uppercase tracking-wide max-w-[360px]">
-              <Target className="w-4 h-4" />
-              <span className="truncate">{valueProp}</span>
+            <div className="inline-flex min-w-0 items-start gap-2 text-primary text-sm max-w-full sm:max-w-[280px]">
+              <Target className="w-4 h-4 shrink-0 mt-0.5" />
+              <span className="break-words">{valueProp}</span>
             </div>
           )}
         </div>
       </div>
 
-      <div className="p-5 gap-5">
+      <div className="p-5 space-y-5">
         <div className="rounded-lg border border-border bg-muted/75 p-5">
           <div className="flex items-center gap-2 mb-2">
             <Layers3 className="w-4 h-4 text-[var(--color-primary-light)]" />
@@ -247,9 +274,37 @@ const ConceptBlueprint = ({ payload = {}, toolCallId, sourceWorkflowName, genera
           )}
         </div>
       </div>
+      {onResponse && payload.review_id && (
+        <section aria-label="Concept review" className="border-t border-border px-5 py-4 space-y-3 text-foreground">
+          {submitted ? <p role="status" className="text-sm text-muted-foreground">Review submitted</p> : (
+            <>
+              <label className="block space-y-2">
+                <span className="text-sm font-medium">Requested changes</span>
+                <textarea value={feedback} onChange={(event) => setFeedback(event.target.value)}
+                  maxLength={4000} rows={3} disabled={submitting}
+                  className="block w-full rounded-md border border-border bg-background p-3 text-sm text-foreground" />
+              </label>
+              {reviewError && <p role="alert" className="text-sm text-destructive">{reviewError}</p>}
+              <div className="flex flex-wrap gap-2">
+                {reviewActions.map((action) => {
+                  const Icon = { approve: Check, request_changes: PencilLine, cancel: X }[action.id];
+                  return (
+                    <button key={action.id} type="button" disabled={submitting} onClick={() => submitReview(action)}
+                      className={`inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50 ${action.id === 'approve' ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-foreground'}`}>
+                      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />{action.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </section>
+      )}
     </div>
   );
 };
+
+const ConceptBlueprint = (props) => <ConceptBlueprintContent key={props.payload?.review_id} {...props} />;
 
 export default ConceptBlueprint;
 

--- a/mozaiksai/core/data/persistence/artifact_store.py
+++ b/mozaiksai/core/data/persistence/artifact_store.py
@@ -54,6 +54,10 @@ class BuilderArtifactStore:
         concept_record: dict[str, Any],
         created_at: str | None = None,
     ) -> None:
+        await self._ensure_indexes(
+            BuilderCollections.CONCEPTS,
+            [((("app_id", 1),), {"unique": True, "name": "concept_app"})],
+        )
         coll = await self._collection(BuilderCollections.CONCEPTS)
         await coll.update_one(
             {"app_id": str(app_id)},
@@ -68,6 +72,22 @@ class BuilderArtifactStore:
             return None
         doc.pop("_id", None)
         return doc
+
+    async def finish_concept_review(
+        self, *, app_id: str, review_id: str, status: str, reviewed_by: str, feedback: str,
+    ) -> bool:
+        """Only the current pending concept proposal can receive this review."""
+        if status not in {"approved", "changes_requested", "cancelled"}:
+            raise ValueError("Invalid concept review status")
+        if not all(isinstance(value, str) and value.strip() for value in (app_id, review_id, reviewed_by)):
+            raise ValueError("App, review, and reviewer identities are required")
+        coll = await self._collection(BuilderCollections.CONCEPTS)
+        result = await coll.update_one(
+            {"app_id": app_id, "review_id": review_id, "review_owner_user_id": reviewed_by, "status": "draft"},
+            {"$set": {"status": status, "review_feedback": feedback, "reviewed_by": reviewed_by,
+                      "reviewed_at": datetime.now(UTC).isoformat()}},
+        )
+        return bool(result.matched_count == 1)
 
     async def save_build_plan(self, *, app_id: str, build_plan: dict[str, Any]) -> None:
         coll = await self._collection(BuilderCollections.BUILD_PLANS)

--- a/tests/test_capability_pack_contracts.py
+++ b/tests/test_capability_pack_contracts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import yaml
@@ -1009,7 +1011,8 @@ def test_valueengine_manifest_preserves_brand_intent_for_downstream_generators(m
         "factory_app/workflows/ValueEngine/tools/manifest.py",
         "tests.valueengine_manifest_direct",
     )
-    module._HAS_PERSISTENCE = False
+    store = SimpleNamespace(save_concept=AsyncMock(), finish_concept_review=AsyncMock(return_value=True))
+    monkeypatch.setattr(module, "BuilderArtifactStore", lambda: store)
     emitted = {}
     summary_artifact = {}
 
@@ -1017,12 +1020,13 @@ def test_valueengine_manifest_preserves_brand_intent_for_downstream_generators(m
         emitted["component"] = component
         emitted["payload"] = payload
         emitted["kwargs"] = kwargs
+        return {"action": "approve", "approved": True, "review_id": payload["review_id"]}
 
     async def _fake_persist_summary_artifact(**kwargs):
         summary_artifact.update(kwargs)
         return type("ArtifactVersion", (), {"id": "av_concept_1"})()
 
-    module.emit_ui_surface = _fake_emit
+    module.use_ui_tool = _fake_emit
     monkeypatch.setattr(module, "persist_summary_artifact", _fake_persist_summary_artifact)
 
     context = _Context(
@@ -1061,7 +1065,7 @@ def test_valueengine_manifest_preserves_brand_intent_for_downstream_generators(m
     assert manifest["brand_intent"]["style_summary"] == "Cinematic sci-fi creator platform"
     assert manifest["app_ui_requirements"] == ["Need an immersive dark shell with strong visual hierarchy"]
     assert manifest["capability_pack_hints"] == ["messaging_pack"]
-    assert emitted["component"] == "ConceptBlueprint"
+    assert emitted["component"] == "save_value_manifest"
     assert emitted["payload"]["blueprint"]["brand_intent"]["appearance_hint"] == "dark"
     assert emitted["payload"]["blueprint"]["agentic_capabilities"] == ["thread_summary"]
     assert summary_artifact["artifact_kind"] == "concept"

--- a/tests/test_concept_review_real_mongo.py
+++ b/tests/test_concept_review_real_mongo.py
@@ -1,0 +1,94 @@
+"""Concept review compare-and-set behavior against a disposable Mongo database."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from mozaiksai.core.data.persistence.artifact_store import BuilderArtifactStore
+
+
+@pytest_asyncio.fixture
+async def concepts(monkeypatch):
+    database_name = f"concept_review_{uuid4().hex}"
+    mongo = AsyncIOMotorClient(os.getenv("MONGO_URI", "mongodb://127.0.0.1:27017"), serverSelectionTimeoutMS=1500)
+    try:
+        await mongo.admin.command("ping")
+    except Exception:
+        mongo.close()
+        if os.getenv("MOZAIKS_REQUIRE_REAL_MONGO"):
+            pytest.fail("Real Mongo is required for concept review acceptance")
+        pytest.skip("Mongo is unavailable")
+    collection = mongo[database_name]["Concepts"]
+    store = BuilderArtifactStore()
+    monkeypatch.setattr(store, "_collection", AsyncMock(return_value=collection))
+    try:
+        yield SimpleNamespace(store=store, collection=collection)
+    finally:
+        assert database_name.startswith("concept_review_")
+        await mongo.drop_database(database_name)
+        mongo.close()
+
+
+async def _draft(concepts, review_id="review-one"):
+    await concepts.store.save_concept(app_id="target-app", concept_record={
+        "app_id": "target-app", "review_id": review_id,
+        "review_owner_user_id": "owner", "status": "draft",
+    })
+
+
+async def _finish(concepts, **overrides):
+    return await concepts.store.finish_concept_review(**{
+        "app_id": "target-app", "review_id": "review-one", "reviewed_by": "owner",
+        "status": "approved", "feedback": "Approved as displayed", **overrides,
+    })
+
+
+@pytest.mark.parametrize("overrides", [
+    {"reviewed_by": "other-user"}, {"app_id": "other-app"}, {"review_id": "other-review"},
+])
+async def test_review_cannot_cross_identity_boundaries(concepts, overrides):
+    await _draft(concepts)
+    assert await _finish(concepts, **overrides) is False
+    assert (await concepts.store.get_concept(app_id="target-app"))["status"] == "draft"
+
+
+async def test_replacement_draft_rejects_stale_review(concepts):
+    await _draft(concepts)
+    await _draft(concepts, "review-two")
+    assert await _finish(concepts) is False
+    assert await _finish(concepts, review_id="review-two") is True
+    assert await _finish(concepts, review_id="review-two") is False
+
+
+async def test_competing_reviews_can_only_finish_once(concepts):
+    await _draft(concepts)
+    results = await asyncio.gather(*(_finish(concepts) for _ in range(12)))
+    assert results.count(True) == 1
+    record = await concepts.store.get_concept(app_id="target-app")
+    assert record["status"] == "approved"
+    assert record["reviewed_by"] == "owner"
+
+
+async def test_concurrent_proposals_have_only_one_current_draft(concepts):
+    await asyncio.gather(*(_draft(concepts, f"review-{index}") for index in range(12)))
+    assert await concepts.collection.count_documents({"app_id": "target-app"}) == 1
+    current = await concepts.store.get_concept(app_id="target-app")
+    for index in range(12):
+        review_id = f"review-{index}"
+        assert await _finish(concepts, review_id=review_id) is (review_id == current["review_id"])
+
+
+@pytest.mark.parametrize("status", ["changes_requested", "cancelled"])
+async def test_negative_decision_cannot_be_replayed_as_approval(concepts, status):
+    await _draft(concepts)
+    assert await _finish(concepts, status=status) is True
+    assert await _finish(concepts) is False
+    assert (await concepts.store.get_concept(app_id="target-app"))["status"] == status

--- a/tests/test_value_engine_concept_review.py
+++ b/tests/test_value_engine_concept_review.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from ag2 import Agent
+
+from factory_app.workflows.ValueEngine.tools import manifest as module
+from mozaiksai.core.adapters import ag2_network_runner as runner
+from mozaiksai.core.ports.orchestration import RunStatus
+from mozaiksai.core.workflow.agents.factory import ContextVariablesBridge, _wrap_tool_with_context
+from mozaiksai.core.workflow.context.authority import build_context_authority_policy
+from mozaiksai.core.workflow.contract_validation import validate_workflow_tool_outcomes
+from mozaiksai.core.workflow.declarative.contracts import ToolOutcomeSpec
+from mozaiksai.core.workflow.validation.tool_outcomes import wrap_tool_outcome
+
+
+class Context(dict):
+    def set(self, key, value):
+        self[key] = value
+
+
+@pytest.fixture
+def review(monkeypatch):
+    store = SimpleNamespace(save_concept=AsyncMock(), finish_concept_review=AsyncMock(return_value=True))
+    persist = AsyncMock(return_value=SimpleNamespace(id="concept-version"))
+    monkeypatch.setattr(module, "BuilderArtifactStore", lambda: store)
+    monkeypatch.setattr(module, "persist_summary_artifact", persist)
+    context = Context(
+        app_id="build-app", chat_id="chat-review", user_id="owner", workflow_name="ValueEngine",
+        concept_review_outcome="blocked", concept_review_attempts=0,
+        concept_presented=False, interview_complete=True,
+        structured_output={"app_name": "Customer Ledger", "concept_overview": "A private customer tracker.",
+                           "core_features": ["List, add, and edit customers"], "deferred_features": []},
+    )
+    emitted = []
+
+    def respond(*, action="approve", approved=True, invalid=None):
+        async def ui(tool_id, payload, **kwargs):
+            emitted.append((tool_id, deepcopy(payload), kwargs))
+            assert store.save_concept.await_count == len(emitted)
+            assert context.get("value_manifest", {}).get("status") != "approved"
+            response = {"action": action, "approved": approved, "review_id": payload["review_id"],
+                        "rationale": "Keep the scope small."}
+            response.update(invalid or {})
+            return response
+        monkeypatch.setattr(module, "use_ui_tool", ui, raising=False)
+
+    respond()
+    return SimpleNamespace(context=context, store=store, persist=persist, emitted=emitted, respond=respond)
+
+
+async def test_approval_is_structured_bound_to_draft_and_persisted(review):
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "approved"
+    assert result["success"] is True
+    assert len(review.emitted) == 1
+    tool_id, payload, kwargs = review.emitted[0]
+    assert tool_id == "save_value_manifest"
+    assert kwargs["display"] == "artifact"
+    assert payload["blueprint"]["app_name"] == "Customer Ledger"
+    finish = review.store.finish_concept_review.await_args.kwargs
+    assert finish["review_id"] == payload["review_id"]
+    assert finish["reviewed_by"] == "owner"
+    assert finish["status"] == "approved"
+    assert review.context["value_manifest"]["status"] == "approved"
+    assert review.context["value_manifest"]["approved_scope"] == ["List, add, and edit customers"]
+    assert review.persist.await_args.kwargs["summary_payload"]["status"] == "approved"
+    assert review.context["app_id"] == "build-app"
+
+
+@pytest.mark.parametrize("action,outcome", [("request_changes", "changes_requested"), ("cancel", "cancelled")])
+async def test_negative_review_never_approves(review, action, outcome):
+    review.respond(action=action, approved=False)
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == outcome
+    assert review.context["value_manifest"]["status"] != "approved"
+    assert review.context["concept_review_feedback"] == "Keep the scope small."
+
+
+@pytest.mark.parametrize("invalid", [
+    {"action": "looks good"}, {"approved": "true"}, {"approved": 1}, {"approved": False},
+    {"review_id": "old-draft"}, {"action": "request_changes", "approved": True},
+    {"rationale": {"approved": True}},
+])
+async def test_invalid_or_stale_response_cannot_advance(review, invalid):
+    review.respond(invalid=invalid)
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "blocked"
+    review.store.finish_concept_review.assert_not_awaited()
+    assert review.context.get("value_manifest", {}).get("status") != "approved"
+
+
+async def test_a_newer_draft_prevents_approval_of_an_older_review(review):
+    review.store.finish_concept_review.return_value = False
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "blocked"
+    assert review.context.get("value_manifest", {}).get("status") != "approved"
+
+
+async def test_failed_draft_persistence_does_not_request_approval(review):
+    review.store.save_concept.side_effect = RuntimeError("database unavailable")
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "blocked"
+    assert review.emitted == []
+
+
+def _workflow_contracts():
+    root = Path(__file__).resolve().parents[1] / "factory_app" / "workflows" / "ValueEngine"
+    config = {name: yaml.safe_load((root / f"{name}.yaml").read_text(encoding="utf-8"))
+              for name in ("tools", "context_variables", "transition_graph")}
+    validate_workflow_tool_outcomes(config)
+    review_tool = next(tool for tool in config["tools"]["tools"] if tool["function"] == "save_value_manifest")
+    return config, ToolOutcomeSpec.model_validate(review_tool["outcome"])
+
+
+@pytest.mark.parametrize("action,expected", [
+    ("approve", RunStatus.COMPLETED), ("cancel", RunStatus.FAILED),
+    ("request_changes", RunStatus.PAUSED), ("invalid", RunStatus.FAILED),
+])
+async def test_review_outcome_drives_native_ag2_graph_and_resumes(review, action, expected):
+    config, contract = _workflow_contracts()
+    policy = build_context_authority_policy(
+        workflow_name="ValueEngine", definitions=config["context_variables"]["definitions"],
+        transition_rules=config["transition_graph"]["transition_rules"],
+    )
+    bridge = ContextVariablesBridge(dict(review.context), authority_policy=policy)
+    review.context = bridge
+    review.respond(action=action, approved=action == "approve")
+
+    class ScriptedAgent(Agent):
+        async def ask(self, *args, **kwargs):
+            return SimpleNamespace(body="Proposed concept, awaiting its structured review.")
+
+    agents = {name: ScriptedAgent(name, prompt="Propose a concept.") for name in
+              ("ValueInterviewAgent", "ResearchAgent", "GapAnalysisAgent")}
+    for name, agent in agents.items():
+        agent._mozaiks_context_bridge = bridge
+        agent._mozaiks_tool_outcome = contract if name == "GapAnalysisAgent" else None
+    invoke = _wrap_tool_with_context(wrap_tool_outcome(module.save_value_manifest, contract), bridge)
+
+    async def before_packet(agent_name, packet):
+        assert agent_name == "GapAnalysisAgent"
+        await invoke()
+
+    result = await runner.AG2NetworkRunner().run(runner.AG2NetworkRunnerRequest(
+        workflow_name="ValueEngine", app_id="build-app", chat_id="chat-review", agents=agents,
+        transition_rules=config["transition_graph"]["transition_rules"], initial_agent_name="GapAnalysisAgent",
+        initial_message="Propose a customer tracker.", context_variables=bridge.snapshot(),
+        context_authority_policy=policy, max_turns=6, close_timeout_seconds=float("inf"),
+        agent_output_handler=before_packet,
+    ))
+    live_run = result.live_run
+    try:
+        assert result.status is expected, result.error
+        if action == "request_changes":
+            review.respond()
+            result = await live_run.continue_with_user_message("Use the feedback to revise the concept.")
+            assert result.status is RunStatus.COMPLETED, result.error
+            assert result.context_variables["concept_review_attempts"] == 2
+            assert len(review.emitted) == 2
+            assert review.emitted[0][1]["review_id"] != review.emitted[1][1]["review_id"]
+        assert result.context_variables["app_id"] == "build-app"
+        if result.status is RunStatus.COMPLETED:
+            assert result.context_variables["value_manifest"]["status"] == "approved"
+            assert result.context_variables["concept_review_feedback"] == "Keep the scope small."
+    finally:
+        if live_run is not None:
+            await live_run.close()
+
+
+async def test_review_attempt_budget_fails_closed_without_another_prompt(review):
+    _, contract = _workflow_contracts()
+    review.context.update(concept_review_attempts=contract.max_attempts, concept_review_outcome="changes_requested")
+    result = await wrap_tool_outcome(module.save_value_manifest, contract)(review.context)
+    assert result["outcome"] == "blocked"
+    assert result["outcome_error"] == "attempts_exhausted"
+    assert review.emitted == []
+
+
+async def test_failed_approved_summary_persistence_does_not_advance(review):
+    review.persist.side_effect = [SimpleNamespace(id="draft-version"), RuntimeError("summary unavailable")]
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "blocked"
+    assert review.context.get("value_manifest", {}).get("status") != "approved"
+
+
+@pytest.mark.parametrize("key", ["app_id", "chat_id", "user_id", "structured_output"])
+async def test_missing_required_context_blocks(review, key):
+    review.context.pop(key)
+    result = await module.save_value_manifest(review.context)
+    assert result["outcome"] == "blocked"
+    assert review.emitted == []

--- a/tests/test_workflow_ui_tool_contracts.py
+++ b/tests/test_workflow_ui_tool_contracts.py
@@ -378,7 +378,6 @@ def test_shared_workflow_ui_contract_is_documented() -> None:
 def test_repo_owned_one_way_ui_emitters_use_canonical_surface_helper() -> None:
     files = [
         "factory_app/workflows/AgentGenerator/tools/mermaid_sequence_diagram.py",
-        "factory_app/workflows/ValueEngine/tools/manifest.py",
         "factory_app/workflows/RuntimeUIPrimitiveSmoke/tools/show_acceptance_diagram.py",
     ]
 
@@ -386,6 +385,18 @@ def test_repo_owned_one_way_ui_emitters_use_canonical_surface_helper() -> None:
         content = _read(relative_path)
         assert "from mozaiksai.core.workflow.ui_tools import emit_ui_surface" in content
         assert "send_ui_tool_event(" not in content
+
+
+def test_value_engine_review_uses_response_bearing_ui_tool() -> None:
+    content = _read("factory_app/workflows/ValueEngine/tools/manifest.py")
+    assert "from mozaiksai.core.workflow.ui_tools import use_ui_tool" in content
+    assert "emit_ui_surface" not in content
+    tools = _read_yaml("factory_app/workflows/ValueEngine/tools.yaml")["tools"]
+    review = next(tool for tool in tools if tool["function"] == "save_value_manifest")
+    assert review["tool_type"] == "UI_Tool"
+    assert review["auto_tool_call"] is True
+    assert review["bind_to_agent"] is False
+    assert review["outcome"]["values"] == ["approved", "changes_requested", "cancelled", "blocked"]
 
 
 def test_ui_system_spec_documents_interactive_vs_one_way_producer_contracts() -> None:

--- a/web_shell/package.json
+++ b/web_shell/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test:workflow-ui": "node --test tests/workflowUi.test.js",
+    "test:concept-review": "node --test tests/conceptReview.browser.test.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/web_shell/tests/conceptReview.browser.test.js
+++ b/web_shell/tests/conceptReview.browser.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from '@playwright/test';
+import postcss from 'postcss';
+import tailwindcss from '@tailwindcss/postcss';
+import YAML from 'yaml';
+
+const shell = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const root = path.dirname(shell);
+const component = path.join(root, 'factory_app/workflows/ValueEngine/ui/ValueEngine/components/ConceptBlueprint.js');
+
+test('concept review renders, submits once, rejects transport errors, and resets for a new draft', async (t) => {
+  const tools = YAML.parse(await fs.readFile(path.join(root, 'factory_app/workflows/ValueEngine/tools.yaml'), 'utf8'));
+  const contract = tools.tools.find((tool) => tool.function === 'save_value_manifest').ui_contract;
+  const entry = `
+    import React, { useState } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import ConceptBlueprint from ${JSON.stringify(component)};
+    function Fixture() {
+      const [draft, setDraft] = useState(1);
+      const [result, setResult] = useState(null);
+      const [reject, setReject] = useState(false);
+      const payload = { title: 'Concept Blueprint: Customer Ledger', app_id: 'customer-ledger',
+        review_id: 'review-' + draft, concept_overview: 'A private customer tracker for independent service businesses.',
+        blueprint: {app_name: 'Customer Ledger', value_proposition: 'Customer records in one place',
+          target_user: 'Independent service businesses', mvp_scope: {core_features: ['List, add, and edit customers', 'Search and status filters']},
+          brand_intent: {style_summary: 'Clear, practical, and accessible', appearance_hint: 'Light'},
+          app_ui_requirements: ['Responsive customer list and edit form']},
+        api_endpoints: [{method: 'GET', path: '/api/customers', description: 'List customers'}],
+        ui_contract: ${JSON.stringify(contract)}};
+      return <main style={{maxWidth: 1100, margin: '0 auto'}}>
+        <button onClick={() => {setDraft(draft + 1); setResult(null);}}>Next draft</button>
+        <label><input type="checkbox" checked={reject} onChange={(event) => setReject(event.target.checked)} />Reject response</label>
+        <ConceptBlueprint payload={payload} toolCallId={'tool-' + draft} sourceWorkflowName="ValueEngine"
+          onResponse={async (value) => { if (reject) throw Error('Simulated transport failure'); setResult(value); }} />
+        <output aria-label="Review response">{result ? JSON.stringify(result) : ''}</output>
+      </main>;
+    }
+    createRoot(document.getElementById('root')).render(<Fixture />);
+  `;
+  const bundle = await build({
+    stdin: {contents: entry, resolveDir: shell, loader: 'jsx'}, bundle: true, write: false,
+    jsx: 'automatic', loader: {'.js': 'jsx'}, nodePaths: [path.join(shell, 'node_modules')],
+    alias: {'@mozaiks/chat-ui': path.join(root, 'chat-ui/src')},
+  });
+  const styles = await postcss([tailwindcss()]).process(
+    (await fs.readFile(path.join(shell, 'styles.css'), 'utf8')) + `\n@source "${component.replaceAll('\\', '/')}";`,
+    {from: path.join(shell, 'styles.css')},
+  );
+  const html = `<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>${styles.css}
+      :root {--mz-background:0 0% 100%;--mz-foreground:0 0% 10%;--mz-card:0 0% 100%;--mz-border:0 0% 80%;
+        --mz-primary:170 80% 25%;--mz-primary-foreground:0 0% 100%;--mz-muted:0 0% 96%;--mz-muted-foreground:0 0% 35%;
+        --mz-destructive:0 80% 40%;--mz-radius:8px;--mz-font-sans:Arial;--mz-font-heading:Arial;
+        --color-text-primary:#1a1a1a;--color-primary-light:#0d7666;}
+    </style></head><body><div id="root"></div><script src="/fixture.js"></script></body></html>`;
+  const server = http.createServer((req, res) => {
+    const script = req.url === '/fixture.js';
+    res.setHeader('Content-Type', script ? 'text/javascript' : 'text/html');
+    res.end(script ? bundle.outputFiles[0].text : html);
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const browser = await chromium.launch({headless: true});
+  t.after(() => browser.close());
+  const screenshots = path.join(shell, 'test-results/concept-review');
+  await fs.mkdir(screenshots, {recursive: true});
+  for (const viewport of [{width: 1440, height: 1100}, {width: 390, height: 844}]) {
+    const page = await browser.newPage({viewport});
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(`http://127.0.0.1:${server.address().port}`);
+    await page.getByRole('button', {name: 'Approve Concept', exact: true}).waitFor();
+    assert.deepEqual(errors, []);
+    assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth));
+    const heading = await page.getByRole('heading', {name: 'Concept Blueprint: Customer Ledger', exact: true}).boundingBox();
+    const valueProp = await page.getByText('Customer records in one place', {exact: true}).boundingBox();
+    assert.ok(heading.x + heading.width <= valueProp.x || heading.y + heading.height <= valueProp.y);
+    await page.getByRole('region', {name: 'Concept review'}).scrollIntoViewIfNeeded();
+    await page.screenshot({path: path.join(screenshots, `${viewport.width}.png`), fullPage: true});
+    await page.getByLabel('Requested changes').fill('Add status filtering.');
+    await page.getByRole('button', {name: 'Request Changes', exact: true}).click();
+    await page.getByRole('status').filter({hasText: 'Review submitted'}).waitFor();
+    assert.deepEqual(JSON.parse(await page.getByLabel('Review response').textContent()), {
+      action: 'request_changes', approved: false, review_id: 'review-1', rationale: 'Add status filtering.',
+    });
+    assert.equal(await page.getByRole('button', {name: 'Approve Concept', exact: true}).count(), 0);
+    await page.getByRole('button', {name: 'Next draft', exact: true}).click();
+    assert.equal(await page.getByLabel('Requested changes').inputValue(), '');
+    await page.getByLabel('Reject response').check();
+    await page.getByRole('button', {name: 'Approve Concept', exact: true}).click();
+    await page.getByRole('alert').waitFor();
+    await page.getByLabel('Reject response').uncheck();
+    await page.getByRole('button', {name: 'Approve Concept', exact: true}).click();
+    await page.getByRole('status').filter({hasText: 'Review submitted'}).waitFor();
+    assert.equal(JSON.parse(await page.getByLabel('Review response').textContent()).review_id, 'review-2');
+    assert.deepEqual(errors, []);
+    await page.close();
+  }
+});


### PR DESCRIPTION
## Summary

- Make ValueEngine concept review one response-bearing UI tool with explicit
  approve, request-changes and cancel outcomes and fail-closed graph routes.
- Persist owner/review-bound compare-and-set decisions, reject stale/replayed
  responses, and bound proposals to three using existing tool-outcome guards.
- Exercise real Mongo concurrency, native AG2 graph pause/resume and the actual
  React component at desktop/mobile widths; add the browser test to CI.

## Verification

- `pytest -q --no-cov`: 16,539 passed, 96 skipped, 3 warnings with disposable Mongo.
- Focused backend tests: 184 passed, 3 skipped; includes native AG2 scripted agents.
- `npm run test:concept-review`: passed desktop/mobile interaction and layout checks.
- `npm run test:workflow-ui`: 6 passed.
- Ruff, governance guardrails, mypy (604 files), and `git diff --check`: passed.
- Separately, the opted-in real-provider tool-outcome smoke passed five scenarios
  through AG2/Mozaiks: 13 model calls and 1,125 tokens. This is not a full app build.

## OSS Change Impact

- Layers: Factory ValueEngine review, shared artifact persistence, workflow UI.
- Build: approval completes; changes pause for user re-entry; cancel, invalid
  response or persistence failure blocks handoff. No sequence/entrypoint changes.
- Runtime: existing UI-tool, tool-outcome and native AG2 graph contracts are reused.
- App workspace: App Zero inherits this when it updates to a merged framework pin.
- Docs: shared workflow infrastructure and unreleased changelog updated.
- Compatibility: pre-1.0 replacement of the one-way concept surface. Existing
  duplicate concept app IDs require explicit cleanup before the unique index.

## Remaining Full-Build Blocker

ValueEngine startup registration currently mixes executing app identity with the
generated target. Authentication alone does not repair artifact and usage scoping.
Do not treat this PR, the three-proposal guard, or the smoke as a full Genesis,
commercial revision quota, wallet reservation, or total-spend guarantee. The
target-reference migration remains separate. No release or paid infrastructure.
