### PR TITLE
Fix shared Studio security findings persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project follows a practical pre-1.0 changelog format:
 - Security Readiness now saves findings through permissioned workflow module
   dispatch using the live session principal. Findings retain project/build
   association and cannot overwrite another project's matching scanner rule.
+  Workflow handoffs tolerate brief reconnects while rechecking the original
+  actor and fresh permissions before dispatch; started actions are never retried.
   Unavailable persistence and uninspected bundles remain explicit in review.
 - Studio workspaces inherit packaged first-party modules through the standard
   app loader. App-local modules override defaults by id, so hosted workspaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ This project follows a practical pre-1.0 changelog format:
 
 ### Fixed
 
+- Security Readiness now saves findings through permissioned workflow module
+  dispatch using the live session principal. Findings retain project/build
+  association and cannot overwrite another project's matching scanner rule.
+  Unavailable persistence and uninspected bundles remain explicit in review.
+- Studio workspaces inherit packaged first-party modules through the standard
+  app loader. App-local modules override defaults by id, so hosted workspaces
+  can reuse Security Readiness without copying its implementation.
+
 - Bind app service imports to the selected workspace on reload and reset
   platform health state for each startup attempt.
 

--- a/docs/architecture/app/platform-authoring.md
+++ b/docs/architecture/app/platform-authoring.md
@@ -37,6 +37,16 @@ Module loading binds the Python `services` package to the active app root.
 Reloading a workspace must not resolve service clients from another app left
 on the process import path. Python package markers remain optional.
 
+Studio composes the packaged `factory_app/app/modules/` as module defaults
+through the same `AppLoader` and `ModuleLoader` used for app modules. Active
+workspace module folders override defaults by id; a broken override fails
+validation rather than silently using the default. This makes shared Studio
+modules such as `security_readiness` callable through the normal authenticated
+module executor without copying their implementation into each workspace.
+The platform-only host loads only its active app modules. Config, services,
+data contracts, and app identity continue to come from the active workspace;
+module defaults do not replace those app families or grant permissions.
+
 | Family | Purpose | Path |
 | --- | --- | --- |
 | App manifest | Small app identity and target manifest | `app/app.json` |

--- a/docs/architecture/modules-systems/module-system.md
+++ b/docs/architecture/modules-systems/module-system.md
@@ -20,11 +20,15 @@ contain orchestration or reasoning logic.
 
 Tools running in a live authenticated workflow may call
 `mozaiksai.core.workflow.module_tools.dispatch_workflow_module_action(module, action, params)`.
-The helper obtains the workflow/app/chat identity from the active AG2 tool invocation
+The helper obtains workflow/app/chat/actor identity from the active AG2 tool invocation
 and the principal from that run's server-owned WebSocket connection. Host scope hooks
 resolve membership before the existing module executor enforces action permissions
 and entitlements. Identity, permissions, and bearer tokens are never taken from model
-arguments. Expired, disconnected, mismatched, or revoked invocations fail closed.
+arguments. During a workflow handoff it allows up to two seconds for a missing or
+replaced socket to reconnect, resolving the live principal and permissions again
+on every attempt. The actor remains bound to the original immutable runtime
+identity. Expired or mismatched principals, permission denials, and revoked
+invocations fail closed. An action is never retried after execution starts.
 Headless runs without a live principal must use their own explicit server-owned
 dispatch contract; this helper does not grant a background bypass.
 

--- a/docs/architecture/modules-systems/module-system.md
+++ b/docs/architecture/modules-systems/module-system.md
@@ -16,6 +16,29 @@ A module is a self-contained unit of **deterministic business logic** declared i
 Modules are **not** AI workflows. They run without AI. Workflows call modules; modules do not
 contain orchestration or reasoning logic.
 
+### Workflow tool dispatch
+
+Tools running in a live authenticated workflow may call
+`mozaiksai.core.workflow.module_tools.dispatch_workflow_module_action(module, action, params)`.
+The helper obtains the workflow/app/chat identity from the active AG2 tool invocation
+and the principal from that run's server-owned WebSocket connection. Host scope hooks
+resolve membership before the existing module executor enforces action permissions
+and entitlements. Identity, permissions, and bearer tokens are never taken from model
+arguments. Expired, disconnected, mismatched, or revoked invocations fail closed.
+Headless runs without a live principal must use their own explicit server-owned
+dispatch contract; this helper does not grant a background bypass.
+
+The Factory `SecurityReadiness` workflow uses this path to record findings in the
+first-party `security_readiness` module. `app_id` retains the runtime host scope;
+`build_registry_id` identifies the reviewed project, while `build_id` and
+`artifact_version_id` retain assessment lineage. List and summary actions accept
+an optional `build_registry_id` filter applied before the result limit. Source-local
+scanner keys become opaque persisted ids scoped to owner, app, project, and artifact.
+The workflow converts scanner evidence paths and recommendations into the module's
+`evidence_ref` and `remediation` fields. Missing persistence stays visible in the
+advisory review, and zero inspected files yields `not_assessed`. An empty findings
+collection does not prove a saved passing assessment; this module stores findings.
+
 ---
 
 ## Canonical Module Shape

--- a/factory_app/app/modules/security_readiness/backend/handler.py
+++ b/factory_app/app/modules/security_readiness/backend/handler.py
@@ -40,6 +40,7 @@ class SecurityReadinessModule:
         ctx: ModuleContext,
         *,
         app_id: str,
+        build_registry_id: str | None = None,
         status: str | None = None,
         severity: str | None = None,
         control_area: str | None = None,
@@ -49,6 +50,7 @@ class SecurityReadinessModule:
         return await self.service.list_findings(
             ctx,
             app_id=app_id,
+            build_registry_id=build_registry_id,
             status=status,
             severity=severity,
             control_area=control_area,
@@ -60,9 +62,12 @@ class SecurityReadinessModule:
         ctx: ModuleContext,
         *,
         app_id: str,
+        build_registry_id: str | None = None,
         **_: object,
     ) -> dict[str, Any]:
