### PR TITLE
Add security readiness factory workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project follows a practical pre-1.0 changelog format:
 
 ### App workspace alignment
 
+- Add an advisory `SecurityReadiness` Factory workflow and build context so generated app bundles can surface baseline auth, secret, permission, tenant-scope, deployment, and eval-readiness findings during AppReview.
+
 - Add a first-party Factory `security_readiness` module for app/build security
   findings, summaries, and review status without introducing hosted-only
   compliance logic into OSS.

--- a/factory_app/build_context/SecurityReadiness/app_security_file_contracts.yaml
+++ b/factory_app/build_context/SecurityReadiness/app_security_file_contracts.yaml
@@ -1,0 +1,24 @@
+contract_id: app_security_file_contracts
+contract_type: generated_app_security_files
+version: 1
+files:
+  - path: app/security/secrets.yaml
+    required: when_app_declares_secret_requirements
+    owner: AppGenerator
+    rules:
+      - Names-only contract; never raw credential values.
+      - Use version 1 and secrets entries with id, env, purpose, required, and optional provider policy.
+      - Do not place Python resolver code under app/security/.
+  - path: app/security/production_operations.yaml
+    required: when_app_declares_production_or_hosted_operations
+    owner: AppGenerator_or_hosted_overlay
+    rules:
+      - Provider-neutral operational authority contract.
+      - No tenant ids, connection strings, tokens, or cloud resource secrets.
+      - Hosted products may extend with stricter operation classes through workspace build_context overlays.
+  - path: app/config/auth.yaml
+    required: when_auth_required_or_provider_configured
+    owner: AppGenerator
+    rules:
+      - Provider-neutral auth behavior lives here.
+      - Provider mechanics belong under app/services/adapters/auth/ only when the app itself owns the provider integration.

--- a/factory_app/build_context/SecurityReadiness/baseline_security_controls.yaml
+++ b/factory_app/build_context/SecurityReadiness/baseline_security_controls.yaml
@@ -1,0 +1,50 @@
+contract_id: security_readiness_baseline
+contract_type: build_security_controls
+version: 1
+mode: advisory
+selection_rules:
+  - id: always_review_generated_app_bundle
+    when:
+      artifact_family: app_bundle
+    action: inspect_after_app_generator
+  - id: record_findings_not_credentials
+    when:
+      finding_source: generated_app_bundle
+    action: record_names_and_evidence_only
+required_checks:
+  - id: no_raw_secret_values
+    severity: critical
+    control_area: secrets
+    rule: Generated app files must not contain raw API keys, tokens, passwords, private keys, or webhook secret values.
+  - id: secret_contract_is_names_only
+    severity: high
+    control_area: secrets
+    rule: app/security/secrets.yaml may declare secret names, env handles, and provider policy only; it must not carry credential values.
+  - id: auth_contract_when_auth_required
+    severity: high
+    control_area: auth
+    rule: Apps that require authentication should declare app/config/auth.yaml or an equivalent app-level auth contract.
+  - id: module_permissions_declared
+    severity: high
+    control_area: permissions
+    rule: Module actions that expose private or mutating APIs must declare permissions that resolve to module.yaml permissions entries.
+  - id: tenant_scope_for_persistent_modules
+    severity: high
+    control_area: tenant_isolation
+    rule: Persistent multi-user modules should keep ownership/scope policy in backend/policy.py and use ctx.persistence through backend/repo.py.
+  - id: production_operations_when_deployable
+    severity: medium
+    control_area: deployment
+    rule: Deployable apps should declare production operation expectations instead of relying on hidden hosted defaults.
+forbidden_outputs:
+  - path_prefix: app/services/security/
+    reason: Secret policy belongs in app/security/secrets.yaml and generic secret resolution belongs in mozaiksai.core.secrets.
+  - path_prefix: app/build_context/
+    reason: Build context lives at workspace root build_context/, beside app/ and workflows/.
+runtime_boundaries:
+  - id: advisory_by_default
+    rule: OSS SecurityReadiness records findings and review evidence by default. Promotion blocking requires an explicit future policy switch.
+  - id: no_compliance_claims
+    rule: OSS readiness checks are not SOC2, ISO, HIPAA, or PCI certification claims.
+  - id: hosted_compliance_overlay
+    rule: Hosted product repos may add proprietary SOC2/ISO/evidence build contexts that apply to SecurityReadiness without forking the OSS workflow.

--- a/factory_app/build_context/SecurityReadiness/context.yaml
+++ b/factory_app/build_context/SecurityReadiness/context.yaml
@@ -1,0 +1,12 @@
+context_id: SecurityReadiness
+applies_to_workflows:
+  - SecurityReadiness
+assets:
+  - path: baseline_security_controls.yaml
+    kind: contract
+  - path: app_security_file_contracts.yaml
+    kind: contract
+  - path: finding_taxonomy.yaml
+    kind: catalog
+projections:
+  context_variables: {}

--- a/factory_app/build_context/SecurityReadiness/finding_taxonomy.yaml
+++ b/factory_app/build_context/SecurityReadiness/finding_taxonomy.yaml
@@ -1,0 +1,18 @@
+catalog_id: security_readiness_finding_taxonomy
+version: 1
+statuses: [open, accepted, resolved]
+severities: [low, medium, high, critical]
+sources: [manual, validation, eval, import]
+control_areas:
+  - auth
+  - secrets
+  - permissions
+  - tenant_isolation
+  - managed_capability_boundary
+  - deployment
+  - data_persistence
+  - evals
+  - compliance_readiness
+blocking_policy:
+  default_mode: advisory
+  advisory_blocking_definition: Open high or critical findings are highlighted as blocking candidates but do not block promotion in OSS.

--- a/factory_app/workflows/AppReview/context_variables.yaml
+++ b/factory_app/workflows/AppReview/context_variables.yaml
@@ -122,6 +122,15 @@ definitions:
       type: state
       default: null
 
+  security_readiness_summary:
+    type: object
+    description: >
+      Advisory SecurityReadiness result for the staged app bundle. The OSS
+      default is review evidence, not a promotion block.
+    source:
+      type: state
+      default: {}
+
   review_complete:
     type: boolean
     description: >

--- a/factory_app/workflows/AppReview/tools/review_context.py
+++ b/factory_app/workflows/AppReview/tools/review_context.py
@@ -151,6 +151,8 @@ def build_review_summary_payload(context_variables: Any | None) -> dict[str, Any
         ),
         "app_bundle_acceptance_status": app_bundle_acceptance_status,
         "integration_tests_passed": integration_tests_passed,
+        "security_readiness_summary": _context_get(context_variables, "security_readiness_summary")
+        or {},
         "promotion_blockers": promotion_blockers,
         "revision_blockers": revision_blockers,
         "review_ready": can_promote and can_revise,

--- a/factory_app/workflows/AppReview/ui/AppReview/AppReviewSummary.jsx
+++ b/factory_app/workflows/AppReview/ui/AppReview/AppReviewSummary.jsx
@@ -17,6 +17,7 @@ const STATUS_TONE = {
   passed: 'success',
   failed: 'destructive',
   skipped: 'default',
+  attention_required: 'warning',
 };
 
 function ValidationRow({ label, status }) {
@@ -67,6 +68,9 @@ export default function AppReviewSummary({ payload = {} }) {
     }
   }, [payload]);
 
+  const securitySummary = payload.security_readiness_summary || {};
+  const securityStatus = securitySummary.status || (securitySummary.finding_count > 0 ? 'attention_required' : 'skipped');
+  const securityFindings = Array.isArray(securitySummary.findings) ? securitySummary.findings : [];
   const validationStatus = payload.app_validation_status || 'skipped';
   const acceptanceStatus = payload.app_bundle_acceptance_status || null;
   const integrationStatus =
@@ -102,7 +106,17 @@ export default function AppReviewSummary({ payload = {} }) {
         )}
         <ValidationRow label="Build validation" status={validationStatus} />
         <ValidationRow label="Integration checks" status={integrationStatus} />
+        <ValidationRow label="Security readiness" status={securityStatus} />
       </div>
