### PR TITLE
ci(cleanup): tag abandoned branches before deleting them

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -45,6 +45,7 @@ jobs:
 
           deleted=()
           flagged=()
+          salvaged=()
 
           for ref in $(git branch -r | grep -v 'HEAD' | sed 's|origin/||'); do
             if [ "$ref" == "main" ]; then
@@ -68,11 +69,26 @@ jobs:
               echo "Deleting merged branch: $ref"
               git push origin --delete "$ref" || true
               deleted+=("$ref (merged)")
+              # No salvage tag: commits are already reachable from main.
             elif [ "$state" == "CLOSED" ]; then
               if [ "$age_days" -ge "$CLOSED_GRACE_DAYS" ]; then
+                # Deleting a closed-unmerged branch is the only case that makes
+                # commits unreachable. Tag first so the work stays recoverable;
+                # this workflow never sweeps tags.
+                tag="salvage/${ref}"
+                if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+                  echo "Salvage tag $tag already exists for $ref"
+                elif git push origin "refs/remotes/origin/${ref}:refs/tags/${tag}"; then
+                  echo "Tagged $ref as $tag before deletion"
+                  salvaged+=("$tag")
+                else
+                  echo "Could not tag $ref; leaving branch in place for manual review"
+                  flagged+=("$ref (salvage tag failed, branch NOT deleted)")
+                  continue
+                fi
                 echo "Deleting abandoned branch: $ref (closed ${age_days}d ago)"
                 git push origin --delete "$ref" || true
-                deleted+=("$ref (closed, ${age_days}d ago)")
+                deleted+=("$ref (closed, ${age_days}d ago, salvaged as $tag)")
               else
                 flagged+=("$ref (closed ${age_days}d ago, still in grace period)")
               fi
@@ -87,4 +103,10 @@ jobs:
             echo ""
             echo "### Left for manual review (${#flagged[@]})"
             if [ "${#flagged[@]}" -eq 0 ]; then echo "_none_"; else printf -- '- %s\n' "${flagged[@]}"; fi
+            echo ""
+            echo "### Salvage tags created (${#salvaged[@]})"
+            echo ""
+            echo "Abandoned branches are tagged before deletion, so no work becomes"
+            echo "unreachable. Recover one with: git fetch origin refs/tags/<tag>"
+            if [ "${#salvaged[@]}" -eq 0 ]; then echo "_none_"; else printf -- '- %s\n' "${salvaged[@]}"; fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The weekly sweep deletes branches whose PR was closed without merging. That is the one case where deleting a ref makes commits unreachable, and there was no recovery path once it ran.

This surfaced concretely. #449 was closed as "built against an older runtime/authority baseline" and `codex/issue-426-queue-admission` was queued for deletion on 2026-09-14. That rationale did not hold for this lane — the authority migration reshaped semantics and compilation, not admission. Drift since the merge-base (`11daf2fa`) on the files it touches:

- `mozaiksai/core/workflow/queue.py` — **zero**
- `mozaiksai/core/transport/workflow_bridge.py` — 13 deletions
- `mozaiksai/core/transport/simple_transport.py` — 3 insertions / 2 deletions
- `mozaiksai/hosts/runtime.py` — 3 insertions / 2 deletions

A trial `git merge-tree` against `origin/main` auto-merges every core file. The only conflicts are `CHANGELOG.md` and three modify/delete pairs on files #463 removed, all resolved by taking main's delete — the branch's edit to `work_assignment_worker.py` is one incidental line adapting a helper to `QueueItem.workspace_id`, and `execution_admission.py` never references that worker.

So 1,424 lines — a 260-line durable admission module, +410 lines of claim/lease/fencing in `queue.py`, and 494 lines of tests including `tests/test_workflow_queue_real_mongo.py` — were three days from being unreachable because of a wrong judgment call. That branch is now preserved by hand as `salvage/pr-449-queue-admission`, and #426 is reopened, but the general hazard remains.

## What changed

Tag each abandoned branch as `salvage/<branch>` before deleting it.

- Merged branches are skipped — their commits are already reachable from main.
- If tagging fails, the branch is flagged and **not** deleted, so the failure mode is a surviving branch rather than lost work.
- Re-running is idempotent: an existing salvage tag is detected and reused.
- The run summary lists the tags created and how to fetch them.

Tags are never swept by this workflow, so a salvage tag is durable.

## Validation

- YAML parses; `permissions.contents: write` already present, which is what the tag push needs.
- `bash -n` clean on the extracted `run` block.
- The push refspec (`refs/remotes/origin/<ref>:refs/tags/<tag>`) is the same one used to create `salvage/pr-449-queue-admission` by hand, against this repo, successfully.
- No Python touched, so `ruff` / `pytest` are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)