### PR TITLE
fix(artifacts): align Mongo indexes with build record identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project follows a practical pre-1.0 changelog format:
 - Bind app service imports to the selected workspace on reload and reset
   platform health state for each startup attempt.
 
+- Build-record and version-counter uniqueness now follows `build_family` and
+  `build_key`. Known retired indexes are replaced without deleting records;
+  failed index initialization is retried instead of leaving a half-ready store.
+
 - Preserve explicitly empty generated files, including Python package markers,
   so app service imports resolve from the generated bundle.
 

--- a/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
+++ b/docs/architecture/foundations/events-and-data/persistence-and-artifact-storage.md
@@ -80,6 +80,14 @@ Framework-owned pipeline artifacts produced and consumed by `factory_app`:
 These collections hold the durable handoff between workflow stages such as
 `ValueEngine`, `DesignDocs`, `AgentGenerator`, and `AppGenerator`.
 
+Versioned `BuildRecord` documents in `ArtifactVersions` use the unique key
+`(app_id, build_family, build_key, version_number)`. Counters in
+`ArtifactVersionCounters` use `(app_id, build_family, build_key)`. Store
+initialization installs these indexes for canonical records and removes only
+the known obsolete unique indexes over `artifact_kind` and `artifact_key`.
+Existing documents are not deleted or rewritten. An unexpected index definition
+or conflicting canonical data fails initialization and requires operator review.
+
 ### 2b. Platform Connector Metadata
 
 Platform-owned, app-scoped connector metadata used by the visible

--- a/mozaiksai/core/artifacts/store.py
+++ b/mozaiksai/core/artifacts/store.py
@@ -7,6 +7,7 @@ from typing import Any
 from uuid import uuid4
 
 from pymongo import ReturnDocument
+from pymongo.errors import OperationFailure
 
 from logs.logging_config import get_workflow_logger
 from mozaiksai.core.core_config import get_mongo_client
@@ -52,15 +53,21 @@ class BuildRecordStore:
         async with self._init_lock:
             if self.client is not None:
                 return
-            self.client = get_mongo_client()
-            await self._ensure_indexes()
+            client = get_mongo_client()
+            await self._ensure_indexes(client["mozaiksai"])
+            self.client = client
 
-    async def _ensure_indexes(self) -> None:
-        versions = await self._coll("ArtifactVersions")
+    async def _ensure_indexes(self, database: Any) -> None:
+        versions = database["ArtifactVersions"]
         await versions.create_index(
-            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
-            name="av_app_kind_key_version",
+            [("app_id", 1), ("build_family", 1), ("build_key", 1), ("version_number", -1)],
+            name="br_app_family_key_version",
             unique=True,
+            partialFilterExpression={"build_family": {"$type": "string"}, "build_key": {"$type": "string"}},
+        )
+        await self._retire_index(
+            versions, "av_app_kind_key_version",
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
         )
         await versions.create_index(
             [("app_id", 1), ("lineage_root_id", 1), ("created_at", -1)],
@@ -71,14 +78,19 @@ class BuildRecordStore:
             name="av_app_status_updated",
         )
 