+
+      {securityFindings.length > 0 && (
+        <div className="mb-4 rounded-lg border border-warning/30 bg-warning/10 px-4 py-3">
+          <p className="text-sm font-medium text-warning">Security readiness needs attention</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {securityFindings.length} advisory finding{securityFindings.length === 1 ? '' : 's'} recorded for review.
+          </p>
+        </div>
+      )}
 
       {payload.app_validation_preview_url && (
         <div className="mb-4">

--- a/factory_app/workflows/SecurityReadiness/agents.yaml
+++ b/factory_app/workflows/SecurityReadiness/agents.yaml
@@ -1,0 +1,23 @@
+agents:
+  - name: SecurityReadinessAgent
+    structured_outputs_required: false
+    description: >
+      Reviews the generated app bundle after AppGenerator and records advisory
+      security readiness findings for AppReview. The agent uses deterministic
+      tools first and does not claim SOC2/ISO certification.
+    system_message: |
+      You are the SecurityReadinessAgent for the Mozaiks Factory build sequence.
+
+      On the first turn, call inspect_generated_app_security. Then call
+      record_security_findings with the returned findings. Treat the result as
+      advisory OSS readiness evidence: do not claim compliance certification and
+      do not request paid infrastructure.
+
+      Focus on canonical app contracts:
+      - app/security/secrets.yaml is names-only secret policy.
+      - app/security/production_operations.yaml is provider-neutral operational authority.
+      - app/config/auth.yaml owns provider-neutral auth behavior.
+      - app/modules/*/module.yaml owns action permissions and emitted events.
+      - app/modules/*/backend/policy.py owns module-local scoping policy.
+
+      When the tools complete, summarize the readiness status briefly and stop.

--- a/factory_app/workflows/SecurityReadiness/context_variables.yaml
+++ b/factory_app/workflows/SecurityReadiness/context_variables.yaml
@@ -1,0 +1,89 @@
+definitions:
+  app_id:
+    type: string
+    description: App identifier passed from AppGenerator.
+    source:
+      type: state
+      default: null
+  build_id:
+    type: string
+    description: Build attempt identifier passed from AppGenerator.
+    source:
+      type: state
+      default: null
+  build_registry_id:
+    type: string
+    description: Hosted app registry record id for this build.
+    source:
+      type: state
+      default: null
+  artifact_version_id:
+    type: string
+    description: App bundle artifact version id being reviewed.
+    source:
+      type: state
+      default: null
+  bundle_path:
+    type: string
+    description: Absolute path to the staged generated app bundle root.
+    source:
+      type: state
+      default: null
+  generated_files:
+    type: object
+    description: Optional generated app files map from AppGenerator context.
+    source:
+      type: state
+      default: {}
+  app_build_plan:
+    type: object
+    description: Optional AppBuildPlan context used to infer auth, deployment, and selected packs.
+    source:
+      type: state
+      default: {}
+  security_readiness_mode:
+    type: string
+    description: Advisory by default; hosted overlays may later opt into blocking gates.
+    source:
+      type: state
+      default: advisory
+  security_readiness_findings:
+    type: array
+    description: Findings produced by inspect_generated_app_security.
+    source:
+      type: computed
+      default: []
+  security_readiness_summary:
+    type: object
+    description: Summary written by SecurityReadiness and surfaced by AppReview.
+    source:
+      type: computed
+      default: {}
+  security_readiness_recorded:
+    type: boolean
+    description: True when record_security_findings has completed for this run.
+    source:
+      type: computed
+      default: false
+  workflow_sequence:
+    type: string
+    description: Active workflow sequence id for build journey continuity.
+    source:
+      type: state
+      default: null
+
+agents:
+  SecurityReadinessAgent:
+    variables:
+      - app_id
+      - build_id
+      - build_registry_id
+      - artifact_version_id
+      - bundle_path
+      - generated_files
+      - app_build_plan
+      - security_readiness_mode
+      - security_readiness_findings
+      - security_readiness_summary
+      - security_readiness_recorded
+      - workflow_sequence

--- a/factory_app/workflows/SecurityReadiness/orchestrator.yaml
+++ b/factory_app/workflows/SecurityReadiness/orchestrator.yaml
@@ -1,0 +1,7 @@
+schema_version: mozaiks.orchestrator.v1
+workflow_name: SecurityReadiness
+max_turns: 8
+human_in_the_loop: false
+workflow_startup_mode: AgentDriven
+orchestration_pattern: ag2_network
+initial_agent: SecurityReadinessAgent

--- a/factory_app/workflows/SecurityReadiness/structured_outputs.yaml
+++ b/factory_app/workflows/SecurityReadiness/structured_outputs.yaml
@@ -1,0 +1,4 @@
+schema_version: mozaiks.structured_outputs.v1
+registry:
+  SecurityReadinessAgent: null
+models: {}

--- a/factory_app/workflows/SecurityReadiness/tools.yaml
+++ b/factory_app/workflows/SecurityReadiness/tools.yaml
@@ -1,0 +1,19 @@
+tools:
+  - agent: SecurityReadinessAgent
+    file: tools/inspect_generated_app_security.py
+    function: inspect_generated_app_security
+    description: >
+      Deterministically inspect generated app files or bundle_path for baseline
+      security readiness issues and persist the security_readiness_summary into
+      context_variables.
+    tool_type: Agent_Tool
+    auto_tool_call: false
+  - agent: SecurityReadinessAgent
+    file: tools/record_security_findings.py
+    function: record_security_findings
+    description: >
+      Persist the latest security_readiness_findings into the first-party
+      security_readiness module when a ModuleContext is available, and always
+      keep the review summary in context_variables for AppReview.
+    tool_type: Agent_Tool
+    auto_tool_call: false

--- a/factory_app/workflows/SecurityReadiness/tools/inspect_generated_app_security.py
+++ b/factory_app/workflows/SecurityReadiness/tools/inspect_generated_app_security.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from factory_app.app.modules.security_readiness.backend.schemas import summarize_findings
+
+_TEXT_FILE_SUFFIXES = {
+    ".css",
+    ".env",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".py",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+_SKIP_PARTS = {".git", ".venv", "node_modules", "__pycache__", "dist", "build"}
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |)?PRIVATE KEY-----"),
+    re.compile(r"(?i)(?:api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=-]{24,}"),
+    re.compile(r"(?i)(?:sk_live|rk_live|ghp_|github_pat_|xox[baprs]-)[A-Za-z0-9_./+=-]{12,}"),
+)
+
+
+def _context_get(context_variables: Any | None, key: str, default: Any = None) -> Any:
+    if context_variables is None:
+        return default
+    if isinstance(context_variables, dict):
+        return context_variables.get(key, default)
+    if hasattr(context_variables, "get"):
+        try:
+            return context_variables.get(key, default)
+        except TypeError:
+            try:
+                return context_variables.get(key)
+            except Exception:
+                return default
+        except Exception:
+            return default
+    return default
+
+
+def _context_set(context_variables: Any | None, key: str, value: Any) -> None:
+    if context_variables is None:
+        return
+    if isinstance(context_variables, dict):
+        context_variables[key] = value
+        return
+    if hasattr(context_variables, "set"):
+        try:
+            context_variables.set(key, value)
+        except Exception:
+            return
+
+
+def _normalize_path(path: str) -> str:
+    return path.replace("\\", "/").lstrip("/")
+
+
+def _iter_context_files(context_variables: Any | None) -> dict[str, str]:
+    raw = _context_get(context_variables, "generated_files", {})
+    if isinstance(raw, dict):
+        return {str(k): str(v) for k, v in raw.items() if isinstance(k, str)}
+    return {}
+
+
+def _iter_bundle_files(bundle_path: str | None) -> dict[str, str]:
+    if not bundle_path:
+        return {}
+    root = Path(bundle_path)
+    if not root.exists() or not root.is_dir():
+        return {}
+    files: dict[str, str] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = set(path.relative_to(root).parts)
+        if rel_parts & _SKIP_PARTS:
+            continue
+        if path.suffix.lower() not in _TEXT_FILE_SUFFIXES:
+            continue
+        try:
+            files[_normalize_path(str(path.relative_to(root)))] = path.read_text(
+                encoding="utf-8", errors="ignore"
+            )
+        except OSError:
+            continue
+    return files
+
+
+def _finding(
+    *,
+    finding_id: str,
+    severity: str,
+    control_area: str,
+    title: str,
+    description: str,
+    evidence_path: str | None = None,
+    recommendation: str,
+) -> dict[str, Any]:
+    finding: dict[str, Any] = {
+        "finding_id": finding_id,
+        "severity": severity,
+        "status": "open",
+        "source": "validation",
+        "control_area": control_area,
+        "title": title,
+        "description": description,
+        "recommendation": recommendation,
+    }
+    if evidence_path:
+        finding["evidence"] = {"path": evidence_path}
+    return finding
+
+
+def _app_json(files: dict[str, str]) -> dict[str, Any]:
+    text = files.get("app.json") or files.get("app/app.json")
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _yaml_file(files: dict[str, str], path: str) -> dict[str, Any] | None:
+    text = files.get(path) or files.get(path.removeprefix("app/"))
+    if not text:
+        return None
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return {"__parse_error__": True}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _declares_auth_required(files: dict[str, str], context_variables: Any | None) -> bool:
+    app = _app_json(files)
+    for key in ("authRequired", "auth_required", "requiresAuth", "requires_auth"):
+        if app.get(key) is True:
+            return True
+    plan = _context_get(context_variables, "app_build_plan", {})
+    if isinstance(plan, dict):
+        auth = plan.get("auth") or plan.get("authentication") or plan.get("auth_config")
+        if isinstance(auth, dict):
+            return any(bool(auth.get(key)) for key in ("enabled", "required", "auth_required"))
+    return False
+
+
+def _declares_deployment(files: dict[str, str], context_variables: Any | None) -> bool:
+    if any(
+        path in files
+        for path in ("Dockerfile", "deployment.manifest.json", ".github/workflows/deploy.yml")
+    ):
+        return True
+    plan = _context_get(context_variables, "app_build_plan", {})
+    return isinstance(plan, dict) and bool(
+        plan.get("deployment_profile") or plan.get("deploymentProfile")
+    )
+
+
+def _scan_raw_secret_values(files: dict[str, str]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for path, text in sorted(files.items()):
+        if path.endswith("package-lock.json"):
+            continue
+        for pattern in _SECRET_VALUE_PATTERNS:
+            if pattern.search(text):
+                findings.append(
+                    _finding(
+                        finding_id=f"raw_secret_value:{path}",
+                        severity="critical",
+                        control_area="secrets",
+                        title="Possible raw secret value in generated file",
+                        description="A generated file matched a raw credential pattern. The finding records only the file path, not the matched value.",
+                        evidence_path=path,
+                        recommendation="Move credential values into the configured secret backend and keep only names/env handles in app/security/secrets.yaml or env.example.",
+                    )
+                )
+                break
+    return findings
+
+
+def _scan_secret_contract(files: dict[str, str]) -> list[dict[str, Any]]:
+    contract = _yaml_file(files, "app/security/secrets.yaml")
+    if contract is None:
+        return []
+    if contract.get("__parse_error__"):
+        return [
+            _finding(
+                finding_id="secret_contract:parse_error",
+                severity="high",
+                control_area="secrets",
+                title="Secret contract is not valid YAML",
+                description="app/security/secrets.yaml could not be parsed as YAML.",
+                evidence_path="app/security/secrets.yaml",
+                recommendation="Regenerate app/security/secrets.yaml as the canonical names-only secret contract.",
+            )
+        ]
+    findings: list[dict[str, Any]] = []
+    secrets = contract.get("secrets")
+    if secrets is not None and not isinstance(secrets, list):
+        findings.append(
+            _finding(
+                finding_id="secret_contract:secrets_not_list",
+                severity="high",
+                control_area="secrets",
+                title="Secret contract secrets field is not a list",
+                description="app/security/secrets.yaml must declare secrets as a list of names-only entries.",
+                evidence_path="app/security/secrets.yaml",
+                recommendation="Use secrets entries with id, env, purpose, required, and optional provider metadata.",
+            )
+        )
+    forbidden_keys = {
+        "value",
+        "secret",
+        "token",
+        "password",
+        "api_key",
+        "connection_string",
+        "private_key",
+    }
+    for index, item in enumerate(secrets or []):
+        if not isinstance(item, dict):
+            continue
+        raw_keys = forbidden_keys.intersection(item)
+        if raw_keys:
+            findings.append(
+                _finding(
+                    finding_id=f"secret_contract:raw_value_field:{index}",
+                    severity="critical",
+                    control_area="secrets",
+                    title="Secret contract contains a raw-value field",
+                    description=f"Secret entry {index} declares forbidden value-bearing fields: {sorted(raw_keys)}.",
+                    evidence_path="app/security/secrets.yaml",
+                    recommendation="Replace value-bearing fields with provider-neutral secret names and env handles only.",
+                )
+            )
+    return findings
+
+
+def _scan_module_contracts(files: dict[str, str]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    module_paths = sorted(
+        path for path in files if path.startswith("app/modules/") and path.endswith("/module.yaml")
+    )
+    for path in module_paths:
+        try:
+            module = yaml.safe_load(files[path])
+        except yaml.YAMLError:
+            findings.append(
+                _finding(
+                    finding_id=f"module_contract:parse_error:{path}",
+                    severity="high",
+                    control_area="permissions",
+                    title="Module contract is not valid YAML",
+                    description="A module.yaml file could not be parsed.",
+                    evidence_path=path,
+                    recommendation="Regenerate the module contract using the canonical mozaiks.module.v1 shape.",
+                )
+            )
+            continue
+        if not isinstance(module, dict):
+            continue
+        declared_permissions = {
+            str(item.get("id") or "").strip()
+            for item in module.get("permissions") or []
+            if isinstance(item, dict)
+        }
+        module_id = str((module.get("module") or {}).get("id") or path).strip()
+        for action in module.get("actions") or []:
+            if not isinstance(action, dict):
+                continue
+            action_id = str(action.get("id") or "").strip()
+            api_surface = str(action.get("api_surface") or "").strip()
+            permissions = [
+                str(item).strip() for item in action.get("permissions") or [] if str(item).strip()
+            ]
+            if api_surface in {"public", "public_mutation", "public_readonly"}:
+                continue
+            if not permissions:
+                findings.append(
+                    _finding(
+                        finding_id=f"module_permissions:missing:{module_id}:{action_id}",
+                        severity="high",
+                        control_area="permissions",
+                        title="Private module action has no permission gate",
+                        description=f"Action {action_id or '<unknown>'} in {module_id} is not public but declares no permissions.",
+                        evidence_path=path,
+                        recommendation="Declare explicit module permissions for private or mutating actions.",
+                    )
+                )
+            unknown = sorted(set(permissions) - declared_permissions)
+            if unknown:
+                findings.append(
+                    _finding(
+                        finding_id=f"module_permissions:undeclared:{module_id}:{action_id}",
+                        severity="high",
+                        control_area="permissions",
+                        title="Module action references undeclared permissions",
+                        description=f"Action {action_id or '<unknown>'} references permissions not declared in module.yaml: {unknown}.",
+                        evidence_path=path,
+                        recommendation="Add the permission declarations or correct the action permission ids.",
+                    )
+                )
+        module_root = path.rsplit("/", 1)[0]
+        repo_path = f"{module_root}/backend/repo.py"
+        policy_path = f"{module_root}/backend/policy.py"
+        if repo_path in files and policy_path not in files:
+            findings.append(
+                _finding(
+                    finding_id=f"tenant_scope:missing_policy:{module_id}",
+                    severity="medium",
+                    control_area="tenant_isolation",
+                    title="Persistent module has no policy.py",
+                    description=f"Module {module_id} has backend/repo.py but no backend/policy.py scoping helper.",
+                    evidence_path=module_root,
+                    recommendation="Add module-local policy helpers for owner, tenant, or workspace scoping when persistence is user or tenant scoped.",
+                )
+            )
+    return findings
+
+
+async def inspect_generated_app_security(context_variables: Any | None = None) -> dict[str, Any]:
+    """Inspect the generated app bundle for baseline advisory security readiness."""
+
+    files = _iter_context_files(context_variables)
+    if not files:
+        files = _iter_bundle_files(str(_context_get(context_variables, "bundle_path", "") or ""))
+    files = {_normalize_path(path): content for path, content in files.items()}
+
+    findings: list[dict[str, Any]] = []
+    findings.extend(_scan_raw_secret_values(files))
+    findings.extend(_scan_secret_contract(files))
+    if _declares_auth_required(files, context_variables) and "app/config/auth.yaml" not in files:
+        findings.append(
+            _finding(
+                finding_id="auth_contract:missing_auth_yaml",
+                severity="high",
+                control_area="auth",
+                title="Auth-required app has no auth contract",
+                description="The app appears to require authentication but app/config/auth.yaml is absent.",
+                evidence_path="app/config/auth.yaml",
+                recommendation="Generate app/config/auth.yaml for provider-neutral authentication behavior.",
+            )
+        )
+    if (
+        _declares_deployment(files, context_variables)
+        and "app/security/production_operations.yaml" not in files
+    ):
+        findings.append(
+            _finding(
+                finding_id="production_operations:missing",
+                severity="medium",
+                control_area="deployment",
+                title="Deployable app has no production operations contract",
+                description="The app declares deployment artifacts or profile data, but no provider-neutral production operations contract was found.",
+                evidence_path="app/security/production_operations.yaml",
+                recommendation="Generate app/security/production_operations.yaml for production operation authority and readiness expectations.",
+            )
+        )
+    findings.extend(_scan_module_contracts(files))
+
+    summary = summarize_findings(findings)
+    result = {
+        "status": "passed" if summary["open"] == 0 else "attention_required",
+        "mode": str(
+            _context_get(context_variables, "security_readiness_mode", "advisory") or "advisory"
+        ),
+        "checked_file_count": len(files),
+        "findings": findings,
+        "summary": summary,
+    }
+    _context_set(context_variables, "security_readiness_findings", findings)
+    _context_set(context_variables, "security_readiness_summary", result)
+    return result

--- a/factory_app/workflows/SecurityReadiness/tools/record_security_findings.py
+++ b/factory_app/workflows/SecurityReadiness/tools/record_security_findings.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from factory_app.app.modules.security_readiness.backend.service import SecurityReadinessService
+
+
+def _context_get(context_variables: Any | None, key: str, default: Any = None) -> Any:
+    if context_variables is None:
+        return default
+    if isinstance(context_variables, dict):
+        return context_variables.get(key, default)
+    if hasattr(context_variables, "get"):
+        try:
+            return context_variables.get(key, default)
+        except TypeError:
+            try:
+                return context_variables.get(key)
+            except Exception:
+                return default
+        except Exception:
+            return default
+    return default
+
+
+def _context_set(context_variables: Any | None, key: str, value: Any) -> None:
+    if context_variables is None:
+        return
+    if isinstance(context_variables, dict):
+        context_variables[key] = value
+        return
+    if hasattr(context_variables, "set"):
+        try:
+            context_variables.set(key, value)
+        except Exception:
+            return
+
+
+def _normalize_findings(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+async def record_security_findings(
+    findings: list[dict[str, Any]] | None = None,
+    context_variables: Any | None = None,
+    module_context: Any | None = None,
+) -> dict[str, Any]:
+    """Record SecurityReadiness findings when module persistence is available."""
+
+    resolved_findings = _normalize_findings(
+        findings
+        if findings is not None
+        else _context_get(context_variables, "security_readiness_findings", [])
+    )
+    app_id = str(_context_get(context_variables, "app_id", "") or "").strip()
+    build_id = str(_context_get(context_variables, "build_id", "") or "").strip() or None
+    artifact_version_id = (
+        str(_context_get(context_variables, "artifact_version_id", "") or "").strip() or None
+    )
+
+    persisted = False
+    result: dict[str, Any] = {"success": True, "persisted": False, "findings": resolved_findings}
+    if module_context is not None and app_id and resolved_findings:
+        service_result = await SecurityReadinessService().record_assessment(
+            module_context,
+            app_id=app_id,
+            build_id=build_id,
+            artifact_version_id=artifact_version_id,
+            source="validation",
+            findings=resolved_findings,
+        )
+        result.update(service_result)
+        persisted = True
+    result["persisted"] = persisted
+
+    summary = {
+        "status": "passed" if not resolved_findings else "attention_required",
+        "mode": str(
+            _context_get(context_variables, "security_readiness_mode", "advisory") or "advisory"
+        ),
+        "persisted": persisted,
+        "finding_count": len(resolved_findings),
+        "findings": resolved_findings,
+    }
+    _context_set(context_variables, "security_readiness_summary", summary)
+    _context_set(context_variables, "security_readiness_recorded", True)
+    return result

--- a/factory_app/workflows/SecurityReadiness/transition_graph.yaml
+++ b/factory_app/workflows/SecurityReadiness/transition_graph.yaml
@@ -1,0 +1,8 @@
+transition_rules:
+  - source_agent: SecurityReadinessAgent
+    target_agent: terminate
+    transition_type: condition
+    condition_type: context_equals
+    condition_key: security_readiness_recorded
+    condition_value: true
+    transition_target: TerminateTarget

--- a/factory_app/workflows/SecurityReadiness/ui_config.yaml
+++ b/factory_app/workflows/SecurityReadiness/ui_config.yaml
@@ -1,0 +1,1 @@
+visual_agents: []

--- a/factory_app/workflows/extended_orchestration/extension_registry.json
+++ b/factory_app/workflows/extended_orchestration/extension_registry.json
@@ -153,6 +153,17 @@
       "handoff_style": "continuous_chat"
     },
     {
+      "id": "SecurityReadiness",
+      "description": "Advisory generated app security readiness review",
+      "startup_mode": "AgentDriven",
+      "interaction_mode": "agent_directed",
+      "launch_behavior": "auto_start",
+      "handoff_style": "continuous_chat",
+      "dependencies": [
+        "AppGenerator"
+      ]
+    },
+    {
       "id": "AppReview",
       "description": "In-chat build review and promote-or-revise HITL step",
       "startup_mode": "AgentDriven",
@@ -233,6 +244,11 @@
         {
           "workflows": [
             "AppGenerator"
+          ]
+        },
+        {
+          "workflows": [
+            "SecurityReadiness"
           ]
         },
         {
@@ -338,6 +354,11 @@
           ]
         },
         {
+          "workflows": [
+            "SecurityReadiness"
+          ]
+        },
+        {
           "transition": "app_review"
         }
       ]
@@ -382,6 +403,11 @@
         {
           "workflows": [
             "AppGenerator"
+          ]
+        },
+        {
+          "workflows": [
+            "SecurityReadiness"
           ]
         },
         {
@@ -432,6 +458,11 @@
           ]
         },
         {
+          "workflows": [
+            "SecurityReadiness"
+          ]
+        },
+        {
           "transition": "app_review"
         }
       ]
