### PR TITLE
docs(agents): one engineering contract, no duplicated rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,17 @@
 
 Repository-level guidance for coding agents working in this repo.
 
-## Working Path Constraint
+## Shared Engineering Contract
 
-**Always work on `C:\Repos\BlocUnitedRepo\mozaiks` (this repo) and `C:\Repos\BlocUnitedRepo\mozaiks-app`.**
-Never read from or write to OneDrive paths (`C:\Users\...\OneDrive\...`). Those are stale copies, not the working repos.
+The rules below are canonical for every agent and live in one place:
+[docs/agent-engineering-contract.md](docs/agent-engineering-contract.md). Read it before
+changing code. Do not restate its rules here — a second copy drifts, and two agents then
+follow two different contracts.
 
-Read [ARCHITECTURE.md](ARCHITECTURE.md) and [CLAUDE.md](CLAUDE.md) first.
-
+It covers: working path constraint, ADR authoring context, AG2 ownership boundary, release
+hold, contributor guidance operating system, generated deployment artifact contract,
+generated persistence contract, structured-output-first contract rule, contract-declared
+customization rule, and decision rules.
 ## Required Pre-Edit Architecture Check
 
 Before editing Mozaiks OSS:
@@ -29,18 +33,6 @@ Before editing Mozaiks OSS:
   cannot satisfy the requirement
 - architectural changes that contradict the frozen north star require an ADR or
   explicit architecture decision