-        counters = await self._coll("ArtifactVersionCounters")
+        counters = database["ArtifactVersionCounters"]
         await counters.create_index(
-            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
-            name="avc_app_kind_key",
+            [("app_id", 1), ("build_family", 1), ("build_key", 1)],
+            name="brc_app_family_key",
             unique=True,
+            partialFilterExpression={"build_family": {"$type": "string"}, "build_key": {"$type": "string"}},
+        )
+        await self._retire_index(
+            counters, "avc_app_kind_key",
+            [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
         )
 
-        change_requests = await self._coll("ChangeRequests")
+        change_requests = database["ChangeRequests"]
         await change_requests.create_index(
             [("app_id", 1), ("build_record_id", 1), ("created_at", -1)],
             name="cr_app_record_created",
@@ -88,7 +100,7 @@ class BuildRecordStore:
             name="cr_app_class_created",
         )
 
-        refinement_sessions = await self._coll("RefinementSessions")
+        refinement_sessions = database["RefinementSessions"]
         await refinement_sessions.create_index(
             [("app_id", 1), ("build_record_id", 1), ("started_at", -1)],
             name="rs_app_record_started",
@@ -103,6 +115,19 @@ class BuildRecordStore:
             name="rs_app_sandbox",
             sparse=True,
         )
+
+    @staticmethod
+    async def _retire_index(collection: Any, name: str, expected_keys: list[tuple[str, int]]) -> None:
+        index = (await collection.index_information()).get(name)
+        if index is None:
+            return
+        if list(index.get("key", [])) != expected_keys or not index.get("unique"):
+            raise RuntimeError(f"Cannot replace unexpected index definition: {name}")
+        try:
+            await collection.drop_index(name)
+        except OperationFailure as exc:
+            if exc.code != 27:  # Another process may have retired the same index.
+                raise
 
     async def _coll(self, name: str):
         await self._ensure_client()

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -31,6 +31,20 @@ BuildRecordStore = _artifact_store_mod.BuildRecordStore
 
 
 @pytest.mark.asyncio
+async def test_index_failure_leaves_store_uninitialized_and_retries(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(_artifact_store_mod, "get_mongo_client", lambda: client)
+    store = BuildRecordStore()
+    store._ensure_indexes = AsyncMock(side_effect=[RuntimeError("index failure"), None])
+    with pytest.raises(RuntimeError, match="index failure"):
+        await store._ensure_client()
+    assert store.client is None
+    await store._ensure_client()
+    assert store.client is client
+    assert store._ensure_indexes.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_create_build_record_persists_manifest_and_lineage() -> None:
     store = BuildRecordStore.__new__(BuildRecordStore)
     versions_coll = MagicMock()

--- a/tests/test_build_record_indexes_mongo.py
+++ b/tests/test_build_record_indexes_mongo.py
@@ -1,0 +1,90 @@
+"""Index behavior against MongoDB, using disposable test-only databases."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo.errors import DuplicateKeyError
+
+from mozaiksai.core.artifacts.store import BuildRecordStore
+
+
+@pytest_asyncio.fixture
+async def records(monkeypatch):
+    database_name = f"build_record_indexes_{uuid4().hex}"
+    client = AsyncIOMotorClient(os.getenv("MONGO_URI", "mongodb://127.0.0.1:27017"), serverSelectionTimeoutMS=1500)
+    try:
+        await client.admin.command("ping")
+    except Exception:
+        client.close()
+        if os.getenv("MOZAIKS_REQUIRE_REAL_MONGO"):
+            pytest.fail("Real MongoDB is required")
+        pytest.skip("MongoDB is unavailable")
+    database = client[database_name]
+    store = BuildRecordStore()
+
+    async def collection(name):
+        return database[name]
+
+    monkeypatch.setattr(store, "_coll", collection)
+    try:
+        yield store, database
+    finally:
+        assert database_name.startswith("build_record_indexes_")
+        await client.drop_database(database_name)
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_index_upgrade_preserves_records_and_separates_families(records):
+    store, database = records
+    await database.ArtifactVersions.create_index(
+        [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1), ("version_number", -1)],
+        name="av_app_kind_key_version", unique=True,
+    )
+    await database.ArtifactVersionCounters.create_index(
+        [("app_id", 1), ("artifact_kind", 1), ("artifact_key", 1)],
+        name="avc_app_kind_key", unique=True,
+    )
+    preexisting = {"_id": "old-record", "app_id": "app", "artifact_kind": "concept", "artifact_key": "concept", "version_number": 1}
+    await database.ArtifactVersions.insert_one(dict(preexisting))
+    await store._ensure_indexes(database)
+    await store._ensure_indexes(database)
+    assert await database.ArtifactVersions.find_one({"_id": "old-record"}) == preexisting
+    assert "av_app_kind_key_version" not in await database.ArtifactVersions.index_information()
+    assert "avc_app_kind_key" not in await database.ArtifactVersionCounters.index_information()
+
+    created = []
+    for app, family, key in [("app", "concept", "concept"), ("app", "design_docs", "design_docs"), ("app", "design_docs", "alternate"), ("other", "concept", "concept")]:
+        record = await store.create_build_record(app_id=app, build_family=family, build_key=key)
+        assert record.version_number == 1
+        created.append(record)
+    next_version = await store.create_build_record(app_id="app", build_family="concept", build_key="concept")
+    assert next_version.version_number == 2
+    duplicate = created[0].model_dump(by_alias=True)
+    duplicate["_id"] = "duplicate"
+    with pytest.raises(DuplicateKeyError):
+        await database.ArtifactVersions.insert_one(duplicate)
+    assert await database.ArtifactVersions.count_documents({}) == 6
+
+
+@pytest.mark.asyncio
+async def test_existing_canonical_records_do_not_collide_on_missing_retired_fields(records):
+    store, database = records
+    for family in ("concept", "design_docs"):
+        await store.create_build_record(app_id="app", build_family=family, build_key=family)
+    await store._ensure_indexes(database)
+    assert await database.ArtifactVersions.count_documents({}) == 2
+
+
+@pytest.mark.asyncio
+async def test_unexpected_operator_index_is_not_dropped(records):
+    store, database = records
+    await database.ArtifactVersions.create_index([("operator_field", 1)], name="av_app_kind_key_version", unique=True)
+    with pytest.raises(RuntimeError, match="unexpected index definition"):
+        await store._ensure_indexes(database)
+    assert "av_app_kind_key_version" in await database.ArtifactVersions.index_information()


### PR DESCRIPTION
## Summary
- Create canonical partial unique indexes for build family/key identity before retiring the exact obsolete indexes.
- Preserve all records and fail closed for unexpected operator-owned index definitions.
- Publish the lazy Mongo client only after successful index setup, allowing setup failures to retry.

## Verification
- ruff check .: passed
- pytest -q --no-cov --reruns 0 with MOZAIKS_REQUIRE_REAL_MONGO=1: 16770 passed, 96 skipped
- Real Mongo regression coverage verifies old-record preservation, canonical uniqueness, and retry after setup failure.

## Runtime Impact
Artifact persistence only; no AG2 scheduling change, product policy, infrastructure provisioning, or release action.