@@ -476,6 +507,11 @@
         {
           "workflows": [
             "AppGenerator"
+          ]
+        },
+        {
+          "workflows": [
+            "SecurityReadiness"
           ]
         },
         {

--- a/scripts/smoke_factory_artifact_lineage.py
+++ b/scripts/smoke_factory_artifact_lineage.py
@@ -472,6 +472,7 @@ async def _run_lineage_smoke_with_store(
         ["SubscriptionContractDesigner"],
         ["AgentGenerator"],
         ["AppGenerator"],
+        ["SecurityReadiness"],
     ]
     expected_transition_steps = [
         "app_type_selector",

--- a/tests/fixtures/workflow-document-version-migration.json
+++ b/tests/fixtures/workflow-document-version-migration.json
@@ -147,6 +147,18 @@
       "parser_document_fingerprint": "0d3382c785c380fc3d490040511eb6b99711746008a5ec085aa91d2331037687"
     },
     {
+      "path": "factory_app/workflows/SecurityReadiness/orchestrator.yaml",
+      "source_bytes_fingerprint": "65479f34a816fdada3e6a11c70c0ab9b2e840dc15ff815831722bb54e0e192c1",
+      "source_document_fingerprint": "5c3cdf20178514e658306bdd0c117fb5af9a44a97c0d276810cda3aa086dabf8",
+      "parser_document_fingerprint": "53d8d2f6d8c77e555388f8ae220cad81ad68a4e3ed67da91e8e097948e9ea67d"
+    },
+    {
+      "path": "factory_app/workflows/SecurityReadiness/structured_outputs.yaml",
+      "source_bytes_fingerprint": "144a92b6408c54fe5b1aaae1bfc07fd558ee20dd721ac5a8c46b936121197419",
+      "source_document_fingerprint": "63dbb51202d48e37649d904010bf4944b9f00e8040816e97de0290187c03b9b8",
+      "parser_document_fingerprint": "63dbb51202d48e37649d904010bf4944b9f00e8040816e97de0290187c03b9b8"
+    },
+    {
       "path": "factory_app/workflows/SubscriptionContractDesigner/orchestrator.yaml",
       "source_bytes_fingerprint": "071aab0449739eb55d49fcc71ca7b6ccc4ba8d1a36f091e43841f7fb6f2d4e56",
       "source_document_fingerprint": "a9bbc609cc94c9119cb88f449f78975f080ff1ef294afa25a8931324d3eaf8b1",

--- a/tests/test_brownfield_adoption_generation_contract.py
+++ b/tests/test_brownfield_adoption_generation_contract.py
@@ -423,6 +423,7 @@ def test_registry_declares_brownfield_overlay_generation_sequence() -> None:
         "SubscriptionContractDesigner",
         "AgentGenerator",
         "AppGenerator",
+        "SecurityReadiness",
     ]
 
 
@@ -441,6 +442,7 @@ def test_registry_declares_brownfield_module_generation_sequence() -> None:
         "SubscriptionContractDesigner",
         "AgentGenerator",
         "AppGenerator",
+        "SecurityReadiness",
     ]
 
 