-        return await self.service.get_summary(ctx, app_id=app_id)
+        return await self.service.get_summary(
+            ctx, app_id=app_id, build_registry_id=build_registry_id,
+        )
 
     async def update_finding_status(
         self,

--- a/factory_app/app/modules/security_readiness/backend/repo.py
+++ b/factory_app/app/modules/security_readiness/backend/repo.py
@@ -21,6 +21,14 @@ def _document(value: Any) -> dict[str, Any] | None:
     return dict(value) if isinstance(value, Mapping) else None
 
 
+def _collection_query(ctx: ModuleContext, query: dict[str, Any]) -> dict[str, Any]:
+    """Verify the requested app scope; the persistence adapter supplies it."""
+    scoped = dict(query)
+    if "app_id" in scoped and scoped.pop("app_id") != ctx.persistence.app_id:
+        raise ValueError("Security findings must use the persistence context app_id.")
+    return scoped
+
+
 class SecurityReadinessRepo:
     async def insert_findings(self, ctx: ModuleContext, findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if not findings:
@@ -28,7 +36,11 @@ class SecurityReadinessRepo:
         collection = _collection(ctx)
         for finding in findings:
             await collection.update_one(
-                {"finding_id": finding["finding_id"], "owner_user_id": finding["owner_user_id"]},
+                _collection_query(ctx, {
+                    "app_id": finding["app_id"],
+                    "finding_id": finding["finding_id"],
+                    "owner_user_id": finding["owner_user_id"],
+                }),
                 {"$set": finding},
                 upsert=True,
             )
@@ -42,7 +54,7 @@ class SecurityReadinessRepo:
         limit: int,
     ) -> list[dict[str, Any]]:
         collection = _collection(ctx)
-        rows = await collection.find_many(query, limit=limit, sort=[("updated_at", -1)])
+        rows = await collection.find_many(_collection_query(ctx, query), limit=limit, sort=[("updated_at", -1)])
         return [public for row in rows if (public := _document(row)) is not None]
 
     async def update_status(
@@ -56,6 +68,7 @@ class SecurityReadinessRepo:
         updated_at: str,
     ) -> dict[str, Any] | None:
         collection = _collection(ctx)
+        query = _collection_query(ctx, query)
         update = {
             "status": status,
             "status_note": note,

--- a/factory_app/app/modules/security_readiness/backend/repo.py
+++ b/factory_app/app/modules/security_readiness/backend/repo.py
@@ -24,7 +24,9 @@ def _document(value: Any) -> dict[str, Any] | None:
 def _collection_query(ctx: ModuleContext, query: dict[str, Any]) -> dict[str, Any]:
     """Verify the requested app scope; the persistence adapter supplies it."""
     scoped = dict(query)
-    if "app_id" in scoped and scoped.pop("app_id") != ctx.persistence.app_id:
+    if "app_id" in scoped and (
+        ctx.persistence is None or scoped.pop("app_id") != ctx.persistence.app_id
+    ):
         raise ValueError("Security findings must use the persistence context app_id.")
     return scoped
 

--- a/factory_app/app/modules/security_readiness/backend/schemas.py
+++ b/factory_app/app/modules/security_readiness/backend/schemas.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any, TypedDict
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 SEVERITIES = ("low", "medium", "high", "critical")
 STATUSES = ("open", "accepted", "resolved")
@@ -87,8 +88,16 @@ def build_finding_document(
         raise ValueError("app_id is required")
     if not title:
         raise ValueError("finding.title is required")
+    source_key = normalize_optional_text(finding.get("finding_id"))
+    # Scanner rule ids repeat between apps. Persist an opaque id scoped to the
+    # owner, project, and assessed artifact so replay cannot overwrite another app.
+    identity = json.dumps(
+        [owner_user_id, app_id, build_registry_id, build_id, artifact_version_id, source, source_key],
+        separators=(",", ":"),
+    )
+    finding_id = f"sr_{uuid5(NAMESPACE_URL, identity).hex}" if source_key else f"sr_{uuid4().hex}"
     return {
-        "finding_id": str(finding.get("finding_id") or f"sr_{uuid4().hex}"),
+        "finding_id": finding_id,
         "app_id": app_id,
         "build_id": normalize_optional_text(build_id),
         "build_registry_id": normalize_optional_text(build_registry_id),

--- a/factory_app/app/modules/security_readiness/backend/service.py
+++ b/factory_app/app/modules/security_readiness/backend/service.py
@@ -65,7 +65,10 @@ class SecurityReadinessService:
         saved = await self.repo.insert_findings(ctx, documents)
         all_findings = await self.repo.list_findings(
             ctx,
-            query=app_findings_query(ctx, app_id=normalized_app_id),
+            query=app_findings_query(
+                ctx, app_id=normalized_app_id,
+                build_registry_id=normalize_optional_text(build_registry_id),
+            ),
             limit=250,
         )
         summary = summarize_findings(all_findings)
@@ -73,8 +76,8 @@ class SecurityReadinessService:
             "domain.security_readiness.assessment_recorded",
             {
                 "app_id": normalized_app_id,
-                "build_id": build_id,
-                "artifact_version_id": artifact_version_id,
+                **({"build_id": build_id} if build_id else {}),
+                **({"artifact_version_id": artifact_version_id} if artifact_version_id else {}),
                 "saved": len(saved),
             },
         )
@@ -85,6 +88,7 @@ class SecurityReadinessService:
         ctx: ModuleContext,
         *,
         app_id: str,
+        build_registry_id: str | None = None,
         status: str | None = None,
         severity: str | None = None,
         control_area: str | None = None,
@@ -96,6 +100,7 @@ class SecurityReadinessService:
         query = app_findings_query(
             ctx,
             app_id=normalized_app_id,
+            build_registry_id=normalize_optional_text(build_registry_id),
             status=normalize_enum(status, STATUSES, default="open", field_name="status") if status else None,
             severity=normalize_enum(severity, SEVERITIES, default="medium", field_name="severity") if severity else None,
             control_area=normalize_enum(
@@ -109,13 +114,18 @@ class SecurityReadinessService:
         public = [public_finding(item) for item in findings]
         return {"app_id": normalized_app_id, "findings": public, "count": len(public)}
 
-    async def get_summary(self, ctx: ModuleContext, *, app_id: str) -> dict[str, Any]:
+    async def get_summary(
+        self, ctx: ModuleContext, *, app_id: str, build_registry_id: str | None = None,
+    ) -> dict[str, Any]:
         normalized_app_id = normalize_optional_text(app_id)
         if not normalized_app_id:
             raise ValueError("app_id is required")
         findings = await self.repo.list_findings(
             ctx,
-            query=app_findings_query(ctx, app_id=normalized_app_id),
+            query=app_findings_query(
+                ctx, app_id=normalized_app_id,
+                build_registry_id=normalize_optional_text(build_registry_id),
+            ),
             limit=250,
         )
         return {"app_id": normalized_app_id, "summary": summarize_findings(findings)}

--- a/factory_app/app/modules/security_readiness/module.yaml
+++ b/factory_app/app/modules/security_readiness/module.yaml
@@ -46,6 +46,9 @@ actions:
               - severity
               - control_area
             properties:
+              finding_id:
+                type: string
+                description: Source-local finding key; storage scopes it to owner, app, project, and artifact.
               title:
                 type: string
               description:
@@ -100,6 +103,8 @@ actions:
       properties:
         app_id:
           type: string
+        build_registry_id:
+          type: string
         status:
           type: string
           enum: [open, accepted, resolved]
@@ -145,6 +150,8 @@ actions:
         - app_id
       properties:
         app_id:
+          type: string
+        build_registry_id:
           type: string
     output_schema:
       type: object

--- a/factory_app/workflows/SecurityReadiness/agents.yaml
+++ b/factory_app/workflows/SecurityReadiness/agents.yaml
@@ -21,3 +21,6 @@ agents:
       - app/modules/*/backend/policy.py owns module-local scoping policy.
 
       When the tools complete, summarize the readiness status briefly and stop.
+      If no files were inspected, say the bundle was not assessed. If recording
+      failed, say findings are available in this review but were not saved;
+      never claim persistence succeeded after a denied or unavailable dispatch.

--- a/factory_app/workflows/SecurityReadiness/tools.yaml
+++ b/factory_app/workflows/SecurityReadiness/tools.yaml
@@ -13,7 +13,8 @@ tools:
     function: record_security_findings
     description: >
       Persist the latest security_readiness_findings into the first-party
-      security_readiness module when a ModuleContext is available, and always
-      keep the review summary in context_variables for AppReview.
+      security_readiness module through the live session's permissioned action
+      dispatch. Keep the review summary and explicit persistence failures in
+      context_variables for AppReview.
     tool_type: Agent_Tool
     auto_tool_call: false

--- a/factory_app/workflows/SecurityReadiness/tools/inspect_generated_app_security.py
+++ b/factory_app/workflows/SecurityReadiness/tools/inspect_generated_app_security.py
@@ -8,6 +8,7 @@ from typing import Any
 import yaml
 
 from factory_app.app.modules.security_readiness.backend.schemas import summarize_findings
+from mozaiksai.core.workflow.context.frozen import detach
 
 _TEXT_FILE_SUFFIXES = {
     ".css",
@@ -39,10 +40,10 @@ def _context_get(context_variables: Any | None, key: str, default: Any = None) -
         return context_variables.get(key, default)
     if hasattr(context_variables, "get"):
         try:
-            return context_variables.get(key, default)
+            return detach(context_variables.get(key, default))
         except TypeError:
             try:
-                return context_variables.get(key)
+                return detach(context_variables.get(key))
             except Exception:
                 return default
         except Exception:
@@ -374,7 +375,7 @@ async def inspect_generated_app_security(context_variables: Any | None = None) -
 
     summary = summarize_findings(findings)
     result = {
-        "status": "passed" if summary["open"] == 0 else "attention_required",
+        "status": "not_assessed" if not files else "passed" if summary["open"] == 0 else "attention_required",
         "mode": str(
             _context_get(context_variables, "security_readiness_mode", "advisory") or "advisory"
         ),

--- a/factory_app/workflows/SecurityReadiness/tools/record_security_findings.py
+++ b/factory_app/workflows/SecurityReadiness/tools/record_security_findings.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from factory_app.app.modules.security_readiness.backend.service import SecurityReadinessService
+from mozaiksai.core.workflow.context.frozen import detach
+from mozaiksai.core.workflow.module_tools import dispatch_workflow_module_action
 
 
 def _context_get(context_variables: Any | None, key: str, default: Any = None) -> Any:
@@ -12,10 +13,10 @@ def _context_get(context_variables: Any | None, key: str, default: Any = None) -
         return context_variables.get(key, default)
     if hasattr(context_variables, "get"):
         try:
-            return context_variables.get(key, default)
+            return detach(context_variables.get(key, default))
         except TypeError:
             try:
-                return context_variables.get(key)
+                return detach(context_variables.get(key))
             except Exception:
                 return default
         except Exception:
@@ -45,9 +46,8 @@ def _normalize_findings(value: Any) -> list[dict[str, Any]]:
 async def record_security_findings(
     findings: list[dict[str, Any]] | None = None,
     context_variables: Any | None = None,
-    module_context: Any | None = None,
 ) -> dict[str, Any]:
-    """Record SecurityReadiness findings when module persistence is available."""
+    """Record findings through the live run's permissioned module dispatch."""
 
     resolved_findings = _normalize_findings(
         findings
@@ -60,30 +60,57 @@ async def record_security_findings(
         str(_context_get(context_variables, "artifact_version_id", "") or "").strip() or None
     )
 
+    build_registry_id = str(_context_get(context_variables, "build_registry_id", "") or "").strip() or None
     persisted = False
     result: dict[str, Any] = {"success": True, "persisted": False, "findings": resolved_findings}
-    if module_context is not None and app_id and resolved_findings:
-        service_result = await SecurityReadinessService().record_assessment(
-            module_context,
-            app_id=app_id,
-            build_id=build_id,
-            artifact_version_id=artifact_version_id,
-            source="validation",
-            findings=resolved_findings,
-        )
-        result.update(service_result)
-        persisted = True
+    if app_id and resolved_findings:
+        params = {
+            "app_id": app_id,
+            "source": "validation",
+            "findings": [
+                {
+                    **{key: item[key] for key in (
+                        "finding_id", "title", "description", "severity", "status", "control_area",
+                    ) if key in item},
+                    **({"evidence_ref": item["evidence"]["path"]} if isinstance(item.get("evidence"), dict) and item["evidence"].get("path") else {}),
+                    **({"remediation": item["recommendation"]} if item.get("recommendation") else {}),
+                }
+                for item in resolved_findings
+            ],
+        }
+        params.update({key: value for key, value in {
+            "build_id": build_id, "build_registry_id": build_registry_id,
+            "artifact_version_id": artifact_version_id,
+        }.items() if value})
+        try:
+            dispatched = await dispatch_workflow_module_action("security_readiness", "record_assessment", params)
+            persisted = dispatched.success and bool((dispatched.data or {}).get("success"))
+            if persisted:
+                result.update(dispatched.data)
+            else:
+                result.update(success=False, persistence_error=dispatched.error_code or "security_findings_record_failed")
+        except PermissionError as exc:
+            result.update(success=False, persistence_error=str(exc))
+        except Exception:
+            result.update(success=False, persistence_error="security_findings_record_failed")
+    elif not app_id and resolved_findings:
+        result.update(success=False, persistence_error="security_findings_app_id_missing")
     result["persisted"] = persisted
 
+    inspected = _context_get(context_variables, "security_readiness_summary", {})
+    checked_file_count = inspected.get("checked_file_count", 0) if isinstance(inspected, dict) else 0
     summary = {
-        "status": "passed" if not resolved_findings else "attention_required",
+        "status": "attention_required" if resolved_findings else "passed" if checked_file_count else "not_assessed",
         "mode": str(
             _context_get(context_variables, "security_readiness_mode", "advisory") or "advisory"
         ),
         "persisted": persisted,
         "finding_count": len(resolved_findings),
+        "checked_file_count": checked_file_count,
         "findings": resolved_findings,
     }
+    if result.get("persistence_error"):
+        summary["persistence_error"] = result["persistence_error"]
     _context_set(context_variables, "security_readiness_summary", summary)
     _context_set(context_variables, "security_readiness_recorded", True)
     return result

--- a/mozaiksai/core/runtime/app/loader.py
+++ b/mozaiksai/core/runtime/app/loader.py
@@ -102,11 +102,14 @@ class AppLoader:
     APP_JSON_NAME = "app.json"
 
     @classmethod
-    async def load(cls, path: str = ".") -> AppLoadResult:
+    async def load(cls, path: str = ".", *, module_defaults_path: str | None = None) -> AppLoadResult:
         """Load app metadata and any discovered modules from a bundle directory.
 
         Args:
             path: Root directory of the platform bundle.
+            module_defaults_path: Optional host-owned app bundle supplying default modules.
+                Active app module folders override defaults by id. Other app families
+                (config, data, services, pages) remain owned by the active app root.
 
         Returns:
             AppLoadResult with parsed definition and loaded modules.
@@ -129,7 +132,7 @@ class AppLoader:
             raise AppLoadError("app.json must be a JSON object")
 
         raw = cls._resolve_env_vars(raw)
-        module_loader = ModuleLoader(base_path=str(base_path))
+        module_loader = ModuleLoader(base_path=str(base_path), module_defaults_path=module_defaults_path)
         module_names = module_loader.discover_module_names()
         workflow_names = cls._discover_workflow_names(base_path)
         page_names = cls._discover_page_names(base_path)

--- a/mozaiksai/core/runtime/app/module_loader.py
+++ b/mozaiksai/core/runtime/app/module_loader.py
@@ -1153,8 +1153,15 @@ class ModuleLoader:
         "policy_hooks": ("policy_hooks.yaml", ModulePolicyHooksManifest),
     }
 
-    def __init__(self, base_path: str, *, taxonomy_advisory: bool = False) -> None:
+    def __init__(self, base_path: str, *, taxonomy_advisory: bool = False, module_defaults_path: str | None = None) -> None:
         self._base = Path(base_path)
+        self._module_roots = [self._base]
+        if module_defaults_path is not None:
+            defaults_root = Path(module_defaults_path)
+            if not defaults_root.is_dir():
+                raise ModuleLoadError(f"Module defaults app root not found: {defaults_root}")
+            if defaults_root.resolve() != self._base.resolve():
+                self._module_roots.append(defaults_root)
         self._taxonomy_advisory = taxonomy_advisory
         import_roots = [self._base.parent, self._base] if self._base.name == "app" else [self._base]
         for root in import_roots:
@@ -1168,15 +1175,14 @@ class ModuleLoader:
         self._register_module_package("services", self._base / "services")
 
     def discover_module_names(self) -> list[str]:
-        """Return module names for every modules/*/module.yaml in the bundle."""
-        modules_dir = self._base / "modules"
-        if not modules_dir.exists():
-            return []
-        names: list[str] = []
-        for child in sorted(modules_dir.iterdir(), key=lambda item: item.name.lower()):
-            if child.is_dir() and (child / self.YAML_FILENAME).exists():
-                names.append(child.name)
-        return names
+        """Discover active app modules and explicitly composed host defaults."""
+        names: set[str] = set()
+        for root in self._module_roots:
+            modules_dir = root / "modules"
+            if modules_dir.is_dir():
+                names.update(child.name for child in modules_dir.iterdir()
+                             if child.is_dir() and (child / self.YAML_FILENAME).exists())
+        return sorted(names, key=str.lower)
 
     async def load_all(
         self,
@@ -1203,7 +1209,10 @@ class ModuleLoader:
 
     def load(self, name: str) -> LoadedModule:
         """Load a single canonical module by folder name."""
-        module_dir = self._base / "modules" / name
+        module_dir = next(
+            (root / "modules" / name for root in self._module_roots if (root / "modules" / name).is_dir()),
+            self._base / "modules" / name,
+        )
         if not module_dir.exists():
             raise ModuleLoadError(f"Module directory not found: {module_dir}")
 

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -166,6 +166,21 @@ _WORKFLOW_TOOL_INVOCATION: ContextVar[_WorkflowToolInvocation | None] = ContextV
 )
 
 
+def active_workflow_tool_run() -> tuple[str, str, str]:
+    """Return server-bound workflow/app/chat identity during a live tool call."""
+    invocation = _WORKFLOW_TOOL_INVOCATION.get()
+    if (
+        invocation is None
+        or not invocation.active
+        or invocation.run_identity is None
+        or invocation.policy is None
+        or invocation.bridge._authority_policy is not invocation.policy
+        or invocation.bridge._run_identity != invocation.run_identity
+    ):
+        raise PermissionError("workflow_tool_invocation_unavailable")
+    return invocation.run_identity
+
+
 @contextmanager
 def _workflow_tool_invocation(bridge: ContextVariablesBridge):
     invocation = _WorkflowToolInvocation(bridge, bridge._authority_policy, bridge._run_identity)

--- a/mozaiksai/core/workflow/agents/factory.py
+++ b/mozaiksai/core/workflow/agents/factory.py
@@ -158,6 +158,7 @@ class _WorkflowToolInvocation:
     bridge: ContextVariablesBridge
     policy: ContextAuthorityPolicy | None
     run_identity: tuple[str, str, str] | None
+    user_id: str | None
     active: bool = True
 
 
@@ -166,24 +167,30 @@ _WORKFLOW_TOOL_INVOCATION: ContextVar[_WorkflowToolInvocation | None] = ContextV
 )
 
 
-def active_workflow_tool_run() -> tuple[str, str, str]:
-    """Return server-bound workflow/app/chat identity during a live tool call."""
+def active_workflow_tool_run() -> tuple[str, str, str, str]:
+    """Return runtime-owned workflow/app/chat/actor identity for this invocation."""
     invocation = _WORKFLOW_TOOL_INVOCATION.get()
     if (
         invocation is None
         or not invocation.active
         or invocation.run_identity is None
         or invocation.policy is None
+        or invocation.user_id is None
         or invocation.bridge._authority_policy is not invocation.policy
         or invocation.bridge._run_identity != invocation.run_identity
+        or invocation.bridge.get("user_id") != invocation.user_id
     ):
         raise PermissionError("workflow_tool_invocation_unavailable")
-    return invocation.run_identity
+    return (*invocation.run_identity, invocation.user_id)
 
 
 @contextmanager
 def _workflow_tool_invocation(bridge: ContextVariablesBridge):
-    invocation = _WorkflowToolInvocation(bridge, bridge._authority_policy, bridge._run_identity)
+    actor = bridge.get("user_id")
+    invocation = _WorkflowToolInvocation(
+        bridge, bridge._authority_policy, bridge._run_identity,
+        actor if isinstance(actor, str) and actor.strip() else None,
+    )
     token = _WORKFLOW_TOOL_INVOCATION.set(invocation)
     try:
         yield

--- a/mozaiksai/core/workflow/module_tools.py
+++ b/mozaiksai/core/workflow/module_tools.py
@@ -1,6 +1,7 @@
 """Permissioned module dispatch for tools attached to a live workflow session."""
 from __future__ import annotations
 
+import asyncio
 import math
 import time
 from typing import Any
@@ -23,19 +24,25 @@ from mozaiksai.core.runtime.composition.module_executor import ModuleResult
 from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
 from mozaiksai.core.workflow.agents.factory import active_workflow_tool_run
 
+_RECONNECT_TIMEOUT_SECONDS = 2.0
+_RECONNECT_POLL_SECONDS = 0.05
 
-def _live_session(transport: Any, *, app_id: str, chat_id: str) -> tuple[Any, Any, WebSocketUser]:
+
+class _ConnectionUnavailable(PermissionError):
+    """A connection changed before dispatch; no action has executed yet."""
+
+
+def _live_session(transport: Any, *, app_id: str, chat_id: str, user_id: str) -> tuple[Any, Any, WebSocketUser]:
     connection = (getattr(transport, "connections", {}) or {}).get(chat_id) or {}
     websocket = connection.get("websocket")
     principal = getattr(getattr(websocket, "state", None), "user", None)
-    if (
-        not connection.get("active") or not isinstance(principal, WebSocketUser)
-        or getattr(websocket, "client_state", None) != WebSocketState.CONNECTED
-        or getattr(websocket, "application_state", None) != WebSocketState.CONNECTED
-    ):
+    if websocket is None:
+        raise _ConnectionUnavailable("workflow_session_connection_unavailable")
+    if not isinstance(principal, WebSocketUser):
         raise PermissionError("workflow_session_principal_unavailable")
     if (
         connection.get("app_id") != app_id
+        or principal.user_id != user_id
         or connection.get("user_id") != principal.user_id
         or not principal.validate_app_id(app_id)
     ):
@@ -54,6 +61,12 @@ def _live_session(transport: Any, *, app_id: str, chat_id: str) -> tuple[Any, An
                 expired = True
             if expired:
                 raise PermissionError("workflow_session_principal_expired")
+    if (
+        not connection.get("active")
+        or getattr(websocket, "client_state", None) != WebSocketState.CONNECTED
+        or getattr(websocket, "application_state", None) != WebSocketState.CONNECTED
+    ):
+        raise _ConnectionUnavailable("workflow_session_connection_unavailable")
     return connection, websocket, principal
 
 
@@ -75,9 +88,34 @@ async def dispatch_workflow_module_action(
     """
     from mozaiksai.core.transport.simple_transport import SimpleTransport
 
-    workflow_name, app_id, chat_id = active_workflow_tool_run()
+    run_identity = active_workflow_tool_run()
     transport = await SimpleTransport.get_instance()
-    connection, websocket, principal = _live_session(transport, app_id=app_id, chat_id=chat_id)
+    deadline = time.monotonic() + _RECONNECT_TIMEOUT_SECONDS
+    while True:
+        if active_workflow_tool_run() != run_identity:
+            raise PermissionError("workflow_session_scope_mismatch")
+        try:
+            request, app = await _prepare_live_dispatch(
+                module, action, params, transport=transport, run_identity=run_identity,
+            )
+            break
+        except _ConnectionUnavailable:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            await asyncio.sleep(min(_RECONNECT_POLL_SECONDS, remaining))
+    # Execution is outside the retry boundary: a started action is never replayed.
+    return await dispatch_module_action(request, app=app)
+
+
+async def _prepare_live_dispatch(
+    module: str, action: str, params: dict[str, Any], *,
+    transport: Any, run_identity: tuple[str, str, str, str],
+) -> tuple[ModuleActionDispatchRequest, Any]:
+    workflow_name, app_id, chat_id, user_id = run_identity
+    connection, websocket, principal = _live_session(
+        transport, app_id=app_id, chat_id=chat_id, user_id=user_id,
+    )
     principal_scope = _principal_scope(principal)
     surfaces = getattr(websocket.app.state, "module_action_surfaces", {})
     module_surfaces = surfaces.get(module, {})
@@ -105,17 +143,18 @@ async def dispatch_workflow_module_action(
     if scope.get("app_id") != app_id or scope.get("user_id") != principal.user_id:
         raise PermissionError("workflow_session_scope_mismatch")
     # Recheck revocation after awaited provider hooks before dispatching.
-    if active_workflow_tool_run() != (workflow_name, app_id, chat_id):
+    if active_workflow_tool_run() != run_identity:
         raise PermissionError("workflow_session_scope_mismatch")
     current_connection, current_websocket, current_principal = _live_session(
-        transport, app_id=app_id, chat_id=chat_id,
+        transport, app_id=app_id, chat_id=chat_id, user_id=user_id,
     )
-    if (
-        current_connection is not connection or current_websocket is not websocket
-        or current_principal is not principal or _principal_scope(principal) != principal_scope
-    ):
+    if _principal_scope(principal) != principal_scope:
         raise PermissionError("workflow_session_principal_changed")
-    return await dispatch_module_action(
+    if current_connection is not connection or current_websocket is not websocket:
+        raise _ConnectionUnavailable("workflow_session_connection_changed")
+    if current_principal is not principal:
+        raise PermissionError("workflow_session_principal_changed")
+    return (
         ModuleActionDispatchRequest(
             module=module, action=action, params=params,
             scope=ModuleDispatchScope(
@@ -130,5 +169,5 @@ async def dispatch_workflow_module_action(
                 surface="workflow_tool", workflow_name=workflow_name, workflow_run_id=chat_id,
             ),
         ),
-        app=websocket.app,
+        websocket.app,
     )

--- a/mozaiksai/core/workflow/module_tools.py
+++ b/mozaiksai/core/workflow/module_tools.py
@@ -1,0 +1,134 @@
+"""Permissioned module dispatch for tools attached to a live workflow session."""
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+from starlette.websockets import WebSocketState
+
+from mozaiksai.core.auth.adapters import get_auth_adapter
+from mozaiksai.core.auth.adapters.registry import is_auth_enabled
+from mozaiksai.core.auth.websocket_auth import WebSocketUser
+from mozaiksai.core.runtime.composition.module_authority import (
+    ModuleDispatchProvenance,
+    workflow_user_authority,
+)
+from mozaiksai.core.runtime.composition.module_dispatch import (
+    ModuleActionDispatchRequest,
+    ModuleDispatchScope,
+    dispatch_module_action,
+)
+from mozaiksai.core.runtime.composition.module_executor import ModuleResult
+from mozaiksai.core.runtime.composition.platform_hooks import get_platform_hooks
+from mozaiksai.core.workflow.agents.factory import active_workflow_tool_run
+
+
+def _live_session(transport: Any, *, app_id: str, chat_id: str) -> tuple[Any, Any, WebSocketUser]:
+    connection = (getattr(transport, "connections", {}) or {}).get(chat_id) or {}
+    websocket = connection.get("websocket")
+    principal = getattr(getattr(websocket, "state", None), "user", None)
+    if (
+        not connection.get("active") or not isinstance(principal, WebSocketUser)
+        or getattr(websocket, "client_state", None) != WebSocketState.CONNECTED
+        or getattr(websocket, "application_state", None) != WebSocketState.CONNECTED
+    ):
+        raise PermissionError("workflow_session_principal_unavailable")
+    if (
+        connection.get("app_id") != app_id
+        or connection.get("user_id") != principal.user_id
+        or not principal.validate_app_id(app_id)
+    ):
+        raise PermissionError("workflow_session_scope_mismatch")
+    # A chat-bound token cannot authorize an aliased successor chat.
+    if not principal.validate_chat_id(chat_id):
+        raise PermissionError("workflow_session_scope_mismatch")
+    if is_auth_enabled():
+        if principal.provider == "none":
+            raise PermissionError("workflow_session_principal_unavailable")
+        expires = principal.raw_claims.get("exp")
+        if expires is not None:
+            try:
+                expired = not math.isfinite(float(expires)) or float(expires) <= time.time()
+            except (TypeError, ValueError):
+                expired = True
+            if expired:
+                raise PermissionError("workflow_session_principal_expired")
+    return connection, websocket, principal
+
+
+def _principal_scope(principal: WebSocketUser) -> tuple[Any, ...]:
+    return (
+        principal.user_id, principal.app_id, principal.chat_id,
+        principal.tenant_id, principal.workspace_id, tuple(principal.scopes),
+        tuple(principal.roles), principal.provider,
+    )
+
+
+async def dispatch_workflow_module_action(
+    module: str, action: str, params: dict[str, Any],
+) -> ModuleResult:
+    """Use the run's authenticated socket principal, never model-supplied identity.
+
+    Background runs without an authenticated live connection fail closed. No
+    bearer token, role, or dispatch authority is copied into workflow state.
+    """
+    from mozaiksai.core.transport.simple_transport import SimpleTransport
+
+    workflow_name, app_id, chat_id = active_workflow_tool_run()
+    transport = await SimpleTransport.get_instance()
+    connection, websocket, principal = _live_session(transport, app_id=app_id, chat_id=chat_id)
+    principal_scope = _principal_scope(principal)
+    surfaces = getattr(websocket.app.state, "module_action_surfaces", {})
+    module_surfaces = surfaces.get(module, {})
+    # A present None value is the canonical authenticated action default. A
+    # missing entry has no loaded contract and must never imply public access.
+    if action not in module_surfaces or module_surfaces[action] not in {None, "public", "public_readonly"}:
+        raise PermissionError("workflow_module_action_unavailable")
+    if is_auth_enabled():
+        permissions = list(principal.scopes)
+    else:
+        # The no-auth path-user binding supplies identity only. Resolve local
+        # permissions from the configured adapter, as HTTP local mode does.
+        permissions = list((await get_auth_adapter().validate_token("")).scopes)
+
+    scope = await get_platform_hooks().call_module_scope(
+        principal=principal, module_name=module, action_name=action,
+        requested_scope={
+            "app_id": app_id, "user_id": principal.user_id,
+            "tenant_id": principal.tenant_id, "workspace_id": principal.workspace_id,
+        },
+        params=params, request=websocket, default_permissions=permissions,
+    )
+    # Hooks may narrow tenant/workspace membership; they cannot turn a workflow
+    # dispatch into a different actor or app.
+    if scope.get("app_id") != app_id or scope.get("user_id") != principal.user_id:
+        raise PermissionError("workflow_session_scope_mismatch")
+    # Recheck revocation after awaited provider hooks before dispatching.
+    if active_workflow_tool_run() != (workflow_name, app_id, chat_id):
+        raise PermissionError("workflow_session_scope_mismatch")
+    current_connection, current_websocket, current_principal = _live_session(
+        transport, app_id=app_id, chat_id=chat_id,
+    )
+    if (
+        current_connection is not connection or current_websocket is not websocket
+        or current_principal is not principal or _principal_scope(principal) != principal_scope
+    ):
+        raise PermissionError("workflow_session_principal_changed")
+    return await dispatch_module_action(
+        ModuleActionDispatchRequest(
+            module=module, action=action, params=params,
+            scope=ModuleDispatchScope(
+                app_id=app_id, user_id=principal.user_id,
+                tenant_id=scope.get("tenant_id"), workspace_id=scope.get("workspace_id"),
+            ),
+            authority=workflow_user_authority(
+                actor_id=principal.user_id, permissions=tuple(scope.get("permissions") or []),
+                workflow_name=workflow_name,
+            ),
+            provenance=ModuleDispatchProvenance(
+                surface="workflow_tool", workflow_name=workflow_name, workflow_run_id=chat_id,
+            ),
+        ),
+        app=websocket.app,
+    )

--- a/mozaiksai/hosts/bootstrap.py
+++ b/mozaiksai/hosts/bootstrap.py
@@ -187,6 +187,26 @@ def _workflow_catalog_bound_to_host_config() -> Iterator[None]:
         manager.__dict__.update(catalog_snapshot)
 
 
+@contextmanager
+def _module_defaults_bound_to_host(target_app: FastAPI, host: str) -> Iterator[None]:
+    """Compose first-party module defaults only for a running Studio host."""
+    if host != "studio":
+        yield
+        return
+    factory_workspace = resolve_factory_app_root()
+    if factory_workspace is None:
+        raise RuntimeError("Studio requires the packaged Factory workspace")
+    previous = getattr(target_app.state, "module_defaults_path", None)
+    target_app.state.module_defaults_path = str(factory_workspace / "app")
+    try:
+        yield
+    finally:
+        if previous is None:
+            del target_app.state.module_defaults_path
+        else:
+            target_app.state.module_defaults_path = previous
+
+
 def register_repo_host_bootstrap(target_app: FastAPI, host: str) -> None:
     """Arrange for ``configure_repo_host_defaults(host)`` to run at server startup.
 
@@ -211,7 +231,7 @@ def register_repo_host_bootstrap(target_app: FastAPI, host: str) -> None:
     @asynccontextmanager
     async def _bootstrap_lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
         configure_repo_host_defaults(normalized_host)
-        with _workflow_catalog_bound_to_host_config():
+        with _workflow_catalog_bound_to_host_config(), _module_defaults_bound_to_host(app_instance, normalized_host):
             async with existing_lifespan(app_instance):
                 yield
 

--- a/mozaiksai/hosts/platform.py
+++ b/mozaiksai/hosts/platform.py
@@ -273,7 +273,9 @@ async def _platform_startup() -> None:
     database_startup_policy = get_database_startup_policy()
     logger.info("DATABASE_STARTUP_POLICY: policy=%s app_root=%s", database_startup_policy, app_root)
     try:
-        load_result = await AppLoader.load(str(app_root))
+        module_defaults_path = getattr(app.state, "module_defaults_path", None)
+        load_options = {"module_defaults_path": module_defaults_path} if module_defaults_path else {}
+        load_result = await AppLoader.load(str(app_root), **load_options)
         app.state.subscriptions_config = load_result.subscriptions_config
         app.state.page_schemas = {
             name: schema.model_dump(mode="json", exclude_none=True)

--- a/tests/test_security_readiness_dispatch.py
+++ b/tests/test_security_readiness_dispatch.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import copy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from starlette.websockets import WebSocketState
+
+from factory_app.app.modules.security_readiness.backend.handler import SecurityReadinessModule
+from factory_app.app.modules.security_readiness.backend.service import SecurityReadinessService
+from factory_app.workflows.SecurityReadiness.tools.inspect_generated_app_security import (
+    inspect_generated_app_security,
+)
+from factory_app.workflows.SecurityReadiness.tools.record_security_findings import (
+    record_security_findings,
+)
+from mozaiksai.core.auth.adapters.base import UserClaims
+from mozaiksai.core.auth.websocket_auth import WebSocketUser
+from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor
+from mozaiksai.core.runtime.composition.platform_hooks import PlatformHookRegistry
+from mozaiksai.core.transport.simple_transport import SimpleTransport
+from mozaiksai.core.workflow import module_tools
+from mozaiksai.core.workflow.agents.factory import ContextVariablesBridge, _wrap_tool_with_context
+from mozaiksai.core.workflow.context.authority import (
+    ContextAuthorityError,
+    build_context_authority_policy,
+)
+from mozaiksai.core.workflow.context.schema import load_context_variables_config
+from tests.test_security_readiness_module import _WrapperStylePersistence
+
+ROOT = Path(__file__).resolve().parents[1]
+RUN = ("SecurityReadiness", "factory-host", "chat_1")
+
+
+def _bridge(project="project_a"):
+    config = yaml.safe_load((ROOT / "factory_app/workflows/SecurityReadiness/context_variables.yaml").read_text())
+    definitions = load_context_variables_config(config).definitions
+    policy = build_context_authority_policy(workflow_name=RUN[0], definitions=definitions)
+    bridge = ContextVariablesBridge({
+        "app_id": RUN[1], "user_id": "owner_1", "build_id": "build_1", "build_registry_id": project,
+        "artifact_version_id": "artifact_1", "security_readiness_mode": "advisory",
+        "generated_files": {"app/app.json": json.dumps({"authRequired": True})},
+    }, authority_policy=policy)
+    bridge._bind_run(RUN, policy)
+    return bridge
+
+
+@pytest.fixture
+def live_runtime(monkeypatch):
+    manifest = yaml.safe_load((ROOT / "factory_app/app/modules/security_readiness/module.yaml").read_text())
+    event_contract = yaml.safe_load((ROOT / "factory_app/app/modules/security_readiness/contracts/events.yaml").read_text())
+    executor = ModuleExecutor()
+    executor.register(
+        "security_readiness", SecurityReadinessModule(),
+        action_method_map={action["id"]: action["handler_method"] for action in manifest["actions"]},
+        action_permissions={action["id"]: action["permissions"] for action in manifest["actions"]},
+        action_schemas={action["id"]: {"input": action["input_schema"], "output": action["output_schema"]} for action in manifest["actions"]},
+        action_emits={action["id"]: action.get("emits", []) for action in manifest["actions"]},
+        event_payload_schemas={event["type"]: event["payload_schema"] for event in event_contract["events"]},
+    )
+    persistence = _WrapperStylePersistence()
+    scopes = []
+
+    def storage(request):
+        scopes.append(request)
+        return persistence
+
+    monkeypatch.setattr(executor, "_build_persistence_context", storage)
+    monkeypatch.setattr(executor, "_emit_dispatch_audit", AsyncMock())
+    principal = WebSocketUser.from_claims(UserClaims(
+        user_id="owner_1", app_id=RUN[1], tenant_id="tenant_1", workspace_id="workspace_1",
+        scopes=["security_readiness.manage"], provider="keycloak", raw_claims={"exp": 9_999_999_999},
+    ))
+    app = SimpleNamespace(state=SimpleNamespace(
+        executor_registry=SimpleNamespace(module_executor=executor),
+        module_action_surfaces={"security_readiness": {action["id"]: action.get("api_surface") for action in manifest["actions"]}},
+    ))
+    socket = SimpleNamespace(
+        state=SimpleNamespace(user=principal), app=app,
+        client_state=WebSocketState.CONNECTED, application_state=WebSocketState.CONNECTED,
+    )
+    conn = {"websocket": socket, "active": True, "app_id": RUN[1], "user_id": "owner_1"}
+    transport = SimpleNamespace(connections={RUN[2]: conn})
+    monkeypatch.setattr(SimpleTransport, "get_instance", AsyncMock(return_value=transport))
+    monkeypatch.setattr(module_tools, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(module_tools, "get_platform_hooks", PlatformHookRegistry)
+    return SimpleNamespace(principal=principal, connection=conn, transport=transport, persistence=persistence, scopes=scopes)
+
+
+@pytest.mark.asyncio
+async def test_real_bound_scan_records_through_executor_and_project_filter(live_runtime):
+    for project in ("project_a", "project_b", "project_a"):
+        bridge = _bridge(project)
+        scanned = await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+        assert scanned["status"] == "attention_required"
+        recorded = await _wrap_tool_with_context(record_security_findings, bridge)()
+        assert recorded["persisted"] is True
+    rows = live_runtime.persistence.collection_handle.rows
+    assert len(rows) == 2
+    assert {row["build_registry_id"] for row in rows} == {"project_a", "project_b"}
+    assert all(row["owner_user_id"] == "owner_1" for row in rows)
+    assert all(row["app_id"] == RUN[1] and row["remediation"] and row["evidence_ref"] for row in rows)
+    request = live_runtime.scopes[0]
+    assert request.authority.kind == "workflow"
+    assert request.authority.permission_mode == "enforce"
+    assert request.auth_token is None
+    assert (request.tenant_id, request.workspace_id) == ("tenant_1", "workspace_1")
+    ctx = SimpleNamespace(user_id="owner_1", persistence=live_runtime.persistence)
+    visible = await SecurityReadinessService().list_findings(ctx, app_id=RUN[1], build_registry_id="project_b")
+    assert visible["count"] == 1
+    assert visible["findings"][0]["build_registry_id"] == "project_b"
+
+
+@pytest.mark.asyncio
+async def test_permission_denial_remains_visible_and_context_cannot_grant(live_runtime):
+    live_runtime.principal.scopes = []
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is False
+    assert result["persistence_error"] == "PERMISSION_DENIED"
+    assert bridge.get("security_readiness_summary")["persistence_error"] == "PERMISSION_DENIED"
+    assert not live_runtime.persistence.collection_handle.rows
+    with pytest.raises(ContextAuthorityError):
+        await _wrap_tool_with_context(record_security_findings, bridge)(context_variables={"permissions": ["security_readiness.manage"]})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fault", ["missing", "expired", "foreign_app", "foreign_user", "foreign_chat"])
+async def test_dispatch_rejects_unavailable_or_mismatched_principal(live_runtime, fault):
+    if fault == "missing":
+        live_runtime.transport.connections.clear()
+    elif fault == "expired":
+        live_runtime.principal.raw_claims["exp"] = 1
+    elif fault == "foreign_app":
+        live_runtime.principal.app_id = "foreign-app"
+    elif fault == "foreign_user":
+        live_runtime.principal.user_id = "other_user"
+    elif fault == "foreign_chat":
+        live_runtime.principal.chat_id = "other_chat"
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is False
+    assert result["persistence_error"].startswith("workflow_session_")
+    assert not live_runtime.persistence.collection_handle.rows
+
+
+@pytest.mark.asyncio
+async def test_detached_child_cannot_reuse_revoked_tool_authority(live_runtime):
+    ready = asyncio.Event()
+
+    async def tool(context_variables):
+        async def later():
+            await ready.wait()
+            return await module_tools.dispatch_workflow_module_action("security_readiness", "record_assessment", {})
+        return asyncio.create_task(later())
+
+    pending = await _wrap_tool_with_context(tool, _bridge())()
+    ready.set()
+    with pytest.raises(PermissionError, match="workflow_tool_invocation_unavailable"):
+        await pending
+    assert not live_runtime.scopes
+
+
+@pytest.mark.asyncio
+async def test_local_dispatch_uses_configured_no_auth_permissions(live_runtime, monkeypatch):
+    from mozaiksai.core.auth.adapters.no_auth import NoAuthAdapter
+
+    monkeypatch.setattr(module_tools, "is_auth_enabled", lambda: False)
+    monkeypatch.setattr(module_tools, "get_auth_adapter", NoAuthAdapter)
+    live_runtime.principal.scopes = ["access_as_user"]
+    live_runtime.principal.provider = "none"
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is True
+    assert live_runtime.scopes[0].authority.permission_mode == "enforce"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["internal", "admin_internal", "missing"])
+async def test_workflow_cannot_dispatch_internal_or_undeclared_action(live_runtime, surface):
+    surfaces = live_runtime.connection["websocket"].app.state.module_action_surfaces["security_readiness"]
+    if surface == "missing":
+        surfaces.pop("record_assessment")
+    else:
+        surfaces["record_assessment"] = surface
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is False
+    assert result["persistence_error"] == "workflow_module_action_unavailable"
+    assert not live_runtime.scopes
+
+
+@pytest.mark.asyncio
+async def test_recording_without_optional_lineage_matches_event_schema(live_runtime):
+    bridge = _bridge()
+    bridge.set("build_id", None)
+    bridge.set("artifact_version_id", None)
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    recorded = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert recorded["persisted"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["disconnect", "closed_socket", "connection", "socket", "principal", "expiry", "scopes"])
+async def test_principal_is_revalidated_after_awaited_scope_hook(live_runtime, monkeypatch, change):
+    async def resolve(**kwargs):
+        if change == "disconnect":
+            live_runtime.connection["active"] = False
+        elif change == "closed_socket":
+            live_runtime.connection["websocket"].client_state = WebSocketState.DISCONNECTED
+        elif change == "connection":
+            live_runtime.transport.connections[RUN[2]] = dict(live_runtime.connection)
+        elif change == "socket":
+            live_runtime.connection["websocket"] = copy(live_runtime.connection["websocket"])
+        elif change == "principal":
+            live_runtime.connection["websocket"].state.user = copy(live_runtime.principal)
+        elif change == "expiry":
+            live_runtime.principal.raw_claims["exp"] = 1
+        else:
+            live_runtime.principal.scopes.clear()
+        return {**kwargs["requested_scope"], "permissions": kwargs["default_permissions"]}
+
+    monkeypatch.setattr(module_tools, "get_platform_hooks", lambda: SimpleNamespace(call_module_scope=resolve))
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is False
+    assert result["persistence_error"].startswith("workflow_session_")
+    assert not live_runtime.persistence.collection_handle.rows

--- a/tests/test_security_readiness_dispatch.py
+++ b/tests/test_security_readiness_dispatch.py
@@ -63,7 +63,7 @@ def live_runtime(monkeypatch):
         action_emits={action["id"]: action.get("emits", []) for action in manifest["actions"]},
         event_payload_schemas={event["type"]: event["payload_schema"] for event in event_contract["events"]},
     )
-    persistence = _WrapperStylePersistence()
+    persistence = _WrapperStylePersistence(RUN[1])
     scopes = []
 
     def storage(request):

--- a/tests/test_security_readiness_dispatch.py
+++ b/tests/test_security_readiness_dispatch.py
@@ -37,12 +37,12 @@ ROOT = Path(__file__).resolve().parents[1]
 RUN = ("SecurityReadiness", "factory-host", "chat_1")
 
 
-def _bridge(project="project_a"):
+def _bridge(project="project_a", *, user_id="owner_1"):
     config = yaml.safe_load((ROOT / "factory_app/workflows/SecurityReadiness/context_variables.yaml").read_text())
     definitions = load_context_variables_config(config).definitions
     policy = build_context_authority_policy(workflow_name=RUN[0], definitions=definitions)
     bridge = ContextVariablesBridge({
-        "app_id": RUN[1], "user_id": "owner_1", "build_id": "build_1", "build_registry_id": project,
+        "app_id": RUN[1], "user_id": user_id, "build_id": "build_1", "build_registry_id": project,
         "artifact_version_id": "artifact_1", "security_readiness_mode": "advisory",
         "generated_files": {"app/app.json": json.dumps({"authRequired": True})},
     }, authority_policy=policy)
@@ -131,8 +131,8 @@ async def test_permission_denial_remains_visible_and_context_cannot_grant(live_r
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fault", ["missing", "expired", "foreign_app", "foreign_user", "foreign_chat"])
-async def test_dispatch_rejects_unavailable_or_mismatched_principal(live_runtime, fault):
+@pytest.mark.parametrize("fault", ["missing", "expired", "foreign_app", "foreign_user", "foreign_actor_and_connection", "foreign_chat"])
+async def test_dispatch_rejects_unavailable_or_mismatched_principal(live_runtime, monkeypatch, fault):
     if fault == "missing":
         live_runtime.transport.connections.clear()
     elif fault == "expired":
@@ -141,14 +141,25 @@ async def test_dispatch_rejects_unavailable_or_mismatched_principal(live_runtime
         live_runtime.principal.app_id = "foreign-app"
     elif fault == "foreign_user":
         live_runtime.principal.user_id = "other_user"
+    elif fault == "foreign_actor_and_connection":
+        live_runtime.principal.user_id = live_runtime.connection["user_id"] = "other_user"
     elif fault == "foreign_chat":
         live_runtime.principal.chat_id = "other_chat"
+    attempts = []
+    original = module_tools._live_session
+    def observe(*args, **kwargs):
+        attempts.append(True)
+        return original(*args, **kwargs)
+    monkeypatch.setattr(module_tools, "_live_session", observe)
+    monkeypatch.setattr(module_tools, "_RECONNECT_TIMEOUT_SECONDS", 0.02)
     bridge = _bridge()
     await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
     result = await _wrap_tool_with_context(record_security_findings, bridge)()
     assert result["persisted"] is False
     assert result["persistence_error"].startswith("workflow_session_")
     assert not live_runtime.persistence.collection_handle.rows
+    if fault != "missing":
+        assert len(attempts) == 1
 
 
 @pytest.mark.asyncio
@@ -236,3 +247,107 @@ async def test_principal_is_revalidated_after_awaited_scope_hook(live_runtime, m
     assert result["persisted"] is False
     assert result["persistence_error"].startswith("workflow_session_")
     assert not live_runtime.persistence.collection_handle.rows
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authorized", [True, False])
+async def test_successor_reconnect_reacquires_principal_and_permissions(live_runtime, monkeypatch, authorized):
+    from mozaiksai.core.workflow.pack.journey_orchestrator import JourneyOrchestrator
+
+    source = {**live_runtime.connection, "ws_id": 1}
+    JourneyOrchestrator()._ensure_connection_alias(
+        transport=live_runtime.transport, source_conn=source, target_chat_id=RUN[2],
+        workflow_name=RUN[0], app_id=RUN[1], user_id="owner_1",
+    )
+    principals = []
+    async def resolve(**kwargs):
+        principals.append(kwargs["principal"])
+        if len(principals) == 1:
+            renewed = copy(live_runtime.principal)
+            renewed.scopes = ["security_readiness.manage"] if authorized else []
+            socket = copy(source["websocket"])
+            socket.state = SimpleNamespace(user=renewed)
+            live_runtime.transport.connections[RUN[2]] = {
+                **source, "websocket": socket, "ws_id": 2,
+            }
+        return {**kwargs["requested_scope"], "permissions": kwargs["default_permissions"]}
+
+    monkeypatch.setattr(module_tools, "get_platform_hooks", lambda: SimpleNamespace(call_module_scope=resolve))
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is authorized
+    if not authorized:
+        assert result["persistence_error"] == "PERMISSION_DENIED"
+    assert len(principals) == 2
+    assert principals[0] is not principals[1]
+    assert len(live_runtime.scopes) == len(live_runtime.persistence.collection_handle.rows) == int(authorized)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gap", ["missing", "disconnected"])
+async def test_connection_gap_waits_for_live_same_owner_socket(live_runtime, gap):
+    initial = live_runtime.connection
+    renewed = copy(initial["websocket"])
+    renewed.state = SimpleNamespace(user=copy(live_runtime.principal))
+    if gap == "missing":
+        live_runtime.transport.connections.clear()
+    else:
+        initial["websocket"].client_state = WebSocketState.DISCONNECTED
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+
+    async def reconnect():
+        await asyncio.sleep(0)
+        live_runtime.transport.connections[RUN[2]] = {**initial, "websocket": renewed}
+
+    reconnecting = asyncio.create_task(reconnect())
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    await reconnecting
+    assert result["persisted"] is True
+    assert len(live_runtime.persistence.collection_handle.rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_runtime_actor_never_uses_connection_as_actor_source(live_runtime):
+    bridge = _bridge(user_id=None)
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persistence_error"] == "workflow_tool_invocation_unavailable"
+    assert not live_runtime.scopes
+
+
+@pytest.mark.asyncio
+async def test_reconnect_wait_cannot_outlive_tool_invocation(live_runtime, monkeypatch):
+    original = module_tools._live_session
+    attempted = asyncio.Event()
+    def observe(*args, **kwargs):
+        attempted.set()
+        return original(*args, **kwargs)
+    monkeypatch.setattr(module_tools, "_live_session", observe)
+    live_runtime.transport.connections.clear()
+
+    async def launch(context_variables):
+        pending = asyncio.create_task(module_tools.dispatch_workflow_module_action(
+            "security_readiness", "record_assessment", {},
+        ))
+        await attempted.wait()
+        return pending
+
+    pending = await _wrap_tool_with_context(launch, _bridge())()
+    live_runtime.transport.connections[RUN[2]] = live_runtime.connection
+    with pytest.raises(PermissionError, match="workflow_tool_invocation_unavailable"):
+        await pending
+    assert not live_runtime.scopes
+
+
+@pytest.mark.asyncio
+async def test_dispatch_is_never_retried_after_execution_begins(live_runtime, monkeypatch):
+    dispatch = AsyncMock(side_effect=module_tools._ConnectionUnavailable("execution_started"))
+    monkeypatch.setattr(module_tools, "dispatch_module_action", dispatch)
+    bridge = _bridge()
+    await _wrap_tool_with_context(inspect_generated_app_security, bridge)()
+    result = await _wrap_tool_with_context(record_security_findings, bridge)()
+    assert result["persisted"] is False
+    assert result["persistence_error"] == "execution_started"
+    dispatch.assert_awaited_once()

--- a/tests/test_security_readiness_module.py
+++ b/tests/test_security_readiness_module.py
@@ -223,7 +223,6 @@ async def test_record_assessment_persists_findings_and_emits_event() -> None:
             {
                 "app_id": "app_1",
                 "build_id": "build_1",
-                "artifact_version_id": None,
                 "saved": 1,
             },
         )
@@ -349,3 +348,44 @@ async def test_repo_uses_canonical_module_persistence_wrapper() -> None:
         ("security_readiness", "findings"),
         ("security_readiness", "findings"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_same_scanner_rule_cannot_overwrite_another_project_or_owner() -> None:
+    ctx = _FakeCtx()
+    ctx.persistence = _WrapperStylePersistence()
+    service = SecurityReadinessService()
+    finding = {"finding_id": "auth:missing", "title": "Auth missing", "severity": "high", "control_area": "auth"}
+    for project in ("project_a", "project_b", "project_a"):
+        await service.record_assessment(
+            ctx, app_id="factory-host", build_registry_id=project,
+            build_id="build_1", artifact_version_id="artifact_1", findings=[finding],
+        )
+    ctx.user_id = "other_user"
+    await service.record_assessment(
+        ctx, app_id="factory-host", build_registry_id="project_a",
+        build_id="build_1", artifact_version_id="artifact_1", findings=[finding],
+    )
+    rows = ctx.persistence.collection_handle.rows
+    assert len(rows) == 3
+    assert len({row["finding_id"] for row in rows}) == 3
+    ctx.user_id = "user_1"
+    a = await service.list_findings(ctx, app_id="factory-host", build_registry_id="project_a")
+    b = await service.list_findings(ctx, app_id="factory-host", build_registry_id="project_b")
+    assert a["count"] == b["count"] == 1
+    assert a["findings"][0]["finding_id"] != b["findings"][0]["finding_id"]
+    assert a["findings"][0]["owner_user_id"] == "user_1"
+
+
+@pytest.mark.asyncio
+async def test_registry_filter_applies_before_limit_and_scopes_summary() -> None:
+    common = {"app_id": "factory-host", "owner_user_id": "user_1", "severity": "high", "status": "open"}
+    repo = _FakeRepo(stored=[
+        {**common, "build_registry_id": "other_project"} for _ in range(251)
+    ] + [{**common, "build_registry_id": "project_a"}, common])
+    module = SecurityReadinessModule(SecurityReadinessService(repo=repo))
+    listed = await module.list_findings(_FakeCtx(), app_id="factory-host", build_registry_id="project_a", limit=1)
+    summary = await module.get_summary(_FakeCtx(), app_id="factory-host", build_registry_id="project_a")
+    assert listed["count"] == summary["summary"]["total"] == 1
+    assert listed["findings"][0]["build_registry_id"] == "project_a"
+    assert repo.last_query == {"app_id": "factory-host", "owner_user_id": "user_1", "build_registry_id": "project_a"}

--- a/tests/test_security_readiness_module.py
+++ b/tests/test_security_readiness_module.py
@@ -107,7 +107,8 @@ class _WrapperStyleCollection:
 
 
 class _WrapperStylePersistence:
-    def __init__(self) -> None:
+    def __init__(self, app_id: str = "app_1") -> None:
+        self.app_id = app_id
         self.collection_handle = _WrapperStyleCollection()
         self.collection_calls: list[tuple[str, str]] = []
 
@@ -344,6 +345,7 @@ async def test_repo_uses_canonical_module_persistence_wrapper() -> None:
     )
 
     assert listed[0]["finding_id"] == "sr_1"
+    assert ctx.persistence.collection_handle.find_many_calls[0]["query"] == {"owner_user_id": "user_1"}
     assert ctx.persistence.collection_calls == [
         ("security_readiness", "findings"),
         ("security_readiness", "findings"),
@@ -351,9 +353,24 @@ async def test_repo_uses_canonical_module_persistence_wrapper() -> None:
 
 
 @pytest.mark.asyncio
+async def test_repo_rejects_app_scope_override_before_read_or_write() -> None:
+    ctx = _WrapperStyleCtx()
+    repo = SecurityReadinessRepo()
+    finding = {"finding_id": "sr_1", "app_id": "foreign-app", "owner_user_id": "user_1"}
+
+    with pytest.raises(ValueError, match="persistence context app_id"):
+        await repo.insert_findings(ctx, [finding])
+    with pytest.raises(ValueError, match="persistence context app_id"):
+        await repo.list_findings(ctx, query={"app_id": "foreign-app", "owner_user_id": "user_1"}, limit=10)
+
+    assert ctx.persistence.collection_handle.update_calls == []
+    assert ctx.persistence.collection_handle.find_many_calls == []
+
+
+@pytest.mark.asyncio
 async def test_same_scanner_rule_cannot_overwrite_another_project_or_owner() -> None:
     ctx = _FakeCtx()
-    ctx.persistence = _WrapperStylePersistence()
+    ctx.persistence = _WrapperStylePersistence("factory-host")
     service = SecurityReadinessService()
     finding = {"finding_id": "auth:missing", "title": "Auth missing", "severity": "high", "control_area": "auth"}
     for project in ("project_a", "project_b", "project_a"):

--- a/tests/test_security_readiness_mongo_adapter.py
+++ b/tests/test_security_readiness_mongo_adapter.py
@@ -1,0 +1,69 @@
+"""The security module must consume the real app-scoped persistence adapter."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory_app.app.modules.security_readiness.backend.service import SecurityReadinessService
+from mozaiksai.core.runtime.persistence.mongo import MongoPersistenceContext
+
+
+@pytest.mark.asyncio
+async def test_record_list_and_update_use_real_mongo_adapter_scope():
+    documents = []
+    queries = []
+
+    def matching(query):
+        queries.append(dict(query))
+        return [row for row in documents if all(row.get(key) == value for key, value in query.items())]
+
+    async def update_one(query, update, *, upsert=False):
+        rows = matching(query)
+        if rows:
+            rows[0].update(update["$set"])
+        elif upsert:
+            documents.append({**query, **update["$set"]})
+
+    def find(query, projection=None):
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.limit.return_value = cursor
+        cursor.to_list = AsyncMock(return_value=matching(query))
+        return cursor
+
+    async def find_one(query, projection=None):
+        return next(iter(matching(query)), None)
+
+    raw = MagicMock()
+    raw.update_one = update_one
+    raw.find = find
+    raw.find_one = find_one
+    client = MagicMock()
+    client.__getitem__.return_value.__getitem__.return_value = raw
+    persistence = MongoPersistenceContext(app_id="host-app", user_id="owner", client=client)
+    ctx = SimpleNamespace(app_id="host-app", user_id="owner", persistence=persistence, emit=AsyncMock())
+    service = SecurityReadinessService()
+    for project in ("project-one", "project-two"):
+        result = await service.record_assessment(ctx, app_id="host-app", build_registry_id=project,
+            findings=[{"finding_id": "same-scanner-key", "title": "Auth review", "severity": "high", "control_area": "auth"}])
+        assert result["saved"] == 1
+        assert result["summary"]["total"] == 1
+    listed = await service.list_findings(ctx, app_id="host-app", build_registry_id="project-one")
+    assert listed["count"] == 1
+    finding_id = listed["findings"][0]["finding_id"]
+    updated = await service.update_finding_status(ctx, finding_id=finding_id, status="resolved")
+    assert updated["finding"]["status"] == "resolved"
+    summary = await service.get_summary(ctx, app_id="host-app", build_registry_id="project-one")
+    assert summary["summary"]["resolved"] == 1
+    assert len(documents) == 2
+    assert len({row["finding_id"] for row in documents}) == 2
+    assert all(query["app_id"] == "host-app" and query["owner_user_id"] == "owner" for query in queries)
+    count_before = len(queries)
+    with pytest.raises(ValueError, match="persistence context app_id"):
+        await service.list_findings(ctx, app_id="other-app")
+    with pytest.raises(ValueError, match="persistence context app_id"):
+        await service.record_assessment(ctx, app_id="other-app", findings=[{"title": "Cannot store here"}])
+    assert len(queries) == count_before
+    assert len(documents) == 2

--- a/tests/test_security_readiness_workflow.py
+++ b/tests/test_security_readiness_workflow.py
@@ -47,8 +47,9 @@ async def test_record_security_findings_updates_context_without_persistence() ->
 
     result = await record_security_findings(context_variables=ctx)
 
-    assert result["success"] is True
+    assert result["success"] is False
     assert result["persisted"] is False
+    assert result["persistence_error"] == "workflow_tool_invocation_unavailable"
     assert ctx["security_readiness_recorded"] is True
     assert ctx["security_readiness_summary"]["finding_count"] == 1
 
@@ -65,6 +66,20 @@ def test_security_readiness_build_context_declares_workflow_assets() -> None:
         "app_security_file_contracts.yaml",
         "finding_taxonomy.yaml",
     } <= asset_paths
+
+
+@pytest.mark.asyncio
+async def test_no_files_is_not_assessed_and_checked_count_survives_recording() -> None:
+    empty = {"app_id": "app_1"}
+    assert (await inspect_generated_app_security(context_variables=empty))["status"] == "not_assessed"
+    await record_security_findings(context_variables=empty)
+    assert empty["security_readiness_summary"]["status"] == "not_assessed"
+    clean = {"app_id": "app_1", "generated_files": {"app/app.json": '{"authRequired": false}'}}
+    await inspect_generated_app_security(context_variables=clean)
+    await record_security_findings(context_variables=clean)
+    assert clean["security_readiness_summary"]["checked_file_count"] == 1
+    assert clean["security_readiness_summary"]["status"] == "passed"
+    assert clean["security_readiness_summary"]["persisted"] is False
 
 
 def test_security_readiness_is_between_app_generator_and_review(monkeypatch) -> None:

--- a/tests/test_studio_module_composition.py
+++ b/tests/test_studio_module_composition.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mozaiksai.core.runtime.app.loader import AppLoader
+from mozaiksai.core.runtime.app.module_loader import ModuleLoader
+from mozaiksai.core.runtime.composition.module_authority import ModuleDispatchAuthority
+from mozaiksai.core.runtime.composition.module_executor import ModuleExecutor, ModuleRequest
+from mozaiksai.resources import resolve_factory_app_root
+
+
+@pytest.fixture(autouse=True)
+def restore_module_imports(monkeypatch):
+    from mozaiksai.core.account.registry import account_data_registry
+
+    monkeypatch.setattr(account_data_registry, "_handlers", {})
+    paths = list(sys.path)
+    modules = dict(sys.modules)
+    yield
+    sys.path[:] = paths
+    for key in list(sys.modules):
+        if key == "services" or key.startswith(("services.", "mozaiks_runtime_module_")):
+            if key in modules:
+                sys.modules[key] = modules[key]
+            else:
+                sys.modules.pop(key, None)
+
+
+def app_root(parent: Path, name: str) -> Path:
+    root = parent / name / "app"
+    root.mkdir(parents=True)
+    (root / "app.json").write_text(json.dumps({"appName": name, "appId": name}), encoding="utf-8")
+    return root
+
+
+def module(root: Path, name: str, label: str, *, import_service: bool = False) -> None:
+    target = root / "modules" / name
+    (target / "backend").mkdir(parents=True)
+    (target / "module.yaml").write_text(
+        f"schema_version: mozaiks.module.v1\nmodule:\n  id: {name}\n  version: 1.0.0\n  handler: backend.handler:Handler\nactions:\n  - id: read\n    description: Read source marker.\n    handler_method: read\n",
+        encoding="utf-8",
+    )
+    source = "from services.support import VALUE\n" if import_service else f"VALUE = {label!r}\n"
+    (target / "backend/handler.py").write_text(source + "class Handler:\n    async def read(self, ctx):\n        return {'source': VALUE}\n", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_platform_app_loader_has_no_implicit_factory_modules(tmp_path):
+    active = app_root(tmp_path, "customer")
+    module(active, "product", "customer")
+    result = await AppLoader.load(str(active))
+    assert [item.name for item in result.modules] == ["product"]
+    assert "security_readiness" not in {item.name for item in result.modules}
+
+
+@pytest.mark.asyncio
+async def test_explicit_defaults_compose_by_id_preserving_workspace_services(tmp_path):
+    active = app_root(tmp_path, "customer")
+    defaults = app_root(tmp_path, "studio_defaults")
+    module(defaults, "shared", "default", import_service=True)
+    module(defaults, "override", "default")
+    module(active, "override", "customer")
+    module(active, "product", "customer")
+    for root, value in ((active, "customer-service"), (defaults, "default-service")):
+        (root / "services").mkdir()
+        (root / "services/support.py").write_text(f"VALUE = {value!r}\n", encoding="utf-8")
+    result = await AppLoader.load(str(active), module_defaults_path=str(defaults))
+    loaded = {item.name: item for item in result.modules}
+    assert set(loaded) == {"product", "override", "shared"}
+    assert (await loaded["shared"].handler.read(None))["source"] == "customer-service"
+    assert (await loaded["override"].handler.read(None))["source"] == "customer"
+    assert loaded["shared"].path == defaults / "modules/shared"
+    assert loaded["override"].path == active / "modules/override"
+    assert list(sys.modules["services"].__path__) == [str(active / "services")]
+    assert result.definition.config["appId"] == "customer"
+    assert result.data_contract is None
+
+
+@pytest.mark.asyncio
+async def test_broken_local_override_cannot_silently_load_default(tmp_path):
+    active = app_root(tmp_path, "customer")
+    defaults = app_root(tmp_path, "studio_defaults")
+    module(defaults, "shared", "default")
+    (active / "modules/shared").mkdir(parents=True)
+    result = await AppLoader.load(str(active), module_defaults_path=str(defaults))
+    assert result.modules == []
+    assert result.failed_module_names == ["shared"]
+
+
+def test_loading_factory_as_active_root_deduplicates_defaults():
+    factory = resolve_factory_app_root() / "app"
+    plain = ModuleLoader(str(factory)).discover_module_names()
+    composed = ModuleLoader(str(factory), module_defaults_path=str(factory)).discover_module_names()
+    assert composed == plain
+
+
+@pytest.mark.asyncio
+async def test_packaged_security_module_and_product_module_dispatch_together(tmp_path, monkeypatch):
+    active = app_root(tmp_path, "host-app")
+    module(active, "security_compliance", "product")
+    factory = resolve_factory_app_root() / "app"
+    loaded = await AppLoader.load(str(active), module_defaults_path=str(factory))
+    assert not loaded.failed_module_names
+    modules = {item.name: item for item in loaded.modules}
+    assert modules["security_readiness"].path == factory / "modules/security_readiness"
+    assert modules["security_compliance"].path == active / "modules/security_compliance"
+    surfaces = {item.name: item.action_api_surface_map for item in loaded.modules}
+    assert "record_assessment" in surfaces["security_readiness"]
+    assert surfaces["security_readiness"]["record_assessment"] is None
+    executor = ModuleExecutor()
+    monkeypatch.setattr(executor, "_emit_dispatch_audit", AsyncMock())
+    for item in loaded.modules:
+        executor.register(item.name, item.handler, action_method_map=item.action_method_map,
+                          action_permissions=item.action_permissions_map, action_schemas=item.action_schemas_map,
+                          action_emits=item.action_emits_map, event_payload_schemas=item.event_payload_schemas_map)
+    documents = []
+    class Collection:
+        async def update_one(self, query, update, *, upsert):
+            documents.append(update["$set"])
+
+        async def find_many(self, query, *, limit, sort):
+            return [row for row in documents if all(row.get(key) == value for key, value in query.items())][:limit]
+
+    class Persistence:
+        def collection(self, module_id, entity_name):
+            assert (module_id, entity_name) == ("security_readiness", "findings")
+            return Collection()
+
+    authority = ModuleDispatchAuthority(kind="authenticated_user", permission_mode="enforce", reason="test user", actor_id="owner", permissions=("security_readiness.manage", "security_readiness.read"))
+    def request(action, params):
+        return ModuleRequest(module="security_readiness", action=action, params=params, app_id="host-app", user_id="owner", authority=authority)
+    substrate = executor._build_persistence_context(request("list_findings", {"app_id": "host-app"}))
+    assert substrate.app_id == "host-app"
+    monkeypatch.setattr(executor, "_build_persistence_context", lambda request: Persistence())
+    for project in ("project-one", "project-two"):
+        saved = await executor.execute(request("record_assessment", {"app_id": "host-app", "build_registry_id": project, "findings": [{"finding_id": "same-scanner-key", "title": "Review auth", "severity": "high", "control_area": "auth"}]}))
+        assert saved.success
+        assert saved.data["saved"] == 1
+    listed = await executor.execute(request("list_findings", {"app_id": "host-app", "build_registry_id": "project-one"}))
+    assert listed.success
+    assert listed.data["count"] == 1
+    assert listed.data["findings"][0]["build_registry_id"] == "project-one"
+    assert len({row["finding_id"] for row in documents}) == 2
+
+
+@pytest.mark.asyncio
+async def test_studio_bootstrap_scopes_defaults_to_the_running_host(tmp_path, monkeypatch):
+    from contextlib import asynccontextmanager, nullcontext
+
+    from fastapi import FastAPI
+
+    from mozaiksai.hosts import bootstrap
+
+    defaults = app_root(tmp_path, "factory")
+    observed = []
+    @asynccontextmanager
+    async def lifespan(app):
+        observed.append(getattr(app.state, "module_defaults_path", None))
+        yield
+
+    host = FastAPI(lifespan=lifespan)
+    monkeypatch.setattr(bootstrap, "configure_repo_host_defaults", lambda host: None)
+    monkeypatch.setattr(bootstrap, "_workflow_catalog_bound_to_host_config", nullcontext)
+    monkeypatch.setattr(bootstrap, "resolve_factory_app_root", lambda: defaults.parent)
+    bootstrap.register_repo_host_bootstrap(host, "platform")
+    assert not hasattr(host.state, "module_defaults_path")
+    async with host.router.lifespan_context(host):
+        assert observed[-1] is None
+    bootstrap.register_repo_host_bootstrap(host, "studio")
+    assert not hasattr(host.state, "module_defaults_path")
+    async with host.router.lifespan_context(host):
+        assert observed[-1] == str(defaults)
+    assert not hasattr(host.state, "module_defaults_path")
+
+
+def test_explicit_missing_module_default_root_fails(tmp_path):
+    from mozaiksai.core.runtime.app.module_loader import ModuleLoadError
+
+    with pytest.raises(ModuleLoadError, match="Module defaults app root not found"):
+        ModuleLoader(str(tmp_path), module_defaults_path=str(tmp_path / "missing"))

--- a/tests/test_studio_module_composition.py
+++ b/tests/test_studio_module_composition.py
@@ -127,6 +127,8 @@ async def test_packaged_security_module_and_product_module_dispatch_together(tmp
             return [row for row in documents if all(row.get(key) == value for key, value in query.items())][:limit]
 
     class Persistence:
+        app_id = "host-app"
+
         def collection(self, module_id, entity_name):
             assert (module_id, entity_name) == ("security_readiness", "findings")
             return Collection()


### PR DESCRIPTION
Security Readiness findings stayed in session state because the workflow expected a ModuleContext that tools never receive, and hosted Studio workspaces did not load the shared findings module. This connects the existing scan to permissioned module dispatch and makes shared Studio modules available through the ordinary app loader.

## Related issue

N/A — cross-repository App Zero integration.

## Current-main verification

- [x] Branched from fresh origin/main at 63472a4a.
- [x] Confirmed the recorder's unused module_context parameter, frozen context inputs discarded by mutable-type checks, missing build_registry_id association, and absent shared module in the hosted AppLoader result.

## Summary

- Tools bind workflow/app/chat/actor identity to the active, revocable invocation and obtain a live server socket principal. Existing platform hooks resolve membership, and ModuleExecutor enforces permissions and entitlements. Brief workflow-handoff reconnects may retry preparation for at most two seconds, always reacquiring the same actor and fresh permissions; execution is outside the retry boundary. Expired or mismatched principals, missing runtime actor, permission denials, and revoked invocations fail closed; internal actions cannot be invoked through this path.
- Studio's existing bootstrap lifespan composes packaged module defaults. Active workspace modules override by id; broken overrides fail rather than falling back. Platform-only loading stays independent of Factory, and services/config/data retain active workspace ownership.
- Scanner inputs work with immutable context views. Findings retain project and artifact lineage, source keys receive scoped persisted ids, and project filtering precedes result limits. Unavailable persistence and zero inspected files stay explicit in advisory review.
- Real Mongo validation exposed a second persistence failure: the repository repeated app_id in filters even though the scoped adapter supplies it. The repository now verifies the requested app against ctx.persistence.app_id and leaves app scoping to the existing adapter; owner and project filters remain explicit.

## Tests run

- python -m ruff check . — passed.
- python -m pytest -q --no-cov — 16,807 passed, 100 skipped, 3 existing warnings in 19m57s on commit 8df9795e.
- After the final reconnect refinement: full mypy passed (616 source files), full Ruff passed, and the complete affected workflow/authority/transport/module slice passed (1,178 passed, 2 skipped across 43 files). An independent reviewer reran the 28 dispatch tests and verified the actor anchor and execution/retry boundary.
- Final CI run 34658909732 passed every check, including coverage aggregation. Full shards: 0 — 4,166 passed/15 skipped; 1 — 4,363 passed/11 skipped; 2 — 4,254 passed/16 skipped; 3 — 4,051 passed/53 skipped. Total: 16,834 passed, 95 skipped. The existing connector metadata-only test passed after one automatic rerun.
- Actual App Zero AppLoader smoke — 43 modules, no failed modules; shared security_readiness loaded alongside app-local modules and services.
- Real MongoPersistenceContext adapter regression — passed record, project-scoped summary/list, status update, and cross-app rejection checks using a stub raw driver.
- App Zero local Mongo integration — 2 passed using the composed AppLoader, ModuleExecutor, actual localhost Mongo storage, and corrected OSS source; separate from the memory-backed dispatcher and composition tests.
- App Zero installed-package consumer checks on final source 0fc47008 — 130 passed, including authenticated HTTP, real Mongo, actor/tenant scope, report, page, and provenance checks.

## OSS Change Impact

- Layer changed: generic workflow dispatch and Studio module composition, plus the first-party SecurityReadiness workflow/module.
- Build impact: the existing SecurityReadiness scan records findings through module dispatch; the build sequence and AG2 execution machinery are unchanged.
- Runtime/platform impact: original actor binding, live principal and permission checks, bounded reconnect preparation, and packaged Studio module defaults.
- Workspace impact: Studio apps inherit shared modules and override by id; services, configuration, and data remain app-owned. Platform-only apps gain no Factory dependency.
- Tests: full local suite before final refinement, final affected slice, independent security review, actual Mongo/App Zero checks, and final full CI as listed above.
- Docs updated: module-system.md, platform-authoring.md, and CHANGELOG.md document the shared-module and authenticated workflow path.
- Compatibility: pre-1.0 replacement removes the unused module_context tool argument. Headless calls without a live authenticated/local session remain unavailable, and legacy findings without project association are not assigned to a guessed project.

## Module Contract Impact

Existing security_readiness actions accept source-local finding keys and optional build_registry_id filters. No new schema family or generated application shape. Removed the unused workflow module_context argument; pre-1.0 findings without project association are not reassigned to a guessed project. The findings collection is not a durable record of passing assessments.

## Boundary confirmation

- [x] Generic OSS behavior only; no hosted compliance mappings, private intelligence, credentials, provider execution, or paid infrastructure.

## Governance check

- [x] Uses the existing enforce-mode workflow authority and public module dispatch contracts; introduces no new authority kind or bypass.
- [x] The existing versioned module contract, implementation, docs, and acceptance tests change together.
- [x] Permissions come from a live server principal and host scope hooks. No identity, permission, or token is accepted from model arguments. Headless runs without this principal report unavailable persistence.

## AI assistance

Implemented and independently reviewed with Codex agents; validation includes real composed app loading and dispatch through the module executor.