-
-## ADR Authoring Context
-
-For an ADR that changes or extends app generation, semantic authority,
-compilation/materialization, or refinement, review
-[issue #411](https://github.com/BlocUnited-LLC/mozaiks/issues/411) and state
-explicitly whether the ADR adopts, modifies, rejects, or defers that direction.
-
-Issue #411 is a design prompt, not architecture authority. Current source and
-Accepted ADRs remain authoritative. Any ADR using the issue must verify its
-claims against the repository and must not make a typed decision ledger a
-second authority for application meaning.
 
 ## Deterministic Generation Rule
 
@@ -122,20 +114,6 @@ Rules for agents:
 - If a task requires a cloud service that costs money, note it as a
   pre-launch prerequisite and stop — do not provision it.
 
-## Release Hold
-
-Do **not** publish this repo yet.
-
-- Do not create or push `v*` Git tags.
-- Do not trigger `.github/workflows/release.yml`.
-- Do not publish to PyPI or create a GitHub release.
-- Do not treat trusted-publisher or GitHub environment setup as approval to
-  release.
-- Do not bump `mozaiksai/version.py` for a public release unless the user
-  explicitly says the repo is production-ready and wants to publish.
-
-Normal code pushes are fine. Public release actions are not.
-
 ## Replacement Policy
 
 When adjusting behavior:
@@ -170,43 +148,6 @@ Prefer:
 - explicit validation
 - small, named abstractions with clear ownership
 - removing drift at the source
-
-## AG2 Ownership Boundary
-
-Mozaiks uses AG2 as the long-term agentic backbone. Do not recreate an
-agentic framework inside Mozaiks when AG2 already owns the primitive or is the
-right upstream home for it. See
-[docs/architecture/workflows/ag2-ownership-boundary.md](docs/architecture/workflows/ag2-ownership-boundary.md)
-for the durable architecture contract and upgrade watchpoints.
-
-AG2 should own agentic execution mechanics wherever practical:
-
-- agent primitives, model calls, tools, middleware, and task execution
-- multi-agent network behavior, hubs, agent clients, channels, adapters, and
-  workflow state progression
-- task observation, task lifecycle events, delegation mechanics, and agent
-  runtime observability primitives
-
-Mozaiks should own deterministic product and runtime contracts around AG2:
-
-- declarative workflow files, structured-output contracts, and validation
-- canonical generated app/workflow/module artifact shapes
-- app/runtime persistence, transport integration, tenant/session boundaries,
-  and Studio/platform lifecycle concerns
-- factory refinement policies and deterministic decomposition contracts
-  that describe what work must be done before AG2 agents execute it
-
-When AG2 does not provide a required capability, first analyze AG2's current
-APIs, docs, and source shape. Implement the smallest Mozaiks-owned layer that
-fits inside AG2's framework, preferably behind `mozaiksai.core.adapters` or a
-similarly narrow boundary. Document every intentional divergence from AG2 so it
-can be revisited when AG2 updates, and raise upstream issues or proposals when
-the missing capability belongs in AG2 rather than Mozaiks.
-
-Do not introduce Mozaiks-owned replacements for AG2 hubs, agent clients,
-network adapters, task observation streams, delegation engines, or generic
-agent scheduling unless AG2 has no usable path and the custom boundary is
-explicitly documented.
 
 ## Canonical Repo Boundary
 
@@ -369,18 +310,6 @@ Primary repo ownership (avoids overlap by default):
 
 See `.claude/rules/multi-agent-coordination.md` for full rules.
 
-## Contributor Guidance Operating System
-
-For nontrivial OSS changes:
-
-- choose the closest active task skill before editing. Codex-facing skills live
-  under `.agents/skills/`; Claude Code-facing skills live under
-  `.claude/skills/`.
-- use `oss-contribution-review` when scope spans layers or the right skill is
-  unclear
-- include the appropriate impact section from `.claude/rules/testing.md` in the
-  final report and always list tests run
-
 ## Module Contract Rule
 
 When working in or generating modules:
@@ -497,27 +426,6 @@ When working in or generating app services:
   data alias, and runtime enforcement is handled by the OSS
   `ConfiguredEntitlementAdapter`.
 
-## Generated Deployment Artifact Contract
-
-Generated deployment artifacts are provider-neutral app-bundle root files:
-
-- `Dockerfile`
-- `docker-compose.yml`
-- `env.example`
-- `deployment.manifest.json`
-- `.github/workflows/deploy.yml`
-
-These files describe how the app runs and which env/CI secret names are
-expected. They must never contain raw secrets, cloud tenant ids, hosted product
-policy defaults, or provider execution code.
-
-AppBuildPlan build tasks must not own these paths. They are emitted by the
-DownloadAgent through the `generate_and_download` deployment contract renderer
-using `deployment_profile`, `include_dockerfiles`, `include_workflow`, and
-`include_compose`. Hosted products consume the manifest and apply provider
-policy, secret delivery, DNS, and deployment adapters outside the generated app
-bundle.
-
 ## Generated Secret Contract
 
 App-owned runtime secret output is names-first, not value-first:
@@ -532,71 +440,6 @@ App-owned runtime secret output is names-first, not value-first:
 - Connector/API-key collection during workflows must store raw credential values
   only through the configured secret backend. App artifacts should carry safe
   metadata and secret references, not raw values.
-
-## Generated Persistence Contract
-
-AppGenerator persistence output is data-contract-first, not runtime-DB-first:
-
-- `data_contract` is the canonical generated data planning object.
-- Generated app bundles write it to `data/contract.json`.
-- Additive refinement plans belong under
-  `data/migrations/{migration_id}.json`.
-- Persistent modules use `backend/repo.py`, `backend/policy.py`, and
-  `backend/schemas.py`; do not generate `backend/models.py` or
-  `backend/models/*.py`.
-- Do not generate `backend/database/schema.json` or
-  `backend/database/seed.json`.
-- Do not put database access in `handler.py`, and do not put raw persistence
-  operations in `service.py`.
-- Runtime injects `ctx.persistence` into `ModuleContext` when `app_id` exists.
-  Generated `backend/repo.py` must use
-  `ctx.persistence.collection(module_id, entity_name)`.
-- `data/contract.json` also covers cross-module aggregate ownership and explicit
-  existing database integration when needed.
-- External database provider mechanics, when explicitly required, belong under
-  `app/services/adapters/database/`. Do not generate `app/services/data/` for
-  customer apps.
-- Do not generate Python helper files under `data/` or `security/`. Those app
-  planes are declarative: data contracts/migrations and names-only secret
-  policy.
-- `ctx.db` remains absent and non-canonical; generated code must not require or
-  emit it.
-
-## Structured-Output-First Contract Rule
-
-When introducing or changing YAML contracts:
-
-- Treat canonical YAML files as structured-output-first contracts, not loose
-  configuration blobs.
-- Every canonical YAML shape must map cleanly to a strict structured output
-  model that agents can produce repeatably and runtime code can validate
-  deterministically.
-- If a taxonomy is used by agents or loaders, define it explicitly as reusable
-  typed fields/enums. Do not rely on prompt prose or naming conventions alone.
-- Prefer shared submodels and finite namespaces over freeform nested objects.
-- When a contract changes, update prompts, structured outputs, runtime
-  validators/loaders, docs, and tests together so generators do not drift from
-  execution.
-
-This applies to `module.yaml`, `contracts/events.yaml`, `contracts/reactions.yaml`,
-`contracts/notifications.yaml`, `contracts/settings.yaml`, `contracts/admin.yaml`,
-`contracts/profile.yaml`, workflow YAMLs, and page schemas.
-
-## Contract-Declared Customization Rule
-
-Customization is allowed, but only as a bounded extension of a strict
-contract.
-
-- YAML may reference helper/customization stubs only through explicit
-  contract-defined fields.
-- Python stubs are for backend/runtime-side extensions. JS/TS stubs are for
-  frontend/admin/workflow UI extensions.
-- Stubs must remain contract-bound: they implement declared hooks or entry
-  points, not alternate schemas or undeclared behavior paths.
-- Generator prompts must understand both the declarative contract and the stub
-  shape they are allowed to emit.
-- If a stub reference is optional, the contract must say when it is omitted and
-  what the canonical no-customization behavior is.
 
 ## Platform Shell Constraints
 
@@ -692,20 +535,6 @@ For runtime, generator, orchestration, or contract changes:
 - run targeted tests
 - update docs
 - prefer at least one real runtime smoke when practical
-
-## Decision Rules
-
-When adding code, decide placement in this order:
-
-1. Is this required for every runtime instance and independent of app semantics? → **Runtime**.
-2. Is this generic Refinement Engine behavior over execution contexts, state, events, and routing? → **`mozaiksai/control_plane`**.
-3. Is this app hosting, routing, sessions, pages, modules, shell config, or app workspace composition? → **Platform**.
-4. Is this workspace management, build lifecycle, artifact review, run history, or configuration UI? → **Studio**.
-5. Is this first-party builder behavior, app generation logic, or builder-specific harness configuration? → **`factory_app`**.
-6. Is this hosted-only capability such as collaboration, billing, marketplace, deployment, or org management? → **Mozaiks App**.
-7. Is this filesystem scaffolding, process management, or terminal diagnostics? → **CLI**.
-
-Key: a feature is not CLI just because it runs locally. If it is management UI, it belongs in Studio. If it is generic intent routing across execution contexts, it belongs in the harness implementation. If it is builder-specific policy, it belongs in the factory harness pack.
 
 ## Autonomy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,3 +706,51 @@ When adding code, decide placement in this order:
 7. Is this filesystem scaffolding, process management, or terminal diagnostics? → **CLI**.
 
 Key: a feature is not CLI just because it runs locally. If it is management UI, it belongs in Studio. If it is generic intent routing across execution contexts, it belongs in the harness implementation. If it is builder-specific policy, it belongs in the factory harness pack.
+
+## Autonomy
+
+Bias toward action. Infer reasonable implementation details from the repository and carry
+the work through rather than interrupting to confirm. The repo — its canonical
+implementations, tests, ADRs, and git history — is the authority on architecture, not the
+prompt that sent you. When the prompt and the repo disagree about how something is built,
+read the code and believe the code.
+
+Stop and ask ONLY when the ambiguity would materially change one of:
+
+- a public contract or API shape
+- a security or authorization boundary
+- a persistence format or migration path
+- an architectural decision that is expensive to reverse
+
+Everything else: decide, implement, and report the decision in the deliverable. A question
+the repository can answer is not a question for the requester.
+
+## Investigate Before Changing
+
+Before editing code: fetch current `origin/main`, read the applicable repository
+instructions, locate the canonical implementation and its tests, inspect git history where
+architectural intent is unclear, and determine whether the change is already partially
+implemented. Do not assume architecture from the prompt when the repository can answer it.
+
+## Verification Proportionality
+
+Run the tests and checks proportionate to the affected surface. Do not re-run broader
+suites after the relevant checks are green unless a failure or an unresolved concern
+justifies it. Conversely, a change to a shared contract is not covered by its own unit
+test — run what the blast radius requires.
+
+## Deliverable
+
+Report these, in this order, on any change that touches code:
+
+1. Verdict — done / blocked / partial
+2. Base SHA the work started from
+3. Branch and PR
+4. Files changed
+5. Architectural decisions made, and what was rejected
+6. Tests and checks run, with exact results — not "tests pass"
+7. Unresolved risks
+8. Whether the PR is safe to merge, and why
+
+Claims must be checkable from the diff or from pasted command output. A green suite that
+was never run against the changed surface is not evidence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Working Path Constraint
+## Shared Engineering Contract
 
-**Always work on `C:\Repos\BlocUnitedRepo\mozaiks` (this repo) and `C:\Repos\BlocUnitedRepo\mozaiks-app`.**
-Never read from or write to OneDrive paths (`C:\Users\...\OneDrive\...`). Those are stale copies, not the working repos.
+The rules below are canonical for every agent and live in one place:
+[docs/agent-engineering-contract.md](docs/agent-engineering-contract.md). Read it before
+changing code. Do not restate its rules here — a second copy drifts, and two agents then
+follow two different contracts.
 
-**Read [ARCHITECTURE.md](ARCHITECTURE.md) first.** That file is the source of truth for how the system works.
-
-This repo uses layered FastAPI hosts as the canonical OSS server composition:
-- `mozaiksai.hosts.runtime`
-- `mozaiksai.hosts.platform`
-- `mozaiksai.hosts.studio`
-
-`mozaiksai.hosts.studio` is the Studio management interface host and the default local run target. Studio is the shared management layer — available in both local and hosted deployments. Hosted product repos compose their own app-local hosts on top of Studio; this OSS repo does not own a hosted-product FastAPI host.
-
-**CLI and Studio are parallel interfaces**, not a superset chain. CLI owns developer tooling (filesystem, scaffolding, process management). Studio owns the management interface (workspace status, build lifecycle, artifacts, run history, config). Do not conflate them.
-
-Profile stays person-scoped. Studio / Workspace Shell is the org/workspace home base. App shells remain separate and brandable per app; do not collapse org management into `/me`.
-
-**`mozaiks gen` is a developer convenience**, not the canonical build lifecycle. Do not expand CLI commands to duplicate Studio surfaces (artifact review, diff, run history, promotion, build state). Those belong in Studio. The CLI hands off to Studio — it does not grow a parallel project-management surface.
-
-The current repo layout is transitional. The canonical target architecture is
-documented in
-[docs/architecture/foundations/distribution-and-workspace-model.md](docs/architecture/foundations/distribution-and-workspace-model.md).
-Do not reintroduce a hybrid root that mixes the starter app bundle with shared
-factory workflows.
-
+It covers: working path constraint, ADR authoring context, AG2 ownership boundary, release
+hold, contributor guidance operating system, generated deployment artifact contract,
+generated persistence contract, structured-output-first contract rule, contract-declared
+customization rule, and decision rules.
 ## Repo Boundary
 
 This repo is the canonical runtime/platform/factory repo.
@@ -69,30 +54,6 @@ Working modes:
 3. **Studio mode** — work on `mozaiksai/hosts/studio.py`, `factory_app/app/ui/pages/custom/studio/`, `factory_app/app/admin/`, `factory_app/app/modules/factory_control_plane/`, `chat-ui/src/admin/` — the management interface that surfaces Factory capabilities
 4. **Hosted product contract mode** — work on contracts that external hosted product workspaces consume; concrete hosted-product hosts live in those product workspaces
 
-## Contributor Guidance Operating System
-
-For nontrivial OSS changes:
-
-- choose the closest active task skill before editing. Codex-facing skills live
-  under `.agents/skills/`; Claude Code-facing skills live under
-  `.claude/skills/`.
-- use `oss-contribution-review` when scope spans layers or the right skill is
-  unclear
-- include the appropriate impact section from `.claude/rules/testing.md` in the
-  final report and always list tests run
-
-## ADR Authoring Context
-
-For an ADR that changes or extends app generation, semantic authority,
-compilation/materialization, or refinement, review
-[issue #411](https://github.com/BlocUnited-LLC/mozaiks/issues/411) and state
-explicitly whether the ADR adopts, modifies, rejects, or defers that direction.
-
-Issue #411 is a design prompt, not architecture authority. Current source and
-Accepted ADRs remain authoritative. Any ADR using the issue must verify its
-claims against the repository and must not make a typed decision ledger a
-second authority for application meaning.
-
 ## Pre-Production Cleanup Policy
 
 This repo is **not in production**. Optimize for the cleanest canonical implementation, not for preserving outdated behavior.
@@ -103,57 +64,6 @@ This repo is **not in production**. Optimize for the cleanest canonical implemen
 - When a contract changes, update the runtime, generators, docs, and tests together.
 
 If a stale implementation conflicts with a clean architecture, prefer the clean replacement unless the user explicitly asks for preserving an existing app contract.
-
-## AG2 Ownership Boundary
-
-Mozaiks uses AG2 as the long-term backbone for agentic execution. Do not build
-a parallel agent framework in this repo when AG2 already owns the concept or is
-the right upstream home for it. See
-[docs/architecture/workflows/ag2-ownership-boundary.md](docs/architecture/workflows/ag2-ownership-boundary.md)
-for the durable architecture contract and upgrade watchpoints.
-
-AG2 should own:
-
-- agent primitives, model calls, tools, middleware, and task execution
-- multi-agent network mechanics, Hub/AgentClient behavior, channels, adapters,
-  and workflow state progression
-- task delegation, task lifecycle observation, event mirroring, and generic
-  agent runtime observability
-
-Mozaiks should own:
-
-- declarative workflow contracts and strict structured-output validation
-- canonical generated app, workflow, module, page, persistence, and secret
-  artifact shapes
-- app/runtime persistence, transport integration, tenant/session boundaries,
-  Studio/platform lifecycle, and artifact promotion
-- deterministic factory refinement policy and decomposition contracts that
-  define what work must be executed by AG2 agents
-
-When a needed capability is missing from AG2, inspect AG2's current docs, APIs,
-and source direction before adding runtime code here. Keep Mozaiks custom logic
-as a small adapter or contract layer around AG2, document the divergence, and
-track it as an AG2 compatibility watchpoint. If the missing capability is
-generic agent orchestration rather than Mozaiks-specific contract enforcement,
-prefer communicating the need upstream to the AG2 team instead of growing a
-permanent Mozaiks substitute.
-
-Do not introduce Mozaiks-owned replacements for AG2 Hub, AgentClient, network
-adapters, task streams, task observation, delegation engines, or generic
-agent scheduling unless there is no viable AG2-aligned implementation path and
-the boundary is documented before or with the code change.
-
-## Release Hold
-
-Do **not** publish Mozaiks yet.
-
-- Do not create or push release tags like `v0.1.0` or `v1.0.0`.
-- Do not trigger `.github/workflows/release.yml`.
-- Do not publish to PyPI or create a GitHub release.
-- Do not interpret configured PyPI trusted publishing or a GitHub `pypi`
-  environment as permission to release.
-- Only prepare or execute a public release after the user explicitly says the
-  repo is production-ready and wants to publish.
 
 ## Development Commands
 
@@ -346,46 +256,6 @@ grant adapters. Data contracts live under `app/data/`; secret policy lives at
 `app/security/secrets.yaml`; SaaS plans live in `app/config/subscriptions.yaml`;
 runtime entitlement enforcement is handled by the OSS `ConfiguredEntitlementAdapter`.
 
-## Generated Deployment Artifact Contract
-
-Generated deployment artifacts are provider-neutral app-bundle root files:
-
-- `Dockerfile`
-- `docker-compose.yml`
-- `env.example`
-- `deployment.manifest.json`
-- `.github/workflows/deploy.yml`
-
-These files describe how the app runs and which env/CI secret names are
-expected. They must never contain raw secrets, cloud tenant ids, hosted product
-policy defaults, or provider execution code.
-
-AppBuildPlan build tasks must not own these paths. They are emitted by the
-DownloadAgent through the `generate_and_download` deployment contract renderer
-using `deployment_profile`, `include_dockerfiles`, `include_workflow`, and
-`include_compose`. Hosted products consume the manifest and apply provider
-policy, secret delivery, DNS, and deployment adapters outside the generated app
-bundle.
-
-## Generated Persistence Contract
-
-Generated app persistence is expressed as staged data-contract artifacts:
-
-- `data_contract` is the canonical machine-readable planning object.
-- `AppGenerator` writes it to `data/contract.json` when present.
-- additive refinement migrations are staged under
-  `data/migrations/{migration_id}.json`.
-- generated modules use `backend/schemas.py` for typed document/request shapes,
-  `backend/repo.py` for persistence operations, and `backend/policy.py` for
-  scoping helpers.
-- do not generate `backend/models.py`, `backend/models/*.py`,
-  `backend/database/schema.json`, or `backend/database/seed.json`.
-- the runtime injects `ctx.persistence` into `ModuleContext` when `app_id`
-  exists; generated `backend/repo.py` uses
-  `ctx.persistence.collection(module_id, entity_name)`.
-- `ctx.db` remains absent and non-canonical; generated code must not require or
-  emit it.
-
 ## Generator Output Boundary
 
 Shared factory workflows live in `factory_app/workflows/`. Generator workflows
@@ -412,44 +282,6 @@ generated/workflows/{app_id}/{build_id}/{workflow_name}/
 
 Promotion is the only path from generated artifacts into active app roots such
 as an app workspace's `app/` bundle.
-
-## Structured-Output-First Contract Rule
-
-Canonical YAML contracts in Mozaiks are **structured-output-first contracts**.
-They are not prose-first configuration files that agents happen to write.
-
-- Every canonical YAML shape must be representable as a strict structured
-  output model before it is treated as a runtime or generator contract.
-- If a YAML shape cannot be generated repeatably and validated
-  deterministically from typed structured output, it is not ready to become a
-  canonical Mozaiks contract.
-- Shared taxonomies such as event namespaces, target kinds, capability kinds,
-  setting types, and admin panel kinds must use explicit reusable fields/enums,
-  not ad hoc freeform strings scattered across prompts.
-- When a contract changes, update the structured output model, generator
-  prompts, runtime validation/loaders, docs, and tests together.
-
-Use this standard for `module.yaml`, `contracts/events.yaml`, `contracts/reactions.yaml`,
-`contracts/notifications.yaml`, `contracts/settings.yaml`, `contracts/admin.yaml`,
-workflow YAMLs, page schemas, and any future declarative contracts.
-
-## Contract-Declared Customization Rule
-
-Mozaiks must allow customization, but customization is an extension of the
-contract, not an escape hatch from it.
-
-- YAML may reference bounded helper/customization stubs only through explicit
-  contract fields with a defined schema and loader behavior.
-- Python stubs extend backend/runtime-adjacent behavior; JS/TS stubs extend UI,
-  admin, or workflow-facing frontend behavior.
-- Referenced stubs must stay local to the declared app/module/workflow
-  boundary and must not invent undeclared fields, side channels, or alternate
-  schemas.
-- Agents generating these contracts must understand both halves of the shape:
-  the YAML contract and the stub entrypoint it references.
-- If a customization point is generator-facing, its prompt and structured
-  output model must define the exact allowable reference shape and when the
-  stub is required vs optional.
 
 ## Workflow Authoring Patterns
 
@@ -648,21 +480,6 @@ Scoped rules live in `.claude/rules/`. Apply them when working in their target d
 Use lowercase kebab-case: `conversation-modes.md`
 
 Exception: `README.md`, `CLAUDE.md`, `ARCHITECTURE.md`
-
-## Decision Rules
-
-When adding code, decide placement in this order:
-
-1. Is this required for every runtime instance and independent of app semantics? → **Runtime**.
-2. Is this generic Refinement Engine behavior over execution contexts, state, events, and routing? → **`mozaiksai/control_plane`**.
-3. Is this app hosting, routing, sessions, pages, modules, shell config, or app workspace composition? → **Platform**.
-4. Is this workspace management, build lifecycle, artifact review, run history, or configuration UI? → **Studio**.
-5. Is this first-party builder behavior, app generation logic, or builder-specific harness configuration? → **`factory_app`**.
-6. Is this hosted-only capability such as collaboration, billing, marketplace, deployment, or org management? → **Mozaiks App**.
-7. Is this filesystem scaffolding, process management, or terminal diagnostics? → **CLI**.
-
-Key: a feature is not CLI just because it runs locally. If it is management UI, it belongs in Studio. If it is generic intent routing across execution contexts, it belongs in the harness implementation. If it is builder-specific policy, it belongs in the factory harness pack.
-
 
 ## Autonomy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,3 +663,36 @@ When adding code, decide placement in this order:
 
 Key: a feature is not CLI just because it runs locally. If it is management UI, it belongs in Studio. If it is generic intent routing across execution contexts, it belongs in the harness implementation. If it is builder-specific policy, it belongs in the factory harness pack.
 
+
+## Autonomy
+
+Infer reasonable implementation details from the repository and continue. The repo — its
+canonical implementations, tests, ADRs, and git history — is the authority on architecture,
+not the prompt that sent you. When the prompt and the repo disagree about how something is
+built, read the code and believe the code.
+
+Stop and ask ONLY when the ambiguity would materially change one of:
+
+- a public contract or API shape
+- a security or authorization boundary
+- a persistence format or migration path
+- an architectural decision that is expensive to reverse
+
+Everything else: decide, implement, and report the decision in the deliverable. A question
+that the repository can answer is not a question for the requester.
+
+## Deliverable
+
+Report these, in this order, on any change that touches code:
+
+1. Verdict — done / blocked / partial
+2. Base SHA the work started from
+3. Branch and PR
+4. Files changed
+5. Architectural decisions made, and what was rejected
+6. Tests and checks run, with exact results — not "tests pass"
+7. Unresolved risks
+8. Whether the PR is safe to merge, and why
+
+Claims must be checkable from the diff or from pasted command output. A green suite that
+was never run against the changed surface is not evidence.

--- a/docs/agent-engineering-contract.md
+++ b/docs/agent-engineering-contract.md
@@ -1,0 +1,220 @@
+# Mozaiks Agent Engineering Contract
+
+Canonical engineering rules shared by every coding agent working in this repository,
+regardless of which agent or model is running.
+
+`AGENTS.md` (Codex entry point) and `CLAUDE.md` (Claude Code entry point) both point
+here. Agent-specific execution guidance stays in those files; the architectural rules
+below live here once, so the two entry points cannot drift apart and hand different
+rules to different agents.
+
+Changing a rule here changes it for every agent. Do not copy a rule from this file back
+into an entry point.
+
+## Working Path Constraint
+
+**Always work on `C:\Repos\BlocUnitedRepo\mozaiks` (this repo) and `C:\Repos\BlocUnitedRepo\mozaiks-app`.**
+Never read from or write to OneDrive paths (`C:\Users\...\OneDrive\...`). Those are stale copies, not the working repos.
+
+**Read [ARCHITECTURE.md](ARCHITECTURE.md) first.** That file is the source of truth for how the system works.
+
+This repo uses layered FastAPI hosts as the canonical OSS server composition:
+- `mozaiksai.hosts.runtime`
+- `mozaiksai.hosts.platform`
+- `mozaiksai.hosts.studio`
+
+`mozaiksai.hosts.studio` is the Studio management interface host and the default local run target. Studio is the shared management layer — available in both local and hosted deployments. Hosted product repos compose their own app-local hosts on top of Studio; this OSS repo does not own a hosted-product FastAPI host.
+
+**CLI and Studio are parallel interfaces**, not a superset chain. CLI owns developer tooling (filesystem, scaffolding, process management). Studio owns the management interface (workspace status, build lifecycle, artifacts, run history, config). Do not conflate them.
+
+Profile stays person-scoped. Studio / Workspace Shell is the org/workspace home base. App shells remain separate and brandable per app; do not collapse org management into `/me`.
+
+**`mozaiks gen` is a developer convenience**, not the canonical build lifecycle. Do not expand CLI commands to duplicate Studio surfaces (artifact review, diff, run history, promotion, build state). Those belong in Studio. The CLI hands off to Studio — it does not grow a parallel project-management surface.
+
+The current repo layout is transitional. The canonical target architecture is
+documented in
+[docs/architecture/foundations/distribution-and-workspace-model.md](docs/architecture/foundations/distribution-and-workspace-model.md).
+Do not reintroduce a hybrid root that mixes the starter app bundle with shared
+factory workflows.
+
+## ADR Authoring Context
+
+For an ADR that changes or extends app generation, semantic authority,
+compilation/materialization, or refinement, review
+[issue #411](https://github.com/BlocUnited-LLC/mozaiks/issues/411) and state
+explicitly whether the ADR adopts, modifies, rejects, or defers that direction.
+
+Issue #411 is a design prompt, not architecture authority. Current source and
+Accepted ADRs remain authoritative. Any ADR using the issue must verify its
+claims against the repository and must not make a typed decision ledger a
+second authority for application meaning.
+
+## AG2 Ownership Boundary
+
+Mozaiks uses AG2 as the long-term backbone for agentic execution. Do not build
+a parallel agent framework in this repo when AG2 already owns the concept or is
+the right upstream home for it. See
+[docs/architecture/workflows/ag2-ownership-boundary.md](docs/architecture/workflows/ag2-ownership-boundary.md)
+for the durable architecture contract and upgrade watchpoints.
+
+AG2 should own:
+
+- agent primitives, model calls, tools, middleware, and task execution
+- multi-agent network mechanics, Hub/AgentClient behavior, channels, adapters,
+  and workflow state progression
+- task delegation, task lifecycle observation, event mirroring, and generic
+  agent runtime observability
+
+Mozaiks should own:
+
+- declarative workflow contracts and strict structured-output validation
+- canonical generated app, workflow, module, page, persistence, and secret
+  artifact shapes
+- app/runtime persistence, transport integration, tenant/session boundaries,
+  Studio/platform lifecycle, and artifact promotion
+- deterministic factory refinement policy and decomposition contracts that
+  define what work must be executed by AG2 agents
+
+When a needed capability is missing from AG2, inspect AG2's current docs, APIs,
+and source direction before adding runtime code here. Keep Mozaiks custom logic
+as a small adapter or contract layer around AG2 — preferably behind
+`mozaiksai.core.adapters` or a similarly narrow boundary, document the divergence, and
+track it as an AG2 compatibility watchpoint. If the missing capability is
+generic agent orchestration rather than Mozaiks-specific contract enforcement,
+prefer communicating the need upstream to the AG2 team instead of growing a
+permanent Mozaiks substitute.
+
+Do not introduce Mozaiks-owned replacements for AG2 Hub, AgentClient, network
+adapters, task streams, task observation, delegation engines, or generic
+agent scheduling unless there is no viable AG2-aligned implementation path and
+the boundary is documented before or with the code change.
+
+## Release Hold
+
+Do **not** publish this repo yet.
+
+- Do not create or push `v*` Git tags (`v0.1.0`, `v1.0.0`, any of them).
+- Do not trigger `.github/workflows/release.yml`.
+- Do not publish to PyPI or create a GitHub release.
+- Do not treat trusted-publisher or GitHub environment setup as approval to
+  release. A configured PyPI trusted publisher or a GitHub `pypi` environment
+  is not permission.
+- Do not bump `mozaiksai/version.py` for a public release unless the user
+  explicitly says the repo is production-ready and wants to publish.
+
+Normal code pushes are fine. Public release actions are not.
+
+## Contributor Guidance Operating System
+
+For nontrivial OSS changes:
+
+- choose the closest active task skill before editing. Codex-facing skills live
+  under `.agents/skills/`; Claude Code-facing skills live under
+  `.claude/skills/`.
+- use `oss-contribution-review` when scope spans layers or the right skill is
+  unclear
+- include the appropriate impact section from `.claude/rules/testing.md` in the
+  final report and always list tests run
+
+## Generated Deployment Artifact Contract
+
+Generated deployment artifacts are provider-neutral app-bundle root files:
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `env.example`
+- `deployment.manifest.json`
+- `.github/workflows/deploy.yml`
+
+These files describe how the app runs and which env/CI secret names are
+expected. They must never contain raw secrets, cloud tenant ids, hosted product
+policy defaults, or provider execution code.
+
+AppBuildPlan build tasks must not own these paths. They are emitted by the
+DownloadAgent through the `generate_and_download` deployment contract renderer
+using `deployment_profile`, `include_dockerfiles`, `include_workflow`, and
+`include_compose`. Hosted products consume the manifest and apply provider
+policy, secret delivery, DNS, and deployment adapters outside the generated app
+bundle.
+
+## Generated Persistence Contract
+
+AppGenerator persistence output is data-contract-first, not runtime-DB-first:
+
+- `data_contract` is the canonical generated data planning object.
+- Generated app bundles write it to `data/contract.json`.
+- Additive refinement plans belong under
+  `data/migrations/{migration_id}.json`.
+- Persistent modules use `backend/repo.py`, `backend/policy.py`, and
+  `backend/schemas.py`; do not generate `backend/models.py` or
+  `backend/models/*.py`.
+- Do not generate `backend/database/schema.json` or
+  `backend/database/seed.json`.
+- Do not put database access in `handler.py`, and do not put raw persistence
+  operations in `service.py`.
+- Runtime injects `ctx.persistence` into `ModuleContext` when `app_id` exists.
+  Generated `backend/repo.py` must use
+  `ctx.persistence.collection(module_id, entity_name)`.
+- `data/contract.json` also covers cross-module aggregate ownership and explicit
+  existing database integration when needed.
+- External database provider mechanics, when explicitly required, belong under
+  `app/services/adapters/database/`. Do not generate `app/services/data/` for
+  customer apps.
+- Do not generate Python helper files under `data/` or `security/`. Those app
+  planes are declarative: data contracts/migrations and names-only secret
+  policy.
+- `ctx.db` remains absent and non-canonical; generated code must not require or
+  emit it.
+
+## Structured-Output-First Contract Rule
+
+Canonical YAML contracts in Mozaiks are **structured-output-first contracts**.
+They are not prose-first configuration files that agents happen to write.
+
+- Every canonical YAML shape must be representable as a strict structured
+  output model before it is treated as a runtime or generator contract.
+- If a YAML shape cannot be generated repeatably and validated
+  deterministically from typed structured output, it is not ready to become a
+  canonical Mozaiks contract.
+- Shared taxonomies such as event namespaces, target kinds, capability kinds,
+  setting types, and admin panel kinds must use explicit reusable fields/enums,
+  not ad hoc freeform strings scattered across prompts.
+- When a contract changes, update the structured output model, generator
+  prompts, runtime validation/loaders, docs, and tests together.
+
+Use this standard for `module.yaml`, `contracts/events.yaml`, `contracts/reactions.yaml`,
+`contracts/profile.yaml`, `contracts/notifications.yaml`, `contracts/settings.yaml`,
+`contracts/admin.yaml`,
+workflow YAMLs, page schemas, and any future declarative contracts.
+
+## Contract-Declared Customization Rule
+
+Mozaiks must allow customization, but customization is an extension of the
+contract, not an escape hatch from it.
+
+- YAML may reference bounded helper/customization stubs only through explicit
+  contract fields with a defined schema and loader behavior.
+- Python stubs extend backend/runtime-adjacent behavior; JS/TS stubs extend UI,
+  admin, or workflow-facing frontend behavior.
+- Referenced stubs must stay local to the declared app/module/workflow
+  boundary and must not invent undeclared fields, side channels, or alternate
+  schemas.
+- Agents generating these contracts must understand both halves of the shape:
+  the YAML contract and the stub entrypoint it references.
+- If a customization point is generator-facing, its prompt and structured
+  output model must define the exact allowable reference shape and when the
+  stub is required vs optional.
+
+## Decision Rules
+
+When adding code, decide placement in this order:
+
+1. Is this required for every runtime instance and independent of app semantics? → **Runtime**.
+2. Is this generic Refinement Engine behavior over execution contexts, state, events, and routing? → **`mozaiksai/control_plane`**.
+3. Is this app hosting, routing, sessions, pages, modules, shell config, or app workspace composition? → **Platform**.
+4. Is this workspace management, build lifecycle, artifact review, run history, or configuration UI? → **Studio**.
+5. Is this first-party builder behavior, app generation logic, or builder-specific harness configuration? → **`factory_app`**.
+6. Is this hosted-only capability such as collaboration, billing, marketplace, deployment, or org management? → **Mozaiks App**.
+7. Is this filesystem scaffolding, process management, or terminal diagnostics? → **CLI**.
+
+Key: a feature is not CLI just because it runs locally. If it is management UI, it belongs in Studio. If it is generic intent routing across execution contexts, it belongs in the harness implementation. If it is builder-specific policy, it belongs in the factory harness pack.

--- a/tests/test_appgenerator_persistence_alignment.py
+++ b/tests/test_appgenerator_persistence_alignment.py
@@ -366,6 +366,7 @@ def test_docs_state_ctx_persistence_is_runtime_supported() -> None:
             ROOT / "docs" / "architecture" / "foundations" / "events-and-data" / "persistence-and-artifact-storage.md",
             ROOT / "AGENTS.md",
             ROOT / "CLAUDE.md",
+            ROOT / "docs" / "agent-engineering-contract.md",
         )
     )
 


### PR DESCRIPTION
## The problem

`CLAUDE.md` (665 lines) and `AGENTS.md` (708 lines) independently carried **ten of the same sections**, and **seven had already drifted apart**. Codex and Claude Code were following different versions of the same architectural rules.

Measured, not assumed:

```
ADR Authoring Context                         IDENTICAL
AG2 Ownership Boundary                        DRIFTED
Contract-Declared Customization Rule          DRIFTED
Contributor Guidance Operating System         IDENTICAL
Decision Rules                                DRIFTED
Generated Deployment Artifact Contract        IDENTICAL
Generated Persistence Contract                DRIFTED
Release Hold                                  DRIFTED
Structured-Output-First Contract Rule         DRIFTED
Working Path Constraint                       DRIFTED
```

Concrete consequences of the drift:

- **Generated Persistence Contract** — AGENTS.md forbids database access in `handler.py`, raw persistence in `service.py`, and Python helpers under `data/`/`security/`. CLAUDE.md carried none of those, so Claude Code generating a module never saw them.
- **Working Path Constraint** — CLAUDE.md has 20 lines of host composition and CLI/Studio boundary rules; AGENTS.md had a one-line pointer, so Codex only got them if it happened to read the other file.
- **Release Hold** — each file had a release prohibition the other lacked.

## The change

1. **`docs/agent-engineering-contract.md`** (new) — the ten shared sections, once. Where versions drifted, the fuller version wins; rules unique to the other version were merged back in rather than dropped.
2. **`CLAUDE.md` / `AGENTS.md`** — duplicated sections replaced by a pointer to the contract. Each keeps only its agent-specific guidance.
3. **Autonomy + Deliverable** (first commit) — neither file said when to decide vs. ask, or what a finished change must report. Escalate only for public contract shape, security boundary, persistence format, or expensive-to-reverse architecture; report eight required fields with exact test results.

## Verification

- **No rule lost:** every backticked identifier and file path appearing in removed text was checked against the post-change tree — 65 identifiers, 0 missing. Four dropped in the first pass (`contracts/profile.yaml`, `pypi`, `v0.1.0`, `v1.0.0`) were restored before commit.
- **`mkdocs build --strict`** — exit 0.
- Internal links in the new doc resolve.

Net: -372 duplicated lines from the entry points, +217 canonical contract.

## Risk

Documentation only; no code, no behavior change. The reviewable question is whether each drifted section resolved to the right version — the per-section source is stated above and the diff shows both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)