--- a/tests/test_existing_app_discovery_contracts.py
+++ b/tests/test_existing_app_discovery_contracts.py
@@ -800,6 +800,7 @@ def test_brownfield_path_selector_routes_into_discovery_with_context() -> None:
         "SubscriptionContractDesigner",
         "AgentGenerator",
         "AppGenerator",
+        "SecurityReadiness",
     ]
 
     # brownfield_overlay_generation sequence

--- a/tests/test_factory_build_context_contract.py
+++ b/tests/test_factory_build_context_contract.py
@@ -40,9 +40,18 @@ EXPECTED_MOZAIKS_CLOUD_CONTRACTS = {
     "provider_api_contract.yaml",
 }
 
+EXPECTED_SECURITY_READINESS_CONTRACTS = {
+    "app_security_file_contracts.yaml",
+    "baseline_security_controls.yaml",
+    "finding_taxonomy.yaml",
+}
+
 LEGACY_WORKFLOW_ROOT_CATALOGS = [
     *(f"factory_app/workflows/AppGenerator/{name}" for name in EXPECTED_APPGENERATOR_CATALOGS),
-    *(f"factory_app/workflows/AppGenerator/tools/{name}" for name in EXPECTED_APPGENERATOR_CATALOGS),
+    *(
+        f"factory_app/workflows/AppGenerator/tools/{name}"
+        for name in EXPECTED_APPGENERATOR_CATALOGS
+    ),
     "factory_app/workflows/_shared/ag2_network_patterns.yaml",
     "factory_app/workflows/_shared/factory_catalogs.py",
     "factory_app/workflows/_shared/pattern_catalog.py",
@@ -88,8 +97,12 @@ def test_factory_build_context_uses_named_context_roots() -> None:
             allowed |= EXPECTED_MOZAIKSPAY_CONTRACTS
         if context_root.name == "mozaiks_cloud":
             allowed |= EXPECTED_MOZAIKS_CLOUD_CONTRACTS
+        if context_root.name == "SecurityReadiness":
+            allowed |= EXPECTED_SECURITY_READINESS_CONTRACTS
         actual = {item.name for item in context_root.iterdir()}
-        assert actual <= allowed, f"{context_root} has non-canonical build-context entries: {sorted(actual - allowed)}"
+        assert actual <= allowed, (
+            f"{context_root} has non-canonical build-context entries: {sorted(actual - allowed)}"
+        )
 
 
 def test_context_yaml_is_structural_not_semantic_guidance() -> None:
@@ -124,7 +137,9 @@ def test_context_yaml_uses_explicit_assets_not_implicit_lanes() -> None:
         assert isinstance(assets, list) and assets, f"{context_path} must declare assets"
         for asset in assets:
             assert isinstance(asset, dict), f"{context_path} asset must be a mapping"
-            assert {"path", "kind"} <= set(asset), f"{context_path} asset must declare path and kind"
+            assert {"path", "kind"} <= set(asset), (
+                f"{context_path} asset must declare path and kind"
+            )
             assert asset["kind"] in allowed_asset_kinds, (
                 f"{context_path} asset kind is not canonical: {asset['kind']!r}"
             )
@@ -133,9 +148,9 @@ def test_context_yaml_uses_explicit_assets_not_implicit_lanes() -> None:
 
 
 def test_appgenerator_treats_in_app_notifications_as_runtime_contracts() -> None:
-    capability_routing = (FACTORY_BUILD_CONTEXT / "AppGenerator" / "capability_routing.yaml").read_text(
-        encoding="utf-8"
-    )
+    capability_routing = (
+        FACTORY_BUILD_CONTEXT / "AppGenerator" / "capability_routing.yaml"
+    ).read_text(encoding="utf-8")
     file_contracts = (FACTORY_BUILD_CONTEXT / "AppGenerator" / "file_contracts.yaml").read_text(
         encoding="utf-8"
     )
@@ -149,7 +164,12 @@ def test_appgenerator_treats_in_app_notifications_as_runtime_contracts() -> None
 
 
 def test_messaging_pack_keeps_contacts_and_hosted_features_out_of_substrate() -> None:
-    data = yaml.safe_load((FACTORY_BUILD_CONTEXT / "messaging" / "contract.yaml").read_text(encoding="utf-8")) or {}
+    data = (
+        yaml.safe_load(
+            (FACTORY_BUILD_CONTEXT / "messaging" / "contract.yaml").read_text(encoding="utf-8")
+        )
+        or {}
+    )
 
     forbidden_prefixes = {item.get("path_prefix") for item in data.get("forbidden_outputs") or []}
     boundary_ids = {item.get("id") for item in data.get("runtime_boundaries") or []}
@@ -200,7 +220,9 @@ def test_catalog_asset_projections_use_canonical_fields() -> None:
         data = yaml.safe_load(context_path.read_text(encoding="utf-8")) or {}
         projections = data.get("projections") or {}
         assert "prompts" not in projections, f"{context_path} must not use projections.prompts"
-        assert "prompt_inputs" not in projections, f"{context_path} prompt projections belong on assets"
+        assert "prompt_inputs" not in projections, (
+            f"{context_path} prompt projections belong on assets"
+        )
         for asset in data.get("assets") or []:
             if asset.get("kind") != "catalog":
                 continue
@@ -246,8 +268,12 @@ def test_appgenerator_hook_tools_use_factory_catalog_resolver() -> None:
     }
     for name in catalog_hooks:
         content = (tools_dir / name).read_text(encoding="utf-8")
