### PR TITLE
fix(build-context): admit operator_pack as a declarable capability_source

### DIFF
--- a/mozaiksai/core/session/build_context_schema.py
+++ b/mozaiksai/core/session/build_context_schema.py
@@ -46,6 +46,7 @@ VALID_CAPABILITY_SOURCES: frozenset[str] = frozenset({
     "managed_capability",
     "generated_module",
     "operator_extension",
+    "operator_pack",
     "external_adapter",
     "framework_pack",
 })

--- a/mozaiksai/core/session/capability_pack.py
+++ b/mozaiksai/core/session/capability_pack.py
@@ -62,11 +62,16 @@ if _PYDANTIC:
             assembly for deterministic template materialization.
             None in OSS/dev contexts where no template files are needed.
         status
-            "active" | "placeholder". Only active packs should be passed to
-            factory workflows. Operators filter before launch.
+            "active" | "inactive" | "archived". Only active packs should be
+            passed to factory workflows. Operators filter before launch.
         capability_source
-            Taxonomy label: "managed_capability" | "framework_pack" | "host_universal"
-            | "generated_module" | "external_adapter".
+            Taxonomy label. Valid values are defined by
+            mozaiksai.core.session.build_context_schema.VALID_CAPABILITY_SOURCES:
+            "config_file" | "managed_capability" | "generated_module" |
+            "operator_extension" | "operator_pack" | "external_adapter" |
+            "framework_pack". Descriptors normalized from a build-context
+            context.yaml default to "operator_pack"; this model's default stays
+            "managed_capability" for existing operator constructors.
         """
         id: str
         display_name: str = ""

--- a/tests/test_community_pack_foundation.py
+++ b/tests/test_community_pack_foundation.py
@@ -229,6 +229,25 @@ def test_unknown_capability_source_rejected() -> None:
     assert any(d.field == "pack.capability_source" for d in result.errors)
 
 
+def test_explicit_operator_pack_capability_source_accepted() -> None:
+    """The normalize_pack_descriptor default must also be declarable explicitly."""
+    from factory_app.workflows.AppGenerator.tools.pack_context_schema import validate_pack_context
+
+    context: dict[str, Any] = {
+        "context_id": "explicit_default",
+        "applies_to_workflows": ["AppGenerator"],
+        "assets": [],
+        "pack": {
+            "id": "explicit_default",
+            "status": "active",
+            "version": "0.1.0",
+            "capability_source": "operator_pack",
+        },
+    }
+    result = validate_pack_context(context)
+    assert result.valid, [d.message for d in result.errors]
+
+
 # ---------------------------------------------------------------------------
 # 3. Dependency validation: satisfied requirement passes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`normalize_pack_descriptor` defaults `capability_source` to `operator_pack` (build_context.py:156), but `VALID_CAPABILITY_SOURCES` rejected that same value when declared explicitly in a pack's context.yaml — the de facto default was un-declarable (the default is applied post-validation, so it escapes; an explicit declaration fails the load). Adds `operator_pack` to the schema set — strictly behavior-preserving (no descriptor output changes; the two tests locking the default stay green) — plus a regression test for the explicit declaration.

Also fixes the `CapabilityPack` docstring, which documented a third, incompatible taxonomy: nonexistent `host_universal`, missing `config_file`/`operator_extension`/`operator_pack`, and status `placeholder` (schema set is active|inactive|archived). An operator following that docstring got a hard `BuildContextError` at launch.

## Verification

- `ruff check` clean on touched files; targeted suites green (134 tests: test_community_pack_foundation, test_build_context_helpers, test_build_context_provider).
- Full `pytest -q --no-cov`: 22 failed / 16791 passed — the identical 22 failures reproduce on a Python-pristine origin/main worktree (verified by full-suite diff: zero branch-only failures). All 22 are local-env drift: the venv carries ag2 1.0.0b0 while the repo pins 1.0.3 (`test_ag2_dependency_declarations_and_installed_runtime_match` fails locally by design; TaskStarted.expires_at appeared after 1.0.0b0). CI installs the pin.

Found by tonight's adversarially-verified defect sweep (claim C1 CONFIRMED + extra-defect docstring taxonomy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)