### PR TITLE
fix(admin): sum total_spent for wallet spend totals in /api/admin/usage

### DIFF
--- a/mozaiksai/core/admin/router.py
+++ b/mozaiksai/core/admin/router.py
@@ -369,7 +369,9 @@ async def get_admin_usage(
                         "_id": "$wallet_id",
                         "total_balance": {"$sum": "$balance"},
                         "total_credited": {"$sum": "$total_credited"},
-                        "total_debited": {"$sum": "$total_debited"},
+                        # Balance documents store spend as total_spent; the
+                        # response keeps the total_debited key for consumers.
+                        "total_debited": {"$sum": "$total_spent"},
                         "scope_count": {"$sum": 1},
                     }
                 },


### PR DESCRIPTION
## What

`/api/admin/usage` wallet_totals aggregated `{\"$sum\": \"$total_debited\"}`, but token wallet balance documents have no such field — spend lives in `total_spent` (initialized `wallet.py:314`, incremented on debit `:598`). Operator-facing spend totals were therefore always 0 no matter how many tokens were consumed. One-line fix summing the real field; the response key is unchanged for consumers.

Found by tonight's usage-metering audit in the App Zero repo (defect M4 of the metering cluster).

## Verification

- `ruff check` clean; `tests/test_admin_router_persisted_usage.py` green (its wallet_totals fixture asserts the empty case; the aggregation path needs real Mongo, which the existing harness doesn't drive).
- Known local-env suite failures (ag2 1.0.0b0 in venv vs 1.0.3 pin, 22 failures) are pre-existing and unrelated — proven by baseline diff in #517's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)