-        assert "_shared.hook_utils" in content, f"{name} must load catalogs through shared hook utilities"
-        assert "workflow_context_path" in content, f"{name} must resolve factory build-context paths deterministically"
+        assert "_shared.hook_utils" in content, (
+            f"{name} must load catalogs through shared hook utilities"
+        )
+        assert "workflow_context_path" in content, (
+            f"{name} must resolve factory build-context paths deterministically"
+        )
         assert "_shared.catalogs" not in content, f"{name} must not use removed _shared.catalogs"
 
 
@@ -265,9 +291,7 @@ def test_pack_templates_with_handlers_use_base_handler_split() -> None:
             continue
         source = handler_path.read_text(encoding="utf-8")
         base_source = base_path.read_text(encoding="utf-8")
-        assert "BaseHandler" in base_source, (
-            f"{base_path} must define a *BaseHandler class"
-        )
+        assert "BaseHandler" in base_source, f"{base_path} must define a *BaseHandler class"
         assert "DO NOT EDIT" in base_source, (
             f"{base_path} must carry the DO NOT EDIT regeneration notice"
         )
@@ -291,14 +315,14 @@ def test_social_and_messaging_packs_have_adopted_base_handler_split() -> None:
         assert (backend_dir / "base_handler.py").exists(), (
             f"{backend_dir}/base_handler.py missing — social/messaging packs are reference implementations"
         )
-        assert (backend_dir / "handler.py").exists(), (
-            f"{backend_dir}/handler.py missing"
-        )
+        assert (backend_dir / "handler.py").exists(), f"{backend_dir}/handler.py missing"
 
 
 def test_workspace_extensions_contract_schema_exists() -> None:
     schema = FACTORY_BUILD_CONTEXT / "AppGenerator" / "workspace_extensions_contract.yaml"
-    assert schema.exists(), "workspace_extensions_contract.yaml must exist in AppGenerator build context"
+    assert schema.exists(), (
+        "workspace_extensions_contract.yaml must exist in AppGenerator build context"
+    )
     data = yaml.safe_load(schema.read_text(encoding="utf-8")) or {}
     assert data.get("schema_version") == 1
     assert data.get("file_location") == "build_context/{pack_id}/extensions.yaml"
