### PR TITLE
fix(runtime): reject startup changes to execution identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Security
 
+- Reject startup hooks that change immutable runtime identity or authorization
+  context before agent creation and model dispatch, including hooks that swallow
+  their own errors. This is a runtime invariant, not a generated-app target resolver.
 - Studio App Registry reads, updates, promotions, and deletes now carry the
   caller's owner scope into Mongo filters. Reopening an app ID cannot transfer
   ownership; concurrent same-owner creation is idempotent. Directory deletion

--- a/docs/architecture/mozaiksai/context-variables-complete.md
+++ b/docs/architecture/mozaiksai/context-variables-complete.md
@@ -39,6 +39,21 @@ Rules:
 
 ## Runtime Resolution Semantics
 
+Before agents are created, the runtime checks that `before_chat` hooks have not
+changed immutable runtime authority. This includes app/user/chat/workflow identity,
+tenant and workspace scope, permissions, secret handles, and variables explicitly
+declared `immutable_runtime_authority`. Adding or deleting an immutable value also
+fails. The check runs after the best-effort hook block, so a hook cannot bypass it
+by catching its own exception. Failure uses the existing failed-run transport and
+`on_fail` lifecycle path; orchestration does not dispatch that run to AG2.
+
+Mutable preload information can still be populated. The check does not undo
+external side effects already performed by a hook, or replace per-writer mutation
+authorization. A generated app's target identity must be resolved separately by
+the owning Factory/Studio build lifecycle; it must never replace the executing
+app's `app_id`. The existing ValueEngine registration hook and downstream artifact
+scoping still require that migration before a hosted full-build proof is safe.
+
 Source types supported by runtime:
 
 - `config`

--- a/mozaiksai/core/workflow/context/authority.py
+++ b/mozaiksai/core/workflow/context/authority.py
@@ -372,6 +372,26 @@ class ScopedContextWriter:
             raise ContextAuthorityError("context_authority.unsupported_target")
 
 
