### PR TITLE
fix(runtime): isolate app services across workspace reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Bind app service imports to the selected workspace on reload and reset
+  platform health state for each startup attempt.
+
 - Preserve explicitly empty generated files, including Python package markers,
   so app service imports resolve from the generated bundle.
 

--- a/docs/architecture/app/platform-authoring.md
+++ b/docs/architecture/app/platform-authoring.md
@@ -33,6 +33,10 @@ Current repo note:
 
 ## Primary Families
 
+Module loading binds the Python `services` package to the active app root.
+Reloading a workspace must not resolve service clients from another app left
+on the process import path. Python package markers remain optional.
+
 | Family | Purpose | Path |
 | --- | --- | --- |
 | App manifest | Small app identity and target manifest | `app/app.json` |

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -1159,9 +1159,13 @@ class ModuleLoader:
         import_roots = [self._base.parent, self._base] if self._base.name == "app" else [self._base]
         for root in import_roots:
             root_text = str(root.resolve())
-            if root_text not in sys.path:
-                sys.path.insert(0, root_text)
+            if root_text in sys.path:
+                sys.path.remove(root_text)
+            sys.path.insert(0, root_text)
         self._clear_registered_package("services")
+        # Bind optional app support code to this workspace, even when another
+        # workspace has a regular services package elsewhere on sys.path.
+        self._register_module_package("services", self._base / "services")
 
     def discover_module_names(self) -> list[str]:
         """Return module names for every modules/*/module.yaml in the bundle."""

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -266,6 +266,9 @@ async def _platform_startup() -> None:
 
     validate_auth_provider_configuration()
 
+    app.state.startup_degraded = False
+    app.state.startup_degraded_reason = None
+    app.state.failed_module_names = []
     app_root = resolve_app_root()
     database_startup_policy = get_database_startup_policy()
     logger.info("DATABASE_STARTUP_POLICY: policy=%s app_root=%s", database_startup_policy, app_root)

--- a/tests/test_workspace_reload_isolation.py
+++ b/tests/test_workspace_reload_isolation.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mozaiksai.core.runtime.app.module_loader import ModuleLoader
+
+
+@pytest.fixture
+def import_state(monkeypatch):
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    names = [key for key in sys.modules if key == "services" or key.startswith("services.")]
+    saved = {key: sys.modules[key] for key in names}
+    yield
+    ModuleLoader._clear_registered_package("services")
+    sys.modules.update(saved)
+
+
+def test_reloading_workspace_prioritizes_its_own_optional_service_package(tmp_path, import_state):
+    first = tmp_path / "first" / "app"
+    second = tmp_path / "second" / "app"
+    for root in (first, second):
+        (root / "services" / "integrations").mkdir(parents=True)
+    (second / "services" / "__init__.py").write_text("", encoding="utf-8")
+    (second / "services" / "integrations" / "__init__.py").write_text("", encoding="utf-8")
+    (first / "services" / "integrations" / "client.py").write_text('WORKSPACE = "first"\n', encoding="utf-8")
+    (second / "services" / "integrations" / "client.py").write_text('WORKSPACE = "second"\n', encoding="utf-8")
+
+    for root, expected in ((first, "first"), (second, "second"), (first, "first")):
+        ModuleLoader(str(root))
+        client = importlib.import_module("services.integrations.client")
+        assert client.WORKSPACE == expected
+        assert sys.path[0] == str(root.resolve())
+        assert sys.path.count(str(root.resolve())) == 1
+
+
+def test_workspace_without_services_cannot_import_another_apps_clients(tmp_path, import_state):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    (first / "services").mkdir(parents=True)
+    second.mkdir()
+    (first / "services" / "__init__.py").write_text("", encoding="utf-8")
+    (first / "services" / "private_client.py").write_text("VALUE = 1\n", encoding="utf-8")
+    ModuleLoader(str(first))
+    assert importlib.import_module("services.private_client").VALUE == 1
+    ModuleLoader(str(second))
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("services.private_client")
+
+
+@pytest.mark.asyncio
+async def test_platform_startup_health_does_not_retain_an_earlier_failure(monkeypatch):
+    from mozaiksai.core.auth.adapters import registry
+    from mozaiksai.hosts import platform
+
+    monkeypatch.setattr(registry, "validate_auth_provider_configuration", lambda: None)
+    monkeypatch.setattr(platform, "get_platform_hooks", lambda: SimpleNamespace(run_startup=AsyncMock()))
+    monkeypatch.setattr(platform.app.state, "startup_degraded", False)
+    monkeypatch.setattr(platform.app.state, "startup_degraded_reason", None)
+    monkeypatch.setattr(platform.app.state, "failed_module_names", [], raising=False)
+    monkeypatch.setattr(platform.AppLoader, "load", AsyncMock(side_effect=[
+        platform.AppLoadError("invalid app contract"),
+        platform.AppLoadError("app.json not found"),
+    ]))
+    await platform._platform_startup()
+    assert platform.app.state.startup_degraded is True
+    assert platform.app.state.startup_degraded_reason == "APP_LOAD_ERROR"
+    await platform._platform_startup()
+    assert platform.app.state.startup_degraded is False
+    assert platform.app.state.startup_degraded_reason is None
+    assert platform.app.state.failed_module_names == []


### PR DESCRIPTION
## Summary
- Bind the optional services package to the selected app so another workspace cannot supply service clients.
- Prioritize the selected app on reload and reset startup health for each startup attempt.
- Add regressions for switching between apps, absent services, and recovery after startup failure.

## Evidence
Three generated-app startup failures reproduced on unchanged main before this repair. After the fix:
- ruff check .: passed
- pytest -q --no-cov --reruns 0: 16,766 passed, 96 skipped
- Focused runtime/module/generated-app tests: 90 passed

## OSS Change Impact
Runtime/platform ownership only. No workflow sequence, generated contract, hosted provider, or release changes. App imports are isolated to the selected workspace. Updated platform authoring documentation and changelog.

Signed-off commits included. No public release requested.