@@ -322,10 +346,7 @@ def test_appgenerator_agents_document_handler_split_rule() -> None:
 
 def test_ai_pack_workflow_hook_uses_current_startup_contract() -> None:
     content = (
-        FACTORY_WORKFLOWS
-        / "AppGenerator"
-        / "tools"
-        / "hook_ai_pack_workflow_context.py"
+        FACTORY_WORKFLOWS / "AppGenerator" / "tools" / "hook_ai_pack_workflow_context.py"
     ).read_text(encoding="utf-8")
     assert "workflow_startup_mode=BackendOnly" in content
     assert re.search(r"(?<!workflow_)startup_mode=BackendOnly", content) is None

--- a/tests/test_generated_app_functional_acceptance.py
+++ b/tests/test_generated_app_functional_acceptance.py
@@ -268,6 +268,8 @@ def _generated_monetized_saas_files() -> dict[str, str]:
     }
     files.update(
         {
+            "services/__init__.py": "",
+            "services/integrations/__init__.py": "",
             "services/integrations/mozaikspay_client.py": _template_file(
                 "services/integrations/mozaikspay_client.py"
             ),
@@ -580,6 +582,24 @@ def _assert_not_missing_or_placeholder(response, *, surface: str) -> None:
 
 
 def _prepare_platform_test_runtime(platform: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mozaiksai.core.runtime.composition.executor_registry import ExecutorRegistry
+
+    platform.executor_registry = ExecutorRegistry()
+    platform.app.state.executor_registry = platform.executor_registry
+    platform.app.state.subscriptions_config = None
+    platform.app.state.startup_degraded = False
+    platform.app.state.startup_degraded_reason = None
+    platform.app.state.failed_module_names = []
+    platform.app.state.page_schemas = {}
+    platform.app.state.module_action_surfaces = {}
+    platform.app.state.workflow_capability_routes = {}
+    platform.app.state.database_index_readiness = None
+    for state_attr in ("module_event_router", "workflow_trigger_guard"):
+        if hasattr(platform.app.state, state_attr):
+            delattr(platform.app.state, state_attr)
+    runtime_services = getattr(platform, "_runtime_services", None)
+    if isinstance(runtime_services, list):
+        runtime_services.clear()
     monkeypatch.setattr(platform.runtime_app, "mongo_client", _RuntimeAcceptanceMongoClient())
 
 

--- a/tests/test_materialized_bundle_production_runtime.py
+++ b/tests/test_materialized_bundle_production_runtime.py
@@ -216,6 +216,20 @@ async def test_exact_materialized_file_map_validates_boots_and_executes_http(
     saved = _save_platform_state(platform)
     platform.executor_registry = ExecutorRegistry()
     platform.app.state.executor_registry = platform.executor_registry
+    platform.app.state.subscriptions_config = None
+    platform.app.state.startup_degraded = False
+    platform.app.state.startup_degraded_reason = None
+    platform.app.state.failed_module_names = []
+    platform.app.state.page_schemas = {}
+    platform.app.state.module_action_surfaces = {}
+    platform.app.state.workflow_capability_routes = {}
+    platform.app.state.database_index_readiness = None
+    for state_attr in ("module_event_router", "workflow_trigger_guard"):
+        if hasattr(platform.app.state, state_attr):
+            delattr(platform.app.state, state_attr)
+    runtime_services = getattr(platform, "_runtime_services", None)
+    if isinstance(runtime_services, list):
+        runtime_services.clear()
     monkeypatch.setattr(platform.runtime_app, "mongo_client", fake_mongo_client)
     try:
         with TestClient(platform.app, raise_server_exceptions=False) as client:

--- a/tests/test_offline_factory_build_sequence_smoke.py
+++ b/tests/test_offline_factory_build_sequence_smoke.py
@@ -131,6 +131,7 @@ async def test_offline_build_sequence_smoke_persists_agent_and_app_artifact_chai
         ["SubscriptionContractDesigner"],
         ["AgentGenerator"],
         ["AppGenerator"],
+        ["SecurityReadiness"],
     ]
     assert transition_steps == [
         "app_type_selector",
@@ -211,6 +212,7 @@ async def test_offline_factory_artifact_lineage_smoke_hydrates_workflow_metadata
         ["SubscriptionContractDesigner"],
         ["AgentGenerator"],
         ["AppGenerator"],
+        ["SecurityReadiness"],
     ]
     assert result["artifact_lineage"]["workflow_bundle_inputs"] == {
         "design_docs": result["artifact_lineage"]["design_docs_id"],

--- a/tests/test_pack_config_paths.py
+++ b/tests/test_pack_config_paths.py
@@ -49,6 +49,7 @@ def test_load_global_pack_graph_uses_canonical_file(monkeypatch) -> None:
         "AgentGenerator",
         "AppGenerator",
         "ExistingAppDiscovery",
+        "SecurityReadiness",
         "AppReview",
     }
 
@@ -58,7 +59,9 @@ def test_load_global_pack_graph_review_transition_uses_chat_session_contract(mon
     graph = load_global_pack_graph()
     assert graph is not None
 
-    review = next((transition for transition in graph.transitions if transition.id == "app_review"), None)
+    review = next(
+        (transition for transition in graph.transitions if transition.id == "app_review"), None
+    )
     assert review is not None
     assert review.transition_type == "chat_session"
     assert review.ui is None
@@ -67,7 +70,9 @@ def test_load_global_pack_graph_review_transition_uses_chat_session_contract(mon
     assert review.cancel_route is None
 
 
-def test_single_root_registry_path_uses_explicit_override_without_factory_merge(monkeypatch, tmp_path) -> None:
+def test_single_root_registry_path_uses_explicit_override_without_factory_merge(
+    monkeypatch, tmp_path
+) -> None:
     _use_repo_factory_workflows(monkeypatch)
 
     app_root = tmp_path / "app"
@@ -168,13 +173,15 @@ def test_registry_extends_packaged_default_with_app_overlay(monkeypatch, tmp_pat
     assert roots[1] == _resources.resolve_factory_workflows_root()
     workflow_paths = discover_workflow_paths(workflows_root)
     assert workflow_paths["HostedOnly"] == hosted_workflow_dir.resolve()
-    assert workflow_paths["AppGenerator"] == (
-        _resources.resolve_factory_workflows_root() / "AppGenerator"
-    ).resolve()
+    assert (
+        workflow_paths["AppGenerator"]
+        == (_resources.resolve_factory_workflows_root() / "AppGenerator").resolve()
+    )
     assert resolve_workflow_path("HostedOnly", workflows_root) == hosted_workflow_dir.resolve()
-    assert resolve_workflow_path("AppGenerator", workflows_root) == (
-        _resources.resolve_factory_workflows_root() / "AppGenerator"
-    ).resolve()
+    assert (
+        resolve_workflow_path("AppGenerator", workflows_root)
+        == (_resources.resolve_factory_workflows_root() / "AppGenerator").resolve()
+    )
 
 
 def test_explicit_app_registry_without_extends_does_not_discover_factory_workflows(
@@ -224,7 +231,9 @@ def test_declared_global_workflows_match_physical_workflow_folders(monkeypatch) 
     physical = {
         p.name
         for p in workflows_root.iterdir()
-        if p.is_dir() and p.name not in {"_pack", "__pycache__", "extended_orchestration"} and not p.name.startswith(".")
+        if p.is_dir()
+        and p.name not in {"_pack", "__pycache__", "extended_orchestration"}
+        and not p.name.startswith(".")
     }
 
     assert declared.issubset(physical)
@@ -297,7 +306,9 @@ def test_default_roots_use_repo_factory_workflows_when_no_active_app(monkeypatch
     assert "__no_active_app__" not in str(root)
 
 
-def test_active_app_root_uses_workspace_env_when_platform_path_missing(monkeypatch, tmp_path: Path) -> None:
+def test_active_app_root_uses_workspace_env_when_platform_path_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
     workspace_root = tmp_path / "external-workspace"
     app_root = workspace_root / "app"
     app_root.mkdir(parents=True)
@@ -319,20 +330,25 @@ def test_chat_ui_src_root_defaults_to_repo_checkout(monkeypatch) -> None:
     assert root == (repo_root / "chat-ui" / "src").resolve()
 
 
-def test_resource_resolution_prefers_repo_assets_over_stale_package_copy(monkeypatch, tmp_path: Path) -> None:
+def test_resource_resolution_prefers_repo_assets_over_stale_package_copy(
+    monkeypatch, tmp_path: Path
+) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     stale_package_root = tmp_path / "stale-package"
     stale_package_root.mkdir()
     monkeypatch.chdir(repo_root)
     monkeypatch.delenv("MOZAIKS_WEB_SHELL_PATH", raising=False)
     monkeypatch.delenv("MOZAIKS_CHAT_UI_PATH", raising=False)
-    monkeypatch.setattr(_resources, "_resolve_package_dir", lambda _package_name: stale_package_root)
+    monkeypatch.setattr(
+        _resources, "_resolve_package_dir", lambda _package_name: stale_package_root
+    )
 
     assert _resources.resolve_web_shell_root() == (repo_root / "web_shell").resolve()
     assert _resources.resolve_chat_ui_root() == (repo_root / "chat-ui").resolve()
 
 
 # ── artifact_dependency_graph ──────────────────────────────────────────────────
+
 
 def test_artifact_dependency_graph_uses_persisted_canonical_families(monkeypatch) -> None:
     _use_repo_factory_workflows(monkeypatch)
@@ -384,6 +400,7 @@ def test_stale_propagation_uses_real_design_and_theme_families(monkeypatch) -> N
 
 
 # ── conceptual_replan sequence ─────────────────────────────────────────────────
+
 
 def test_conceptual_replan_sequence_exists(monkeypatch) -> None:
     _use_repo_factory_workflows(monkeypatch)
@@ -444,5 +461,6 @@ def test_all_factory_sequence_ids_are_unique(monkeypatch) -> None:
     graph = load_global_pack_graph()
     assert graph is not None
     ids = [s.id for s in graph.journeys]
-    assert len(ids) == len(set(ids)), f"Duplicate sequence ids: {[x for x in ids if ids.count(x) > 1]}"
-
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate sequence ids: {[x for x in ids if ids.count(x) > 1]}"
+    )

--- a/tests/test_security_readiness_workflow.py
+++ b/tests/test_security_readiness_workflow.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from factory_app.workflows.AppReview.tools.review_context import build_review_summary_payload
+from factory_app.workflows.SecurityReadiness.tools.inspect_generated_app_security import (
+    inspect_generated_app_security,
+)
+from factory_app.workflows.SecurityReadiness.tools.record_security_findings import (
+    record_security_findings,
+)
+from mozaiksai.core.workflow.pack.config import load_global_pack_graph
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.asyncio
+async def test_security_readiness_detects_secret_and_contract_findings() -> None:
+    ctx = {
+        "app_id": "app_1",
+        "generated_files": {
+            "app/app.json": json.dumps({"authRequired": True}),
+            "app/security/secrets.yaml": "version: 1\nsecrets:\n  - id: stripe\n    value: test_sentinel_raw_value\n",
+            "app/modules/orders/module.yaml": "schema_version: mozaiks.module.v1\nmodule:\n  id: orders\nactions:\n  - id: create_order\n    api_surface: private\n    permissions: []\n",
+            "Dockerfile": "FROM python:3.13-slim\n",
+        },
+    }
+
+    result = await inspect_generated_app_security(context_variables=ctx)
+
+    assert result["status"] == "attention_required"
+    finding_ids = {item["finding_id"] for item in result["findings"]}
+    assert "secret_contract:raw_value_field:0" in finding_ids
+    assert "auth_contract:missing_auth_yaml" in finding_ids
+    assert "module_permissions:missing:orders:create_order" in finding_ids
+    assert "production_operations:missing" in finding_ids
+    assert ctx["security_readiness_summary"]["summary"]["open"] >= 4
+
+
+@pytest.mark.asyncio
+async def test_record_security_findings_updates_context_without_persistence() -> None:
+    ctx = {"app_id": "app_1", "security_readiness_findings": [{"finding_id": "x"}]}
+
+    result = await record_security_findings(context_variables=ctx)
+
+    assert result["success"] is True
+    assert result["persisted"] is False
+    assert ctx["security_readiness_recorded"] is True
+    assert ctx["security_readiness_summary"]["finding_count"] == 1
+
+
+def test_security_readiness_build_context_declares_workflow_assets() -> None:
+    path = ROOT / "factory_app" / "build_context" / "SecurityReadiness" / "context.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert data["context_id"] == "SecurityReadiness"
+    assert data["applies_to_workflows"] == ["SecurityReadiness"]
+    asset_paths = {asset["path"] for asset in data["assets"]}
+    assert {
+        "baseline_security_controls.yaml",
+        "app_security_file_contracts.yaml",
+        "finding_taxonomy.yaml",
+    } <= asset_paths
+
+
+def test_security_readiness_is_between_app_generator_and_review(monkeypatch) -> None:
+    monkeypatch.setenv("PLATFORM_PATH", str(ROOT / "__no_active_app__"))
+    monkeypatch.setenv("MOZAIKS_WORKFLOWS_PATH", str(ROOT / "factory_app" / "workflows"))
+
+    graph = load_global_pack_graph()
+    assert graph is not None
+    workflow_ids = {workflow.id for workflow in graph.workflows}
+    assert "SecurityReadiness" in workflow_ids
+
+    build = next(seq for seq in graph.journeys if seq.id == "build")
+    flattened = [workflow for step in build.steps for workflow in step.workflows]
+    assert flattened.index("AppGenerator") < flattened.index("SecurityReadiness")
+
+    review_index = next(
+        index for index, step in enumerate(build.steps) if step.transition == "app_review"
+    )
+    security_index = next(
+        index for index, step in enumerate(build.steps) if step.workflows == ["SecurityReadiness"]
+    )
+    assert security_index < review_index
+
+
+def test_app_review_payload_carries_security_readiness_summary() -> None:
+    payload = build_review_summary_payload(
+        {
+            "build_registry_id": "reg_1",
+            "artifact_version_id": "art_1",
+            "lifecycle_state": "review",
+            "app_validation_status": "passed",
+            "app_bundle_acceptance_status": "passed",
+            "integration_tests_passed": True,
+            "security_readiness_summary": {"status": "attention_required", "finding_count": 1},
+        }
+    )
+
+    assert payload["can_promote"] is True
+    assert payload["security_readiness_summary"] == {
+        "status": "attention_required",
+        "finding_count": 1,
+    }

--- a/tests/test_workflow_document_identity_migration.py
+++ b/tests/test_workflow_document_identity_migration.py
@@ -25,7 +25,9 @@ from tests.test_structured_output_canonical_identity import _model, _ref
 from tests.test_workflow_interface_rematerialization import _direct_bytes, _state, _unit
 
 ROOT = Path(__file__).resolve().parents[1]
-BASELINE = json.loads((ROOT / "tests/fixtures/workflow-document-version-migration.json").read_text(encoding="utf-8"))
+BASELINE = json.loads(
+    (ROOT / "tests/fixtures/workflow-document-version-migration.json").read_text(encoding="utf-8")
+)
 VERSIONS = {
     "orchestrator.yaml": ("mozaiks.orchestrator.v1", parse_orchestrator_config),
     "structured_outputs.yaml": ("mozaiks.structured_outputs.v1", parse_structured_outputs_config),
@@ -35,7 +37,10 @@ VERSIONS = {
 def test_exact_base_capture_and_governed_document_census():
     assert BASELINE["base_commit"] == "5ff00cb1c040d694632e2ec530678c4e9571dc0d"
     assert BASELINE["base_tree"] == "dd750e01833fb127061d085fc2f718a081d8266c"
-    assert canonical_digest(BASELINE) == "a3d53b6dc39f4bd110bd1a51b52e74fed98ae260cce9f792eb4f214a31011a94"
+    assert (
+        canonical_digest(BASELINE)
+        == "9f463cad6357e577de3acc51ac9a14bdc421bae4933c7f4b6fac663391faeadd"
+    )
     actual = sorted(
         path.relative_to(ROOT).as_posix()
         for directory in (ROOT / "factory_app/workflows", ROOT / "examples")
@@ -43,8 +48,8 @@ def test_exact_base_capture_and_governed_document_census():
         for path in directory.rglob(filename)
     )
     assert actual == [row["path"] for row in BASELINE["documents"]]
-    assert len(actual) == 30
-    assert sum(Path(path).name == "orchestrator.yaml" for path in actual) == 15
+    assert len(actual) == 32
+    assert sum(Path(path).name == "orchestrator.yaml" for path in actual) == 16
 
 
 @pytest.mark.parametrize("before", BASELINE["documents"], ids=lambda row: row["path"])
@@ -69,11 +74,16 @@ def test_current_corpus_has_no_changed_units_plans_graph_or_payloads():
     before = BASELINE["corpus"]
     plan = _corpus_plan()
     graph, payloads = _corpus_graph()
-    records = [{
-        "unit_id": unit.unit_id, "document": unit.model_dump(mode="json"),
-        "identity": unit.identity_payload, "serialized_json": unit.model_dump_json(),
-        "unit_digest": unit.unit_digest,
-    } for unit in plan.units]
+    records = [
+        {
+            "unit_id": unit.unit_id,
+            "document": unit.model_dump(mode="json"),
+            "identity": unit.identity_payload,
+            "serialized_json": unit.model_dump_json(),
+            "unit_digest": unit.unit_digest,
+        }
+        for unit in plan.units
+    ]
     assert len(records) == before["unit_count"] == 61
     assert canonical_digest(records) == before["unit_records_fingerprint"]
     # The later package-marker registry addition changes aggregate identity,
@@ -81,9 +91,15 @@ def test_current_corpus_has_no_changed_units_plans_graph_or_payloads():
     historical_plan = corpus_plan_before_service_package_markers()
     assert historical_plan.units == plan.units
     assert historical_plan.plan_digest == before["plan_digest"]
-    assert hashlib.sha256(historical_plan.model_dump_json().encode()).hexdigest() == before["serialized_plan_fingerprint"]
+    assert (
+        hashlib.sha256(historical_plan.model_dump_json().encode()).hexdigest()
+        == before["serialized_plan_fingerprint"]
+    )
     assert graph.graph_digest == before["graph_digest"]
-    assert [{"node_id": payload.node_id, "payload_digest": payload.payload_digest} for payload in payloads] == before["payload_fingerprints"]
+    assert [
+        {"node_id": payload.node_id, "payload_digest": payload.payload_digest}
+        for payload in payloads
+    ] == before["payload_fingerprints"]
 
 
 def test_document_version_changes_only_whole_source_authority_identity():
@@ -92,35 +108,55 @@ def test_document_version_changes_only_whole_source_authority_identity():
     assert stable_digest(current["configs"]) != before["configs_fingerprint"]
     authority = current["authority_inputs"]
     assert compilation_plan_authority_digest(authority) != before["input_document_fingerprint"]
-    assert hashlib.sha256(authority.model_dump_json().encode()).hexdigest() != before["input_document_bytes_fingerprint"]
+    assert (
+        hashlib.sha256(authority.model_dump_json().encode()).hexdigest()
+        != before["input_document_bytes_fingerprint"]
+    )
     original_configs = copy.deepcopy(current["configs"])
     for config in original_configs.values():
         assert config.pop("schema_version") == "mozaiks.structured_outputs.v1"
     assert stable_digest(original_configs) == before["configs_fingerprint"]
     original_document = authority.model_dump(mode="json")
-    original_document["structured_output_configs"] = CanonicalJsonObject.from_python(original_configs).model_dump(mode="json")
+    original_document["structured_output_configs"] = CanonicalJsonObject.from_python(
+        original_configs
+    ).model_dump(mode="json")
     # Restore only metadata for historical comparison, never runtime parsing.
     restored = type(authority).model_validate(original_document)
     assert compilation_plan_authority_digest(restored) == before["input_document_fingerprint"]
-    assert hashlib.sha256(restored.model_dump_json().encode()).hexdigest() == before["input_document_bytes_fingerprint"]
+    assert (
+        hashlib.sha256(restored.model_dump_json().encode()).hexdigest()
+        == before["input_document_bytes_fingerprint"]
+    )
 
     assert current["base"].plan_digest == before["base_plan_digest"]
     assert current["successor"].plan_digest == before["successor_plan_digest"]
     units = current["successor"].units
     assert len(units) == 6
-    assert canonical_digest([unit.model_dump(mode="json") for unit in units]) == before["unit_records_fingerprint"]
+    assert (
+        canonical_digest([unit.model_dump(mode="json") for unit in units])
+        == before["unit_records_fingerprint"]
+    )
     assert current["assignments"].assignment_set_digest == before["assignment_set_fingerprint"]
     assert current["result"].result_digest == before["artifact_result_fingerprint"]
-    selected = [unit.required_structured_output_ref.model_dump(mode="json") for unit in units if unit.required_structured_output_ref is not None]
+    selected = [
+        unit.required_structured_output_ref.model_dump(mode="json")
+        for unit in units
+        if unit.required_structured_output_ref is not None
+    ]
     assert selected == [before["selected_reference"]]
 
 
 def test_canonical_model_acceptance_and_workflow_interface_bytes_are_unchanged():
     assert _ref().model_dump(mode="json") == BASELINE["canonical_probe_reference"]
-    assert canonical_digest(_model().model_json_schema()) == BASELINE["canonical_probe_model_schema_fingerprint"]
+    assert (
+        canonical_digest(_model().model_json_schema())
+        == BASELINE["canonical_probe_model_schema_fingerprint"]
+    )
     state = _state()
     unit = _unit(state)
     assert {
-        "unit_id": unit.unit_id, "unit_digest": unit.unit_digest,
-        "identity": unit.identity_payload, "content_hex": _direct_bytes(state).hex(),
+        "unit_id": unit.unit_id,
+        "unit_digest": unit.unit_digest,
+        "identity": unit.identity_payload,
+        "content_hex": _direct_bytes(state).hex(),
     } == BASELINE["workflow_interface"]


### PR DESCRIPTION
Adds an advisory SecurityReadiness Factory workflow between AppGenerator and AppReview so generated app bundles surface baseline security findings before review. The workflow inspects names-only secret contracts, auth config, module permissions, tenant policy files, deployment operations contracts, and raw secret patterns, then records advisory findings through the first-party security_readiness module when persistence is available.

The change also adds a reusable SecurityReadiness build context with typed baseline controls and file contracts, threads the summary into AppReview, updates exact workflow sequence contracts, and fixes generated-app test isolation around app-owned services package markers.

OSS Change Impact:
- Adds one workflow-owned Factory workflow: SecurityReadiness.
- Adds one named build context: factory_app/build_context/SecurityReadiness.
- Reuses the existing first-party app module factory_app/app/modules/security_readiness for persisted assessments.
- Does not add hosted-product policy, certification claims, paid infrastructure, or provider-specific security adapters to OSS.

Build Workflow Sequence Impact:
- Inserts SecurityReadiness after AppGenerator and before app_review in build, brownfield_overlay_generation, brownfield_module_generation, full_rebuild, and conceptual_replan.
- AppReview consumes security_readiness_summary as advisory context only.
- No new AppReview dependency or reroute behavior is introduced.

Validation:
- ruff check .
- mypy mozaiksai factory_app --ignore-missing-imports --disable-error-code=import-untyped
- pytest -q tests/test_security_readiness_workflow.py tests/test_pack_config_paths.py tests/test_brownfield_adoption_generation_contract.py tests/test_existing_app_discovery_contracts.py tests/test_factory_build_context_contract.py tests/test_factory_workflow_integration_contracts.py tests/test_offline_factory_build_sequence_smoke.py tests/test_refinement_router.py tests/test_studio_workflow_trigger.py tests/test_workflow_document_identity_migration.py --no-cov
- pytest -q tests/test_generated_app_functional_acceptance.py::test_generated_crud_bundle_boots_and_serves_declared_http_surfaces tests/test_generated_app_functional_acceptance.py::test_generated_monetized_saas_bundle_boots_and_serves_mozaikspay_runtime_surfaces tests/test_generated_app_functional_acceptance.py::test_generated_workflow_agent_bundle_loads_catalog_and_starts_runtime_session tests/test_materialized_bundle_production_runtime.py::test_exact_materialized_file_map_validates_boots_and_executes_http --no-cov
- pytest -q tests/test_managed_capability_artifact_replay.py::test_mozaikspay_replay_uses_templates_and_passes_runtime_acceptance tests/test_generated_app_functional_acceptance.py::test_generated_monetized_saas_bundle_boots_and_serves_mozaikspay_runtime_surfaces --no-cov -vv
- pytest -q --no-cov (16768 passed, 100 skipped)
- ruff check tests/test_security_readiness_workflow.py
- pytest -q tests/test_security_readiness_workflow.py --no-cov