+def require_unchanged_runtime_authority(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    *,
+    policy: ContextAuthorityPolicy | None = None,
+) -> None:
+    """Reject lifecycle changes to runtime authority before agent execution."""
+    missing = object()
+    for key in sorted(before.keys() | after.keys()):
+        authority = policy.variables.get(key) if policy is not None else None
+        immutable = _is_immutable_key(key) or (
+            authority is not None
+            and authority.authority_class is ContextAuthorityClass.IMMUTABLE_RUNTIME_AUTHORITY
+        )
+        if immutable and before.get(key, missing) != after.get(key, missing):
+            raise ContextAuthorityError(
+                f"context_authority.lifecycle_changed_runtime_authority key={key}"
+            )
+
+
 def resolve_declared_context_writer(
     key: str,
     *,
@@ -724,6 +744,7 @@ __all__ = [
     "ContextVariableAuthority",
     "ContextWriterId",
     "ScopedContextWriter",
+    "require_unchanged_runtime_authority",
     "build_context_authority_policy",
     "validate_transition_context_authority",
 ]

--- a/mozaiksai/core/workflow/orchestration_patterns.py
+++ b/mozaiksai/core/workflow/orchestration_patterns.py
@@ -34,6 +34,8 @@ from mozaiksai.core.workflow.execution.network_graph import (
 from mozaiksai.core.workflow.outputs.runtime_validation import normalize_json_candidate_text
 
 from .context import DerivedContextManager
+from .context.authority import require_unchanged_runtime_authority
+from .context.frozen import detach
 from .execution.run_bootstrap import merge_persisted_extra_context, prepare_network_trigger
 from .orchestration_utils import _load_workflow_config
 
@@ -846,6 +848,7 @@ async def run_workflow_orchestration(
             )
 
         # 6) Preload deterministic context before agent prompts are composed.
+        pre_lifecycle_context = detach(ctx_dict)
         try:
             from mozaiksai.core.workflow.execution.lifecycle import get_lifecycle_manager
 
@@ -864,11 +867,19 @@ async def run_workflow_orchestration(
         # bridge source before agent prompts and AG2 channel state are created.
         if context is not None:
             if hasattr(context, "to_dict"):
-                ctx_dict.update(context.to_dict())
+                ctx_dict = context.to_dict()
             elif hasattr(context, "snapshot") and callable(getattr(context, "snapshot", None)):
-                ctx_dict.update(context.snapshot())
+                ctx_dict = context.snapshot()
             elif isinstance(context, dict):
-                ctx_dict.update(context)
+                ctx_dict = dict(context)
+
+        # Hooks can catch their own errors; validate the resulting snapshot
+        # outside the best-effort hook block before agent creation and AG2 dispatch.
+        require_unchanged_runtime_authority(
+            pre_lifecycle_context,
+            ctx_dict,
+            policy=getattr(context, "_mozaiks_context_authority_policy", None),
+        )
 
         _conv_logger.info(
             "[%s] PRE_AGENT_CONTEXT_READY keys=%s key_count=%s",

--- a/tests/test_lifecycle_identity_guard.py
+++ b/tests/test_lifecycle_identity_guard.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mozaiksai.core.workflow.context.adapter import create_context_container
+from mozaiksai.core.workflow.context.authority import (
+    ContextAuthorityError,
+    build_context_authority_policy,
+    require_unchanged_runtime_authority,
+)
+from mozaiksai.core.workflow.context.frozen import detach
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["app_id", "user_id", "chat_id", "workflow_name", "workspace_id",
+     "build_registry_id", "target_app_id", "permissions", "api_key_handle"],
+)
+@pytest.mark.parametrize("mutation", ["replace", "add", "delete"])
+def test_immutable_authority_changes_are_rejected(key, mutation):
+    before = {} if mutation == "add" else {key: "original-private-value"}
+    after = {} if mutation == "delete" else {key: "changed-private-value"}
+    with pytest.raises(ContextAuthorityError, match=f"key={key}") as exc:
+        require_unchanged_runtime_authority(before, after)
+    assert "private-value" not in str(exc.value)
+
+
+def test_custom_immutable_declaration_is_checked():
+    policy = build_context_authority_policy(
+        workflow_name="GuardSmoke",
+        definitions={"execution_scope": {
+            "type": "object", "source": {"type": "state", "default": {}},
+            "authority_class": "immutable_runtime_authority",
+        }},
+    )
+    with pytest.raises(ContextAuthorityError, match="key=execution_scope"):
+        require_unchanged_runtime_authority(
+            {"execution_scope": {"owner": "one"}},
+            {"execution_scope": {"owner": "two"}}, policy=policy,
+        )
+
+
+def test_mutable_preload_and_identical_authority_are_allowed():
+    require_unchanged_runtime_authority(
+        {"app_id": "host", "permissions": ["read"], "summary": "old"},
+        {"app_id": "host", "permissions": ["read"], "summary": "new", "ready": True},
+    )
+
+
+def test_missing_authority_is_not_equivalent_to_null():
+    with pytest.raises(ContextAuthorityError, match="key=app_id"):
+        require_unchanged_runtime_authority({"app_id": None}, {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("container_kind", ["runtime", "dict"])
+@pytest.mark.parametrize("mutation", ["replace", "delete", "nested", "caught_error", "factory_hook"])
+async def test_startup_identity_change_stops_before_agent_creation(
+    monkeypatch, container_kind, mutation,
+):
+    from mozaiksai.core.transport.simple_transport import SimpleTransport
+    from mozaiksai.core.workflow import orchestration_patterns as orchestration
+    from mozaiksai.core.workflow import task_batches
+    from mozaiksai.core.workflow.execution import lifecycle
+    from mozaiksai.core.workflow.outputs import structured
+
+    initial = {"app_id": "factory-host", "permissions": ["read"]}
+    policy = build_context_authority_policy(workflow_name="GuardSmoke", definitions={
+        "permissions": {"type": "array", "source": {"type": "state", "default": []}},
+    })
+    context = (create_context_container(initial, authority_policy=policy)
+               if container_kind == "runtime" else detach(initial))
+    persistence = SimpleNamespace(
+        load_run_events=AsyncMock(return_value=[]),
+        create_chat_session=AsyncMock(),
+        get_or_assign_cache_seed=AsyncMock(return_value=1),
+        fetch_chat_session_extra_context=AsyncMock(return_value={}),
+        mark_chat_completed=AsyncMock(),
+    )
+    transport = SimpleNamespace(connections={}, send_event_to_ui=AsyncMock())
+    agents_factory = AsyncMock(return_value={})
+    network_phase = AsyncMock()
+    manager = lifecycle.LifecycleToolManager("GuardSmoke")
+    manager._emit_lifecycle_event = AsyncMock()
+
+    def mutate(context_variables):
+        if mutation == "delete":
+            if container_kind == "runtime":
+                context_variables.remove("app_id")
+            else:
+                del context_variables["app_id"]
+            return
+        key, value = ("permissions", ["read", "admin"]) if mutation == "nested" else ("app_id", "target-app")
+        if container_kind == "runtime":
+            context_variables.set(key, value)
+        elif mutation == "nested":
+            context_variables[key].append("admin")
+        else:
+            context_variables[key] = value
+        if mutation == "caught_error":
+            raise RuntimeError("hook error swallowed by LifecycleToolManager")
+
+    hook = mutate
+    if mutation == "factory_hook":
+        from factory_app.workflows.ValueEngine.tools import create_app_record
+
+        monkeypatch.setattr(create_app_record, "_create_studio_app", AsyncMock(return_value={
+            "success": True,
+            "app": {"build_registry_id": "build-one", "app_id": "target-app"},
+        }))
+        hook = create_app_record.create_app_record
+
+    manager.tools[lifecycle.LifecycleTrigger.BEFORE_CHAT] = [lifecycle.LifecycleTool(
+        trigger=lifecycle.LifecycleTrigger.BEFORE_CHAT, agent=None,
+        file="mutate.py", function="mutate", description=None,
+        callable=hook, accepts_context=True,
+    )]
+    monkeypatch.setattr(orchestration, "AG2PersistenceManager", lambda: persistence)
+    monkeypatch.setattr(SimpleTransport, "get_instance", AsyncMock(return_value=transport))
+    monkeypatch.setattr(orchestration, "_run_ag2_network_phase", network_phase)
+    monkeypatch.setattr(orchestration, "_load_workflow_config", lambda name: {
+        "config": {"workflow_startup_mode": "AgentDriven"},
+        "max_turns": 2, "workflow_startup_mode": "AgentDriven",
+        "initial_agent_name": "PlannerAgent",
+    })
+    monkeypatch.setattr(task_batches, "load_task_batches_config", lambda name: None)
+    monkeypatch.setattr(structured, "load_workflow_structured_outputs", lambda name: ({}, {}))
+    monkeypatch.setattr(lifecycle, "get_lifecycle_manager", lambda name: manager)
+
+    with pytest.raises(ContextAuthorityError, match="lifecycle_changed_runtime_authority"):
+        await orchestration.run_workflow_orchestration(
+            workflow_name="GuardSmoke", app_id="factory-host", chat_id="chat-one",
+            user_id="user-one", initial_message="Build an app",
+            agents_factory=agents_factory, context_factory=lambda: context,
+        )
+
+    agents_factory.assert_not_awaited()
+    network_phase.assert_not_awaited()
+    persistence.mark_chat_completed.assert_not_awaited()
+    assert persistence.create_chat_session.await_args.kwargs["app_id"] == "factory-host"
+    events = [call.args[0] for call in transport.send_event_to_ui.await_args_list]
+    assert [event["kind"] for event in events] == ["error", "run_complete"]
+    assert events[-1]["status"] == "failed"
+    assert events[-1]["run_completed"] is False


### PR DESCRIPTION
## Summary

- Snapshot startup context and reject immutable runtime authority changes after
  before-chat hooks, outside their best-effort exception handling.
- Reuse the canonical authority taxonomy; cover replacement, addition, deletion,
  declared immutable fields and nested permission changes without logging values.
- Replace context snapshot refresh instead of merging, so deleted identities do
  not survive in a stale copy and escape validation.
- Exercise the real lifecycle manager and ValueEngine registration hook with
  a simulated registration response. Assert no agent creation/AG2 dispatch and
  normal failed-run UI events. Existing valid AG2 execution stays covered.

## Verification

- `pytest -q --no-cov`: 16,548 passed, 96 skipped, 4 warnings in 1,378.34s.
  This local run used the branch based on a79469e7; PR CI also checks integration
  with the now-merged concept review change (#506).
- Focused authority, lifecycle and native AG2 execution tests: 133 passed.
- Ruff, governance guardrails, mypy (604 source files), `git diff --check`: passed.
- No paid model requests for these tests. Local Mongo is disposable and separate
  from the operator's Docker services.

## OSS Change Impact

- Primitives: Run and runtime authority around ExecutionEngine dispatch.
- Owner: generic workflow context authority and orchestration, not hosted policy.
- Build workflow: any startup hook changing executing identity now fails before
  agent creation. No workflow-specific branch, schema, transition or billing rule.
- Runtime/platform: existing failed-run and on_fail paths are used; immutable
  keys come from the existing authority contract. AG2 keeps execution ownership.
- App workspace: no App Zero or generated-app config changes in this PR.
- Docs: context variable contract and unreleased security changelog updated.
- Compatibility: intentional pre-1.0 enforcement. Hooks must not repurpose app_id
  or other runtime authority as a generated target.

## Not Solved Here

This is an invariant check, not per-writer authorization or a transaction over
hook side effects. It does not fix required registration, create hosted records,
resolve generated targets, or migrate artifact/session/refinement scopes. The
existing Factory target migration remains required before a hosted Genesis
proof. No fabricated target wallet grants or product-specific runtime fork.
