### PR TITLE
chore(runtime): hygiene sweep — 'off' typo, stale DefaultPattern, wallet client dormancy notice

### DIFF
--- a/factory_app/build_context/mozaikspay/templates/services/integrations/wallet_client.py
+++ b/factory_app/build_context/mozaikspay/templates/services/integrations/wallet_client.py
@@ -1,5 +1,12 @@
 """Thin MozaiksPay wallet client for generated apps.
 
+DORMANT SURFACE — DO NOT WIRE UP YET. The hosted wallet API this client
+targets (/api/mozaikspay/v1/wallet/*) is not published by any MozaiksPay
+provider deployment today; every call returns 404. The file ships only so
+the integration seam stays versioned with the rest of the pack. Do not
+call it from generated modules or pages until the provider publishes the
+wallet endpoints and this notice is removed.
+
 This file is copied to:
     services/integrations/wallet_client.py
 

--- a/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
+++ b/factory_app/workflows/BrandAssetGeneratorWorkflow/orchestrator.yaml
@@ -3,5 +3,5 @@ workflow_name: BrandAssetGeneratorWorkflow
 max_turns: 30
 human_in_the_loop: true
 workflow_startup_mode: AgentDriven
-orchestration_pattern: DefaultPattern
+orchestration_pattern: ag2_network
 initial_agent: BrandDesignerAgent

--- a/mozaiksai/core/workflow/orchestration_utils.py
+++ b/mozaiksai/core/workflow/orchestration_utils.py
@@ -38,7 +38,7 @@ def _normalize_human_in_the_loop(value) -> bool:
         v = value.strip().lower()
         if v in {"true", "yes", "1", "on", "always"}:
             return True
-        if v in {"false", "no", "0", "of", "never"}:
+        if v in {"false", "no", "0", "off", "never"}:
             return False
     return False
 


### PR DESCRIPTION
## What

Three verified, behavior-preserving hygiene fixes from tonight's defect sweep:

- `orchestration_utils` falsy-string set had `'of'` where `'off'` was meant. Behavior is identical for every input (both mapped to False — one by match, one by fallthrough), but the typo invited breakage if the fallthrough ever changes.
- `BrandAssetGeneratorWorkflow/orchestrator.yaml` still declared `orchestration_pattern: DefaultPattern` — the last occurrence anywhere of a value the runtime never implemented (verified runtime-inert: free-string field, nothing branches on it, no drift guard asserts values). Normalized to `ag2_network`.
- `wallet_client.py` pack template now carries an explicit DORMANT notice: the `/api/mozaikspay/v1/wallet/*` API it targets is not published by any provider deployment (verified against the hosted provider's main), so generated apps must not wire it up yet. Deletion was rejected because six test files deliberately pin the template; the surface decision is tracked in #516.

## Verification

- `ruff check` clean; targeted run green (106 tests across orchestration-utils/declarative-contracts/pattern-examples/brand selections).
- Python diff is provably behavior-identical; full-suite risk assessed via the taxonomy-branch full run + pristine-main baseline diff (identical 22 pre-existing failures, all ag2 1.0.0b0-vs-1.0.3 local venv drift; CI installs the pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)